### PR TITLE
KNL-1332 Add source generation by default

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -69,7 +69,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+            <version>2.4</version>
             <executions>
               <execution>
                 <goals>
@@ -519,6 +519,20 @@
         <configuration>
           <warSourceDirectory>${basedir}/src/main/webapp</warSourceDirectory>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
 


### PR DESCRIPTION
Turns on source jar generation by default so that mvn eclipse:eclipse automatically links it up in other projects.