### PR TITLE
SAK-29155 Cleanup empty realms when no longer needed.

### DIFF
--- a/authz/authz-tool/tool/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
+++ b/authz/authz-tool/tool/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
@@ -531,7 +531,13 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 			// commit the change
 			try
 			{
-				AuthzGroupService.save(edit);
+				removeEmptyRoles(edit);
+
+				if (hasNothingSet(edit)) {
+					AuthzGroupService.removeAuthzGroup(edit);
+				} else {
+					AuthzGroupService.save(edit);
+				}
 			}
 			catch (GroupNotDefinedException e)
 			{
@@ -545,6 +551,26 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 
 		// clean up state
 		cleanupState(state);
+	}
+
+	/**
+	 * Removes all the roles in an AuthzGroup that don't have any permissions set on them.
+	 * @param edit The AuthzGroup to cleanup.
+	 */
+	private void removeEmptyRoles(AuthzGroup edit) {
+		for (Role role : edit.getRoles()) {
+			if(role.getAllowedFunctions().isEmpty()) {
+				edit.removeRole(role.getId());
+			}
+		}
+	}
+
+	/**
+	 * @param edit The AuthzGroup to check.
+	 * @return <code>true</code> if there are no roles and no members in this AuthzGroup.
+	 */
+	private boolean hasNothingSet(AuthzGroup edit) {
+		return edit.getRoles().isEmpty() && edit.getMembers().isEmpty();
 	}
 
 	/**


### PR DESCRIPTION
If a realm being edited doesn’t have any permissions of users against it then it can be removed as it’s not granting anything.