### PR TITLE
SAM-1874 - Samigo should generate it's temp directory automatically from

### DIFF
--- a/samigo/samigo-app/src/java/com/corejsf/UploadFilter.java
+++ b/samigo/samigo-app/src/java/com/corejsf/UploadFilter.java
@@ -116,6 +116,15 @@ public class UploadFilter implements Filter {
       DiskFileUpload upload = new DiskFileUpload();
       if (repositoryPath != null)
          upload.setRepositoryPath(repositoryPath);
+      else {
+        String tempdir = System.getProperty("java.io.tmpdir");
+        if ( tempdir != null) {
+          if ( !(tempdir.endsWith("/") || tempdir.endsWith("\\")) ) {
+            tempdir = tempdir + System.getProperty("file.separator");
+          }
+          upload.setRepositoryPath(tempdir);
+          }
+        }
 
       try {
          List list = upload.parseRequest(httpRequest);


### PR DESCRIPTION
This old issue was coming up on nightly this week. It looks like it was just a fix to the UploadFilter local to Samigo. Other JSF tools (msgcntr, postem, syllabus) also seem to have a similar upload filter which may also possibly have this problem. I'd like to test this some more and get maybe a little feed back.

It seemed to be happening on nightly even submitting multipart data on a regular assessment, this was the error. On my local host, it doesn't seem to be coming up the same, so I'll probably have to test on nightly. The problem there was this directory existed but it was owned by another user so it conflicted.

Caused by: org.apache.commons.fileupload.FileUploadBase$IOFileUploadException: Processing of multipart/form-data request failed. /tmp/tomcat-nightly-mysql/upload_00a55aad_2fb7_468f_a038_2861d5c73d0d_00000044.tmp (Permission denied)
        at org.apache.commons.fileupload.FileUploadBase.parseRequest(FileUploadBase.java:351)
        at org.apache.commons.fileupload.FileUploadBase.parseRequest(FileUploadBase.java:288)
        at com.corejsf.UploadFilter.doFilter(UploadFilter.java:121)
        ... 52 more
