### PR TITLE
SAM-2495 need to round doubles to two decimals in a consistent way

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemBean.java
@@ -33,23 +33,23 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.sakaiproject.util.ResourceLoader;
-
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 import javax.faces.event.ValueChangeEvent;
 import javax.faces.model.SelectItem;
 import javax.faces.model.SelectItemGroup;
 
+import org.apache.commons.math.util.MathUtils;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.tool.assessment.facade.TypeFacade;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService; 
-
 import org.sakaiproject.tool.assessment.data.dao.assessment.FavoriteColChoices;
 import org.sakaiproject.tool.assessment.data.dao.assessment.FavoriteColChoicesItem;
+import org.sakaiproject.util.ResourceLoader;
+
 
 /**
  * UI bean for authoring an Item
@@ -72,8 +72,8 @@ public class ItemBean
   private String itemText;
   private String itemId;
   private String itemType;
-  private String itemScore= "0";
-  private String itemDiscount = "0";
+  private double itemScore= 0.0d;
+  private double itemDiscount = 0.0d;
   private String partialCreditFlag = "Defualt";
   private String[] answers;
   private String[] answerLabels;  //  such as A, B, C
@@ -239,16 +239,16 @@ public class ItemBean
    * value of question
    * @return score it is worth
    */
-  public String getItemScore()
+  public double getItemScore()
   {
-    return itemScore;
+    return MathUtils.round(itemScore, 2);
   }
 
   /**
    * value of question
    * @param score
    */
-  public void setItemScore(String score)
+  public void setItemScore(double score)
   {
     this.itemScore= score;
   }
@@ -257,23 +257,18 @@ public class ItemBean
    * value of question discount
    * @return discountit is worth
    */
-  public String getItemDiscount()
+  public double getItemDiscount()
   {
-    return itemDiscount;
+    return MathUtils.round(itemDiscount, 2);
   }
 
   /**
    * value of question discount
    * @param discount
    */
-  public void setItemDiscount(String discount)
+  public void setItemDiscount(double discount)
   {
-	if (discount.startsWith("-"))
-    	{
- 	  this.itemDiscount= discount.substring(1);
-    	}else{
-     	  this.itemDiscount= discount;
-        }
+    this.itemDiscount = Math.abs(discount);
   }
   
   /**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ContentsDeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ContentsDeliveryBean.java
@@ -24,6 +24,7 @@
 package org.sakaiproject.tool.assessment.ui.bean.delivery;
 
 import java.io.Serializable;
+import org.apache.commons.math.util.MathUtils;
 
 /**
  * <p> Table of Contents and Contents Data</p>
@@ -128,7 +129,7 @@ private java.util.ArrayList partsContents;
 	  String pointsDisplayString = "";
 	  if (showStudentScore)
 	  {
-		  pointsDisplayString = "" + currentScore;
+		  pointsDisplayString = "" + MathUtils.round(currentScore, 2);
 	  }
 	  return pointsDisplayString;
   }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
@@ -34,6 +34,7 @@ import javax.faces.model.SelectItem;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.math.util.MathUtils;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.MediaData;
@@ -248,7 +249,7 @@ public class ItemContentsBean implements Serializable {
 	 * @return String representation of the points.
 	 */
 	public double getPoints() {
-		return SectionContentsBean.roundTo2Decimals(points);
+		return MathUtils.round(points, 2);
 	}
 
 	/**
@@ -304,7 +305,7 @@ public class ItemContentsBean implements Serializable {
      * @return String representation of the discount.
      */
     public double getDiscount() {
-    	 return SectionContentsBean.roundTo2Decimals(discount);
+    	 return MathUtils.round(discount, 2);
     }
 
     /**
@@ -471,7 +472,7 @@ public class ItemContentsBean implements Serializable {
 	 * @return String representation of the max points.
 	 */
 	public double getRoundedMaxPoints() {
-		return SectionContentsBean.roundTo2Decimals(maxPoints);
+		return MathUtils.round(maxPoints, 2);
 	}
 
 	/**
@@ -1235,8 +1236,9 @@ public class ItemContentsBean implements Serializable {
 	 */
 	public String getPointsDisplayString() {
 		String pointsDisplayString = "";
+System.out.println("zz01: " + points);
 		if (showStudentQuestionScore) {
-			pointsDisplayString = SectionContentsBean.roundTo2Decimals(points)
+			pointsDisplayString = MathUtils.round(points, 2)
 					+ "/";
 		}
 		return pointsDisplayString;
@@ -1284,7 +1286,7 @@ public class ItemContentsBean implements Serializable {
   }
 
   public Double getUpdatedScore () {
-	  return itemData.getScore();
+	  return MathUtils.round(itemData.getScore(), 2);
   }
 	 
   public void setUpdatedScore(Double score) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
@@ -39,6 +39,7 @@ import javax.faces.model.SelectItem;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.math.util.MathUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -180,7 +181,7 @@ public class SectionContentsBean
   {
     // only show 2 decimal places 
     
-    return roundTo2Decimals(maxPoints);
+    return MathUtils.round(maxPoints, 2);
   }
 
   /**
@@ -667,17 +668,9 @@ public class SectionContentsBean
     String pointsDisplayString = "";
     if (showStudentQuestionScore)
     {
-      pointsDisplayString = roundTo2Decimals(points) + "/";
+      pointsDisplayString = MathUtils.round(points, 2) + "/";
     }
     return pointsDisplayString;
-  }
-
-  public static double roundTo2Decimals(double points)
-  {
-    Double dTmp = points * 100.0d;
-    int tmp = dTmp.intValue();
-    points = (double) tmp / 100.0d;
-    return points;
   }
 
   public List getAttachmentList() {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -38,6 +38,7 @@ import javax.faces.event.ActionEvent;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.math.util.MathUtils;
 import org.sakaiproject.jsf.model.PhaseAware;
 import org.sakaiproject.tool.assessment.business.entity.RecordingData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentAccessControl;
@@ -70,7 +71,7 @@ public class QuestionScoresBean
   private String itemId;
   private String anonymous;
   private String groupName;
-  private String maxScore;
+  private double maxScore;
   private Collection agents;
   //private Collection sortedAgents;
   private Collection sections;
@@ -336,9 +337,9 @@ public class QuestionScoresBean
    *
    * @return the max score
    */
-  public String getMaxScore()
+  public double getMaxScore()
   {
-    return Validator.check(maxScore, "N/A");
+    return MathUtils.round(maxScore, 2);
   }
 
   /**
@@ -346,10 +347,11 @@ public class QuestionScoresBean
    *
    * @param pmaxScore set the max score
    */
-  public void setMaxScore(String pmaxScore)
+  public void setMaxScore(double pmaxScore)
   {
     maxScore = pmaxScore;
   }
+
 /**
    * get the max Point
    *
@@ -359,9 +361,8 @@ public class QuestionScoresBean
     {  
 	  ResourceLoader rb=new ResourceLoader("org.sakaiproject.tool.assessment.bundle.EvaluationMessages");
 	try{
-		if (Double.parseDouble(this.getMaxScore())==1.0)
+		if (this.getMaxScore() == 1.0)
 			return this.getMaxScore()+ " " + rb.getString("point");
-
 	else
 		return this.getMaxScore()+ " " + rb.getString("points");
 	}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
@@ -145,27 +145,19 @@ public class ItemModifyListener implements ActionListener
         itemauthorbean.setItemNo(String.valueOf(itemfacade.getSequence().intValue() ));
       }
 
-      Double points = itemfacade.getScore();
-      String score;
-      if (points!=null)
+      Double score = itemfacade.getScore();
+      if (score == null)
        {
-        score = points.toString();
-       }
-      else // cover modifying an imported XML assessment that has no score yet
-       {
-         score ="0.0";
+         // cover modifying an imported XML assessment that has no score yet
+         score = 0.0d;
        }
       bean.setItemScore(score);
 
-      Double discountpoints = itemfacade.getDiscount();
-      String discount;
-      if (discountpoints!=null)
+      Double discount = itemfacade.getDiscount();
+      if (discount == null)
       {
-    	  discount = discountpoints.toString();
-      }
-      else // cover modifying an imported XML assessment that has no score yet
-      {
-    	  discount ="0.0";
+        // cover modifying an imported XML assessment that has no score yet
+    	  discount = 0.0d;
       }
       bean.setItemDiscount(discount);
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -412,7 +412,7 @@ public class QuestionScoreListener implements ActionListener,
 			}
 			try {
 				bean.setMaxScore(publishedAssessment.getEvaluationModel()
-						.getFixedTotalScore().toString());
+						.getFixedTotalScore());
 			} catch (RuntimeException e) {
 				double score = (double) 0.0;
 				Iterator iter2 = publishedAssessment.getSectionArraySorted()
@@ -427,7 +427,7 @@ public class QuestionScoreListener implements ActionListener,
 							score = idata.getScore().doubleValue();
 					}
 				}
-				bean.setMaxScore(Double.toString(score));
+				bean.setMaxScore(score);
 			}
 			
 			// need to get id from somewhere else, not from data. data only

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
@@ -180,7 +180,7 @@ public class TotalScoreListener
     // reset question score page content 
     questionbean.setSections(new ArrayList());
     questionbean.setTypeId("0");   // if setting "", QuestionScoreBean.getTypeId will default to 1. Thus setting it to 0. 
-    questionbean.setMaxScore("");
+    questionbean.setMaxScore(0.0d);
     questionbean.setDeliveryItem(new ArrayList());
     questionbean.setSelectedSARationaleView(QuestionScoresBean.SHOW_SA_RATIONALE_RESPONSES_INLINE);
     

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -354,8 +354,7 @@ document.links[newindex].onclick();
       <h:outputText value=" #{deliveryMessages.dash} #{part.nonDefaultText}" escape="false"/>
          </h:panelGroup>
 
-      <h:outputText value="#{part.pointsDisplayString} #{part.maxPoints} #{deliveryMessages.pt}" 
-         rendered="#{delivery.actionString=='reviewAssessment'}"/>
+      <h:outputText value="#{part.pointsDisplayString} #{part.roundedMaxPoints} #{deliveryMessages.pt}" rendered="#{delivery.actionString=='reviewAssessment'}"/>
 </h:panelGrid>
       <f:verbatim></h4></f:verbatim>
       <h:outputText value="#{part.description}" escape="false"/>
@@ -377,9 +376,9 @@ document.links[newindex].onclick();
            <f:verbatim></h5></f:verbatim>
          </h:panelGroup>
 <h:panelGroup>
-<h:outputText value=" #{question.pointsDisplayString} #{question.maxPoints} #{deliveryMessages.pt}" rendered="#{delivery.actionString=='reviewAssessment'}"/>
+<h:outputText value=" #{question.pointsDisplayString} #{question.roundedMaxPoints} #{deliveryMessages.pt}" rendered="#{delivery.actionString=='reviewAssessment'}"/>
 
-        <h:outputText value="#{question.maxPoints} #{deliveryMessages.pt}" rendered="#{delivery.actionString!='reviewAssessment'}" />
+        <h:outputText value="#{question.roundedMaxPoints} #{deliveryMessages.pt}" rendered="#{delivery.actionString!='reviewAssessment'}" />
 </h:panelGroup>
 </h:panelGrid>
           <f:verbatim><div class="tier3"></f:verbatim>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/reviewAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/reviewAssessment.jsp
@@ -65,7 +65,7 @@
       <h:outputText value=" #{deliveryMessages.dash} #{part.text} />
       <!-- h:outputText value="#{part.unansweredQuestions}/#{part.questions} " / -->
       <!-- h:outputText value="#{deliveryMessages.ans_q}, " / -->
-      <!-- h:outputText value="#{part.points}/#{part.maxPoints} #{deliveryMessages.pt}" / -->
+      <!-- h:outputText value="#{part.points}/#{part.roundedMaxPoints} #{deliveryMessages.pt}" / -->
       <f:verbatim></h4><div class="tier1"></f:verbatim>
       <h:outputText value="#{part.description}" escape="false"/>
       <f:verbatim></div></f:verbatim>
@@ -75,7 +75,7 @@
           <f:verbatim><h4 class="tier1"></f:verbatim>
           <h:outputText value="#{deliveryMessages.q} #{question.number} #{deliveryMessages.of} " />
           <h:outputText value="#{part.itemContentsSize} " />
-          <h:outputText value="#{question.points}#{deliveryMessages.splash}#{question.maxPoints} " />
+          <h:outputText value="#{question.points}#{deliveryMessages.splash}#{question.roundedMaxPoints} " />
           <h:outputText value="#{deliveryMessages.pt}"/>
           <f:verbatim></h4></f:verbatim>
           <h:outputText value="#{question.itemData.description}" escape="false"/>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -125,13 +125,13 @@ function toPoint(id)
   <h:column>
     <h:panelGroup>
       <samigo:hideDivision id="part" title = " #{deliveryMessages.p} #{part.number} #{evaluationMessages.dash} #{part.text} #{evaluationMessages.dash}
-       #{part.questions-part.unansweredQuestions}#{evaluationMessages.splash}#{part.questions} #{deliveryMessages.ans_q}, #{part.pointsDisplayString} #{part.maxPoints} #{deliveryMessages.pt}" > 
+       #{part.questions-part.unansweredQuestions}#{evaluationMessages.splash}#{part.questions} #{deliveryMessages.ans_q}, #{part.pointsDisplayString} #{part.roundedMaxPoints} #{deliveryMessages.pt}" > 
         <h:dataTable value="#{part.itemContents}" var="question">
           <h:column>
             <f:verbatim><h4 class="tier3"></f:verbatim>
               <h:panelGroup>
                 <h:outputLink value="##{part.number}#{deliveryMessages.underscore}#{question.number}"> 
-                  <h:outputText escape="false" value="#{question.number}#{deliveryMessages.dot} #{question.strippedText} #{question.maxPoints} #{deliveryMessages.pt} ">
+                  <h:outputText escape="false" value="#{question.number}#{deliveryMessages.dot} #{question.strippedText} #{question.roundedMaxPoints} #{deliveryMessages.pt} ">
 				  </h:outputText>
                 </h:outputLink>
               </h:panelGroup>
@@ -170,7 +170,7 @@ function toPoint(id)
 <f:validateDoubleRange/>
 <%--SAK-3776    <f:convertNumber maxFractionDigits="2"/> --%>
             </h:inputText>
-            <h:outputText value=" #{deliveryMessages.splash} #{question.maxPoints} " />
+            <h:outputText value=" #{deliveryMessages.splash} #{question.roundedMaxPoints} " />
             <h:outputText value="#{deliveryMessages.pt}"/>
           <f:verbatim><br/></f:verbatim>
 <h:message for="adjustedScore" style="color:red"/>


### PR DESCRIPTION
Following the steps in https://jira.sakaiproject.org/browse/SAM-2495 you can easily see several places in Samigo where 10 digits of decimal precision will display to the student or instructor.

This PR modifies both student and instructor view.  I also remove any custom rounding methods and just depend on MathUtils