### PR TITLE
KNL-1333 - Adding support for hikaricp

### DIFF
--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -54,6 +54,17 @@
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-jdbc</artifactId>
     </dependency>
+    <!-- Java 8 Maven Artifact -->
+    <!--
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    -->
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP-java6</artifactId>
+    </dependency>
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>

--- a/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
+++ b/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
@@ -1,0 +1,187 @@
+/**********************************************************************************
+ * $URL: $
+ * $Id: SakaiBasicDataSource.java 105077 2012-02-24 22:54:29Z ottenhoff@longsight.com $
+ ***********************************************************************************
+ *
+ * Copyright (c) 2015 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.hikaricp.jdbc.pool;
+
+import java.lang.management.ManagementFactory;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * <p>
+ * SakaiBasicDataSource extends hikari CP's DataSource for compatibility with prior settings...
+ * </p>
+ */
+public class SakaiBasicDataSource extends HikariDataSource
+{
+    /** Our logger. */
+    private static Log M_log = LogFactory.getLog(SakaiBasicDataSource.class);
+
+    /** Configuration: to rollback each connection when returned to the pool. */
+    //TODO: Is this a data source property?
+    protected boolean m_rollbackOnReturn = false;
+    //Needed for DBCP compat, not sure if these are still useful
+    //TODO: Are these data source properties?
+    private boolean poolPreparedStatements;
+    private int maxOpenPreparedStatements;
+
+    private String isolationLevel;
+    
+    //For compatibility with previous
+    private String url;
+    //DriveclassName in AbstractHikariConfig is protected and no getter, we need to get at it
+    private String driverClassName;
+
+    public void setMaxOpenPreparedStatements(int maxOpenPreparedStatements) {
+        M_log.info("MaxOpenPreparedStatments not used");
+        this.maxOpenPreparedStatements = maxOpenPreparedStatements;
+    }
+
+    public void setPoolPreparedStatements(boolean poolPreparedStatements) {
+        M_log.info("PoolPreparedStatements not used");
+        this.poolPreparedStatements = poolPreparedStatements;
+    }
+
+    private void setDefaultTransactionIsolation(String isolationLevel) {
+        this.isolationLevel = isolationLevel;
+        
+    }
+    /**
+     * Set the default transaction isolation level from a string value, based on the settings and values in java.sql.Connection
+     * 
+     * @param defaultTransactionIsolation
+     */
+    public void setDefaultTransactionIsolationString(String defaultTransactionIsolation)
+    {
+        if ((defaultTransactionIsolation == null) || (defaultTransactionIsolation.trim().length() == 0))
+        {
+            setDefaultTransactionIsolation(null);
+        }
+        else if (defaultTransactionIsolation.trim().equalsIgnoreCase("TRANSACTION_NONE"))
+        {
+            setDefaultTransactionIsolation("TRANSACTION_NONE");
+        }
+        else if (defaultTransactionIsolation.trim().equalsIgnoreCase("TRANSACTION_READ_UNCOMMITTED"))
+        {
+            setDefaultTransactionIsolation("TRANSACTION_READ_UNCOMMITTED");
+        }
+        else if (defaultTransactionIsolation.trim().equalsIgnoreCase("TRANSACTION_READ_COMMITTED"))
+        {
+            setDefaultTransactionIsolation("TRANSACTION_READ_COMMITTED");
+        }
+        else if (defaultTransactionIsolation.trim().equalsIgnoreCase("TRANSACTION_REPEATABLE_READ"))
+        {
+            setDefaultTransactionIsolation("TRANSACTION_REPEATABLE_READ");
+        }
+        else if (defaultTransactionIsolation.trim().equalsIgnoreCase("TRANSACTION_SERIALIZABLE"))
+        {
+            setDefaultTransactionIsolation("TRANSACTION_SERIALIZABLE");
+        }
+        else
+        {
+            setDefaultTransactionIsolation(null);
+            M_log.warn("invalid transaction isolation level: " + defaultTransactionIsolation);
+        }
+    }
+
+    /**
+     * Set the rollback on borrow configuration.
+     * 
+     * @param value
+     *        if true, rollback each connection when borrowed from the pool, if false, do not.
+     */
+    public synchronized void setRollbackOnBorrow(boolean value)
+    {
+        m_rollbackOnReturn = value;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+        this.driverClassName = driverClassName;
+    }
+
+    /**
+     * @exception SQLException
+     *            if the object pool cannot be created.
+     */
+    protected void init() throws SQLException
+    {
+        M_log.info("init()");
+
+        //Do some quick validation
+        if (getUsername() == null) {
+            M_log.warn("Hikari DataSource configured without a 'username'");
+        }
+        
+        if (getPassword() == null) {
+            M_log.warn("Hikari DataSource configured without a 'password'");
+        }
+
+        //For backward compatibility with old methods
+        if (url != null && !"".equals(url)) {
+            super.setJdbcUrl(url);
+            //This seems to also be required as HikariCP isn't registering this class if it's specified and it gives an error
+            if (driverClassName != null) {
+                super.setDriverClassName(driverClassName);
+                try {
+                    Class driverClass;
+                    driverClass = Class.forName(driverClassName);
+                    DriverManager.registerDriver((Driver) driverClass.newInstance());
+                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                    // TODO Auto-generated catch block
+                    String message = "driverClass not specified, might not be able to load the driver'";
+                    M_log.warn(message, e);
+                }
+            }
+        }
+        
+        super.setTransactionIsolation(isolationLevel);
+        
+        //Validate the class to verify it loaded
+        try {
+            super.validate();
+        }
+        catch (Exception t)
+        {
+            String message = "Cannot load JDBC driver class '" + driverClassName + "'";
+            M_log.warn(message, t);
+            throw new SQLException(message,t);
+        }
+    }
+}

--- a/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
+++ b/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
@@ -136,6 +136,15 @@ public class SakaiBasicDataSource extends HikariDataSource
         this.driverClassName = driverClassName;
     }
 
+    //validationQuery in Hikari is called connectionTestQuery, map to it
+    public String getValidationQuery() {
+        return super.getConnectionTestQuery();
+    }
+
+    public void setValidationQuery(String validationQuery) {
+        super.setConnectionTestQuery(validationQuery);
+    }
+
     /**
      * @exception SQLException
      *            if the object pool cannot be created.

--- a/kernel/deploy/shared/pom.xml
+++ b/kernel/deploy/shared/pom.xml
@@ -250,6 +250,19 @@
             <artifactId>ehcache-terracotta</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- Java 8 Maven Artifact -->
+        <!--
+        <dependency>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        -->
+        <dependency>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java6</artifactId>
+          <scope>compile</scope>
+        </dependency> 
         <dependency>
             <groupId>org.mnode.ical4j</groupId>
             <artifactId>ical4j</artifactId>

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/db-components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/db-components.xml
@@ -178,6 +178,98 @@
 		</property>
 	</bean>
 
+
+	<bean id="javax.sql.hikaricp.BaseDataSource" abstract="true"
+			class="org.sakaiproject.hikaricp.jdbc.pool.SakaiBasicDataSource"
+            init-method="init"
+			destroy-method="close">
+
+		<!--  The fully qualified Java class name of the JDBC driver to be used. -->
+		<property name="driverClassName">
+			<value>org.hsqldb.jdbcDriver</value>
+		</property>
+
+		<!-- The connection URL to be passed to our JDBC driver to establish a connection. -->
+		<property name="url">
+			<value>jdbc:hsqldb:mem:sakai</value>
+		</property>
+
+		<!-- The connection username to be passed to our JDBC driver to establish a connection. -->
+		<property name="username">
+			<value>sa</value>
+		</property>
+
+		<!-- The connection password to be passed to our JDBC driver to establish a connection. -->
+		<property name="password">
+			<value></value>
+		</property>
+
+		<!-- Use TRANSACTION_READ_COMMITTED for MySQL -->
+		<!-- DO NOT SET for Oracle (the default TRANSACTION_READ_COMMITTED is fine, and setting it causes performance problems) -->
+		<!-- Up to and including 1.7.1, HSQLDB supports only Connection.TRANSACTION_READ_UNCOMMITTED. -->
+		<property name="defaultTransactionIsolationString">
+			<value>TRANSACTION_READ_UNCOMMITTED</value>
+		</property>
+
+		<!-- Whether or not to autocommit, setting to true is causing an error in content, so might not be a great idea -->
+		<property name="autoCommit">
+			<value>false</value>
+		</property>
+
+		<!-- These are some of the additional hikari properties. See the webpage for more info https://github.com/brettwooldridge/HikariCP 
+		 Note: There *may* be some other much less commonly used beans that cannot or are not currently defined here. Check the webpage if you want to see them. -->
+		<!-- Number of ms to wait for a connection, default 30 seconds -->
+		<property name="connectionTimeout">
+			<value>30000</value>
+		</property>
+
+		<!-- Time that a connection is allowed to sit idle, default 10 minutes -->
+		<property name="idleTimeout">
+			<value>600000</value>
+		</property>
+
+		<!-- This property controls the maximum lifetime of a connection in the pool, default 30 minutes -->
+		<property name="maxLifetime">
+			<value>1800000</value>
+		</property>
+
+		<!-- If your driver supports JDBC4 we strongly recommend not setting this property. This is for "legacy" databases that do not support the JDBC4 Connection.isValid() API. Default null (important). -->
+		<!-- This seems like it might need to be specified with MySQL to something like "SELECT 1" depending on the driver: https://github.com/brettwooldridge/HikariCP/issues/206 -->
+		<property name="connectionTestQuery">
+		<null />
+		</property>
+
+		<!-- This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool. Default 10 -->
+		<property name="minimumIdle">
+			<value>10</value>
+		</property>
+
+		<!-- This property controls the maximum size of the pool for idle and in use. Default 10 (TODO: Seems low)-->
+		<property name="maximumPoolSize">
+			<value>10</value>
+		</property>
+
+		<!-- Register MBeans -->
+		<property name="registerMbeans">
+			<value>true</value>
+		</property>
+
+		<!-- The default name of the pool -->
+		<property name="poolName">
+			<value>sakai</value>
+		</property>
+
+		<!-- Additional data source properties -->
+		<property name="dataSourceProperties">
+			<props>
+				<prop key="cachePrepStmts">true</prop>
+				<prop key="prepStmtCacheSize">250</prop>
+				<prop key="prepStmtCacheSqlLimit">2048</prop>
+				<prop key="useServerPrepStmts">true</prop>
+			</props>
+		</property>
+</bean>
+
 	<bean id="javax.sql.tomcat.BaseDataSource" abstract="true"
 			class="org.sakaiproject.tomcat.jdbc.pool.SakaiBasicDataSource"
             init-method="init"

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -372,6 +372,19 @@
       <artifactId>tomcat-jdbc</artifactId>
       <scope>test</scope>
    </dependency>
+       <!-- Java 8 Maven Artifact -->
+    <!--
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <scope>test</scope>
+    </dependency>
+    -->
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP-java6</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -124,6 +124,21 @@
         <version>2.6.6</version>
         <scope>provided</scope>
       </dependency>
+      <!-- Java 8 Maven Artifact -->
+      <!--
+      <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>2.3.2</version>
+        <scope>compile</scope>
+      </dependency>
+      -->
+      <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP-java6</artifactId>
+        <version>2.3.2</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This PR adds support for HikariCP. This could for sure use some testing, but it starts up without any warnings. There is some cleanup still but it's seems to be a great first (or in my case about sixth) pass

Some notes

* I had to turn off autocommit as that default to on and there's warnings if that is on. I think I'll just move that property into the XML since it's identical to Hikari so a slight re-factor.
* I believe that just setting registerMBeans has Hikari register them, previously on the tomcat driver we had to explicitly do that. I have not tested the mbeans
* It has compatibility with all of the old properties (url@ driverClassName@ etc), but I think to set the hikariCP properties we'll need to add them with defaults to the bean here.
* I only tested this with MySQL, same driver as the tomcat and dbcp ones

Java 7/8 note
They have two versions of the jar, one for Java 7 (which is currently the default in this patch) and one for Java 8. I'd anticipate making Java 8 the minimum requirement for Sakai 11, but for now this would (probably) not be compatible with java 8 without changing that dependency.