### PR TITLE
SAK-28975: preferences missing active primary button at bottom of form

### DIFF
--- a/user/user-tool-prefs/tool/src/webapp/prefs/tab.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/tab.jsp
@@ -215,7 +215,7 @@ if ( inIframe() ) {
 		</t:dataList>
                 <f:verbatim></div></f:verbatim>
                 <f:verbatim></div></div>
-<div style="float:none;clear:both;margin:2em 0">
+<div class="act">
 </f:verbatim>
 
 <%-- ## SAK-23895 :Display full name of course, not just code, in site tab  --%>


### PR DESCRIPTION
The main preferences page has buttons at the top and bottom of the form. The ones in the bottom of the form are not wrapped in a div with a class of "act".

This poses a problem for institutions that styles the primary action buttons based on this structure (.act input.active[type="submit|button|reset"]).

The attached patch simply changes the parent div of the bottom buttons to apply the "act" class (and remove some unnecessary formatting).