### PR TITLE
SAK-29000 Create sakai.property to show/hide authorization fields when adding roster(s) to a course site

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2660,6 +2660,11 @@
 # DEFAULT: 10
 #site.adminperms.sitesuntilpause=10
 
+### SAK-29000
+# Determines if the authorization fields are presented to the user in Site Info -> Edit Rosters -> Add Roster
+# DEFAULT: true
+# site.addroster.authorizationrequired=false
+
 # Allow instructors to create and manage sections by themselves while also 
 # having some types of sections locked (read only). With this configuration 
 # (and MANUAL type set) an Instructor can create and manage sections except 

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -792,6 +792,9 @@ public class SiteAction extends PagedResourceActionII {
 	// SAK-28990 - enable/disable continue with no roster
 	private static final String VM_CONT_NO_ROSTER_ENABLED = "contNoRosterEnabled";
 	private static final String SAK_PROP_CONT_NO_ROSTER_ENABLED = "sitemanage.continueWithNoRoster";
+	
+	private static final String SAK_PROP_ADD_ROSTER_AUTH_REQUIRED = "site.addroster.authorizationrequired";
+	private static final String VM_ADD_ROSTER_AUTH_REQUIRED = "authorizationRequired";
 
 	/**
 	 * what are the tool ids within Home page?
@@ -3214,6 +3217,10 @@ public class SiteAction extends PagedResourceActionII {
 			List ll = (List) state.getAttribute(STATE_TERM_COURSE_LIST);
 			context.put("termCourseList", state
 					.getAttribute(STATE_TERM_COURSE_LIST));
+
+			// SAK-29000
+			Boolean isAuthorizationRequired = ServerConfigurationService.getBoolean( SAK_PROP_ADD_ROSTER_AUTH_REQUIRED, Boolean.TRUE );
+			context.put( VM_ADD_ROSTER_AUTH_REQUIRED, isAuthorizationRequired );
 
 			// added for 2.4 -daisyf
 			context.put("campusDirectory", getCampusDirectory());

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
@@ -309,7 +309,9 @@ function redirectBasedOnSelection(){
 				
 
 		
-		#if ($termCourseList && $currentUserId != $userId)
+		## SAK-29000
+		#if ($authorizationRequired)
+			#if ($termCourseList && $currentUserId != $userId)
 					<div class="shorttext required">
 						<span class="reqStar">*</span>						
 						<label for="uniqname">		
@@ -329,6 +331,7 @@ function redirectBasedOnSelection(){
 					<p  class="instruction labelindnt">
 						$tlang.getString("man.please")
 					</p>
+			#end
 		#end
 		<p/>
 		<input type="hidden" name="back" value="$!backIndex" />
@@ -389,8 +392,11 @@ function redirectBasedOnSelection(){
 				</p>
 			#else
 				#if( !$skipCourseSectionSelection || !$skipManualCourseCreation)
-					<!-- Add Not Listed Courses -->
-					<a href="#" onclick="javascript:submitFindCourse();">$tlang.getString('nscourse.add_course_not_listed')</a>
+					## SAK-29000
+					#if( $authorizationRequired )
+						<!-- Add Not Listed Courses -->
+						<a href="#" onclick="javascript:submitFindCourse();">$tlang.getString('nscourse.add_course_not_listed')</a>
+					#end
 				#end
 				<p class="act">
 				<input type="hidden" name="option" id="option" value="x" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29000

Site Info -> Edit Rosters -> Add Roster

The authorization fields are not actually required and can create roster attachment issues (waiting for authorization).

This introduces a sakai.property (site.addroster.authorizationrequired) to control whether or not these fields are visible to the user. Default is true (original functionality). Only when set to false are the fields not visible to the user. 