### PR TITLE
SAK-28184 new account tool should email users a link to activate their accounts

### DIFF
--- a/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/model/ValidationAccount.java
+++ b/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/model/ValidationAccount.java
@@ -59,7 +59,10 @@ public class ValidationAccount {
 	 */
 	public static final int ACCOUNT_STATUS_PASSWORD_RESET = 5;
 	
-	
+	/**
+	 * Status for requested accounts (non-mergeable)
+	 **/
+	public static final int ACCOUNT_STATUS_REQUEST_ACCOUNT = 6;
 	
 	private Long id;
 	private String userId;

--- a/reset-pass/account-validator-impl/src/bundle/validate_requestAccount.xml
+++ b/reset-pass/account-validator-impl/src/bundle/validate_requestAccount.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<emailTemplates>
+   <emailTemplate>
+       <subject>Welcome To ${localSakaiName}!</subject>
+       <message>Thank you for requesting an account for ${localSakaiName}, ${institution}'s learning management system. You're almost done!
+
+To create an account, click on the following link or paste it into your favourite web browser, and fill in the form.
+${url}
+
+If you haven't requested this account, you can safely ignore this message.
+        </message>
+       <locale></locale>
+   </emailTemplate>
+</emailTemplates>

--- a/reset-pass/account-validator-impl/src/java/org/sakaiproject/accountvalidator/logic/impl/ValidationLogicImpl.java
+++ b/reset-pass/account-validator-impl/src/java/org/sakaiproject/accountvalidator/logic/impl/ValidationLogicImpl.java
@@ -84,6 +84,7 @@ public class ValidationLogicImpl implements ValidationLogic {
 	private static final String TEMPLATE_KEY_LEGACYUSER = "validate.legacyuser";
 	private static final String TEMPLATE_KEY_PASSWORDRESET = "validate.passwordreset";
 	private static final String TEMPLATE_KEY_DELETED = "validate.deleted";
+	private static final String TEMPLATE_KEY_REQUEST_ACCOUNT = "validate.requestAccount";
 	
 	private static final int VALIDATION_PERIOD_MONTHS = -36;
 	private static Log log = LogFactory.getLog(ValidationLogicImpl.class);
@@ -98,6 +99,7 @@ public class ValidationLogicImpl implements ValidationLogic {
 		loadTemplate("validate_legacyUser.xml", TEMPLATE_KEY_LEGACYUSER);
 		loadTemplate("validate_newPassword.xml", TEMPLATE_KEY_PASSWORDRESET);
 		loadTemplate("validate_deleted.xml", TEMPLATE_KEY_DELETED);
+		loadTemplate("validate_requestAccount.xml", TEMPLATE_KEY_REQUEST_ACCOUNT);
 		
 		//seeing the GroupProvider is optional we need to load it here
 		if (groupProvider == null) {
@@ -494,22 +496,26 @@ public class ValidationLogicImpl implements ValidationLogic {
 	 */
 	public String getPageForAccountStatus(Integer accountStatus)
 	{
+		if (accountStatus == null)
+		{
+			log.warn("can't determine which account validation page to use - accountStatus is null. Returning the legacy 'validate'");
+			return "validate";
+		}
+
+		if (accountStatus.equals(ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT))
+		{
+			return "requestAccount";
+		}
+
 		if (!serverConfigurationService.getBoolean("accountValidator.sendLegacyLinks", false))
 		{
-			if (accountStatus != null)
+			if (accountStatus.equals(ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET))
 			{
-				if (accountStatus.equals(ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET))
-				{
-					return "passwordReset";
-				}
-				else
-				{
-					return "newUser";
-				}
+				return "passwordReset";
 			}
 			else
 			{
-				log.warn("can't determine which account validation page to use - accountStatus is null");
+				return "newUser";
 			}
 		}
 		return "validate";
@@ -526,6 +532,8 @@ public class ValidationLogicImpl implements ValidationLogic {
 			templateKey  = TEMPLATE_KEY_LEGACYUSER;
 		} else if ( (ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET == accountStatus.intValue())) {
 			templateKey  = TEMPLATE_KEY_PASSWORDRESET;
+		} else if ( (ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT == accountStatus.intValue())) {
+			templateKey = TEMPLATE_KEY_REQUEST_ACCOUNT;
 		}
 		return templateKey;
 	}

--- a/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages.properties
+++ b/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages.properties
@@ -16,6 +16,7 @@ validate.welcome1=Welcome to {0}!
 validate.welcome1.reset=Reset your password in {0}
 validate.welcome=You have been invited to join the following site(s) in {0}:
 validate.welcome.reset=You have access to the following site(s) in {0}:
+validate.welcome.request=To activate your new {0} account, please complete the form below.
 validate.welcome2=A new account has been reserved for you with user ID {3}.
 validate.wait.newUser.1=Wait!
 validate.wait.newUser.2=I already have an account in {0}
@@ -54,7 +55,7 @@ lastname=Last name
 lastname.required=Last name is a required field
 password=Password
 newpassword=New password
-password2=Confirm new password
+password2=Confirm password
 
 # bbailla2, bjones86 - SAK-24427
 password.fail = Strength: too weak
@@ -77,3 +78,4 @@ submit.new.reset=Change password and log in
 activateAccount.title=Activate your account
 transferMemberships.title=Accept invitation
 passwordReset.title=Reset your password
+requestAccount.title=Activate your account

--- a/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/AcountValidationLocator.java
+++ b/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/AcountValidationLocator.java
@@ -197,7 +197,7 @@ public class AcountValidationLocator implements BeanLocator  {
 
                    int accountStatus = item.getAccountStatus();
                    //names are required in all cases except password resets
-                   if (ValidationAccount.ACCOUNT_STATUS_NEW == accountStatus || ValidationAccount.ACCOUNT_STATUS_LEGACY_NOPASS == accountStatus)
+                   if (ValidationAccount.ACCOUNT_STATUS_NEW == accountStatus || ValidationAccount.ACCOUNT_STATUS_LEGACY_NOPASS == accountStatus || ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT == accountStatus)
                    {
                      if (firstName == null || firstName.isEmpty())
                      {
@@ -253,7 +253,7 @@ public class AcountValidationLocator implements BeanLocator  {
 				
 				
 				//if this is a new account set the password
-				if (ValidationAccount.ACCOUNT_STATUS_NEW == accountStatus || ValidationAccount.ACCOUNT_STATUS_LEGACY_NOPASS == accountStatus || ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET == accountStatus) {
+				if (ValidationAccount.ACCOUNT_STATUS_NEW == accountStatus || ValidationAccount.ACCOUNT_STATUS_LEGACY_NOPASS == accountStatus || ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET == accountStatus || ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT == accountStatus) {
 					if (item.getPassword() == null || !item.getPassword().equals(item.getPassword2())) {
 						//Abandon the edit
 						userDirectoryService.cancelEdit(u);

--- a/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/ClaimLocator.java
+++ b/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/ClaimLocator.java
@@ -138,7 +138,7 @@ public class ClaimLocator implements BeanLocator {
 		}
 
 		//With sendLegacyLinks disabled, the option to transfer memberships is not available for password resets
-		if (!serverConfigurationService.getBoolean("accountValidator.sendLegacyLinks", false) && ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET == va.getStatus())
+		if (!serverConfigurationService.getBoolean("accountValidator.sendLegacyLinks", false) && (ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET == va.getStatus() || ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT == va.getStatus()))
 		{
 			log.warn("Was attempting to transfer memberships for a ValidationAccount of status " + va.getStatus());
 			return "error";

--- a/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/producers/RequestAccountProducer.java
+++ b/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/producers/RequestAccountProducer.java
@@ -1,0 +1,128 @@
+package org.sakaiproject.accountvalidator.tool.producers;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.accountvalidator.model.ValidationAccount;
+import org.sakaiproject.entitybroker.EntityReference;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserNotDefinedException;
+import uk.org.ponder.messageutil.TargettedMessage;
+import uk.org.ponder.rsf.components.*;
+import uk.org.ponder.rsf.flow.ActionResultInterceptor;
+import uk.org.ponder.rsf.view.ComponentChecker;
+import uk.org.ponder.rsf.view.ViewComponentProducer;
+import uk.org.ponder.rsf.viewstate.ViewParameters;
+
+
+/**
+ * Produces requestAccount.html - builds a form that allows the user to claim an account that has been created for them
+ * @author bbailla2
+ */
+public class RequestAccountProducer extends BaseValidationProducer implements ViewComponentProducer, ActionResultInterceptor
+{
+    private static final Log log = LogFactory.getLog(RequestAccountProducer.class);
+    public static final String VIEW_ID = "requestAccount";
+
+    public String getViewID()
+    {
+        return VIEW_ID;
+    }
+
+    public void init()
+    {
+
+    }
+
+    public void fillComponents(UIContainer tofill, ViewParameters viewparams, ComponentChecker checker)
+    {
+        Object[] args = new Object[]{serverConfigurationService.getString("ui.service", "Sakai")};
+        UIMessage.make(tofill, "welcome1", "validate.welcome1", args);
+        UIMessage.make(tofill, "welcome2", "validate.welcome.request", args);
+
+        ValidationAccount va = getValidationAccount(viewparams, tml);
+        if (va == null)
+        {
+            // handled by getValidationAccount
+            return;
+        }
+        else if (!va.getAccountStatus().equals(ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT))
+        {
+            // this form is not appropriate
+            args = new Object[] {va.getValidationToken()};
+            // no such validation of the required account status
+            tml.addMessage(new TargettedMessage("msg.noSuchValidation", args, TargettedMessage.SEVERITY_ERROR));
+            return;
+        }
+        else if (ValidationAccount.STATUS_CONFIRMED.equals(va.getStatus()))
+        {
+            args = new Object[] {va.getValidationToken()};
+            tml.addMessage(new TargettedMessage("msg.alreadyValidated", args, TargettedMessage.SEVERITY_ERROR));
+            return ;
+        }
+        else if (sendLegacyLinksEnabled())
+        {
+            // Ignore; the request account feature should work independently of legacy links
+        }
+
+        User u = null;
+        try
+        {
+            u = userDirectoryService.getUser(EntityReference.getIdFromRef(va.getUserId()));
+        }
+        catch (UserNotDefinedException e)
+        {
+            log.error("user ID does not exist for ValidationAccount with tokenId: " + va.getValidationToken());
+            tml.addMessage(new TargettedMessage("validate.userNotDefined", new Object[]{}, TargettedMessage.SEVERITY_ERROR));
+        }
+
+        if (u != null)
+        {
+            // we need some values to fill in. The nulls are placeholders. Other UIs use the same message with createdBy.getDisplayName() and createdBy.getEmailAddress().
+            args = new Object[]{
+                serverConfigurationService.getString("ui.service", "Sakai"),
+                null,
+                null,
+                u.getDisplayId()
+            };
+
+            UIForm detailsForm = UIForm.make(tofill, "setDetailsForm");
+
+            UICommand.make(detailsForm, "addDetailsSub", UIMessage.make("submit.new.account"), "accountValidationLocator.validateAccount");
+
+            String otp = "accountValidationLocator." + va.getId();
+            UIMessage.make(detailsForm, "username.new", "username.new", args);
+            UIOutput.make(detailsForm, "eid", u.getDisplayId());
+
+            UIInput.make(detailsForm, "firstName", otp + ".firstName", u.getFirstName());
+            UIInput.make(detailsForm, "surName", otp + ".surname", u.getLastName());
+
+            boolean passwordPolicyEnabled = userDirectoryService.getPasswordPolicy() != null;
+            String passwordPolicyEnabledJavaScript = "VALIDATOR.isPasswordPolicyEnabled = " + Boolean.toString(passwordPolicyEnabled) + ";";
+            UIVerbatim.make(tofill, "passwordPolicyEnabled", passwordPolicyEnabledJavaScript);
+
+            UIBranchContainer row1 = UIBranchContainer.make(detailsForm, "passrow1:");
+            UIInput.make(row1, "password1", otp + ".password");
+
+            UIBranchContainer row2 = UIBranchContainer.make(detailsForm, "passrow2:");
+            UIInput.make(row2, "password2", otp + ".password2");
+
+            // If we have some terms, get the user to accept them.
+            if (!"".equals(serverConfigurationService.getString("account-validator.terms")))
+            {
+                String termsURL = serverConfigurationService.getString("account-validator.terms");
+                UIBranchContainer termsRow = UIBranchContainer.make(detailsForm, "termsrow:");
+
+                UIBoundBoolean.make(termsRow, "terms", otp + ".terms");
+                // If someone wants to re-write this to be RSF like great, but this works.
+                // Although it doesn't escape the bundle strings.
+                String terms = messageLocator.getMessage("terms", new Object[]
+                {
+                    "<a href='" + termsURL + "' target='_new'>" + messageLocator.getMessage("terms.link")+"</a>"
+                });
+                UIVerbatim.make(termsRow, "termsLabel", terms);
+            }
+
+            detailsForm.parameters.add(new UIELBinding(otp + ".userId", va.getUserId()));
+        }
+    }
+}

--- a/reset-pass/account-validator-tool/src/webapp/WEB-INF/requestContext.xml
+++ b/reset-pass/account-validator-tool/src/webapp/WEB-INF/requestContext.xml
@@ -51,6 +51,17 @@
 		<property name="springMessageLocator" ref="messageLocator"/>
 	</bean>
 
+	<bean class="org.sakaiproject.accountvalidator.tool.producers.RequestAccountProducer" init-method="init">
+		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
+		<property name="validationLogic" ref="org.sakaiproject.accountvalidator.logic.ValidationLogic"/>
+		<property name="targettedMessageList" ref="targettedMessageList"/>
+		<property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
+		<property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+		<property name="developerHelperService" ref="org.sakaiproject.entitybroker.DeveloperHelperService"/>
+		<property name="springMessageLocator" ref="messageLocator"/>
+	</bean>
+
 	<bean name="accountValidationLocator" class="org.sakaiproject.accountvalidator.tool.otp.AcountValidationLocator">
 		<property name="validationLogic" ref="org.sakaiproject.accountvalidator.logic.ValidationLogic"/>
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>

--- a/reset-pass/account-validator-tool/src/webapp/css/requestAccount.css
+++ b/reset-pass/account-validator-tool/src/webapp/css/requestAccount.css
@@ -1,0 +1,247 @@
+body {
+    background:#cccccc;
+    font-family:'Helvetica Neue',Arial,'Nimbus Sans L','Liberation Sans',sans-serif;
+    font-size:12px;
+}
+p, h1, form, button {
+    border: 0;
+    margin: 0;
+    padding: 0;
+}
+
+.spacer {
+    clear: both;
+    height: 1px;
+}
+
+/* ----------- My Form ----------- */
+table.myform {
+    width:100%;
+}
+.myform {
+    margin:0 auto;
+}
+
+/* ----------- wrapper ------------*/
+.wrapper {
+    border: 2px solid #336699;
+    padding: 10px 20px 20px 20px;
+    background: #fff;
+    margin: 2em auto;
+    width: 50em;
+}
+
+.header {
+    padding: 5px 0 15px;
+    border-bottom: 1px solid #E4E4E4;
+    margin-bottom: 10px;
+}
+
+/* ----------- stylized ----------- */
+.stylized {
+    word-wrap: break-word;
+}
+
+.stylized h1 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-bottom: 8px;
+}
+
+.stylized h3 {
+    text-align: center;
+}
+
+.instruction{
+    text-align: center;
+}
+
+.stylized .instruction {
+    text-align: left;
+}
+
+.stylized div.instruction {
+    display:block;
+    margin:0 auto;
+    text-align: center;
+}
+
+.stylized ul.instruction {
+    display:block;
+    width:50%;
+}
+
+.stylized p {
+    font-size: 11px;
+    color: #666666;
+    border-bottom: solid 1px #E4E4E4;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+
+.stylized label {
+    display:block;
+    float:left;
+    font-weight: bold;
+    margin-top: 0.3em;
+    text-align: right;
+    width: 39%;
+    font-size: 12px;
+}
+
+.stylized span.reqStar {
+    /* needed to override tool.css */
+    float:none;
+    margin-left: 2px;
+    border: 0 none;
+    font-size: 1em;
+    font-weight: bold;
+}
+
+.stylized .info {
+    background:transparent url(/library/image/sakai/information.png) no-repeat scroll 0 0;
+    color:#666666;
+    font-size:11px;
+    padding-left:20px;
+    padding-bottom: 20px;
+}
+
+.stylized > form {
+    position: relative;
+    text-align: center;
+}
+
+.stylized .small {
+    color: #666666;
+    display: block;
+    font-size: 11px;
+    font-weight: normal;
+    text-align: right;
+    width: 110px;
+}
+
+.stylized .inputBox {
+    display: block;
+    float: left;
+    font-size: 12px;
+    padding: 4px 2px;
+    border: 1px solid #aacfe4;
+    width: 150px;
+    margin: 0 0 6px 1em;
+}
+
+.stylized .terms {
+    /*float: left;*/
+    padding: 5px;
+    border: 1px solid transparent; /* Stop layout jumping when isn't checked. */
+}
+
+.stylized .terms label {
+    width: auto;
+    float: none;
+    display: inline;
+}
+
+.terms input, .terms label {
+    vertical-align: middle;
+}
+
+.stylized input[type=submit] {
+    display: block;
+    position: relative;
+    margin: 1em auto 0 auto;
+    clear: both;
+    text-align: center;
+}
+
+.username {
+    color: #336699;
+    font-weight: bold;
+}
+
+.usernameParent {
+    display: block;
+    margin-bottom: 15px;
+    text-align: center;
+}
+
+.inputDiv {
+    height: 2.5em;
+}
+
+.inputDiv label {
+    position: relative;
+    top: 5px;
+}
+
+.centeredFeedback span {
+    margin: auto;
+}
+
+.stylized > div.instruction {
+    text-align: center;
+}
+
+#strengthInfo {
+    display: block;
+    color: #000;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.2);
+    left: 34.5em;
+    padding: 1em;
+    position: absolute;
+    margin-top: -6em;
+    width: 50%;
+}
+
+#strengthInfo:before {
+    border-bottom: 15px solid rgba(0, 0, 0, 0);
+    border-right: 15px solid #ccc;
+    border-top: 15px solid rgba(0, 0, 0, 0);
+    position: absolute;
+    content: "";
+    left: -15px;
+    top: 3px;
+    width: 0;
+    height: 0;
+}
+
+#matchMsg, #strongMsg, #noMatchMsg,
+#weakMsg, #failMsg, #moderateMsg {
+    display: block;
+    padding-left: 1.5em;
+    vertical-align: top;
+    line-height: 1.4em;
+    margin: 0 0 0 20.5em;
+    width: 150px;
+    text-align: left;
+    line-height: 16px;
+}
+
+#noMatchMsg, #failMsg {
+    background: transparent url("/library/image/silk/cancel.png") no-repeat left center;
+    color: #000;
+}
+
+#matchMsg, #strongMsg,
+#moderateMsg, #weakMsg {
+    background: transparent url("/library/image/silk/accept.png") no-repeat left center;
+    color: #000;
+}
+
+#strengthBar {
+    background-color: #ccc;
+    width: 156px;
+    height: 5px;
+    margin: 5px 0px 10px 20.5em;
+    text-align: left;
+}
+
+#strengthBarMeter {
+    display: inline-block;
+    width: 0%;
+    height: 100%;
+    background-color: #900;
+}

--- a/reset-pass/account-validator-tool/src/webapp/templates/requestAccount.html
+++ b/reset-pass/account-validator-tool/src/webapp/templates/requestAccount.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns:rsf="http://ponder.org.uk/rsf" xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title rsf:id="msg=requestAccount.title">Request Account</title>
+		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
+		<link href="../css/requestAccount.css" type="text/css" rel="stylesheet" media="all" />
+		<script rsf:id="src=portal-matter" type="text/javascript" src="/library/js/headscripts.js"></script>
+		<script type="text/javascript" src="/library/js/jquery/1.4.2/jquery-1.4.2.min.js"></script>
+
+		<script type="text/javascript" language="JavaScript" src="../js/accountValidator.js"></script>
+		<script type="text/javascript" language="JavaScript" rsf:id="passwordPolicyEnabled"></script>
+	</head>
+	<body>
+		<div class="wrapper">
+			<div class="header">
+				<div class="stylized">
+					<h3 rsf:id="welcome1">Welcome to Sakai</h3>
+					<div rsf:id="welcome2" class="instruction">To activate your new Sakai account, please complete the form below.</div>
+				</div>
+			</div>
+			<div class="centeredFeedback">
+				<div rsf:id="message-for:*"><span>Message for user here</span></div>
+			</div>
+			<table class="myform">
+				<tr>
+					<td valign="top">
+						<div class="myform stylized">
+							<form rsf:id="setDetailsForm" id="form" name="form" method="post">
+								<div class="usernameParent">
+									<span rsf:id="username.new" class="info">Your login user ID will be:</span>
+									<span id="eid" rsf:id="eid" class="username">User ID</span>
+								</div>
+								<div class="inputDiv">
+									<label>
+										<span rsf:id="msg=firstname">First name</span>
+										<span class="reqStar">*</span>
+									</label>
+									<input rsf:id="firstName" class="inputBox required" type="text" oninput="VALIDATOR.validateFirstName();" required="required" onkeyup="VALIDATOR.validateFirstName();" value="" name="firstName"/>
+								</div>
+								<div class="inputDiv">
+									<label>
+										<span rsf:id="msg=lastname">Last name</span>
+										<span class="reqStar">*</span>
+									</label>
+									<input rsf:id="surName" class="inputBox required" type="text" oninput="VALIDATOR.validateLastName();" required="required" onkeyup="VALIDATOR.validateLastName();" value="" name="surName" />
+								</div>
+								<div rsf:id="passrow1:" class="inputDiv">
+									<label>
+										<span rsf:id="msg=password">Password</span>
+										<span class="reqStar">*</span>
+									</label>
+									<input id="passrow1::password1" rsf:id="password1" class="inputBox required password1" type="password" onkeyup="VALIDATOR.validatePassword();" oninput="VALIDATOR.validatePassword();" onblur="VALIDATOR.displayStrengthInfo();" onfocus="VALIDATOR.displayStrengthInfo();" required="required" value="" name="password1" />
+								</div>
+								<div id="strongMsg" style="display:none;" rsf:id="msg=password.strong"></div>
+								<div id="moderateMsg" style="display:none;" rsf:id="msg=password.moderate"></div>
+								<div id="weakMsg" style="display:none;" rsf:id="msg=password.weak"></div>
+								<div id="failMsg" style="display:none;" rsf:id="msg=password.fail"></div>
+								<div id="strengthBar" style="display:none;">
+									<span id="strengthBarMeter" style="display:none;"></span>
+								</div>
+								<div id="strengthInfo" style="display:none;" rsf:id="msg=password.strengthInfo"></div>
+
+								<div rsf:id="passrow2:" class="inputDiv">
+									<label>
+										<span rsf:id="msg=password2">Confirm password</span>
+										<span class="reqStar">*</span>
+									</label>
+									<input id="passrow2::password2" type="password" class="inputBox required" rsf:id="password2" onkeyup="VALIDATOR.verifyPasswordsMatch();" oninput="VALIDATOR.verifyPasswordsMatch();" required="required"/>
+								</div>
+								<div id="matchMsg" rsf:id="msg=password.match" style="display:none;"></div>
+								<div id="noMatchMsg" rsf:id="msg=password.noMatch" style="display:none;"></div>
+								<div class=" required terms" rsf:id="termsrow:">
+									<input id="terms" type="checkbox" rsf:id="terms" onclick="VALIDATOR.validateTermsChecked();" required="required"/>
+									<label rsf:id="termsLabel" for="terms">I accept the terms and conditions</label>
+								</div>
+								<input id="addDetailsSub" class="submit" type="submit" rsf:id="addDetailsSub" />
+							</form>
+						</div>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</body>
+</html>

--- a/user/README.md
+++ b/user/README.md
@@ -1,0 +1,21 @@
+# Users/New Account tool
+
+This is the source code for the Users and New Account tools in Sakai.
+
+## Tool Properties
+
+The following tool properties are available for configuration on a per instance basis:
+
+* create-blurb
+  * text to be displayed in the UI (default is empty)
+  * ex. Please enter your account details below
+* force-eid-equals-email
+  * true/false (default is false)
+  * if true, removes the field for the user to type their own ID; the eid will be the user's email address
+* validate-through-email
+  * true/false (default is false)
+  * if true, integrates with account-validator:
+    1. user creates/requests inactive account
+    2. email is sent containing confirmation link
+    3. user navigates to link
+    4. user fills out the form to complete/activate their account

--- a/user/user-tool/tool/pom.xml
+++ b/user/user-tool/tool/pom.xml
@@ -72,6 +72,10 @@
 		<groupId>org.sakaiproject.portal</groupId>
 		<artifactId>sakai-portal-util</artifactId>
 	</dependency>
+	<dependency>
+		<groupId>org.sakaiproject.accountvalidator</groupId>
+		<artifactId>accountvalidator-api</artifactId>
+	</dependency>
   </dependencies>
   <build>
     <resources>

--- a/user/user-tool/tool/src/bundle/admin.properties
+++ b/user/user-tool/tool/src/bundle/admin.properties
@@ -47,6 +47,7 @@ useconrem.sites   = {0} sites
 useconrem.rem       = Remove
 
 usecre.creaco     = Create Account
+usecre.reqaco     = Request Account
 usecre.entthe     = Enter the following information to create a new account.
 usecre.instruc    = Indicates a required field.
 usecre.pass       = Please enter the password the same in both fields.
@@ -125,3 +126,5 @@ pw.strong = Password strength: strong
 pw.strengthInfo = Strong passwords are long and/or use a mix of character types (ie. letters, numbers, symbols, etc.). They do not contain all or part of the user id.
 pw.match = Passwords match
 pw.noMatch = Passwords do not match
+
+email.validation.success = An account has been created for you! An email has been sent to "{0}" containing the final steps to activate your account.

--- a/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -90,6 +90,8 @@ import org.sakaiproject.util.StringUtil;
 import org.sakaiproject.portal.util.PortalUtils;
 
 import au.com.bytecode.opencsv.CSVReader;
+import org.sakaiproject.accountvalidator.logic.ValidationLogic;
+import org.sakaiproject.accountvalidator.model.ValidationAccount;
 
 /**
  * <p>
@@ -117,6 +119,11 @@ public class UsersAction extends PagedResourceActionII
 	private static final String MSG_KEY_PW_STRENGTH_INFO = "pw.strengthInfo";
 
 	private static final String SAK_PROP_UNENROLL_BEFORE_DELETE = "user.unenroll.before.delete";
+
+	private static final String CONFIG_CREATE_BLURB = "create-blurb";
+	private static final String CONFIG_FORCE_EID_EQUALS_EMAIL = "force-eid-equals-email";
+	private static final String CONFIG_VALIDATE_THROUGH_EMAIL = "validate-through-email";
+	private static final String STATE_SUCCESS_MESSAGE = "successMessage";
 
     private static final String USER_TEMPLATE_PREFIX = "!user.template.";
 
@@ -176,6 +183,21 @@ public class UsersAction extends PagedResourceActionII
 		if (state.getAttribute("create-type") == null)
 		{
 			state.setAttribute("create-type", config.getInitParameter("create-type", ""));
+		}
+
+		if (state.getAttribute(CONFIG_VALIDATE_THROUGH_EMAIL) == null)
+		{
+			state.setAttribute(CONFIG_VALIDATE_THROUGH_EMAIL, new Boolean(config.getInitParameter(CONFIG_VALIDATE_THROUGH_EMAIL, "false")));
+		}
+
+		if (state.getAttribute(CONFIG_FORCE_EID_EQUALS_EMAIL) == null)
+		{
+			state.setAttribute(CONFIG_FORCE_EID_EQUALS_EMAIL, new Boolean(config.getInitParameter(CONFIG_FORCE_EID_EQUALS_EMAIL, "false")));
+		}
+
+		if (state.getAttribute(CONFIG_CREATE_BLURB) == null)
+		{
+			state.setAttribute(CONFIG_CREATE_BLURB, config.getInitParameter(CONFIG_CREATE_BLURB, ""));
 		}
 		
 		if (state.getAttribute("user.recaptcha-enabled") == null)
@@ -259,8 +281,8 @@ public class UsersAction extends PagedResourceActionII
 		context.put(Menu.CONTEXT_ACTION, state.getAttribute(STATE_ACTION));
 
 		//put successMessage into context and remove from state
-	    context.put("successMessage", state.getAttribute("successMessage"));
-	    state.removeAttribute("successMessage");
+		context.put("successMessage", state.getAttribute(STATE_SUCCESS_MESSAGE));
+		state.removeAttribute(STATE_SUCCESS_MESSAGE);
 
 		// SAK-23568
 		pwHelper.addJavaScriptParamsToContext(context);
@@ -434,13 +456,30 @@ public class UsersAction extends PagedResourceActionII
 		// put the service in the context
 		context.put("service", UserDirectoryService.getInstance());
 
+		String blurb = (String) state.getAttribute(CONFIG_CREATE_BLURB);
+		if (!StringUtils.isEmpty(blurb))
+		{
+			context.put("createBlurb", blurb);
+		}
+
 		// is the type to be pre-set
 		context.put("type", state.getAttribute("create-type"));
+
+		boolean isValidatedWithAccountValidator = isValidatedWithAccountValidator(state);
+		boolean isEidEditable = isEidEditable(state);
+
+		// if the tool is configured to validate through email, we will use AccountValidator to set name fields, etc. So we indicate this in the context to hide fields that are redundant
+		context.put("isValidatedWithAccountValidator", isValidatedWithAccountValidator);
+
+		// If we're using account validator, an email needs to be sent
+		// If the eid is not editable, the email will be used as the eid
+		context.put("emailRequired", isValidatedWithAccountValidator || !isEidEditable);
 
 		// password is required when using Gateway New Account tool
 		// attribute "create-user" is true only for New Account tool
 		context.put("pwRequired", state.getAttribute("create-user"));
 
+		context.put("displayEid", isEidEditable);
 		String value = (String) state.getAttribute("valueEid");
 		if (value != null) context.put("valueEid", value);
 
@@ -741,7 +780,7 @@ public class UsersAction extends PagedResourceActionII
 			}
 			
 			//set a message to show it was successful
-			state.setAttribute("successMessage", rb.getString("import.success"));
+			state.setAttribute(STATE_SUCCESS_MESSAGE, rb.getString("import.success"));
 			
 			//cleanup
 			state.removeAttribute("importedUsers");
@@ -926,23 +965,32 @@ public class UsersAction extends PagedResourceActionII
 
 		if ((user != null) && ((Boolean) state.getAttribute("create-login")).booleanValue())
 		{
-			try
+			if (isValidatedWithAccountValidator(state))
 			{
-				// login - use the fact that we just created the account as external evidence
-				Evidence e = new ExternalTrustedEvidence(user.getEid());
-				Authentication a = AuthenticationManager.authenticate(e);
-				if (!UsageSessionService.login(a, (HttpServletRequest) ThreadLocalManager.get(RequestFilter.CURRENT_HTTP_REQUEST)))
+				// Don't log the user in, their account is not activated yet.
+				// inform them that an email has been sent
+				state.setAttribute(STATE_SUCCESS_MESSAGE, rb.getFormattedMessage("email.validation.success", user.getEmail()));
+			}
+			else
+			{
+				try
 				{
-					addAlert(state, rb.getString("useact.tryloginagain"));
+					// login - use the fact that we just created the account as external evidence
+					Evidence e = new ExternalTrustedEvidence(user.getEid());
+					Authentication a = AuthenticationManager.authenticate(e);
+					if (!UsageSessionService.login(a, (HttpServletRequest) ThreadLocalManager.get(RequestFilter.CURRENT_HTTP_REQUEST)))
+					{
+						addAlert(state, rb.getString("useact.tryloginagain"));
+					}
 				}
-			}
-			catch (AuthenticationException ex)
-			{
-				Log.warn("chef", "UsersAction.doSave: authentication failure: " + ex);
-			}
+				catch (AuthenticationException ex)
+				{
+					Log.warn("chef", "UsersAction.doSave: authentication failure: " + ex);
+				}
 
-			// redirect to home (on next build)
-			state.setAttribute("redirect", "");
+				// redirect to home (on next build)
+				state.setAttribute("redirect", "");
+			}
 		}
 
 	} // doSave
@@ -1225,9 +1273,11 @@ public class UsersAction extends PagedResourceActionII
 		}
 		
 		
-		//insure valid email address
+		//Ensure valid email address. Empty emails are invalid iff email validation is required. For non-empty email Strings, use EmailValidator.
 		//email.matches(".+@.+\\..+")
-		if(email != null && !EmailValidator.getInstance().isValid(email)) {
+		boolean validateWithAccountValidator = isValidatedWithAccountValidator(state);
+		boolean emailInvalid = StringUtils.isEmpty(email) ? validateWithAccountValidator : !EmailValidator.getInstance().isValid(email);
+		if(emailInvalid) {
 				addAlert(state, rb.getString("useact.invemail"));	
 				return false;
 		}
@@ -1291,33 +1341,51 @@ public class UsersAction extends PagedResourceActionII
 		if (user == null)
 		{
 			// make sure we have eid
-			if (eid == null)
+			if (isEidEditable(state))
 			{
-				addAlert(state, rb.getString("usecre.eidmis"));
-				return false;
+				if (eid == null)
+				{
+					addAlert(state, rb.getString("usecre.eidmis"));
+					return false;
+				}
 			}
 			
-			// if in create mode, make sure we have a password
-			if (createUser)
+			else
 			{
-				if (pw == null)
+				// eid is not editable, so we're using the email as the eid
+				if (email == null)
 				{
-					addAlert(state, rb.getString("usecre.pasismis"));
+					addAlert(state, rb.getString("useact.invemail"));
 					return false;
-				}				
+				}
+				eid = email;
 			}
 
-			// make sure we have matching password fields
-			if (StringUtil.different(pw, pwConfirm))
+			// if we validate through email, passwords will be handled in AccountValidator
+			TempUser tempUser = new TempUser(eid, null, null, null, eid, pw, null);
+			if (!validateWithAccountValidator)
 			{
-				addAlert(state, rb.getString("usecre.pass"));
-				return false;
-			}
+				// if in create mode, make sure we have a password
+				if (createUser)
+				{
+					if (pw == null)
+					{
+						addAlert(state, rb.getString("usecre.pasismis"));
+						return false;
+					}
+				}
 
-			// SAK-23568 - make sure password meets policy requirements
-			TempUser tempUser = new TempUser(eid, email, null, null, eid, pw, null);
-			if (!validatePassword(pw, tempUser, state)) {
-				return false;
+				// make sure we have matching password fields
+				if (StringUtil.different(pw, pwConfirm))
+				{
+					addAlert(state, rb.getString("usecre.pass"));
+					return false;
+				}
+
+				// SAK-23568 - make sure password meets policy requirements
+				if (!validatePassword(pw, tempUser, state)) {
+					return false;
+				}
 			}
 
 			//Check if the email is duplicated
@@ -1338,24 +1406,35 @@ public class UsersAction extends PagedResourceActionII
 				if (!SecurityService.isSuperUser()) {
 					id = null;
 				}
-				User newUser = UserDirectoryService.addUser(id, eid, firstName, lastName, email, pw, type, properties);
+				User newUser;
+				if (validateWithAccountValidator)
+				{
+					// the eid is their email address. The password is random
+					newUser = UserDirectoryService.addUser(id, eid, firstName, lastName, email, generatePassword(), type, properties);
+					// Invoke AccountValidator to send an email to the user containing a link to a form on which they can set their name and password
+					ValidationLogic validationLogic = (ValidationLogic) ComponentManager.get(ValidationLogic.class);
+					validationLogic.createValidationAccount(newUser.getId(), ValidationAccount.ACCOUNT_STATUS_REQUEST_ACCOUNT);
+				}
+				else
+				{
+					newUser = UserDirectoryService.addUser(id, eid, firstName, lastName, email, pw, type, properties);
 
-                                if (SecurityService.isSuperUser()) {
-                                        if(disabled == 1){
-                                                try {
-                                                        UserEdit editUser = UserDirectoryService.editUser(newUser.getId());
-                                                        editUser.getProperties().addProperty("disabled", "true");
-                                                        newUser = editUser;
-                                                } catch (UserNotDefinedException e) {
-                                                        addAlert(state, rb.getString("usecre.disableFailed"));
-                                                        return false;
-                                                } catch (UserLockedException e) {
-                                                        addAlert(state, rb.getString("usecre.disableFailed"));
-                                                        return false;
-                                                }
-                                        }
-                                }
-
+					if (SecurityService.isSuperUser()) {
+						if(disabled == 1){
+							try {
+								UserEdit editUser = UserDirectoryService.editUser(newUser.getId());
+								editUser.getProperties().addProperty("disabled", "true");
+								newUser = editUser;
+							} catch (UserNotDefinedException e) {
+								addAlert(state, rb.getString("usecre.disableFailed"));
+								return false;
+							} catch (UserLockedException e) {
+								addAlert(state, rb.getString("usecre.disableFailed"));
+								return false;
+							}
+						}
+					}
+				}
 
 				// put the user in the state
 				state.setAttribute("newuser", newUser);
@@ -1466,6 +1545,47 @@ public class UsersAction extends PagedResourceActionII
 		}
 
 		return true;
+	}
+
+	// duplicates site-manage's SiteAddParticipantHandler.generatePassword()
+	protected String generatePassword()
+	{
+
+		char[] LOWER_ALPHA_ARRAY =
+		{
+			'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n', 'p',
+			'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+		};
+		char[] UPPER_ALPHA_ARRAY =
+		{
+			'A', 'B', 'C', 'E', 'F',
+			'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+			'W', 'X', 'Y', 'Z'
+		};
+		char[] NUMBER_ARRAY =
+		{
+			'2', '3', '4', '5', '6', '7', '8', '9'
+		};
+		// set random password
+		int length = 9;
+		StringBuilder rndbld = new StringBuilder(length);
+		for (int i = 0; i < length; ++i){
+				int chooseArray = (int) (4 * Math.random());
+			switch (chooseArray) {
+				case 0:
+					rndbld.append(LOWER_ALPHA_ARRAY[(int) ( LOWER_ALPHA_ARRAY.length * Math.random())]);
+					break;
+				case 1:
+					rndbld.append(UPPER_ALPHA_ARRAY[(int) ( UPPER_ALPHA_ARRAY.length * Math.random())]);
+					break;
+				case 2:
+					rndbld.append(NUMBER_ARRAY[(int) ( NUMBER_ARRAY.length * Math.random())]);
+					break;
+				default:
+					break;
+			}
+		}
+		return rndbld.toString();
 	}
 	
 	/**
@@ -1856,7 +1976,41 @@ public class UsersAction extends PagedResourceActionII
 		}
 		return provided;
 	}
-    /**
+
+	/**
+	 * Determines whether Account Validator is to be used to ensure that users don't enter bogus email addresses.
+	 * This is only required in the gateway's New Account tool if you're not admin.
+	 * If this is true, the user account will be inactive (ie. it will be assigned a random unguessable password).
+	 * Then, Account Validator will send an email to the user containing a link to a form where they can activate their account by setting their password.
+	 * @return true if the state says that this is the gateway's New Account tool, and you're not a super user, and validate-through-email is set in the tool properties
+	 */
+	private boolean isValidatedWithAccountValidator(SessionState state)
+	{
+		boolean isGatewayTool = (boolean) state.getAttribute("create-user");
+		if (isGatewayTool && !SecurityService.isSuperUser())
+		{
+			return (boolean) state.getAttribute(CONFIG_VALIDATE_THROUGH_EMAIL);
+		}
+		return false;
+	}
+
+	private boolean isEidEditable(SessionState state)
+	{
+		if (SecurityService.isSuperUser())
+		{
+			return true;
+		}
+
+		boolean isGatewayTool = (boolean) state.getAttribute("create-user");
+		if (!isGatewayTool)
+		{
+			return true;
+		}
+
+		return !(Boolean)state.getAttribute(CONFIG_FORCE_EID_EQUALS_EMAIL);
+	}
+
+	/**
      * Determine user types by looking at realms that start with "!user.template."
      * Doesn't include sample type
      *

--- a/user/user-tool/tool/src/webapp/js/userCreateValidation.js
+++ b/user/user-tool/tool/src/webapp/js/userCreateValidation.js
@@ -22,8 +22,22 @@
 
 // Validate the password from the form
 USER.validatePassword = function () {
-    var username = USER.trim(USER.get("user_eid").value);
-    var pw = USER.get("user_pw").value;
+    var username = USER.get("user_eid");
+    if (!username)
+    {
+        // There's no userEid; so we'll use the email field instead
+        username = USER.get("email");
+    }
+    username = USER.trim(username.value);
+    var pw = USER.get("user_pw");
+    if (!pw)
+    {
+        // There's no password field to validate; consider the password valid.
+        USER.passwordValid = true;
+        USER.passwordsMatch = true;
+        return;
+    }
+    pw = pw.value;
     var strongMsg = USER.get("strongMsg");
     var moderateMsg = USER.get("moderateMsg");
     var weakMsg = USER.get("weakMsg");
@@ -54,7 +68,12 @@ USER.validatePassword = function () {
 
 // Verify the passwords match
 USER.verifyPasswordsMatch = function () {
-    var pw = USER.get("user_pw").value;
+    var pw = USER.get("user_pw");
+    if (!pw)
+    {
+        return;
+    }
+    pw = pw.value;
     var pw2 = USER.get("user_pw0").value;
     var matchMsg = USER.get("matchMsg");
     var noMatchMsg = USER.get("noMatchMsg");
@@ -74,18 +93,33 @@ USER.verifyPasswordsMatch = function () {
 
 // Validate the user ID from the form
 USER.validateUserId = function () {
-    var userId = USER.trim(USER.get("user_eid").value);
-    USER.userValid = userId.length > 0;
-    USER.validatePassword();
+    var user_eid = USER.get("user_eid");
+    if (user_eid)
+    {
+        var userId = USER.trim(user_eid.value);
+        USER.userValid = userId.length > 0;
+        USER.validatePassword();
+    }
+    else
+    {
+        USER.userValid = true;
+    }
+    USER.validateForm();
 };
 
 // Validate the email address from the form
 USER.validateEmail = function () {
+    var emailRequired = USER.get("email").required;
     var email = USER.trim(USER.get("email").value);
     var emailWarningMsg = USER.get("emailWarningMsg");
 
     if (email.length < 1) {
-        USER.emailValid = true;
+        if (emailRequired) {
+            USER.emailValid = false;
+        }
+        else {
+            USER.emailValid = true;
+        }
     }
     else {
         USER.emailValid = USER.checkEmail(email);
@@ -111,6 +145,15 @@ USER.validateForm = function () {
 
 // Initialization function
 jQuery(document).ready(function () {
-    USER.validateEmail();
     USER.validateUserId();
+    if (!USER.get('user_eid'))
+    {
+        USER.userValid = true;
+    }
+    if (!USER.get("user_pw"))
+    {
+        USER.passwordValid = true;
+        USER.passwordsMatch = true;
+    }
+    USER.validateForm();
 });

--- a/user/user-tool/tool/src/webapp/tools/sakai.createuser.xml
+++ b/user/user-tool/tool/src/webapp/tools/sakai.createuser.xml
@@ -7,7 +7,10 @@
 			title="New Account"
 			description="Create a new user account.">
 
+		<configuration name="create-blurb" value="" />
 		<configuration name="create-type" value="registered" />
+		<configuration name="force-eid-equals-email" value="false" />
+		<configuration name="validate-through-email" value="false" />
 
 		<configuration name="create-login" value="true" type="final" />
 		<configuration name="create-user" value="true" type="final" />

--- a/user/user-tool/tool/src/webapp/vm/user/chef_users_create.vm
+++ b/user/user-tool/tool/src/webapp/vm/user/chef_users_create.vm
@@ -12,79 +12,90 @@ ${includeLatestJQuery}
 	#toolbar($menu)
 #end
 
+	#if ($successMessage)<span class="success">$successMessage</span>#end
+
 	<h3>
 		$tlang.getString("usecre.entthe")
 	</h3>
-    
+
 	#if ($alertMessage)<div class="alertMessage">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end	
 
 	<form name="user-create_edit" id="user-create_edit" action="#toolForm("$action")" method="post" autocomplete="on">
-        <fieldset>
+		<fieldset>
 			<legend>
 				$tlang.getString("usecre.creaco")
 			</legend>
 			<div class="instruction">
+				#if ($createBlurb)
+					<div>$createBlurb</div>
+				#end
 				<span class="reqStarInline">*</span> $tlang.getString("usecre.instruc")
 			</div>
+			#if ($displayEid)
+				<div class="shorttext required">
+					<label #if(!$user) for="user_eid" #end>
+						#if(!$user)<span class="reqStar">*</span>#end $tlang.getString("useconrem.useid")
+					</label>
+					#if(!$user)<input type="text" name="eid" id="user_eid" oninput="USER.validateUserId();" onkeyup="USER.validateUserId();" autocomplete="off" #if($valueEid)value="$validator.escapeHtml($valueEid)"#end />#else$validator.escapeHtml($user.Eid)#end
+				</div>
+			#end
+			#if (!$isValidatedWithAccountValidator)
+				<div class="shorttext">
+					<label for="first-name">
+						$tlang.getString("usecre.firnam")
+					</label>
+					<input type="text" name="first-name" id="first-name" #if($user)value="$validator.escapeHtml($user.FirstName)"#elseif($valueFirstName)value="$validator.escapeHtml($valueFirstName)"#end/>
+				</div>
+				<div class="shorttext">
+					<label for="last-name">
+						$tlang.getString("usecre.lasnam")
+					</label>
+					<input type="text" name="last-name" id="last-name" #if($user)value="$validator.escapeHtml($user.LastName)"#elseif($valueLastName)value="$validator.escapeHtml($valueLastName)"#end/>
+				</div>
+			#end
 			<div class="shorttext required">
-				<label #if(!$user) for="user_eid" #end>
-					#if(!$user)<span class="reqStar">*</span>#end $tlang.getString("useconrem.useid")
-				</label>
-				#if(!$user)<input type="text" name="eid" id="user_eid" oninput="USER.validateUserId();" onkeyup="USER.validateUserId();" autocomplete="off" #if($valueEid)value="$validator.escapeHtml($valueEid)"#end />#else$validator.escapeHtml($user.Eid)#end
-			</div>
-			<div class="shorttext">
-				<label for="first-name">
-					$tlang.getString("usecre.firnam")
-				</label>
-				<input type="text" name="first-name" id="first-name" #if($user)value="$validator.escapeHtml($user.FirstName)"#elseif($valueFirstName)value="$validator.escapeHtml($valueFirstName)"#end/>
-			</div>
-			<div class="shorttext">
-				<label for="last-name">
-					$tlang.getString("usecre.lasnam")
-				</label>
-				<input type="text" name="last-name" id="last-name" #if($user)value="$validator.escapeHtml($user.LastName)"#elseif($valueLastName)value="$validator.escapeHtml($valueLastName)"#end/>
-			</div>
-			<div class="shorttext">
 				<label for="email">
-					$tlang.getString("useconrem.ema")
+					#if ($emailRequired) <span class="reqStar">*</span> #end $tlang.getString("useconrem.ema")
 				</label>
-				<input type="text" name="email" id="email" oninput="USER.validateEmail();" onkeyup="USER.validateEmail();" autocomplete="off"#if($user)value="$validator.escapeHtml($user.Email)"#elseif($valueEmail)value="$validator.escapeHtml($valueEmail)"#end />
+				<input type="text" name="email" id="email" oninput="USER.validateEmail();" onkeyup="USER.validateEmail();" autocomplete="off"#if($user)value="$validator.escapeHtml($user.Email)"#elseif($valueEmail)value="$validator.escapeHtml($valueEmail)"#end #if ($emailRequired) required='required' #end/>
 				<div id="emailWarningMsg" style="display:none">$tlang.getString("useact.invemail")</div>
 			</div>
-			<div class="shorttext required">
-				<label for="user_pw">
-					#if ($pwRequired) <span class="reqStar">*</span> #end $tlang.getString("usecre.crenewpass")
-				</label>
-				<input type="password" name="pw" id="user_pw" oninput="USER.validatePassword();" onkeyup="USER.validatePassword();" onblur="USER.displayStrengthInfo();" onfocus="USER.displayStrengthInfo();" autocomplete="off" />
-				<div id="strongMsg" style="display:none">$tlang.getString("pw.strong")</div>
-				<div id="moderateMsg" style="display:none">$tlang.getString("pw.moderate")</div>
-				<div id="weakMsg" style="display:none">$tlang.getString("pw.weak")</div>
-				<div id="failMsg" style="display:none">$tlang.getString("pw.fail")</div>
-				<div id="strengthBar" style="display:none">
-                	<span id="strengthBarMeter" style="display:none"></span>
+			#if (!$isValidatedWithAccountValidator)
+				<div class="shorttext required">
+					<label for="user_pw">
+						#if ($pwRequired) <span class="reqStar">*</span> #end $tlang.getString("usecre.crenewpass")
+					</label>
+					<input type="password" name="pw" id="user_pw" oninput="USER.validatePassword();" onkeyup="USER.validatePassword();" onblur="USER.displayStrengthInfo();" onfocus="USER.displayStrengthInfo();" autocomplete="off" />
+					<div id="strongMsg" style="display:none">$tlang.getString("pw.strong")</div>
+					<div id="moderateMsg" style="display:none">$tlang.getString("pw.moderate")</div>
+					<div id="weakMsg" style="display:none">$tlang.getString("pw.weak")</div>
+					<div id="failMsg" style="display:none">$tlang.getString("pw.fail")</div>
+					<div id="strengthBar" style="display:none">
+						<span id="strengthBarMeter" style="display:none"></span>
+					</div>
+					<div id="strengthInfo" style="display:none">$tlang.getString("pw.strengthInfo")</div>
 				</div>
-				<div id="strengthInfo" style="display:none">$tlang.getString("pw.strengthInfo")</div>
-			</div>
-			<div class="shorttext required">
-				<label for="user_pw0">
-					#if ($pwRequired) <span class="reqStar">*</span> #end $tlang.getString("usecre.vernewpass")
-				</label>
-				<input type="password" name="pw0" id="user_pw0" oninput="USER.verifyPasswordsMatch();" onkeyup="USER.verifyPasswordsMatch();" autocomplete="off" />
-				<div id="matchMsg" style="display:none">$tlang.getString("pw.match")</div>
-				<div id="noMatchMsg" style="display:none">$tlang.getString("pw.noMatch")</div>
-			</div>
-			<div class="shorttext">
-				<label for="dtype">
-					$tlang.getString("usecre.typ")
-				</label>
-				<input disabled type="text" name="dtype" id="dtype" value="$type"/>
-				<input type="hidden" name="type" id="type" value="$type"/>
-			</div>
+				<div class="shorttext required">
+					<label for="user_pw0">
+						#if ($pwRequired) <span class="reqStar">*</span> #end $tlang.getString("usecre.vernewpass")
+					</label>
+					<input type="password" name="pw0" id="user_pw0" oninput="USER.verifyPasswordsMatch();" onkeyup="USER.verifyPasswordsMatch();" autocomplete="off" />
+					<div id="matchMsg" style="display:none">$tlang.getString("pw.match")</div>
+					<div id="noMatchMsg" style="display:none">$tlang.getString("pw.noMatch")</div>
+				</div>
+				<div class="shorttext">
+					<label for="dtype">
+						$tlang.getString("usecre.typ")
+					</label>
+					<input disabled type="text" name="dtype" id="dtype" value="$type"/>
+					<input type="hidden" name="type" id="type" value="$type"/>
+				</div>
+			#end
 			$!recaptchaScript
 			<div class="act">
-				<input type="submit" id="eventSubmit_doSave" class="active"  name="eventSubmit_doSave" value="$tlang.getString("usecre.creaco")"  accesskey="s" />
-	                        <input type="submit" id="eventSubmit_doCancel" name="eventSubmit_doCancel" value="$tlang.getString("useconrem.can")"  accesskey="x" />
+				<input type="submit" id="eventSubmit_doSave" class="active"  name="eventSubmit_doSave" #if ($isValidatedWithAccountValidator) value="$tlang.getString("usecre.reqaco")" #else value="$tlang.getString("usecre.creaco")" #end  accesskey="s" />
+				<input type="submit" id="eventSubmit_doCancel" name="eventSubmit_doCancel" value="$tlang.getString("useconrem.can")"  accesskey="x" />
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-        </fieldset>
+		</fieldset>
 	</form>
 </div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-28184

To ensure that users are creating accounts using their real email addresses, the New Account tool should be configurable to send an email with a link to activate their account.

Also, when we add unofficial participants through Site Info, the user eids match their email addresses. For consistency, the New Account tool should have configuration to similarly force the eid to match the user's email address.

Finally, it would be handy to display instructions in the tool. But note that institutions may have multiple instances of this tool to serve different purposes (eg. to create users with different account types), so the instructions should be configurable in the tool properties.