### PR TITLE
SAK-29233 missing message bundle key in announcements

### DIFF
--- a/announcement/announcement-tool/tool/src/bundle/announcement.properties
+++ b/announcement/announcement-tool/tool/src/bundle/announcement.properties
@@ -62,6 +62,7 @@ gen.attach = attachment
 # {0} is the announcement subject
 gen.draft.subject = <span class="highlight">Draft - </span>  {0}
 gen.save = Save
+gen.draft = Draft
 gen.update = Update
 gen.cancel = Cancel
 gen.first = First


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29233

Unnecessary log bloat:

015-04-06 14:40:43,689 WARN http-bio-8080-exec-5 org.sakaiproject.util.ResourceLoader - bundle 'announcement' missing key: 'gen.draft' from: sun.reflect.GeneratedMethodAccessor456.invoke(Unknown Source)

Even though this is only referenced once and from within an HTML comment, the Velocity engine will still try to resolve 'gen.draft' because it's not a Velocity comment, and thus has to be output in the resulting HTML. 