### PR TITLE
SAK-29145 Don’t allow some tools to be re-named.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1967,6 +1967,11 @@
 # iframe.allowed.macros=${USER_ID},${USER_EID},${USER_FIRST_NAME},${USER_LAST_NAME},${SITE_ID},${USER_ROLE},${SESSION_ID},${SITE_PROP:course-unique-id},${SITE_PROP:course-section-key}
 
 # PAGE ORDER HELPER
+# List of tool IDs that if present in a page prevent the page's title from being edited.
+# Multiple tools should be separated by commas.
+# DEFAULT: null
+# poh.uneditables=sakai.siteinfo
+
 # Allow users to edit the titles of tools. 
 # DEFAULT: true
 # org.sakaiproject.site.tool.helper.order.rsf.PageListProducer.allowTitleEdit=false

--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
@@ -41,6 +41,7 @@ public class SitePageEditHandler {
     private Map<String, SitePage> pages;
     public String[] selectedTools = new String[] {};
     private Set<String> unhideables;
+    private Set<String> uneditables;
     public String state;
     public String title = "";
     public String test;
@@ -56,6 +57,10 @@ public class SitePageEditHandler {
     private final String SITE_UPD = "site.upd";
     private final String HELPER_ID = "sakai.tool.helper.id";
     private final String UNHIDEABLES_CFG = "poh.unhideables";
+    /**
+     * Configuration: Tool IDs that page order help shouldn't allow to be hidden
+     */
+    private final String UNEDITABLES_CFG = "poh.uneditables";
     /**
      * Configuration: Should the page order helper allow pages to be disabled?
      */
@@ -74,6 +79,9 @@ public class SitePageEditHandler {
     private final String PAGE_DISABLE = "pageorder.disable";
     private final String SITE_REORDER = "pageorder.reorder";
     private final String SITE_RESET = "pageorder.reset";
+
+    // Preserve for configuration backward compat
+    public String ALLOW_TITLE_EDIT = "org.sakaiproject.site.tool.helper.order.rsf.PageListProducer.allowTitleEdit";
 
     //System config for which tools can be added to a site more then once
     private final String MULTI_TOOLS = "sakai.site.multiPlacementTools";
@@ -159,6 +167,11 @@ public class SitePageEditHandler {
             for (int i = 0; i < toolIds.length; i++) {
                 unhideables.add(toolIds[i].trim());
             }
+        }
+        String uneditablesConfig = serverConfigurationService.getString(UNEDITABLES_CFG, "");
+        uneditables = new HashSet<String>();
+        for (String tool: uneditablesConfig.split(",")) {
+            uneditables.add(tool);
         }
     }
     
@@ -757,5 +770,26 @@ public class SitePageEditHandler {
         }    // compare
         
     } //ToolComparator    
+
+
+    /**
+     * Is the current user allowed to edit the title of the page.
+     * @param page The page in question.
+     * @return <code>true</code> if the page title can be edited.
+     */
+    public boolean allowEdit(SitePage page) {
+        //default value is to allow the Title to be edited.  If the sakai properties
+        //specifically requests this to be set to false, then do not allow this function
+        boolean allow = serverConfigurationService.getBoolean(ALLOW_TITLE_EDIT, true);
+        if (!(uneditables.isEmpty())) {
+            for(Iterator<ToolConfiguration> toolIt = page.getTools().iterator(); toolIt.hasNext() && allow;) {
+                ToolConfiguration toolConfig = toolIt.next();
+                if (uneditables.contains(toolConfig.getToolId())) {
+                    allow = false;
+                }
+            }
+        }
+        return allow;
+    }
 }
 

--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageListProducer.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageListProducer.java
@@ -100,9 +100,7 @@ public class PageListProducer
                 param.viewID = PageEditProducer.VIEW_ID;
                 Object[] pageTitle = new Object[] {page.getTitle()};
 
-                //default value is to allow the Title to be edited.  If the sakai properties 
-                //specifically requests this to be set to false, then do not allow this function
-                if (serverConfigurationService.getBoolean(ALLOW_TITLE_EDIT, true)) {
+                if (handler.allowEdit(page)) {
 
                     fullyDecorate(UIInternalLink.make(pagerow, "edit-link", param), 
                         UIMessage.make("page_edit", pageTitle));


### PR DESCRIPTION
The config poh.uneditables is a comma separated list of tools IDs that should be editable. By default it’s empty.