### PR TITLE
SAM-2518 inconsistent markup in samigo -> event log

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/event/eventLog.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/event/eventLog.jsp
@@ -17,17 +17,16 @@
 <div class="portletBody">
 
   <h:form id="eventLogId">
-<h:messages infoClass="validation" warnClass="validation" errorClass="validation" fatalClass="validation"/>
   <!-- HEADINGS -->
   <%@ include file="/jsf/event/eventLogHeadings.jsp" %>
+  
+  <h:messages rendered="#{! empty facesContext.maximumSeverity}" infoClass="validation" warnClass="validation" errorClass="validation" fatalClass="validation"/>
 
 <!-- content... -->
- <div align="center">
-   <h3>
-      <h:outputText value="#{eventLog.siteTitle} "/>
-      <h:outputText value="#{eventLogMessages.log}"/>
-   </h3>
- </div>
+ <h3>
+    <h:outputText value="#{eventLog.siteTitle} "/>
+    <h:outputText value="#{eventLogMessages.log}"/>
+ </h3>
 
  <div align="right">
  	<h:panelGroup>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2518

There are some inconsistencies in the markup for the Event Log page:

1. messages list is above the navIntraTool actionToolBar
    - when it's above the toolbar, it creates a gap which looks bad; it should be below the toolbar
    - if there are no messages, the element should not be rendered

2. page title is centred, which contrasts all other Samigo interfaces where the title is left aligned 