### PR TITLE
SAK-28202 Add indexed field to hold the documents indexed state

### DIFF
--- a/search/elasticsearch/impl/src/java/org/sakaiproject/search/elasticsearch/ElasticSearchService.java
+++ b/search/elasticsearch/impl/src/java/org/sakaiproject/search/elasticsearch/ElasticSearchService.java
@@ -544,7 +544,7 @@ public class ElasticSearchService implements SearchService {
     public int getNDocs() {
         indexBuilder.assureIndex();
         CountResponse response = client.prepareCount(indexName)
-                .setQuery(filteredQuery(matchAllQuery(),existsFilter(SearchService.FIELD_CONTENTS)))
+                .setQuery(filteredQuery(matchAllQuery(),termFilter(SearchService.FIELD_INDEXED, true)))
                 .execute()
                 .actionGet();
         return (int) response.getCount();

--- a/search/elasticsearch/impl/src/resources/org/sakaiproject/search/elastic/bundle/mapping.json
+++ b/search/elasticsearch/impl/src/resources/org/sakaiproject/search/elastic/bundle/mapping.json
@@ -52,6 +52,12 @@
                 "index": "not_analyzed",
                 "store": "yes"
             },
+            "indexed": {
+                "type": "boolean",
+                "index": "not_analyzed",
+                "null_value": "false",
+                "store": "no"
+            },
             "contents": {
                 "type": "string",
                 "analyzer": "standard",

--- a/search/elasticsearch/impl/src/test/org/sakaiproject/search/elasticsearch/ElasticSearchTest.java
+++ b/search/elasticsearch/impl/src/test/org/sakaiproject/search/elasticsearch/ElasticSearchTest.java
@@ -425,7 +425,7 @@ public class ElasticSearchTest {
 
         elasticSearchIndexBuilder.refreshIndex();
 
-        System.out.println(elasticSearchService.getNDocs());
+        System.out.println("testRebuildSiteIndex: " + elasticSearchService.getNDocs());
         assertTrue(elasticSearchService.getNDocs() == 106);
     }
 

--- a/search/search-api/api/src/java/org/sakaiproject/search/api/SearchService.java
+++ b/search/search-api/api/src/java/org/sakaiproject/search/api/SearchService.java
@@ -119,8 +119,10 @@ public interface SearchService extends Diagnosable
 	
 	
 	public static final String FIELD_DIGEST_COUNT = "digestCount";
-
+	
 	public static final String DATE_STAMP = "indexdate";
+
+	public static final String FIELD_INDEXED = "indexed";
 
 	/**
 	 * Perform a search, return results in a list.


### PR DESCRIPTION
SAK-28202 Add indexed field to indicate the state of whether a document 
was indexed. Previously it depended on whether the content field had valid
data but some ECP's didn't produce the appropriate content.