### PR TITLE
SAK-29135: remove unused mathjax property from sakai.properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3837,9 +3837,6 @@
 # URL to MathJax.js, you can use the one on the mathjax CDN or put one locally. Currently this is not included with Sakai
 #portal.mathjax.src.path=http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe 
 
-# URL to display linking to more information about mathjax and equations
-#portal.mathjax.website.url=http://www.mathjax.org 
-
 # Whether to allow useres to enable or disable MathJAX, this still has to be enabled on a per site basis
 #portal.mathjax.enabled=true
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29135

portal.mathjax.website.url was part of the initial MathJax feature, however it was removed during one of the revisions.

The sakai.property remains and should be removed. 