### PR TITLE
SAM-2511 a more sane way of grabbing the samigo.questionScore.answerText.length property

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -630,22 +630,11 @@ public class QuestionScoreListener implements ActionListener,
 					// non-abbreviated answers
 					// for essay questions
 
-					int answerTextLength = 1000;
-					if (!bean.getTypeId().equals("5")) {
-						String s = ServerConfigurationService.getString("samigo.questionScore.answerText.length");
-						if (s != null) {
-							try {
-								answerTextLength = Integer.parseInt(s);
-							}
-							catch (NumberFormatException e) {
-								log.warn("NumberFormatException. Use the default value for answerTextLength");
-							}
-						}
-					}
-					else {
+					int answerTextLength = ServerConfigurationService.getInt("samigo.questionScore.answerText.length", 1000);
+					if (bean.getTypeId().equals("5")) {
 						answerTextLength = 35;
 					}
-					
+
 					// Fix for SAK-6932: Strip out all HTML tags except image tags
  					if (answerText.length() > answerTextLength) {
 						String noHTMLAnswerText;


### PR DESCRIPTION
I saw this error quite a bit in the logs.

https://jira.sakaiproject.org/browse/SAM-2511

My instinct is that the getString returns a null or empty string when unset.