### PR TITLE
SAK-27715 support ability to make sakai nodes client only to ES

### DIFF
--- a/search/elasticsearch/impl/src/java/org/sakaiproject/search/elasticsearch/ElasticSearchService.java
+++ b/search/elasticsearch/impl/src/java/org/sakaiproject/search/elasticsearch/ElasticSearchService.java
@@ -92,6 +92,13 @@ public class ElasticSearchService implements SearchService {
     private ElasticSearchIndexBuilder indexBuilder;
     private SiteService siteService;
     private boolean localNode = false;
+
+    /**
+     * set this to true if you intend to run an ElasticSearch cluster that is external to Sakai
+     * this instructs ES to not store any data on the local node but only act as a client
+     */
+    private boolean clientNode = false;
+
     private boolean useSiteFilters = false;
 
     /**
@@ -228,6 +235,7 @@ public class ElasticSearchService implements SearchService {
         ImmutableSettings.Builder settings = settingsBuilder().put(properties);
 
         node = nodeBuilder()
+                .client(clientNode)
                 .settings(settings)
                 .local(localNode).node();
 
@@ -854,6 +862,10 @@ public class ElasticSearchService implements SearchService {
 
     public void setLocalNode(boolean localNode) {
         this.localNode = localNode;
+    }
+
+    public void setClientNode(boolean clientNode) {
+        this.clientNode = clientNode;
     }
 
     public void setUseSiteFilters(boolean useSiteFilters) {


### PR DESCRIPTION
see https://jira.sakaiproject.org/browse/SAK-27715

Its a super small change but enables a lot of better architectures.  Especially if we want to start doing things like indexing sakai events into ES.  You really don't want ES embedded in Tomcat once you start really using it at any scale, but for smaller installations, it certainly more cost effective.  But this little gem gives people flexibility.