### PR TITLE
SAK-29236 Peer assessment assignments average score misses the last record sometimes

### DIFF
--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/AssignmentPeerAssessmentServiceImpl.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/AssignmentPeerAssessmentServiceImpl.java
@@ -367,6 +367,7 @@ public class AssignmentPeerAssessmentServiceImpl extends HibernateDaoSupport imp
 	public void savePeerAssessmentItem(PeerAssessmentItem item){
 		if(item != null && item.getAssessorUserId() != null && item.getSubmissionId() != null){
 			getHibernateTemplate().saveOrUpdate(item);
+			getHibernateTemplate().flush();
 		}
 	}
 	


### PR DESCRIPTION
When a student is grading another student submission in a peer assessment assignment the score is recorded in the db but the calculated score average is missing the last commited result.

What it's happening here is that process saves and retrieves rows in the same thread process and in some cases it has no time to store it to the db before the list is gotten.

Flushing must prevent that cases.

