### PR TITLE
SAK-29182 new account tool should respect invalidEmailInIdAccountString sakai.property

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -889,6 +889,16 @@
 # Default: 3
 #user.password.maximum.sequence.length=3
 
+# SAK-29182
+# Defines a customizable, paramaterized user facing message in the event that the New Account tool
+# is being forced use the email address of the user as their EID (SAK-28184), and the user attempts to use an 
+# email with a domain restricted via invalidEmailInIdAccountString sakai.property.
+# NOTE: You can utilize the two parameters {0} and {1} as often as necessary. {0} will be replaced with the contents 
+# of the sakai.property ui.institution. {1} will be replaced with the offending email domain string.
+# Default: You have entered an email address ending with "{1}", which is restricted. Please try again with a different email address.
+# user.email.invalid.domain.message=You have entered a {0} email address ending with "{1}". Please log in with your existing {0} account.
+
+
 
 # ########################################################################
 # LOGGING

--- a/user/user-tool/tool/src/bundle/admin.properties
+++ b/user/user-tool/tool/src/bundle/admin.properties
@@ -128,3 +128,6 @@ pw.match = Passwords match
 pw.noMatch = Passwords do not match
 
 email.validation.success = An account has been created for you! An email has been sent to "{0}" containing the final steps to activate your account.
+
+# SAK-29182
+email.invalid.domain=You have entered an email address ending with "{0}", which is restricted. Please try again with a different email address.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29182

The existing sakai.property invalidEmailInIdAccountString defines a list of domain names that are not allowed in guest accounts, which is useful for preventing accidental creation of guest accounts for users (based on email address) that already have an external account (based on user name).

When the New Account tool has the tool property force-eid-equals-email set to true (introduced in SAK-28184), the tool is essentially doing exactly what the sakai.property descibes, and as such it should respect the property if it's set.

This introduces a new sakai.property (user.email.invalid.domain.message) to provide a customizable, paramaterized error message which is presented to the user when in the event that they attempt to use an email address with one of the offending domains. This sakai.property can utilize the following two parameters as often as necessary, and in any order. "{0}" will be replaced with the contents of the sakai.property "ui.institution". "{1}" will be replaced with the offending email domain string. 