### PR TITLE
SAK-29156 Allow permission changes to be limited.

### DIFF
--- a/authz/authz-tool/tool/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
+++ b/authz/authz-tool/tool/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
@@ -22,14 +22,7 @@
 package org.sakaiproject.authz.tool;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -46,11 +39,13 @@ import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.authz.api.RoleAlreadyDefinedException;
 import org.sakaiproject.authz.cover.AuthzGroupService;
 import org.sakaiproject.authz.cover.FunctionManager;
+import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.cheftool.Context;
 import org.sakaiproject.cheftool.JetspeedRunData;
 import org.sakaiproject.cheftool.RunData;
 import org.sakaiproject.cheftool.VelocityPortlet;
 import org.sakaiproject.cheftool.VelocityPortletPaneledAction;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.cover.EntityManager;
 import org.sakaiproject.event.api.SessionState;
@@ -449,7 +444,10 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 				rolesAbilities.put(role.getId(), locks);
 			}
 		}
-		
+
+		PermissionLimiter limiter = getPermissionLimiter();
+
+		context.put("limiter", limiter);
 
 		context.put("realm", viewEdit != null ? viewEdit : edit);
 		context.put("prefix", prefix);
@@ -465,6 +463,48 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 
 		return TEMPLATE_MAIN;
 	}
+	/**
+	 * Find a map of permissions based on a config prefix.
+	 * If there aren't any permissions list all are allowed.
+	 *
+	 * @param configPrefix The prefix to get permissions for.
+	 */
+	private static Map<String, Set<String>> getPermissions(String configPrefix)
+	{
+		Map<String, Set<String>> roleMap = new HashMap<String, Set<String>>();
+		ServerConfigurationService scs = org.sakaiproject.component.cover.ServerConfigurationService.getInstance();
+		String roleList = scs.getString(configPrefix+ "roles", "");
+		Set<String> defaultPermissionSet = createPermissionSet(configPrefix, "default");
+		for (String roleName :roleList.split(","))
+		{
+			roleName = roleName.trim();
+			if (roleName.length() == 0)
+			{
+				continue;
+			}
+			Set<String> permissionSet = createPermissionSet(configPrefix, roleName);
+			roleMap.put(roleName, (permissionSet.size() > 0)?permissionSet:defaultPermissionSet);
+
+		}
+		return roleMap;
+	}
+	
+	private static Set<String> createPermissionSet(String config, String roleName)
+	{
+		String permissionList = org.sakaiproject.component.cover.ServerConfigurationService.getString(config +roleName,"");
+		Set<String> permissionSet = new HashSet<String>();
+		for (String permissionName : permissionList.split(","))
+		{
+			permissionName = permissionName.trim();
+			if (permissionName.length() > 0)
+			{
+				permissionSet.add(permissionName);
+			}
+		}
+		return permissionSet;
+	}
+
+
 	/**
 	 * Remove the state variables used internally, on the way out.
 	 */
@@ -566,6 +606,7 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 		List abilities = (List) state.getAttribute(STATE_ABILITIES);
 		List roles = (List) state.getAttribute(STATE_ROLES);
 
+		PermissionLimiter limiter = getPermissionLimiter();
 		// look for each role's ability field
 		for (Iterator iRoles = roles.iterator(); iRoles.hasNext();)
 		{
@@ -574,8 +615,14 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 			for (Iterator iLocks = abilities.iterator(); iLocks.hasNext();)
 			{
 				String lock = (String) iLocks.next();
+				boolean checked = (data.getParameters().getString(role.getId() + lock) != null);
+				// Don't allow changes to some permissions.
+				if ( !(limiter.isEnabled(role.getId(), lock, role.isAllowed(lock))) )
+				{
+					M_log.debug("Can't change permission '"+ lock+ "' on role '"+role.getId()+ "'.");
+					continue;
+				}
 
-				boolean checked = data.getParameters().getBoolean(role.getId() + lock);
 				if (checked)
 				{
 					// we have an ability! Make sure there's a role
@@ -607,4 +654,61 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 			}
 		}
 	}
+
+	public static PermissionLimiter getPermissionLimiter() {
+		Map allowedPermissions = getPermissions("realm.allowed."); // Whitelisted permissions for some roles
+		Map frozenPermissions = getPermissions("realm.frozen."); // Permissions that can't be changed
+		Map addOnlyPermissions = getPermissions("realm.add.only."); // Permissions that can only be added.	}
+		return new PermissionLimiter(allowedPermissions, frozenPermissions, addOnlyPermissions);
+	}
+
+	/**
+	 * The class is put into the velocity context to limit the permission that can be set.
+	 */
+	public static class PermissionLimiter
+	{
+		private Map<String, Set<String>> allowedPermissions;
+		private Map<String, Set<String>> frozenPermissions;
+		private Map<String, Set<String>> addOnlyPermissions;
+
+		/**
+		 * Create a permission limiter. This is put into the velocity context to remove complex logic from the template.
+		 *
+		 * @param allowedPermissions A complete set of permissions for a role. If the role exists in this map but the
+		 *                           permission isn't present the user can't set it.
+		 * @param frozenPermissions A set of permissions that can't be changed for each role.
+		 * @param addOnlyPermissions A set of permissions which the user can only grant and can't take away.
+		 */
+		public PermissionLimiter(Map<String, Set<String>> allowedPermissions, Map<String, Set<String>> frozenPermissions,
+								 Map<String, Set<String>> addOnlyPermissions)
+		{
+			this.allowedPermissions = allowedPermissions;
+			this.frozenPermissions = frozenPermissions;
+			this.addOnlyPermissions = addOnlyPermissions;
+		}
+
+		public boolean isEnabled(String roleId, String permission, boolean enabled)
+		{
+			// Sysadmin doesn't have any restrictions
+			if (SecurityService.isSuperUser()) {
+				return true;
+			}
+			if (frozenPermissions.containsKey(roleId)) {
+				if ( frozenPermissions.get(roleId).contains(permission) ) {
+					return false;
+				}
+			}
+			// Only check when permission is enabled.
+			if (enabled && addOnlyPermissions.containsKey(roleId)) {
+				if ( addOnlyPermissions.get(roleId).contains(permission) ) {
+					return false;
+				}
+			}
+			if (allowedPermissions.containsKey(roleId)) {
+				return allowedPermissions.get(roleId).contains(permission);
+			}
+			return true;
+		}
+	}
+
 }

--- a/authz/authz-tool/tool/src/webapp/js/authz.js
+++ b/authz/authz-tool/tool/src/webapp/js/authz.js
@@ -1,88 +1,48 @@
 $(document).ready(function(){
+	// When the checkboxes change update the cell.
+	$('input:checkbox').change(function(){
+		$(this).parents('td').toggleClass('active', this.checked);
+	}).change();
     $("table.checkGrid tr:even").addClass("evenrow");
-    $(':checked').parents('td').addClass('active');
+    // Save the default selected
     $(':checked').parents('td').addClass('defaultSelected');
-    $('input:checkbox').click(function(){
-        if (this.checked) {
-            $(this).parents('td').addClass('active');
-        }
-        else {
-            $(this).parents('td').removeClass('active');
-        }
+    
+    $('.permissionDescription').hover(function(e){
+        $(this).parents('tr').children('td').toggleClass('rowHover', e.type == "mouseenter");
     });
     
-    $('.permissionDescription').mouseenter(function(){
-        $(this).parents('tr').children('td').addClass('rowHover');
-    }).mouseleave(function(){
-        $(this).parents('tr').children('td').removeClass('rowHover');
+    $('th').hover(function(event){
+    	var col = ($(this).prevAll().size());
+        $('.' + col).add(this).toggleClass('rowHover', event.type == "mouseenter");
     });
     
-    $('th').mouseenter(function(){
-        var col = ($(this).prevAll().size());
-        $(this).addClass('rowHover');
-        $('.' + col).addClass('rowHover');
-    }).mouseleave(function(){
-        var col = ($(this).prevAll().size());
-        $(this).removeClass('rowHover');
-        $('.' + col).removeClass('rowHover');
-    });
-    $('th#permission').mouseenter(function(){
-        $('.checkGrid td.checkboxCell').addClass('rowHover');
-    }).mouseleave(function(){
-        $('.checkGrid td.checkboxCell').removeClass('rowHover');
+    $('th#permission').hover(function(event){
+        $('.checkGrid td.checkboxCell').toggleClass('rowHover', event.type == "mouseenter");
     });
     
     $('th#permission a').click(function(e){
-        if ($('.checkGrid :checked').length > 0) {
-            $('.checkGrid input').attr('checked', '');
-            $('.checkGrid td.checkboxCell').removeClass('active');
-        }
-        else {
-            $('.checkGrid input').attr('checked', 'checked');
-            $('.checkGrid td.checkboxCell').addClass('active');
-            
-        }
+        $('.checkGrid input').prop('checked', ($('.checkGrid :checked').length == 0)).change();
         e.preventDefault();
-        
     });
     $('.permissionDescription a').click(function(e){
-        if ($(this).parents('tr').children('td').children('label').children('input:checked').length > 0) {
-            $(this).parents('tr').children('td').children('label').children('input').attr('checked', '');
-            $(this).parents('tr').children('td').removeClass('active');
-            
-        }
-        else {
-            $(this).parents('tr').children('td').children('label').children('input').attr('checked', 'checked');
-            $(this).parents('tr').children('td').addClass('active');
-            $(this).removeClass('active');
-        }
+        var anyChecked = $(this).parents('tr').find('input:checked').not('[disabled]').length > 0;
+        $(this).parents('tr').find('input:checkbox').not('[disabled]').prop('checked', !anyChecked).change();
         e.preventDefault();
-        
     });
     $('th.role a').click(function(e){
         var col = ($(this).parent('th').prevAll().size());
-        if ($('.' + col + ' label input:checked').length > 0) {
-            $('.' + col + ' label input').attr('checked', '');
-            $('.' + col).removeClass('active');
-        }
-        else {
-            $('.' + col + ' label input').attr('checked', 'checked');
-            $('.' + col).addClass('active');
-        }
+        var anyChecked = $('.' + col + ' input:checked').not('[disabled]').length > 0;
+        $('.' + col + ' input').not('[disabled]').prop('checked', !anyChecked).change();
         e.preventDefault();
-        
     });
     
     $('#clearall').click(function(e){
-        $("input").attr("checked", "");
-        $('td').removeClass('active');
+        $("input").not('[disabled]').prop("checked", false).change();
         e.preventDefault();
     });
     $('#restdef').click(function(e){
-        $("input").attr("checked", "");
-        $('td').removeClass('active');
-        $(".defaultSelected").addClass("active");
-        $(".defaultSelected input ").attr("checked", "checked");
+        $("input").prop("checked", false);
+        $(".defaultSelected input").prop("checked", true).change();
         e.preventDefault();
     });
     

--- a/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
+++ b/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
@@ -92,8 +92,8 @@
 										<input type="hidden" name="$role.Id$lock" value="$granted"/>
 									#else
 										<span class="skip">$thelp.getString("gen.enable") $role.Id: $desc</span>
-										<input class="$role.Id$lock" type="checkbox" name="$role.Id$lock" id="$role.Id$lock"
-											value="true" #if($granted)checked="checked"#end/>
+										#set ($checked = ($myRole) && ($myRole.Id==$role.Id) && ($myRole.AllowedFunctions.contains($lock)))
+										<input class="$role.Id$lock" type="checkbox" name="$role.Id$lock" id="$role.Id$lock" value="$role.Id$lock" #if($checked)checked="checked"#end  #if(! $limiter.isEnabled($role.id, $lock, $checked))disabled="true"#end />
 									#end
 									</label>
 								</td>

--- a/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
+++ b/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
@@ -1,7 +1,7 @@
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/helper/chef_permissions.vm,v 1.4 2005/05/28 03:04:36 ggolden.umich.edu Exp $ -->
 <div class="portletBody">
 <link href="/sakai-authz-tool/css/authz.css" type="text/css" rel="stylesheet" media="all" />
-<script type="text/javascript" src="/library/js/jquery-ui-latest/js/jquery.min.js"></script>
+<script type="text/javascript" src="/library/js/jquery/jquery-1.9.1.min.js"></script>
 <script type="text/javascript" src="/sakai-authz-tool/js/authz.js"></script>
 	
 #if($menu)

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3873,6 +3873,32 @@
 # provider.kerberos.showconfig=true
 
 # #####
+# Permissions Helper Limiting
+# #####
+
+# Limit some permissions in some roles to only allow them to be added.
+# DEFAULT: null
+# # List of roles separated by commas
+# realm.add.only.roles=access,maintain
+# # For each role a list of permissions that are add only
+# realm.add.only.access=content.read
+# realm.add.only.maintain=content.read
+
+# Limit some permissions in some roles so they cannot be changed.
+# DEFAULT: null
+# # List of roles separated by commas
+# realm.frozen.roles=access
+# # For each role a list of permissions that cannot be added/removed.
+# realm.frozen.access=content.delete.own
+
+# Only allow a limited set of permissions to be changed for a role.
+# DEFAULT: null
+# # List of roles separated by commas
+# realm.allowed.roles=access
+# # For each role a list of permissions that can be changed.
+# realm.allowed.access=annc.read,poll.vote
+
+# #####
 # SAK-27743 Quartz job to seed sites, users, and resources
 # #####
 # number of course sites to create


### PR DESCRIPTION
This introduces new permissions that can control what permission changes are allowed. Superusers aren’t limited at all in what changes they can make.

There are 3 ways of restricting permission changes:

Add Only - For roles defines permissions that can only be added (but not removed).
e.g. These properties say that content.read can only be added for access and maintain roles:

realm.add.only.roles=access,maintain
realm.add.only.access=content.read
realm.add.only.maintain=content.read

Frozen - For roles defines permissions that cannot be changed (not added or removed).
e.g. These properties say that you can’t change content.delete.own for access role.

realm.frozen.roles=access
realm.frozen.access=content.delete.own

Whitelist - For roles defines permissions complete set of editable permissions.
e.g. These properties say for the access role you can only edit the accouncements
read permission and the poll voting permission. All other changes to access role aren’t allowed.

realm.whitelist.roles.access
realm.whitelist.access=annc.read,poll.vote.