### PR TITLE
SAK-29214 Cope with time changes (clock going forward)

### DIFF
--- a/calendar/calendar-util/util/pom.xml
+++ b/calendar/calendar-util/util/pom.xml
@@ -26,6 +26,18 @@
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-component-manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-kernel-util</artifactId>
         </dependency>
         <dependency>

--- a/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
+++ b/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
@@ -548,24 +548,32 @@ public class CalendarUtil
 	
 	/**
 	 * Get the String representing AM in the users Locale 
-	 * @return
+	 * @return A String representing the morning for the current user.
 	 */
 	public static String getLocalAMString() {
-		
+		return getLocalAMString(new DateTime());
+	}
+
+	// Used for tests
+	static String getLocalAMString(DateTime now) {
 		//we need an AM date
-		DateTime dt = new DateTime().withTime(1, 0, 0, 0);
+		DateTime dt = now.withTime(1, 0, 0, 0);
 		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(new ResourceLoader("calendar").getLocale());
 		return df.print(dt);
 	}
 	
 	/**
 	 * Get the string representing PM in the users Locale
-	 * @return
+	 * @return A String representing the afternoon for the current user.
 	 */
 	public static String getLocalPMString() {
+		return getLocalPMString(new DateTime());
+	}
 
+	// Used for tests
+	static String getLocalPMString(DateTime now) {
 		//we need an PM date
-		DateTime dt = new DateTime().withTime(14, 0, 0, 0);
+		DateTime dt = now.withTime(14, 0, 0, 0);
 		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(new ResourceLoader("calendar").getLocale());
 		return df.print(dt);
 	}

--- a/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
+++ b/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
@@ -557,8 +557,9 @@ public class CalendarUtil
 	// Used for tests
 	static String getLocalAMString(DateTime now) {
 		//we need an AM date
-		DateTime dt = now.withTime(1, 0, 0, 0);
-		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(new ResourceLoader("calendar").getLocale());
+		DateTime dt = now.withTimeAtStartOfDay();
+		Locale locale= new ResourceLoader("calendar").getLocale();
+		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(locale);
 		return df.print(dt);
 	}
 	
@@ -573,8 +574,9 @@ public class CalendarUtil
 	// Used for tests
 	static String getLocalPMString(DateTime now) {
 		//we need an PM date
-		DateTime dt = now.withTime(14, 0, 0, 0);
-		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(new ResourceLoader("calendar").getLocale());
+		DateTime dt = now.withTimeAtStartOfDay().plusHours(14);
+		Locale locale = new ResourceLoader("calendar").getLocale();
+		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(locale);
 		return df.print(dt);
 	}
 	

--- a/calendar/calendar-util/util/src/test/org/sakaiproject/util/CalendarUtilTest.java
+++ b/calendar/calendar-util/util/src/test/org/sakaiproject/util/CalendarUtilTest.java
@@ -1,0 +1,52 @@
+package org.sakaiproject.util;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class CalendarUtilTest {
+
+
+    @Before
+    public void setUp() {
+        // Need this so that developers in locales that don't use AM/PM have passing tests
+        // If you want to test this setting is working set it to Locale.JAPAN which should
+        // result in failing tests.
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @Test
+    public void testLocalAMString() {
+        // This is to test that the schedule tool works through GMT -> BST transitions
+        DateTimeZone zone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/London"));
+        // This a day that the clocks go forward in London
+        DateTime dateTime = new DateTime(2015, 3, 29, 3,0, zone);
+        assertEquals("AM", CalendarUtil.getLocalAMString(dateTime));
+    }
+
+    @Test
+    public void testLocalPMString() {
+        // This is to test that the schedule tool works through GMT -> BST transitions
+        DateTimeZone zone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/London"));
+        // This a day that the clocks go forward in London
+        DateTime dateTime = new DateTime(2015, 3, 29, 16,0, zone);
+        assertEquals("PM", CalendarUtil.getLocalPMString(dateTime));
+    }
+
+    @Test
+    public void testLocalPMStringStartOfDay() {
+        // This is to test that the schedule tool works through GMT -> BST transitions
+        DateTimeZone zone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/London"));
+        // This a day that the clocks go forward in London
+        DateTime dateTime = new DateTime(2015, 3, 29, 0, 0, zone);
+        assertEquals("PM", CalendarUtil.getLocalPMString(dateTime));
+    }
+
+
+}


### PR DESCRIPTION
The schedule tool would fail when the clocks went forward as there wasn't a 01:00:00 time on that day. The tool would however recover the next day. I've left this as 2 commits so it's easy to see the bug (checking out the first commit) and the fix separately. 