### PR TITLE
SAM-2519 indicate current page in samigo like other tools

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/assessmentHeadings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/assessmentHeadings.jsp
@@ -21,7 +21,7 @@
 -->
 <h:panelGroup rendered="#{authorization.adminQuestionPool or authorization.adminTemplate}">
 <f:verbatim><ul class="navIntraTool actionToolbar" role="menu"> 
-<li role="menuitem" class="firstToolBarItem"> <span></f:verbatim>
+<li role="menuitem" class="firstToolBarItem"> <span class="current"></f:verbatim>
       <h:outputText value="#{generalMessages.assessment}"/>
 <f:verbatim></span></li></f:verbatim>
 <h:panelGroup rendered="#{authorization.adminTemplate and template.showAssessmentTypes}">

--- a/samigo/samigo-app/src/webapp/jsf/event/eventLogHeadings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/event/eventLogHeadings.jsp
@@ -21,7 +21,7 @@
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.questionpool.QuestionPoolListener" />
     </h:commandLink>
 <f:verbatim></span></li>
-<li role="menuitem" ><span></f:verbatim>
+<li role="menuitem" ><span class="current"></f:verbatim>
       <h:outputText value="#{generalMessages.eventLog}" />
 <f:verbatim></span></li>
 </ul></f:verbatim>

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
@@ -74,7 +74,7 @@
 
 <f:verbatim></span></li></f:verbatim>
 </h:panelGroup>
-<f:verbatim><li role="menuitem" ><span></f:verbatim>
+<f:verbatim><li role="menuitem" ><span class="current"></f:verbatim>
 
         <h:outputText value="#{questionPoolMessages.qps}"/>
 

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/sharePool.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/sharePool.jsp
@@ -96,7 +96,7 @@
 
 <f:verbatim></span></li></f:verbatim>
 </h:panelGroup>
-<f:verbatim><li role="menuitem"><span></f:verbatim>
+<f:verbatim><li role="menuitem"><span class="current"></f:verbatim>
 
    	<h:outputText value="#{questionPoolMessages.qps}"/>
 <f:verbatim></span></li>

--- a/samigo/samigo-app/src/webapp/jsf/template/templateHeadings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/template/templateHeadings.jsp
@@ -31,7 +31,7 @@
    </h:commandLink>
 
 <f:verbatim></span></li>
-<li role="menuitem" ><span></f:verbatim>
+<li role="menuitem" ><span class="current"></f:verbatim>
 
       <h:outputText value="#{generalMessages.template}" />
       


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2519

Most other tools, such as Resources and Gradebook, indicate which page you're on by applying a class to the menu item that the user is currently on. Samigo kind of does this too, but it's not consistent with the other tools.

The linked PR adds 'class="current"' to the span in the navIntraTool bar when you're on the given page. This helps institutional branding that targets the 'current' class. 