### PR TITLE
SAK-29245 possibility of stack trace in logs and user action not taking place in assignments -> grade submission -> unsaved changes + submission navigation buttons

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4611,9 +4611,9 @@ public class AssignmentAction extends PagedResourceActionII
 				Assignment a = getAssignment(assignmentRef, "integrateGradebook", state);
 				if (a != null)
 				{
+					String propAddToGradebook = a.getProperties().getProperty(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK);
 					if ("update".equals(updateRemoveSubmission)
-							&& a.getProperties().getProperty(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK) != null
-							&& !a.getProperties().getProperty(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK).equals(AssignmentService.GRADEBOOK_INTEGRATION_NO)
+							&& (StringUtils.equals( propAddToGradebook, AssignmentService.GRADEBOOK_INTEGRATION_ADD) || StringUtils.equals( propAddToGradebook, AssignmentService.GRADEBOOK_INTEGRATION_ASSOCIATE))
 							&& a.getContent().getTypeOfGrade() == Assignment.SCORE_GRADE_TYPE)
 					{
 						if (submissionRef == null)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29245

We have seen that it is possible for an assignment to get into a state where the property which defines gradebook integration gets set to an empty string rather than the three available values ('no', 'add', 'associate').

This becomes a problem when the integrateGradebook() method is run inside AssignmentAction.java in the situation where an instructor/maintainer is grading submissions for an assignment that is not set to send grades to the gradebook:

1) the instructor navigates to the assignment submission they wish to grade
2) they provide a grade and/or some comments, etc
3) they click any of the submission navigation buttons ('Return to List', 'Next' or 'Previous')
4) the changes are saved and the page is refreshed rather than saving and taking the desired action of the button clicked in the previous step
5) the attached stack trace will come up in catalina.out

The problem with the integrateGradebook() method, is that it checks that the assignment property is != to 'no'. However, when comparing against an empty string, this check returns false and the gradebook integration code is run when it shouldn't, thus producing the attached stack trace.

The attached PR takes the approach of changing the algorithm in integrateGradebook() to check that the property == either 'add' or 'associate', rather than checking that it is != 'no'.

In this way, the algorithm will correctly determine that the gradebook integration code should not be run if the property is either an empty string or 'no'. We chose not to identify when/where the property is being set to an empty string rather than 'no' simply because that approach would not rectify the situation for assignments that already have an empty string in the database for this property.