### PR TITLE
SAM-2502 - Inline images in print pdf do not display

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2886,6 +2886,10 @@
 # Default: false
 #samigo.removePubAssessment.restricted.afterStart=true
 
+# In the PDF print output, setting this to true will remove all HTML formatting from the questions and answers (This was a legacy setting just added incase someone was using it or it was causing problems)
+# Default: false
+# samigo.pdf.convertformattedtext=true
+
 #########################################
 # WORKSITE SETUP/SITE INFO
 #########################################

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -107,7 +107,7 @@ public class PDFAssessmentBean implements Serializable {
 	 * @param intro in html
 	 */
 	public void setIntro(String intro) {
-		this.intro = FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(FormattedText.unEscapeHtml(intro)));
+		this.intro = convertFormattedText(FormattedText.unEscapeHtml(intro));
 	}
 
 	/**
@@ -375,7 +375,7 @@ public class PDFAssessmentBean implements Serializable {
 
 				if (!(item.getItemData().getTypeId().equals(TypeIfc.FILL_IN_BLANK) || item.getItemData().getTypeId().equals(TypeIfc.FILL_IN_NUMERIC))) {
 					contentBuffer.append("<br />");
-					contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(item.getItemData().getText())));
+					contentBuffer.append(convertFormattedText(item.getItemData().getText()));
 					contentBuffer.append("<br />");
 				}
 				if (item.getItemData().getItemAttachmentList() != null && item.getItemData().getItemAttachmentList().size() > 0) {
@@ -409,7 +409,7 @@ public class PDFAssessmentBean implements Serializable {
 						contentBuffer.append("<br />");
 					}
 					contentBuffer.append("<br />");
-					contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(item.getItemData().getText())));
+					contentBuffer.append(convertFormattedText(item.getItemData().getText()));
 					contentBuffer.append("<br />");
 				}
 
@@ -478,10 +478,10 @@ public class PDFAssessmentBean implements Serializable {
 						if (matching.getText() == null) break;
 						
 						contentBuffer.append("<tr><td colspan='10'>");
-						contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(matching.getText())));
+						contentBuffer.append(convertFormattedText(matching.getText()));
 						contentBuffer.append("</td>");
 						contentBuffer.append("<td colspan='10'>");
-						contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(answer)));
+						contentBuffer.append(convertFormattedText(answer));
 						contentBuffer.append("</td></tr>");
 					}
 
@@ -576,14 +576,14 @@ public class PDFAssessmentBean implements Serializable {
 					contentBuffer.append(". ");
 				}
 				
-				contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(answer.getText())));
+				contentBuffer.append(convertFormattedText(answer.getText()));
 				contentBuffer.append("</td>");
 				contentBuffer.append("<td colspan='9'>");
 				contentBuffer.append("<h6>");
 				contentBuffer.append(commonMessages.getString("feedback"));
 				contentBuffer.append(": ");
 				if (answer.getGeneralAnswerFeedback() != null && !answer.getGeneralAnswerFeedback().equals(""))
-					contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(answer.getGeneralAnswerFeedback())));
+					contentBuffer.append(convertFormattedText(answer.getGeneralAnswerFeedback()));
 				else 
 					contentBuffer.append("--------");
 				contentBuffer.append("</h6>");
@@ -595,7 +595,7 @@ public class PDFAssessmentBean implements Serializable {
 					contentBuffer.append(". ");
 				}
 				
-				contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(answer.getText())));
+				contentBuffer.append(convertFormattedText(answer.getText()));
 				contentBuffer.append("</td>");
 			}
 			contentBuffer.append("</td>");
@@ -604,7 +604,7 @@ public class PDFAssessmentBean implements Serializable {
 		if (item.getItemData().getTypeId().equals(TypeIfc.TRUE_FALSE)) {
 			contentBuffer.append("<td colspan='1'><img src='/samigo-app/images/radiounchecked.gif' /></td>");
 			contentBuffer.append("<td colspan='19'>");
-			contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(answer.getText())));
+			contentBuffer.append(convertFormattedText(answer.getText()));
 			contentBuffer.append("</td>");
 		}
 
@@ -656,7 +656,7 @@ public class PDFAssessmentBean implements Serializable {
 				contentBuffer.append(commonMessages.getString("feedback"));
 				contentBuffer.append(": ");
 				if (item.getItemData().getGeneralItemFeedback() != null && !item.getItemData().getGeneralItemFeedback().equals(""))
-					contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(item.getItemData().getGeneralItemFeedback())));
+					contentBuffer.append(convertFormattedText(item.getItemData().getGeneralItemFeedback()));
 				else 
 					contentBuffer.append("--------");
 			}
@@ -672,14 +672,14 @@ public class PDFAssessmentBean implements Serializable {
 				contentBuffer.append(printMessages.getString("correct_feedback"));
 				contentBuffer.append(": ");
 				if (item.getItemData().getCorrectItemFeedback() != null && !item.getItemData().getCorrectItemFeedback().equals(""))
-					contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(item.getItemData().getCorrectItemFeedback())));
+					contentBuffer.append(convertFormattedText(item.getItemData().getCorrectItemFeedback()));
 				else 
 					contentBuffer.append("--------");
 				contentBuffer.append("<br />");
 				contentBuffer.append(printMessages.getString("incorrect_feedback"));
 				contentBuffer.append(": ");
 				if (item.getItemData().getInCorrectItemFeedback() != null && !item.getItemData().getInCorrectItemFeedback().equals(""))
-					contentBuffer.append(FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(item.getItemData().getInCorrectItemFeedback())));
+					contentBuffer.append(convertFormattedText(item.getItemData().getInCorrectItemFeedback()));
 				else 
 					contentBuffer.append("--------");
 			}
@@ -689,6 +689,15 @@ public class PDFAssessmentBean implements Serializable {
 		return contentBuffer.toString();
 	}
 
+	public String convertFormattedText(String text) {
+	    //To preserve old behavior, set this to true
+	    //Possibly consider using jsoup with a whitelist so some formatted text gets though, I'm not sure why this was here in the first place
+	    if (ServerConfigurationService.getBoolean("samigo.pdf.convertformattedtext",false)) {
+	        return FormattedText.convertPlaintextToFormattedText(FormattedText.convertFormattedTextToPlaintext(text));
+	    }
+	    return text;
+	}
+	
 	public void getPDFAttachment() {
 		prepDocumentPDF();
 		ByteArrayOutputStream pdf = getStream();


### PR DESCRIPTION
It looks like all of the content both questions and answers was being converted to plaintext by the pdf processor. This was in the original commit so I don't know why this was happening. I moved it to a method and left the option in here so old behavior could be preserved, but it just returns the text-as is. In some limited testing images and most HTML is coming up as expected. This would need more testing as I think some HTML tags could cause a problem and we might need to pass this through something like jsoup so that only valid HTML is returned rather than everything, but removing everything I think isn't right.

In addition if you're running the server in SSL you will get an SSL exception with a self signed certificate or one that isn't in the truststore, so you have a have an explicitly defined trust store in that case or certificate that java recognizes.