### PR TITLE
SAM-2468 remove all use of static loggers in samigo-services 

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/spring/SpringBeanLocator.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/spring/SpringBeanLocator.java
@@ -26,7 +26,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 public class SpringBeanLocator
 {
 
-  //private static Log log = LogFactory.getLog(SpringBeanLocator.class);
   private static WebApplicationContext waCtx = null;
   private static ConfigurableApplicationContext caCtx = null;
   private static boolean inWebContext = false;
@@ -70,12 +69,10 @@ public class SpringBeanLocator
   {
     if (inWebContext)
     {
-      //log.info("** context in Locator " + waCtx);
       return waCtx.getBean(name);
     }
     else
     {
-      //log.info("** context in Locator " + caCtx);
       return caCtx.getBean(name);
     }
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/FileNamer.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/FileNamer.java
@@ -56,8 +56,6 @@ import org.sakaiproject.tool.assessment.util.StringParseUtils;
  */
 public class FileNamer
 {
-  private static Log log = LogFactory.getLog(RecordingData.class);
-
   // internals
   private static final int maxAgentName = 20;
   private static final int maxAgentId = 10;
@@ -118,6 +116,8 @@ public class FileNamer
    */
   public static void unitTest()
   {
+    Log log = LogFactory.getLog(RecordingData.class);
+
     String s;
     s = make("Ed Smiley", "esmiley", "Intro to Wombats 101");
     log.debug("esmiley file: " + s);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/RecordingData.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/RecordingData.java
@@ -77,8 +77,6 @@ public class RecordingData
 	 */
 	private static final long serialVersionUID = 4398684269227144959L;
 
-private static Log log = LogFactory.getLog(RecordingData.class);
-
   //properties
   private String agentName;
   private String agentId;
@@ -390,6 +388,7 @@ private static Log log = LogFactory.getLog(RecordingData.class);
  */
 public Document getXMLDataModel()
 {
+  Log log = LogFactory.getLog(RecordingData.class);
   Document document = null;
   DocumentBuilderFactory builderFactory =
     DocumentBuilderFactory.newInstance();
@@ -463,6 +462,8 @@ public Document getXMLDataModel()
    */
   public static void unitTest()
   {
+    Log log = LogFactory.getLog(RecordingData.class);
+
     RecordingData rd =
       new RecordingData(
         "Ed Smiley", "esmiley", "Intro to Wombats 101", "10", "30");

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SortableDate.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SortableDate.java
@@ -56,7 +56,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class SortableDate
 {
-  private static Log log = LogFactory.getLog(SortableDate.class);
+  private Log log = LogFactory.getLog(SortableDate.class);
 
   /**
    * standard date format string used in AAM
@@ -95,17 +95,5 @@ public class SortableDate
     }
 
     return "unknown date";
-  }
-
-  /**
-   * Unit test only
-   *
-   * @param args not used
-   */
-  public static void main(String[] args)
-  {
-    Date d = new Date();
-    SortableDate sd = new SortableDate(d);
-    log.debug("debug: " + sd);
   }
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentBaseFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentBaseFacade.java
@@ -45,7 +45,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
 
 public class AssessmentBaseFacade
     implements java.io.Serializable, AssessmentBaseIfc{
-  private static Log log = LogFactory.getLog(AssessmentBaseFacade.class);
+  private Log log = LogFactory.getLog(AssessmentBaseFacade.class);
 
   private AssessmentImpl assessmentImpl = new AssessmentImpl(); //<-- place holder
   protected org.osid.assessment.Assessment assessment =

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentFacadeQueries.java
@@ -99,7 +99,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class AssessmentFacadeQueries extends HibernateDaoSupport implements
 		AssessmentFacadeQueriesAPI {
-	private static Log log = LogFactory.getLog(AssessmentFacadeQueries.class);
+	private Log log = LogFactory.getLog(AssessmentFacadeQueries.class);
 
 	// private ResourceBundle rb =
 	// ResourceBundle.getBundle("org.sakaiproject.tool.assessment.bundle.Messages");

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -100,7 +100,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.sakaiproject.event.cover.EventTrackingService;
 
 public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implements AssessmentGradingFacadeQueriesAPI{
-  private static Log log = LogFactory.getLog(AssessmentGradingFacadeQueries.class);
+  private Log log = LogFactory.getLog(AssessmentGradingFacadeQueries.class);
 
   /**
    * Default empty Constructor

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/EventLogFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/EventLogFacade.java
@@ -9,7 +9,7 @@ public class EventLogFacade
 implements java.io.Serializable
 {
 	private static final long serialVersionUID = 1L;
-	private static Log log = LogFactory.getLog(EventLogFacade.class);
+	private Log log = LogFactory.getLog(EventLogFacade.class);
 
 	private EventLogData data;
 	

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/EventLogFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/EventLogFacadeQueries.java
@@ -24,7 +24,7 @@ import org.hibernate.Session;
 public class EventLogFacadeQueries extends HibernateDaoSupport
 implements EventLogFacadeQueriesAPI {
 
-	private static Log log = LogFactory
+	private Log log = LogFactory
 	.getLog(EventLogFacadeQueries.class);
 
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/FavoriteColChoicesFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/FavoriteColChoicesFacadeQueries.java
@@ -17,7 +17,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class FavoriteColChoicesFacadeQueries extends HibernateDaoSupport 
 					implements FavoriteColChoicesFacadeQueriesAPI {
-	private static Log log = LogFactory.getLog(FavoriteColChoicesFacadeQueries.class);
+	private Log log = LogFactory.getLog(FavoriteColChoicesFacadeQueries.class);
 	 public FavoriteColChoicesFacadeQueries () {
 	  }
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/GradebookFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/GradebookFacade.java
@@ -42,7 +42,7 @@ public class GradebookFacade implements Serializable
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
-private static Log log = LogFactory.getLog(GradebookFacade.class);
+private Log log = LogFactory.getLog(GradebookFacade.class);
   private static final GradebookHelper helper =
       IntegrationContextFactory.getInstance().getGradebookHelper();
   private static final boolean integrated =

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/ItemFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/ItemFacade.java
@@ -56,7 +56,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
  * agreement.
  */
 public class ItemFacade implements Serializable, ItemDataIfc, Comparable<ItemDataIfc> {
-  private static Log log = LogFactory.getLog(ItemFacade.class);
+  private Log log = LogFactory.getLog(ItemFacade.class);
 
   private static final long serialVersionUID = 7526471155622776147L;
   protected org.osid.assessment.Item item;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/ItemFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/ItemFacadeQueries.java
@@ -52,7 +52,7 @@ import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class ItemFacadeQueries extends HibernateDaoSupport implements ItemFacadeQueriesAPI {
-  private static Log log = LogFactory.getLog(ItemFacadeQueries.class);
+  private Log log = LogFactory.getLog(ItemFacadeQueries.class);
 
   public ItemFacadeQueries() {
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
@@ -49,7 +49,7 @@ public class PublishedAssessmentFacade
     implements java.io.Serializable, PublishedAssessmentIfc, Cloneable
 {
   private static final long serialVersionUID = 7526471155622776147L;
-  private static Log log = LogFactory.getLog(PublishedAssessmentFacade.class);
+  private Log log = LogFactory.getLog(PublishedAssessmentFacade.class);
   public static final Integer ACTIVE_STATUS =  Integer.valueOf(1);
   public static final Integer INACTIVE_STATUS = Integer.valueOf(0);
   public static final Integer ANY_STATUS = Integer.valueOf(2);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -119,7 +119,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport
 		implements PublishedAssessmentFacadeQueriesAPI {
 
-	private static Log log = LogFactory
+	private Log log = LogFactory
 			.getLog(PublishedAssessmentFacadeQueries.class);
 
 	public static final String STARTDATE = "assessmentAccessControl.startDate";

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedItemFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedItemFacadeQueries.java
@@ -15,7 +15,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class PublishedItemFacadeQueries extends HibernateDaoSupport implements
 		PublishedItemFacadeQueriesAPI {
-	private static Log log = LogFactory
+	private Log log = LogFactory
 			.getLog(PublishedItemFacadeQueries.class);
 
 	public IdImpl getItemId(String id) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedSectionFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedSectionFacade.java
@@ -40,7 +40,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
 public class PublishedSectionFacade extends SectionFacade implements Serializable, Comparable {
 
 	private static final long serialVersionUID = 5788637014806801101L;
-	private static Log log = LogFactory.getLog(PublishedSectionFacade.class);
+	private Log log = LogFactory.getLog(PublishedSectionFacade.class);
 	
   /**
    * This is a very important constructor. Please make sure that you have

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedSectionFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedSectionFacadeQueries.java
@@ -7,7 +7,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class PublishedSectionFacadeQueries extends HibernateDaoSupport
 		implements PublishedSectionFacadeQueriesAPI {
-	private static Log log = LogFactory.getLog(PublishedSectionFacadeQueries.class);
+	private Log log = LogFactory.getLog(PublishedSectionFacadeQueries.class);
 
 	  public IdImpl getId(String id) {
 	    return new IdImpl(id);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacade.java
@@ -48,7 +48,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
 public class QuestionPoolFacade
     implements java.io.Serializable, QuestionPoolDataIfc, Cloneable
 {
-  private static Log log = LogFactory.getLog(QuestionPoolFacade.class);
+  private Log log = LogFactory.getLog(QuestionPoolFacade.class);
   private static final long serialVersionUID = 7526471155622776147L;
 
   public static final Long ACCESS_DENIED =  Long.valueOf(30);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
@@ -64,7 +64,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class QuestionPoolFacadeQueries
     extends HibernateDaoSupport implements QuestionPoolFacadeQueriesAPI {
-  private static Log log = LogFactory.getLog(QuestionPoolFacadeQueries.class);
+  private Log log = LogFactory.getLog(QuestionPoolFacadeQueries.class);
   
   // SAM-2049
   private static final String VERSION_START = " - ";

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/SectionFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/SectionFacade.java
@@ -49,7 +49,7 @@ import org.sakaiproject.tool.assessment.osid.assessment.impl.SectionImpl;
 import org.sakaiproject.tool.assessment.services.PersistenceService;
 
 public class SectionFacade implements Serializable, SectionDataIfc, Comparable {
-  private static Log log = LogFactory.getLog(SectionFacade.class);
+  private Log log = LogFactory.getLog(SectionFacade.class);
 
   private static final long serialVersionUID = 7526471155622776147L;
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/SectionFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/SectionFacadeQueries.java
@@ -36,7 +36,7 @@ import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class SectionFacadeQueries  extends HibernateDaoSupport implements SectionFacadeQueriesAPI {
-  private static Log log = LogFactory.getLog(SectionFacadeQueries.class);
+  private Log log = LogFactory.getLog(SectionFacadeQueries.class);
 
   public SectionFacadeQueries () {
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/TypeFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/TypeFacadeQueries.java
@@ -41,7 +41,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class TypeFacadeQueries extends HibernateDaoSupport implements TypeFacadeQueriesAPI{
 
-  private static Log log = LogFactory.getLog(TypeFacadeQueries.class);
+  private Log log = LogFactory.getLog(TypeFacadeQueries.class);
   private HashMap typeFacadeMap;
   private List itemTypes;
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/authz/AuthorizationFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/authz/AuthorizationFacadeQueries.java
@@ -47,7 +47,7 @@ import org.apache.commons.logging.LogFactory;
 public class AuthorizationFacadeQueries
    extends HibernateDaoSupport implements AuthorizationFacadeQueriesAPI{
 
-  private static Log log = LogFactory.getLog(AuthorizationFacadeQueries.class);
+  private Log log = LogFactory.getLog(AuthorizationFacadeQueries.class);
 
   public AuthorizationFacadeQueries() {
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/authz/standalone/AuthzQueriesFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/authz/standalone/AuthzQueriesFacade.java
@@ -46,7 +46,7 @@ import org.sakaiproject.tool.assessment.facade.AuthzQueriesFacadeAPI;
 public class AuthzQueriesFacade
           extends HibernateDaoSupport implements AuthzQueriesFacadeAPI
 {
-  private static Log log = LogFactory.getLog(AuthzQueriesFacade.class);
+  private Log log = LogFactory.getLog(AuthzQueriesFacade.class);
 
   // stores sql strings
   private static ResourceBundle res = ResourceBundle.getBundle(

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/util/PagingUtilQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/util/PagingUtilQueries.java
@@ -36,7 +36,7 @@ import org.hibernate.Session;
 
 public class PagingUtilQueries
     extends HibernateDaoSupport implements PagingUtilQueriesAPI{
-    private static Log log = LogFactory.getLog(PagingUtilQueries.class);
+    private Log log = LogFactory.getLog(PagingUtilQueries.class);
 
   public PagingUtilQueries () {
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/IntegrationContextFactory.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/IntegrationContextFactory.java
@@ -41,7 +41,6 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.CalendarServiceHe
  */
 public abstract class IntegrationContextFactory
 {
-  private static Log log = LogFactory.getLog(IntegrationContextFactory.class);
   private static IntegrationContextFactory instance=null;
 
   /**
@@ -50,6 +49,7 @@ public abstract class IntegrationContextFactory
    */
   public static IntegrationContextFactory getInstance()
   {
+    Log log = LogFactory.getLog(IntegrationContextFactory.class);
     log.debug("IntegrationContextFactory.getInstance()");
     if (instance==null)
     {
@@ -69,6 +69,7 @@ public abstract class IntegrationContextFactory
   
   public static IntegrationContextFactory getTestInstance()
   {
+	    Log log = LogFactory.getLog(IntegrationContextFactory.class);
 	    log.debug("IntegrationContextFactory.getTestInstance()");
 	    if (instance==null)
 	    {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/spring/FactoryUtil.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/spring/FactoryUtil.java
@@ -40,7 +40,7 @@ import org.sakaiproject.spring.SpringBeanLocator;
  */
 public class FactoryUtil
 {
-  private static Log log = LogFactory.getLog(FactoryUtil.class);
+  private Log log = LogFactory.getLog(FactoryUtil.class);
   private static boolean useLocator = false;
 //  private static boolean useLocator = true;
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/spring/IntegrationContext.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/spring/IntegrationContext.java
@@ -41,7 +41,7 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.CalendarServiceHe
  */
 public class IntegrationContext extends IntegrationContextFactory
 {
-  private static Log log = LogFactory.getLog(IntegrationContext.class);
+  private Log log = LogFactory.getLog(IntegrationContext.class);
 
   private boolean integrated;
   private AgentHelper agentHelper;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/AgentHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/AgentHelperImpl.java
@@ -63,7 +63,7 @@ import org.sakaiproject.user.cover.UserDirectoryService;
  */
 public class AgentHelperImpl implements AgentHelper
 {
-  private static Log log = LogFactory.getLog(AgentHelperImpl.class);
+  private Log log = LogFactory.getLog(AgentHelperImpl.class);
   AgentImpl agent;
 
   /**

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookHelperImpl.java
@@ -49,7 +49,7 @@ import org.sakaiproject.tool.cover.ToolManager;
 
 public class GradebookHelperImpl implements GradebookHelper
 {
-  private static Log log = LogFactory.getLog(GradebookHelperImpl.class);
+  private Log log = LogFactory.getLog(GradebookHelperImpl.class);
 
   /**
    * Get current gradebook uid.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
@@ -64,7 +64,7 @@ import org.sakaiproject.tool.cover.ToolManager;
  */
 public class GradebookServiceHelperImpl implements GradebookServiceHelper
 {
-  private static Log log = LogFactory.getLog(GradebookServiceHelperImpl.class);
+  private Log log = LogFactory.getLog(GradebookServiceHelperImpl.class);
 
   /**
    * Does a gradebook exist?

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/PublishingTargetHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/PublishingTargetHelperImpl.java
@@ -50,7 +50,7 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.PublishingTargetH
 
 public class PublishingTargetHelperImpl implements PublishingTargetHelper
 {
-  private static Log log = LogFactory.getLog(PublishingTargetHelperImpl.class);
+  private Log log = LogFactory.getLog(PublishingTargetHelperImpl.class);
 
     //private org.sakaiproject.component.api.ComponentManager cm;
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/AgentHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/AgentHelperImpl.java
@@ -55,7 +55,7 @@ import org.sakaiproject.user.cover.UserDirectoryService;
  */
 public class AgentHelperImpl implements AgentHelper
 {
-  private static Log log = LogFactory.getLog(AgentHelperImpl.class);
+  private Log log = LogFactory.getLog(AgentHelperImpl.class);
   String agentString;
 
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/GradebookHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/GradebookHelperImpl.java
@@ -47,7 +47,7 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookHelper;
  */
 public class GradebookHelperImpl implements GradebookHelper
 {
-  private static Log log = LogFactory.getLog(GradebookHelperImpl.class);
+  private Log log = LogFactory.getLog(GradebookHelperImpl.class);
 
   /**
    * Hardcoded stub.  Get current gradebook uid.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/GradebookServiceHelperImpl.java
@@ -47,7 +47,7 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceH
  */
 public class GradebookServiceHelperImpl implements GradebookServiceHelper
 {
-	private static Log log = LogFactory.getLog(GradebookServiceHelperImpl.class);
+	private Log log = LogFactory.getLog(GradebookServiceHelperImpl.class);
 
 	public boolean isAssignmentDefined(String assessmentTitle, GradebookExternalAssessmentService g)
 	{

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/PublishingTargetHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/standalone/PublishingTargetHelperImpl.java
@@ -50,7 +50,7 @@ import org.sakaiproject.tool.assessment.qti.constants.AuthoringConstantStrings;
 
 public class PublishingTargetHelperImpl implements PublishingTargetHelper
 {
-  private static Log log = LogFactory.getLog(PublishingTargetHelperImpl.class);
+  private Log log = LogFactory.getLog(PublishingTargetHelperImpl.class);
 
   /**
    * Gets to whom you can publish.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/osid/assessment/impl/SectionIteratorImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/osid/assessment/impl/SectionIteratorImpl.java
@@ -33,7 +33,7 @@ import org.osid.assessment.Section;
 public class SectionIteratorImpl
   implements org.osid.assessment.SectionIterator
 {
-  private static Log log = LogFactory.getLog(SectionIteratorImpl.class);
+  private Log log = LogFactory.getLog(SectionIteratorImpl.class);
   private Iterator sectionIterator;
 
   private Iterator sectionIter;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -115,7 +115,7 @@ public class GradingService
   final Pattern CALCQ_FORMULA_SPLIT_PATTERN = Pattern.compile("(" + OPEN_BRACKET + OPEN_BRACKET + CALCQ_VAR_FORM_NAME + CLOSE_BRACKET + CLOSE_BRACKET + ")");
   final Pattern CALCQ_CALCULATION_PATTERN = Pattern.compile("\\[\\[([^\\[\\]]+?)\\]\\]?"); // non-greedy
 
-  private static Log log = LogFactory.getLog(GradingService.class);
+  private Log log = LogFactory.getLog(GradingService.class);
 
   /**
    * Get all scores for a published assessment from the back end.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/ItemService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/ItemService.java
@@ -49,7 +49,7 @@ import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
  */
 public class ItemService
 {
-  private static Log log = LogFactory.getLog(ItemService.class);
+  private Log log = LogFactory.getLog(ItemService.class);
 
   /**
    * Creates a new ItemService object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PersistenceHelper.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PersistenceHelper.java
@@ -31,7 +31,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class PersistenceHelper {
 	
-	private static Log log = LogFactory.getLog(PersistenceHelper.class);
+	private Log log = LogFactory.getLog(PersistenceHelper.class);
 	
 	
 	private Integer deadlockInterval; // in ms

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PersistenceService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PersistenceService.java
@@ -49,7 +49,7 @@ import org.sakaiproject.tool.assessment.facade.util.PagingUtilQueriesAPI;
  */
 public class PersistenceService{
 
-	private static Log log = LogFactory.getLog(PersistenceService.class);
+	private Log log = LogFactory.getLog(PersistenceService.class);
 	private QuestionPoolFacadeQueriesAPI questionPoolFacadeQueries;
 	private TypeFacadeQueriesAPI typeFacadeQueries;
 	private SectionFacadeQueriesAPI sectionFacadeQueries;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PublishedItemService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PublishedItemService.java
@@ -6,7 +6,7 @@ import org.sakaiproject.tool.assessment.facade.ItemFacade;
 import org.sakaiproject.tool.assessment.facade.PublishedItemFacade;
 
 public class PublishedItemService extends ItemService {
-	private static Log log = LogFactory.getLog(PublishedItemService.class);
+	private Log log = LogFactory.getLog(PublishedItemService.class);
 
 	public ItemFacade getItem(Long itemId, String agentId) {
 		PublishedItemFacade item = null;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/QuestionPoolService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/QuestionPoolService.java
@@ -48,7 +48,7 @@ import org.sakaiproject.tool.assessment.facade.QuestionPoolIteratorFacade;
  */
 public class QuestionPoolService
 {
-    private static Log log = LogFactory.getLog(QuestionPoolService.class);
+    private Log log = LogFactory.getLog(QuestionPoolService.class);
 
   /**
    * Creates a new QuestionPoolService object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/SectionService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/SectionService.java
@@ -33,7 +33,7 @@ import org.sakaiproject.tool.assessment.facade.SectionFacade;
  */
 public class SectionService
 {
-  private static Log log = LogFactory.getLog(SectionService.class);
+  private Log log = LogFactory.getLog(SectionService.class);
 
   /**
    * Creates a new SectionService object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
@@ -54,7 +54,7 @@ public class AssessmentEntityProducer implements EntityTransferrer,
 
     private static final int QTI_VERSION = 1;
     private static final String ARCHIVED_ELEMENT = "assessment";
-    private static Log log = LogFactory.getLog(AssessmentEntityProducer.class);
+    private Log log = LogFactory.getLog(AssessmentEntityProducer.class);
     private QTIServiceAPI qtiService;
 
 	public void init() {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentService.java
@@ -84,7 +84,7 @@ import org.sakaiproject.tool.cover.ToolManager;
  * @author Rachel Gollub <rgollub@stanford.edu>
  */
 public class AssessmentService {
-	private static Log log = LogFactory.getLog(AssessmentService.class);
+	private Log log = LogFactory.getLog(AssessmentService.class);
 	public static final int UPDATE_SUCCESS = 0;
 	public static final int UPDATE_ERROR_DRAW_SIZE_TOO_LARGE = 1;
 
@@ -980,6 +980,7 @@ public class AssessmentService {
 		}
 		catch (Exception e)
 		{
+			Log log = LogFactory.getLog(AssessmentService.class);
 			log.warn("escapeResourceName: ", e);
 			return id;
 		}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/EventLogService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/EventLogService.java
@@ -9,7 +9,7 @@ import org.sakaiproject.tool.assessment.facade.EventLogFacade;
 import org.sakaiproject.tool.assessment.services.PersistenceService;
 
 public class EventLogService{
-	private static Log log = LogFactory.getLog(EventLogService.class);
+	private Log log = LogFactory.getLog(EventLogService.class);
 
 	public EventLogService() {
 	}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
@@ -62,7 +62,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
  * @author Rachel Gollub <rgollub@stanford.edu>
  */
 public class PublishedAssessmentService extends AssessmentService{
-  private static Log log = LogFactory.getLog(PublishedAssessmentService.class);
+  private Log log = LogFactory.getLog(PublishedAssessmentService.class);
 
   /**
    * Creates a new QuestionPoolService object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/gradebook/GradebookServiceHelper.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/gradebook/GradebookServiceHelper.java
@@ -33,7 +33,7 @@ import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
  */
 public class GradebookServiceHelper
 {
-    private static Log log = LogFactory.getLog(GradebookServiceHelper.class);
+    private Log log = LogFactory.getLog(GradebookServiceHelper.class);
 
     public static boolean addToGradebook(PublishedAssessmentData publishedAssessment) throws Exception {
       return false;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/shared/MediaService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/shared/MediaService.java
@@ -35,7 +35,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
  */
 public class MediaService
 {
-  private static Log log = LogFactory.getLog(MediaService.class);
+  private Log log = LogFactory.getLog(MediaService.class);
 
   /**
    * Creates a new QuestionPoolService object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/shared/TypeService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/shared/TypeService.java
@@ -38,7 +38,7 @@ import org.sakaiproject.tool.assessment.services.PersistenceService;
  */
 public class TypeService
 {
-  private static Log log = LogFactory.getLog(TypeService.class);
+  private Log log = LogFactory.getLog(TypeService.class);
 
   /**
    * Creates a new QuestionPoolService object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/AssessmentServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/AssessmentServiceImpl.java
@@ -43,7 +43,7 @@ import org.sakaiproject.tool.assessment.services.assessment.AssessmentServiceExc
  */
 public class AssessmentServiceImpl implements AssessmentServiceAPI
 {
-  private static Log log = LogFactory.getLog(AssessmentServiceImpl.class);
+  private Log log = LogFactory.getLog(AssessmentServiceImpl.class);
 
   /**
    * Get assessment template from id string.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/ItemServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/ItemServiceImpl.java
@@ -44,7 +44,7 @@ import org.sakaiproject.tool.assessment.shared.api.assessment.ItemServiceAPI;
 public class ItemServiceImpl implements ItemServiceAPI
 {
 
-  private static Log log = LogFactory.getLog(ItemServiceImpl.class);
+  private Log log = LogFactory.getLog(ItemServiceImpl.class);
 
  /**
  * Get a particular item.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/PublishedAssessmentServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/PublishedAssessmentServiceImpl.java
@@ -56,7 +56,7 @@ import org.sakaiproject.tool.assessment.shared.api.assessment.PublishedAssessmen
  */
 public class PublishedAssessmentServiceImpl implements PublishedAssessmentServiceAPI
 {
-  private static Log log = LogFactory.getLog(PublishedAssessmentServiceImpl.class);
+  private Log log = LogFactory.getLog(PublishedAssessmentServiceImpl.class);
 
   /**
   * Get list of all active published assessments with basic info populated.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/SectionServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/SectionServiceImpl.java
@@ -37,7 +37,7 @@ import org.sakaiproject.tool.assessment.shared.api.assessment.SectionServiceAPI;
  */
 public class SectionServiceImpl implements SectionServiceAPI
 {
-  private static Log log = LogFactory.getLog(SectionServiceImpl.class);
+  private Log log = LogFactory.getLog(SectionServiceImpl.class);
   public SectionServiceImpl()
   {
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/SecureDeliveryServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/assessment/SecureDeliveryServiceImpl.java
@@ -29,7 +29,7 @@ import org.springframework.core.io.Resource;
  */
 public class SecureDeliveryServiceImpl implements SecureDeliveryServiceAPI {
 	
-	private static Log log = LogFactory.getLog( SecureDeliveryServiceImpl.class );
+	private Log log = LogFactory.getLog( SecureDeliveryServiceImpl.class );
 	
 	/*
 	 * Implementation of the SecureDeliveryModuleIfc interface with name,id ordering, except for id=NONE_ID

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/common/MediaServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/common/MediaServiceImpl.java
@@ -36,7 +36,7 @@ import org.sakaiproject.tool.assessment.shared.api.common.MediaServiceAPI;
  */
 public class MediaServiceImpl implements MediaServiceAPI
 {
-  private static Log log = LogFactory.getLog(MediaServiceImpl.class);
+  private Log log = LogFactory.getLog(MediaServiceImpl.class);
 
   public void remove(String mediaId)
   {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/common/TypeServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/common/TypeServiceImpl.java
@@ -39,7 +39,7 @@ import org.sakaiproject.tool.assessment.shared.api.common.TypeServiceAPI;
  */
 public class TypeServiceImpl implements TypeServiceAPI
 {
-  private static Log log = LogFactory.getLog(TypeServiceImpl.class);
+  private Log log = LogFactory.getLog(TypeServiceImpl.class);
 
   /**
    * Get type for id

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradebookServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradebookServiceImpl.java
@@ -41,7 +41,7 @@ import org.sakaiproject.tool.assessment.shared.api.grading.GradebookServiceAPI;
  */
 public class GradebookServiceImpl implements GradebookServiceAPI
 {
-  //private static Log log = LogFactory.getLog(GradebookServiceImpl.class);
+  //private Log log = LogFactory.getLog(GradebookServiceImpl.class);
 
 
   public boolean isAssignmentDefined(String assessmentTitle)

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradingSectionAwareServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradingSectionAwareServiceImpl.java
@@ -36,7 +36,6 @@ import org.sakaiproject.tool.assessment.shared.api.grading.GradingSectionAwareSe
 
 public class GradingSectionAwareServiceImpl implements GradingSectionAwareServiceAPI
 {
-  //private static Log log = LogFactory.getLog(GradingServiceImpl.class);
   private static final SectionAwareServiceHelper helper =
     IntegrationContextFactory.getInstance().getSectionAwareServiceHelper();
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradingServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradingServiceImpl.java
@@ -44,7 +44,7 @@ import org.sakaiproject.tool.assessment.shared.api.grading.GradingServiceAPI;
 
 public class GradingServiceImpl implements GradingServiceAPI
 {
-  private static Log log = LogFactory.getLog(GradingServiceImpl.class);
+  private Log log = LogFactory.getLog(GradingServiceImpl.class);
 
   /**
    * Get all scores for a published assessment from the back end.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/questionpool/QuestionPoolServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/questionpool/QuestionPoolServiceImpl.java
@@ -46,7 +46,7 @@ import org.sakaiproject.tool.assessment.services.QuestionPoolServiceException;
 public class QuestionPoolServiceImpl
   implements QuestionPoolServiceAPI
 {
-  private static Log log = LogFactory.getLog(QuestionPoolServiceImpl.class);
+  private Log log = LogFactory.getLog(QuestionPoolServiceImpl.class);
 
   /**
    * Creates a new QuestionPoolServiceImpl object.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/MimeType.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/MimeType.java
@@ -34,8 +34,6 @@ import org.apache.commons.logging.LogFactory;
  * @version $Id$
  */
 public class MimeType {
-  private static Log log = LogFactory.getLog(MimeType.class);
-
   private static HashMap extensionMime = new HashMap();
   private static HashMap mimeExtension = new HashMap();
   private static boolean loaded = false;
@@ -47,6 +45,7 @@ public class MimeType {
    */
   public static void main(String[] args)
   {
+    Log log = LogFactory.getLog(MimeType.class);
     log.info("mime for BMP= " + get("BMP"));
     log.info("mime for .zip= " + get(".zip"));
     log.info("mime for .HTM= " + get (".HTM"));

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/MimeTypesLocator.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/MimeTypesLocator.java
@@ -27,7 +27,6 @@ import java.io.File;
  
 public class MimeTypesLocator{
 
-  //private static Log log = LogFactory.getLog(MimeTypesLocator.class);
   private static MimeTypesLocator instance = null;
   private static MimetypesFileTypeMap map = null;
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/TextFormat.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/TextFormat.java
@@ -40,7 +40,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class TextFormat
 {
-  private static Log log = LogFactory.getLog(TextFormat.class);
+  private Log log = LogFactory.getLog(TextFormat.class);
   private static final String HTML;
   private static final String SMART;
   private static final String PLAIN;
@@ -317,26 +317,6 @@ public class TextFormat
     return min;
   }
 
-  /**
-   * test
-   *
-   * @param args
-   */
-  public static void main(String[] args)
-  {
-    TextFormat tf = new TextFormat();
-    log.info(
-      tf.formatText(
-        "www.cs.iupui.edu ui.edu dd dd dd:):-) ff telnet:dd dddddupui.edu",
-        "SMART", ("http://oncourse.iu.edu/images/icons/")));
-    log.info(
-      tf.formatText(
-        "http://www.iupui.edu:80 www.ui.edu :( ::-( ddd", "SMART",
-        ("http://oncourse.iu.edu/images/icons/")));
-
-    log.debug(String.valueOf(System.identityHashCode(tf)));
-  }
-  
   public static String convertPlaintextToFormattedTextNoHighUnicode(Log log, String value) {
 	  if (value == null) return "";
 


### PR DESCRIPTION
per Apache   Commons logging documentation and FAQs

https://jira.sakaiproject.org/browse/SAM-2468

Per commons logging documentation: 

Note that for application code, declaring the log member as "static" is more efficient as one Log object is created per class, and is recommended. However this is not safe to do for a class which may be deployed via a "shared" classloader in a servlet or j2ee container or similar environment. If the class may end up invoked with different thread-context-classloader values set then the member must not be declared static. The use of "static" should therefore be avoided in code within any "library" type project.