### PR TITLE
SAK-28026 - build user type list from user template realms

### DIFF
--- a/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -118,6 +118,8 @@ public class UsersAction extends PagedResourceActionII
 
 	private static final String SAK_PROP_UNENROLL_BEFORE_DELETE = "user.unenroll.before.delete";
 
+    private static final String USER_TEMPLATE_PREFIX = "!user.template.";
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -216,12 +218,8 @@ public class UsersAction extends PagedResourceActionII
 		UsersActionState sstate = (UsersActionState)getState(context, rundata, UsersActionState.class);
 		String status = sstate.getStatus();
 
-		String[] userTypes = ServerConfigurationService.getStrings("user.type.selector");
-		if (userTypes != null && userTypes.length > 0)
-		{
-			context.put("userTypes", userTypes);
-		}
-
+        context.put("userTypes", getUserTypes());
+         
 		// if not logged in as the super user, we won't do anything
 		if ((!singleUser) && (!createUser) && (!SecurityService.isSuperUser()))
 		{
@@ -1815,4 +1813,22 @@ public class UsersAction extends PagedResourceActionII
 		}
 		return provided;
 	}
+    /**
+     * Determine user types by looking at realms that start with "!user.template."
+     * Doesn't include sample type
+     *
+     * @return list of user types in the system
+     */
+    protected List getUserTypes() {
+        List userTypes = new ArrayList();
+        List groups = AuthzGroupService.getInstance().getAuthzGroups(USER_TEMPLATE_PREFIX, null);
+        for (Iterator i = groups.iterator(); i.hasNext();) {
+            AuthzGroup group = (AuthzGroup) i.next();
+            String type = group.getId().replaceFirst(USER_TEMPLATE_PREFIX, "");
+            if (!type.equals("sample")) {
+                userTypes.add(type);
+            }
+        }
+        return userTypes;
+    }
 }

--- a/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -218,8 +218,16 @@ public class UsersAction extends PagedResourceActionII
 		UsersActionState sstate = (UsersActionState)getState(context, rundata, UsersActionState.class);
 		String status = sstate.getStatus();
 
-        context.put("userTypes", getUserTypes());
-         
+		String[] userTypes = ServerConfigurationService.getStrings("user.type.selector");
+		if (userTypes != null && userTypes.length > 0)
+		{
+			context.put("userTypes", userTypes);
+		} else {
+			context.put("userTypes", getUserTypes());
+		}
+
+
+
 		// if not logged in as the super user, we won't do anything
 		if ((!singleUser) && (!createUser) && (!SecurityService.isSuperUser()))
 		{


### PR DESCRIPTION
 different approach to populating the dropdown for Account User Types. We have been using this approach for some time now. With this patch you are assured that the user types in the dropdown are valid user types as they are based on the !user.template.<type> realm and a restart is not required.