### PR TITLE
DASH-340 Use the normalized way to load local hbm files in dashboard

### DIFF
--- a/dashboard/hbm/src/java/org/sakaiproject/dash/dao/JobRunImpl.hbm.xml
+++ b/dashboard/hbm/src/java/org/sakaiproject/dash/dao/JobRunImpl.hbm.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE hibernate-mapping
     PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
     "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
-<hibernate-mapping>
+<hibernate-mapping auto-import="false">
 	<class name="org.sakaiproject.dash.dao.JobRunImpl"
 		table="DASH_JOB_RUN"
 		lazy="true">

--- a/dashboard/pack/src/webapp/WEB-INF/components.xml
+++ b/dashboard/pack/src/webapp/WEB-INF/components.xml
@@ -204,8 +204,8 @@
 
   
 
-  <bean id="org.sakaiproject.dash.dao.SessionFactory"
-      parent="org.sakaiproject.springframework.orm.hibernate.SessionFactoryBase">
+  <bean id="org.sakaiproject.springframework.orm.hibernate.impl.AdditionalHibernateMappingsImpl.dashboard"
+      class="org.sakaiproject.springframework.orm.hibernate.impl.AdditionalHibernateMappingsImpl">
       <property name="mappingResources">
           <list>
               <value>org/sakaiproject/dash/dao/JobRunImpl.hbm.xml</value>
@@ -216,14 +216,14 @@
   <bean id="org.sakaiproject.dash.dao.HibernateTransactionManager"
       class="org.springframework.orm.hibernate3.HibernateTransactionManager">
       <property name="sessionFactory">
-          <ref bean="org.sakaiproject.dash.dao.SessionFactory" />
+          <ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
       </property>
   </bean>
 
   <bean id="org.sakaiproject.dash.dao.DashHibernateDaoTarget"
       class="org.sakaiproject.dash.dao.DashHibernateDao">
       <property name="sessionFactory">
-          <ref bean="org.sakaiproject.dash.dao.SessionFactory" />
+          <ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
       </property>
   </bean>
 


### PR DESCRIPTION
Remove org.sakaiproject.dash.dao.SessionFactory to use org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory.
Adding org.sakaiproject.springframework.orm.hibernate.impl.AdditionalHibernateMappingsImpl to load custom hbm file.
Change auto-import to false to avoid name collision with SiteStats JobRunImpl.