### PR TITLE
SAK-27978 Correctly generate mailing list IDs.

### DIFF
--- a/mailarchive/mailarchive-james/james/src/java/org/sakaiproject/james/SakaiMailet.java
+++ b/mailarchive/mailarchive-james/james/src/java/org/sakaiproject/james/SakaiMailet.java
@@ -504,8 +504,9 @@ public class SakaiMailet extends GenericMailet
 					    //e.printStackTrace();
 						M_log.warn("IOException: service(): msg.getContent() threw: " + e, e);
 					}
-					
-					mailHeaders.add("List-Id: <"+ channel.getId()+ "."+ serverConfigurationService.getServerName()+ ">");
+
+					mailHeaders.add("List-Id: <"+ channel.getId()+ "."+ channel.getContext()
+							+ "."+ serverConfigurationService.getServerName()+ ">");
 
 					// post the message to the group's channel
 					String body[] = new String[2];


### PR DESCRIPTION
You need to included the context in the List-ID: header as the id is just the channel ID (e.g. main) which isn’t unique across the whole service.