### PR TITLE
KNL-1055 - 101st proposal of same uploads fails with Bug Report screen

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -3517,7 +3517,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					name = basename + "-" + attempts + extension;
 					id = collectionId + name;
 
-					if (attempts > maximum_tries)
+					if (attempts >= maximum_tries)
 					{
 						throw new IdUniquenessException(id);
 					}


### PR DESCRIPTION
Contributed patch from KNL-1055, tested this out by making the recommend change to ResourcesAction. No longer a bug report that locks up resources, just makes it so you can't have more than 100 of the same file.
```
-       public static final int MAXIMUM_ATTEMPTS_FOR_UNIQUENESS = 100;
+       public static final int MAXIMUM_ATTEMPTS_FOR_UNIQUENESS = 3;
```