### PR TITLE
SAM-2477 active/inactive links display as insert cursor rather than hand cursor

### DIFF
--- a/reference/library/src/webapp/skin/neo-default/tool.css
+++ b/reference/library/src/webapp/skin/neo-default/tool.css
@@ -1261,6 +1261,10 @@ input[type="checkbox"][disabled="disabled"], input[type="checkbox"][disabled="tr
     background: #ffffff url("/library/image/silk/font.png") no-repeat right;
 }
 
+#tabs .ui-widget-content>#assessment-status-limiter>span>a.active {
+    color:#000;
+}
+
 #helpSearchForm\\:searchField {
   width: 100px;
   padding-right: 6px;

--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -396,6 +396,12 @@ tr.list-row-even td, tr.list-row-odd td {
 	text-decoration: none !important;
 	color: #000000;
 }
+#assessment-link-status-all, #assessment-link-status-active, #assessment-link-status-inactive {
+	cursor:pointer;
+}
+#assessment-link-status-all.active, #assessment-link-status-active.active, #assessment-link-status-inactive.active {
+	cursor:text;
+}
 #tabs, #tabs .ui-widget-content {
 	border-width: 0;
 	background: none;


### PR DESCRIPTION
Samigo -> Published Copies tab:

The 'Active' and 'Inactive' links beside the 'View' text display the insert cursor rather than the hand cursor. 