### PR TITLE
SAK-23247 - When grading students if you press the back button some of

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -25,6 +25,7 @@ function handleEnterKeyPress(ev)
 			var $pan = $('#peerReviewInfo')
    	 		if ($pan.is(':visible') && ev.target.id !== 'peerReviewInfo' && ev.target.id !== 'infoImg' && ev.target.id !== 'grade') $pan.hide();
 		});
+		disableBackButton();
     });
 
 var reportsExpanded = false;

--- a/reference/library/src/webapp/js/headscripts.js
+++ b/reference/library/src/webapp/js/headscripts.js
@@ -652,3 +652,16 @@ function browserSafeDocHeight() {
 	}
 	return Math.max(winHeight,docHeight); 
 }
+
+function supports_history_api() {
+	return !!(window.history && history.pushState);
+}
+//Call this to disable the back button in a page context - SAK-23247
+function disableBackButton() {
+	if (supports_history_api()) {
+		history.pushState(null, null, 'no-back-button');
+		window.addEventListener('popstate', function(event) {
+			history.pushState(null, null, 'no-back-button');
+		});
+	}
+}


### PR DESCRIPTION
I was thinking about this again and saw this suggestion on http://stackoverflow.com/a/23794555/3708872

It's not the ideal fix since it disables the problem rather than really fixing why it's happening but it looks like it works in all modern browsers I tested (IE11, Chrome, Firefox). We might have avoided it in the past because history management was not compatible with IE9 [1] but we aren't supporting IE9 really anymore (I don't think?). It might need testing in IE9 and some workaround because it would possibly cause a javascript error. I was thinking of putting up an alert box or something too rather than the non action, maybe that would be useful? 

This is really just a quick idea that has application in a few places where there are serious problems when hitting the back button, such as this grading page, and also will be useful for assessment delivery.

[1] http://caniuse.com/#feat=history