### PR TITLE
SAM-2496: can't add questions to question pools

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/questionpool/QuestionPoolItemIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/questionpool/QuestionPoolItemIfc.java
@@ -28,8 +28,8 @@ package org.sakaiproject.tool.assessment.data.ifc.questionpool;
  */
 public interface QuestionPoolItemIfc
 {
-  public String getItemId();
-  public void setItemId(String itemId);
+  public Long getItemId();
+  public void setItemId(Long itemId);
   public Long getQuestionPoolId();
   public void setQuestionPoolId(Long questionPoolId);
 }

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/shared/api/questionpool/QuestionPoolServiceAPI.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/shared/api/questionpool/QuestionPoolServiceAPI.java
@@ -95,12 +95,12 @@ public interface QuestionPoolServiceAPI
   /**
    * Save a question to a pool.
    */
-  public void addItemToPool(String itemId, Long poolId);
+  public void addItemToPool(Long itemId, Long poolId);
 
   /**
    * Move a question to a pool.
    */
-  public void moveItemToPool(String itemId, Long sourceId, Long destId);
+  public void moveItemToPool(Long itemId, Long sourceId, Long destId);
 
   /**
    * Is a pool a descendant of the other?
@@ -120,7 +120,7 @@ public interface QuestionPoolServiceAPI
   /**
    * removes a Question from the question pool. This does not  *delete* the question itself
    */
-  public void removeQuestionFromPool(String questionId, Long poolId);
+  public void removeQuestionFromPool(Long questionId, Long poolId);
 
   /**
    * Copy a subpool to a pool.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -1264,7 +1264,7 @@ public String getAddOrEdit()
 					// just to skip that item. One could argue for a warning
 					// message.
 					if (!hasItemInDestPool(sourceItemId, destId)) {
-						delegate.moveItemToPool(sourceItemId,
+						delegate.moveItemToPool(new Long(sourceItemId),
 								new Long(sourceId), new Long(destId));
 					}
 				}
@@ -1362,9 +1362,8 @@ public String getAddOrEdit()
 						// just to skip that item. One could argue for a warning
 						// message.
 						if (!hasItemInDestPool(sourceItemId, destId)) {
-							String copyItemFacadeId = questionPoolService
-									.copyItemFacade(sourceItem.getData())
-									.toString();
+							Long copyItemFacadeId = questionPoolService
+									.copyItemFacade(sourceItem.getData());
 							delegate.addItemToPool(copyItemFacadeId, new Long(
 									destId));
 						}
@@ -1405,7 +1404,7 @@ public String getAddOrEdit()
 					Iterator iter2 = itemSet.iterator();
 					while (iter2.hasNext()) {
 			            ItemDataIfc sourceItem = (ItemDataIfc)iter2.next();
-			            String sourceItemId = delegate.copyItemFacade(sourceItem).toString();
+			            Long sourceItemId = delegate.copyItemFacade(sourceItem);
 		                delegate.addItemToPool(sourceItemId, new Long(destId));
 					}
 				} catch (Exception e) {
@@ -1428,7 +1427,7 @@ public String getAddOrEdit()
      {
 
        ItemFacade itemfacade = (ItemFacade) iter.next();
-       String itemid = itemfacade.getItemIdString();
+       Long itemid = itemfacade.getItemId();
        QuestionPoolService delegate = new QuestionPoolService();
        delegate.removeQuestionFromPool(itemid, new Long(sourceId));
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
@@ -835,7 +835,7 @@ public class ItemAddListener
 
         if (!qpdelegate.hasItem(item.getItemIdString(),
         		Long.valueOf(itemauthor.getQpoolId()))) {
-          qpdelegate.addItemToPool(item.getItemIdString(),
+          qpdelegate.addItemToPool(item.getItemId(),
                                    Long.valueOf(itemauthor.getQpoolId()));
 
         }
@@ -1000,7 +1000,7 @@ public class ItemAddListener
         QuestionPoolService qpdelegate = new QuestionPoolService();
 	// removed the old pool-item mappings
           if ( (bean.getOrigPool() != null) && (!bean.getOrigPool().equals(""))) {
-            qpdelegate.removeQuestionFromPool(item.getItemIdString(),
+            qpdelegate.removeQuestionFromPool(item.getItemId(),
             		Long.valueOf(bean.getOrigPool()));
           }
 
@@ -1014,7 +1014,7 @@ public class ItemAddListener
 
           if (!qpdelegate.hasItem(item.getItemIdString(),
                                  Long.valueOf(bean.getSelectedPool()))) {
-            qpdelegate.addItemToPool(item.getItemIdString(),
+            qpdelegate.addItemToPool(item.getItemId(),
             					Long.valueOf(bean.getSelectedPool()));
           }
         }

--- a/samigo/samigo-archive/sam-handlers/src/java/org/sakaiproject/importer/impl/handlers/SamigoPoolHandler.java
+++ b/samigo/samigo-archive/sam-handlers/src/java/org/sakaiproject/importer/impl/handlers/SamigoPoolHandler.java
@@ -89,7 +89,7 @@ public class SamigoPoolHandler implements HandlesImportable {
 		for (int i = 0;i < questionItemsArray.length; i++) {
 			ItemFacade item = (ItemFacade)questionItemsArray[i];
 			item.setSequence(Integer.valueOf(i + 1));
-			qps.addItemToPool(item.getItemIdString(),savedPool.getQuestionPoolId());
+			qps.addItemToPool(item.getItemId(),savedPool.getQuestionPoolId());
 		}
 	}
 	

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/questionpool/QuestionPoolItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/questionpool/QuestionPoolItemData.java
@@ -37,19 +37,19 @@ public class QuestionPoolItemData
   private final static long serialVersionUID = 9180085666292824370L;
 
   private Long questionPoolId;
-  private String itemId;
+  private Long itemId;
   private ItemData itemData; //<-- is the item
     //private QuestionPool questionPool;
 
   public QuestionPoolItemData(){
   }
 
-  public QuestionPoolItemData(Long questionPoolId, String itemId){
+  public QuestionPoolItemData(Long questionPoolId, Long itemId){
     this.questionPoolId = questionPoolId;
     this.itemId = itemId;
   }
 
-  public QuestionPoolItemData(Long questionPoolId, String itemId, ItemData itemData){
+  public QuestionPoolItemData(Long questionPoolId, Long itemId, ItemData itemData){
     this.questionPoolId = questionPoolId;
     this.itemId = itemId;
     this.itemData = itemData;
@@ -59,7 +59,7 @@ public class QuestionPoolItemData
     this.itemData = itemData;
     //this.questionPool = questionPool;
     //setQuestionPoolId(questionPoolProperties.getId());
-    setItemId(itemData.getItemIdString());
+    setItemId(itemData.getItemId());
     setQuestionPoolId(questionPoolData.getQuestionPoolId());
   }
 
@@ -73,12 +73,12 @@ public class QuestionPoolItemData
     this.questionPoolId = questionPoolId;
   }
 
-  public String getItemId()
+  public Long getItemId()
   {
     return itemId;
   }
 
-  public void setItemId(String itemId)
+  public void setItemId(Long itemId)
   {
     this.itemId = itemId;
   }

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
@@ -856,7 +856,7 @@ public class AuthoringHelper
                
                QuestionPoolItemData questionPoolItem = new QuestionPoolItemData();
                questionPoolItem.setQuestionPoolId(questionpool.getQuestionPoolId());
-               questionPoolItem.setItemId(item.getItemIdString());         
+               questionPoolItem.setItemId(item.getItemId());         
                questionpool.addQuestionPoolItem((QuestionPoolItemIfc) questionPoolItem);
                
              } // ... end for each item

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
@@ -627,7 +627,7 @@ public class QuestionPoolFacadeQueries
           // pool that item is attached to
           ArrayList metaList = new ArrayList();
           for (int j=0; j<list.size(); j++){
-            String itemId = ((QuestionPoolItemData)list.get(j)).getItemId();
+            Long itemId = ((QuestionPoolItemData)list.get(j)).getItemId();
             String query = "from ItemMetaData as meta where meta.item.itemId=? and meta.label=?";
             Object [] values = {Long.valueOf(itemId), ItemMetaDataIfc.POOLID};
     	    List m = getHibernateTemplate().find(query, values);
@@ -792,7 +792,7 @@ public class QuestionPoolFacadeQueries
    * @param itemId DOCUMENTATION PENDING
    * @param poolId DOCUMENTATION PENDING
    */
-  public void removeItemFromPool(String itemId, Long poolId) {
+  public void removeItemFromPool(Long itemId, Long poolId) {
     QuestionPoolItemData qpi = new QuestionPoolItemData(poolId, itemId);
     int retryCount = PersistenceService.getInstance().getPersistenceHelper().getRetryCount().intValue();
     while (retryCount > 0){
@@ -813,7 +813,7 @@ public class QuestionPoolFacadeQueries
    * @param itemId DOCUMENTATION PENDING
    * @param poolId DOCUMENTATION PENDING
    */
-  public void moveItemToPool(String itemId, Long sourceId, Long destId) {
+  public void moveItemToPool(Long itemId, Long sourceId, Long destId) {
     QuestionPoolItemData qpi = new QuestionPoolItemData(sourceId, itemId);
     int retryCount = PersistenceService.getInstance().getPersistenceHelper().getRetryCount().intValue();
     while (retryCount > 0){
@@ -1232,7 +1232,7 @@ public class QuestionPoolFacadeQueries
     Iterator iter = itemDataArray.iterator();
     while (iter.hasNext()){
       ItemDataIfc itemData = (ItemDataIfc) iter.next();
-      set.add(new QuestionPoolItemData(questionPoolId, itemData.getItemIdString(), (ItemData) itemData));
+      set.add(new QuestionPoolItemData(questionPoolId, itemData.getItemId(), (ItemData) itemData));
     }
     return set;
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueriesAPI.java
@@ -140,7 +140,7 @@ public interface QuestionPoolFacadeQueriesAPI
    * @param itemId DOCUMENTATION PENDING
    * @param poolId DOCUMENTATION PENDING
    */
-  public void removeItemFromPool(String itemId, Long poolId);
+  public void removeItemFromPool(Long itemId, Long poolId);
 
   /**
    * DOCUMENTATION PENDING
@@ -148,7 +148,7 @@ public interface QuestionPoolFacadeQueriesAPI
    * @param itemId DOCUMENTATION PENDING
    * @param poolId DOCUMENTATION PENDING
    */
-  public void moveItemToPool(String itemId, Long sourceId, Long destId);
+  public void moveItemToPool(Long itemId, Long sourceId, Long destId);
 
   /**
    * DOCUMENTATION PENDING

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/QuestionPoolService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/QuestionPoolService.java
@@ -292,7 +292,7 @@ public class QuestionPoolService
   /**
    * Save a question to a pool.
    */
-  public void addItemToPool(String itemId, Long poolId)
+  public void addItemToPool(Long itemId, Long poolId)
   {
     try
     {
@@ -308,7 +308,7 @@ public class QuestionPoolService
   /**
    * Move a question to a pool.
    */
-  public void moveItemToPool(String itemId, Long sourceId, Long destId)
+  public void moveItemToPool(Long itemId, Long sourceId, Long destId)
   {
     try
     {
@@ -396,7 +396,7 @@ public class QuestionPoolService
   /**
    * removes a Question from the question pool. This does not  *delete* the question itself
    */
-  public void removeQuestionFromPool(String questionId, Long poolId)
+  public void removeQuestionFromPool(Long questionId, Long poolId)
   {
     try
     {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/questionpool/QuestionPoolServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/questionpool/QuestionPoolServiceImpl.java
@@ -242,7 +242,7 @@ public class QuestionPoolServiceImpl
   /**
    * Save a question to a pool.
    */
-  public void addItemToPool(String itemId, Long poolId)
+  public void addItemToPool(Long itemId, Long poolId)
   {
     try
     {
@@ -258,7 +258,7 @@ public class QuestionPoolServiceImpl
   /**
    * Move a question to a pool.
    */
-  public void moveItemToPool(String itemId, Long sourceId, Long destId)
+  public void moveItemToPool(Long itemId, Long sourceId, Long destId)
   {
     try
     {
@@ -322,7 +322,7 @@ public class QuestionPoolServiceImpl
   /**
    * removes a Question from the question pool. This does not  *delete* the question itself
    */
-  public void removeQuestionFromPool(String questionId, Long poolId)
+  public void removeQuestionFromPool(Long questionId, Long poolId)
   {
     try
     {


### PR DESCRIPTION

You currently cannot add questions to a question pool (I've tried several types but not all).

On the first attempt, you don't get a bug report on the UI. It just transfers you to the author index and appears like nothing happened. The question is not added to the question pool.

On the second attempt, you'll get the attached stack trace.

This is directly related to the DDL changes in SAM-2242; however there is a bunch of code laying around that assumes the IDs to be Strings, but they've been changed to ints.