### PR TITLE
SAK-28950 - updating default.sakai.properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2670,6 +2670,13 @@
 # Since: 10.0
 # content.import.hidden=true
 
+## SYLLABUS
+# When you are on the main page and you click "add item", 
+# the item is added as draft by default. 
+# Setting this property to true, items are added as published by default. 
+# DEFAULT: false (items save as draft)
+# syllabus.new.published.default=true
+
 ## TEST & QUIZZES (SAMIGO)
 # Samigo File Upload question type settings default settings:
 # DEFAULT: 1024


### PR DESCRIPTION
 with new syllabus.new.published.default property, added in Sakai 10.3 .
