### PR TITLE
SAK-29144 Allow hidden/disabled to be enabled/disabled.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1968,6 +1968,14 @@
 # DEFAULT: true
 # org.sakaiproject.site.tool.helper.order.rsf.PageListProducer.allowTitleEdit=false
 
+# Allow users to hide tools in Page Order Helper.
+# DEFAULT: true
+# poh.allow.hide=false
+
+# Allow users to lock tools in Page Order Helper.
+# DEFAULT: true
+# poh.allow.lock=false
+
 ## PODCAST
 # Configurable toolId for Resources tool check
 # DEFAULT: sakai.resources

--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
@@ -56,6 +56,15 @@ public class SitePageEditHandler {
     private final String SITE_UPD = "site.upd";
     private final String HELPER_ID = "sakai.tool.helper.id";
     private final String UNHIDEABLES_CFG = "poh.unhideables";
+    /**
+     * Configuration: Should the page order helper allow pages to be disabled?
+     */
+    public final String DISABLE_ENABLED_CFG = "poh.allow.lock";
+
+    /**
+     * Configuration: Should the page order helper allow pages to be hidden?
+     */
+    public final String HIDDEN_ENABLED_CFG = "poh.allow.hide";
     private final String PAGE_ADD = "pageorder.add";
     private final String PAGE_DELETE = "pageorder.delete";
     private final String PAGE_RENAME = "pageorder.rename";
@@ -409,7 +418,7 @@ public class SitePageEditHandler {
      *
      * @return true if this tool is allowed to be hidden
      */
-    public boolean allowsHide(String toolId) {
+    private boolean allowsHide(String toolId) {
         if (unhideables == null || !unhideables.contains(toolId))
             return true;
         return false;
@@ -425,6 +434,9 @@ public class SitePageEditHandler {
      * @return true if this tool is allowed to be hidden
      */
     public boolean allowsHide(SitePage page) {
+        if (!(serverConfigurationService.getBoolean(HIDDEN_ENABLED_CFG, true)))
+            return false;
+
         List<ToolConfiguration> tools = page.getTools();
         Iterator<ToolConfiguration> iPt = tools.iterator();
 
@@ -438,6 +450,17 @@ public class SitePageEditHandler {
             }
         }
         return hideable;
+    }
+
+    /**
+     * Can the page be disabled?
+     * @param page The SitePage that in question.
+     * @return <code>true</code> if the page can be disabled.
+     * @see #DISABLE_ENABLED_CFG
+     */
+    public boolean allowDisable(SitePage page) {
+        return serverConfigurationService.getBoolean(DISABLE_ENABLED_CFG, true) && allowsHide(page);
+
     }
  
     /**

--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageListProducer.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageListProducer.java
@@ -161,7 +161,7 @@ public class PageListProducer
                 
 		// NEW
 		// TODO: Force hidden if disabled
-                if (handler.allowsHide(page)) {
+                if (handler.allowDisable(page)) {
                     param.viewID = PageEditProducer.VIEW_ID;
                     param.visible = null;
                     if (handler.isEnabled(page)) {


### PR DESCRIPTION
This changes allows a deployment to disable functions of the Page Order Helper tool.