### PR TITLE
SAK-28187 Fix Edit Tools when Site type is empty.

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -381,7 +381,7 @@ public class SiteAction extends PagedResourceActionII {
 	private final static String SITE_DEFAULT_LIST = ServerConfigurationService
 			.getString("site.types");
 
-	private final static String DEFAULT_SITE_TYPE_SAK_PROP = ServerConfigurationService.getString("site.types.defaultType");
+	private final static String DEFAULT_SITE_TYPE_SAK_PROP = ServerConfigurationService.getString("site.types.defaultType", null);
 	private final static String[] PUBLIC_CHANGEABLE_SITE_TYPES_SAK_PROP = ServerConfigurationService.getStrings("site.types.publicChangeable");
 	private final static String[] PUBLIC_SITE_TYPES_SAK_PROP = ServerConfigurationService.getStrings("site.types.publicOnly");
 	private final static String[] PRIVATE_SITE_TYPES_SAK_PROP = ServerConfigurationService.getStrings("site.types.privateOnly");


### PR DESCRIPTION
When the site type was empty it should have been falling back to the default site type for getting the list of tools but this wasn’t working because the default type was being set to empty.

The call to ServerConfigurationService was getting back an empty string and therefore not falling back to the defaultSiteType tool registration parameter.