### PR TITLE
SAK-29164: course site -> add rosters should use existing term filtering if sakai.property set to true

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3124,7 +3124,7 @@ public class SiteAction extends PagedResourceActionII {
 				coursesIntoContext(state, context, site);
 
 				// bjones86 - SAK-23256
-				List<AcademicSession> terms = setTermListForContext( context, state, true, false ); // true -> upcoming only
+				List<AcademicSession> terms = setTermListForContext( context, state, true, true ); // true -> upcoming only
 				
 				AcademicSession t = (AcademicSession) state.getAttribute(STATE_TERM_SELECTED);
 				


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29164

The sakai.property worksitesetup.filtertermdropdowns (default = false) determines if the term drop downs should be filtered to only terms which the user has (instructor) section enrollments.

The same behaviour should be expected when an instructor is adding roster(s) to an existing course site via Site Info -> Edit Class Roster(s) -> Add Roster(s). 