### PR TITLE
SAM-2499: Whitespace from CKEditor affects question text sorting and display in Question Pool's questions table

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
@@ -1246,7 +1246,8 @@ public class ItemContentsBean implements Serializable {
 		if (text != null) {
 			//text = text.replaceAll("<.*?>", " ");
 			//text = FormattedText.convertFormattedTextToPlaintext(text);
-			text = FormattedText.stripHtmlFromText(text, true); // SAM-2277
+			//text = FormattedText.stripHtmlFromText(text, true); // SAM-2277
+			text = FormattedText.stripHtmlFromText( text, false, true ).trim(); // SAM-2499
 		}
 		return text;
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
@@ -43,6 +43,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.tool.assessment.data.dao.assessment.Answer;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AnswerFeedback;
 import org.sakaiproject.tool.assessment.data.dao.assessment.ItemData;
@@ -58,6 +59,7 @@ import org.sakaiproject.tool.assessment.osid.shared.impl.IdImpl;
 import org.sakaiproject.tool.assessment.services.ItemService;
 import org.sakaiproject.tool.assessment.services.PersistenceService;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
+import org.sakaiproject.util.api.FormattedText;
 import org.springframework.dao.DataAccessException;
 import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
@@ -68,6 +70,9 @@ public class QuestionPoolFacadeQueries
   
   // SAM-2049
   private static final String VERSION_START = " - ";
+  
+  // SAM-2499
+  private final FormattedText formattedText = (FormattedText) ComponentManager.get( FormattedText.class );
 
   public QuestionPoolFacadeQueries() {
   }
@@ -329,7 +334,10 @@ public class QuestionPoolFacadeQueries
 	    	facadeVector.add(itemFacade);
 	    	log.debug("QuestionPoolFacadeQueries: getAllItemFacadesOrderByItemText:: getItemId = " + itemData.getItemId());
 	    	log.debug("QuestionPoolFacadeQueries: getAllItemFacadesOrderByItemText:: getText = " + itemData.getText());
-	    	text = itemFacade.getText();
+	    	
+	    	// SAM-2499
+	    	text = formattedText.stripHtmlFromText( itemFacade.getText(), false, true ).trim();
+	    	
 	    	log.debug("QuestionPoolFacadeQueries: getAllItemFacadesOrderByItemText:: getTextHtmlStrippedAll = '" + text + "'");
 	    	
 	    	origValueV = (Vector) hp.get(text);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2499

When creating questions using the CKEditor, the editor adds a paragraph tag around the question text.

When the question text is displayed in the Questions table in Question Pools, the markup is removed, but the sort order is not correct. Behind the scenes, it is taking into account the markup and any leading/trailing whitespace in the question text when determining the sort order.

Adding manual leading/tailing whitespace in the CKEditor will also affect the sort order.

When viewing the table, leading/tailing whitespace for questions created with the basic (text area) editor is stripped for display in the UI, but questions created with the CKEditor do not get the whitespace striped for the UI.