### PR TITLE
SAK-22252 Allows login text and site urls in site member notification email

### DIFF
--- a/site-manage/site-manage-api/api/src/java/org/sakaiproject/sitemanage/api/UserNotificationProvider.java
+++ b/site-manage/site-manage-api/api/src/java/org/sakaiproject/sitemanage/api/UserNotificationProvider.java
@@ -21,19 +21,22 @@ public interface UserNotificationProvider {
 	public static final String SITE_REF_PREFIX	= "/site/";
 
 	/**
-	 * Send an email to newly added user informing password
+	 * Send an email to newly added user informing them of their password.
 	 * 
-	 * @param newnonOfficialAccount
-	 * @param emailId
-	 * @param userName
-	 * @param siteTitle
+	 * @param newUser The newly created user.
+	 * @param newUserPassword The password for the newly created user.
+	 * @param site The site in which the new user was created.
 	 */
-	public void notifyNewUserEmail(User user, String newUserPassword, String siteTitle);
+	public void notifyNewUserEmail(User newUser, String newUserPassword, Site site);
 
 	/**
-	 * send email notification to added participant
+	 * Send email notification to added participant indicating they have been added to a site.
+	 * 
+	 * @param nonOfficialAccount <code>true</code> if the added user is a guest user rather than an official one.
+	 * @param user The user who was newly added to the site.
+	 * @param site The site to which the user was added as a participant.
 	 */
-	public void notifyAddedParticipant(boolean newNonOfficialAccount, User user, String siteTitle); 
+	public void notifyAddedParticipant(boolean nonOfficialAccount, User user, Site site); 
 	
 	/**
 	 * send email notification to template contact people about template usage

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
@@ -101,24 +101,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 	public void init() {
 		//nothing realy to do
 		M_log.info("init()");
-		
-		
-		//do we need to load data?
-		Map<String, String> replacementValues = new HashMap<String, String>();
-		
-		// put placeholders for replacement values 
-		replacementValues.put("userName", "");
-        replacementValues.put("userEid", "");
-        replacementValues.put("localSakaiName", "");
-        replacementValues.put("currentUserName", "");
-        replacementValues.put("currentUserDisplayName", "");
-        replacementValues.put("localSakaiURL", "");
-        replacementValues.put("siteName", "");
-        replacementValues.put("productionSiteName", "");
-        replacementValues.put("newNonOfficialAccount", "false");
-        replacementValues.put("newPassword", "");
-        replacementValues.put("productionSiteName", "");
-        
+
     	loadTemplate("notifyAddedParticipants.xml", NOTIFY_ADDED_PARTICIPANT);
     	loadTemplate("notifyNewuser.xml", NOTIFY_NEW_USER);
     	loadTemplate("notifyTemplateUse.xml", NOTIFY_TEMPLATE_USE);
@@ -133,7 +116,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 	}
 	
 	public void notifyAddedParticipant(boolean newNonOfficialAccount,
-			User user, String siteTitle) {
+			User user, Site site) {
 		
 		String from = serverConfigurationService.getBoolean(NOTIFY_FROM_CURRENT_USER, false)?
 				getCurrentUserEmailAddress():getSetupRequestEmailAddress();
@@ -162,16 +145,18 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 			 Map<String, String> replacementValues = new HashMap<String, String>();
 			 replacementValues.put("userName", user.getDisplayName());
 			 replacementValues.put("userEid", user.getEid());
-			 replacementValues.put("localSakaiName",serverConfigurationService.getString(
-	    				"ui.service", ""));
+			 replacementValues.put("localSakaiName", productionSiteName);
 			 replacementValues.put("currentUserName",userDirectoryService.getCurrentUser().getDisplayName());
 			 replacementValues.put("localSakaiUrl", serverConfigurationService.getPortalUrl());
 			 String nonOfficialAccountUrl = serverConfigurationService.getString("nonOfficialAccount.url", null);
 			 replacementValues.put("hasNonOfficialAccountUrl", nonOfficialAccountUrl!=null?Boolean.TRUE.toString().toLowerCase():Boolean.FALSE.toString().toLowerCase());
 			 replacementValues.put("nonOfficialAccountUrl",nonOfficialAccountUrl);
-			 replacementValues.put("siteName", siteTitle);
+			 replacementValues.put("siteName", site.getTitle());
 			 replacementValues.put("productionSiteName", productionSiteName);
 			 replacementValues.put("newNonOfficialAccount", Boolean.valueOf(newNonOfficialAccount).toString().toLowerCase());
+			 replacementValues.put("xloginText", serverConfigurationService.getString("xlogin.text", "Login"));
+			 replacementValues.put("loginText", serverConfigurationService.getString("login.text", "Login"));
+			 replacementValues.put("siteUrl", site.getUrl());
 			 
 			 // send email
 			 emailTemplateServiceSend(NOTIFY_ADDED_PARTICIPANT, null, user, from, to, headerTo, replyTo, replacementValues);
@@ -182,7 +167,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 	}
 
 	public void notifyNewUserEmail(User user, String newUserPassword,
-			String siteTitle) {
+			Site site) {
 		
 		
 		String from = getSetupRequestEmailAddress();
@@ -208,7 +193,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 			replacementValues.put("userEid", user.getEid());
 			replacementValues.put("localSakaiUrl", serverConfigurationService.getPortalUrl());
 			replacementValues.put("newPassword",newUserPassword);
-			replacementValues.put("siteName", siteTitle);
+			replacementValues.put("siteName", site.getTitle());
 			replacementValues.put("productionSiteName", productionSiteName);
 
 			// send email

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UserNotificationProviderImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UserNotificationProviderImpl.java
@@ -61,7 +61,7 @@ public class UserNotificationProviderImpl implements UserNotificationProvider {
 	 * {@inheritDoc}
 	 */
 	public void notifyAddedParticipant(boolean newNonOfficialAccount,
-			User user, String siteTitle) {
+			User user, Site site) {
 		ResourceLoader rb = new ResourceLoader(user.getId(), "UserNotificationProvider");
 		
 		String from = serverConfigurationService.getBoolean(NOTIFY_FROM_CURRENT_USER, false)?
@@ -90,7 +90,7 @@ public class UserNotificationProviderImpl implements UserNotificationProvider {
 			buf.append(rb.getString("java.following") + " "
 					+ productionSiteName + " "
 					+ rb.getString("java.simplesite") + "\n");
-			buf.append(siteTitle + "\n");
+			buf.append(site.getTitle() + "\n");
 			buf.append(rb.getString("java.simpleby") + " ");
 			buf.append(userDirectoryService.getCurrentUser().getDisplayName()
 					+ ". \n\n");
@@ -130,7 +130,7 @@ public class UserNotificationProviderImpl implements UserNotificationProvider {
 	 * {@inheritDoc}
 	 */
 	public void notifyNewUserEmail(User user, String newUserPassword,
-			String siteTitle) {
+			Site site) {
 		ResourceLoader rb = new ResourceLoader("UserNotificationProvider");
 		// set the locale to individual receipient's setting
 		rb.setContextLocale(rb.getLocale(user.getId()));

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -622,8 +622,8 @@ public class SiteAddParticipantHandler {
 
 								// send notification
 								if (notify) {
-									// send notification email
-									notiProvider.notifyAddedParticipant(!isOfficialAccount(eId), user, site.getTitle());
+									// send notification email 
+									notiProvider.notifyAddedParticipant(!isOfficialAccount(eId), user, site);
 									
 								}
 							}
@@ -732,7 +732,7 @@ public class SiteAddParticipantHandler {
 								.equalsIgnoreCase(Boolean.TRUE.toString());
 						boolean validateUsers = serverConfigurationService.getBoolean("siteManage.validateNewUsers", true);
 						if (notifyNewUserEmail && !validateUsers) {    						
-								notiProvider.notifyNewUserEmail(uEdit, pw, site != null ? site.getTitle():"");
+								notiProvider.notifyNewUserEmail(uEdit, pw, site);
 						} else if (notifyNewUserEmail && validateUsers) {
 							validationUsers.add(uEdit.getId());
 						}


### PR DESCRIPTION
Allows login text and site urls in site member notification email
templates. This doesn't change the actual templates, just injects the
values if the placeholders are there.