### PR TITLE
SAK-29114 /direct/grades REST endpoint not saving gradeitems (grades-res...

### DIFF
--- a/gradebook/grades-rest/src/main/java/org/sakaiproject/gradebook/entity/GradesEntityProvider.java
+++ b/gradebook/grades-rest/src/main/java/org/sakaiproject/gradebook/entity/GradesEntityProvider.java
@@ -181,6 +181,7 @@ Resolvable, Outputable, Inputable, Describeable, ActionsExecutable, Redirectable
             GradebookItem gbItemIn = new GradebookItem(courseId, gbItemName);
             gbItemIn.pointsPossible = cvu.convert(input.get("pointsPossible"), Double.class);
             gbItemIn.dueDate = cvu.convert(input.get("dueDate"), Date.class);
+            gbItemIn.eid = cvu.convert(input.get("externalID"), String.class);
             @SuppressWarnings("unchecked")
             List<Object> scores = cvu.convert(input.get("scores"), List.class);
             if (scores != null) {


### PR DESCRIPTION
There is currently a validation before saving the gradeitem for the externalID (eid). The problem is, the eid of the gradeitem is never set. Have the user of the endpoint determine the eid that will be associated with the gradeitem.