### PR TITLE
SAM-2530 update button on question pool list should be named appropriately

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages.properties
@@ -132,7 +132,7 @@ q_tf=True/False Question
 q_matrix_choices_surv=Survey: Matrix of Choices
 
 # list navigation
-update=Update
+delete=Delete
 previous=Previous
 show_per_page=Show 10 Items per Page
 

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
@@ -132,7 +132,7 @@
 
 <p class="act">
  
-<h:commandButton rendered="#{questionpool.importToAuthoring == 'false' && authorization.deleteOwnQuestionPool}" type="submit" immediate="true" id="Submit" value="#{questionPoolMessages.update}" action="#{questionpool.startRemovePool}" styleClass="active" >
+<h:commandButton rendered="#{questionpool.importToAuthoring == 'false' && authorization.deleteOwnQuestionPool}" type="submit" immediate="true" id="Submit" value="#{questionPoolMessages.delete}" action="#{questionpool.startRemovePool}" styleClass="active" >
   </h:commandButton>
 
   <h:commandButton rendered="#{questionpool.importToAuthoring == 'true'}"  type="submit" immediate="true" id="cancel" value="#{commonMessages.cancel_action}" action="#{questionpool.cancelImport}"  >


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2530

The only action this button applies to is deleting question pools, and should thus be named 'Delete' appropriately. 