### PR TITLE
SAM-2475 avoid NPE when instructor overrides a student score before student begins the assessment.

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
@@ -344,7 +344,7 @@ public class BeginDeliveryActionListener implements ActionListener
     	delivery.setHasTimeLimit(true);
     	delivery.setTimerId((new Date()).getTime()+"");
 
-    	if (unSubmittedAssessmentGrading == null) {
+    	if (unSubmittedAssessmentGrading == null || unSubmittedAssessmentGrading.getAttemptDate() == null) {
     		try {
     			if (control.getTimeLimit() != null) {
     				delivery.setTimeLimit(control.getTimeLimit().toString());


### PR DESCRIPTION
This setTimedAssessment method will be skipped if the instructor "started" the assessment before
the student gets their chance.