### PR TITLE
SAK-29176 - Allow samigo to be linked to existing GB Items which are non-externally maintained

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2802,7 +2802,7 @@ public class AssignmentAction extends PagedResourceActionII
 			for (Iterator i=gradebookAssignments.iterator(); i.hasNext();)
 			{
 				org.sakaiproject.service.gradebook.shared.Assignment gAssignment = (org.sakaiproject.service.gradebook.shared.Assignment) i.next();
-				if (!gAssignment.isExternallyMaintained() || gAssignment.isExternallyMaintained() && gAssignment.getExternalAppName().equals(getToolTitle()))
+				if (!gAssignment.isExternallyMaintained())
 				{
 					gradebookAssignmentsExceptSamigo.add(gAssignment);
 				
@@ -7749,6 +7749,12 @@ public class AssignmentAction extends PagedResourceActionII
 				// SAK-17606
 				editAssignmentProperties(a, checkAddDueTime, checkAutoAnnounce, addtoGradebook, associateGradebookAssignment, allowResubmitNumber, aPropertiesEdit, post, resubmitCloseTime, checkAnonymousGrading);
 
+				/* Before posting, handle gradebook item add or associate */
+				if(gradePoints != null && addtoGradebook.equals(AssignmentService.GRADEBOOK_INTEGRATION_ASSOCIATE)) {
+					linkAssignmentToGradebookItem(title,gradePoints,new Date(dueTime.getTime()),addtoGradebook, associateGradebookAssignment);
+				}
+				/* */
+				
 				//TODO: ADD_DUE_DATE
 				// the notification option
 				if (state.getAttribute(Assignment.ASSIGNMENT_INSTRUCTOR_NOTIFICATIONS_VALUE) != null)
@@ -16809,6 +16815,46 @@ public class AssignmentAction extends PagedResourceActionII
 						}
 					}
 				}
+			}
+		}
+	}
+	
+	/**
+	 * Called to associate a new or edited Assignment to a GB item.
+	 * @param pTitle
+	 * @param pGradePoints
+	 * @param pDueTime
+	 * @param pAddToGradbook
+	 * @param pGradebookItem
+	 */
+	private void linkAssignmentToGradebookItem(String pTitle, String pGradePoints, Date pDueTime, String pAddToGradbook, String pGradebookItem) {
+		/*
+		 * IFF an empty GB item with the same name exists, drop it and create a new one linked to the assignment.
+		 */
+		
+		GradebookService g = (GradebookService) ComponentManager.get("org.sakaiproject.service.gradebook.GradebookService");
+		GradebookExternalAssessmentService gExternal = (GradebookExternalAssessmentService) ComponentManager.get("org.sakaiproject.service.gradebook.GradebookExternalAssessmentService");
+		String gradebookUid = ToolManager.getInstance().getCurrentPlacement().getContext();
+		
+		if(pAddToGradbook.equals(AssignmentService.GRADEBOOK_INTEGRATION_ASSOCIATE)) {
+			try {
+				
+				if(gExternal.isAssignmentDefined(gradebookUid, pGradebookItem)) {
+					g.removeAssignment( g.getAssignment(gradebookUid,pGradebookItem).getId() );
+				}
+				gExternal.addExternalAssessment(	gradebookUid, 
+													pGradebookItem, 
+													null, 
+													pTitle, 
+													Double.parseDouble(pGradePoints)/10.0, 
+													pDueTime, 
+													getToolTitle(),
+													false, 
+													null);
+													
+													
+			} catch (Exception e) {
+				M_log.warn(this + "Unable to associate assignment with existing GB item");
 			}
 		}
 	}

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/EvaluationModelIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/EvaluationModelIfc.java
@@ -39,7 +39,8 @@ public interface EvaluationModelIfc
   public static final Integer TO_DEFAULT_GRADEBOOK = Integer.valueOf(1);
   //public static Integer TO_SELECTED_GRADEBOOK = new Integer(2);  // this is confusing, we are using 2 for 'None' but the name is confusing, 
   public static final Integer NOT_TO_GRADEBOOK = Integer.valueOf(2);		// so now we added this new constant, SAK-7162
-  public static final Integer TO_SELECTED_GRADEBOOK = Integer.valueOf(3);  // not used, but leave it for now 
+  public static final Integer TO_SELECTED_GRADEBOOK = Integer.valueOf(3);  // not used, but leave it for now
+  public static final Integer TO_EXISTING_GRADEBOOK_ITEM = Integer.valueOf(4);
 
   // scoring type 
   public static final Integer HIGHEST_SCORE = Integer.valueOf(1);

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -175,6 +175,11 @@
             <artifactId>jstl</artifactId>
             <scope>compile</scope>
         </dependency>
+          <dependency>
+			<groupId>jstl</groupId>
+			<artifactId>jstl</artifactId>
+			<version>1.2</version>
+  		</dependency>
 		<dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -145,6 +145,9 @@ grader_comments=Grader's Comments
 
 student_identity=Hide student identity from grader (anonymous grading)
 gradebook_options=Send assessment score to Gradebook immediately, regardless of options below
+to_no_gradebook=Do not link this test with gradebook
+to_associate_existing_gradebook_item=Associate this test with the Gradebook item with the same name.
+to_default_gradebook=Create a new Gradebook item
 
 recorded_score=If multiple submissions, record the
 highest_score=highest score

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -45,6 +45,7 @@ import javax.faces.model.SelectItem;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.content.api.FilePickerHelper;
 import org.sakaiproject.entity.api.Reference;
@@ -52,6 +53,7 @@ import org.sakaiproject.entity.cover.EntityManager;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.TypeException;
+import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.cover.SiteService;
@@ -177,13 +179,14 @@ public class AssessmentSettingsBean
   // properties of EvaluationModel
   private boolean anonymousGrading;
   private boolean gradebookExists;
-  private boolean toDefaultGradebook;
+  private String toDefaultGradebook;
   private String scoringType;
   private String bgColor;
   private String bgImage;
   private HashMap values = new HashMap(); // contains only "can edit" element
   private String bgColorSelect;
   private String bgImageSelect;
+  private boolean gradebookLinkeable;
 
   // extra properties
   private boolean noTemplate;
@@ -418,7 +421,7 @@ public class AssessmentSettingsBean
         if (evaluation.getAnonymousGrading()!=null)
           this.anonymousGrading = evaluation.getAnonymousGrading().toString().equals("1") ? true : false;
         if (evaluation.getToGradeBook()!=null )
-          this.toDefaultGradebook = evaluation.getToGradeBook().toString().equals("1") ? true : false;
+          this.toDefaultGradebook = evaluation.getToGradeBook().toString();
         if (evaluation.getScoringType()!=null)
           this.scoringType = evaluation.getScoringType().toString();
 
@@ -435,6 +438,10 @@ public class AssessmentSettingsBean
         this.gradebookExists = gbsHelper.gradebookExists(
         	GradebookFacade.getGradebookUId(), g);
         */
+        
+        /* Check if the Assessment can be linked to an existing gradebook item with the same name */
+        this.gradebookLinkeable = gradebookItemAvailable(); // true if there exist an empty GB item with same name as the assignment.
+        
       }
 
       // ip addresses
@@ -923,11 +930,11 @@ public class AssessmentSettingsBean
     this.anonymousGrading = anonymousGrading;
   }
 
-  public boolean getToDefaultGradebook() {
+  public String getToDefaultGradebook() {
     return this.toDefaultGradebook;
   }
 
-  public void setToDefaultGradebook(boolean toDefaultGradebook) {
+  public void setToDefaultGradebook(String toDefaultGradebook) {
     this.toDefaultGradebook = toDefaultGradebook;
   }
 
@@ -1799,5 +1806,34 @@ public class AssessmentSettingsBean
 	  
 	  return selections;
   }
+  
+	  /**
+	   * To be set if an empty, non externally maintained gradebook item exists.
+	   * @return
+	   */
+	  public boolean getGradebookLinkeable() {
+		  return this.gradebookLinkeable;
+	  }
+	  
+	  public void setGradebookLinkeable(boolean pLink) {
+		  this.gradebookLinkeable = pLink;
+	  }
+	
+	  /** 
+	  *
+	  * Returns true if at the time of creating or editing an assessment, there exist an empty GB item with 
+	  * the same title as the assignment for it to be potentially linked to it.
+	  * @return
+	  */
+	 private boolean gradebookItemAvailable() {
+		  GradebookService g = (GradebookService) ComponentManager.get("org.sakaiproject.service.gradebook.GradebookService");
+		  String gradebookId = ToolManager.getInstance().getCurrentPlacement().getContext();
+		  List allGradebookItems = g.getAssignments(gradebookId);
+		  for(Object a : allGradebookItems) {
+			  org.sakaiproject.service.gradebook.shared.Assignment curGBItem = (org.sakaiproject.service.gradebook.shared.Assignment) a;
+			  if(!curGBItem.isExternallyMaintained() && curGBItem.getName().equals(this.title)) return true;
+		  }
+		  return false;
+	 }
 
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -291,7 +291,7 @@ public class ConfirmPublishAssessmentListener
     }
     
     //Gradebook right now only excep if total score >0 check if total score<=0 then throw error.
-    if(assessmentSettings.getToDefaultGradebook())
+    if(assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK)))
 	{
  	    if(assessmentBean.getTotalScore()<=0)
 		{
@@ -301,18 +301,24 @@ public class ConfirmPublishAssessmentListener
 		}
 	}
 
-    //#2b - check if gradebook exist, if so, if assessment title already exists in GB
+  //#2b - check if gradebook exist, if so, if assessment title already exists in GB
     GradebookExternalAssessmentService g = null;
     if (integrated){
       g = (GradebookExternalAssessmentService) SpringBeanLocator.getInstance().
             getBean("org.sakaiproject.service.gradebook.GradebookExternalAssessmentService");
     }
+    String toGradebook = assessmentSettings.getToDefaultGradebook();
     try{
-	if (assessmentSettings.getToDefaultGradebook() && gbsHelper.isAssignmentDefined(assessmentSettings.getTitle(), g)){
-        String gbConflict_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "gbConflict_error");
-        context.addMessage(null,new FacesMessage(gbConflict_err));
-        error=true;
-      }
+    	if (toGradebook!=null && toGradebook.equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK)) &&
+    			gbsHelper.isAssignmentDefined(assessmentSettings.getTitle(), g)) {
+    		String gbConflict_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "gbConflict_error");
+    		context.addMessage(null,new FacesMessage(gbConflict_err));
+    		error=true;
+    	} else if (toGradebook != null && toGradebook.equals(EvaluationModelIfc.TO_EXISTING_GRADEBOOK_ITEM.toString()) &&
+    		  !gbsHelper.isAssignmentDefined(assessmentSettings.getTitle(), g)) {
+    		context.addMessage(null,new FacesMessage("The empty gradebook item is no longer available, please select a new option"));
+    		error=true;
+    	}
     }
     catch(Exception e){
       log.warn("external assessment in GB has the same title:"+e.getMessage());

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RepublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RepublishAssessmentListener.java
@@ -162,7 +162,7 @@ public class RepublishAssessmentListener implements ActionListener {
 			}
 			
 			Integer scoringType = evaluation.getScoringType();
-			if (evaluation.getToGradeBook() != null	&& evaluation.getToGradeBook().equals(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK.toString())) {
+			if (evaluation.getToGradeBook() != null	&& evaluation.getToGradeBook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK))) {
 
 				try {
 					log.debug("before gbsHelper.removeGradebook()");

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -51,6 +51,7 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessCont
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
 import org.sakaiproject.tool.assessment.facade.AuthzQueriesFacadeAPI;
@@ -266,8 +267,10 @@ public class SaveAssessmentSettings
 		else {
 			evaluation.setAnonymousGrading(Integer.valueOf(2));
 		}
-		if (assessmentSettings.getToDefaultGradebook()) {
+		if (assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK))) {
 			evaluation.setToGradeBook("1");
+		} else if (assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_EXISTING_GRADEBOOK_ITEM))) {
+			evaluation.setToGradeBook(String.valueOf(EvaluationModelIfc.TO_EXISTING_GRADEBOOK_ITEM));
 		}
 		else {
 			evaluation.setToGradeBook("2");

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -579,7 +579,7 @@ implements ActionListener
 	    
 		// If there is value set for toDefaultGradebook, we reset it
 		// Otherwise, do nothing
-		if (assessmentSettings.getToDefaultGradebook()) {
+		if (assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK))) {
 			evaluation.setToGradeBook("1");
 		}
 		else {
@@ -614,7 +614,7 @@ implements ActionListener
 		// point = 0.
 		boolean gbError = false;
 
-		if (assessmentSettings.getToDefaultGradebook()) {
+		if (assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK))) {
 			if (assessment.getTotalScore().doubleValue() <= 0) {
 				String gb_err = (String) ContextUtil.getLocalizedString(
 						"org.sakaiproject.tool.assessment.bundle.AuthorMessages","gradebook_exception_min_points");
@@ -651,7 +651,7 @@ implements ActionListener
 			try{
 				assessmentName = TextFormat.convertPlaintextToFormattedTextNoHighUnicode(log, assessmentSettings.getTitle().trim());
 				gbItemExists = gbsHelper.isAssignmentDefined(assessmentName, g);
-				if (assessmentSettings.getToDefaultGradebook() && gbItemExists && isTitleChanged){
+				if (assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK)) && gbItemExists && isTitleChanged){
 					String gbConflict_error=ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages","gbConflict_error");
 					context.addMessage(null,new FacesMessage(gbConflict_error));
 					return false;
@@ -661,7 +661,7 @@ implements ActionListener
 				log.warn("external assessment in GB has the same title:"+e.getMessage());
 			}
 			
-			if (assessmentSettings.getToDefaultGradebook()) {
+			if (assessmentSettings.getToDefaultGradebook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK))) {
 				evaluation.setToGradeBook("1");
 			}
 			else {
@@ -674,7 +674,7 @@ implements ActionListener
 			}
 			Integer scoringType = evaluation.getScoringType();
 			if (evaluation.getToGradeBook()!=null && 
-					evaluation.getToGradeBook().equals(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK.toString())){
+					evaluation.getToGradeBook().equals(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK))){
 				if (isTitleChanged || isScoringTypeChanged) {
 					// Because GB use title instead of id, we remove and re-add to GB if title changes.
 					try {

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -3,6 +3,7 @@
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%@ taglib uri="http://www.sakaiproject.org/samigo" prefix="samigo" %>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"  %>
 
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -349,11 +350,26 @@
     </h:panelGroup>
     
     <f:verbatim><br /></f:verbatim>
+    <f:verbatim><br /></f:verbatim>
     
     <!-- GRADEBOOK OPTION -->
     <h:panelGroup rendered="#{assessmentSettings.valueMap.toGradebook_isInstructorEditable==true && assessmentSettings.gradebookExists==true}">
-      <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{assessmentSettings.toDefaultGradebook}"/>
+      <!-- <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{assessmentSettings.toDefaultGradebook}"/> -->
+      <f:verbatim><br /></f:verbatim>
       <h:outputLabel value="#{assessmentSettingsMessages.gradebook_options}"/>
+      <f:verbatim><br /></f:verbatim>
+      <h:selectOneRadio id="toDefaultGradebook1" value="#{assessmentSettings.toDefaultGradebook}"  layout="pageDirection">
+	        <c:choose>
+	        	<c:when test="${ assessmentSettings.gradebookLinkeable == true }">
+	        		<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	        		<f:selectItem itemValue="4" itemLabel="#{assessmentSettingsMessages.to_associate_existing_gradebook_item}"/>
+	        	</c:when>
+	        	<c:otherwise>
+	          		<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	          		<f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.to_default_gradebook}"/>
+	        	</c:otherwise>
+	       	</c:choose>
+        </h:selectOneRadio>
     </h:panelGroup>
 
     <f:verbatim><br /></f:verbatim>

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -3,6 +3,7 @@
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%@ taglib uri="http://www.sakaiproject.org/samigo" prefix="samigo" %>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"  %>
 
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -340,11 +341,26 @@
     </h:panelGroup>
     
     <f:verbatim><br /></f:verbatim>
+    <f:verbatim><br /></f:verbatim>
     
     <!-- GRADEBOOK OPTION -->
     <h:panelGroup rendered="#{publishedSettings.valueMap.toGradebook_isInstructorEditable==true && publishedSettings.gradebookExists==true}">
-      <h:selectBooleanCheckbox value="#{publishedSettings.toDefaultGradebook}" disabled="#{publishedSettings.firstTargetSelected == 'Anonymous Users'}"/>
+      <!-- <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{assessmentSettings.toDefaultGradebook}"/> -->
+      <f:verbatim><br /></f:verbatim>
       <h:outputLabel value="#{assessmentSettingsMessages.gradebook_options}"/>
+      <f:verbatim><br /></f:verbatim>
+      <h:selectOneRadio id="toDefaultGradebook1" value="#{publishedSettings.toDefaultGradebook}"  layout="pageDirection">
+	        <c:choose>
+	        	<c:when test="${ publishedSettings.gradebookLinkeable == true }">
+	        		<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	        		<f:selectItem itemValue="4" itemLabel="#{assessmentSettingsMessages.to_associate_existing_gradebook_item}"/>
+	        	</c:when>
+	        	<c:otherwise>
+	          		<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	          		<f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.to_default_gradebook}"/>
+	        	</c:otherwise>
+	       	</c:choose>
+        </h:selectOneRadio>
     </h:panelGroup>
 
     <f:verbatim><br /></f:verbatim>


### PR DESCRIPTION
Samigo test can be linked to an existing empty GB item with the same name of the test.
Assignment will no longer just maintain an
internal reference of the GB item associated to them but with mark it as
externally maintained by them such that no overlappings on grading can
existing between these tools.