### PR TITLE
SAM-2520 samigo -> event log page doesn't respect sakai.property to hide assessment types

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/event/eventLogHeadings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/event/eventLogHeadings.jsp
@@ -8,14 +8,16 @@
        <h:outputText value="#{generalMessages.assessment}" />
        <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.AuthorActionListener" />
     </h:commandLink>
-<f:verbatim></span></li>
-<li role="menuitem" ><span></f:verbatim>
+<f:verbatim></span></li></f:verbatim>
+<h:panelGroup rendered="#{authorization.adminTemplate and template.showAssessmentTypes}">
+<f:verbatim><li role="menuitem" ><span></f:verbatim>
     <h:commandLink title="#{generalMessages.t_template}" action="template" immediate="true" rendered="#{authorization.adminTemplate}">
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.TemplateListener" />
       <h:outputText value="#{generalMessages.template}" />
     </h:commandLink>
-<f:verbatim></span></li>
-<li role="menuitem" ><span></f:verbatim>
+<f:verbatim></span></li></f:verbatim>
+</h:panelGroup>
+<f:verbatim><li role="menuitem" ><span></f:verbatim>
     <h:commandLink id="questionPoolsLink" title="#{generalMessages.t_questionPool}" action="poolList" immediate="true" rendered="#{authorization.adminQuestionPool}">
       <h:outputText value="#{generalMessages.questionPool}" />
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.questionpool.QuestionPoolListener" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2520

The sakai.property samigo.showAssessmentTypes controls whether the user sees the drop down for assessment type creation and the assessment types/templates menu button.

The event log page does not respect this sakai.property, and will display a menu link for the assessment types UI, giving the user access to this interface regardless of the sakai.property.

The linked PR simply implements the existing check from the other headers in the event log headers. 