### PR TITLE
SAK-23666 Add OAuth module to Sakai, PR2

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3877,3 +3877,10 @@
 # SAK-26283 Unenroll users before delete
 # ######################################
 # user.unenroll.before.delete=true
+
+# #####
+# OAuth
+# #####
+# Enable OAuth support
+# DEFAULT: false
+# oauth.enabled=true

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
@@ -146,3 +146,6 @@ preference.pages=prefs_tab_title, prefs_noti_title, prefs_timezone_title, prefs_
 
 # SAK-26063
 portal.chat.video = true
+
+# Enable OAuth
+oauth.enabled=true

--- a/entitybroker/tool/pom.xml
+++ b/entitybroker/tool/pom.xml
@@ -42,6 +42,13 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>
+        <!-- oAuth dependency -->
+        <dependency>
+            <groupId>org.sakaiproject.oauth</groupId>
+            <artifactId>oauth-api</artifactId>
+            <version>1.2-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Sakai K1 dependencies -->
 <!-- -->

--- a/entitybroker/tool/src/webapp/WEB-INF/web.xml
+++ b/entitybroker/tool/src/webapp/WEB-INF/web.xml
@@ -10,14 +10,38 @@
   <filter>
     <filter-name>sakai.request</filter-name>
     <filter-class>org.sakaiproject.util.RequestFilter</filter-class>
+    <!-- This also stops the session cookie being set -->
+    <init-param>
+      <param-name>sakai.session.auth</param-name>
+      <param-value>basic</param-value>
+    </init-param>
+  </filter>
+  <!-- OAuth Filters -->
+  <filter>
+    <filter-name>oauth.pre</filter-name>
+    <filter-class>org.sakaiproject.oauth.filter.OAuthPreFilter</filter-class>
+  </filter>
+  <filter>
+    <filter-name>oauth.post</filter-name>
+    <filter-class>org.sakaiproject.oauth.filter.OAuthPostFilter</filter-class>
   </filter>
 
+  <filter-mapping>
+    <filter-name>oauth.pre</filter-name>
+    <servlet-name>sakai.entitybroker.direct</servlet-name>
+    <dispatcher>REQUEST</dispatcher>
+  </filter-mapping>
   <filter-mapping>
     <filter-name>sakai.request</filter-name>
     <servlet-name>sakai.entitybroker.direct</servlet-name>
     <dispatcher>REQUEST</dispatcher>
     <dispatcher>FORWARD</dispatcher>
     <dispatcher>INCLUDE</dispatcher>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>oauth.post</filter-name>
+    <servlet-name>sakai.entitybroker.direct</servlet-name>
+    <dispatcher>REQUEST</dispatcher>
   </filter-mapping>
 
   <servlet>

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -1,0 +1,176 @@
+### Sakai OAuth
+
+Sakai OAuth allows any external application to connect to Sakai as any user
+thanks to the [OAuth system](http://oauth.net/) 1.0.
+
+### Structure
+
+The project is divided in five modules similar to the structure of many Sakai
+projects:
+
+- *api* contains a basic API for OAuth login, such as DAO for accessors and
+consumers, and mandatory services.
+- *impl* contains the actual code of the default OAuth implementation.
+- *pack* is the module defining the [Spring](http://www.springsource.org/)
+configuration.
+- *tool* is a simple web tool allowing users to remove an authorised *consumer*
+and and let administrators add new *consumers* to the system.
+
+### Terminology
+
+The OAuth terminology isn't really strict and may vary depending the libraries
+you're working with. Here is what is used in this project:
+
+- **Accessor**, also known as *token (see note)*.  
+    Two kinds of accessors are used:
+    - *Request*, temporary credentials authorised manually by the *user*.
+	This accessor allows a *consumer* to generate one *Access Accessor*.  
+        The request accessor goes through three states before being revoked:
+        - *new*, the accessor has been created by the OAuth service on
+		the request of a *consumer* and is not yet bound to a specific *user*.
+        - *authorising*, it's the part during which the *consumer* waits for a
+		*user* to grant it an access to the resources.
+        - *authorised*, the accessor can be used to generate one (and only one)
+		*Access Accessor*.
+
+    - *Access*, used by a *consumer* to directly access some protected resources
+	without requiring the *user* to log in.
+
+    *note:* a token is actually the unique identifier of an accessor.  
+	*Request accessor* states are specific to Sakai OAuth.
+- **Consumer**, also known as *client* or *third party application*.  
+It's the application the user will allow to access Sakai on his behalf.
+Consumers have to be declared in the OAuth service by an administrator first.
+- **Consumer secret**  
+Secret password shared only between *one consumer* and the OAuth service.  
+It will allow the consumer to *sign* its requests to the OAuth Service to check
+the validity of every request.
+- [**Access token secret**](http://wiki.oauth.net/w/page/12238553/SignatureMethods)
+also known as *signature* or simply *token secret*.  
+Secret password generated for each *accessor*, based on the *consumer secret*,
+it allows to exchange messages without using directly the actual
+*consumer secret* which is really sensitive, while allowing to check the
+validity of the request.
+- [**Accessor Secret**](http://wiki.oauth.net/w/page/12238502/AccessorSecret).  
+Secret independant from the *Consumer secret* and the *Access token secret*, it 
+can be defined in advance (the same way a *Consumer secret* is) or during the 
+creation of the *request accessor*.  
+It is used to replace the *consumer secret* during the generation of the
+*Access token secret* for an *access accessor*. This avoids using the
+*consumer secret* too much and increase the security.  
+*It is not mandatory*
+- **Callback URL**  
+During the authorisation procedure, a message is sent from the OAuth service to
+the *consumer*. This message is initated by the OAuth service and is sent on the
+callback URL which has been specified beforehand or during the creation of the
+*Request accessor*.
+- **User**, also known as *resource owner*. He is the actual Sakai user.
+
+### API
+
+The API relies on three different parts:
+
+- The DAO, used to create new ways to store informations about accessors and consumers
+- The service, allowing to specify an implementation respecting the
+[OAuth 1.0 workflow](http://hueniverse.com/oauth/guide/workflow/)
+- The filters, that will be applied on different parts of Sakai that should be accessible through OAuth
+*eg: access and entity-broker*
+
+#### API workflow
+
+This is step by step which method and how they're supposed to be called.
+
+##### [Creation of the *Request accessor*](http://tools.ietf.org/html/rfc5849#section-2.1)
+
+- `OAuthHttpService.handleRequestToken()`, the *customer* sends a direct request
+to the OAuthProvider on `/request_token`, asking for a *Request accessor*, the
+content of this http request is extracted to obtain a `Consumer`.
+- `OAuthService.createRequestAccessor()`, is called by the `OAuthHttpService` in
+order to generate a valid *Request accessor*.  
+If a *callback URL* or *accessor secret* was defined during the request, they
+are included in the *Request accessor* settings.
+- A reply containing, the *token*, the *Accessor token secret* is sent back.
+
+The *request accessor* is *new*, isn't linked to any user yet and cannot
+generate an *access accessor*.
+
+##### [Authorisation by the *user*](http://tools.ietf.org/html/rfc5849#section-2.2)
+
+- The *consumers* sends the *user* on `/authorize` page of Sakai with the 
+*request token* in parameter.
+- `AuthorisationServlet` will determine if the *user* is already logged in Sakai
+or not, and redirect him to the login screen if needed. The login screen
+redirects to `/authorize` with the *request token* in parameter.
+- `/authorize` starts the "authorisation procedure" (specific to Sakai OAuth).
+    - The *request accessor* is now in the *authorising* step.
+    - A `verifier` code is generated and stored with the *request accessor*,
+	this verifier allows to check that the result of the authorisation is a
+	choice by the *user* (as the *consumer* can't possibly know about this code).
+	- A form allowing the *user* to either grant or deny the permission to the
+	*consumer* to access the protected resources on his behalf.  
+	*The `verifier` is sent with the form*
+- Whether the *user* accepts or refuses, `OAuthHttpService.handleRequestAuthorisation()`
+is called with the answer of the user, the *token*, the *verifier* and the
+current userId.
+- If the user accepted, `OAuthHttpService` calls `OAuthService.authoriseAccessor()`
+    - The *request accessor* is now in the *authorised* step.
+	- The `verifier` is checked and the user ID is verified (**superusers**
+	can't use OAuth)
+	
+
+### The default implementation
+
+- Any administrator is not permitted authenticate via OAuth.
+
+#### Configuration
+
+The OAuth service can be configured through sakai.properties.
+
+The OAuth service is enabled by default. To disable OAuth on all requests this in the sakai.properties:
+`oauth.enabled=false`
+
+### Testing
+
+To test that OAuth is setup correctly you need a tool which will make HTTP requests with OAuth headers.
+There is a small Java utility called [oacurl](http://code.google.com/p/oacurl) which can make OAuth requests.
+
+#### Sakai Setup
+
+- Login to your Sakai instance as admin and go to the Administration Workspace.
+- Using the Sites tool edit the Administration Workspace (!admin), add a page, on the page put the OAuth
+ Administration Tool that allows you to manage OAuth consumers (tool ID: sakai.oauth.admin) and save the site.
+- Also using the Sites tool edit the My Workspace template (!user), add a page, on the page put the OAuth Trusted
+Applications tool which allows end users to manage their autorized applications (tool ID: sakai.oauth).
+- Refresh the browser on the Administration Workspace and you should see the oAuth Admin page appear. 
+- In the oAuth Admin tool add a new consumer.
+- The consumer key should be unique and meaningful. Eg: oacurl-test.
+- The consumer name is displayed to the users when they are allowing it access to their account. Eg oacurl.
+- The description should be used to describe what the consumer is doing or used for, again this is shown to
+end users.
+- The secret is the password for the consumer and should be secure. Eg: ooWaebai2Aep
+- Save the new consumer, then enable record mode which will set the permission filter to record permissions
+requested and allow them.
+
+#### oacurl Setup
+
+- Download the  oacurl .jar file and put if somewhere sensible.
+- Create a properties file (eg oacurl-test.properties) configured with the consumer you have just created.
+
+```
+    consumerKey=oacurl-test
+    consumerSecret=ooWaebai2Aep
+    requestTokenUrl=http://localhost:8080/oauth-tool/request_token
+    userAuthorizationUrl=http://localhost:8080/oauth-tool/authorize/
+    accessTokenUrl=http://localhost:8080/oauth-tool/access_token
+```
+
+- Launch the oacurl login:
+    `java -cp oacurl-1.3.0.jar  com.google.oacurl.Login --service-provider=oacurl-test.properties --consumer=oacurl-test.properties`
+- Your browser should popup now and ask you to login.
+- After logging in as a non-admin user you should be asked to allow the oacurl consumer access to your account.
+- After accepting it, a token will be save for later use.
+- To test login create a text file in the users My Workspace and save it (eg: test.txt).
+- Test the download using oacurl:
+    `java -cp oacurl-1.3.0.jar com.google.oacurl.Fetch http://localhost:8080/access/content/user/21096/test.txt`
+
+

--- a/oauth/api/pom.xml
+++ b/oauth/api/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oauth-api</artifactId>
+    <packaging>jar</packaging>
+
+    <name>OAuth API</name>
+    <description>Api allowing an access to a Sakai instance through OAuth 1.0.</description>
+
+    <properties>
+        <deploy.target>shared</deploy.target>
+    </properties>
+
+    <dependencies>
+        <!-- For filter declaration -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-component-manager</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oauth/api/src/java/org/sakaiproject/oauth/dao/AccessorDao.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/dao/AccessorDao.java
@@ -1,0 +1,59 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.sakaiproject.oauth.domain.Accessor;
+
+import java.util.Collection;
+
+/**
+ * Data access object for accessors (tokens).
+ *
+ * @author Colin Hebert
+ */
+public interface AccessorDao {
+    void create(Accessor accessor);
+
+    Accessor get(String accessorId);
+
+    /**
+     * Gets every accessor for a specific user.
+     *
+     * @param userId user associated with accessors
+     * @return accessors for a user
+     */
+    Collection<Accessor> getByUser(String userId);
+
+    /**
+     * Gets every accessor created for a consumer.
+     * @param consumerId consumer responsible of these accessors
+     * @return accessors for a consumer
+     */
+    Collection<Accessor> getByConsumer(String consumerId);
+
+    Accessor update(Accessor accessor);
+
+    void remove(Accessor accessor);
+
+    /**
+     * Checks every accessor and set them as expired if the date of expiration has passed.
+     */
+    void markExpiredAccessors();
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/dao/ConsumerDao.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/dao/ConsumerDao.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.Collection;
+
+/**
+ * Data access object for consumers (clients).
+ *
+ * @author Colin Hebert
+ */
+public interface ConsumerDao {
+    void create(Consumer consumer);
+
+    Consumer get(String consumerId);
+
+    Consumer update(Consumer consumer);
+
+    /**
+     * Removes a consumer, making it impossible to connect through oAuth with its credentials.
+     * <p>
+     * A proper implementation of this method MUST also revoke every token associated with the consumer.
+     * </p>
+     *
+     * @param consumer consumer to remove
+     */
+    void remove(Consumer consumer);
+
+    Collection<Consumer> getAll();
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/domain/Accessor.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/domain/Accessor.java
@@ -1,0 +1,221 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.domain;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Plain OAuth accessor.
+ *
+ * @author Colin Hebert
+ */
+public class Accessor implements Serializable {
+    /**
+     * Unique token associated with the accessor.
+     */
+    private String token;
+    /**
+     * Type of the accessor (request or access) during every stage of the authentication.
+     */
+    private Type type;
+    /**
+     * Status of the accessor (valid or not).
+     */
+    private Status status;
+    /**
+     * Verifier associated with the accessor, used during the authorisation phase.
+     */
+    private String verifier;
+    /**
+     * Token's secret.
+     * <p>
+     * Be careful, this is not the accessor's secret defined in http://wiki.oauth.net/w/page/12238502/AccessorSecret
+     * </p>
+     */
+    private String secret;
+    /**
+     * Consumer (client) requiring an OAuth token.
+     */
+    private String consumerId;
+    /**
+     * Date when the accessor has been created (should not change).
+     */
+    private Date creationDate;
+    /**
+     * Date when the accessor will expire, if set to null, the accessor doesn't expire.
+     */
+    private Date expirationDate;
+    /**
+     * URL used by a request token to send the user back on the web site he's coming from and validate his token.
+     */
+    private String callbackUrl;
+    /**
+     * User's id, only available in access accessors and authorised request accessors.
+     */
+    private String userId;
+    /**
+     * Variable accessor secret as defined in http://wiki.oauth.net/w/page/12238502/AccessorSecret.
+     * <p>
+     * Should be only set on request accessors, if null OAuth will use either the accessor secret or the consumer secret
+     * </p>
+     */
+    private String accessorSecret;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getVerifier() {
+        return verifier;
+    }
+
+    public void setVerifier(String verifier) {
+        this.verifier = verifier;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public void setConsumerId(String consumerId) {
+        this.consumerId = consumerId;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    public void setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
+    public String getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public void setCallbackUrl(String callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getAccessorSecret() {
+        return accessorSecret;
+    }
+
+    public void setAccessorSecret(String accessorSecret) {
+        this.accessorSecret = accessorSecret;
+    }
+
+    @Override
+    public String toString() {
+        return "Accessor{"
+                + "token='" + token + '\''
+                + ", type=" + type
+                + ", status=" + status
+                + ", consumerId='" + consumerId + '\''
+                + ", expirationDate=" + expirationDate
+                + ", userId='" + userId + '\''
+                + '}';
+    }
+
+    /**
+     * Types of accessors available.
+     */
+    public static enum Type {
+        /**
+         * Request accessor, used to initiate the authentication.
+         */
+        REQUEST,
+        /**
+         * Request accessor, during the authorisation phase.
+         */
+        REQUEST_AUTHORISING,
+        /**
+         * Authorised request accessor, associated with a user who accepted the connection.
+         */
+        REQUEST_AUTHORISED,
+        /**
+         * Access accessor, used to access to protected resources.
+         */
+        ACCESS
+    }
+
+    /**
+     * Possible status for a token.
+     */
+    public static enum Status {
+        /**
+         * Valid token, can be used either to access resources or authenticate an user.
+         */
+        VALID,
+        /**
+         * Invalid token which has either already been used (request token) or revoked by the user.
+         */
+        REVOKED,
+        /**
+         * Invalid token which hasn't been used during the validity period.
+         */
+        EXPIRED
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/domain/Consumer.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/domain/Consumer.java
@@ -1,0 +1,160 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.domain;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * Consumer (client) allowed to connect through an OAuth authentication.
+ *
+ * @author Colin Hebert
+ */
+public class Consumer implements Serializable {
+    /**
+     * Unique identifier of the consumer, also used as consumer's key.
+     */
+    private String id;
+    /**
+     * Name of the consumer, used for display.
+     */
+    private String name;
+    /**
+     * Consumer's description, contains messages addressed to the user during the authorisation phase.
+     */
+    private String description;
+    /**
+     * Consumer's URL, not the callback URL, a simple URL to allow the user to access the consumer's web site.
+     */
+    private String url;
+    /**
+     * Callback URL, used during the authorisation phase.
+     */
+    private String callbackUrl;
+    /**
+     * Consumer's secret (password), used to sign oauth messages.
+     */
+    private String secret;
+    /**
+     * Consumer's accessor secret, as defined in http://wiki.oauth.net/w/page/12238502/AccessorSecret.
+     */
+    private String accessorSecret;
+    /**
+     * Set of rights available for this specific consumer.
+     */
+    private Set<String> rights;
+    /**
+     * Default access token validity in minutes. The token won't expire if the value is 0.
+     */
+    private int defaultValidity;
+    /**
+     * Enable or disable the record mode. The default value should always be false for security reasons.
+     */
+    private boolean recordModeEnabled;
+
+    public String getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public void setCallbackUrl(String callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getAccessorSecret() {
+        return accessorSecret;
+    }
+
+    public void setAccessorSecret(String accessorSecret) {
+        this.accessorSecret = accessorSecret;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Set<String> getRights() {
+        return rights;
+    }
+
+    public void setRights(Set<String> rights) {
+        this.rights = rights;
+    }
+
+    public int getDefaultValidity() {
+        return defaultValidity;
+    }
+
+    public void setDefaultValidity(int defaultValidity) {
+        this.defaultValidity = defaultValidity;
+    }
+
+    public boolean isRecordModeEnabled() {
+        return recordModeEnabled;
+    }
+
+    public void setRecordModeEnabled(boolean recordModeEnabled) {
+        this.recordModeEnabled = recordModeEnabled;
+    }
+
+    @Override
+    public String toString() {
+        return "Consumer{"
+                + "id='" + id + '\''
+                + ", name='" + name + '\''
+                + ", url='" + url + '\''
+                + '}';
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/exception/ExpiredAccessorException.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/exception/ExpiredAccessorException.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.exception;
+
+/**
+ * Exception thrown when the accessor used is considered as expired.
+ *
+ * @author Colin Hebert
+ */
+public class ExpiredAccessorException extends InvalidAccessorException {
+    public ExpiredAccessorException() {
+        super();
+    }
+
+    public ExpiredAccessorException(Throwable cause) {
+        super(cause);
+    }
+
+    public ExpiredAccessorException(String message) {
+        super(message);
+    }
+
+    public ExpiredAccessorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/exception/InvalidAccessorException.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/exception/InvalidAccessorException.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.exception;
+
+/**
+ * Exception thrown when the accessor used is considered as invalid (expired, revoked, ...).
+ *
+ * @author Colin Hebert
+ */
+public class InvalidAccessorException extends OAuthException {
+    public InvalidAccessorException() {
+        super();
+    }
+
+    public InvalidAccessorException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidAccessorException(String message) {
+        super(message);
+    }
+
+    public InvalidAccessorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/exception/InvalidConsumerException.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/exception/InvalidConsumerException.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.exception;
+
+/**
+ * Exception thrown when a consumer can't be used, because it's nonexistant or disabled.
+ *
+ * @author Colin Hebert
+ */
+public class InvalidConsumerException extends OAuthException {
+    public InvalidConsumerException() {
+    }
+
+    public InvalidConsumerException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidConsumerException(String message) {
+        super(message);
+    }
+
+    public InvalidConsumerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/exception/InvalidVerifierException.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/exception/InvalidVerifierException.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.exception;
+
+/**
+ * Exception thrown when the given verifier doesn't match the expected verifier.
+ *
+ * @author Colin Hebert
+ */
+public class InvalidVerifierException extends OAuthException {
+    public InvalidVerifierException() {
+    }
+
+    public InvalidVerifierException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidVerifierException(String message) {
+        super(message);
+    }
+
+    public InvalidVerifierException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/exception/OAuthException.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/exception/OAuthException.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.exception;
+
+/**
+ * Exceptions thrown during the use of OAuth protocol.
+ *
+ * @author Colin Hebert
+ */
+public class OAuthException extends RuntimeException {
+    public OAuthException() {
+    }
+
+    public OAuthException(Throwable cause) {
+        super(cause);
+    }
+
+    public OAuthException(String message) {
+        super(message);
+    }
+
+    public OAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/exception/RevokedAccessorException.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/exception/RevokedAccessorException.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.exception;
+
+/**
+ * Thrown when an accessor is considered as revoked.
+ *
+ * @author Colin Hebert
+ */
+public class RevokedAccessorException extends InvalidAccessorException {
+    public RevokedAccessorException() {
+        super();
+    }
+
+    public RevokedAccessorException(Throwable cause) {
+        super(cause);
+    }
+
+    public RevokedAccessorException(String message) {
+        super(message);
+    }
+
+    public RevokedAccessorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/filter/OAuthPostFilter.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/filter/OAuthPostFilter.java
@@ -1,0 +1,102 @@
+
+package org.sakaiproject.oauth.filter;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.component.api.ComponentManager;
+import org.sakaiproject.event.api.UsageSessionService;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.user.api.Authentication;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.user.api.UserNotDefinedException;
+import org.sakaiproject.oauth.service.OAuthHttpService;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.Principal;
+
+/**
+ * Last filter applied for the OAuth protocol
+ * <p>
+ * Gets the current user from the principal and log the user in.
+ * </p>
+ *
+ * @author Colin Hebert
+ */
+public class OAuthPostFilter implements Filter {
+    private static final Log log = LogFactory.getLog(OAuthPostFilter.class);
+    private OAuthHttpService oAuthHttpService;
+    private SessionManager sessionManager;
+    private UserDirectoryService userDirectoryService;
+    private UsageSessionService usageSessionService;
+    // private AuthenticationManager authenticationManager;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        ComponentManager componentManager = org.sakaiproject.component.cover.ComponentManager.getInstance();
+        oAuthHttpService = (OAuthHttpService) componentManager.get(OAuthHttpService.class);
+        sessionManager = (SessionManager) componentManager.get(SessionManager.class);
+        userDirectoryService = (UserDirectoryService) componentManager.get(UserDirectoryService.class);
+        usageSessionService = (UsageSessionService) componentManager.get(UsageSessionService.class);
+        // authenticationManager = (AuthenticationManager) componentManager.get(AuthenticationManager.class);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        // Only apply filter if there is an OAuth implementation and a valid OAuth request
+        if (oAuthHttpService == null || !oAuthHttpService.isEnabled()
+                || !oAuthHttpService.isValidOAuthRequest(req, res)) {
+            chain.doFilter(req, response);
+            return;
+        }
+
+        Principal principal = req.getUserPrincipal();
+        // Do not log the user in if there is already an opened session
+        if (principal != null && sessionManager.getCurrentSessionUserId() == null) {
+            try {
+                // Force the authentication/login with the user Eid
+                final String eid = userDirectoryService.getUserEid(principal.getName());
+                final String uid = principal.getName();
+
+                // TODO This is a hack and we should go through the AuthenticationManager API.
+                Authentication authentication = new Authentication() {
+
+                    @Override
+                    public String getUid() {
+                        return uid;
+                    }
+
+                    @Override
+                    public String getEid() {
+                        return eid;
+                    }
+                };
+
+                // Authentication authentication = authenticationManager.authenticate(new ExternalTrustedEvidence() {
+                //    public String getIdentifier() {
+                //        return eid;
+                //    }
+                // });
+                usageSessionService.login(authentication, req);
+            } catch (UserNotDefinedException e) {
+                log.warn("Failed to find user \"" + principal.getName() + "\". This shouldn't happen", e);
+            }
+        }
+        chain.doFilter(req, res);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/filter/OAuthPreFilter.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/filter/OAuthPreFilter.java
@@ -1,0 +1,134 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.filter;
+
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.util.RequestFilter;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.exception.InvalidAccessorException;
+import org.sakaiproject.oauth.service.OAuthHttpService;
+import org.sakaiproject.oauth.service.OAuthService;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+
+/**
+ * First filter to apply with OAuth protocol
+ * <p>
+ * Checks the validity of the current request and OAuth parameters.
+ * Sets a security advisor for the request.
+ * </p>
+ *
+ * @author Colin Hebert
+ */
+public class OAuthPreFilter implements Filter {
+    private String encoding;
+    private OAuthHttpService oAuthHttpService;
+    private OAuthService oAuthService;
+    private SecurityService securityService;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        this.oAuthService = (OAuthService) ComponentManager.getInstance().get(OAuthService.class);
+        this.oAuthHttpService = (OAuthHttpService) ComponentManager.getInstance().get(OAuthHttpService.class);
+        this.securityService = (SecurityService) ComponentManager.getInstance().get(SecurityService.class);
+        String initEncoding = filterConfig.getInitParameter(RequestFilter.CONFIG_CHARACTER_ENCODING);
+        this.encoding = initEncoding != null ? initEncoding : "UTF-8";
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        // Force the character encoding for HTTP body content
+        setEncoding(request);
+
+        // Only apply filter if there is an OAuth implementation and a valid OAuth request
+        if (oAuthHttpService == null || !oAuthHttpService.isEnabled()
+                || !oAuthHttpService.isValidOAuthRequest(req, res)) {
+            chain.doFilter(req, response);
+            return;
+        }
+
+        try {
+            String oAuthToken = oAuthHttpService.getOAuthAccessToken(req);
+            final Accessor accessor = oAuthService.getAccessor(oAuthToken, Accessor.Type.ACCESS);
+
+            HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(req) {
+                @Override
+                public Principal getUserPrincipal() {
+                    return new Principal() {
+                        public String getName() {
+                            return accessor.getUserId();
+                        }
+                    };
+                }
+            };
+
+            securityService.pushAdvisor(oAuthService.getSecurityAdvisor(accessor.getToken()));
+
+            chain.doFilter(wrappedRequest, response);
+        } catch (InvalidAccessorException e) {
+            // TODO: Redirect to an error page
+        }
+    }
+
+    /**
+     * Sets the encoding for parameters submitted through a POST request.
+     * <p>
+     * If a charset isn't set manually, OAuth will try to decode some of the submitted parameters by the user with
+     * ISO-8859-1 (those parameters are supposed to be in ASCII in the first place).<br />
+     * Parameters are only decoded once, and {@link org.sakaiproject.util.RequestFilter} usually sets the charset
+     * encoding itself, but the pre-filter reads the parameters first, so it needs to be done here.
+     * </p>
+     * <p>
+     * Usually only parameters sent through a multipart/form-data POST request already provide the character encoding
+     * used to encode the parameters.<br />
+     * Parameters sent through a application/x-www-form-urlencoded POST request are expected to be only
+     * ASCII characters.<br />
+     * To avoid problems with developers who forget to set their POST forms in multipart/form-data, it will be assumed
+     * that every client sends their forms (multipart/form-data and application/x-www-form-urlencoded POST forms)
+     * using UTF-8.<br />
+     * This might cause some problems if the client doesn't actually use UTF-8 though.
+     * </p>
+     * <p>
+     * It's possible to specify an other encoding than "UTF-8" by setting the charset with in the filter configuration
+     * parameter {@link RequestFilter#CONFIG_CHARACTER_ENCODING}
+     * </p>
+     *
+     * @param request request on which the character encoding will be specified.
+     * @throws UnsupportedEncodingException
+     */
+    private void setEncoding(ServletRequest request) throws UnsupportedEncodingException {
+        request.setCharacterEncoding(this.encoding);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/service/OAuthAdminService.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/service/OAuthAdminService.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.service;
+
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.Collection;
+
+/**
+ * Administration service handling every sensitive tasks.
+ *
+ * @author Colin Hebert
+ */
+public interface OAuthAdminService {
+    /**
+     * Get a raw consumer based on its id.
+     *
+     * @param consumerId Id of the desired consumer
+     * @return consumer if it exists,
+     */
+    Consumer getConsumer(String consumerId);
+
+    /**
+     * Create a new consumer available for future oAuth communications.
+     *
+     * @param consumer consumer to create
+     */
+    void createConsumer(Consumer consumer);
+
+    /**
+     * Update a consumer with new settings.
+     *
+     * @param consumer consumer to update
+     * @return the updated consumer
+     */
+    Consumer updateConsumer(Consumer consumer);
+
+    /**
+     * Delete a consumer and associated accessors.
+     *
+     * @param consumer consumer to delete
+     */
+    void deleteConsumer(Consumer consumer);
+
+    /**
+     * Get a list of every available consumer.
+     *
+     * @return every consumer
+     */
+    Collection<Consumer> getAllConsumers();
+
+    /**
+     * Change the record mode of a consumer.
+     * <p>
+     * A consumer with the record mode enabled will have every right and will keep every right it uses.
+     * When the record mode is disabled, every right used before is still available, but others aren't anymore.<br />
+     * This is useful to setup a new consumer and enable its rights without having to look for every necessary right.
+     * </p>
+     *
+     * @param consumer consumer on which the record mode will be enabled or disabled.
+     */
+    void switchRecordMode(Consumer consumer);
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/service/OAuthHttpService.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/service/OAuthHttpService.java
@@ -1,0 +1,103 @@
+
+package org.sakaiproject.oauth.service;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * OAuthHttpService handles incoming OAuth requests and interactions with filters. *
+ *
+ * @author Colin Hebert
+ */
+public interface OAuthHttpService {
+    /**
+     * Check the validity of a request toward a protected resource
+     * <p>
+     * Mostly used in filters, this method checks the validity of the token provided by a consumer when accessing
+     * protected resources on the behalf of a client.
+     * </p>
+     * <p>
+     * If the request is an OAuth request but some issues due to invalid values or unauthorised access the response
+     * will be modified to return an HTTP error.
+     * </p>
+     *
+     * @param request  Incoming request
+     * @param response Outgoing response
+     * @return True if the request is an OAuth request and is valid, false otherwise
+     * @throws IOException
+     * @throws ServletException
+     */
+    boolean isValidOAuthRequest(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException;
+
+    /**
+     * Extract the access token from an OAuth request.
+     *
+     * @param request OAuth request
+     * @return The access token if it exists, null otherwise
+     * @throws IOException
+     */
+    String getOAuthAccessToken(HttpServletRequest request) throws IOException;
+
+    /**
+     * Handle the first step of the OAuth 1.0 authentication.
+     * <p>
+     * Check consumer's signature and provide temporary credentials
+     * </p>
+     *
+     * @param request  Incoming request
+     * @param response Outgoing response
+     * @throws IOException
+     * @throws ServletException
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.1">Temporary Credentials</a>
+     */
+    void handleRequestToken(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException;
+
+    /**
+     * Handle the last step of the OAuth 1.0 authentication.
+     * <p>
+     * Check consumer's signature, the request accessor's verifier<br />
+     * Create an access accessor for the user who accepted the connection
+     * </p>
+     *
+     * @param request  Incoming request
+     * @param response Outgoing response
+     * @throws IOException
+     * @throws ServletException
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.3">Token Credentials</a>
+     */
+    void handleGetAccessToken(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException;
+
+    /**
+     * Handle the authorisation step of the OAuth 1.0 authentication.
+     * <p>
+     * Check if the user has authorised the consumer.<br />
+     * Assign the user to the request token.<br />
+     * Check an optional verifier (not from the OAuth protocol).<br />
+     * Once the user is logged-in and has accepted (or denied) the authorisation, send him back on the callback URL.
+     * </p>
+     *
+     * @param request    Incoming request
+     * @param response   Outgoing response
+     * @param authorised Has the user accepted to give access to the consumer
+     * @param token      Request token from the consumer
+     * @param verifier   Optionnal verifier, unknown to the consumer so the client has to actually accept the token.
+     * @param userId     Current user's id
+     * @throws IOException
+     * @throws ServletException
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.2">Resource Owner Authorization</a>
+     */
+    void handleRequestAuthorisation(HttpServletRequest request, HttpServletResponse response, boolean authorised,
+                                    String token, String verifier, String userId)
+            throws IOException, ServletException;
+
+    /**
+     * Checks if OAuth is enabled.
+     * @return <code>true</code> if the OAuth service is enabled.
+     */
+    boolean isEnabled();
+}

--- a/oauth/api/src/java/org/sakaiproject/oauth/service/OAuthService.java
+++ b/oauth/api/src/java/org/sakaiproject/oauth/service/OAuthService.java
@@ -1,0 +1,150 @@
+/*
+ * #%L
+ * OAuth API
+ * %%
+ * Copyright (C) 2009 - 2013 Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.service;
+
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.Collection;
+
+/**
+ * OAuthService handles OAuth operations without interacting with HTTP data.
+ *
+ * @author Colin Hebert
+ */
+public interface OAuthService {
+    /**
+     * Callback used when the client is unable to receive callbacks
+     * or a callback URI has been established via other means.
+     *
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.1">Temporary credentials</a>
+     */
+    String OUT_OF_BAND_CALLBACK = "oob";
+
+    /**
+     * Get the valid accessor using the given token.
+     * <p>
+     * If the accessor doesn't exist, or the token isn't valid an exception is thrown.
+     * </p>
+     * <p>
+     * getAccessor is expected to return an accessor with a specific type.<br />
+     * If an accessor is found but the type doesn't match the expected type, an exception is thrown.
+     * </p>
+     *
+     * @param oAuthToken   Token associated to the accessor
+     * @param expectedType Expected accessor's type
+     * @return the matching accessor
+     */
+    Accessor getAccessor(String oAuthToken, Accessor.Type expectedType);
+
+    /**
+     * Get the security advisor associated with an access accessor.
+     * <p>
+     * Each accessor can define its own set of rules to allow access to certain protected resources.
+     * </p>
+     *
+     * @param accessorId token of the said accessor
+     * @return A security advisor allowing access to some protected resources
+     */
+    SecurityAdvisor getSecurityAdvisor(String accessorId);
+
+    /**
+     * Get a consumer given its key (id).
+     *
+     * @param consumerKey identifier of the consumer
+     * @return the requested consumer
+     * @throws org.sakaiproject.oauth.exception.InvalidConsumerException
+     *          if the consumer doesn't exists or isn't valid
+     */
+    Consumer getConsumer(String consumerKey);
+
+    /**
+     * Create a request accessor.
+     * <p>
+     * The created accessor's type is {@link Accessor.Type#REQUEST}
+     * </p>
+     *
+     * @param consumerId     consumer associated to the accessor
+     * @param callback       callback used when the authorisation is done
+     * @param accessorSecret optional variable accessor secret
+     *                       <a href="http://wiki.oauth.net/w/page/12238502/AccessorSecret">AccessorSecret</a>
+     * @return the new request accessor
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.1">Temporary credentials</a>
+     */
+    Accessor createRequestAccessor(String consumerId, String callback, String accessorSecret);
+
+    /**
+     * Start the authorisation process.
+     * <p>
+     * Changes the accessor's type to {@link Accessor.Type#REQUEST_AUTHORISING}
+     * </p>
+     *
+     * @param accessorId access accessor used for the autorisation process
+     * @return the request accessor used for the authorisation
+     */
+    Accessor startAuthorisation(String accessorId);
+
+    /**
+     * Finish the authorisation process when the client has authorised the consumer to connect.
+     * <p>
+     * Changes the accessor's type to {@link Accessor.Type#REQUEST_AUTHORISED}<br/>
+     * Sets the verifier.
+     * </p>
+     *
+     * @param accessorId Request token
+     * @param verifier   Optional verifier (not a part of OAuth)
+     * @param userId     User accepting the connection
+     * @return the request accessor used for the authorisation
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.2">Resource owner authorization</a>
+     */
+    Accessor authoriseAccessor(String accessorId, String verifier, String userId);
+
+    /**
+     * Create an accessor allowing to access protected resources.
+     *
+     * @param requestAccessorId the allowed request accessor
+     * @return a new Accessor allowed to access protected resources
+     * @see <a href="http://tools.ietf.org/html/rfc5849#section-2.3">Token credentials</a>
+     */
+    Accessor createAccessAccessor(String requestAccessorId);
+
+    /**
+     * Get a collection of every valid access accessors for one user.
+     *
+     * @param userId unique identifier of a Sakai user
+     * @return a collection of {@link Accessor.Status#VALID} accessors
+     */
+    Collection<Accessor> getAccessAccessorForUser(String userId);
+
+    /**
+     * Manually revoke an accessor.
+     *
+     * @param accessorId accessor's token
+     */
+    void revokeAccessor(String accessorId);
+
+    /**
+     * Finish the authorisation process when the client has NOT authorised the consumer to connect.
+     *
+     * @param accessorId accessor's token
+     */
+    void denyRequestAccessor(String accessorId);
+}

--- a/oauth/impl/dao-hbm/pom.xml
+++ b/oauth/impl/dao-hbm/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>oauth-dao-hbm</artifactId>
+    <packaging>jar</packaging>
+
+    <name>OAuth Hibernate DAO</name>
+    <description>
+        Hibernate implementation of the DAO used by the OAuth tool, allowing to save the configuration and tokens in a
+        database.
+    </description>
+
+    <properties>
+        <deploy.target>shared</deploy.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/resources</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </build>
+    
+</project>
+

--- a/oauth/impl/dao-hbm/src/java/org/sakaiproject/oauth/dao/HibernateAccessorDao.java
+++ b/oauth/impl/dao-hbm/src/java/org/sakaiproject/oauth/dao/HibernateAccessorDao.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * OAuth Hibernate DAO
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.springframework.orm.hibernate3.HibernateCallback;
+import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+import org.sakaiproject.oauth.domain.Accessor;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+public class HibernateAccessorDao extends HibernateDaoSupport implements AccessorDao {
+    @Override
+    public void create(final Accessor accessor) {
+        getHibernateTemplate().save(accessor);
+    }
+
+    @Override
+    public Accessor get(String accessorId) {
+        return (Accessor) getHibernateTemplate().get(Accessor.class, accessorId);
+    }
+
+    @Override
+    public List<Accessor> getByUser(String userId) {
+        return (List<Accessor>) getHibernateTemplate().find(
+                "FROM Accessor a WHERE a.userId = ?",
+                new Object[]{userId});
+    }
+
+    @Override
+    public Collection<Accessor> getByConsumer(String consumerId) {
+        return (List<Accessor>) getHibernateTemplate().find(
+                "FROM Accessor a WHERE a.consumerId = ?",
+                new Object[]{consumerId});
+    }
+
+    @Override
+    public void markExpiredAccessors() {
+        getHibernateTemplate().execute(new HibernateCallback() {
+            public Object doInHibernate(Session session) throws HibernateException, SQLException {
+                session.createQuery(
+                        "UPDATE Accessor a SET a.status=? WHERE a.expirationDate < ?")
+                        .setParameter(0, Accessor.Status.EXPIRED)
+                        .setDate(1, new Date())
+                        .executeUpdate();
+                return null;
+            }
+        });
+    }
+
+
+    @Override
+    public Accessor update(Accessor accessor) {
+        getHibernateTemplate().update(accessor);
+        return accessor;
+    }
+
+    @Override
+    public void remove(Accessor accessor) {
+        getHibernateTemplate().delete(accessor);
+    }
+}

--- a/oauth/impl/dao-hbm/src/java/org/sakaiproject/oauth/dao/HibernateConsumerDao.java
+++ b/oauth/impl/dao-hbm/src/java/org/sakaiproject/oauth/dao/HibernateConsumerDao.java
@@ -1,0 +1,53 @@
+/*
+ * #%L
+ * OAuth Hibernate DAO
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.Collection;
+
+public class HibernateConsumerDao extends HibernateDaoSupport implements ConsumerDao {
+    @Override
+    public void create(final Consumer consumer) {
+        getHibernateTemplate().save(consumer);
+    }
+
+    @Override
+    public Consumer get(String consumerId) {
+        return (Consumer) getHibernateTemplate().get(Consumer.class, consumerId);
+    }
+
+    @Override
+    public Consumer update(Consumer consumer) {
+        getHibernateTemplate().update(consumer);
+        return consumer;
+    }
+
+    @Override
+    public void remove(Consumer consumer) {
+        getHibernateTemplate().delete(consumer);
+    }
+
+    @Override
+    public Collection<Consumer> getAll() {
+        return getHibernateTemplate().loadAll(Consumer.class);
+    }
+}

--- a/oauth/impl/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Accessor.hbm.xml
+++ b/oauth/impl/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Accessor.hbm.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  OAuth Hibernate DAO
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.sakaiproject.oauth.domain">
+    <class name="Accessor" table="OAUTH_ACCESSORS">
+        <id name="token" type="string">
+            <column name="token"/>
+        </id>
+        <property name="secret" type="string"/>
+        <property name="consumerId" type="string"/>
+        <property name="userId" type="string" index="user_idx"/>
+        <property name="callbackUrl" type="string"/>
+        <property name="verifier" type="string"/>
+        <property name="creationDate" type="timestamp"/>
+        <property name="expirationDate" type="timestamp"/>
+        <property name="status">
+            <type name="org.hibernate.type.EnumType">
+                <param name="enumClass">org.sakaiproject.oauth.domain.Accessor$Status</param>
+            </type>
+        </property>
+        <property name="type">
+            <type name="org.hibernate.type.EnumType">
+                <param name="enumClass">org.sakaiproject.oauth.domain.Accessor$Type</param>
+            </type>
+        </property>
+        <property name="accessorSecret"/>
+    </class>
+</hibernate-mapping>

--- a/oauth/impl/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Consumer.hbm.xml
+++ b/oauth/impl/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Consumer.hbm.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  OAuth Hibernate DAO
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.sakaiproject.oauth.domain">
+    <class name="Consumer" table="OAUTH_CONSUMERS">
+        <id name="id" type="string">
+            <column name="id"/>
+        </id>
+        <set name="rights" table="OAUTH_RIGHTS" lazy="false">
+            <key column="id"/>
+            <element type="string" column="accessright" not-null="true"/>
+        </set>
+
+        <property name="name" type="string" not-null="true"/>
+        <property name="description" type="string"/>
+        <property name="url" type="string"/>
+        <property name="callbackUrl" type="string"/>
+        <property name="secret" type="string" not-null="true"/>
+        <property name="accessorSecret" type="string"/>
+        <property name="recordModeEnabled" type="boolean"/>
+        <property name="defaultValidity" type="int" not-null="true"/>
+    </class>
+</hibernate-mapping>

--- a/oauth/impl/dao-memory/pom.xml
+++ b/oauth/impl/dao-memory/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>oauth-dao-memory</artifactId>
+    <packaging>jar</packaging>
+
+    <name>OAuth In-memory DAO</name>
+    <description>
+        In memory implementation of the DAO used by the OAuth tool, allowing to save the configuration and tokens in
+        memory.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oauth/impl/dao-memory/src/java/org/sakaiproject/oauth/dao/MemoryAccessorDao.java
+++ b/oauth/impl/dao-memory/src/java/org/sakaiproject/oauth/dao/MemoryAccessorDao.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * OAuth In-memory DAO
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.sakaiproject.oauth.domain.Accessor;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * @author Colin Hebert
+ */
+public class MemoryAccessorDao implements AccessorDao {
+    private final Map<String, Accessor> accessors;
+
+    public MemoryAccessorDao(Map<String, Accessor> accessors) {
+        this.accessors = accessors;
+    }
+
+    @Override
+    public void create(Accessor accessor) {
+        accessors.put(accessor.getToken(), accessor);
+    }
+
+    @Override
+    public Accessor get(String accessorId) {
+        return accessors.get(accessorId);
+    }
+
+    @Override
+    public Collection<Accessor> getByUser(String userId) {
+        Collection<Accessor> retrievedAccessors = new LinkedList<Accessor>();
+        for (Accessor accessor : accessors.values()) {
+            if (userId.equals(accessor.getUserId()))
+                retrievedAccessors.add(accessor);
+        }
+
+        return retrievedAccessors;
+    }
+
+    @Override
+    public Collection<Accessor> getByConsumer(String consumerId) {
+        Collection<Accessor> retrievedAccessors = new LinkedList<Accessor>();
+        for (Accessor accessor : accessors.values()) {
+            if (consumerId.equals(accessor.getConsumerId()))
+                retrievedAccessors.add(accessor);
+        }
+
+        return retrievedAccessors;
+    }
+
+    @Override
+    public Accessor update(Accessor accessor) {
+        accessors.put(accessor.getToken(), accessor);
+        return get(accessor.getToken());
+    }
+
+    @Override
+    public void remove(Accessor accessor) {
+        accessors.remove(accessor.getToken());
+    }
+
+    @Override
+    public void markExpiredAccessors() {
+        Collection<String> expiredIds = new LinkedList<String>();
+        for (Accessor accessor : accessors.values()) {
+            if (accessor.getExpirationDate().before(new Date()))
+                expiredIds.add(accessor.getToken());
+        }
+
+        for (String expiredId : expiredIds) {
+            accessors.remove(expiredId);
+        }
+    }
+}

--- a/oauth/impl/dao-memory/src/java/org/sakaiproject/oauth/dao/MemoryConsumerDao.java
+++ b/oauth/impl/dao-memory/src/java/org/sakaiproject/oauth/dao/MemoryConsumerDao.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * OAuth In-memory DAO
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * @author Colin Hebert
+ */
+public class MemoryConsumerDao implements ConsumerDao {
+    private final Map<String, Consumer> consumers;
+
+    public MemoryConsumerDao(Map<String, Consumer> consumers) {
+        this.consumers = consumers;
+    }
+
+    @Override
+    public void create(Consumer consumer) {
+        // TODO: Throw an exception if the consumer already exists?
+        consumers.put(consumer.getId(), consumer);
+    }
+
+    @Override
+    public Consumer get(String consumerId) {
+        return consumers.get(consumerId);
+    }
+
+    @Override
+    public Consumer update(Consumer consumer) {
+        consumers.put(consumer.getId(), consumer);
+        // Two steps, to be sure, because we don't know the Map implementation
+        return get(consumer.getId());
+    }
+
+    @Override
+    public void remove(Consumer consumer) {
+        consumers.remove(consumer.getId());
+    }
+
+    @Override
+    public Collection<Consumer> getAll() {
+        return consumers.values();
+    }
+}

--- a/oauth/impl/dao-server-config/pom.xml
+++ b/oauth/impl/dao-server-config/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>oauth-dao-server-config</artifactId>
+    <packaging>jar</packaging>
+
+    <name>OAuth ServerConfig DAO</name>
+    <description>
+        In properties implementation of the DAO used by the OAuth tool, allowing to retrieve the configuration from the
+        sakai.properties file. It must be used with an other DAO implementation to store tokens.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-component-manager</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/oauth/impl/dao-server-config/src/java/org/sakaiproject/oauth/dao/ServerConfigConsumerDao.java
+++ b/oauth/impl/dao-server-config/src/java/org/sakaiproject/oauth/dao/ServerConfigConsumerDao.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * OAuth ServerConfig DAO
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.dao;
+
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.*;
+
+/**
+ * @author Colin Hebert
+ */
+public class ServerConfigConsumerDao implements ConsumerDao {
+    /**
+     * Property prefix for OAuth settings
+     */
+    private static final String OAUTH_PREFIX = "oauth";
+    private Map<String, Consumer> consumers;
+
+    public ServerConfigConsumerDao(ServerConfigurationService serverConfig) {
+        Collection<String> consumerKeys = getStringsOrSplit(OAUTH_PREFIX + ".consumers", serverConfig);
+        consumers = new HashMap<String, Consumer>(consumerKeys.size());
+        for (String consumerKey : consumerKeys) {
+            Consumer consumer = new Consumer();
+            consumer.setId(consumerKey);
+            String consumerPrefix = OAUTH_PREFIX + "." + consumerKey;
+            consumer.setName(serverConfig.getString(consumerPrefix + ".name", null));
+            consumer.setDescription(serverConfig.getString(consumerPrefix + ".description", null));
+            consumer.setUrl(serverConfig.getString(consumerPrefix + ".url", null));
+            consumer.setCallbackUrl(serverConfig.getString(consumerPrefix + ".callbackUrl", null));
+            consumer.setSecret(serverConfig.getString(consumerPrefix + ".secret"));
+            consumer.setAccessorSecret(serverConfig.getString(consumerPrefix + ".accessorsecret", null));
+            consumer.setDefaultValidity(serverConfig.getInt(consumerPrefix + ".validity", 0));
+            consumer.setRights(new HashSet<String>(getStringsOrSplit(consumerPrefix + ".rights", serverConfig)));
+            consumer.setRecordModeEnabled(serverConfig.getBoolean(consumerPrefix + ".record", false));
+
+            consumers.put(consumerKey, consumer);
+        }
+    }
+
+    private static Collection<String> getStringsOrSplit(String name, ServerConfigurationService serverConfig) {
+        String stringValue = serverConfig.getString(name, null);
+        String[] values;
+        if (stringValue != null)
+            values = stringValue.split(",");
+        else
+            values = serverConfig.getStrings(name);
+
+        return (values != null) ? Arrays.asList(values) : Collections.<String>emptyList();
+    }
+
+    @Override
+    public void create(Consumer consumer) {
+        throw new UnsupportedOperationException("Can't create a consumer in the server config");
+    }
+
+    @Override
+    public Consumer get(String consumerId) {
+        return consumers.get(consumerId);
+    }
+
+    @Override
+    public Consumer update(Consumer consumer) {
+        throw new UnsupportedOperationException("Can't update a consumer in the server config");
+    }
+
+    @Override
+    public void remove(Consumer consumer) {
+        throw new UnsupportedOperationException("Can't remove a consumer in the server config");
+    }
+
+    @Override
+    public Collection<Consumer> getAll() {
+        return consumers.values();
+    }
+}

--- a/oauth/impl/pom.xml
+++ b/oauth/impl/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oauth-impl</artifactId>
+    <packaging>jar</packaging>
+
+    <name>OAuth Implementation</name>
+    <description>Default implementation of the OAuth project for Sakai CLE using OAuth 1.0.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.oauth.core</groupId>
+            <artifactId>oauth-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.oauth.core</groupId>
+            <artifactId>oauth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>
+

--- a/oauth/impl/src/java/org/sakaiproject/oauth/advisor/CollectingPermissionsAdvisor.java
+++ b/oauth/impl/src/java/org/sakaiproject/oauth/advisor/CollectingPermissionsAdvisor.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * OAuth Implementation
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.advisor;
+
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sakaiproject.oauth.dao.ConsumerDao;
+import org.sakaiproject.oauth.domain.Consumer;
+
+/**
+ * Advisor used during record phase to determine which permissions must be enabled for the service
+ * <p>
+ * Every permission used during one request will be enabled automatically.
+ * </p>
+ *
+ * @author Colin Hebert
+ */
+public class CollectingPermissionsAdvisor implements SecurityAdvisor {
+    private static final Logger logger = LoggerFactory.getLogger(CollectingPermissionsAdvisor.class);
+    private ConsumerDao consumerDao;
+    private Consumer consumer;
+
+    public CollectingPermissionsAdvisor(ConsumerDao consumerDao, Consumer consumer) {
+        this.consumerDao = consumerDao;
+        this.consumer = consumer;
+    }
+
+    @Override
+    public SecurityAdvice isAllowed(String userId, String function, String reference) {
+        if (!consumer.getRights().contains(function)) {
+            logger.info("'" + consumer.getId() + "' requires '" + function + "' right in order to work, enable it.");
+            try {
+                consumer.getRights().add(function);
+                consumerDao.update(consumer);
+            } catch (Exception e) {
+                // If the update doesn't work, carry on
+                logger.warn("Activation of the '" + function + "' right on '" + consumer.getId() + "' failed.", e);
+            }
+        }
+        return SecurityAdvice.PASS;
+    }
+
+    @Override
+    public String toString() {
+        return "Permission collector";
+    }
+}

--- a/oauth/impl/src/java/org/sakaiproject/oauth/advisor/LimitedPermissionsAdvisor.java
+++ b/oauth/impl/src/java/org/sakaiproject/oauth/advisor/LimitedPermissionsAdvisor.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * OAuth Implementation
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.advisor;
+
+import org.sakaiproject.authz.api.SecurityAdvisor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Advisor allowing only permissions authorised to a specific consumer.
+ *
+ * @author Colin Hebert
+ */
+public class LimitedPermissionsAdvisor implements SecurityAdvisor {
+
+    private Set<String> allowedPermissions;
+
+    public LimitedPermissionsAdvisor(Set<String> permissions) {
+        allowedPermissions = new HashSet<String>(permissions);
+    }
+
+    @Override
+    public SecurityAdvice isAllowed(String userId, String function, String reference) {
+        return (allowedPermissions.contains(function)) ? SecurityAdvice.PASS : SecurityAdvice.NOT_ALLOWED;
+    }
+
+    @Override
+    public String toString() {
+        return "Allowed permissions: " + allowedPermissions;
+    }
+}

--- a/oauth/impl/src/java/org/sakaiproject/oauth/service/OAuthAdminServiceImpl.java
+++ b/oauth/impl/src/java/org/sakaiproject/oauth/service/OAuthAdminServiceImpl.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * OAuth Implementation
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.service;
+
+import org.sakaiproject.oauth.dao.AccessorDao;
+import org.sakaiproject.oauth.dao.ConsumerDao;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+
+import java.util.Collection;
+
+/**
+ * @author Colin Hebert
+ */
+public class OAuthAdminServiceImpl implements OAuthAdminService {
+    private OAuthService oauthService;
+    private ConsumerDao consumerDao;
+    private AccessorDao accessorDao;
+
+    @Override
+    public Consumer getConsumer(String consumerId) {
+        return consumerDao.get(consumerId);
+    }
+
+    @Override
+    public void createConsumer(Consumer consumer) {
+        consumerDao.create(consumer);
+    }
+
+    @Override
+    public Consumer updateConsumer(Consumer consumer) {
+        return consumerDao.update(consumer);
+    }
+
+    @Override
+    public void deleteConsumer(Consumer consumer) {
+        Collection<Accessor> accessors = accessorDao.getByConsumer(consumer.getId());
+        for (Accessor accessor : accessors) {
+            oauthService.revokeAccessor(accessor.getToken());
+        }
+        consumerDao.remove(consumer);
+    }
+
+    @Override
+    public Collection<Consumer> getAllConsumers() {
+        return consumerDao.getAll();
+    }
+
+    @Override
+    public void switchRecordMode(Consumer consumer) {
+        consumer.setRecordModeEnabled(!consumer.isRecordModeEnabled());
+        consumerDao.update(consumer);
+    }
+
+    public void setOauthService(OAuthService oauthService) {
+        this.oauthService = oauthService;
+    }
+
+    public void setConsumerDao(ConsumerDao consumerDao) {
+        this.consumerDao = consumerDao;
+    }
+
+    public void setAccessorDao(AccessorDao accessorDao) {
+        this.accessorDao = accessorDao;
+    }
+}

--- a/oauth/impl/src/java/org/sakaiproject/oauth/service/OAuthHttpServiceImpl.java
+++ b/oauth/impl/src/java/org/sakaiproject/oauth/service/OAuthHttpServiceImpl.java
@@ -1,0 +1,233 @@
+/*
+ * #%L
+ * OAuth Implementation
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.service;
+
+import net.oauth.*;
+import net.oauth.OAuthException;
+import net.oauth.server.OAuthServlet;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+import org.sakaiproject.oauth.exception.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/**
+ * @author Colin Hebert
+ */
+public class OAuthHttpServiceImpl implements OAuthHttpService {
+    private OAuthService oAuthService;
+    private OAuthValidator oAuthValidator;
+    // Keep track of is OAuth should be enabled, this allows us to shutdown OAuth if we need to.
+    private boolean enabled = true;
+
+    /**
+     * Sends a response respecting the OAuth format.
+     * <p>
+     * The content type of the response is "application/x-www-form-urlencoded"
+     * </p>
+     *
+     * @param response   HttpServletResponse used to send the response
+     * @param parameters List of parameters in the form of key/value
+     * @throws IOException
+     */
+    private static void sendOAuthResponse(HttpServletResponse response, List<OAuth.Parameter> parameters)
+            throws IOException {
+        response.setContentType(OAuth.FORM_ENCODED);
+        ServletOutputStream os = response.getOutputStream();
+        OAuth.formEncode(parameters, os);
+        os.flush();
+        os.close();
+    }
+
+    private static void handleException(Exception e, HttpServletRequest request,
+                                        HttpServletResponse response, boolean sendBody)
+            throws IOException, ServletException {
+        String realm = (request.isSecure()) ? "https://" : "http://";
+        realm += request.getLocalName();
+        OAuthServlet.handleException(response, e, realm, sendBody);
+    }
+
+    private static OAuthException convertException(org.sakaiproject.oauth.exception.OAuthException originalException) {
+        if (originalException instanceof InvalidConsumerException)
+            return new OAuthProblemException(OAuth.Problems.CONSUMER_KEY_UNKNOWN);
+        else if (originalException instanceof ExpiredAccessorException)
+            return new OAuthProblemException(OAuth.Problems.TOKEN_EXPIRED);
+        else if (originalException instanceof RevokedAccessorException)
+            return new OAuthProblemException(OAuth.Problems.TOKEN_REVOKED);
+        else if (originalException instanceof InvalidAccessorException)
+            return new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+        else if (originalException instanceof InvalidVerifierException)
+            return new OAuthProblemException(OAuth.Problems.PARAMETER_REJECTED);
+        else
+            return new OAuthProblemException();
+    }
+
+    public void setoAuthValidator(OAuthValidator oAuthValidator) {
+        this.oAuthValidator = oAuthValidator;
+    }
+
+    public void setoAuthService(OAuthService oAuthService) {
+        this.oAuthService = oAuthService;
+    }
+
+    @Override
+    public boolean isValidOAuthRequest(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        try {
+            OAuthMessage message = OAuthServlet.getMessage(request, null);
+            // Non existing token, just continue
+            if (message.getToken() == null)
+                return false;
+            OAuthConsumer oAuthConsumer = Util.convertToOAuthConsumer(
+                    oAuthService.getConsumer(message.getConsumerKey()));
+            OAuthAccessor oAuthAccessor = Util.convertToOAuthAccessor(
+                    oAuthService.getAccessor(message.getToken(), Accessor.Type.ACCESS), oAuthConsumer);
+            oAuthValidator.validateMessage(message, oAuthAccessor);
+        } catch (org.sakaiproject.oauth.exception.OAuthException e) {
+            handleException(convertException(e), request, response, true);
+        } catch (OAuthException e) {
+            handleException(new OAuthProblemException(), request, response, true);
+        } catch (URISyntaxException e) {
+            handleException(e, request, response, true);
+        }
+        return true;
+    }
+
+    @Override
+    public String getOAuthAccessToken(HttpServletRequest request) throws IOException {
+        OAuthMessage message = OAuthServlet.getMessage(request, null);
+        return message.getToken();
+    }
+
+    @Override
+    public void handleRequestToken(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        try {
+            OAuthMessage oAuthMessage = OAuthServlet.getMessage(request, null);
+            Consumer consumer = oAuthService.getConsumer(oAuthMessage.getConsumerKey());
+            OAuthConsumer oAuthConsumer = Util.convertToOAuthConsumer(consumer);
+            oAuthValidator.validateMessage(oAuthMessage, new OAuthAccessor(oAuthConsumer));
+
+            String callback = oAuthMessage.getParameter(OAuth.OAUTH_CALLBACK);
+            String accessorSecret = oAuthMessage.getParameter(OAuthConsumer.ACCESSOR_SECRET);
+            Accessor accessor = oAuthService.createRequestAccessor(consumer.getId(), callback, accessorSecret);
+            OAuthAccessor oAuthAccessor = Util.convertToOAuthAccessor(accessor, oAuthConsumer);
+
+            sendOAuthResponse(response, OAuth.newList(
+                    OAuth.OAUTH_TOKEN, oAuthAccessor.requestToken,
+                    OAuth.OAUTH_TOKEN_SECRET, oAuthAccessor.tokenSecret,
+                    OAuth.OAUTH_CALLBACK_CONFIRMED, "true"));
+        } catch (org.sakaiproject.oauth.exception.OAuthException e) {
+            handleException(convertException(e), request, response, true);
+        } catch (OAuthException e) {
+            handleException(new OAuthProblemException(), request, response, true);
+        } catch (URISyntaxException e) {
+            handleException(e, request, response, true);
+        }
+    }
+
+    @Override
+    public void handleGetAccessToken(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        try {
+            OAuthMessage oAuthMessage = OAuthServlet.getMessage(request, null);
+            Accessor requestAccessor = oAuthService.getAccessor(oAuthMessage.getToken(),
+                    Accessor.Type.REQUEST_AUTHORISED);
+            Consumer consumer = oAuthService.getConsumer(requestAccessor.getConsumerId());
+            OAuthConsumer oAuthConsumer = Util.convertToOAuthConsumer(consumer);
+            OAuthAccessor oAuthAccessor = Util.convertToOAuthAccessor(requestAccessor, oAuthConsumer);
+            oAuthValidator.validateMessage(oAuthMessage, oAuthAccessor);
+            if (requestAccessor.getVerifier() != null
+                    && !requestAccessor.getVerifier().equals(oAuthMessage.getParameter(OAuth.OAUTH_VERIFIER)))
+                throw new InvalidVerifierException();
+
+            Accessor accessAccessor = oAuthService.createAccessAccessor(requestAccessor.getToken());
+            sendOAuthResponse(response, OAuth.newList(
+                    OAuth.OAUTH_TOKEN, accessAccessor.getToken(),
+                    OAuth.OAUTH_TOKEN_SECRET, accessAccessor.getSecret()));
+        } catch (org.sakaiproject.oauth.exception.OAuthException e) {
+            handleException(convertException(e), request, response, true);
+        } catch (OAuthException e) {
+            handleException(new OAuthProblemException(), request, response, true);
+        } catch (URISyntaxException e) {
+            handleException(e, request, response, true);
+        }
+    }
+
+    @Override
+    public void handleRequestAuthorisation(HttpServletRequest request, HttpServletResponse response,
+                                           boolean authorised, String token, String verifier, String userId)
+            throws IOException, ServletException {
+        try {
+            Accessor accessor = oAuthService.getAccessor(token, Accessor.Type.REQUEST_AUTHORISING);
+            Consumer consumer = oAuthService.getConsumer(accessor.getConsumerId());
+            if (authorised) {
+                accessor = oAuthService.authoriseAccessor(accessor.getToken(), verifier, userId);
+                if (accessor.getCallbackUrl().equals(OAuthService.OUT_OF_BAND_CALLBACK)) {
+                    response.setContentType("text/plain");
+                    PrintWriter out = response.getWriter();
+                    out.println("You have successfully authorized '" + consumer.getName() + "'.\n"
+                            + "The authorisation verifier is: " + accessor.getVerifier() + "\n"
+                            + "Please close this browser window and click continue in the client.");
+                    out.flush();
+                    out.close();
+                } else {
+                    String callbackUrl = OAuth.addParameters(accessor.getCallbackUrl(),
+                            OAuth.OAUTH_TOKEN, accessor.getToken(),
+                            OAuth.OAUTH_VERIFIER, accessor.getVerifier());
+
+                    response.setStatus(HttpServletResponse.SC_SEE_OTHER);
+                    response.setHeader("Location", callbackUrl);
+                }
+            } else {
+                oAuthService.denyRequestAccessor(accessor.getToken());
+                if (accessor.getCallbackUrl().equals(OAuthService.OUT_OF_BAND_CALLBACK)) {
+                    response.setContentType("text/plain");
+                    PrintWriter out = response.getWriter();
+                    out.println("You have not authorized '" + consumer.getName() + "'.\n"
+                            + "Please close this browser window and click continue in the client.");
+                    out.flush();
+                    out.close();
+                } else {
+                    response.setStatus(HttpServletResponse.SC_SEE_OTHER);
+                    response.setHeader("Location", accessor.getCallbackUrl());
+                }
+
+            }
+        } catch (org.sakaiproject.oauth.exception.OAuthException e) {
+            handleException(convertException(e), request, response, true);
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/oauth/impl/src/java/org/sakaiproject/oauth/service/OAuthServiceImpl.java
+++ b/oauth/impl/src/java/org/sakaiproject/oauth/service/OAuthServiceImpl.java
@@ -1,0 +1,295 @@
+/*
+ * #%L
+ * OAuth Implementation
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.service;
+
+import org.joda.time.DateTime;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.oauth.advisor.CollectingPermissionsAdvisor;
+import org.sakaiproject.oauth.advisor.LimitedPermissionsAdvisor;
+import org.sakaiproject.oauth.dao.AccessorDao;
+import org.sakaiproject.oauth.dao.ConsumerDao;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+import org.sakaiproject.oauth.exception.*;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Random;
+
+/**
+ * @author Colin Hebert
+ */
+public class OAuthServiceImpl implements OAuthService {
+    private static final int VERIFIER_MAX_VALUE = 10000;
+    private AccessorDao accessorDao;
+    private ConsumerDao consumerDao;
+    private boolean keepOldAccessors;
+    private SiteService siteService;
+    private SecurityService securityService;
+
+    private static String generateToken(Accessor accessor) {
+        // TODO Need a better way of generating tokens in the long run.
+        return generateHash(accessor.getConsumerId() + System.nanoTime());
+    }
+
+    private static String generateSecret(Accessor accessor, Consumer consumer) {
+        // TODO Need a better way of generating tokens in the long run.
+        return generateHash(accessor.getToken() + consumer.getSecret() + System.nanoTime());
+    }
+
+    private static String generateHash(String string) {
+        try {
+            MessageDigest messageDigest;
+            try {
+                messageDigest = MessageDigest.getInstance("SHA-1");
+            } catch (NoSuchAlgorithmException e) {
+                messageDigest = MessageDigest.getInstance("MD5");
+            }
+            byte[] hashBytes = messageDigest.digest(string.getBytes("UTF-8"));
+
+            StringBuilder md5String = new StringBuilder();
+            for (byte hashByte : hashBytes) {
+                md5String.append(Integer.toString((hashByte & 0xff) + 0x100, 16).substring(1));
+            }
+            return md5String.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // Unless you don't have md5 on your JVM it will work (so this exception won't happen)
+            throw new RuntimeException(e);
+        } catch (UnsupportedEncodingException e) {
+            // Unless you don't have UTF-8 on your JVM it will work (so this exception won't happen)
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String generateVerifier(Accessor accessor) {
+        return String.valueOf(new Random().nextInt(VERIFIER_MAX_VALUE));
+    }
+
+    private static boolean isStillValid(Accessor accessor) {
+        return accessor.getExpirationDate() == null || new DateTime(accessor.getExpirationDate()).isAfterNow();
+    }
+
+    public void setAccessorDao(AccessorDao accessorDao) {
+        this.accessorDao = accessorDao;
+    }
+
+    public void setConsumerDao(ConsumerDao consumerDao) {
+        this.consumerDao = consumerDao;
+    }
+
+    public void setKeepOldAccessors(boolean keepOldAccessors) {
+        this.keepOldAccessors = keepOldAccessors;
+    }
+
+    @Override
+    public Accessor getAccessor(String token, Accessor.Type expectedType) {
+        Accessor accessor = accessorDao.get(token);
+
+        if (accessor == null)
+            throw new InvalidAccessorException("Accessor '" + token + "' doesn't exist.");
+
+        if (accessor.getStatus() == Accessor.Status.VALID && !isStillValid(accessor))
+            updateAccessorStatus(accessor, Accessor.Status.EXPIRED);
+
+        if (accessor.getStatus() == Accessor.Status.EXPIRED)
+            throw new ExpiredAccessorException("Accessor '" + token + " expired");
+        else if (accessor.getStatus() == Accessor.Status.REVOKED)
+            throw new RevokedAccessorException("Accessor '" + token + " revoked");
+        else if (accessor.getStatus() != Accessor.Status.VALID)
+            throw new InvalidAccessorException("Accessor '" + token + "' is not valid. (" + accessor.getStatus() + ")");
+
+        if (accessor.getType() != expectedType)
+            throw new InvalidAccessorException("Accessor with unexpected type " + accessor.getType());
+
+        return accessor;
+    }
+
+    @Override
+    public SecurityAdvisor getSecurityAdvisor(String accessorId) {
+        Accessor accessor = getAccessor(accessorId, Accessor.Type.ACCESS);
+        Consumer consumer = consumerDao.get(accessor.getConsumerId());
+        if (consumer.isRecordModeEnabled())
+            return new CollectingPermissionsAdvisor(consumerDao, consumer);
+        else
+            return new LimitedPermissionsAdvisor(consumer.getRights());
+    }
+
+    @Override
+    public Consumer getConsumer(String consumerKey) {
+        Consumer consumer = consumerDao.get(consumerKey);
+        if (consumer == null)
+            throw new InvalidConsumerException("Consumer '" + consumerKey + " doesn't exist");
+
+        return consumer;
+    }
+
+    @Override
+    public Accessor createRequestAccessor(String consumerId, String callback, String accessorSecret) {
+        Consumer consumer = consumerDao.get(consumerId);
+        Accessor accessor = new Accessor();
+        accessor.setConsumerId(consumer.getId());
+        accessor.setType(Accessor.Type.REQUEST);
+        accessor.setStatus(Accessor.Status.VALID);
+        accessor.setCreationDate(new DateTime().toDate());
+        // A request accessor is valid for 15 minutes only
+        accessor.setExpirationDate(new DateTime().plusMinutes(15).toDate());
+        accessor.setAccessorSecret(accessorSecret);
+
+        if (callback != null)
+            accessor.setCallbackUrl(callback);
+        else if (consumer.getCallbackUrl() != null)
+            accessor.setCallbackUrl(consumer.getCallbackUrl());
+        else
+            accessor.setCallbackUrl(OUT_OF_BAND_CALLBACK);
+
+        accessor.setToken(generateToken(accessor));
+        accessor.setSecret(generateSecret(accessor, consumer));
+        accessorDao.create(accessor);
+
+        return accessor;
+    }
+
+    @Override
+    public Accessor startAuthorisation(String accessorId) {
+        Accessor accessor = getAccessor(accessorId, Accessor.Type.REQUEST);
+        accessor.setVerifier(generateVerifier(accessor));
+        accessor.setType(Accessor.Type.REQUEST_AUTHORISING);
+        // The authorisation must be done in less than 15 minutes
+        accessor.setExpirationDate(new DateTime().plusMinutes(15).toDate());
+        accessor = accessorDao.update(accessor);
+        return accessor;
+    }
+
+    @Override
+    public Accessor authoriseAccessor(String accessorId, String verifier, String userId) {
+        Accessor accessor = getAccessor(accessorId, Accessor.Type.REQUEST_AUTHORISING);
+        if (!accessor.getVerifier().equals(verifier))
+            throw new OAuthException("Accessor verifier invalid.");
+        if (securityService.isSuperUser(userId))
+            throw new OAuthException("Super users can't use OAuth for security reasons.");
+        accessor.setVerifier(generateVerifier(accessor));
+        accessor.setType(Accessor.Type.REQUEST_AUTHORISED);
+        accessor.setUserId(userId);
+        // An authorised request accessor is valid for one month only
+        accessor.setExpirationDate(new DateTime().plusMonths(1).toDate());
+        accessor = accessorDao.update(accessor);
+
+        generateUserSite(userId);
+        return accessor;
+    }
+
+    /**
+     * Generate user's site if this is the very first login.
+     *
+     * @param userId
+     */
+    private void generateUserSite(String userId) {
+        try {
+            String userSiteId = siteService.getUserSiteId(userId);
+            siteService.getSite(userSiteId);
+        } catch (IdUnusedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Accessor createAccessAccessor(String requestAccessorId) {
+        Accessor requestAccessor = getAccessor(requestAccessorId, Accessor.Type.REQUEST_AUTHORISED);
+
+        Consumer consumer = consumerDao.get(requestAccessor.getConsumerId());
+        Accessor accessAccessor = new Accessor();
+        accessAccessor.setConsumerId(consumer.getId());
+        accessAccessor.setUserId(requestAccessor.getUserId());
+        accessAccessor.setType(Accessor.Type.ACCESS);
+        accessAccessor.setStatus(Accessor.Status.VALID);
+        accessAccessor.setCreationDate(new DateTime().toDate());
+
+        // An access accessor is valid based on the number of minutes given by the consumer
+        if (consumer.getDefaultValidity() > 0)
+            accessAccessor.setExpirationDate(DateTime.now().plusMinutes(consumer.getDefaultValidity()).toDate());
+        accessAccessor.setToken(generateToken(accessAccessor));
+        accessAccessor.setSecret(generateSecret(accessAccessor, consumer));
+
+        updateAccessorStatus(requestAccessor, Accessor.Status.EXPIRED);
+        accessorDao.create(accessAccessor);
+
+        return accessAccessor;
+    }
+
+    @Override
+    public void denyRequestAccessor(String accessorId) {
+        try {
+            Accessor accessor = getAccessor(accessorId, Accessor.Type.REQUEST_AUTHORISING);
+            updateAccessorStatus(accessor, Accessor.Status.REVOKED);
+        } catch (OAuthException ignored) {
+            // If the accessor is already expired/revoked, nothing to do/handle
+        }
+    }
+
+    @Override
+    public Collection<Accessor> getAccessAccessorForUser(String userId) {
+        Collection<Accessor> accessors = new ArrayList<Accessor>(accessorDao.getByUser(userId));
+
+        for (Iterator<Accessor> iterator = accessors.iterator(); iterator.hasNext();) {
+            Accessor accessor = iterator.next();
+
+            if (accessor.getStatus() == Accessor.Status.VALID && !isStillValid(accessor))
+                updateAccessorStatus(accessor, Accessor.Status.EXPIRED);
+
+            if (accessor.getStatus() != Accessor.Status.VALID
+                    || accessor.getType() != Accessor.Type.ACCESS)
+                iterator.remove();
+        }
+        return accessors;
+    }
+
+    @Override
+    public void revokeAccessor(String accessorId) {
+        try {
+            Accessor accessor = getAccessor(accessorId, Accessor.Type.ACCESS);
+            updateAccessorStatus(accessor, Accessor.Status.REVOKED);
+        } catch (OAuthException ignored) {
+            // If the accessor is already expired/revoked, nothing to do/handle
+        }
+    }
+
+    private void updateAccessorStatus(Accessor accessor, Accessor.Status status) {
+        if (keepOldAccessors || status == Accessor.Status.VALID) {
+            accessor.setStatus(status);
+            accessorDao.update(accessor);
+        } else
+            accessorDao.remove(accessor);
+    }
+
+    public void setSiteService(SiteService siteService) {
+        this.siteService = siteService;
+    }
+
+    public void setSecurityService(SecurityService securityService) {
+        this.securityService = securityService;
+    }
+}

--- a/oauth/impl/src/java/org/sakaiproject/oauth/service/Util.java
+++ b/oauth/impl/src/java/org/sakaiproject/oauth/service/Util.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * OAuth Implementation
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.service;
+
+import net.oauth.OAuth;
+import net.oauth.OAuthAccessor;
+import net.oauth.OAuthConsumer;
+import net.oauth.OAuthProblemException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sakaiproject.oauth.dao.ConsumerDao;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+
+/**
+ * @author Colin Hebert
+ */
+public final class Util {
+    private static final Logger logger = LoggerFactory.getLogger(Util.class);
+
+    private Util() {
+    }
+
+    public static OAuthAccessor convertToOAuthAccessor(Accessor accessor, OAuthConsumer oAuthConsumer)
+            throws OAuthProblemException {
+        if (accessor == null)
+            return null;
+        if (!oAuthConsumer.consumerKey.equals(accessor.getConsumerId()))
+            throw new OAuthProblemException(OAuth.Problems.CONSUMER_KEY_REFUSED);
+        OAuthAccessor oAuthAccessor = new OAuthAccessor(oAuthConsumer);
+        if (accessor.getType() == Accessor.Type.ACCESS)
+            oAuthAccessor.accessToken = accessor.getToken();
+        else
+            oAuthAccessor.requestToken = accessor.getToken();
+        oAuthAccessor.tokenSecret = accessor.getSecret();
+        // Support Variable Accessor Secret http://wiki.oauth.net/w/page/12238502/AccessorSecret
+        if (accessor.getAccessorSecret() != null)
+            oAuthConsumer.setProperty(OAuthConsumer.ACCESSOR_SECRET, accessor.getAccessorSecret());
+        return oAuthAccessor;
+    }
+
+    public static OAuthConsumer convertToOAuthConsumer(Consumer consumer) {
+        if (consumer == null)
+            return null;
+        OAuthConsumer oAuthConsumer = new OAuthConsumer(consumer.getCallbackUrl(), consumer.getId(),
+                consumer.getSecret(), null);
+        // Support Accessor Secret http://wiki.oauth.net/w/page/12238502/AccessorSecret
+        oAuthConsumer.setProperty(OAuthConsumer.ACCESSOR_SECRET, consumer.getAccessorSecret());
+        return oAuthConsumer;
+    }
+
+    public static void importConsumers(ConsumerDao source, ConsumerDao destination) {
+        for (Consumer consumer : source.getAll()) {
+            try {
+                destination.create(consumer);
+                logger.info("New consumer imported '" + consumer.getId() + "'");
+            } catch (Exception e) {
+                logger.warn("Impossible to import '" + consumer.getId() + "' as a consumer.", e);
+            }
+        }
+    }
+}

--- a/oauth/pack/pom.xml
+++ b/oauth/pack/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oauth-pack</artifactId>
+    <packaging>sakai-component</packaging>
+
+    <name>OAuth Component</name>
+    <description>Spring component defining the Spring configuration for the OAuth project.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-dao-memory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-dao-hbm</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-dao-server-config</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+   
+</project>

--- a/oauth/pack/src/webapp/WEB-INF/components.xml
+++ b/oauth/pack/src/webapp/WEB-INF/components.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  OAuth Component
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+    <!-- Add our HBM files to the Sakai global session factory -->
+    <bean class="org.sakaiproject.springframework.orm.hibernate.impl.AdditionalHibernateMappingsImpl">
+        <property name="mappingResources">
+            <list>
+                <value>org/sakaiproject/oauth/dao/Accessor.hbm.xml</value>
+                <value>org/sakaiproject/oauth/dao/Consumer.hbm.xml</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="org.sakaiproject.oauth.service.OAuthService" class="org.sakaiproject.oauth.service.OAuthServiceImpl">
+        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+        <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+        <property name="accessorDao" ref="org.sakaiproject.oauth.dao.AccessorDao"/>
+        <property name="consumerDao" ref="org.sakaiproject.oauth.dao.ConsumerDao"/>
+        <property name="keepOldAccessors" value="true"/>
+    </bean>
+
+    <bean id="org.sakaiproject.oauth.service.OAuthAdminService" class="org.sakaiproject.oauth.service.OAuthAdminServiceImpl">
+        <property name="oauthService" ref="org.sakaiproject.oauth.service.OAuthService"/>
+        <property name="consumerDao" ref="org.sakaiproject.oauth.dao.ConsumerDao"/>
+        <property name="accessorDao" ref="org.sakaiproject.oauth.dao.AccessorDao"/>
+    </bean>
+
+    <bean id="org.sakaiproject.oauth.dao.AccessorDao"
+          class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+        <property name="transactionManager"
+                  ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager"/>
+        <property name="target">
+            <bean class="org.sakaiproject.oauth.dao.HibernateAccessorDao">
+                <property name="sessionFactory"
+                          ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/>
+            </bean>
+        </property>
+        <property name="transactionAttributes">
+            <props>
+                <prop key="*">PROPAGATION_REQUIRED</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="org.sakaiproject.oauth.dao.ConsumerDao"
+          class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+        <property name="transactionManager"
+                  ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager"/>
+        <property name="target">
+            <bean class="org.sakaiproject.oauth.dao.HibernateConsumerDao">
+                <property name="sessionFactory"
+                          ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/>
+            </bean>
+        </property>
+        <property name="transactionAttributes">
+            <props>
+                <prop key="*">PROPAGATION_REQUIRED</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="org.sakaiproject.oauth.service.OAuthHttpService" class="org.sakaiproject.oauth.service.OAuthHttpServiceImpl">
+        <property name="oAuthService" ref="org.sakaiproject.oauth.service.OAuthService"/>
+        <property name="oAuthValidator">
+            <bean class="net.oauth.SimpleOAuthValidator"/>
+        </property>
+        <!-- This means we don't have to put another dependency in the bean -->
+        <property name="enabled">
+            <bean factory-bean="org.sakaiproject.component.api.ServerConfigurationService"
+                    factory-method="getBoolean">
+                <constructor-arg value="oauth.enabled"/>
+                <constructor-arg value="true"/>
+            </bean>
+        </property>
+    </bean>
+
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="targetObject">
+            <bean class="org.sakaiproject.oauth.service.Util"/>
+        </property>
+        <property name="targetMethod" value="importConsumers"/>
+        <property name="arguments">
+            <list>
+                <bean class="org.sakaiproject.oauth.dao.ServerConfigConsumerDao">
+                    <constructor-arg ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+                </bean>
+                <ref bean="org.sakaiproject.oauth.dao.ConsumerDao"/>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sakaiproject.oauth</groupId>
+    <artifactId>oauth-base</artifactId>
+    <version>1.2-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    
+    <parent>
+        <groupId>org.sakaiproject</groupId>
+        <artifactId>master</artifactId>
+        <version>11-SNAPSHOT</version>
+        <relativePath>../master/pom.xml</relativePath>
+    </parent>
+
+    <name>OAuth Base</name>
+    <description>Add OAuth capabilities to an instance of Sakai CLE.</description>
+    <organization>
+        <name>The Sakai Foundation</name>
+        <url>http://www.sakaiproject.org/sakai-foundation</url>
+    </organization>
+    <inceptionYear>2009</inceptionYear>
+    <licenses>
+        <license>
+            <name>ECL-2.0</name>
+            <url>http://opensource.org/licenses/ECL-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>buckett</id>
+            <name>Matthew Buckett</name>
+            <organization>University of Oxford - IT Services</organization>
+            <organizationUrl>https://www.it.ox.ac.uk/</organizationUrl>
+        </developer>
+        <developer>
+            <id>ColinHebert</id>
+            <name>Colin Hebert</name>
+            <organization>University of Oxford - IT Services</organization>
+            <organizationUrl>https://www.it.ox.ac.uk/</organizationUrl>
+        </developer>
+    </developers>
+    
+    <contributors>
+        <contributor>
+            <name>Steve Swinsburg</name>
+            <email>steve.swinsburg@gmail.com</email>
+        </contributor>
+    </contributors>
+
+    <modules>
+        <module>api</module>
+        <module>impl</module>
+        <module>impl/dao-hbm</module>
+        <module>impl/dao-memory</module>
+        <module>impl/dao-server-config</module>
+        <module>pack</module>
+        <module>tool</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- maven-compiler-plugin config -->
+        <maven.compiler.source>6</maven.compiler.source>
+        <maven.compiler.target>6</maven.compiler.target>
+
+        <!-- dependencies versions -->
+        <oauth.version>20100527</oauth.version>
+        <joda-time.version>2.2</joda-time.version>
+        <commons-logging.version>1.1.1</commons-logging.version>
+        <servlet-api.version>2.5</servlet-api.version>
+        <wicket.version>1.4.20</wicket.version>
+        <slf4j.version>1.7.5</slf4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Internal dependencies -->
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-dao-hbm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-dao-server-config</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-dao-memory</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-tool</artifactId>
+                <version>${project.version}</version>
+                <type>war</type>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oauth-pack</artifactId>
+                <version>${project.version}</version>
+                <type>sakai-component</type>
+            </dependency>
+
+            <!-- Dependencies -->
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${joda-time.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.oauth.core</groupId>
+                <artifactId>oauth</artifactId>
+                <version>${oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.oauth.core</groupId>
+                <artifactId>oauth-provider</artifactId>
+                <version>${oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- Wicket -->
+            <dependency>
+                <groupId>org.apache.wicket</groupId>
+                <artifactId>wicket</artifactId>
+                <version>${wicket.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.wicket</groupId>
+                <artifactId>wicket-spring</artifactId>
+                <version>${wicket.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            
+            <!-- enforce Java 6 compiler -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerVersion>${sakai.jdk.version}</compilerVersion>
+                    <source>${sakai.jdk.version}</source>
+                    <target>${sakai.jdk.version}</target>
+                </configuration>
+            </plugin>
+            
+        </plugins>
+    </build>
+
+<!--
+    <repositories> 
+        <repository> 
+            <id>sonatype-nexus-snapshots</id> 
+            <name>Sonatype Nexus Snapshots</name> 
+            <url> https://oss.sonatype.org/content/repositories/snapshots </url> 
+            <releases> 
+                <enabled>false</enabled> 
+            </releases> 
+            <snapshots> 
+                <enabled>true</enabled> 
+            </snapshots> 
+        </repository> 
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>Sakai Plugin Repo</id>
+            <url>http://source.sakaiproject.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+    -->
+</project>

--- a/oauth/tool/pom.xml
+++ b/oauth/tool/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-base</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oauth-tool</artifactId>
+    <packaging>war</packaging>
+
+    <name>OAuth Tool</name>
+    <description>Web interface to manage and administrate OAuth consumers and user tokens.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oauth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-component-manager</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket-spring</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/resources</directory>
+                <includes>
+                    <include>**/*.html</include>
+                    <include>**/*.properties</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/oauth/tool/src/java/org/sakaiproject/oauth/servlet/AccessTokenServlet.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/servlet/AccessTokenServlet.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.servlet;
+
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.oauth.service.OAuthHttpService;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Colin Hebert
+ */
+public class AccessTokenServlet extends HttpServlet {
+    private OAuthHttpService oAuthService;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        oAuthService = (OAuthHttpService) ComponentManager.getInstance().get(OAuthHttpService.class.getCanonicalName());
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        oAuthService.handleGetAccessToken(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        oAuthService.handleGetAccessToken(request, response);
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/servlet/AuthorisationServlet.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/servlet/AuthorisationServlet.java
@@ -1,0 +1,196 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.servlet;
+
+import org.sakaiproject.component.api.ComponentManager;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.tool.api.*;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+import org.sakaiproject.oauth.exception.OAuthException;
+import org.sakaiproject.oauth.service.OAuthHttpService;
+import org.sakaiproject.oauth.service.OAuthService;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Colin Hebert
+ */
+public class AuthorisationServlet extends HttpServlet {
+    /**
+     * Name of the "authorise" button in the authorisation page.
+     */
+    public static final String AUTHORISE_BUTTON = "authorise";
+    /**
+     * Name of the "deny" button in the authorisation page.
+     */
+    public static final String DENY_BUTTON = "deny";
+    private static final String LOGIN_PATH = "/login";
+    private static final String SAKAI_LOGIN_TOOL = "sakai.login";
+
+    // Services and settings
+    private OAuthService oAuthService;
+    private OAuthHttpService oAuthHttpService;
+    private UserDirectoryService userDirectoryService;
+    private SessionManager sessionManager;
+    private ActiveToolManager activeToolManager;
+    private ServerConfigurationService serverConfigurationService;
+    private String authorisePath;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        ComponentManager componentManager = org.sakaiproject.component.cover.ComponentManager.getInstance();
+        oAuthService = (OAuthService) componentManager.get(OAuthService.class);
+        oAuthHttpService = (OAuthHttpService) componentManager.get(OAuthHttpService.class);
+        sessionManager = (SessionManager) componentManager.get(SessionManager.class);
+        activeToolManager = (ActiveToolManager) componentManager.get(ActiveToolManager.class);
+        userDirectoryService = (UserDirectoryService) componentManager.get(UserDirectoryService.class);
+        serverConfigurationService =
+                (ServerConfigurationService) componentManager.get(ServerConfigurationService.class);
+        // TODO: get this path from the configuration (injection?)
+        authorisePath = "/authorise.jsp";
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        handleRequest(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        handleRequest(request, response);
+    }
+
+    /**
+     * Filter users trying to obtain an OAuth authorisation token.
+     * <p/>
+     * Three outcomes are possible:
+     * <ul>
+     * <li>The user isn't logged in the application: He's sent toward the login tool</li>
+     * <li>The user is logged in but hasn't filled the authorisation form: He's sent toward the form</li>
+     * <li>The user has filled the form: The OAuth system attenpts to grant a token</li>
+     * </ul>
+     *
+     * @param request  current servlet request
+     * @param response current servlet response
+     * @throws IOException
+     * @throws ServletException
+     */
+    private void handleRequest(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        String pathInfo = request.getPathInfo();
+        String currentUserId = sessionManager.getCurrentSessionUserId();
+        if (currentUserId == null || (pathInfo != null && pathInfo.startsWith(LOGIN_PATH)))
+            // Redirect non logged-in users and currently logging-in users requests
+            sendToLoginPage(request, response);
+
+        else if (request.getParameter(AUTHORISE_BUTTON) == null && request.getParameter(DENY_BUTTON) == null)
+            // If logged-in but haven't yet authorised (or denied)
+            sendToAuthorisePage(request, response);
+
+        else
+            // Even if the authorisation has been denied, send the client to the consumer's callback
+            handleRequestAuth(request, response);
+    }
+
+    private void sendToLoginPage(HttpServletRequest request, HttpServletResponse response) throws ToolException {
+        // If not logging-in, set the return path and proceed to the login steps
+        String pathInfo = request.getPathInfo();
+        if (pathInfo == null || !pathInfo.startsWith(LOGIN_PATH)) {
+            Session session = sessionManager.getCurrentSession();
+
+            // Set the return path for after login if needed
+            // (Note: in session, not tool session, special for Login helper)
+            StringBuffer returnUrl = request.getRequestURL();
+            if (request.getQueryString() != null)
+                returnUrl.append('?').append(request.getQueryString());
+            session.setAttribute(Tool.HELPER_DONE_URL, returnUrl.toString());
+        }
+
+        // Redirect to the login tool
+        ActiveTool loginTool = activeToolManager.getActiveTool(SAKAI_LOGIN_TOOL);
+        String context = request.getContextPath() + request.getServletPath() + LOGIN_PATH;
+        loginTool.help(request, response, context, LOGIN_PATH);
+    }
+
+    /**
+     * Pre-set request attributes to provide additional information on the authorisation form.
+     *
+     * @param request  current servlet request
+     * @param response current servlet response
+     * @throws IOException
+     * @throws ServletException
+     */
+    private void sendToAuthorisePage(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        Accessor accessor = null;
+        try {
+            accessor = oAuthService.getAccessor(request.getParameter("oauth_token"), Accessor.Type.REQUEST);
+            Consumer consumer = oAuthService.getConsumer(accessor.getConsumerId());
+            accessor = oAuthService.startAuthorisation(accessor.getToken());
+
+            User user = userDirectoryService.getCurrentUser();
+            request.setAttribute("userName", user.getDisplayName());
+            request.setAttribute("userId", user.getDisplayId());
+            request.setAttribute("uiName", serverConfigurationService.getString("ui.service", "Sakai"));
+            request.setAttribute("skinPath", serverConfigurationService.getString("skin.repo", "/library/skin"));
+            request.setAttribute("defaultSkin", serverConfigurationService.getString("skin.default", "default"));
+            request.setAttribute("authorise", AUTHORISE_BUTTON);
+            request.setAttribute("deny", DENY_BUTTON);
+            request.setAttribute("oauthVerifier", accessor.getVerifier());
+            request.setAttribute("appName", consumer.getName());
+            request.setAttribute("appDesc", consumer.getDescription());
+            request.setAttribute("token", accessor.getToken());
+
+            request.getRequestDispatcher(authorisePath).forward(request, response);
+        } catch (OAuthException e) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        }
+    }
+
+    /**
+     * Pre-set request attributes to provide additional information to the token creation process.
+     *
+     * @param request  current servlet request
+     * @param response current servlet response
+     * @throws IOException
+     * @throws ServletException
+     */
+    private void handleRequestAuth(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        boolean authorised = request.getParameter(AUTHORISE_BUTTON) != null
+                && request.getParameter(DENY_BUTTON) == null;
+        String token = request.getParameter("oauthToken");
+        String verifier = request.getParameter("oauthVerifier");
+        String userId = sessionManager.getCurrentSessionUserId();
+
+        oAuthHttpService.handleRequestAuthorisation(request, response, authorised, token, verifier, userId);
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/servlet/RequestTokenServlet.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/servlet/RequestTokenServlet.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.servlet;
+
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.oauth.service.OAuthHttpService;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Colin Hebert
+ */
+public class RequestTokenServlet extends HttpServlet {
+    private OAuthHttpService oAuthHttpService;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        oAuthHttpService = (OAuthHttpService) ComponentManager.getInstance().get(OAuthHttpService.class);
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        oAuthHttpService.handleRequestToken(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        oAuthHttpService.handleRequestToken(request, response);
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/AdminFilter.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/AdminFilter.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.tool.admin;
+
+import org.sakaiproject.authz.api.FunctionManager;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.cover.ComponentManager;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Filter users before displaying the oAuth administration page.
+ *
+ * @author Colin Hebert
+ */
+public class AdminFilter implements Filter {
+    private static final String OAUTH_ADMIN_RIGHT = "oauth.admin";
+    private SecurityService securityService;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        FunctionManager functionManager = (FunctionManager) ComponentManager.get(FunctionManager.class);
+        functionManager.registerFunction(OAUTH_ADMIN_RIGHT, false);
+        securityService = (SecurityService) ComponentManager.get(SecurityService.class);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (securityService.unlock(OAUTH_ADMIN_RIGHT, "")) {
+            chain.doFilter(request, response);
+        } else {
+            HttpServletResponse res = (HttpServletResponse) response;
+            res.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/OauthAdminApplication.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/OauthAdminApplication.java
@@ -1,0 +1,24 @@
+
+package org.sakaiproject.oauth.tool.admin;
+
+import org.apache.wicket.Page;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
+import org.sakaiproject.oauth.tool.admin.pages.ListConsumers;
+
+/**
+ * @author Colin Hebert
+ */
+public class OauthAdminApplication extends WebApplication {
+    @Override
+    protected void init() {
+        // Configure for Spring injection
+        addComponentInstantiationListener(new SpringComponentInjector(this));
+        // getComponentInstantiationListeners().add(new SpringComponentInjector(this));
+    }
+
+    @Override
+    public Class<? extends Page> getHomePage() {
+        return ListConsumers.class;
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.tool.admin.pages;
+
+import org.apache.wicket.PageParameters;
+import org.apache.wicket.behavior.SimpleAttributeModifier;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.*;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.authz.api.FunctionManager;
+import org.sakaiproject.oauth.domain.Consumer;
+import org.sakaiproject.oauth.service.OAuthAdminService;
+import org.sakaiproject.oauth.tool.pages.SakaiPage;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * @author Colin Hebert
+ */
+public class ConsumerAdministration extends SakaiPage {
+    private final Consumer consumer;
+    @SpringBean
+    private FunctionManager functionManager;
+    @SpringBean
+    private OAuthAdminService oAuthAdminService;
+
+    public ConsumerAdministration() {
+        consumer = new Consumer();
+        // Manually set an empty Set for rights to avoid confusion with CheckBoxMultipleChoice
+        // and not ending up with a List
+        consumer.setRights(new HashSet<String>());
+        init(false);
+    }
+
+    public ConsumerAdministration(PageParameters parameters) {
+        super(parameters);
+
+        String consumerId = parameters.getString("consumer");
+        consumer = oAuthAdminService.getConsumer(consumerId);
+        init(true);
+    }
+
+    private void init(final boolean edit) {
+        addMenuLink(ListConsumers.class, new ResourceModel("menu.list.consumer"), null);
+        addMenuLink(ConsumerAdministration.class, new ResourceModel("menu.add.consumer"), null);
+
+        Form consumerForm = new Form<Void>("consumerForm") {
+            @Override
+            protected void onSubmit() {
+                super.onSubmit();
+                try {
+                    if (edit)
+                        oAuthAdminService.updateConsumer(consumer);
+                    else
+                        oAuthAdminService.createConsumer(consumer);
+                    setResponsePage(ListConsumers.class);
+                    getSession().info(consumer.getName() + " has been saved.");
+                } catch (Exception e) {
+                    error("Couldn't update '" + consumer.getName() + "': " + e.getLocalizedMessage());
+                }
+            }
+        };
+
+        TextField<String> idTextField;
+        if (edit) {
+            idTextField = new TextField<String>("id");
+            idTextField.add(new SimpleAttributeModifier("disabled", "disabled"));
+            idTextField.setModel(Model.of(consumer.getId()));
+        } else {
+            idTextField = new RequiredTextField<String>("id", new PropertyModel<String>(consumer, "id"));
+        }
+        consumerForm.add(idTextField);
+
+        consumerForm.add(new RequiredTextField<String>("name", new PropertyModel<String>(consumer, "name")));
+        consumerForm.add(new TextArea<String>("description", new PropertyModel<String>(consumer, "description")));
+        consumerForm.add(new TextField<String>("url", new PropertyModel<String>(consumer, "url")));
+        consumerForm.add(new TextField<String>("callbackUrl", new PropertyModel<String>(consumer, "callbackUrl")));
+        consumerForm.add(new RequiredTextField<String>("secret", new PropertyModel<String>(consumer, "secret")));
+        consumerForm.add(new TextField<String>("accessorSecret",
+                new PropertyModel<String>(consumer, "accessorSecret")));
+        consumerForm.add(new TextField<Integer>("defaultValidity",
+                new PropertyModel<Integer>(consumer, "defaultValidity")));
+
+        // Create a list of possible rights as checkboxes, pre-check already granted permissions
+        CheckBoxMultipleChoice<String> rightCheckboxes = new CheckBoxMultipleChoice<String>("rights",
+                new PropertyModel<Collection<String>>(consumer, "rights"), getAvailableFunctions());
+        consumerForm.add(rightCheckboxes);
+
+        add(new Label("consumerName", consumer.getName()));
+        add(consumerForm);
+    }
+
+    private List<String> getAvailableFunctions() {
+        return functionManager.getRegisteredFunctions();
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.java
@@ -1,0 +1,102 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.tool.admin.pages;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.oauth.domain.Consumer;
+import org.sakaiproject.oauth.service.OAuthAdminService;
+import org.sakaiproject.oauth.tool.pages.SakaiPage;
+
+import java.util.ArrayList;
+
+/**
+ * @author Colin Hebert
+ */
+public class ListConsumers extends SakaiPage {
+    @SpringBean
+    private OAuthAdminService oAuthAdminService;
+
+    public ListConsumers() {
+        addMenuLink(ListConsumers.class, new ResourceModel("menu.list.consumer"), null);
+        addMenuLink(ConsumerAdministration.class, new ResourceModel("menu.add.consumer"), null);
+
+        ListView<Consumer> consumerList = new ListView<Consumer>("consumerlist",
+                new ArrayList<Consumer>(oAuthAdminService.getAllConsumers())) {
+            @Override
+            protected void populateItem(ListItem<Consumer> components) {
+                components.add(new Label("id", components.getModelObject().getId()));
+                components.add(new Label("name", components.getModelObject().getName()));
+                components.add(new Label("description", components.getModelObject().getDescription()));
+
+                components.add(new BookmarkablePageLink<Consumer>("edit", ConsumerAdministration.class)
+                        .setParameter("consumer", components.getModelObject().getId()));
+
+                components.add(new Link<Consumer>("delete", components.getModel()) {
+                    @Override
+                    public void onClick() {
+                        try {
+                            oAuthAdminService.deleteConsumer(getModelObject());
+                            setResponsePage(getPage().getClass());
+                            getSession().info(getModelObject().getName() + " has been removed.");
+                        } catch (Exception e) {
+                            warn("Couldn't remove '" + getModelObject().getName() + "': " + e.getLocalizedMessage());
+                        }
+                    }
+                });
+
+                Link<Consumer> recordLink = new Link<Consumer>("record", components.getModel()) {
+                    @Override
+                    public void onClick() {
+                        try {
+                            oAuthAdminService.switchRecordMode(getModelObject());
+                            setResponsePage(getPage().getClass());
+                            getSession().info(getModelObject().getName() + " record mode has changed.");
+                        } catch (Exception e) {
+                            warn("Couldn't change record mode on " + getModelObject().getName() + "': "
+                                    + e.getLocalizedMessage());
+                        }
+                    }
+                };
+                if (components.getModelObject().isRecordModeEnabled())
+                    recordLink.add(new Label("recordLink", new ResourceModel("record.disable.link")));
+                else
+                    recordLink.add(new Label("recordLink", new ResourceModel("record.enable.link")));
+                components.add(recordLink);
+
+            }
+
+            @Override
+            public boolean isVisible() {
+                return !getModelObject().isEmpty() && super.isVisible();
+            }
+        };
+        add(consumerList);
+
+        Label noConsumerLabel = new Label("noConsumer", new ResourceModel("no.consumer"));
+        noConsumerLabel.setVisible(!consumerList.isVisible());
+        add(noConsumerLabel);
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/pages/SakaiPage.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/pages/SakaiPage.java
@@ -1,0 +1,175 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.tool.pages;
+
+import org.apache.wicket.*;
+import org.apache.wicket.behavior.SimpleAttributeModifier;
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.feedback.IFeedbackMessageFilter;
+import org.apache.wicket.markup.html.IHeaderContributor;
+import org.apache.wicket.markup.html.IHeaderResponse;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.markup.repeater.RepeatingView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.SessionManager;
+
+/**
+ * @author Colin Hebert
+ */
+public abstract class SakaiPage extends WebPage implements IHeaderContributor {
+    @SpringBean
+    private ServerConfigurationService serverConfigurationService;
+    @SpringBean
+    private SiteService siteService;
+    @SpringBean
+    private SessionManager sessionManager;
+    private RepeatingView menu;
+
+    protected SakaiPage() {
+        init();
+    }
+
+    protected SakaiPage(IModel<?> model) {
+        super(model);
+        init();
+    }
+
+    protected SakaiPage(IPageMap pageMap) {
+        super(pageMap);
+        init();
+    }
+
+    protected SakaiPage(IPageMap pageMap, IModel<?> model) {
+        super(pageMap, model);
+        init();
+    }
+
+    protected SakaiPage(PageParameters parameters) {
+        super(parameters);
+        init();
+    }
+
+    protected SakaiPage(IPageMap pageMap, PageParameters parameters) {
+        super(pageMap, parameters);
+        init();
+    }
+
+    private void init() {
+        FeedbackPanel feedbackPanel = new FeedbackPanel("feedback") {
+            @Override
+            protected Component newMessageDisplayComponent(final String id, final FeedbackMessage message) {
+                if (message.getLevel() == FeedbackMessage.INFO)
+                    add(new SimpleAttributeModifier("class", "success"));
+                else
+                    add(new SimpleAttributeModifier("class", "alertMessage"));
+
+                return super.newMessageDisplayComponent(id, message);
+            }
+
+            // If we don't link up visibility to having messages, then when changing the filter after displaying
+            // the message, the message disappears but they surrounding box remains.
+            public boolean isVisible() {
+                return anyMessage();
+            }
+        };
+        feedbackPanel.setFilter(new IFeedbackMessageFilter() {
+            public boolean accept(FeedbackMessage message) {
+                return !message.isRendered();
+            }
+        });
+        add(feedbackPanel);
+        menu = new RepeatingView("menu") {
+            /**
+             * Automatically hide the repeating view if there is no element present in there.
+             * @return true if there is at least one child element, false otherwise
+             */
+            @Override
+            public boolean isVisible() {
+                return iterator().hasNext() && super.isVisible();
+            }
+        };
+        add(menu);
+    }
+
+    @Override
+    public void renderHead(IHeaderResponse response) {
+        // get Sakai skin
+        String skinRepo = serverConfigurationService.getString("skin.repo");
+        String skin = siteService.findTool(sessionManager.getCurrentToolSession().getPlacementId()).getSkin();
+        if (skin == null) {
+            skin = serverConfigurationService.getString("skin.default");
+        }
+        String toolCSS = skinRepo + "/" + skin + "/tool.css";
+        String toolBaseCSS = skinRepo + "/tool_base.css";
+
+        // Sakai additions
+        response.renderJavascriptReference("/library/js/headscripts.js");
+        response.renderCSSReference(toolBaseCSS);
+        response.renderCSSReference(toolCSS);
+        response.renderOnLoadJavascript("\nif (typeof setMainFrameHeight !== 'undefined'){\n"
+                + "setMainFrameHeight( window.name );\n"
+                + "}");
+
+        // Tool additions (at end so we can override if required)
+        response.renderString("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n");
+        response.renderCSSReference(new ResourceReference(getClass(), "style.css"));
+    }
+
+    /**
+     * Add a menu entry linking to a class page.
+     * <p>
+     * Automatically disable the link if it's to the current page.
+     * </p>
+     *
+     * @param clazz classPage
+     * @param text  Link's text
+     * @param title Title attribute for the link
+     */
+    protected void addMenuLink(Class<? extends Page> clazz, IModel<String> text, IModel<String> title) {
+        Link<Page> link = new BookmarkablePageLink<Page>("menuItem", clazz);
+        link.setEnabled(!getClass().equals(clazz));
+        addMenuLink(link, text, title);
+    }
+
+    /**
+     * Add a menu entry with a custom link.
+     *
+     * @param link  Link to add to the menu bar
+     * @param text  Link's text
+     * @param title Title attribute for the link
+     */
+    protected void addMenuLink(Link<Page> link, IModel<String> text, IModel<String> title) {
+        WebMarkupContainer parent = new WebMarkupContainer(menu.newChildId());
+        menu.add(parent);
+        link.add(new Label("menuItemText", text).setRenderBodyOnly(true));
+        if (title != null)
+            link.add(new AttributeModifier("title", true, title));
+
+        parent.add(link);
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/user/OAuthApplication.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/user/OAuthApplication.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.tool.user;
+
+import org.apache.wicket.Page;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
+import org.sakaiproject.oauth.tool.user.pages.ListAccessors;
+
+/**
+ * @author Colin Hebert
+ */
+public class OAuthApplication extends WebApplication {
+    @Override
+    protected void init() {
+        // Configure for Spring injection
+        addComponentInstantiationListener(new SpringComponentInjector(this));
+        // getComponentInstantiationListeners().add(new SpringComponentInjector(this));
+    }
+
+    @Override
+    public Class<? extends Page> getHomePage() {
+        return ListAccessors.class;
+    }
+}

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/user/pages/ListAccessors.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/user/pages/ListAccessors.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * OAuth Tool
+ * %%
+ * Copyright (C) 2009 - 2013 The Sakai Foundation
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.sakaiproject.oauth.tool.user.pages;
+
+import org.apache.wicket.behavior.SimpleAttributeModifier;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.oauth.domain.Accessor;
+import org.sakaiproject.oauth.domain.Consumer;
+import org.sakaiproject.oauth.exception.InvalidConsumerException;
+import org.sakaiproject.oauth.service.OAuthService;
+import org.sakaiproject.oauth.tool.pages.SakaiPage;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author Colin Hebert
+ */
+public class ListAccessors extends SakaiPage {
+    @SpringBean
+    private SessionManager sessionManager;
+    @SpringBean
+    private OAuthService oAuthService;
+
+    public ListAccessors() {
+        String userId = sessionManager.getCurrentSessionUserId();
+        Collection<Accessor> accessors = oAuthService.getAccessAccessorForUser(userId);
+        ListView<Accessor> accessorList = new ListView<Accessor>("accessorlist", new ArrayList<Accessor>(accessors)) {
+            @Override
+            protected void populateItem(ListItem<Accessor> components) {
+                try {
+                    final Consumer consumer = oAuthService.getConsumer(components.getModelObject().getConsumerId());
+                    ExternalLink consumerHomepage = new ExternalLink("consumerUrl", consumer.getUrl(),
+                            consumer.getName());
+                    consumerHomepage.add(new SimpleAttributeModifier("target", "_blank"));
+                    consumerHomepage.setEnabled(consumer.getUrl() != null && !consumer.getUrl().isEmpty());
+                    components.add(consumerHomepage);
+                    components.add(new Label("consumerDescription", consumer.getDescription()));
+                    components.add(new Label("creationDate", new StringResourceModel("creation.date", null,
+                            new Object[]{components.getModelObject().getCreationDate()})));
+                    components.add(new Label("expirationDate", new StringResourceModel("expiration.date", null,
+                            new Object[]{components.getModelObject().getExpirationDate()})));
+
+                    components.add(new Link<Accessor>("delete", components.getModel()) {
+                        @Override
+                        public void onClick() {
+                            try {
+                                oAuthService.revokeAccessor(getModelObject().getToken());
+                                setResponsePage(getPage().getClass());
+                                getSession().info(consumer.getName() + "' token has been removed.");
+                            } catch (Exception e) {
+                                warn("Couldn't remove " + consumer.getName() + "'s token': " + e.getLocalizedMessage());
+                            }
+                        }
+                    });
+                } catch (InvalidConsumerException invalidConsumerException) {
+                    // Invalid consumer, it is probably deleted
+                    // For security reasons, this token should be revoked
+                    oAuthService.revokeAccessor(components.getModelObject().getToken());
+                    components.setVisible(false);
+                }
+            }
+
+            @Override
+            public boolean isVisible() {
+                return !getModelObject().isEmpty() && super.isVisible();
+            }
+        };
+        add(accessorList);
+
+        Label noAccessorLabel = new Label("noAccessor", new ResourceModel("no.accessor"));
+        noAccessorLabel.setVisible(!accessorList.isVisible());
+        add(noAccessorLabel);
+    }
+}

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.html
@@ -1,0 +1,83 @@
+<?xml encoding="UTF-8" ?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+<head>
+    <title><wicket:message key="page.title">OAuth - Edit consumer</wicket:message></title>
+</head>
+<body>
+<wicket:extend>
+
+    <h3><span wicket:id="consumerName">Consumer name</span></h3>
+
+    <form wicket:id="consumerForm" action="post">
+        <h2><wicket:message key="section.settings">Settings</wicket:message></h2>
+
+        <div>
+            <label wicket:for="id"><wicket:message key="consumer.id">Unique identifier (consumer's key)</wicket:message></label>
+            <input type="text" id="id" value="consumer's key" wicket:id="id"/>
+        </div>
+        <div>
+            <label wicket:for="name"><wicket:message key="consumer.name">Consumer's name (used for display)</wicket:message></label>
+            <input type="text" id="name" value="consumer's name" wicket:id="name"/>
+        </div>
+        <div>
+            <label wicket:for="description"><wicket:message key="consumer.description">Description</wicket:message></label>
+            <textarea id="description" cols="0" rows="0" wicket:id="description">Consumer's description</textarea>
+        </div>
+        <div>
+            <label wicket:for="url"><wicket:message key="consumer.url">URL (website, homepage)</wicket:message></label>
+            <input type="text" id="url" value="http://www.consumersite.com/" wicket:id="url"/>
+        </div>
+        <div>
+            <label wicket:for="callbackUrl"><wicket:message key="consumer.callbackUrl">Callback URL (used during the authorisation phase)</wicket:message></label>
+            <input type="text" id="callbackUrl" value="http://www.consumersite.com/oauth/callback"
+                   wicket:id="callbackUrl"/>
+        </div>
+        <div>
+            <label wicket:for="secret"><wicket:message key="consumer.secret">Consumer's secret (password), used to sign oauth messages</wicket:message></label>
+            <input type="text" id="secret" value="sEcre7/p@s$W0rd" wicket:id="secret"/>
+        </div>
+        <div>
+            <label wicket:for="accessorSecret"><wicket:message key="consumer.accessorSecret">Accessor's secret</wicket:message></label>
+            <input type="text" id="accessorSecret" value="sEcre7/p@s$W0rd" wicket:id="accessorSecret"/>
+        </div>
+        <div>
+            <label wicket:for="defaultValidity"><wicket:message key="consumer.defaultValidity">Default validity (in minutes)</wicket:message></label>
+            <input type="text" id="defaultValidity" value="42" wicket:id="defaultValidity"/>
+        </div>
+
+        <input type="submit" value="Save" wicket:message="value:consumer.save"/>
+
+        <h2><wicket:message key="section.rights">Rights</wicket:message></h2>
+        <span wicket:id="rights">
+            <input type="checkbox" id="right.name" checked="checked"/><label for="right.name">Right's name</label><br/>
+            <input type="checkbox" id="otherright.name"/><label for="otherright.name">Other right's name</label>
+        </span>
+        <input type="submit" value="Save" wicket:message="value:consumer.save"/>
+    </form>
+
+</wicket:extend>
+</body>
+</html>

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.properties
@@ -1,0 +1,31 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+page.title=Edit oAuth consumer
+section.settings=Settings
+section.rights=Rights
+consumer.id=Consumer's key
+consumer.name=Consumer's name
+consumer.description=Description (should include a brief description of rights granted)
+consumer.url=Consumer's website
+consumer.callbackUrl=oAuth callback url (leave empty if there is none)
+consumer.secret=oAuth secret
+consumer.accessorSecret=Accessor secret (http://wiki.oauth.net/w/page/12238502/AccessorSecret)
+consumer.defaultValidity=Period of validity of a token (in minutes)
+consumer.save=Save

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration_fr.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration_fr.properties
@@ -1,0 +1,31 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+page.title=Edition d'un client oAuth
+section.settings=Configuration
+section.rights=Droits d'accès
+consumer.id=Clé client
+consumer.name=Nom du client
+consumer.description=Description (devrait inclure une description des droits donnés à l'application)
+consumer.url=Site web du client
+consumer.callbackUrl=URL de callback oAuth (laisser vide si non utilisé)
+consumer.secret=Secret oAuth
+consumer.accessorSecret=Secret d'Accessor (http://wiki.oauth.net/w/page/12238502/AccessorSecret)
+consumer.defaultValidity=Période de validité d'un ticket (en minutes)
+consumer.save=Enregistrer

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.html
@@ -1,0 +1,46 @@
+<?xml encoding="UTF-8" ?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+<head>
+    <title><wicket:message key="page.title">Consumers list</wicket:message></title>
+</head>
+<body>
+<wicket:extend>
+
+    <div class="oAuthConsumer" wicket:id="consumerlist">
+        <h2><span wicket:id="name">Consumer's name</span> <em><span wicket:id="id">Consumer's id</span></em></h2>
+
+        <div><span wicket:id="description">Consumer's description</span></div>
+        <div>
+            <a href="#" wicket:id="edit"><wicket:message key="edit.link">Edit</wicket:message></a>
+            <a href="#" wicket:id="delete"><wicket:message key="delete.link">delete</wicket:message></a>
+            <a href="#" wicket:id="record"><span wicket:id="recordLink">enable/disable record mode</span></a>
+        </div>
+    </div>
+    <span class="no-consumer" wicket:id="noConsumer">There is no consumer to administrate</span>
+
+</wicket:extend>
+</body>
+</html>

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.properties
@@ -1,0 +1,25 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+page.title=List of OAuth authorized consumers
+delete.link=Remove
+edit.link=Edit
+record.enable.link=Enable record mode
+record.disable.link=Disable record mode
+no.consumer=So far, no consumers have been created.

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers_fr.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers_fr.properties
@@ -1,0 +1,25 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+page.title=Liste des clients oAuth authorisés
+delete.link=Supprimer
+edit.link=Modifier
+record.enable.link=Activer l'enregistrement
+record.disable.link=Desactiver l'enregistrement
+no.consumer=Il n'existe aucun client pour le moment.

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage.html
@@ -1,0 +1,42 @@
+<?xml encoding="UTF-8" ?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+<head></head>
+<body>
+
+<div class="portletBody">
+    <ul class="navIntraTool actionToolbar" role="menu" wicket:enclosure="menu">
+        <li role="menuitem" wicket:id="menu">
+            <a wicket:id="menuItem"><span wicket:id="menuItemText">Link Label</span></a>
+        </li>
+    </ul>
+
+    <span wicket:id="feedback">feedbackmessages will be put here</span>
+
+    <wicket:child/>
+</div>
+
+</body>
+</html>

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage.properties
@@ -1,0 +1,21 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+menu.add.consumer=Add a consumer
+menu.list.consumer=List consumers

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage_fr.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage_fr.properties
@@ -1,0 +1,21 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+menu.add.consumer=Ajouter un client
+menu.list.consumer=Liste des clients

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/user/pages/ListAccessors.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/user/pages/ListAccessors.html
@@ -1,0 +1,54 @@
+<?xml encoding="UTF-8" ?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+<head>
+    <title>
+        <wicket:message key="page.title">Trusted Applications</wicket:message>
+    </title>
+</head>
+<body>
+<wicket:extend>
+
+    <h3><wicket:message key="page.header">List of Applications.</wicket:message></h3>
+    <table wicket:enclosure="accessorlist">
+        <tr class="accessor" wicket:id="accessorlist">
+            <td class="name"><a href="http://consumerurl" wicket:id="consumerUrl">Consumer's name</a></td>
+            <td class="description">
+                <div class="description" wicket:id="consumerDescription">Consumer's description</div>
+                <div class="creation-date" wicket:id="creationDate">creationDate</div>
+                <div class="expiration-date" wicket:id="expirationDate">expirationDate</div>
+            </td>
+            <td class="actions">
+                <a wicket:id="delete">
+                    <wicket:message key="accessor.delete">delete</wicket:message>
+                </a>
+            </td>
+        </tr>
+    </table>
+    <span wicket:id="noAccessor">You currently don't have any applications able to access your account.</span>
+
+</wicket:extend>
+</body>
+</html>

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/user/pages/ListAccessors.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/user/pages/ListAccessors.properties
@@ -1,0 +1,28 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+page.title=Trusted Applications
+page.header=List of Applications.
+accessor.delete=Remove
+no.accessor=You currently don't have any applications able to access your account.
+creation.date=Creation date: {0, date, full}
+expiration.date=Expiration date: {0, date, full}
+
+instructions=Here you can manage the applications that you wish to allow access to your account.
+removed.ok=Removed {0} from having access to your account.

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/user/pages/ListAccessors_fr.properties
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/user/pages/ListAccessors_fr.properties
@@ -1,0 +1,25 @@
+###
+# #%L
+# OAuth Tool
+# %%
+# Copyright (C) 2009 - 2013 The Sakai Foundation
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+page.title=Applications autorisées
+page.header=Liste des applications
+accessor.delete=Supprimer
+no.accessor=Vous n'avez actuellement aucune application autorisée à se connecter sur votre compte.
+creation.date=Créé le {0, date, full}
+expiration.date=Expire le {0, date, full}

--- a/oauth/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/oauth/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+    <!-- We need this file to satisfy Spring, but we don't need anything in it since we use Wicket's dependency injection -->
+</beans>

--- a/oauth/tool/src/webapp/WEB-INF/web.xml
+++ b/oauth/tool/src/webapp/WEB-INF/web.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+	http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+    <display-name>oAuth tools</display-name>
+
+    <!-- oAuth servlets -->
+    <servlet>
+        <servlet-name>RequestTokenServlet</servlet-name>
+        <servlet-class>org.sakaiproject.oauth.servlet.RequestTokenServlet</servlet-class>
+    </servlet>
+    <servlet>
+        <servlet-name>AuthorizationServlet</servlet-name>
+        <servlet-class>org.sakaiproject.oauth.servlet.AuthorisationServlet</servlet-class>
+    </servlet>
+    <servlet>
+        <servlet-name>AccessTokenServlet</servlet-name>
+        <servlet-class>org.sakaiproject.oauth.servlet.AccessTokenServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>RequestTokenServlet</servlet-name>
+        <url-pattern>/request_token</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>AuthorizationServlet</servlet-name>
+        <url-pattern>/authorize/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>AccessTokenServlet</servlet-name>
+        <url-pattern>/access_token</url-pattern>
+    </servlet-mapping>
+
+    <!-- oAuth tool -->
+    <servlet>
+        <servlet-name>sakai.oauth</servlet-name>
+        <servlet-class>org.apache.wicket.protocol.http.WicketServlet</servlet-class>
+        <init-param>
+            <param-name>applicationClassName</param-name>
+            <param-value>org.sakaiproject.oauth.tool.user.OAuthApplication</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>sakai.oauth</servlet-name>
+        <url-pattern>/tool/*</url-pattern>
+    </servlet-mapping>
+
+    <!-- Admin tool -->
+    <servlet>
+        <servlet-name>sakai.oauth.admin</servlet-name>
+        <servlet-class>org.apache.wicket.protocol.http.WicketServlet</servlet-class>
+        <init-param>
+            <param-name>applicationClassName</param-name>
+            <param-value>org.sakaiproject.oauth.tool.admin.OauthAdminApplication</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>sakai.oauth.admin</servlet-name>
+        <url-pattern>/admin/*</url-pattern>
+    </servlet-mapping>
+
+
+    <!-- Wicket deployment mode -->
+    <context-param>
+        <param-name>configuration</param-name>
+        <param-value>deployment</param-value>
+    </context-param>
+
+    <!-- Sakai Tool Listener -->
+    <listener>
+        <listener-class>org.sakaiproject.util.ToolListener</listener-class>
+    </listener>
+
+    <context-param>
+        <param-name>org.sakaiproject.util.ToolListener.PATH</param-name>
+        <param-value>/WEB-INF/tools</param-value>
+    </context-param>
+
+    <!-- Sakai Spring Listener -->
+    <listener>
+        <listener-class>org.sakaiproject.util.ContextLoaderListener</listener-class>
+    </listener>
+
+    <!-- Sakai Request Filter -->
+    <filter>
+        <filter-name>request-filter</filter-name>
+        <filter-class>org.sakaiproject.util.RequestFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>request-filter</filter-name>
+        <servlet-name>AuthorizationServlet</servlet-name>
+    </filter-mapping>
+
+    <!-- Administration filter -->
+    <filter>
+        <filter-name>oauth.admin</filter-name>
+        <filter-class>org.sakaiproject.oauth.tool.admin.AdminFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>oauth.admin</filter-name>
+        <servlet-name>sakai.oauth.admin</servlet-name>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>INCLUDE</dispatcher>
+    </filter-mapping>
+</web-app>

--- a/oauth/tool/src/webapp/authorise.jsp
+++ b/oauth/tool/src/webapp/authorise.jsp
@@ -1,0 +1,75 @@
+<%--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@page contentType="text/html" %>
+<%@page pageEncoding="UTF-8" %>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link href="${requestScope.skinPath}/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
+    <link href="${requestScope.skinPath}/${requestScope.defaultSkin}/tool.css" type="text/css" rel="stylesheet"
+          media="all"/>
+    <link href="${requestScope.skinPath}/${requestScope.defaultSkin}/mobile.css" type="text/css" rel="stylesheet"
+          media="handheld"/>
+    <link href="${requestScope.skinPath}/${requestScope.defaultSkin}/mobile.css" type="text/css" rel="stylesheet"
+          media="only screen and (max-device-width: 420px)"/>
+    <script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
+    <title>${requestScope.uiName} : OAuth Provider</title>
+    <meta name="viewport" content="width=device-width"/>
+    <style type="text/css">
+        #wrapper {
+            /* Max width of 420px and centre */
+            margin: auto;
+            max-width: 420px;
+            width: expression(document.body.clientWidth > 420? "420px": "auto");
+        }
+    </style>
+</head>
+<body>
+<div id="wrapper">
+    <table class="login" cellpadding="3px" cellspacing="0" border="0" summary="layout">
+        <tr>
+            <th>${requestScope.uiName} : Authorisation Required</th>
+        </tr>
+        <tr>
+            <td class="logo" align="center"></td>
+        </tr>
+        <tr>
+            <td align="center">
+                <h3>"${requestScope.appName}" would like to access your account.</h3>
+
+                <div class="instruction" style="text-align: center">
+                    <p>${requestScope.appDesc}</p>
+
+                    <p>You are currently logged in as  ${requestScope.userName} (${requestScope.userId})</p>
+
+                    <form name="authZForm" action="authorize" method="post">
+                        <input type="hidden" name="oauthToken" value="${requestScope.token}"/>
+                        <input type="hidden" name="oauthVerifier" value="${requestScope.oauthVerifier}"/>
+                        <input type="submit" name="${requestScope.authorise}" value="${requestScope.authorise}"/>
+                        <input type="submit" name="${requestScope.deny}" value="${requestScope.deny}"/>
+                    </form>
+                </div>
+            </td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/oauth/tool/src/webapp/tools/sakai.oauth.admin.xml
+++ b/oauth/tool/src/webapp/tools/sakai.oauth.admin.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<registration>
+    <tool id="sakai.oauth.admin"
+          title="oAuth Admin"
+          description="Tool to allow you to manage applications that can use oAuth." />
+</registration>
+

--- a/oauth/tool/src/webapp/tools/sakai.oauth.xml
+++ b/oauth/tool/src/webapp/tools/sakai.oauth.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  #%L
+  OAuth Tool
+  %%
+  Copyright (C) 2009 - 2013 The Sakai Foundation
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<registration>
+    <tool id="sakai.oauth"
+          title="Trusted Applications"
+          description="Tool to allow you to manage applications that can access the service.">
+        <category name="myworkspace"/>
+    </tool>
+</registration>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
                 <module>memory</module>
                 <module>message</module>
                 <module>msgcntr</module>
+                <module>oauth</module>
                 <module>podcasts</module>
                 <module>polls</module>
                 <module>portal</module>

--- a/reference/docs/conversion/sakai_11_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_mysql_conversion.sql
@@ -279,3 +279,11 @@ ALTER TABLE SAM_AUTHZDATA_T ADD INDEX SAM_IDX_FUNC_QUAL (FUNCTIONID,QUALIFIERID)
 ALTER TABLE SAM_AUTHZDATA_T MODIFY COLUMN AGENTID varchar(99);
 ALTER TABLE SAM_AUTHZDATA_T MODIFY COLUMN LASTMODIFIEDBY varchar(99);
 -- End SAM-2259
+
+-- SAK-23666 Add OAuth Admin tool to Administration workspace
+INSERT INTO sakai_site_page VALUES('!admin-1500', '!admin', 'OAuth Admin', '0', 20, '0');
+INSERT INTO sakai_site_tool VALUES('!admin-1550', '!admin-1500', '!admin', 'sakai.oauth.admin', 1, 'OAuth Admin', NULL);
+
+-- SAK-23666 Add OAuth Admin tool to My Workspace template 
+INSERT INTO sakai_site_page VALUES('!user-650', '!user', 'Trusted Applications', '0', 9, '0');
+INSERT INTO sakai_site_tool VALUES('!user-655', '!user-650', '!user', 'sakai.oauth', 1, 'Trusted Applications', NULL);

--- a/reference/docs/conversion/sakai_11_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_11_oracle_conversion.sql
@@ -283,3 +283,11 @@ CREATE INDEX SAM_IDX_FUNC_QUAL ON SAM_AUTHZDATA_T (FUNCTIONID, QUALIFIERID);
 ALTER TABLE SAM_AUTHZDATA_T MODIFY (AGENTID VARCHAR2(99 CHAR));
 ALTER TABLE SAM_AUTHZDATA_T MODIFY (LASTMODIFIEDBY VARCHAR2(99 CHAR));
 -- End SAM-2259
+
+-- SAK-23666 Add OAuth Admin tool to Administration workspace
+INSERT INTO sakai_site_page VALUES('!admin-1500', '!admin', 'OAuth Admin', '0', 20, '0');
+INSERT INTO sakai_site_tool VALUES('!admin-1550', '!admin-1500', '!admin', 'sakai.oauth.admin', 1, 'OAuth Admin', NULL);
+
+-- SAK-23666 Add OAuth Admin tool to My Workspace template 
+INSERT INTO sakai_site_page VALUES('!user-650', '!user', 'Trusted Applications', '0', 9, '0');
+INSERT INTO sakai_site_tool VALUES('!user-655', '!user-650', '!user', 'sakai.oauth', 1, 'Trusted Applications', NULL);


### PR DESCRIPTION
Accidentally closed the original PR via a branch cleanup.

This PR adds the OAuth module to Sakai, as well as the hooks to EntityBroker for it to work. It is turned OFF by default though the tools are added to the Admin Workspace and My Workspace templates via the SQL upgrade.