### PR TITLE
KNL-1338 Remove duplicate SQL for all grants.

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -2631,10 +2631,6 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 			Map<String,String> target = m_provider.getUserRolesForGroup(realm.getProviderGroupId());
 
 			// read the realm's grants
-			sql = dbAuthzGroupSql.getSelectRealmRoleGroup4Sql();
-			Object[] fields = new Object[1];
-			fields[0] = caseId(realm.getId());
-
 			List<UserAndRole> grants = getGrants(realm);
 
 			// make a map, user id -> role granted, each for provider and non-provider (or inactive)
@@ -2837,7 +2833,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 
 				// delete
 				sql = dbAuthzGroupSql.getDeleteRealmRoleGroup4Sql();
-				fields = new Object[2];
+				Object[] fields = new Object[2];
 				fields[0] = caseId(realm.getId());
 				for (String userId : toDelete)
 				{
@@ -2867,7 +2863,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 
 		private List<UserAndRole> getGrants(AuthzGroup realm) {
 			// read the realm's grants
-			String sql = dbAuthzGroupSql.getSelectRealmRoleGroup4Sql();
+			String sql = dbAuthzGroupSql.getSelectRealmRoleGroup2Sql();
 			Object[] fields = new Object[1];
 			fields[0] = caseId(realm.getId());
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
@@ -127,8 +127,6 @@ public interface DbAuthzGroupSql
 
 	String getSelectRealmRoleGroup3Sql();
 
-	String getSelectRealmRoleGroup4Sql();
-
 	String getSelectRealmUserGroupSql( String inClause );
 
 	String getSelectRealmRoleGroupUserIdSql(String inClause1, String inClause2);

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlDefault.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlDefault.java
@@ -400,17 +400,6 @@ public class DbAuthzGroupSqlDefault implements DbAuthzGroupSql
 		return sqlBuf.toString();
 	}
 
-	public String getSelectRealmRoleGroup4Sql()
-	{
-		StringBuilder sqlBuf = new StringBuilder();
-		sqlBuf.append("select SRRG.USER_ID, SRR.ROLE_NAME, SRRG.ACTIVE, SRRG.PROVIDED ");
-		sqlBuf.append("from SAKAI_REALM_RL_GR SRRG ");
-		sqlBuf.append("inner join SAKAI_REALM SR on SRRG. REALM_KEY = SR. REALM_KEY ");
-		sqlBuf.append("inner join SAKAI_REALM_ROLE SRR on SRRG.ROLE_KEY = SRR.ROLE_KEY ");
-		sqlBuf.append("where SR.REALM_ID = ?");
-		return sqlBuf.toString();
-	}
-
 	public String getSelectRealmUserGroupSql( String inClause )
 	{
 		StringBuilder sqlBuf = new StringBuilder();


### PR DESCRIPTION
There is duplicate SQL for getting a resultset of all users and their role in a realm. This is useless duplication and can go.

getSelectRealmRoleGroup4Sql() is the same as getSelectRealmRoleGroup2Sql with just the table aliases being different.