### PR TITLE
SAK-29013 enable the great new opaque url subscription functionality for...

### DIFF
--- a/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/MenuBean.java
+++ b/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/MenuBean.java
@@ -43,6 +43,6 @@ public class MenuBean implements Serializable {
 	}
 
 	public boolean isSubscribeEnabled() {
-		return serverConfigurationService.getBoolean("ical.opaqueurl.subscribe",false);
+		return serverConfigurationService.getBoolean("ical.opaqueurl.subscribe", true);
 	}
 }

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -7638,7 +7638,7 @@ extends VelocityPortletStateAction
 			}
 		
 		// A link for subscribing to the implicit calendar
-		if ( ServerConfigurationService.getBoolean("ical.opaqueurl.subscribe",false) )
+		if ( ServerConfigurationService.getBoolean("ical.opaqueurl.subscribe", true) )
 		{
 			bar.add( new MenuEntry(rb.getString("java.opaque_subscribe"), null, allow_subscribe_this, MenuItem.CHECKED_NA, "doOpaqueUrl") );
 		}

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1831,9 +1831,13 @@
 
 
 ## iCAL
-# Enable iCal import/export
+# Allows iCal/ics subscriptions to calendar via impossible-to-guess (opaque) url. Introduced in SAK-21497
+# DEFAULT: true
+# ical.opaqueurl.subscribe=false
+
+# Enable iCal import/export via instructor-named ICS file. This is legacy: recommend using ical.opaqueurl.subscribe instead
 # DEFAULT: false
-# ical.experimental=false
+# ical.experimental=true
 
 
 ## CONDITIONAL RELEASE

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
@@ -111,9 +111,6 @@ assignment.usePeerAssessment=true
 #Test SAK-22306
 content.upload.dragndrop=true
 
-#Test SAK-18799
-ical.experimental=true
-
 #SAK-24423
 sitemanage.join.joinerGroup.enabled=true
 sitemanage.join.notification.enabled=true


### PR DESCRIPTION
... calendars by default.

This should be our recommended path forward instead of the older ical.experimental, instructor-named feeds.