### PR TITLE
SAK-29232 Hide templates of type a user can't add

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-type.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-type.vm
@@ -193,6 +193,11 @@
                             #set($siteType = false)
                             #set($siteType = $!templateSite.type)
 
+                            #if (
+                                ($siteType == $projectSiteType && $canAddProject) || 
+                                ($courseSiteTypeStrings.contains($siteType) && $canAddCourse) ||
+                                ($siteType == $portfolioSiteType && $canAddPortfolio)
+                             )
                             #if($siteTypePrev != $siteType)
 
                               #if ($siteType == "course")
@@ -228,6 +233,7 @@
                                 <div class="templateSettingsPlaceholder"></div>
                             </li>
                             #set($siteTypePrev = $!templateSite.type)
+                            #end
                         #end
                 </ul>
             </div>   ## end of child of  div#templateSettings


### PR DESCRIPTION
When building the list of site templates a user can choose, only include templates if the user can create sites of that type.