### PR TITLE
SAK-29157: tab order in certain gradebook UIs can lead to loss of user's data

### DIFF
--- a/gradebook/app/ui/src/webapp/assignmentDetails.jsp
+++ b/gradebook/app/ui/src/webapp/assignmentDetails.jsp
@@ -26,23 +26,20 @@
 				actionListener="#{assignmentDetailsBean.processAssignmentIdChange}"
 				value="#{msgs.assignment_details_previous_assignment}"
 				title="#{assignmentDetailsBean.previousAssignment.name}"
-				accesskey="p"
-				tabindex="4">
+				accesskey="p">
 					<f:param name="assignmentId" value="#{assignmentDetailsBean.previousAssignment.id}"/>
 			</h:commandButton>
 			<h:commandButton
 				action="#{assignmentDetailsBean.processCancel}"
 				immediate="true"
 				value="#{assignmentDetailsBean.returnString}"
-				accesskey="l"
-				tabindex="6"/>
+				accesskey="l"/>
 			<h:commandButton
 				disabled="#{assignmentDetailsBean.last}"
 				actionListener="#{assignmentDetailsBean.processAssignmentIdChange}"
 				value="#{msgs.assignment_details_next_assignment}"
 				title="#{assignmentDetailsBean.nextAssignment.name}"
-				accesskey="n"
-				tabindex="5">
+				accesskey="n">
 					<f:param name="assignmentId" value="#{assignmentDetailsBean.nextAssignment.id}"/>
 			</h:commandButton>
 		</p>
@@ -92,7 +89,6 @@
 					<h:commandLink
 						action="#{assignmentDetailsBean.navigateToEdit}"
 						accesskey="e"
-						tabindex="7"
 						title="#{msgs.assignment_details_edit}">
 						<h:outputFormat id="editAssignment" value="#{msgs.assignment_details_edit}" />
 						<f:param name="assignmentId" value="#{assignmentDetailsBean.assignment.id}"/>
@@ -101,7 +97,6 @@
 						action="removeAssignment"
 						rendered="#{!assignmentDetailsBean.assignment.externallyMaintained}"
 						accesskey="r"
-						tabindex="8"
 						title="#{msgs.assignment_details_remove}">
 							<h:outputText id="removeAssignment" value="#{msgs.assignment_details_remove}"/>
 						<f:param name="assignmentId" value="#{assignmentDetailsBean.assignment.id}"/>
@@ -111,7 +106,6 @@
 						value="#{assignmentDetailsBean.assignment.externalInstructorLink}"
 						rendered="#{assignmentDetailsBean.assignment.externallyMaintained && not empty assignmentDetailsBean.assignment.externalInstructorLink}"
 						accesskey="x"
-						tabindex="9"
 						title="#{msgs.assignment_details_edit}">
 							<h:outputFormat value="#{msgs.assignment_details_external_edit}">
 								<f:param value="#{assignmentDetailsBean.assignment.externalAppName}"/>
@@ -144,7 +138,6 @@
 				disabled="#{assignmentDetailsBean.assignment.externallyMaintained || assignmentDetailsBean.allStudentsViewOnly}"
 				rendered="#{!assignmentDetailsBean.emptyEnrollments}"
 				accesskey="s"
-				tabindex="9998"
 				title="#{msgs.assignment_details_submit}"
 				onclick="disableButton('buttonDiv1', this)"/>
 			<h:commandButton
@@ -155,7 +148,6 @@
 				rendered="#{!assignmentDetailsBean.emptyEnrollments}"
 				accesskey="c"
 				immediate="true"
-				tabindex="9999"
 				title="#{msgs.assignment_details_cancel}" onclick="disableButton('buttonDiv1', this)">
 					<f:param name="breadcrumbPage" value="#{assignmentDetailsBean.breadcrumbPage}"/>
 			</h:commandButton>
@@ -307,7 +299,6 @@
 				actionListener="#{assignmentDetailsBean.processUpdateScores}"
 				disabled="#{assignmentDetailsBean.assignment.externallyMaintained || assignmentDetailsBean.allStudentsViewOnly}"
 				rendered="#{!assignmentDetailsBean.emptyEnrollments}"
-				tabindex="9998"
 				title="#{msgs.assignment_details_submit}"
 				onclick="disableButton('buttonDiv2', this)"/>
 			<h:commandButton
@@ -317,7 +308,6 @@
 				immediate="true"
 				disabled="#{assignmentDetailsBean.assignment.externallyMaintained || assignmentDetailsBean.allStudentsViewOnly}"
 				rendered="#{!assignmentDetailsBean.emptyEnrollments}"
-				tabindex="9999"
 				title="#{msgs.assignment_details_cancel}"
 				onclick="disableButton('buttonDiv2', this)">
 					<f:param name="breadcrumbPage" value="#{assignmentDetailsBean.breadcrumbPage}"/>

--- a/gradebook/app/ui/src/webapp/instructorView.jsp
+++ b/gradebook/app/ui/src/webapp/instructorView.jsp
@@ -43,24 +43,21 @@
 				actionListener="#{instructorViewBean.processStudentUidChange}"
 				value="#{msgs.inst_view_prev}"
 				title="#{instructorViewBean.previousStudent.user.displayName}"
-				accesskey="p"
-				tabindex="4" >
+				accesskey="p">
 					<f:param name="studentUid" value="#{instructorViewBean.previousStudent.user.userUid}"/>
 				</h:commandButton>
 			
 			<h:commandButton
 				action="#{instructorViewBean.processCancel}"
 				value="#{instructorViewBean.returnToPageButtonName}"
-				accesskey="l"
-				tabindex="6"/>
+				accesskey="l"/>
 			
 			<h:commandButton
 				disabled="#{instructorViewBean.last}"
 				actionListener="#{instructorViewBean.processStudentUidChange}"
 				value="#{msgs.inst_view_next}"
 				title="#{instructorViewBean.nextStudent.user.displayName}"
-				accesskey="n"
-				tabindex="5">
+				accesskey="n">
 					<f:param name="studentUid" value="#{instructorViewBean.nextStudent.user.userUid}"/>
 			</h:commandButton>
 		</div>
@@ -112,7 +109,6 @@
 						value="#{msgs.inst_view_save}"
 						action="#{instructorViewBean.processUpdateScores}"
 						accesskey="s"
-						tabindex="9998"
 						title="#{msgs.inst_view_save}"
 						disabled="#{instructorViewBean.allItemsViewOnly}"
 						onclick="disableButton('buttonDiv2', this)"/>
@@ -122,7 +118,6 @@
 						action=""
 						immediate="true"
 						accesskey="c"
-						tabindex="9999"
 						title="#{msgs.inst_view_clear}"
 						disabled="#{instructorViewBean.allItemsViewOnly}"
 						onclick="disableButton('buttonDiv2', this)"/>
@@ -326,7 +321,6 @@
 					value="#{msgs.inst_view_save}"
 					action="#{instructorViewBean.processUpdateScores}"
 					accesskey="s"
-					tabindex="9998"
 					title="#{msgs.inst_view_save}"
 					disabled="#{instructorViewBean.allItemsViewOnly}"
 					onclick="disableButton('buttonDiv1', this)"/>
@@ -336,7 +330,6 @@
 					action=""
 					immediate="true"
 					accesskey="c"
-					tabindex="9999"
 					title="#{msgs.inst_view_clear}"
 					disabled="#{instructorViewBean.allItemsViewOnly}"
 					onclick="disableButton('buttonDiv1', this)"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29157

On the gradebook item page (entering grades for a specific gradebook item), tabbing off the last grade input text field puts the focus on the 'Gateway' link at the bottom of the page rather than the 'Save' button, which would be the expected behaviour.

If the user doesn't notice that the focus is not on the save button, they will hit enter and be transferred to the Gateway page. They will effectively lose all information they've input on the gradebook item page.

This is caused by the save and cancel buttons (both on the top and bottom of the form) having a tabindex=9998 and 9999 respectively. This essentially makes it so that the user would have to tab through every clickable control on the page before they would get focus on these buttons.

Removing the arbitrary tabindex from the form controls allows the browser to determine the natural tab order based on the order of elements in the form. Without the tab order, tabbing off the last grade input field puts focus on the Save button, as the user would expect. 