### PR TITLE
INFRSTR-310 Allow the build to work with travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: java
+sudo: false
+cache:
+  directories:
+  - $HOME/.m2

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -123,6 +123,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sakai.jdk.version>1.7</sakai.jdk.version>
     <sakai.build.directory>target</sakai.build.directory>
+    <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
   </properties>
   <distributionManagement>
     <snapshotRepository>


### PR DESCRIPTION
This means our build output becomes reasonable again and we can cache our m2 repository so that builds are a little faster on travis-ci.org