### PR TITLE
SAK-25284 Special characters in message subject do not display correctly

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -2236,7 +2236,7 @@ private   int   getNum(char letter,   String   a)
     if (aMsg != null)
     {
       StringBuilder alertMsg = new StringBuilder();
-      aMsg.setTitle(FormattedText.processFormattedText(getComposeSubject(), alertMsg));
+      aMsg.setTitle(getComposeSubject());
       aMsg.setBody(FormattedText.processFormattedText(getComposeBody(), alertMsg));
       
       aMsg.setAuthor(getAuthorString());
@@ -2799,7 +2799,7 @@ private   int   getNum(char letter,   String   a)
     	PrivateMessage rrepMsg = messageManager.createPrivateMessage() ;
 
     	StringBuilder alertMsg = new StringBuilder();
-    	rrepMsg.setTitle(FormattedText.processFormattedText(getReplyToSubject(), alertMsg));
+    	rrepMsg.setTitle(getReplyToSubject());
     	rrepMsg.setBody(FormattedText.processFormattedText(getReplyToBody(), alertMsg));
     	rrepMsg.setDraft(Boolean.FALSE);
     	rrepMsg.setDeleted(Boolean.FALSE);
@@ -2989,7 +2989,7 @@ private   int   getNum(char letter,   String   a)
     	PrivateMessage rrepMsg = messageManager.createPrivateMessage() ;
 
     	StringBuilder alertMsg = new StringBuilder();
-    	rrepMsg.setTitle(FormattedText.processFormattedText(getForwardSubject(), alertMsg));
+    	rrepMsg.setTitle(getForwardSubject());
     	rrepMsg.setDraft(Boolean.FALSE);
     	rrepMsg.setDeleted(Boolean.FALSE);
 
@@ -3194,7 +3194,7 @@ private   int   getNum(char letter,   String   a)
 
 
 	  StringBuilder alertMsg = new StringBuilder();
-	  rrepMsg.setTitle(FormattedText.processFormattedText(getForwardSubject(), alertMsg));
+	  rrepMsg.setTitle(getForwardSubject());
 	  rrepMsg.setDraft(isDraft);
 	  rrepMsg.setDeleted(Boolean.FALSE);
 

--- a/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgForward.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgForward.jsp
@@ -72,7 +72,10 @@
 	  		      <h:commandLink action="#{PrivateMessagesTool.processActionPrivateMessages}" value="#{msgs.pvt_message_nav}" title=" #{msgs.cdfm_message_forums}"/>
 	              <f:verbatim><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " /></f:verbatim>
 				<h:commandLink action="#{PrivateMessagesTool.processDisplayForum}" value="#{(PrivateMessagesTool.msgNavMode == 'pvt_received' || PrivateMessagesTool.msgNavMode == 'pvt_sent' || PrivateMessagesTool.msgNavMode == 'pvt_deleted' || PrivateMessagesTool.msgNavMode == 'pvt_drafts')? msgs[PrivateMessagesTool.msgNavMode]: PrivateMessagesTool.msgNavMode}" title=" #{(PrivateMessagesTool.msgNavMode == 'pvt_received' || PrivateMessagesTool.msgNavMode == 'pvt_sent' || PrivateMessagesTool.msgNavMode == 'pvt_deleted' || PrivateMessagesTool.msgNavMode == 'pvt_drafts')? msgs[PrivateMessagesTool.msgNavMode]: PrivateMessagesTool.msgNavMode}"/><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
-				<h:commandLink action="#{PrivateMessagesTool.processDisplayMessages}" value="#{PrivateMessagesTool.detailMsg.msg.title}" title=" #{PrivateMessagesTool.detailMsg.msg.title}"/><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
+				<h:commandLink action="#{PrivateMessagesTool.processDisplayMessages}" title=" #{PrivateMessagesTool.detailMsg.msg.title}">
+					<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.title}"/>
+				</h:commandLink>
+				<h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 				<h:outputText value="#{msgs.pvt_forward}" />
 			<f:verbatim></h3></div></f:verbatim>
 	</h:panelGroup>

--- a/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgReply.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgReply.jsp
@@ -70,7 +70,10 @@
 	  		      <h:commandLink action="#{PrivateMessagesTool.processActionPrivateMessages}" value="#{msgs.pvt_message_nav}" title=" #{msgs.cdfm_message_forums}"/>
 	              <f:verbatim><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " /></f:verbatim>
 				<h:commandLink action="#{PrivateMessagesTool.processDisplayForum}" value="#{(PrivateMessagesTool.msgNavMode == 'pvt_received' || PrivateMessagesTool.msgNavMode == 'pvt_sent' || PrivateMessagesTool.msgNavMode == 'pvt_deleted' || PrivateMessagesTool.msgNavMode == 'pvt_drafts')? msgs[PrivateMessagesTool.msgNavMode]: PrivateMessagesTool.msgNavMode}" title=" #{(PrivateMessagesTool.msgNavMode == 'pvt_received' || PrivateMessagesTool.msgNavMode == 'pvt_sent' || PrivateMessagesTool.msgNavMode == 'pvt_deleted' || PrivateMessagesTool.msgNavMode == 'pvt_drafts')? msgs[PrivateMessagesTool.msgNavMode]: PrivateMessagesTool.msgNavMode}"/><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
-				<h:commandLink action="#{PrivateMessagesTool.processDisplayMessages}" value="#{PrivateMessagesTool.detailMsg.msg.title}" title=" #{PrivateMessagesTool.detailMsg.msg.title}"/><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
+				<h:commandLink action="#{PrivateMessagesTool.processDisplayMessages}" title=" #{PrivateMessagesTool.detailMsg.msg.title}">
+					<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.title}"/>
+				</h:commandLink>
+				<h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 				<h:outputText value="#{msgs.pvt_reply}" />
 			<f:verbatim></h3></div></f:verbatim>
 	</h:panelGroup>	

--- a/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgReplyAll.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgReplyAll.jsp
@@ -74,7 +74,10 @@
 	  		      <h:commandLink action="#{PrivateMessagesTool.processActionPrivateMessages}" value="#{msgs.pvt_message_nav}" title=" #{msgs.cdfm_message_forums}"/>
 	              <f:verbatim><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " /></f:verbatim>
 				<h:commandLink action="#{PrivateMessagesTool.processDisplayForum}" value="#{(PrivateMessagesTool.msgNavMode == 'pvt_received' || PrivateMessagesTool.msgNavMode == 'pvt_sent' || PrivateMessagesTool.msgNavMode == 'pvt_deleted' || PrivateMessagesTool.msgNavMode == 'pvt_drafts')? msgs[PrivateMessagesTool.msgNavMode]: PrivateMessagesTool.msgNavMode}" title=" #{(PrivateMessagesTool.msgNavMode == 'pvt_received' || PrivateMessagesTool.msgNavMode == 'pvt_sent' || PrivateMessagesTool.msgNavMode == 'pvt_deleted' || PrivateMessagesTool.msgNavMode == 'pvt_drafts')? msgs[PrivateMessagesTool.msgNavMode]: PrivateMessagesTool.msgNavMode}"/><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
-				<h:commandLink action="#{PrivateMessagesTool.processDisplayMessages}" value="#{PrivateMessagesTool.detailMsg.msg.title}" title=" #{PrivateMessagesTool.detailMsg.msg.title}"/><h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
+				<h:commandLink action="#{PrivateMessagesTool.processDisplayMessages}" title=" #{PrivateMessagesTool.detailMsg.msg.title}">
+					<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.title}"/>
+				</h:commandLink>
+				<h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 				<h:outputText value="#{msgs.pvt_repmsg_ALL}" />
 			<f:verbatim></h3></div></f:verbatim>
 	</h:panelGroup>


### PR DESCRIPTION
I have removed the "FormattedText.processFormattedText" against the message titles since the message titles are never displayed with the JSF tag "escape=false". Therefore, there is never an instance where the title is display unescaped. This is standard for the Forums messages. I tested with titles like:

"/><script>alert('xss')</script></a>
<script>alert('xss')</script>
"/></a><script>alert('xss')</script>