### PR TITLE
SAK-28989 Roster2: DA users can't view groups because of permission check

### DIFF
--- a/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -898,7 +898,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		List<RosterGroup> siteGroups = new ArrayList<RosterGroup>();
 
 		boolean viewAll = isAllowed(currentUserId,
-				RosterFunctions.ROSTER_FUNCTION_VIEWALL, site);
+				RosterFunctions.ROSTER_FUNCTION_VIEWALL, site.getReference());
 
 		Collection<Group> groupsCollection = site.getGroups();
 
@@ -984,15 +984,6 @@ public class SakaiProxyImpl implements SakaiProxy {
 			enrollmentSetIdsProcessed.add(enrollmentSet.getEid());
 		}
 		return siteEnrollmentSets;
-	}
-	
-	private boolean isAllowed(String userId, String permision, AuthzGroup authzGroup) {
-		
-		if (securityService.isSuperUser(userId)) {
-			return true;
-		}
-		
-		return authzGroup.isAllowed(userId, permision);
 	}
 	
 	/**


### PR DESCRIPTION
SAK-28989 Roster2: DA users can't view groups because of permission check