### PR TITLE
SAK-29228 Make tests run headless by default

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1791,6 +1791,8 @@
             <!--suppress MavenModelInspection -->
             <test.sakai.home>${test.sakai.home}</test.sakai.home>
           </systemPropertyVariables>
+          <!-- This is to stop it stealing focus on developer machines (OSX) -->
+          <argLine>-Djava.awt.headless=true</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This prevents the surefire plugin from stealing focus on OS X.
Developers can set JAVA_TOOL_OPTIONS='-Djava.awt.headless=true' 
environmental variable but this requires more setup by each developer.