### PR TITLE
SAK-12034 Allow non ISO-8859-1 in download names.

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -6917,8 +6917,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 			else
 			{
 				// use the last part, the file name part of the id, for the download file name
-				String fileName = Web.encodeFileName( req, Validator.getFileName(ref.getId()) );
-
+				String fileName = Validator.getFileName(ref.getId());
 				String disposition = null;
 
 				if (Validator.letBrowserInline(contentType))
@@ -6950,17 +6949,17 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 						}		
 						
 						if (fileInline || folderInline) {
-							disposition = "inline; filename=\"" + fileName + "\"";
+							disposition = Web.buildContentDisposition(fileName, false);
 						}
 					} else {
-						disposition = "inline; filename=\"" + fileName + "\"";
+						disposition = Web.buildContentDisposition(fileName, false);
 					}
 				}
 				
 				// drop through to attachment
 				if (disposition == null)
 				{
-					disposition = "attachment; filename=\"" + fileName + "\"";
+					disposition = Web.buildContentDisposition(fileName, true);
 				}
 
 				// NOTE: Only set the encoding on the content we have to.

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/Web.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/Web.java
@@ -23,6 +23,8 @@ package org.sakaiproject.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -546,6 +548,8 @@ public class Web
 	 ** Sadly, Safari has a known bug where doesn't correctly translate encoding for user
 	 **
 	 ** This method require inclusion of the javamail mail package. 
+	 ** @deprecated  It is now possible to specify encoded filenames for the browser
+	 **              see @link{Web#buildContentDisposition}
 	 **/
 	public static String encodeFileName(HttpServletRequest req, String fileName )
 	{
@@ -567,8 +571,37 @@ public class Web
 		return fileName;		
 	}
 
+	/**
+	 * This attempts to build the value of the content disposition header. It provides a ISO-8859-1 representation
+	 * and a full UTF-8 version. This allows browser that understand the full version to use that and
+	 * for mainly IE 8 the old limited one.
+	 * @param filename The filename to encode
+	 * @param isDownload Whether the file is a download, will use "attachment" if true and "inline" if false.
+	 * @return The value of the content disposition header specifying it's inline content.
+	 */
+	public static String buildContentDisposition(String filename, boolean isDownload) {
+		try {
+			// This will replace all non US-ASCII characters with '?'
+			// Although this behaviour is unspecified doing it manually is overkill (too much work).
+			// Make sure we escape double quotes.
+			String iso8859Filename = new String(filename.getBytes("ISO-8859-1"), "ISO-8859-1")
+					.replace("\\", "\\\\")
+					.replace("\"", "\\\"");
+			String utf8Filename = URLEncoder.encode(filename, "UTF-8").replace("+", "%20");
+			return new StringBuilder()
+					.append(isDownload ? "attachment; " : "inline; ")
+					.append("filename=\"").append(iso8859Filename).append("\"; ")
+							// For sensible browser give them a full UTF-8 encoded string.
+					.append("filename*=UTF-8''").append(utf8Filename)
+					.toString();
+		} catch (UnsupportedEncodingException shouldNeverHappen) {
+			throw new RuntimeException(shouldNeverHappen);
+		}
+	}
+
 	private static String internalEscapeHtml(String value, boolean escapeNewlines) {
 	    // FIXME this method needs to be removed entirely and is only here as a reference of how this used to work
+
 
 	    if (value == null) return "";
 

--- a/kernel/kernel-util/src/test/java/org/sakaiproject/util/WebTest.java
+++ b/kernel/kernel-util/src/test/java/org/sakaiproject/util/WebTest.java
@@ -1,0 +1,38 @@
+package org.sakaiproject.util;
+
+import junit.framework.TestCase;
+
+public class WebTest extends TestCase {
+
+	public void testContentDispositionInline() {
+		assertEquals("inline; filename=\"file.txt\"; filename*=UTF-8''file.txt",
+				Web.buildContentDisposition("file.txt", false));
+	}
+
+	public void testContentDispositionAttachment() {
+		assertEquals("attachment; filename=\"file.txt\"; filename*=UTF-8''file.txt",
+				Web.buildContentDisposition("file.txt", true));
+	}
+
+	public void testContentDispositionSemiColon() {
+		assertEquals("inline; filename=\"start;stop.txt\"; filename*=UTF-8''start%3Bstop.txt",
+				Web.buildContentDisposition("start;stop.txt", false));
+	}
+
+	public void testContentDispositionQuotes() {
+		assertEquals("inline; filename=\"start\\\"stop.txt\"; filename*=UTF-8''start%22stop.txt",
+				Web.buildContentDisposition("start\"stop.txt", false));
+	}
+
+	public void testContentDispositionUTF8() {
+		// encoding hello world in greek.
+		assertEquals("inline; filename=\"???? ??? ?????.txt\"; " +
+				"filename*=UTF-8''%CE%93%CE%B5%CE%B9%CE%B1%20%CF%83%CE%B1%CF%82%20%CE%BA%CF%8C%CF%83%CE%BC%CE%BF.txt",
+				Web.buildContentDisposition("\u0393\u03B5\u03B9\u03B1 \u03C3\u03B1\u03C2 \u03BA\u03CC\u03C3\u03BC\u03BF.txt", false));
+	}
+
+	public void testContentDispositionISO8859() {
+		assertEquals("inline; filename=\"exposé.txt\"; filename*=UTF-8''expos%C3%A9.txt",
+				Web.buildContentDisposition("exposé.txt", false));
+	}
+}


### PR DESCRIPTION
When a file is downloaded we supply an old ISO-8859-1 filename for old browsers (IE8) and a good UTF-8 filename for modern browers. We also no longer encode spaces as plus in downloaded files but leave them alone in the UTF-8 version.