### PR TITLE
SAM-2531 missing message bundle keys in Samigo creating log bloat

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/GeneralMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/GeneralMessages.properties
@@ -24,6 +24,8 @@ t_questionPool=Go to Question Pool Page
 t_eventLog=Go to Event Log Page
 # Accesskey: all accesskey name start with a_
 a_log=l
+a_assessment=a
+a_pool=p
 
 # Error message for the date input field that uses date picker
 # Please sync the date format of follow error message with 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2531

You'll get these warnings in the logs every time you hit the Event Log page in Samigo:

2015-03-31 15:02:22,746 WARN http-bio-8080-exec-5 org.sakaiproject.util.ResourceLoader - bundle 'org.sakaiproject.tool.assessment.bundle.GeneralMessages' missing key: 'a_assessment' from: org.sakaiproject.util.ResourceLoader.get(ResourceLoader.java:164)
2015-03-31 15:02:22,748 WARN http-bio-8080-exec-5 org.sakaiproject.util.ResourceLoader - bundle 'org.sakaiproject.tool.assessment.bundle.GeneralMessages' missing key: 'a_pool' from: org.sakaiproject.util.ResourceLoader.get(ResourceLoader.java:164) 