### PR TITLE
SAK-28986 Fix public ical subscriptions.

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -171,8 +171,10 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	 */
 	protected boolean unlockCheck(String lock, String reference)
 	{
-		return m_securityService.unlock(lock, reference);
+		if (lock.equals(AUTH_READ_CALENDAR) &&  getExportEnabled(reference))
+			return true;
 
+		return m_securityService.unlock(lock, reference);
 	} // unlockCheck
 
 	/**
@@ -187,12 +189,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	 */
 	protected void unlock(String lock, String reference) throws PermissionException
 	{
-		// check if publicly accessible via export
-		if ( getExportEnabled(reference) && lock.equals(AUTH_READ_CALENDAR) )
-			return;
-			
-		// otherwise check permissions
-		else if (!m_securityService.unlock(lock, reference))
+		if (!unlockCheck(lock, reference))
 			throw new PermissionException(m_sessionManager.getCurrentSessionUserId(), lock, reference);
 
 	} // unlock


### PR DESCRIPTION
If used to be the case that when ical subscriptions were enabled they would just return the ical for the current site. In another issue this got changed so that they returned the calendar entries for all sites what are displayed in the calendar (including merged ones). However with this change the permission check would fail on the current site due to only one of the unlock methods being aware of getExportEnabled(). In this fix we make all permission checks aware of getExportEnabled() which allows the public iCal feed to work again.