### PR TITLE
LSNBLDR-453: fix inconsistent and improper syntax in CSS and JavaScript

### DIFF
--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -247,18 +247,20 @@ a.edit-link:link, a.edit-link:visited, a.itemLink:link, a.itemLink:visited, a.mu
 }
 .mainList li {
     position: relative;
-#    border:1px solid transparent
-#    padding:26px;
-#    margin: 15px 0;
-#    -webkit-border-radius: 3px;
-#    -moz-border-radius: 3px;
-#    border-radius: 3px;
-#    border: 1px solid #ccc;
+/*
+    border:1px solid transparent
+    padding:26px;
+    margin: 15px 0;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    border: 1px solid #ccc;
+*/
 }
-.mainList li:hover {
-#    border: 1px solid #B3B3B3;
+/*.mainList li:hover {
+    border: 1px solid #B3B3B3;
 }
-/*.mainList li.canEdit > div {
+.mainList li.canEdit > div {
     position: relative;
     padding-left: 40px
 }*/
@@ -309,11 +311,12 @@ a.edit-link:link, a.edit-link:visited, a.itemLink:link, a.itemLink:visited, a.mu
 
 .statusCol,.contentCol {
  display: inline-block;
-
-#    position: absolute;
-#    top:2px;
-#    left:2px;
-#    z-index:2;
+/*
+    position: absolute;
+    top:2px;
+    left:2px;
+    z-index:2;
+*/
 }
 .contentCol {
     width:95%;
@@ -546,11 +549,13 @@ h3.author {
     padding:5px;
 }
 .commentGradePanel {
-float:right;
-vertical-align:top;
-#    position: absolute;
-#    top: 10px;
-#    right: 0;
+    float:right;
+    vertical-align:top;
+/*
+    position: absolute;
+    top: 10px;
+    right: 0;
+*/
 }
 .commentDiv .editLink:hover, .commentDiv .deleteLink:hover,  .commentDiv .replyLink:hover {
     cursor:pointer;

--- a/lessonbuilder/tool/src/webapp/js/SakaiRSFWidgets.js
+++ b/lessonbuilder/tool/src/webapp/js/SakaiRSFWidgets.js
@@ -13,7 +13,7 @@ SakaiProject.fckeditor = function() {
       
       var oFCKeditor = new FCKeditor(textarea_id);
       oFCKeditor.BasePath = basepath;
-      if (collection_id != "") {
+      if (collection_id !== "") {
         oFCKeditor.Config['ImageBrowserURL'] = browsePrefix + "Type=Image&CurrentFolder=" + collection_id;
         oFCKeditor.Config['LinkBrowserURL'] = browsePrefix + "Type=Link&CurrentFolder=" + collection_id;
         oFCKeditor.Config['FlashBrowserURL'] = browsePrefix + "Type=Flash&CurrentFolder=" + collection_id;

--- a/lessonbuilder/tool/src/webapp/js/commentGrading.js
+++ b/lessonbuilder/tool/src/webapp/js/commentGrading.js
@@ -36,7 +36,7 @@ $(function() {
 			if($(value).is(":visible")) {
 				$(value).hide();
 			}else if(!$(value).is(":visible") && $(value).attr("id") === $(firstRow).next().attr("id")) {
-				if($(value).find(".replaceWithComments").children().length == 0) {
+				if($(value).find(".replaceWithComments").children().length === 0) {
 					var oldSrc = $(firstRow).find(".toggleStatus").attr("src");
 					oldSrc = oldSrc.replace("loading.gif", "");
 					oldSrc = oldSrc.replace("no-status.png", "");
@@ -90,7 +90,7 @@ $(function() {
 	
 	// cr on individual box, update that box
 	$(".pointsBox").keyup(function(event){
-		if(event.keyCode == 13)
+		if(event.keyCode === 13)
 		    updateGrade($(this));
         });
 
@@ -129,7 +129,7 @@ function updateGrade(item) {
 
 function prefetchComments(value) {
 	// Prefetch the next one as well, so that it's ready when they need it.
-	if($(value).length > 0 && $(value).find(".replaceWithComments").children().length == 0) {
+	if($(value).length > 0 && $(value).find(".replaceWithComments").children().length === 0) {
 		var href=$(value).find(".commentsLink").attr("href");
 		var ci = href.indexOf("Comment");
 		href = "/lessonbuilder-tool/faces/" + href.substring(ci);

--- a/lessonbuilder/tool/src/webapp/js/comments.js
+++ b/lessonbuilder/tool/src/webapp/js/comments.js
@@ -13,10 +13,10 @@ var ckEditor = false;
 
 $(function() {
 	
-	noEditor = ($(".using-editor").size() == 0);
+	noEditor = ($(".using-editor").size() === 0);
 	if (!noEditor) {
 	    try {
-		if (sakai.editor.editors.ckeditor==undefined)
+		if (sakai.editor.editors.ckeditor===undefined)
 		    fckEditor = true;
 	    } catch (err) {
 		fckEditor = true;
@@ -42,7 +42,7 @@ $(function() {
 	});
 	
 	$.ajaxSetup ({
-		cache: false,
+		cache: false
 	});
 	
 	$(".replaceWithComments").each(function(index) {
@@ -66,7 +66,7 @@ $(function() {
 		resizable: false,
 		buttons: {
 			"Cancel": function() {
-				if(originalDeleteDialogText != null) {
+				if(originalDeleteDialogText !== null) {
 					$("#delete-comment-confirm").text(originalDeleteDialogText);
 				}
 				
@@ -97,7 +97,7 @@ function commentsLoaded() {
 	});
 	
 	$(".pointsBox").keyup(function(event){
-		if(event.keyCode == 13) {
+		if(event.keyCode === 13) {
 			var img = $(this).parent().children("img");
 			
 			$(this).removeClass("unsubmitted");
@@ -115,7 +115,7 @@ function commentsLoaded() {
 
 function loadMore(link) {
 	$.ajaxSetup ({
-		cache: false,
+		cache: false
 	});
 	
 	var pageToRequest = $(link).parent().parent().find(".to-load").attr("href");
@@ -173,7 +173,7 @@ function replyToComment(link, replytext) {
 
 
 function switchEditors(link, show) {
-	if(show==undefined) show = true;
+	if(show===undefined) show = true;
 	
 	var evolved;
 	
@@ -201,13 +201,13 @@ function switchEditors(link, show) {
  		    var frame = $(link).parents(".commentsDiv").find("iframe");
  
  		    // the builtin title is grossly too long, and not internationalized
- 		    if (frame != null) {
+ 		    if (frame !== null) {
  		    	frame.attr("title", msg("simplepage.ckeditor"));
 		    }
  
  		    // seem to need this to make focus show up in VoiceOver. Looks like it's
  		    // not seeing into the iframe, although Safari shows it as selected
- 		    if (frame != null) {
+ 		    if (frame !== null) {
  			frame.focus();
  		    }
  		    CKEDITOR.instances[evolved.children("textarea").attr("name")].focus();
@@ -263,7 +263,7 @@ function switchEditors(link, show) {
 
 function deleteComment(link) {
 	$.ajaxSetup ({
-		cache: false,
+		cache: false
 	});
 	
 	deleteDialogCommentURL = $(link).parent().children(".deleteComment").attr("href");

--- a/lessonbuilder/tool/src/webapp/js/gradingAjax.js
+++ b/lessonbuilder/tool/src/webapp/js/gradingAjax.js
@@ -28,8 +28,8 @@ function initGradingForm(idFieldId, pointsFieldId, jsIdFieldId, typeFieldId, csr
 		var jsId = results.EL[elBinding][1];
 		var points = results.EL[elBinding][2];
 		
-		if(status == "success") {
-			if (gradingReturnHook != null)
+		if(status === "success") {
+			if (gradingReturnHook !== null)
 			    window.location = gradingReturnHook;
 
 			var jsObj = $("#" + jsId);
@@ -43,10 +43,10 @@ function initGradingForm(idFieldId, pointsFieldId, jsIdFieldId, typeFieldId, csr
 		}else {
 			$("#" + jsId).attr("src", getStrippedImgSrc(jsId) + "failed.png");
 		}
-		if (gradingDoneHook != null) {
+		if (gradingDoneHook !== null) {
 		    gradingDoneHook.call();
 		}
-	}
+	};
 
 	// setup the function which initiates the AJAX request
 	var updater = RSF.getAJAXUpdater([idField, pointsField, jsIdField, typeField, csrfField], ajaxUrl, [elBinding], callback);

--- a/lessonbuilder/tool/src/webapp/js/peer-eval.js
+++ b/lessonbuilder/tool/src/webapp/js/peer-eval.js
@@ -6,8 +6,8 @@ $(function() {
 	if ($(".studentContentType").length > 0) {
 		//nextNumber has been negated...
 		addEmptyCategoryRow = function(tableSelector, customId) {
-			var nextNumber = (customId != -1) ? customId : ($(tableSelector + " .newRow").length + 1) * -1;
-			var newRow = (customId == -1) ? "newRow" : "";
+			var nextNumber = (customId !== -1) ? customId : ($(tableSelector + " .newRow").length + 1) * -1;
+			var newRow = (customId === -1) ? "newRow" : "";
 
 			$(tableSelector + " tbody").append('<tr><td><span class="rubricRowIndex ' + newRow + '" style="display:none;">' + nextNumber + '</span>' + blankRubricRow + '</td><td></td><td></td><td></td><td></td><td></td></tr>');
 			$firstInput = $(tableSelector + " tbody tr:last input:first");
@@ -141,9 +141,9 @@ $(function() {
 		getGradeeByUserId = function(userId) {
 			//console.log('getGradeeByUserId(' + userId + ')');
 			for (w in gradees) {
-				if (gradees[w].userid == userId) return gradees[w];
+				if (gradees[w].userid === userId) return gradees[w];
 			}
-		}
+		};
 
 		//Build the JSON Object.
 		$(".peer-eval-gradee-branch").each(function() {
@@ -190,7 +190,7 @@ $(function() {
 			$(".peer-eval-gradee-branch").each(function() {
 				var countPerGradee = 0;
 				$(".peer-eval-grader-id", this).each(function() {
-					if ($(this).text() == target) countPerGradee++;
+					if ($(this).text() === target) countPerGradee++;
 				});
 				if (countPerGradee > (numCategories / 2)) gradees[x].activity++;
 			});
@@ -213,7 +213,7 @@ $(function() {
 
 				var isValidGrade = false;
 				$(".peer-eval-rubric-table:last .peer-eval-row").each(function() {
-					if ($("td:first", this).text().trim() == text) {
+					if ($("td:first", this).text().trim() === text) {
 						isValidGrade = true;
 						var graderString = [];
 						for (z in gradees[x].grades[y].graders) {
@@ -281,7 +281,7 @@ $(function() {
 						$(this).parent().css("background-color", "");
 						var htmlSS = $(this).html();
 						//console.log(userid);
-						if (htmlSS.indexOf(userid) != -1) {
+						if (htmlSS.indexOf(userid) !== -1) {
 							$(this).parent().css("background-color", CELL_SELECTED_BACKGROUND_COLOR);
 						}
 					});
@@ -328,7 +328,7 @@ $(function() {
 				var count = $(".peer-eval-count", this).text();
 
 				$(".peer-eval-row").each(function() {
-					if ($(".peerReviewText", this).text() == text) $("." + grade, this).text(count);
+					if ($(".peerReviewText", this).text() === text) $("." + grade, this).text(count);
 				});
 			});
 		}
@@ -356,7 +356,7 @@ $(function() {
 				var grade = $(".peer-eval-grade", this).text();
 
 				$(".peer-eval-row").each(function() {
-					if ($(".peerReviewText", this).text() == text) $("." + grade, this).css("background-color", "lightblue");
+					if ($(".peerReviewText", this).text() === text) $("." + grade, this).css("background-color", "lightblue");
 				});
 			});
 
@@ -372,7 +372,7 @@ function initialSetupForGrading() {
 		var grade = $(".peer-eval-grade", this).text();
 
 		$(".peer-eval-row").each(function() {
-			if ($(".peerReviewText", this).text() == text) $("." + grade, this).click();
+			if ($(".peerReviewText", this).text() === text) $("." + grade, this).click();
 		});
 	});
 }

--- a/lessonbuilder/tool/src/webapp/js/periodicalupdater.js
+++ b/lessonbuilder/tool/src/webapp/js/periodicalupdater.js
@@ -20,7 +20,7 @@
       try {
         console.log(msg);
       } catch(err) {}
-    }
+    };
 
     // Now back to our regularly scheduled work
     $.PeriodicalUpdater = function(url, options, callback, autoStopCallback){
@@ -46,13 +46,13 @@
         var originalMaxCalls = maxCalls;
 
         var reset_timer = function(interval) {
-          if (timer != null) {
+          if (timer !== null) {
             clearTimeout(timer);
           }
           timerInterval = interval;
           pu_log('resetting timer to '+ timerInterval +'.');
           timer = setTimeout(getdata, timerInterval);
-        }
+        };
 
         // Function to boost the timer 
         var boostPeriod = function() {
@@ -93,17 +93,17 @@
         // TODO It'd be nice to do the options.data check once (a la boostPeriod)
         function getdata() {
           var toSend  = jQuery.extend(true, {}, ajaxSettings); // jQuery screws with what you pass in
-          if(typeof(options.data) == 'function') {
+          if(typeof(options.data) === 'function') {
             toSend.data = options.data();
             if(toSend.data) {
               // Handle transformations (only strings and objects are understood)
-              if(typeof(toSend.data) == "number") {
+              if(typeof(toSend.data) === "number") {
                 toSend.data = toSend.data.toString();
               }
             }
           }
 
-          if(maxCalls == 0) {
+          if(maxCalls === 0) {
             $.ajax(toSend);
           } else if(maxCalls > 0 && calls < maxCalls) {
             $.ajax(toSend);
@@ -123,17 +123,17 @@
 
         ajaxSettings.complete = function(xhr, success) {
           //pu_log("Status of call: " + success + " (In 'complete')");
-          if(maxCalls == -1) return;
-          if(success == "success" || success == "notmodified") {
+          if(maxCalls === -1) return;
+          if(success === "success" || success === "notmodified") {
             var rawData = $.trim(xhr.responseText);
-            if(rawData == 'STOP_AJAX_CALLS') {
+            if(rawData === 'STOP_AJAX_CALLS') {
 							handle.stop();
               return;
             }
-            if(prevData == rawData) {
+            if(prevData === rawData) {
               if(autoStop > 0) {
                 noChange++;
-                if(noChange == autoStop) {
+                if(noChange === autoStop) {
 									handle.stop();
                   if(autoStopCallback) autoStopCallback(noChange);
                   return;
@@ -144,10 +144,10 @@
               noChange        = 0;
               reset_timer(settings.minTimeout);
               prevData        = rawData;
-              if(remoteData == null) remoteData = rawData;
+              if(remoteData === null) remoteData = rawData;
               // jQuery 1.4+ $.ajax() automatically converts "data" into a JS Object for "type:json" requests now
               // For compatibility with 1.4+ and pre1.4 jQuery only try to parse actual strings, skip when remoteData is already an Object
-              if((ajaxSettings.dataType === 'json') && (typeof(remoteData) === 'string') && (success == "success")) {
+              if((ajaxSettings.dataType === 'json') && (typeof(remoteData) === 'string') && (success === "success")) {
                 remoteData = JSON.parse(remoteData);
               }
               if(settings.success) { settings.success(remoteData, success, xhr, handle); }
@@ -155,12 +155,12 @@
             }
           }
           remoteData = null;
-        }
+        };
 
 
         ajaxSettings.error = function (xhr, textStatus) {
           //pu_log("Error message: " + textStatus + " (In 'error')");
-          if(textStatus != "notmodified") {
+          if(textStatus !== "notmodified") {
             prevData = null;
             reset_timer(settings.minTimeout);
           }

--- a/lessonbuilder/tool/src/webapp/js/questionGrading.js
+++ b/lessonbuilder/tool/src/webapp/js/questionGrading.js
@@ -41,7 +41,7 @@ $(function() {
 	
 	// cr on individual box, update that box
 	$(".pointsBox").keyup(function(event){
-		if(event.keyCode == 13)
+		if(event.keyCode === 13)
 		    updateGrade($(this));
         });
 

--- a/lessonbuilder/tool/src/webapp/js/rsf.js
+++ b/lessonbuilder/tool/src/webapp/js/rsf.js
@@ -36,14 +36,14 @@ var RSF = RSF || {};
     }
 
   function isFossil(element, input) {
-    if (element.id && input.id == element.id + "-fossil") return true;
-    return (input.name == element.name + "-fossil");
+    if (element.id && input.id === element.id + "-fossil") return true;
+    return (input.name === element.name + "-fossil");
     }
     
   function normaliseBinding(element) {
     RSF.log("normaliseBinding name " + element.name + " id " + element.id);
     if (!element.name) return element.id;
-    else return element.name == "virtual-el-binding"? "el-binding" : element.name;
+    else return element.name === "virtual-el-binding"? "el-binding" : element.name;
     }
 
   var requestactive = false;
@@ -89,11 +89,11 @@ var RSF = RSF || {};
     
   fixEvent.preventDefault = function() {
     this.returnValue = false;
-    }
+    };
     
   fixEvent.stopPropagation = function() {
     this.cancelBubble = true;
-    }
+    };
   
   function getEventFirer() {
     var listeners = {};
@@ -175,8 +175,8 @@ var RSF = RSF || {};
             clearObject(primaryElements, elementscopy);
             RSF.log("Restoration cleared");
             }
-          }
-        }
+          };
+        };
       }
  // A "ClassLoader"-wide cache of scripts which have been loaded, to avoid
  // duplicate fetches
@@ -204,7 +204,7 @@ var RSF = RSF || {};
       });
       
       return uri;
-   }
+   };
    parseUri.options = {
       strictMode: false,
       key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"],
@@ -216,10 +216,10 @@ var RSF = RSF || {};
          strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
          loose: /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
       }
-   }
+   };
 
     function ignorableNode(node) {
-      return node.tagName.toLowerCase() == 'select';
+      return node.tagName.toLowerCase() === 'select';
       }
 
     function getNextNode(iterator) {
@@ -267,7 +267,7 @@ var RSF = RSF || {};
   RSF.computeDocumentHeight = function (dokkument) {
     var currentNode = {node: dokkument.body, depth: 0};
     var biggestOffset = 0;
-    while (currentNode.node != null && currentNode.depth >= 0 && currentNode.depth < RSF.DOM_BAIL_DEPTH) {
+    while (currentNode.node !== null && currentNode.depth >= 0 && currentNode.depth < RSF.DOM_BAIL_DEPTH) {
       if (currentNode.node.offsetHeight) {
         var tempOffset = RSF.computeCorrectedHeight(currentNode.node);
         if (tempOffset > biggestOffset) {
@@ -298,11 +298,11 @@ var RSF = RSF || {};
    /** method to handle logging, logging is off by default so you may need to turn it on */
   RSF.log = function(message) {
     if (logging) {
-      if (typeof(YAHOO) != "undefined") {
+      if (typeof(YAHOO) !== "undefined") {
         YAHOO.log(message);
-      } else if (typeof(console) != "undefined") {
+      } else if (typeof(console) !== "undefined") {
         console.log(message);
-      } else if (typeof(opera) != "undefined") {
+      } else if (typeof(opera) !== "undefined") {
         opera.postError(message);
         }
       }
@@ -323,7 +323,7 @@ var RSF = RSF || {};
 
    /** method to allow user to enable logging (off by default) */
   RSF.setLogging = function(enabled) {
-    if (typeof enabled == "boolean") {
+    if (typeof enabled === "boolean") {
       logging = enabled;
       } else {
       logging = false;
@@ -336,7 +336,7 @@ var RSF = RSF || {};
     if (typeof jQuery !== "undefined") {
       return jQuery.data(elem, name, value);
       }
-    }
+    };
   
   /** Recursively find any data stored under a given name from a node upwards
    * in its DOM hierarchy **/
@@ -347,7 +347,7 @@ var RSF = RSF || {};
       if (data) return data;
       elem = elem.parentNode;
       }
-    }
+    };
    /**
     * This is a set of three methods to easily accumulate events on elements
     */
@@ -357,14 +357,14 @@ var RSF = RSF || {};
     * RETURN: the return of the final function is sent back, other returns are discarded
     */
   RSF.addEventToElement = function(element, event, newFunction) {
-    if (typeof newFunction == "function") {
+    if (typeof newFunction === "function") {
       var origEvent = element["on" + event];
-      if (typeof origEvent == "function") {
+      if (typeof origEvent === "function") {
         element["on" + event] = function() {
           var result = false;
           try {
             var r = origEvent();
-            if (r != null && typeof r != 'undefined') {
+            if (r !== null && typeof r !== 'undefined') {
               result = r;
               }
             } 
@@ -373,7 +373,7 @@ var RSF = RSF || {};
             }
           try {
             var r = newFunction();
-            if (r != null && typeof r != 'undefined') {
+            if (r !== null && typeof r !== 'undefined') {
               result = r;
               }
             } 
@@ -381,14 +381,14 @@ var RSF = RSF || {};
             alert("function ("+newFunction+") failure occurred: " + e.message);
             }
           return result;
-          }
+          };
         } 
       else {
         element["on" + event] = function() {
           var result = false;
           try {
             var r = newFunction();
-            if (r != null && typeof r != 'undefined') {
+            if (r !== null && typeof r !== 'undefined') {
               result = r;
               }
             } 
@@ -396,7 +396,7 @@ var RSF = RSF || {};
             alert("function ("+newFunction+") failure occurred: " + e.message);
             }
           return result;
-          }
+          };
         }
       }
     };
@@ -455,9 +455,9 @@ var RSF = RSF || {};
         RSF.log("Censored model fire for non-primary element " + element.id);
         return;
         }
-      var actualold = arguments.length == 3? oldvalue : element.value;
+      var actualold = arguments.length === 3? oldvalue : element.value;
       RSF.log("Actual old value " + actualold);
-      if (newvalue != actualold) {
+      if (newvalue !== actualold) {
         if (primary) {
           RSF.log("Set primary element for " + element.id);
           primaryElements[element.id] = true;
@@ -475,7 +475,7 @@ var RSF = RSF || {};
             }
           }
         }
-      }
+      };
     };
     /** target is the element on which the listener is to be attached.
      */
@@ -524,8 +524,8 @@ var RSF = RSF || {};
     options = options || {};
     var is_http_request = url.indexOf("http") === 0;
     var readyCallback = function() {
-      if (http_request.readyState == 4) {
-        if (http_request.status == 200 || !is_http_request) {
+      if (http_request.readyState === 4) {
+        if (http_request.status === 200 || !is_http_request) {
           RSF.log("AJAX request success status: " + http_request.status);
           if (callback && callback.success) {
             callback.success(http_request);
@@ -539,11 +539,11 @@ var RSF = RSF || {};
           RSF.log("AJAX request error status: " + http_request.status);
           }
         }
-      }
+      };
     var http_request = false;
     if (window.XMLHttpRequest) { // Mozilla, Safari,...
       http_request = new XMLHttpRequest();
-      if (method == "POST" && http_request.overrideMimeType) {
+      if (method === "POST" && http_request.overrideMimeType) {
          // set type accordingly to anticipated content type
           //http_request.overrideMimeType('text/xml');
         http_request.overrideMimeType('text/xml');
@@ -565,11 +565,11 @@ var RSF = RSF || {};
        }
        
        http_request.onreadystatechange = readyCallback;
-       if (method == "GET") {
+       if (method === "GET") {
           url = url + "?" + parameters;
        }
        http_request.open(method, url, true);
-       if (method == "GET") {
+       if (method === "GET") {
           http_request.send(null);
        } else { // assume POST
           var contentType = "application/x-www-form-urlencoded";
@@ -596,7 +596,7 @@ var RSF = RSF || {};
     fossilex = /(.)(.*)#\{(.*)\}(.*)/;
     var matches = fossil.match(fossilex);
     var togo = new Object();
-    togo.input = matches[1] != 'o';
+    togo.input = matches[1] !== 'o';
     togo.uitype = matches[2];
     togo.lvalue = matches[3];
     togo.oldvalue = matches[4];
@@ -607,10 +607,10 @@ var RSF = RSF || {};
     bindingex = /(.)#\{(.*)\}(.*)/;
     var matches = binding.match(bindingex);
     var togo = new Object();
-    togo.EL = matches[1] == 'e';
+    togo.EL = matches[1] === 'e';
     togo.lvalue = matches[2];
     togo.rvalue = matches[3];
-    togo.isdeletion = deletion == "deletion";
+    togo.isdeletion = deletion === "deletion";
     return togo;
     };
 
@@ -664,9 +664,9 @@ var RSF = RSF || {};
     var elements = form.elements;
     for (var i = 0; i < elements.length; i++) {
       var element = elements[i];
-      if (submittingel != null && typeof (submittingel) != "undefined") {
-        if (element.nodeName.toLowerCase() == "input" &&
-          element.getAttribute("type") == "submit" && element != submittingel) 
+      if (submittingel !== null && typeof (submittingel) !== "undefined") {
+        if (element.nodeName.toLowerCase() === "input" &&
+          element.getAttribute("type") === "submit" && element !== submittingel) 
           continue;
         }
       queries.push(RSF.encodeElement(element.name, element.value));
@@ -677,7 +677,7 @@ var RSF = RSF || {};
   RSF.hasUVBError = function(UVB, namebase) {
     for (var i = 0; i < UVB.message.length; ++ i) {
       var message = UVB.message[i];
-      if (message.severity == "error" && message.target.indexOf(namebase) == 0) return true;
+      if (message.severity === "error" && message.target.indexOf(namebase) === 0) return true;
       }
       return false;
     };  
@@ -700,11 +700,11 @@ var RSF = RSF || {};
       var id = value.getAttribute("id");
       var text = RSF.getElementText(value);
       RSF.log("Value id " + id + " text " + text);
-      if (id.substring(0, 4) == "tml:") {
+      if (id.substring(0, 4) === "tml:") {
         var target = value.getAttribute("target");
         var severity = value.getAttribute("severity");
         togo.message.push( {target: target, severity: severity, text: text});
-        if (severity == "error") {
+        if (severity === "error") {
           togo.isError = true;
           }
         }
@@ -722,7 +722,7 @@ var RSF = RSF || {};
     var text = "";
     for (var i = 0; i < nodes.length; ++ i) {
       var child = nodes[i];
-      if (child.nodeType == 3) {
+      if (child.nodeType === 3) {
         text = text + child.nodeValue;
         }
       }
@@ -731,7 +731,7 @@ var RSF = RSF || {};
     
   RSF.findForm = function (element) {
     while(element) {
-    if (element.nodeName.toLowerCase() == "form") return element;
+    if (element.nodeName.toLowerCase() === "form") return element;
       element = element.parentNode;
       }
     };  
@@ -743,7 +743,7 @@ var RSF = RSF || {};
     togo.push(EL);
     while (true) {
       var lastdotpos = EL.lastIndexOf(".");
-      if (lastdotpos == -1) break;
+      if (lastdotpos === -1) break;
       EL = EL.substring(0, lastdotpos);
       togo.push(EL);
       }
@@ -777,7 +777,7 @@ var RSF = RSF || {};
           RSF.log("Own Fossil " + fossil.lvalue + " oldvalue " + fossil.oldvalue);
           }
         var matches = name.match(bindingex);
-        if (matches != null) {
+        if (matches !== null) {
           var binding = RSF.parseBinding(input.value, matches[0]);
           RSF.log("Binding lvalue " + binding.lvalue + " " + binding.rvalue);
           binding.element = input;
@@ -871,9 +871,9 @@ var RSF = RSF || {};
     var elid = element.getAttribute('id');
     if (elid) {
     //      nameBase:dynamic-list-input-row::1:remove
-      if (elid.indexOf(nameBase) == 0) {
+      if (elid.indexOf(nameBase) === 0) {
         var colpos = elid.indexOf(':', nameBase.length);
-        var newid = nameBase + localID + (colpos == -1? "" : elid.substring(colpos + 1));
+        var newid = nameBase + localID + (colpos === -1? "" : elid.substring(colpos + 1));
         element.setAttribute('id', newid);
       }
     }
@@ -881,7 +881,7 @@ var RSF = RSF || {};
     if (element.childNodes) {
       for (var i = 0; i < element.childNodes.length; ++ i) {
         var child = element.childNodes[i];
-        if (child.nodeType == 1) {
+        if (child.nodeType === 1) {
           RSF.rewriteIDs(child, newBranchId);
           }
         }
@@ -898,7 +898,7 @@ var RSF = RSF || {};
 
   RSF.getBaseID = function(id) {
     colpos = id.lastIndexOf(':');
-    return id.substring(0, colpos + 1)
+    return id.substring(0, colpos + 1);
     };
 
 
@@ -921,12 +921,12 @@ var RSF = RSF || {};
         RSF.log("Accumulated " + UVB);
         callback(UVB);
         }
-      }
+      };
     return function() {
       var body = RSF.getUVBSubmissionBody(sourceFields, bindings);
       RSF.log("Firing AJAX request " + body);
       RSF.queueAJAXRequest(bindings[0], "POST", AJAXURL, body, AJAXcallback);
-    }
+    };
   };
 
  /** Submit a form via AJAX, the results of the submit are returned in the 
@@ -953,7 +953,7 @@ var RSF = RSF || {};
        RSF.queueAJAXRequest(form, form.method, ajaxUrl, body, AJAXcallback);
        // ensure the non-ajax action does not fire
        return false;
-    }
+    };
   };
 
  /** Submit a link (anchor) via AJAX,
@@ -983,7 +983,7 @@ var RSF = RSF || {};
        RSF.queueAJAXRequest(link, "get", ajaxUrl, body, AJAXcallback);
        // ensure the non-ajax action does not fire
        return false;
-    }
+    };
   };
 
  /** Submit part of a form via AJAX,
@@ -1009,14 +1009,14 @@ var RSF = RSF || {};
        RSF.queueAJAXRequest(sourceFields[0], form.method, ajaxUrl, body, AJAXcallback);
        // ensure the non-ajax action does not fire
        return false;
-    }
+    };
   };
   RSF.parseUri = function(URI) {
     return parseUri(URI);
     };
 
   RSF.hasCSSClass = function(element, cssClass) {
-    return new RegExp('\\b'+ cssClass +'\\b').test(element.className)
+    return new RegExp('\\b'+ cssClass +'\\b').test(element.className);
     };
   RSF.addCSSClass = function(element, cssClass) {
     if (!RSF.hasCSSClass(element, cssClass)) {
@@ -1040,7 +1040,7 @@ var RSF = RSF || {};
 
   RSF.getRequiredFirer = function(element, invalidCSSClass, packageBase) {
     return function() {
-      var isBlank = !element.value || element.value == "";
+      var isBlank = !element.value || element.value === "";
       if (isBlank) {
         RSF.addCSSClass(element, invalidCSSClass);
         }
@@ -1075,7 +1075,7 @@ var RSF = RSF || {};
       var element = form.elements[i];
       var valid = element.getAttribute("rsf:valid");
       if (!valid) continue;
-      if (valid.indexOf("required") != -1) {
+      if (valid.indexOf("required") !== -1) {
         RSF.setRequiredStyle(element, requiredCSSClass);
         
         RSF.addRequiredValidator(element, invalidCSSClass, packageBase);
@@ -1162,7 +1162,7 @@ var RSF = RSF || {};
   * RETURN: the list of updated action elements
   */
   RSF.transformActionDomToAJAX = function (parentNode, targetNode) {
-    if (typeof(targetNode) == "undefined" || targetNode == null) {
+    if (typeof(targetNode) === "undefined" || targetNode === null) {
       targetNode = parentNode;
       }
     RSF.log("transformActionDomToAJAX: node=" + parentNode);
@@ -1183,12 +1183,12 @@ var RSF = RSF || {};
        RSF.getDOMModifyFirer().fireEvent();
        // rerun the dom transformer on the replacement xhtml
        RSF.transformActionDomToAJAX(targetNodeRes, targetNodeRes);
-    }
+    };
 
     var inputs = parentNode.getElementsByTagName("input");
     for (var i = 0; i < inputs.length; ++ i) {
       var input = inputs[i];
-      if (input.getAttribute("type").toLowerCase() != "submit") continue;
+      if (input.getAttribute("type").toLowerCase() !== "submit") continue;
       var updater = RSF.getAJAXFormUpdater(input.form, callback, null, input);
       RSF.addEventToElement(input, "click", updater);
       updatedElements.push(input);
@@ -1212,13 +1212,13 @@ var RSF = RSF || {};
     for (var i = 0; i < links.length; i++) {
       var link = links[i];
 
-      if (!link.href || link.href.length == 0) {
+      if (!link.href || link.href.length === 0) {
         RSF.log("link is empty or appears to be invalid so skipping it: " + link.href);
         continue;            
       }
        
       var parsed = parseUri(link.href);
-      if (parsed.host == "" || parsed.host == document.domain) {
+      if (parsed.host === "" || parsed.host === document.domain) {
         var updater = RSF.getAJAXLinkUpdater(link, callback);
  
         RSF.addEventToElement(link, "click", updater);

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -20,7 +20,7 @@ $(window).load(function () {
 
 function msg(s) {
     var m = document.getElementById(s);
-    if (m == null) {
+    if (m === null) {
        return s;
     }  else 
        return m.innerHTML;;
@@ -40,7 +40,7 @@ function checkgroups(elt, groups) {
     elt.find('input').prop('checked', false);
     for (i = 0; i < groupar.length; i++) {
 	var inp = elt.find('input[value="' + groupar[i] + '"]');
-	if (inp != null)
+	if (inp !== null)
 	    inp.prop('checked', true);
     }
 }
@@ -229,7 +229,7 @@ $(function() {
 			$('#edit-title-error-container').hide();
 			var position =  $(this).position();
 			$("#edit-title-dialog").dialog("option", "position", [position.left, position.top]);
-			if ($("#page-points").val() == '') {
+			if ($("#page-points").val() === '') {
 				$("#page-gradebook").prop("checked", false);
 				$("#page-points").prop("disabled", true);
 			} else { 
@@ -243,7 +243,7 @@ $(function() {
 				    val: $("#currentReleaseDate").text(),
 				    ashidden: { iso8601: 'releaseDateISO8601' }
 			    });
-			if ($("#currentReleaseDate").text() == '')
+			if ($("#currentReleaseDate").text() === '')
 			    $("#page-releasedate").prop('checked', false);
 
 			oldloc = $(".dropdown a");
@@ -324,8 +324,8 @@ $(function() {
 			// mm-display-type is 1 -- embed code, 2 -- av type, 3 -- oembed, 4 -- iframe
 			
 			var url = $('#mm-url').val();
-			if (url != '' && $('#mm-is-mm').val() == 'true') {
-			    if (mm_testing == 0) {
+			if (url !== '' && $('#mm-is-mm').val() === 'true') {
+			    if (mm_testing === 0) {
 				// initial submit for URL. see what we've got
 				if (url.indexOf('<') >= 0) {
 				    // < in the field, it's embed. just show it after filtering
@@ -339,7 +339,7 @@ $(function() {
 				// not embed. Treat as a url
 				// first normalize it
 
-				if (document.URL.indexOf("https:") == 0 && url.trim().match('^http:')) {
+				if (document.URL.indexOf("https:") === 0 && url.trim().match('^http:')) {
 				    // using https: to display and URL starts with http, use warning
 				    alert('Please use URLs starting with https:. URLs starting with http: will not work with some browsers, e.g. Firefox.');
 				}
@@ -400,7 +400,7 @@ $(function() {
 		// button lets us try an iframe
 		$('#mm-test-tryother').click(function() {
 			var url = $('#mm-url').val();
-			if (mm_testing == 1) {
+			if (mm_testing === 1) {
 			    $('#mm-test-oembed-results').hide();
 			    $('#mm-test-iframe-results').show();
 			    $('#mm-test-iframe-iframe').attr('src', url);
@@ -438,7 +438,7 @@ $(function() {
 		
 		$("#page-gradebook").click(function(){
 			if ($("#page-gradebook").prop("checked")) {
-				if ($("#page-points").val() == '')
+				if ($("#page-points").val() === '')
 					$("#page-points").val('1');
 				$("#page-points").prop("disabled", false);
 			} else {
@@ -509,7 +509,7 @@ $(function() {
 			if ($('#grouplist input').size() > 0) {
 			    $("#editgroups-youtube").show();
 			    $("#grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
@@ -574,7 +574,7 @@ $(function() {
 			if ($('#grouplist input').size() > 0) {
 			    $("#editgroups-movie").show();
 			    $("#grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
@@ -585,7 +585,7 @@ $(function() {
 			$("#movie-height").val(row.find(".mm-height").text());
 			$("#movie-width").val(row.find(".mm-width").text());
 			$("#description3").val(row.find(".description").text());
-			if (row.find(".movie-prerequisite").text() == 'true') {
+			if (row.find(".movie-prerequisite").text() === 'true') {
 			    $('#movie-prerequisite').prop('checked', true);
 			} else {
 			    $('#movie-prerequisite').prop('checked', false);
@@ -617,7 +617,7 @@ $(function() {
 			if ($('#grouplist input').size() > 0) {
 			    $("#editgroups-comments").show();
 			    $("#grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
@@ -627,37 +627,37 @@ $(function() {
 			$("#commentsEditId").val(itemId);
 			
 			var anon = row.find(".commentsAnon").text();
-			if(anon == "true") {
+			if(anon === "true") {
 				$("#comments-anonymous").prop("checked", true);
-				$("#comments-anonymous").attr("defaultChecked", true)
+				$("#comments-anonymous").attr("defaultChecked", true);
 			}else {
 				$("#comments-anonymous").prop("checked", false);
 			}
 			
 			var required = row.find(".commentsitem-required").text();
-			if(required == "true") {
+			if(required === "true") {
 				$("#comments-required").prop("checked", true);
 			}else {
 				$("#comments-required").prop("checked", false);
 			}
 			
 			var prerequisite = row.find(".commentsitem-prerequisite").text();
-			if(prerequisite == "true") {
+			if(prerequisite === "true") {
 				$("#comments-prerequisite").prop("checked", true);
 			}else {
 				$("#comments-prerequisite").prop("checked", false);
 			}
 			
 			var grade = row.find(".commentsGrade").text();
-			if(grade == "true") {
+			if(grade === "true") {
 				$("#comments-graded").prop("checked", true);
-				$("#comments-graded").attr("defaultChecked", true)
+				$("#comments-graded").attr("defaultChecked", true);
 			}else {
 				$("#comments-graded").prop("checked", false);
 			}
 			
 			$("#comments-max").val(row.find(".commentsMaxPoints").text());
-			if($("#comments-max").val() == "null") {
+			if($("#comments-max").val() === "null") {
 				$("#comments-max").val("");
 			}
 			
@@ -694,7 +694,7 @@ $(function() {
 			if ($('#grouplist input').size() > 0) {
 			    $("#editgroups-student").show();
 			    $("#grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
@@ -703,13 +703,13 @@ $(function() {
 			var grouplist = $("#student-grouplist");
 			if ($('#student-grouplist input').size() > 0) {
 			    $("#student-grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
 			var groupOwned = row.find(".student-group-owned").text();
-			$("#student-group-owned").prop("checked",(groupOwned == "true"));
-			if (groupOwned == "true")
+			$("#student-group-owned").prop("checked",(groupOwned === "true"));
+			if (groupOwned === "true")
 			    $("#student-group-show").show();
 
 			var itemId = row.find(".student-id").text();
@@ -717,17 +717,17 @@ $(function() {
 			$("#studentEditId").val(itemId);
 			
 			var anon = row.find(".studentAnon").text();
-			if(anon == "true") {
+			if(anon === "true") {
 				$("#student-anonymous").prop("checked", true);
-				$("#student-anonymous").attr("defaultChecked", true)
+				$("#student-anonymous").attr("defaultChecked", true);
 			}else {
 			        $("#student-anonymous").prop("checked", false);
 			}
 			
 			var comments = row.find(".studentComments").text();
-			if(comments == "true") {
+			if(comments === "true") {
 				$("#student-comments").prop("checked", true);
-				$("#student-comments").attr("defaultChecked", true)
+				$("#student-comments").attr("defaultChecked", true);
 			}else {
 				$("#student-comments").prop("checked", false);
 			}
@@ -736,7 +736,7 @@ $(function() {
 			//Because all Student Content boxes use the same dialog, the settings are applied when Edit is clicked. 
 			//The following decides whether to have the box already checked when it is first opened.
 			var peerReview = row.find(".peer-eval").text();
-			if(peerReview == "true") {
+			if(peerReview === "true") {
 				$("#peer-eval-check").prop("checked", true);
 				$("#peer-eval-check").attr("defaultChecked", true);
 			}else {
@@ -767,21 +767,21 @@ $(function() {
 			//console.log(rubric);
 			
 			var forcedAnon = row.find(".forcedAnon").text();
-			if(forcedAnon == "true") {
+			if(forcedAnon === "true") {
 				$("#student-comments-anon").prop("checked", true);
-				$("#student-comments-anon").attr("defaultChecked", true)
+				$("#student-comments-anon").attr("defaultChecked", true);
 			}else {
 				$("#student-comments-anon").prop("checked", false);
 			}
 			
 			var required = row.find(".studentitem-required").text();
-			if(required == "true") {
+			if(required === "true") {
 				$("#student-required").prop("checked", true);
 			}else {
 				$("#student-required").prop("checked", false);
 			}
 			var prerequisite = row.find(".studentitem-prerequisite").text();
-			if(prerequisite == "true") {
+			if(prerequisite === "true") {
 				$("#student-prerequisite").prop("checked", true);
 			}else {
 				$("#student-prerequisite").prop("checked", false);
@@ -834,35 +834,35 @@ $(function() {
 			}
 			var selfEval = row.find(".peer-eval-allow-self").text();
 			
-			if(selfEval == "true") {
+			if(selfEval === "true") {
 				$("#peer-eval-allow-selfgrade").prop("checked", true);
 	 			$("#peer-eval-allow-selfgrade").attr("defaultChecked", true);
 			}else {
 				$("#peer-eval-allow-selfgrade").prop("checked", false);
 			}
 			var grade = row.find(".studentGrade").text();
-			if(grade == "true") {
+			if(grade === "true") {
 				$("#student-graded").prop("checked", true);
-				$("#student-graded").attr("defaultChecked", true)
+				$("#student-graded").attr("defaultChecked", true);
 			}else {
 				$("#student-graded").prop("checked", false);
 			}
 			
 			$("#student-max").val(row.find(".studentMaxPoints").text());
-			if($("#student-max").val() == "null") {
+			if($("#student-max").val() === "null") {
 				$("#student-max").val("");
 			}
 			
 			grade = row.find(".studentGrade2").text();
-			if(grade == "true") {
+			if(grade === "true") {
 				$("#student-comments-graded").prop("checked", true);
-				$("#student-comments-graded").attr("defaultChecked", true)
+				$("#student-comments-graded").attr("defaultChecked", true);
 			}else {
 				$("#student-comments-graded").prop("checked", false);
 			}
 			
 			$("#student-comments-max").val(row.find(".studentMaxPoints2").text());
-			if($("#student-comments-max").val() == "null") {
+			if($("#student-comments-max").val() === "null") {
 				$("#student-comments-max").val("");
 			}
 			
@@ -889,7 +889,7 @@ $(function() {
 				groups = groups.substring(1);
 			    }
 			    var errors = getGroupErrors(groups);
-			    if (errors != "ok") {
+			    if (errors !== "ok") {
 				$("#student-group-errors").text(errors);
 				$("#student-group-errors-container").show();
 				insist = true;
@@ -944,7 +944,7 @@ $(function() {
 			}
 		});
 		
-		$("#student-peer-review-create").hover(function(){$(this).css("cursor", "default")});
+		$("#student-peer-review-create").hover(function(){$(this).css("cursor", "default");});
 		$("#student-peer-review-create").click(function(){
 			if(!$("#peer-eval-check").prop("checked")) {
 				$("#peer-eval-check").prop("checked", true);
@@ -1032,7 +1032,7 @@ $(function() {
 			if ($('#grouplist input').size() > 0) {
 			    $("#question-editgroups").show();
 			    $("#grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
@@ -1059,7 +1059,7 @@ $(function() {
 				var questionAnswers = row.find(".questionAnswer").text().split("\n");
 				for(var index = 0; index < questionAnswers.length - 1; index++) {
 					var answerSlot;
-					if(index == 0) {
+					if(index === 0) {
 						answerSlot = $("#copyableShortanswerDiv").first();
 					}else {
 						answerSlot = addShortanswer();
@@ -1078,7 +1078,7 @@ $(function() {
 					var correct = $(el).find(".questionMultipleChoiceAnswerCorrect").text();
 					
 					var answerSlot;
-					if(index == 0) {
+					if(index === 0) {
 						answerSlot = $("#copyableMultipleChoiceAnswerDiv").first();
 					}else {
 						answerSlot = addMultipleChoiceAnswer();
@@ -1086,7 +1086,7 @@ $(function() {
 					
 					answerSlot.find(".question-multiplechoice-answer-id").val(id);
 					answerSlot.find(".question-multiplechoice-answer").val(text);
-					if(correct == "true") {
+					if(correct === "true") {
 						answerSlot.find(".question-multiplechoice-answer-correct").prop("checked", true);
 					}else {
 						answerSlot.find(".question-multiplechoice-answer-correct").prop("checked", false);
@@ -1094,7 +1094,7 @@ $(function() {
 				});
 				
 				var questionShowPoll = row.find(".questionShowPoll").text();
-				if(questionShowPoll == "true") {
+				if(questionShowPoll === "true") {
 					$("#question-show-poll").prop("checked", true);
 				}else {
 					$("#question-show-poll").prop("checked", false);
@@ -1106,7 +1106,7 @@ $(function() {
 			$("#shortanswerSelect").prop("disabled", true);
 			
 			var questionGraded = row.find(".questionGrade").text();
-			if(questionGraded == "true") {
+			if(questionGraded === "true") {
 				$("#question-graded").prop("checked", true);
 			}else {
 				$("#question-graded").prop("checked", false);
@@ -1115,14 +1115,14 @@ $(function() {
 			checkQuestionGradedForm();
 			
 			var gradebookTitle = row.find(".questionGradebookTitle").text();
-			if(gradebookTitle == "null") {
+			if(gradebookTitle === "null") {
 				$("#question-gradebook-title").val("");
 			}else {
 				$("#question-gradebook-title").val(gradebookTitle);
 			}
 			
 			var maxPoints = row.find(".questionMaxPoints").text();
-			if(maxPoints == "null") {
+			if(maxPoints === "null") {
 				$("#question-max").val("");
 			}else {
 				$("#question-max").val(maxPoints);
@@ -1135,14 +1135,14 @@ $(function() {
 			$("#question-incorrect-text").val(questionIncorrectText);
 			
 			var required = row.find(".questionitem-required").text();
-			if(required == "true") {
+			if(required === "true") {
 				$("#question-required").prop("checked", true);
 			}else {
 				$("#question-required").prop("checked", false);
 			}
 			
 			var prerequisite = row.find(".questionitem-prerequisite").text();
-			if(prerequisite == "true") {
+			if(prerequisite === "true") {
 				$("#question-prerequisite").prop("checked", true);
 			}else {
 				$("#question-prerequisite").prop("checked", false);
@@ -1254,7 +1254,7 @@ $(function() {
 					      
 			var prereq = row.find(".prerequisite-info").text();
 
-			if(prereq == "true") {
+			if(prereq === "true") {
 				$("#item-prerequisites").prop("checked", true);
 				$("#item-prerequisites").attr("defaultChecked", true);
 			}else {
@@ -1262,8 +1262,8 @@ $(function() {
 			}
 			
 	                var samewindow = row.find(".item-samewindow").text();
-	                if (samewindow != '') {
-	                    if (samewindow == "true")
+	                if (samewindow !== '') {
+	                    if (samewindow === "true")
 	                        $("#item-newwindow").prop("checked", false);
 	                    else
 	                        $("#item-newwindow").prop("checked", true);
@@ -1277,10 +1277,10 @@ $(function() {
 			var editurl = row.find(".edit-url").text();
 			var editsettingsurl = row.find(".edit-settings-url").text();
 			
-			if(type == 'page') {
+			if(type === 'page') {
 	                    $("#pagestuff").show();
 			    var pagenext = row.find(".page-next").text();
-			    if(pagenext == "true") {
+			    if(pagenext === "true") {
 				$("#item-next").prop("checked", true);
 				$("#item-next").attr("defaultChecked", true);
 			    }else {
@@ -1288,7 +1288,7 @@ $(function() {
 			    }
 
 			    var pagebutton = row.find(".page-button").text();
-			    if(pagebutton == "true") {
+			    if(pagebutton === "true") {
 				$("#item-button").prop("checked", true);
 				$("#item-button").attr("defaultChecked", true);
 			    }else {
@@ -1304,12 +1304,12 @@ $(function() {
 			    if ($('#grouplist input').size() > 0) {
 				$("#editgroups").show();
 				$("#grouplist").show();
-				if (groups != null) {
+				if (groups !== null) {
 				    checkgroups(grouplist, groups);
 				}
 			    }
 
-			} else if(type != '') {
+			} else if(type !== '') {
 				// Must be an assignment, assessment, forum
 
 				var groups = row.find(".item-groups").text();
@@ -1317,12 +1317,12 @@ $(function() {
 				if ($('#grouplist input').size() > 0) {
 				    $("#editgroups").show();
 				    $("#grouplist").show();
-				    if (groups != null) {
+				    if (groups !== null) {
 					checkgroups(grouplist, groups);
 				    }
 				}
 
-				if(type == 6) {
+				if(type === 6) {
 					$("#change-quiz-p").show();
 					$("#change-quiz").attr("href", 
 					      $("#change-quiz").attr("href").replace("itemId=-1", "itemId=" + itemid));
@@ -1336,7 +1336,7 @@ $(function() {
 						$("#edit-item-settings").attr("href").replace(/(source=).*?(&)/, '$1' + escape(editsettingsurl) + '$2'));
 					$("#edit-item-settings-text").text(msg("simplepage.edit_quiz_settings"));
 
-				}else if (type == 8){
+				}else if (type === 8){
 					$("#change-forum-p").show();
 					$("#change-forum").attr("href", 
 					      $("#change-forum").attr("href").replace("itemId=-1", "itemId=" + itemid));
@@ -1346,7 +1346,7 @@ $(function() {
 						$("#edit-item-object").attr("href").replace(/(source=).*?(&)/, '$1' + escape(editurl) + '$2'));
 					$("#edit-item-text").text(msg("simplepage.edit_topic"));
 
-				}else if (type == 'b'){
+				}else if (type === 'b'){
 					var height = row.find(".item-height").text();
 					$("#edit-height-value").val(height);
 					$("#edit-height").show();				
@@ -1354,7 +1354,7 @@ $(function() {
 					$("#change-blti").attr("href", 
 					      $("#change-blti").attr("href").replace("itemId=-1", "itemId=" + itemid));
 					$("#require-label").text(msg("simplepage.require_submit_blti"));
-					if (format == '')
+					if (format === '')
 					    format = 'page';
 					$(".format").prop("checked", false);
 					$("#format-" + format).prop("checked", true);
@@ -1374,14 +1374,14 @@ $(function() {
 
 				}
 				
-				if(type == 3 || type == 6) {
+				if(type === 3 || type === 6) {
 					// Points or Assessment
 					
 					$("#require-label2").show();
 					$("#require-label2").html(msg("simplepage.require_receive") + " ");
-					if(type == 3) {
+					if(type === 3) {
 					    $("#assignment-points-label").text(" " + msg("simplepage.require_points_assignment"));
-					}else if(type == 6) {
+					}else if(type === 6) {
 					    $("#assignment-points-label").text(" " + msg("simplepage.require_points_assessment"));
 					}
 					
@@ -1390,7 +1390,7 @@ $(function() {
 					$("#assignment-points").show();
 					$("#assignment-points-label").show();
 					
-					if(req == "false") {
+					if(req === "false") {
 						$("#item-required2").prop("checked", false);
 					}else {
 						// Need both of these statements, because of a stupid
@@ -1400,13 +1400,13 @@ $(function() {
 						
 						$("#assignment-points").val(req);
 					}
-				}else if(type == 4) {
+				}else if(type === 4) {
 					// Pass / Fail
 					$("#require-label2").show();
 					$("#require-label2").html(msg("simplepage.require_pass_assignment"));
 					$("#item-required2").show();
 					
-					if(req == "true") {
+					if(req === "true") {
 						// Need both of these statements, because of a stupid
 						// little IE bug.
 						$("#item-required2").prop("checked", true);
@@ -1414,7 +1414,7 @@ $(function() {
 					}else {
 						$("#item-required2").prop("checked", false);
 					}
-				}else if(type == 2) {
+				}else if(type === 2) {
 					// Letter Grade
 					
 					$("#require-label2").show();
@@ -1422,7 +1422,7 @@ $(function() {
 					$("#item-required2").show();
 					$("#assignment-dropdown-selection").show();
 					
-					if(req == "false") {
+					if(req === "false") {
 						$("#item-required2").prop("checked", false);
 					}else {
 						// Need both of these statements, because of a stupid
@@ -1432,16 +1432,16 @@ $(function() {
 						
 						$("#assignment-dropdown-selection").val(req);
 					}
-				}else if(type == 1) {
+				}else if(type === 1) {
 					// Ungraded
 					// Nothing more that we need to do
-				}else if(type == 5) {
+				}else if(type === 5) {
 					// Checkmark
 					$("#require-label2").show();
 					$("#require-label2").text(msg("simplepage.require_checkmark"));
 					$("#item-required2").show();
 					
-					if(req == "true") {
+					if(req === "true") {
 						// Need both of these statements, because of a stupid
 						// little IE bug.
 						$("#item-required2").prop("checked", true);
@@ -1457,13 +1457,13 @@ $(function() {
 			        $("#change-resource").attr("href").replace("pageItemId=-1", "pageItemId=" + itemid));
 			    var groups = row.find(".item-groups").text();
 			    var grouplist = $("#grouplist");
-			    if (groups == "--inherited--")
+			    if (groups === "--inherited--")
 				$("#resource-group-inherited").show();
 			    else if ($('#grouplist input').size() > 0) {
 				$("#editgroups").show();
 				$("#grouplist").show();
 				$("#select-resource-group").show();
-				if (groups != null) {
+				if (groups !== null) {
 				    checkgroups(grouplist, groups);
 				}
 			    }
@@ -1472,7 +1472,7 @@ $(function() {
 
 			}
 
-			if(row.find(".status-image").attr("src") == undefined) {
+			if(row.find(".status-image").attr("src") === undefined) {
 			    $("#item-required").prop("checked", false);
 			} else if (row.find(".status-image").attr("src").indexOf("not-required.png") > -1) {
 				$("#item-required").prop("checked", false);
@@ -1643,7 +1643,7 @@ $(function() {
 			var row = $(this).parent().parent().parent();
 
 			var itemPath = row.find(".item-path");
-			if (itemPath != null && itemPath.size() > 0) {
+			if (itemPath !== null && itemPath.size() > 0) {
 			    row.find(".path-url").attr("href", row.find(".multimedia").attr("src"));
 			    $("#mm-path").html(itemPath.html());
 			    $(".mm-path").show();
@@ -1656,7 +1656,7 @@ $(function() {
 			if ($('#grouplist input').size() > 0) {
 			    $("#editgroups-mm").show();
 			    $("#grouplist").show();
-			    if (groups != null) {
+			    if (groups !== null) {
 				checkgroups(grouplist, groups);
 			    }
 			}
@@ -1669,7 +1669,7 @@ $(function() {
 
 			$("#height").val(row.find(".mm-height").text());
 			$("#width").val(row.find(".mm-width").text());
-			if (row.find(".mm-embedtype").text() == '1') {
+			if (row.find(".mm-embedtype").text() === '1') {
 			    // embed code, can't edit size
 			    $('#width-p').hide();
 			    $('#height-p').hide();
@@ -1680,7 +1680,7 @@ $(function() {
 			$("#description2").val(row.find(".description").text());
 			$("#mimetype").val(row.find(".mm-type").text());
 			var tagname = row.find(".multimedia").get(0).nodeName.toLowerCase();
-			if (tagname == "img") {
+			if (tagname === "img") {
 			    $("#alt").val(row.find(".multimedia").attr("alt"));
 			    $("#alt").parent().show();
 			    // $("#tagnameused").html(msg("simplepage.tag_img"));
@@ -1690,7 +1690,7 @@ $(function() {
 			    //			    $("#tagnameused").html(msg("simplepage.tag_iframe"));
 			    //			    $("#iframe-note").show();
 			    //}
-			} else if (tagname == "iframe") {
+			} else if (tagname === "iframe") {
 			    $("#alt").parent().hide();
 			    // $("#tagnameused").html(msg("simplepage.tag_iframe"));
 			    $("#iframe-note").show();
@@ -1780,7 +1780,7 @@ $(function() {
 		$('#delete-comments-item').click(function(event) {
 			// edit row is set by edit-comments. We're current in the dialog. need
 			// to look in the actual page row.
-			if (editrow.find('.commentDiv').size() == 0)
+			if (editrow.find('.commentDiv').size() === 0)
 			    return true;
 			delbutton = $('#delete-comments-item');
 			return delete_confirm(event, msg("simplepage.deletecommentsubmissionexist"));
@@ -1789,7 +1789,7 @@ $(function() {
 		$('#delete-student-item').click(function(event) {
 			// edit row is set by edit-comments. We're current in the dialog. need
 			// to look in the actual page row.
-			if (editrow.find('.studentLink').size() == 0)
+			if (editrow.find('.studentLink').size() === 0)
 			    return true;
 			delbutton = $('#delete-student-item');
 			return delete_confirm(event, msg("simplepage.deletestudentsubmissionexist"));
@@ -1817,7 +1817,7 @@ $(function() {
 				$('#question-dialog').dialog('isOpen')) {
 		    unhideMultimedia();
                     $('.edit-col').removeClass('edit-colHidden');
-                    $('li').removeClass('editInProgress')
+                    $('li').removeClass('editInProgress');
 				}
 		});
 		 
@@ -1834,7 +1834,7 @@ $(function() {
 		});
 		
 		$("#studentPointsBox").keyup(function(event){
-			if(event.keyCode == 13) {
+			if(event.keyCode === 13) {
 			    submitgrading($(this));
 			    return false;
 			}
@@ -1890,7 +1890,7 @@ $(function() {
 	});
 	
 	// don't do this twice. if portal is loaded portal will do it
-        if(typeof portal == 'undefined')
+        if(typeof portal === 'undefined')
 	$('a.tool-directurl').cluetip({
 		local: true,
 		    arrows: true,
@@ -1937,11 +1937,11 @@ $(function() {
 
 	function fixitemshows(){
 		var val = $(".format:checked").val();
-		if (val == "window")
+		if (val === "window")
 		    $("#edit-height").hide();
 		else
 		    $("#edit-height").show();
-		if (val == "inline") {
+		if (val === "inline") {
 		    $("#prereqstuff").hide();
 		} else {
 		    $("#prereqstuff").show();
@@ -1950,7 +1950,7 @@ $(function() {
 
 	$('.textbox a[class!=itemcopylink]').each(function(index) {
 		try {
-		    if ($(this).attr('href').match("^http://lessonbuilder.sakaiproject.org/") != null) {
+		    if ($(this).attr('href').match("^http://lessonbuilder.sakaiproject.org/") !== null) {
 			var item = $(this).attr('href').substring(38).replace('/','');
 			var a = $('a[lessonbuilderitem=' + item + ']').first();
 			$(this).replaceWith(a);
@@ -2124,7 +2124,7 @@ function closePeerReviewDialog() {
 }
 
 function checkEditTitleForm() {
-	if($('#pageTitle').val() == '') {
+	if($('#pageTitle').val() === '') {
 		$('#edit-title-error').text(msg("simplepage.title_notblank"));
 		$('#edit-title-error-container').show();
 		return false;
@@ -2143,12 +2143,12 @@ function checkEditTitleForm() {
 
 // these tests assume \d finds all digits. This may not be true for non-Western charsets
 function checkNewPageForm() {
-    if($('#newPage').val() == '') {
+    if($('#newPage').val() === '') {
         $('#new-page-error').text(msg("simplepage.title_notblank"));
         $('#new-page-error-container').show();
         return false;
     }
-    if($('#new-page-number').val() != '') {
+    if($('#new-page-number').val() !== '') {
         if(! $('#new-page-number').val().match('^\\d*$')) {
             $('#new-page-error').text(msg("simplepage.number_pages_not_number"));
             $('#new-page-error-container').show();
@@ -2197,11 +2197,11 @@ function checkMovieForm(w, h, y) {
 		eitem = $(pre + '-error');
 		econtainer = $(pre + '-error-container');
 
-		if (w.trim() == "") {			// empty input is ok
+		if (w.trim() === "") {			// empty input is ok
 			wvalid = true;
 		} 
 
-		if (h.trim() == "") {
+		if (h.trim() === "") {
 			hvalid = true;
 		}
 
@@ -2232,14 +2232,14 @@ function checkMovieForm(w, h, y) {
 		wmatch = checkWidthHeight(w);	// if it's not a percentage, check to make sure it's of the form ### or ###px
 		hmatch = checkWidthHeight(h);
 
-		if (wmatch == null && !wvalid) {
+		if (wmatch === null && !wvalid) {
 			// paint error message
 			eitem.text(msg("simplepage.width-height"));
 			econtainer.show();
 			return false;
 		}
 
-		if (hmatch == null && !hvalid) {
+		if (hmatch === null && !hvalid) {
 			// paint error message
 			eitem.text(msg("simplepage.width-height"));
 			econtainer.show();
@@ -2264,11 +2264,11 @@ function checkCommentsForm() {
 }
 
 function checkEditItemForm() {
-	if($('#name').val() == '') {
+	if($('#name').val() === '') {
 		$('#edit-item-error').text(msg("simplepage.item_notblank"));
 		$('#edit-item-error-container').show();
 		return false;
-        } else if ((requirementType == 3 || requirementType == 6) && 
+        } else if ((requirementType === 3 || requirementType === 6) && 
 		   $("#item-required2").prop("checked") && !isFinite(parseFloat($("#assignment-points").val()))) {
 		$('#edit-item-error').text(msg("simplepage.integer-expected"));
 		$('#edit-item-error-container').show();
@@ -2280,7 +2280,7 @@ function checkEditItemForm() {
 }
 
 function checkSubpageForm() {
-	if($('#subpage-title').val() == '') {
+	if($('#subpage-title').val() === '') {
 		$('#subpage-error').text(msg("simplepage.page_notblank"));
 		$('#subpage-error-container').show();
 		return false;
@@ -2325,7 +2325,7 @@ function setUpRequirements() {
  */
 $(function() {
 	$(".edit-multimedia-input").keypress(function (e) { 
-	    if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) {  
+	    if ((e.which && e.which === 13) || (e.keyCode && e.keyCode === 13)) {  
 	        $('#edit-multimedia-item').click();  
 	        return false;  
 	    } else {  
@@ -2334,7 +2334,7 @@ $(function() {
 	});  
 	
 	$(".edit-form-input").keypress(function (e) {  
-		if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) {  
+		if ((e.which && e.which === 13) || (e.keyCode && e.keyCode === 13)) {  
 	        $('#edit-item').click();  
 	        return false;  
 	    } else {  
@@ -2343,7 +2343,7 @@ $(function() {
 	});
 	
 	$(".edit-youtube-input").keypress(function (e) {  
-		if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) {  
+		if ((e.which && e.which === 13) || (e.keyCode && e.keyCode === 13)) {  
 	        $('#update-youtube').click();  
 	        return false;  
 	    } else {  
@@ -2352,7 +2352,7 @@ $(function() {
 	});
 	
 	$(".edit-movie-input").keypress(function (e) {  
-		if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) {  
+		if ((e.which && e.which === 13) || (e.keyCode && e.keyCode === 13)) {  
 	        $('#update-movie').click();  
 	        return false;  
 	    } else {  
@@ -2616,21 +2616,21 @@ function prepareQuestionDialog() {
 	    $('#question-error').text(msg("simplepage.integer-expected"));
 	    $('#question-error-container').show();
 	    return false;
-	} else if($("#question-graded").prop("checked") && $("#question-gradebook-title").val() == '') {
+	} else if($("#question-graded").prop("checked") && $("#question-gradebook-title").val() === '') {
 	    $('#question-error').text(msg("simplepage.gbname-expected"));
 	    $('#question-error-container').show();
 	    return false;
-	} else if ($("#question-text-input").val() == '') {
+	} else if ($("#question-text-input").val() === '') {
 	    $('#question-error').text(msg("simplepage.missing-question-text"));
 	    $('#question-error-container').show();
 	    return false;
 	} else if ($("#multipleChoiceSelect").prop("checked") && 
-		   $(".question-multiplechoice-answer").filter(function(index){return $(this).val() != '';}).length < 2) {
+		   $(".question-multiplechoice-answer").filter(function(index){return $(this).val() !== '';}).length < 2) {
 	    $('#question-error').text(msg("simplepage.question-need-2"));
 	    $('#question-error-container').show();
 	    return false;
 	} else if ($("#shortanswerSelect").prop("checked") && $("#question-graded").prop("checked") &&
-		   $(".question-shortanswer-answer").filter(function(index){return $(this).val()!="";}).length < 1) {
+		   $(".question-shortanswer-answer").filter(function(index){return $(this).val()!=="";}).length < 1) {
 	    $('#question-error').text(msg("simplepage.question-need-1"));
 	    $('#question-error-container').show();
 	    return false;
@@ -2720,7 +2720,7 @@ function mm_test_reset() {
 resizeFrame = function (updown) {
       var frame = parent.document.getElementById( window.name );
       if( frame ) {
-        if(updown=='shrink')
+        if(updown==='shrink')
         {
         var clientH = document.body.clientHeight + 30;
       }

--- a/lessonbuilder/tool/src/webapp/js/simple-page.js
+++ b/lessonbuilder/tool/src/webapp/js/simple-page.js
@@ -10,7 +10,7 @@ function spiffyUp() {
  * insted of opening in a popup like things cleaned with FormattedText want to do
  */
 function portalClick(link) {
-  if ($(link).attr('target') == '_blank') {
+  if ($(link).attr('target') === '_blank') {
     $(link).removeAttr('target');
   }
 }


### PR DESCRIPTION
The file Simplepagetool.css uses an invalid character ('#') to comment out lines, which is invalid syntax:

http://webdesign.about.com/cs/css/ht/htcommentcss.htm

Several of the JavaScript files (excluding jQuery stuff) use improper equation operators ( ==/!= vs ===/!==). These files are also missing several semicolons, which are syntax errors. An explanation of the differences between the operators, and why the identity operators should be used instead of the equality operators can be found on the following StackOverflow:

https://stackoverflow.com/questions/359494/does-it-matter-which-equals-operator-vs-i-use-in-javascript-comparisons