### PR TITLE
SAK-29159 Enhance Import from Site to automatically add any missing tools - part 3

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/ContentExistsAware.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/ContentExistsAware.java
@@ -1,0 +1,19 @@
+package org.sakaiproject.entity.api;
+
+/**
+ * Services which implement ContentExistsAware declare that they are able to determine if they contain content for the site they are in.
+ * Note that services must also be registered EntityProducers.
+ *
+ * @since 11.0
+ * @author Steve Swinsburg (steve.swinsburg@gmail.com)
+ */
+public interface ContentExistsAware {
+
+	/**
+	 * Does this tool contain content in this site?
+	 * 
+	 * @param siteId the siteId to use when checking if content exists
+	 */
+	public boolean hasContent(String siteId);
+	
+}

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2912,7 +2912,7 @@ public class SiteAction extends PagedResourceActionII {
 			//otherwise, only import content for the tools that already exist in the 'destination' site
 			boolean addMissingTools = isAddMissingToolsOnImportEnabled();
 			
-			//helper var to hold the list we use for the seletedTools context variable, as we use it for the alternate toolnames too
+			//helper var to hold the list we use for the selectedTools context variable, as we use it for the alternate toolnames too
 			List<String> selectedTools = new ArrayList<>();
 			
 			if(addMissingTools) {
@@ -2926,11 +2926,25 @@ public class SiteAction extends PagedResourceActionII {
 				context.put("selectedTools", selectedTools);
 			}
 			
-			//get any alternate tool names from the sites selected to import from (importSites) and the selectedTools list
-			Map<String,Set<String>> alternateToolNames = this.getToolNames(selectedTools, importSites);
-			System.out.println("names: " + alternateToolNames.toString());			
+			//get all known tool names from the sites selected to import from (importSites) and the selectedTools list
+			Map<String,Set<String>> toolNames = this.getToolNames(selectedTools, importSites);
 			
-			//need to set this into context and adjust the front end to also look at it.
+			//filter this list so its just the alternate ones and turn it into a string for the UI
+			Map<String,String> alternateToolTitles = new HashMap<>();
+			for(MyTool myTool : allTools) {
+				String toolId = myTool.getId();
+				String toolTitle = myTool.getTitle();
+				Set<String> allToolNames = toolNames.get(toolId);
+				if(allToolNames != null) {
+					allToolNames.remove(toolTitle);
+				
+					//if we have something left then we have alternates, so process them
+					if(!allToolNames.isEmpty()) {
+						alternateToolTitles.put(toolId, StringUtils.join(allToolNames, ", "));
+					}
+				}
+			}
+			context.put("alternateToolTitlesMap", alternateToolTitles);
 			
 			// set the flag for the UI
 			context.put("addMissingTools", addMissingTools);
@@ -3026,22 +3040,49 @@ public class SiteAction extends PagedResourceActionII {
 			//ensure this is the original tool list and set the sorted list back into context.
 			context.put(STATE_TOOL_REGISTRATION_LIST, allTools);
 			state.setAttribute(STATE_TOOL_REGISTRATION_SELECTED_LIST, state.getAttribute(STATE_TOOL_REGISTRATION_SELECTED_LIST));
-		
-			
 			
 			//if option is enabled, import into ALL tools, not just the ones in this site
 			//otherwise, only import content for the tools that already exist in the 'destination' site
 			boolean addMissingTools = isAddMissingToolsOnImportEnabled();
+			
+			//helper var to hold the list we use for the selectedTools context variable, as we use it for the alternate toolnames too
+			List<String> selectedTools = new ArrayList<>();
+			
 			if(addMissingTools) {
-				context.put("selectedTools", allImportableToolIdsInOriginalSites); 
+				
+                selectedTools = allImportableToolIdsInOriginalSites;
+				
+				context.put("selectedTools", selectedTools); 
 				//set tools in destination site into context so we can markup the lists and show which ones are new
 				context.put("toolsInDestinationSite", importableToolsIdsInDestinationSite);
 				
 			} else {
+				
+                selectedTools = importableToolsIdsInDestinationSite;
+
 				//just just the ones in the destination site
-				context.put("selectedTools", importableToolsIdsInDestinationSite); 
+				context.put("selectedTools", selectedTools); 
 			}
 			
+			//get all known tool names from the sites selected to import from (importSites) and the selectedTools list
+			Map<String,Set<String>> toolNames = this.getToolNames(selectedTools, importSites);
+			
+			//filter this list so its just the alternate ones and turn it into a string for the UI
+			Map<String,String> alternateToolTitles = new HashMap<>();
+			for(MyTool myTool : allTools) {
+				String toolId = myTool.getId();
+				String toolTitle = myTool.getTitle();
+				Set<String> allToolNames = toolNames.get(toolId);
+				if(allToolNames != null) {
+					allToolNames.remove(toolTitle);
+				
+					//if we have something left then we have alternates, so process them
+					if(!allToolNames.isEmpty()) {
+						alternateToolTitles.put(toolId, StringUtils.join(allToolNames, ", "));
+					}
+				}
+			}
+			context.put("alternateToolTitlesMap", alternateToolTitles);
 						
 			// set the flag for the UI
 			context.put("addMissingTools", addMissingTools);

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
@@ -66,6 +66,8 @@
 					<tr>					
 						<td>
 								#set($toolTitle = "")
+								#set($alternateToolTitles = "")
+								
 								#foreach($t in $toolRegistrationList)
 									#if ($t.getId() == $toolId)
 										#set($toolTitle = $t.getTitle())
@@ -74,7 +76,14 @@
 								#if($toolId == "sakai.iframe.site")
 									#set($toolTitle = $siteInfoToolTitle)
 								#end
+								
+								#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
+								
 								<h4>$toolTitle
+									
+									#if ($alternateToolTitles != "")
+										<span class="instruction">($alternateToolTitles)</span>
+									#end
 								
     								#if ($addMissingTools)
     									## if the tool doesnt exist in the selected site, output icon

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
@@ -108,6 +108,12 @@
 												#end
 											#end
 										#end
+										
+										#set ($toolsWithContent = $!siteToolsWithContent.get($site.getId()))
+										#if(!$toolsWithContent.contains($toolId))
+											#set($toolFound = false)
+    									#end
+										
 										#if ($toolFound)
 											<input type="checkbox" id="toolSite$toolCount$siteCount" name="$toolId" value="$site.Id" #if($!selectedSites.contains($site.Id))checked="checked"#end />
 											<label  class="skip" for="toolSite$toolCount$siteCount">$tlang.getString('import.choose.label1')  $toolTitle $tlang.getString('import.choose.label2') $validator.escapeHtml($site.getTitle())</label>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
@@ -74,6 +74,12 @@
 										#end
 									#end
 								#end
+								
+								#set ($toolsWithContent = $!siteToolsWithContent.get($site.getId()))
+								#if(!$toolsWithContent.contains($toolId))
+									#set($toolFound = false)
+								#end
+								
 								#if ($toolFound)
 									<input type="checkbox" id="toolSite$toolCount$siteCount" name="$toolId" value="$site.Id" #if($!selectedSites.contains($site.Id))checked="checked"#end />
 									<label  class="skip" for="toolSite$toolCount$siteCount">$tlang.getString('import.choose.label1')  $toolTitle $tlang.getString('import.choose.label2') $validator.escapeHtml($site.getTitle())</label>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
@@ -33,6 +33,8 @@
 					<tr>
 						<td>
 							#set($toolTitle = "")
+							#set($alternateToolTitles = "")
+
 							#foreach($t in $toolRegistrationList)
 								#if ($t.getId() == $toolId)
 									#set($toolTitle = $t.getTitle())
@@ -41,7 +43,15 @@
 							#if($toolId == "sakai.iframe.site")
 								#set($toolTitle = $siteInfoToolTitle)
 							#end
+							
+							#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
+							
 							<h4>$toolTitle
+								
+								#if ($alternateToolTitles != "")
+									<span class="instruction">($alternateToolTitles)</span>
+								#end
+								
 								#if ($addMissingTools)
 									## if the tool doesnt exist in the selected site, output icon
 									#if(!$toolsInDestinationSite.contains($toolId))

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/report/ReportDefEntityProducer.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/report/ReportDefEntityProducer.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import org.sakaiproject.entity.api.ContentExistsAware;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.EntityTransferrer;
@@ -38,7 +39,7 @@ import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-public class ReportDefEntityProducer implements EntityProducer, EntityTransferrer {
+public class ReportDefEntityProducer implements EntityProducer, EntityTransferrer, ContentExistsAware {
 	private ReportManager			M_rm;
 		
 	// --- Sakai services --------------------------------
@@ -182,5 +183,21 @@ public class ReportDefEntityProducer implements EntityProducer, EntityTransferre
 	public HttpAccess getHttpAccess() {
 		return null;
 	}
+
+	/**
+	 * This implementation simply checks if we have reports in the site. If so, consider it content.
+	 * 
+	 * @see org.sakaiproject.entity.api.ContentExistsAware#hasContent()
+	 */
+	@Override
+	public boolean hasContent(String siteId) {
+		List<ReportDef> existingReportDefinitions = M_rm.getReportDefinitions(siteId, false, true);
+		if(!existingReportDefinitions.isEmpty()){
+			return true;
+		}
+		return false;
+	}
+
+	
 
 }


### PR DESCRIPTION
This ticket builds on SAK-26069 and SAK-28993 which improves the Import from Site feature to automatically provision existing tools.

This ticket will provide the following features:

1. Tools that have names in the sites that have been selected for import, that are different to the standard name for the tool will be shown next to the tool name. This is so that the user can make an informed decision about including that tool, when they might know it by a different name.

2. Only tools that contain content will be listed for import. An entity interface will be added that tools can implement that allows them to explicitly say whether or not they have content. There is no point showing a tool for import if it has no content. The initial candidate for this is SiteStats but it can be extended to other tools. Default will be to include the tool if the interface is not implemented, to maintain backwards compatibility 