### PR TITLE
SAK-28074 Changing the Forum feed permission logic

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/ForumsEntityProviderImpl.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/ForumsEntityProviderImpl.java
@@ -19,6 +19,7 @@ import org.sakaiproject.api.app.messageforums.Topic;
 import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
 import org.sakaiproject.api.app.messageforums.ui.UIPermissionsManager;
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entitybroker.EntityView;
 import org.sakaiproject.entitybroker.entityprovider.annotations.EntityCustomAction;
 import org.sakaiproject.entitybroker.entityprovider.capabilities.*;
@@ -361,7 +362,7 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 		if(baseForum instanceof OpenForum) {
 			
 			// If the supplied user is the super user or an instructor, return true.
-			if(securityService.isSuperUser(userId) || forumManager.isInstructor(userId, "/site/" + siteId)) {
+			if(securityService.isSuperUser(userId) || forumManager.isInstructor(userId, Entity.SEPARATOR + SiteService.SITE_SUBTYPE + Entity.SEPARATOR + siteId)) {
 				return true;
 			}
 			

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/ForumsEntityProviderImpl.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/ForumsEntityProviderImpl.java
@@ -159,7 +159,7 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 		
 		for(DiscussionForum fatForum : fatFora) {
 			
-			if( ! checkAccess(fatForum,userId)) {
+			if( ! checkAccess(fatForum,userId,siteId)) {
 				LOG.warn("Access denied for user id '" + userId + "' to forum '" + fatForum.getId()
 							+ "'. This forum will not be returned.");
 				continue;
@@ -205,7 +205,7 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 		
 		DiscussionForum fatForum = forumManager.getForumByIdWithTopicsAttachmentsAndMessages(forumId);
 		
-		if(checkAccess(fatForum,userId)) {
+		if(checkAccess(fatForum,userId,siteId)) {
 			
 			SparseForum sparseForum = new SparseForum(fatForum,developerHelperService);
 			
@@ -356,12 +356,12 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 		
 	}
 	
-	private boolean checkAccess(BaseForum baseForum, String userId) {
+	private boolean checkAccess(BaseForum baseForum, String userId, String siteId) {
 		
 		if(baseForum instanceof OpenForum) {
 			
-			// If the supplied user is the super user, return true.
-			if(securityService.isSuperUser(userId)) {
+			// If the supplied user is the super user or an instructor, return true.
+			if(securityService.isSuperUser(userId) || forumManager.isInstructor(userId, "/site/" + siteId)) {
 				return true;
 			}
 			


### PR DESCRIPTION
The Forums Feed returns the drafted forum info to the site instructor (Who is not the super user) and when  he did not created the forum. The Forum UI was doing this but now that logic is changed to Such that Forums Feed also flow the same behavior.

https://jira.sakaiproject.org/browse/SAK-28074

@bkirschn @dovek please review