### PR TITLE
KNL-1330 - resource folder not removed on import when replace data selec...

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -13596,9 +13596,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 						{
 							try
 							{
-								ContentCollectionEdit edit = editCollection(oId);
-
-								this.removeCollection(edit.getId());
+								this.removeCollection(oId);
 							}
 							catch (Exception ee)
 							{


### PR DESCRIPTION
...ted
Resource folders are not removed when selecting replace data option of site import.
The collectionEdit was placing a lock on the table before calling the removeCollection causing a referentialIntegrity error.