### PR TITLE
SAK-28997 improve user experience for Site Browser (gateway tool)

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2946,6 +2946,10 @@
 # DEFAULT: none (null) 
 # sitebrowser.termsearch.property=term_eid
 
+# SAK-28997 - the term attribute to display to the user
+# DEFAULT: title
+# sitebrowser.termsearch.display=title
+
 # A type of site to exclude from site search results. "My Workspace" sites are excluded whether or not this is set. 
 # DEFAULT: none (null)
 # sitesearch.noshow.sitetype=portfolioAdmin

--- a/site-manage/site-manage-tool/tool/src/bundle/sitebrowser.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitebrowser.properties
@@ -7,7 +7,8 @@ gen.alert = Alert
 #List VM
 list.search = Search
 list.results = Results
-list.sites = sites were found that matches your search for
+list.sites = site(s) were found that match your search for
+list.type3 = sites.
 list.type2 = sites,
 list.type1 = sites, and
 list.text = and

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitebrowser/chef_sitebrowser_list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitebrowser/chef_sitebrowser_list.vm
@@ -45,17 +45,27 @@
 					#else
 						#set($siteTypeDisplay=$siteType)
 					#end
-						#if ($termSelection)
-							#if ($termSelection == "Any")
-								#set ($termDisplay = $tlang.getString("se.any"))
-							#else
-								#set ($termDisplay = $termSelection)
-							#end
+					#if ($termSelection)
+						#if ($termSelection == "Any")
+							#set ($termDisplay = $tlang.getString("se.any"))
+						#else
+							#set( $termDisplay = $termsmap.get( $termSelection ) )
+						#end
+						## SAK-28997
+						#if( $searchText )
 							$allMsgNumber $tlang.getString("list.sites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type2") "$validator.escapeHtml($!searchText)" $tlang.getString("list.text") "$validator.escapeHtml($!termDisplay)" $tlang.getString("list.aca")
 						#else
-							$allMsgNumber $tlang.getString("list.sites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type1") "$validator.escapeHtml($!searchText)".
+							$allMsgNumber $tlang.getString("list.sites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type1") "$validator.escapeHtml($!termDisplay)" $tlang.getString("list.aca")
 						#end
-					</p>	
+					#else
+						#set( $termDisplay = $tlang.getString( "list.noterm" ) )
+						#if( $searchText )
+							$allMsgNumber $tlang.getString("list.sites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type1") "$validator.escapeHtml($!searchText)".
+						#else
+							$allMsgNumber $tlang.getString("list.sites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type3")
+						#end
+					#end
+				</p>
 			</div>
 			<div class="listNav">
 				<div class="instruction">$tlang.getString("list.view") $topMsgPos - $btmMsgPos $tlang.getString("list.of") $allMsgNumber $tlang.getString("list.items")</div>
@@ -197,24 +207,17 @@
                         #end
                         </td>
 
-                        <td headers="term">
-             			#if ($termProp)
-             				#if ($site.getProperties().getProperty($termProp))
-                                #set ($termprop = $site.getProperties().getProperty($termProp).toString())
-                                #if ($termsmap.get($termprop))
-                                  $termsmap.get($termprop)
-                                #else
-                                  $termprop
-                                #end
+						<td headers="term">
+							## SAK-28997
+							#if( $termProp && $site.getProperties().getProperty( $termProp ) )
+								#set( $termprop = $site.getProperties().getProperty( $termProp ) )
+								#set( $termDisplay = $termsmap.get( $termprop ) )
+							#else
+								#set( $termDisplay = $tlang.getString( "list.noterm" ) )
+							#end
+							$termDisplay
+						</td>
 
-	                        #else
-	                        	$tlang.getString("list.noterm")
-	                        #end
-             			#else
-	                        n/a
-	                    #end
-                        </td>
-                                                
                         <td headers="description">
 													#set ($desc = $site.Description)
 													$siteBrowserTextEdit.doPlainTextAndLimit($desc,50,$tlang.getString("list.desc.ellipse")) 
@@ -244,10 +247,19 @@
                 #else
                     #set ($termDisplay = $termSelection)
                 #end
-                $tlang.getString("list.nosites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type2") "$validator.escapeHtml($!searchText)" $tlang.getString("list.text") "$validator.escapeHtml($!termDisplay)" $tlang.getString("list.aca")
-            #else
-                $tlang.getString("list.nosites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type1") "$validator.escapeHtml($!searchText)".
-            #end
+				## SAK-28997
+				#if( $searchText )
+					$tlang.getString("list.nosites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type2") "$validator.escapeHtml($!searchText)" $tlang.getString("list.text") "$validator.escapeHtml($termDisplay)" $tlang.getString("list.aca")
+				#else
+					$tlang.getString("list.nosites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type2") $tlang.getString("list.text") $validator.escapeHtml("$termDisplay") $tlang.getString("list.aca")
+				#end
+			#else
+				#if( $searchText )
+					$tlang.getString("list.nosites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type1") "$validator.escapeHtml($!searchText)".
+				#else
+					$tlang.getString("list.nosites") "$validator.escapeHtml($siteTypeDisplay)" $tlang.getString("list.type3")
+				#end
+			#end
 		</p>
 		#if ($helperMode)
 			<p class="act">

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitebrowser/chef_sitebrowser_simpleSearch.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitebrowser/chef_sitebrowser_simpleSearch.vm
@@ -45,8 +45,10 @@
 							<label for="selectTerm">$tlang.getString("se.term")</label>
 							<select name="selectTerm" id="selectTerm" disabled="disabled">
 							<option value="Any">$tlang.getString("se.any")</option>
-							#foreach ($term in $terms)
-							<option value="$term.eid">$term.title</option>
+
+							## SAK-28997
+							#foreach( $term in $terms.entrySet() )
+								<option value="$term.key">$term.value</option>
 							#end
 							</select>
 						</div>	


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-28997

* create sakai.property (sitebrowser.termsearch.display) that controls what the user sees in the Site Browser search dropdown (course radio button), in the message at the top of the results, and in the table of results
     * can be set to: "eid", "title", or "description" (title is default)
* remove blank search terms in the results message/improve wording of results message

Currently, you can get a results message in the following format:

'No sites found that match your search for "course sites", "" and "<termSelected>" Academic Term.'

The logic behind these messages has been changed to not display empty quotes when no search string is provided, and to handle singular/plural. 