### PR TITLE
SAK-28996 Don't log error when a user can't be found.

### DIFF
--- a/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
+++ b/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
@@ -1566,7 +1566,8 @@ public class ChatTool implements RoomObserver, PresenceObserver {
       try {
          sender = UserDirectoryService.getUser(message.getOwner());
       } catch(UserNotDefinedException e) {
-         logger.error(e);
+          // Expected some users will get deleted.
+         logger.debug("Failed to find user for ID: "+ message.getOwner(), e);
          return message.getOwner();
       }
       return sender.getDisplayName();


### PR DESCRIPTION
The deleting of users is expected to happen and chat shouldn't fill the logs with errors when it comes across a message posted from a user who no longer exists.