### PR TITLE
SAK-28032 Depend on master spring and common-logging versions

### DIFF
--- a/common/import-parsers/blackboard_6/impl/pom.xml
+++ b/common/import-parsers/blackboard_6/impl/pom.xml
@@ -63,8 +63,7 @@
 		</dependency>
 		<dependency>
                         <groupId>org.springframework</groupId>
-                        <artifactId>spring</artifactId>
-                        <version>2.5.6.SEC01</version>
+                        <artifactId>spring-core</artifactId>
                 </dependency>
 		<dependency>
                         <groupId>jaxen</groupId>
@@ -86,7 +85,6 @@
 		<dependency>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
-                        <version>1.0.4</version>
                 </dependency>
 	</dependencies>
   <build>


### PR DESCRIPTION
The blackboard parser was incorrectly depending on an old version of Spring and commons-logging. It should be pulling these versions from master.