### PR TITLE
SAK-29154 Lookup LTI user by eid if provided

### DIFF
--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/UserFinderOrCreatorImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/UserFinderOrCreatorImpl.java
@@ -72,7 +72,11 @@ public class UserFinderOrCreatorImpl implements UserFinderOrCreator {
         // otherwise this will fail since they don't exist. Perhaps this should be addressed?
         if (trustedConsumer) {
             try {
-                user = userDirectoryService.getUser(user_id);
+                if (BasicLTIUtil.isNotBlank((String) payload.get(BasicLTIConstants.EXT_SAKAI_PROVIDER_EID))) {
+                    user = userDirectoryService.getUserByEid(eid);
+                } else {
+                    user = userDirectoryService.getUser(user_id);
+                }
             } catch (UserNotDefinedException e) {
                 throw new LTIException("launch.user.invalid", "user_id=" + user_id, e);
             }


### PR DESCRIPTION
Trusted consumers can now supply the sakai eid as the primary means of
user lookup.