### PR TITLE
SAK-29086 Quartz job to log messages.

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/logmessage/LogMessageJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/logmessage/LogMessageJob.java
@@ -1,0 +1,34 @@
+package org.sakaiproject.component.app.scheduler.jobs.logmessage;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.quartz.JobExecutionException;
+import org.sakaiproject.component.app.scheduler.jobs.AbstractConfigurableJob;
+
+/**
+ * This is a simple Job that allows a message to be logged.
+ * This is useful for testing and time stamping the log files.
+ */
+public class LogMessageJob extends AbstractConfigurableJob {
+
+    @Override
+    public void runJob() throws JobExecutionException {
+        String level = getConfiguredProperty("level");
+        String message = getConfiguredProperty("message");
+        String logger = getConfiguredProperty("logger");
+        Log log = LogFactory.getLog(logger);
+        if ("trace".equalsIgnoreCase(level)) {
+            log.trace(message);
+        } else if ("debug".equalsIgnoreCase(level)) {
+            log.debug(message);
+        } else if ("info".equalsIgnoreCase(level)) {
+            log.info(message);
+        } else if ("warn".equalsIgnoreCase(level)) {
+            log.warn(message);
+        } else if ("error".equalsIgnoreCase(level)) {
+            log.error(message);
+        } else if ("fatal".equalsIgnoreCase(level)) {
+            log.fatal(message);
+        }
+    }
+}

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/logmessage/Messages.properties
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/logmessage/Messages.properties
@@ -1,0 +1,6 @@
+level=Level
+level.description=The level of the logging (eg: trace,debug,info,warn,error,fatal)
+message=Message
+message.description=The message to be logged.
+logger=Logger
+logger.description=The logger to use.

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -160,7 +160,49 @@
 	   <bean id="datetimeJob"
 	   		class="org.sakaiproject.conditions.job.DatetimeEventJob">
 	   	</bean>
-	   	
+
+   <!-- Job to allow logging of an arbitrary message to an arbitrary logger at an arbitrary level. -->
+   <bean id="org.sakaiproject.component.app.scheduler.jobs.logmessage.LogMessageJob"
+         class="org.sakaiproject.component.app.scheduler.jobs.logmessage.LogMessageJob"
+         singleton="true">
+   </bean>
+
+   <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.LogMessageJob"
+         class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobBeanWrapper"
+         singleton="true" init-method="init">
+       <property name="beanId">
+           <value>org.sakaiproject.component.app.scheduler.jobs.logmessage.LogMessageJob</value>
+       </property>
+       <property name="jobName">
+           <value>Log a message</value>
+       </property>
+       <property name="resourceBundleBase" value="org.sakaiproject.component.app.scheduler.jobs.logmessage.Messages"/>
+       <property name="configurableJobProperties">
+           <set>
+               <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                   <property name="required" value="true"/>
+                   <property name="labelResourceKey" value="level"/>
+                   <property name="descriptionResourceKey" value="level.description"/>
+                   <property name="defaultValue" value="info"/>
+               </bean>
+               <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                   <property name="required" value="true"/>
+                   <property name="labelResourceKey" value="message"/>
+                   <property name="descriptionResourceKey" value="message.description"/>
+                   <property name="defaultValue" value="This is a test message"/>
+               </bean>
+               <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                   <property name="required" value="true"/>
+                   <property name="labelResourceKey" value="logger"/>
+                   <property name="descriptionResourceKey" value="logger.description"/>
+                   <property name="defaultValue" value="org.sakaiproject.component.app.scheduler.jobs.logmessage.LogMessageJob"/>
+               </bean>
+           </set>
+       </property>
+       <property name="schedulerManager">
+           <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
+       </property>
+   </bean>
 
 	   <!-- this is the helper that will register the above bean with the job scheduler -->
 	   <!--


### PR DESCRIPTION
The is a simple quartz jobs that allows an administrator to write an arbitrary message into the logs. This can be used for regular timestamping of the log files or for debugging the logging configuration.