### PR TITLE
SAK-29099: password validation for users tool and reset-pass makes too many queries, which can result in lost keystrokes

### DIFF
--- a/reset-pass/account-validator-tool/src/webapp/js/accountValidator.js
+++ b/reset-pass/account-validator-tool/src/webapp/js/accountValidator.js
@@ -13,6 +13,7 @@ VALIDATOR.firstNameValid = false;
 VALIDATOR.lastNameValid = false;
 VALIDATOR.termsChecked = false;
 VALIDATOR.isPasswordPolicyEnabled = false;
+VALIDATOR.lastSentPasswordLength = 0; // SAK-29099
 
 // Validate the password from the form
 VALIDATOR.validatePassword = function() {
@@ -25,6 +26,11 @@ VALIDATOR.validatePassword = function() {
 	var strengthInfo = VALIDATOR.get("strengthInfo");
 	var strengthBar = VALIDATOR.get("strengthBar");
 	var strengthBarMeter = VALIDATOR.get("strengthBarMeter");
+	
+	// SAK-29099 - password likely hasn't changed, so abort
+	if (pw.length === VALIDATOR.lastSentPasswordLength) {
+		return;
+	}
 	
 	// If the password policy is enabled and the password field has a value
 	if (VALIDATOR.isPasswordPolicyEnabled && pw.length > 0) {
@@ -53,6 +59,9 @@ VALIDATOR.validatePassword = function() {
 					VALIDATOR.passwordValid = true;
 					VALIDATOR.passwordStrong = true;
 				}
+				
+				// SAK-29099 - track current length of input password
+				VALIDATOR.lastSentPasswordLength = pw.length;
 	    	}
 	    });
 		
@@ -99,7 +108,7 @@ VALIDATOR.validatePassword = function() {
 	
 	// Verify the passwords match (which in turn validates the form)
 	VALIDATOR.verifyPasswordsMatch();
-}
+};
 
 // Verify the passwords match
 VALIDATOR.verifyPasswordsMatch = function() {
@@ -119,7 +128,7 @@ VALIDATOR.verifyPasswordsMatch = function() {
 	}
 	
 	VALIDATOR.validateActivateForm();
-}
+};
 
 // Validate the first name on the form
 VALIDATOR.validateFirstName = function() {
@@ -130,7 +139,7 @@ VALIDATOR.validateFirstName = function() {
 	}
 	
 	VALIDATOR.validateActivateForm();
-}
+};
 
 // Validate the last name on the form
 VALIDATOR.validateLastName = function() {
@@ -141,7 +150,7 @@ VALIDATOR.validateLastName = function() {
 	}
 	
 	VALIDATOR.validateActivateForm();
-}
+};
 
 VALIDATOR.validateTermsChecked = function() {
 	VALIDATOR.termsChecked = true;
@@ -152,7 +161,7 @@ VALIDATOR.validateTermsChecked = function() {
 	}
 
 	VALIDATOR.validateActivateForm();
-}
+};
 
 // Conditionally show/hide the strength info message
 VALIDATOR.displayStrengthInfo = function() {
@@ -168,12 +177,12 @@ VALIDATOR.displayStrengthInfo = function() {
 		
 		VALIDATOR.display(strengthInfo, showStrengthInfo);
 	}
-}
+};
 
 // Validate the form (enable/disable the submit button)
 VALIDATOR.validateActivateForm = function() {
 	var submitButton = VALIDATOR.get("addDetailsSub");
-	if (submitButton != null)
+	if (submitButton !== null)
 	{
 		if (VALIDATOR.firstNameValid && VALIDATOR.lastNameValid && VALIDATOR.passwordValid && VALIDATOR.passwordsMatch && VALIDATOR.termsChecked) {
 			submitButton.disabled = false;
@@ -182,7 +191,7 @@ VALIDATOR.validateActivateForm = function() {
 			submitButton.disabled = true;
 		}
 	}
-}
+};
 
 // bbailla2 - enables/disables the Transfer memberships button as well as the yes button based on how the required fields are filled
 VALIDATOR.checkTransferStatus = function() {
@@ -205,17 +214,17 @@ VALIDATOR.checkTransferStatus = function() {
 			transfer.disabled = true;
 		}
 	}
-}
+};
 
 // Get an element by ID
 VALIDATOR.get = function(id) {
 	return document.getElementById(id);
-}
+};
 
 //Determine if the given string is empty/null
 VALIDATOR.isEmpty = function(inputString) {
 	return inputString === null || inputString.length === 0 || inputString.replace(/^\s*/, "").replace(/\s*$/, "") === "";
-}
+};
 
 // Show/hide the given element
 VALIDATOR.display = function(element, show) {
@@ -225,7 +234,7 @@ VALIDATOR.display = function(element, show) {
 	else {
 		element.style.display = "none";
 	}
-}
+};
 
 // Original document ready function
 $(document).ready(function() {

--- a/user/user-tool/tool/src/webapp/js/userCreateValidation.js
+++ b/user/user-tool/tool/src/webapp/js/userCreateValidation.js
@@ -70,7 +70,7 @@ USER.verifyPasswordsMatch = function () {
     }
 
     USER.validateForm();
-}
+};
 
 // Validate the user ID from the form
 USER.validateUserId = function () {

--- a/user/user-tool/tool/src/webapp/js/userEditValidation.js
+++ b/user/user-tool/tool/src/webapp/js/userEditValidation.js
@@ -30,7 +30,7 @@ USER.validateUserId = function () {
     }
 
     USER.validatePassword();
-}
+};
 
 // Validate the password from the form
 USER.validatePassword = function () {

--- a/user/user-tool/tool/src/webapp/js/userValidationCommon.js
+++ b/user/user-tool/tool/src/webapp/js/userValidationCommon.js
@@ -31,6 +31,7 @@ USER.passwordModerate = false;
 USER.passwordStrong = false;
 USER.passwordsMatch = false;
 USER.isPasswordPolicyEnabled = false;
+USER.lastSentPasswordLength = 0; // SAK-29099
 
 // Get an element by ID
 USER.get = function (id) {
@@ -54,7 +55,7 @@ USER.display = function (element, show) {
             element.style.display = "none";
         }
     }
-}
+};
 
 // Validate the given email address string
 USER.checkEmail = function (email) {
@@ -64,7 +65,7 @@ USER.checkEmail = function (email) {
 
     var simpleRegexForEmail = /\S+@\S+\.\S\S+/;
     return simpleRegexForEmail.test(email);
-}
+};
 
 // Conditionally hide/show the strength info message
 USER.displayStrengthInfo = function () {
@@ -80,10 +81,16 @@ USER.displayStrengthInfo = function () {
 
         USER.display(strengthInfo, showStrengthInfo);
     }
-}
+};
 
 // Make the AJAX call to the validate password REST endpoint
 USER.validatePasswordREST = function (password, username) {
+    
+    // SAK-29099 - password likely hasn't changed, so abort
+    if (password.length === USER.lastSentPasswordLength) {
+        return;
+    }
+    
     jQuery.ajax({
         url: "/direct/user/validatePassword",
         type: "POST",
@@ -107,9 +114,12 @@ USER.validatePasswordREST = function (password, username) {
                 USER.passwordValid = true;
                 USER.passwordStrong = true;
             }
+            
+            // SAK-29099 - track current length of input password
+            USER.lastSentPasswordLength = password.length;
         }
     });
-}
+};
 
 // Display the appropriate messages based on the current password valid and strength status
 USER.displayMessages = function (strongMsg, moderateMsg, weakMsg, failMsg, strengthBar, strengthBarMeter) {
@@ -138,7 +148,7 @@ USER.displayMessages = function (strongMsg, moderateMsg, weakMsg, failMsg, stren
     var showStrengthBar = (USER.passwordStrong || USER.passwordModerate || USER.passwordWeak || !USER.passwordValid);
     USER.display(strengthBar, showStrengthBar);
     USER.display(strengthBarMeter, showStrengthBar);
-}
+};
 
 // Hide all password policy related messages
 USER.hideAllElements = function (strongMsg, moderateMsg, weakMsg, failMsg, strengthInfo, strengthBar, strengthBarMeter) {
@@ -149,4 +159,4 @@ USER.hideAllElements = function (strongMsg, moderateMsg, weakMsg, failMsg, stren
     USER.display(strengthInfo, false);
     USER.display(strengthBar, false);
     USER.display(strengthBarMeter, false);
-}
+};


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29099

Currently, the password validation algorithm makes a REST call for every keystroke entered by the user. If the user types quickly, this can result in lost keystrokes due to the latency of the REST call.

Our solution to this is to track the length of the input password. If the length has not changed since the last REST call, don't make another one. By doing so, it eliminates un-necessary calls to the REST service and improves the reliability of the algorithm so that keystrokes are not lost.

The linked PR/patch also addresses some minor JavaScript syntax errors.