### PR TITLE
SAK-26085 CalendarService depends on a Threadlocal for lookup, should be changed to a cache

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -60,7 +60,6 @@ import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
-import org.sakaiproject.thread_local.api.ThreadLocalManager;
 import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.api.TimeBreakdown;
 import org.sakaiproject.time.api.TimeRange;
@@ -494,9 +493,6 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	/** Depedency: SessionManager */
 	protected SessionManager m_sessionManager = null;
 
-	/** Dependency: ThreadLocalManager */
-	protected ThreadLocalManager m_threadLocalManager = null;
-
 	/** Dependency: TimeService */
 	protected TimeService m_timeService = null;
 
@@ -589,16 +585,6 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	public void setSessionManager(SessionManager sessionManager)
 	{
 		this.m_sessionManager = sessionManager;
-	}
-
-	/**
-	 * Dependency: ThreadLocalManager.
-	 * @param threadLocalManager
-	 *        The ThreadLocalManager.
-	 */
-	public void setThreadLocalManager(ThreadLocalManager threadLocalManager)
-	{
-		this.m_threadLocalManager = threadLocalManager;
 	}
 
 	/**
@@ -764,19 +750,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	 */
 	protected Calendar findCalendar(String ref)
 	{
-        // TODO: do we really want to do this? -ggolden
-        // if we have done this already in this thread, use that
-        Calendar calendar = (Calendar) m_threadLocalManager.get(ref);
-        if (calendar == null)
-        {
-            calendar = m_storage.getCalendar(ref);
-
-            // "cache" the calendar in the current service in case they are needed again in this thread...
-            if (calendar != null)
-            {
-                m_threadLocalManager.set(ref, calendar);
-            }
-        }
+		Calendar calendar = m_storage.getCalendar(ref);
 		return calendar;
 	} // findCalendar
 

--- a/calendar/calendar-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/calendar/calendar-impl/pack/src/webapp/WEB-INF/components.xml
@@ -20,7 +20,6 @@
 		<property name="securityService"><ref bean="org.sakaiproject.authz.api.SecurityService"/></property>
 		<property name="eventTrackingService"><ref bean="org.sakaiproject.event.api.EventTrackingService"/></property>
 		<property name="sessionManager"><ref bean="org.sakaiproject.tool.api.SessionManager"/></property>
-		<property name="threadLocalManager"><ref bean="org.sakaiproject.thread_local.api.ThreadLocalManager"/></property>
 		<property name="timeService"><ref bean="org.sakaiproject.time.api.TimeService"/></property>
 		<property name="toolManager"><ref bean="org.sakaiproject.tool.api.ToolManager"/></property>
 		<property name="userDirectoryService"><ref bean="org.sakaiproject.user.api.UserDirectoryService"/></property>


### PR DESCRIPTION
Removed the threadlocal and added a cache. findCalendar is called around 20 times per page load so this should be effective.

One thing to consider is the cache config, at the moment its a very basic cache, this may need tuning, either in code defaults or via sakai.properties.