### PR TITLE
SAK-29053 - Double-clicking reply in forums triggers multiple tabs error

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -647,3 +647,7 @@ div.msgcntr-profile-qtip {
     margin: 0;
     display: block;
 }
+
+.disable_a_href{
+    pointer-events: none;
+}

--- a/msgcntr/messageforums-app/src/webapp/js/sak-10625.js
+++ b/msgcntr/messageforums-app/src/webapp/js/sak-10625.js
@@ -2,8 +2,12 @@
 var click=0;
 sak10625_disabler = function(){
   var existing_event = this.onclick;
+  $("a, input[type=button], input[type=submit]").attr("onclick", "");
+  $(this).addClass("disable_a_href"); 
   this.onclick = null;
-  if(existing_event) $(this).click(existing_event);
+  if(existing_event) { 
+    $(this).click(existing_event);
+  }
 }
 if (typeof window.jQuery != "undefined") {
 


### PR DESCRIPTION
Adding back in the javascript to remove all onclick events from all anchors. Also adding new css for pointer-events which seems to prevent the links from being hit a lot better.

I refactored the if case a litle better. I'm not sure if returning true or false from this method makes any difference.