### PR TITLE
SAK-25903 Upgrade to Java 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - oraclejdk8
 sudo: false
 cache:
  directories:

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/tool/impl/SessionComponentRegressionTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/tool/impl/SessionComponentRegressionTest.java
@@ -810,7 +810,7 @@ public class SessionComponentRegressionTest extends BaseSessionComponentTest {
 			allowing(threadLocalManager).get(with(equal(SessionComponent.CURRENT_SESSION)));
 //			exactly(2).of(threadLocalManager).get(with(any(String.class)));
 			will(returnValue(session));
-			allowing(threadLocalManager).set(with(equal(SessionComponent.CURRENT_SESSION)),with(equal(null)));
+			allowing(threadLocalManager).set(with(equal(SessionComponent.CURRENT_SESSION)),with(equal((Object)null)));
 		}});
 	}
 	

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -115,13 +115,13 @@
     <sakairsf.components.version>11-SNAPSHOT</sakairsf.components.version>
     <sakairsf.version>11-SNAPSHOT</sakairsf.version>
     <generic-dao.version>0.9.18</generic-dao.version>
-    <reflectutils.version>0.9.19</reflectutils.version>
+    <reflectutils.version>0.9.20-SNAPSHOT</reflectutils.version>
     <!-- Sakai modules that are versioned separately -->
     <!-- lessonbuilder tool pom depends on msgcntr ver prop. Need to add a profile to the LB tool pom to mark change between 10.x master and earlier versions -->
     <sakai.msgcntr.version>11-SNAPSHOT</sakai.msgcntr.version> 
     <!-- Set the source encoding to avoid maven warnings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sakai.jdk.version>1.7</sakai.jdk.version>
+    <sakai.jdk.version>1.8</sakai.jdk.version>
     <sakai.build.directory>target</sakai.build.directory>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
   </properties>


### PR DESCRIPTION
With a local build of reflect-utils this builds and starts up for me (with tests) using Java 8.
Entitybroker works (quick rough test).

These are basically the changes @jonespm suggested in email.