### PR TITLE
KNL-1268 - Extract content file operations to support multiple backends

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/content/api/FileSystemHandler.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/FileSystemHandler.java
@@ -1,0 +1,43 @@
+package org.sakaiproject.content.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This is the api for reading and writing files to some file system.
+ *
+ */
+public interface FileSystemHandler {
+
+    /**
+     * Retrieves an input stream from the file.
+     * 
+     * @param id The id of the resource. Will not be null or empty.
+     * @param root The root of the storage. Could be null or empty.
+     * @param filePath The path to the file. Will not be null or empty.
+     * @return The valid input stream. Must not be null.
+     * @throws IOException If the stream could not be created.
+     */
+    public InputStream getInputStream(String id, String root, String filePath) throws IOException;
+
+    /**
+     * Save the file from the input stream to the path and return the content size.
+     * 
+     * @param id The id of the resource. Will not be null or empty.
+     * @param root The root of the storage. Could be null or empty.
+     * @param filePath The path to save the file to. Will not be null or empty.
+     * @param stream The stream to read the file from.
+     * @return The content size.
+     */
+    public long saveInputStream(String id, String root, String filePath, InputStream stream) throws IOException;
+
+    /**
+     * Delete the file from the path.
+     * 
+     * @param id The id of the resource. Will not be null or empty.
+     * @param root The root of the storage. Could be null or empty.
+     * @param filePath The path to delete. Will not be null or empty.
+     * @return If the path was deleted.
+     */
+    public boolean delete(String id, String root, String filePath);
+}

--- a/kernel/api/src/main/java/org/sakaiproject/exception/ServerOverloadException.java
+++ b/kernel/api/src/main/java/org/sakaiproject/exception/ServerOverloadException.java
@@ -33,4 +33,12 @@ public class ServerOverloadException extends SakaiException
 	{
 		super(id);
 	}
+
+	/**
+	 * Constructor setting exception message and the cause of the exception.
+	 */
+	public ServerOverloadException(String message, Throwable t)
+	{
+		super(message, t);
+	}
 }

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
@@ -18,6 +18,7 @@
 			class="org.sakaiproject.content.impl.DbContentService"
             init-method="init" destroy-method="destroy" singleton="true">
 
+        <property name="fileSystemHandler">          <ref bean="org.sakaiproject.content.api.FileSystemHandler.file"/>       </property>
         <property name="memoryService">              <ref bean="org.sakaiproject.memory.api.MemoryService"/>                 </property>
         <property name="functionManager">			<ref bean="org.sakaiproject.authz.api.FunctionManager"/>				</property>
         <property name="aliasService">               <ref bean="org.sakaiproject.alias.api.AliasService"/>                   </property>
@@ -72,6 +73,10 @@
            </map>
         </property>
         <property name="contentFilterService" ref="org.sakaiproject.content.api.ContentFilterService"/>
+    </bean>
+
+    <bean id="org.sakaiproject.content.api.FileSystemHandler.file" class="org.sakaiproject.content.impl.DefaultFileSystemHandler">
+        <property name="useIdForFilePath" value="true" />
     </bean>
 
     <bean id="org.sakaiproject.content.impl.CollectionAccessFormatter"

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
@@ -18,7 +18,7 @@
 			class="org.sakaiproject.content.impl.DbContentService"
             init-method="init" destroy-method="destroy" singleton="true">
 
-        <property name="fileSystemHandler">          <ref bean="org.sakaiproject.content.api.FileSystemHandler.file"/>       </property>
+        <property name="fileSystemHandler">          <ref bean="org.sakaiproject.content.api.FileSystemHandler"/>            </property>
         <property name="memoryService">              <ref bean="org.sakaiproject.memory.api.MemoryService"/>                 </property>
         <property name="functionManager">			<ref bean="org.sakaiproject.authz.api.FunctionManager"/>				</property>
         <property name="aliasService">               <ref bean="org.sakaiproject.alias.api.AliasService"/>                   </property>
@@ -78,6 +78,10 @@
     <bean id="org.sakaiproject.content.api.FileSystemHandler.file" class="org.sakaiproject.content.impl.DefaultFileSystemHandler">
         <property name="useIdForFilePath" value="true" />
     </bean>
+
+    <!-- Alias the default filesystem-backed handler to be used by ContentHosting; override the alias to plug in an alternative -->
+    <alias name="org.sakaiproject.content.api.FileSystemHandler.file" alias="org.sakaiproject.content.api.FileSystemHandler" />
+
 
     <bean id="org.sakaiproject.content.impl.CollectionAccessFormatter"
           class="org.sakaiproject.content.impl.CollectionAccessFormatter">

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -387,4 +387,72 @@
     -->
   </dependencies>
 
+  <profiles>
+    <profile>
+      <!-- This profile will enable you to run the StorageConverter -->
+      <id>storage-convert</id>
+      <dependencies>
+        <!-- need to setup this dependency to your database driver.
+        <dependency>
+          <groupId>mysql</groupId>
+           <artifactId>connector</artifactId>
+           <version>5.1.30</version>
+           <scope>system</scope>
+           <systemPath>path/to/mysql-connector-java-5.1.30-bin.jar</systemPath>
+        </dependency>
+        -->
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+            <!-- This execution runs the storage conversion from one FileSystemHandler to another. -->
+            <configuration>
+              <classpathScope>test</classpathScope>
+              <skip>false</skip>
+              <executable>java</executable>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.sakaiproject.content.impl.util.StorageConverter</argument>
+                <!-- Use either a properties file or the properties...or both
+                <argument>-p</argument>
+                <argument>src/main/resource/my.properties</argument>
+                -->
+                <!-- just set the properties
+                <argument>-connectionDriver</argument>
+                <argument>The database connection driver class.</argument>
+                <argument>-connectionURL</argument>
+                <argument>The database connection URL.</argument>
+                <argument>-connectionUsername</argument>
+                <argument>The database connection username.</argument>
+                <argument>-connectionPassword</argument>
+                <argument>The database connection password.</argument>
+                <argument>-sourceFileSystemHandler</argument>
+                <argument>This is the full class name of the source FileSystemHandler.</argument>
+                <argument>-sourceFileSystemHandler.{some property}</argument>
+                <argument>You can set any property on the source FileSystemHandler by referensing their property names.</argument>
+                <argument>-sourceBodyPath</argument>
+                <argument>The path set in sakai.properties for the source.</argument>
+                <argument>-destinationFileSystemHandler</argument>
+                <argument>This is the full class name of the destination FileSystemHandler.</argument>
+                <argument>-destinationFileSystemHandler.{some property}</argument>
+                <argument>You can set any property on the destination FileSystemHandler by referensing their property names.</argument>
+                <argument>-destinationBodyPath</argument>
+                <argument>The path set in sakai.properties for the destination.</argument>
+                <argument>-deleteFromSource</argument>
+                <argument>Whether to delete the source files. Default false.</argument>
+                <argument>-contentSql</argument>
+                <argument>The sql statement to retrieve the resource id's and paths. Default is new ContentServiceSqlDefault().getResourceIdAndFilePath()</argument>
+                -->
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -23,7 +23,6 @@ package org.sakaiproject.content.impl;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -906,21 +905,6 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 			DropboxNotification dropboxNotification = new DropboxNotification(m_securityService, this, m_entityManager, m_siteService,
 					userDirectoryService, m_serverConfigurationService);
 			dbNoti.setAction(dropboxNotification);
-
-			if (m_bodyPathDeleted != null) {
-				File deletedFolder = new File(m_bodyPathDeleted);
-				if (!deletedFolder.exists()) {
-					if (!deletedFolder.mkdirs()) {
-						M_log.error("failed to create bodyPathDeleted " + m_bodyPathDeleted + ". Resource backup to file system has been disabled! Please set with the property: bodyPathDeleted@org.sakaiproject.content.api.ContentHostingService");
-						m_bodyPathDeleted = null;
-					}
-				}
-			} else {
-				if (m_bodyPath != null) {
-					M_log.info("m_bodyPathDeleted is not set as a property. Please set with the property: bodyPathDeleted@org.sakaiproject.content.api.ContentHostingService if you want to allow for deletion of resources");
-				}
-			}
-
 
 			StringBuilder buf = new StringBuilder();
 			if (m_bodyVolumes != null)

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentServiceSql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentServiceSql.java
@@ -87,6 +87,12 @@ public interface ContentServiceSql
 	String getResourceIdXmlSql();
 
 	/**
+	 * returns the sql statement which retrieves all id's and file paths where the file path is not null.
+	 * This is used for converting storage from one FileSystemHandler to another.
+	 */
+	public String getResourceIdAndFilePath();
+
+	/**
 	 * returns the sql statement which retrieves resource uuid from the content_resource table.
 	 */
 	String getResourceUuidSql();

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentServiceSqlDefault.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentServiceSqlDefault.java
@@ -124,6 +124,14 @@ public class ContentServiceSqlDefault implements ContentServiceSql
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	public String getResourceIdAndFilePath()
+	{
+		return "select RESOURCE_ID, FILE_PATH from CONTENT_RESOURCE where FILE_PATH IS NOT NULL";
+	}
+
+	/**
 	 * returns the sql statement which retrieves the resource uuid from the content_resource table.
 	 */
 	public String getResourceUuidSql()

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -24,10 +24,6 @@ package org.sakaiproject.content.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Blob;
@@ -55,6 +51,7 @@ import org.sakaiproject.content.api.ContentCollection;
 import org.sakaiproject.content.api.ContentCollectionEdit;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.content.api.ContentResourceEdit;
+import org.sakaiproject.content.api.FileSystemHandler;
 import org.sakaiproject.content.api.Lock;
 import org.sakaiproject.content.api.LockManager;
 import org.sakaiproject.content.impl.serialize.impl.conversion.Type1BlobCollectionConversionHandler;
@@ -168,6 +165,33 @@ public class DbContentService extends BaseContentService
     /*************************************************************************************************************************************************
      * Constructors, Dependencies and their setter methods
      ************************************************************************************************************************************************/
+
+    /**
+     * The file system handler to use when files are not stored in the database.
+     */
+    private FileSystemHandler fileSystemHandler = new DefaultFileSystemHandler();
+
+    /**
+     * Get the file system handler to use when files are not stored in the database.
+     * <p/>
+     * This can be null if files are stored in the database.
+     * <p/>
+     * The Default is DefaultFileSystemHandler.
+     */
+    public FileSystemHandler getFileSystemHandler(){
+        return fileSystemHandler;
+    }
+
+    /**
+     * Set the file system handler to use when files are not stored in the database.
+     * <p/>
+     * This can be null if files are stored in the database.
+     * <p/>
+     * The Default is DefaultFileSystemHandler.
+     */
+    public void setFileSystemHandler(FileSystemHandler fileSystemHandler){
+        this.fileSystemHandler = fileSystemHandler;
+    }
 
     /** Dependency: LockManager */
     protected LockManager m_lockManager = null;
@@ -436,6 +460,12 @@ public class DbContentService extends BaseContentService
             {
                 m_convertToFile = false;
                 convertToFile();
+            }
+
+            //Check that there is a valid file system handler
+            if (m_bodyPath != null && fileSystemHandler == null)
+            {
+                throw new IllegalStateException("There is no FileSystemHandler set for the ContentService!");
             }
 
             M_log.info("init(): tables: " + m_collectionTableName + " " + m_resourceTableName + " " + m_resourceBodyTableName + " "
@@ -1906,16 +1936,7 @@ public class DbContentService extends BaseContentService
                    // if we have been configured to use an external file system
                    if (m_bodyPath != null)
                    {
-                       if (m_bodyPathDeleted != null) {
-                           // form the file name
-                           File file = new File(externalResourceFileName(m_bodyPathDeleted, edit));
-
-                           // delete
-                           if (file.exists())
-                           {
-                               file.delete();
-                           }                   
-                       }
+                       delResourceBodyFilesystem(m_bodyPathDeleted, edit);
                    }
 
                    // otherwise use the database
@@ -2101,7 +2122,7 @@ public class DbContentService extends BaseContentService
 					   // if we have been configured to use an external file system
 					   if (removeContent) {
 						   M_log.info("Removing resource ("+edit.getId()+") content: "+m_bodyPath);
-						   delResourceBodyFilesystem(edit);
+						   delResourceBodyFilesystem(m_bodyPath, edit);
 					   } else {
 						   M_log.info("Removing original resource reference ("+edit.getId()+") without removing the actual content: "+m_bodyPath);
 					   }
@@ -2290,35 +2311,29 @@ public class DbContentService extends BaseContentService
         /**
          * Return an input stream.
          * 
-         * @param resource -
-         *        the resource for the stream It is a non-fatal error for the file not to be readible as long as the resource's expected length is
-         *        zero. We check for the body length *after* we try to read the file. If the file
-         *        is readible, we simply read it and return it as the body.
+         * @param resource the resource to resolve to a stream
+         *        It is a non-fatal error for the file not to be readible as long as the resource's expected length is
+         *        zero. In this case, a null stream is returned. Otherwise, attempt to prepare a stream for reading the
+         *        file body and fail with an exception on error.
          */
 
         protected InputStream streamResourceBodyFilesystem(String rootFolder, ContentResource resource) throws ServerOverloadException
         {
-            // form the file name
-            File file = new File(externalResourceFileName(rootFolder,resource));
+            if (((BaseResourceEdit) resource).m_contentLength == 0)
+            {
+                // Zero-length files are not written, so don't bother checking the filesystem.
+                return null;
+            }
 
-            // read the new
             try
             {
-                FileInputStream in = new FileInputStream(file);
-                return in;
+                return fileSystemHandler.getInputStream(((BaseResourceEdit) resource).m_id, rootFolder, ((BaseResourceEdit) resource).m_filePath);
             }
-            catch (FileNotFoundException t)
+            catch (IOException e)
             {
-                // If there is not supposed to be data in the file - simply return null
-                if (((BaseResourceEdit) resource).m_contentLength == 0)
-                {
-                    return null;
-                }
-
                 // If we have a non-zero body length and reading failed, it is an error worth of note
-                M_log.warn(": failed to read resource: " + resource.getId() + " len: " + ((BaseResourceEdit) resource).m_contentLength + " : " + t);
-                throw new ServerOverloadException("failed to read resource body");
-                // return null;
+                M_log.warn("Failed to read resource: " + resource.getId() + " len: " + ((BaseResourceEdit) resource).m_contentLength, e);
+                throw new ServerOverloadException("Failed to read resource body", e);
             }
         }
 
@@ -2453,91 +2468,23 @@ public class DbContentService extends BaseContentService
          */
         private boolean putResourceBodyFilesystem(ContentResourceEdit resource, InputStream stream, String rootFolder)
         {
-			// Do not create the files for resources with zero length bodies
-			if ((stream == null)) return true;
-
-			// form the file name
-			File file = new File(externalResourceFileName(rootFolder, resource));
-
-			// delete the old
-			if (file.exists())
-			{
-				file.delete();
-			}
-
-			FileOutputStream out = null;
-
-			// add the new
-			try
-			{
-				// make sure all directories are there
-				File container = file.getParentFile();
-				if (container != null)
-				{
-					container.mkdirs();
-				}
-
-				// write the file
-				out = new FileOutputStream(file);
-
-				long byteCount = 0;
-				// chunk
-				byte[] chunk = new byte[STREAM_BUFFER_SIZE];
-				int lenRead;
-				while ((lenRead = stream.read(chunk)) != -1)
-				{
-					out.write(chunk, 0, lenRead);
-					byteCount += lenRead;
-				}
-
-				resource.setContentLength(byteCount);
-				ResourcePropertiesEdit props = resource.getPropertiesEdit();
-				props.addProperty(ResourceProperties.PROP_CONTENT_LENGTH, Long.toString(byteCount));
-				if (resource.getContentType() != null)
-				{
-					props.addProperty(ResourceProperties.PROP_CONTENT_TYPE, resource.getContentType());
-				}
-			}
-			// catch (Throwable t)
-			// {
-			// M_log.warn(": failed to write resource: " + resource.getId() + " : " + t);
-			// return false;
-			// }
-			catch (IOException e)
-			{
-				M_log.warn("IOException", e);
-				return false;
-			}
-			finally
-			{
-				if (stream != null)
-				{
-					try
-					{
-						stream.close();
-					}
-					catch (IOException e)
-					{
-						// TODO Auto-generated catch block
-						M_log.warn("IOException ", e);
-					}
-				}
-
-				if (out != null)
-				{
-					try
-					{
-						out.close();
-					}
-					catch (IOException e)
-					{
-						// TODO Auto-generated catch block
-						M_log.warn("IOException ", e);
-					}
-				}
-			}
-
-			return true;
+            try
+            {
+                long byteCount = fileSystemHandler.saveInputStream(((BaseResourceEdit) resource).m_id, rootFolder, ((BaseResourceEdit) resource).m_filePath, stream);
+                resource.setContentLength(byteCount);
+                ResourcePropertiesEdit props = resource.getPropertiesEdit();
+                props.addProperty(ResourceProperties.PROP_CONTENT_LENGTH, Long.toString(byteCount));
+                if (resource.getContentType() != null)
+                {
+                    props.addProperty(ResourceProperties.PROP_CONTENT_TYPE, resource.getContentType());
+                }
+                return true;
+            }
+            catch (IOException e)
+            {
+                M_log.warn("IOException", e);
+                return false;
+            }
         }
 
         /**
@@ -2585,16 +2532,9 @@ public class DbContentService extends BaseContentService
          * @param resource
          *        The resource whose body is being written.
          */
-        protected void delResourceBodyFilesystem(ContentResourceEdit resource)
+        protected void delResourceBodyFilesystem(String rootFolder, ContentResourceEdit resource)
         {
-            // form the file name
-            File file = new File(externalResourceFileName(m_bodyPath,resource));
-
-            // delete
-            if (file.exists())
-            {
-                file.delete();
-            }
+            fileSystemHandler.delete(((BaseResourceEdit) resource).m_id, rootFolder, ((BaseResourceEdit) resource).m_filePath);
         }
 
         public int getMemberCount(String collectionId)
@@ -2796,18 +2736,6 @@ public class DbContentService extends BaseContentService
         }
 
     } // DbStorage
-
-    /**
-     * Form the full file path+name used to store the resource body in an external file system.
-     * 
-     * @param resource
-     *        The resource.
-     * @return The resource external file name.
-     */
-    protected String externalResourceFileName(String rootFolder, ContentResource resource)
-    {
-        return rootFolder + ((BaseResourceEdit) resource).m_filePath;
-    }
 
     @SuppressWarnings("unchecked")
     public Map<String, Long> getMostRecentUpdate(String id) 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DefaultFileSystemHandler.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DefaultFileSystemHandler.java
@@ -1,0 +1,91 @@
+package org.sakaiproject.content.impl;
+
+import org.sakaiproject.content.api.FileSystemHandler;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.util.FileCopyUtils;
+
+/**
+ * The default implementation of FileSystemHandler, targeting local disk.
+ *
+ * This class read and writes content files to local filesystem paths.
+ */
+public class DefaultFileSystemHandler implements FileSystemHandler {
+    private boolean useIdForFilePath = false;
+
+    /**
+     * Default constructor.
+     */
+    public DefaultFileSystemHandler() {
+    }
+
+    /**
+     * Whether to use the id for the file path.
+     */
+    public void setUseIdForFilePath(boolean useIdForFilePath){
+        this.useIdForFilePath = useIdForFilePath;
+    }
+
+    /**
+     * A Helper method to get the File object for the parameters.
+     * This method will look at the property useIdForFilePath to see if the
+     * id must be used in the file path.
+     * 
+     * @param id The id of the resource.
+     * @param root The root of the storage.
+     * @param filePath The path to save the file to.
+     * @return The File object.
+     */
+    private File getFile(String id, String root, String filePath){
+        if (useIdForFilePath) {
+            return new File(root, id);
+        } else {
+            return new File(root, filePath);
+        }
+    }
+
+    @Override
+    public InputStream getInputStream(String id, String root, String filePath) throws IOException {
+        return new FileInputStream(getFile(id, root, filePath));
+    }
+
+    @Override
+    public long saveInputStream(String id, String root, String filePath, InputStream stream) throws IOException {
+        // Do not create the files for resources with zero length bodies
+        if ((stream == null)) {
+            return 0L;
+        }
+
+        // form the file name
+        File file = getFile(id, root, filePath);
+
+        // delete the old
+        if (file.exists()) {
+            file.delete();
+        }
+
+        // add the new
+        // make sure all directories are there
+        File parent = file.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+
+        // write the file
+        return FileCopyUtils.copy(stream, new FileOutputStream(file));
+    }
+
+    @Override
+    public boolean delete(String id, String root, String filePath){
+        File file = getFile(id, root, filePath);
+
+        // delete
+        if (file.exists()) {
+            return file.delete();
+        }
+        return false;
+    }
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/util/StorageConverter.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/util/StorageConverter.java
@@ -1,0 +1,409 @@
+package org.sakaiproject.content.impl.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils.MethodUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.content.api.FileSystemHandler;
+import org.sakaiproject.content.impl.ContentServiceSqlDefault;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * This is a utility class to convert the storage from one FileSystem to
+ * another.
+ *
+ * @author Jaques
+ */
+public class StorageConverter {
+    private static final Log log = LogFactory.getLog(StorageConverter.class);
+
+    /**
+     * The datasource for the database connections.
+     */
+    private DataSource dataSource;
+
+    /**
+     * The connection to the database.
+     */
+    private Connection connection;
+
+    /**
+     * The database connection driver.
+     */
+    private String connectionDriver;
+
+    /**
+     * The database connection URL.
+     */
+    private String connectionURL;
+
+    /**
+     * The database connection username.
+     */
+    private String connectionUsername;
+
+    /**
+     * The database connection password.
+     */
+    private String connectionPassword;
+
+    /**
+     * The sql to retrieve the content id's and paths.
+     * The id field must be the first field.
+     * The path field must be the second field.
+     */
+    private String contentSql = new ContentServiceSqlDefault().getResourceIdAndFilePath();
+
+    /**
+     * The root body path for the source resources.
+     */
+    private String sourceBodyPath;
+
+    /**
+     * The root body path for the destination resources.
+     */
+    private String destinationBodyPath;
+
+    /**
+     * The source file system handler.
+     */
+    private FileSystemHandler sourceFileSystemHandler;
+
+    /**
+     * The destination file system handler.
+     */
+    private FileSystemHandler destinationFileSystemHandler;
+
+    /**
+     * Whether to delete the resources from the source.
+     */
+    private boolean deleteFromSource = false;
+
+    /**
+     * Whether to ignore missing resources.
+     */
+    private boolean ignoreMissing = true;
+
+    /**
+     * Set the datasource for the database connections.
+     * Either the datasource, connection or the connection details (driver, url,
+     * username and password) must be set.
+     */
+    public void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * Set the connection to the database.
+     * Either the datasource, connection or the connection details (driver, url,
+     * username and password) must be set.
+     */
+    public void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * Set the database connection driver.
+     * Either the datasource, connection or the connection details (driver, url,
+     * username and password) must be set.
+     */
+    public void setConnectionDriver(String connectionDriver) {
+        this.connectionDriver = connectionDriver;
+    }
+
+    /**
+     * Set the database connection URL.
+     * Either the datasource, connection or the connection details (driver, url,
+     * username and password) must be set.
+     */
+    public void setConnectionURL(String connectionURL) {
+        this.connectionURL = connectionURL;
+    }
+
+    /**
+     * Set the database connection username.
+     * Either the datasource, connection or the connection details (driver, url,
+     * username and password) must be set.
+     */
+    public void setConnectionUsername(String connectionUsername) {
+        this.connectionUsername = connectionUsername;
+    }
+
+    /**
+     * Set the database connection password.
+     * Either the datasource, connection or the connection details (driver, url,
+     * username and password) must be set.
+     */
+    public void setConnectionPassword(String connectionPassword) {
+        this.connectionPassword = connectionPassword;
+    }
+
+    /**
+     * Set the sql to retrieve the content id's and paths.
+     * The id field must be the first field.
+     * The path field must be the second field.
+     */
+    public void setContentSql(String contentSql) {
+        this.contentSql = contentSql;
+    }
+
+    /**
+     * Set the root body path for the source resources.
+     */
+    public void setSourceBodyPath(String sourceBodyPath) {
+        this.sourceBodyPath = sourceBodyPath;
+    }
+
+    /**
+     * Set the root body path for the destination resources.
+     */
+    public void setDestinationBodyPath(String destinationBodyPath) {
+        this.destinationBodyPath = destinationBodyPath;
+    }
+
+    /**
+     * Set the source file system handler.
+     */
+    public void setSourceFileSystemHandler(FileSystemHandler source) {
+        this.sourceFileSystemHandler = source;
+    }
+
+    /**
+     * Set the destination file system handler.
+     */
+    public void setDestinationFileSystemHandler(FileSystemHandler destination) {
+        this.destinationFileSystemHandler = destination;
+    }
+
+    /**
+     * Set whether to delete the resources from the source.
+     */
+    public void setDeleteFromSource(boolean deleteFromSource) {
+        this.deleteFromSource = deleteFromSource;
+    }
+
+    /**
+     * Setup the datasource. THis method first look for a valid datasource,
+     * then a connection and lastly will create a datasource from the
+     * connection details.
+     */
+    private void setupDataSource() throws IllegalStateException {
+        if (dataSource != null) {
+            return;
+        }
+        if (connection != null) {
+            dataSource = new SingleConnectionDataSource(connection, false);
+            return;
+        }
+        try {
+            Class.forName(connectionDriver);
+            dataSource = new SimpleDriverDataSource(DriverManager.getDriver(connectionURL), connectionURL, connectionUsername, connectionPassword);
+        } catch (Exception e) {
+            throw new IllegalStateException("Either a valid datasource, connection or the connection details must be set!", e);
+        }
+    }
+
+    /**
+     * Transfer the resources from the source file system handler to the
+     * destination.
+     */
+    public void convertStorage() {
+        log.info("Start converting storage....");
+        setupDataSource();
+        if (sourceFileSystemHandler == null) {
+            throw new IllegalStateException("The source FileSystemHandler must be set!");
+        }
+        if (destinationFileSystemHandler == null) {
+            throw new IllegalStateException("The destination FileSystemHandler must be set!");
+        }
+        final AtomicInteger counter = new AtomicInteger(0);
+        // read content_resource records that have null file path
+        JdbcTemplate template = new JdbcTemplate(dataSource);
+        template.query(contentSql, new RowCallbackHandler() {
+            public void processRow(ResultSet resultSet) throws SQLException {
+                counter.incrementAndGet();
+                String id = resultSet.getString(1);
+                String path = resultSet.getString(2);
+                try {
+                    InputStream input = sourceFileSystemHandler.getInputStream(id, sourceBodyPath, path);
+                    if (input != null) {
+                        destinationFileSystemHandler.saveInputStream(id, destinationBodyPath, path, input);
+                    }
+                    if (deleteFromSource) {
+                        sourceFileSystemHandler.delete(id, sourceBodyPath, path);
+                    }
+                } catch (IOException e) {
+                    if (ignoreMissing) {
+                        print("Missing file: " + id);
+                    } else {
+                        log.error("Failed to read or write resources from or to the FileSystemHandlers", e);
+                        throw new SQLException("Failed to read or write resources from or to the FileSystemHandlers", e);
+                    }
+                }
+            }
+        });
+        log.info("Converted " + counter.get() + " records....");
+        log.info("Finished converting storage....");
+    }
+
+    public static void main(String[] args) throws IOException, ClassNotFoundException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, InstantiationException{
+        print("Checking arguments...");
+        if (args == null || args.length == 0 || args[0].contains("help")) {
+            printHelp();
+            return;
+        }
+
+        Properties p = readProperties(args);
+        print("Properties: " + p);
+        StorageConverter sc = new StorageConverter();
+        FileSystemHandler sourceFSH = null;
+        FileSystemHandler destinationFSH = null;
+
+        try {
+            print("Database connection...");
+            sc.setConnectionDriver(p.getProperty("connectionDriver"));
+            sc.setConnectionURL(p.getProperty("connectionURL"));
+            sc.setConnectionUsername(p.getProperty("connectionUsername"));
+            sc.setConnectionPassword(p.getProperty("connectionPassword"));
+            print("Source FileSystemHandler...");
+            sourceFSH = getFileSystemHandler(p, "sourceFileSystemHandler");
+            sc.setSourceBodyPath(p.getProperty("sourceBodyPath"));
+            sc.setSourceFileSystemHandler(sourceFSH);
+            sc.setDeleteFromSource(Boolean.parseBoolean(p.getProperty("deleteFromSource")));
+            print("Destination FileSystemHandler...");
+            destinationFSH = getFileSystemHandler(p, "destinationFileSystemHandler");
+            sc.setDestinationBodyPath(p.getProperty("destinationBodyPath"));
+            sc.setDestinationFileSystemHandler(destinationFSH);
+
+            if(p.containsKey("contentSql")){
+                sc.setContentSql(p.getProperty("contentSql"));
+            }
+
+            print("Running convert...");
+            sc.convertStorage();
+            print("Done...");
+        } finally {
+            destroy(sourceFSH);
+            destroy(destinationFSH);
+        }
+    }
+
+    /**
+     * Calls the objects destroy method is it exists.
+     */
+    private static void destroy(Object o) throws IllegalAccessException, InvocationTargetException {
+        if (o == null) return;
+        print("Destroying " + o + "...");
+        try {
+            print("Check if there is a destroy method...");
+            MethodUtils.invokeExactMethod(o, "destroy", (Object[])null);
+            print("destroy method invoked...");
+        } catch (NoSuchMethodException e) {
+            print("No destroy method...");
+        }
+    }
+
+    /**
+     * Creates the FileSystemHandler and set all its properties.
+     * Will also call the init method if it exists.
+     */
+    private static FileSystemHandler getFileSystemHandler(Properties p, String fileSystemHandlerName) throws ClassNotFoundException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, InstantiationException{
+        String clazz = p.getProperty(fileSystemHandlerName);
+        print("Building FileSystemHandler: " + clazz);
+        Class<? extends FileSystemHandler> fshClass = Class.forName(clazz).asSubclass(FileSystemHandler.class);
+        FileSystemHandler fsh = fshClass.newInstance();
+
+        Enumeration<String> propertyNames = (Enumeration<String>) p.propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            String fullProperty = propertyNames.nextElement();
+            if (fullProperty.startsWith(fileSystemHandlerName + ".")) {
+                String property = fullProperty.substring(fullProperty.indexOf(".")+1);
+                print("Setting property: " + property);
+                BeanUtils.setProperty(fsh, property, p.getProperty(fullProperty));
+            }
+        }
+
+        try {
+            print("Check if there is a init method...");
+            MethodUtils.invokeExactMethod(fsh, "init", (Object[])null);
+            print("init method invoked...");
+        } catch (NoSuchMethodException e) {
+            print("No init method...");
+        }
+        print("Done with FileSystemHandler: " + clazz);
+        return fsh;
+    }
+
+    /**
+     * Read the properties file. Return null of the file is not found.
+     */
+    private static Properties readProperties(String[] args) throws IOException {
+        Properties p = new Properties(){
+
+            @Override
+            public String getProperty(String key) {
+                String prop = super.getProperty(key);
+                print("- Property " + key + "='" + prop + "'");
+                return prop;
+            }
+
+        };
+        for(int i = 0; i < args.length; i++){
+            if("-p".equals(args[i])){
+                p.load(new FileInputStream(new File(args[++i])));
+            }
+            if(args[i].startsWith("-")){
+                p.put(args[i].substring(1), args[++i]);
+            }
+        }
+        return p;
+    }
+
+    private static void printHelp(){
+        print("----------------------------------------------------------------------");
+        print("StorageConverter Help");
+        print("The StorageConverter needs properties to complete the conversion.");
+        print("These properties can either be loaded in a properties file indicated with '-p' followed by the location of the properties file");
+        print("or the properties specified in the arguments with a leading '-' followed by the values.");
+        print("");
+        print("Properties (mandatory):");
+        print("- connectionDriver: The database connection driver class.");
+        print("- connectionURL: The database connection URL.");
+        print("- connectionUsername: The database connection username.");
+        print("- connectionPassword: The database connection password.");
+        print("- sourceFileSystemHandler: This is the full class name of the source FileSystemHandler.");
+        print("- sourceFileSystemHandler.<some property>: You can set any property on the source FileSystemHandler by referensing their property names.");
+        print("- sourceBodyPath: The path set in sakai.properties for the source.");
+        print("- destinationFileSystemHandler: This is the full class name of the destination FileSystemHandler.");
+        print("- destinationFileSystemHandler.<some property>: You can set any property on the destination FileSystemHandler by referensing their property names.");
+        print("- destinationBodyPath: The path set in sakai.properties for the destination.");
+        print("");
+        print("Properties (optional):");
+        print("- deleteFromSource: Whether to delete the source files. Default false.");
+        print("- contentSql: The sql statement to retrieve the resource id's and paths. Default is new ContentServiceSqlDefault().getResourceIdAndFilePath()");
+        print("----------------------------------------------------------------------");
+    }
+
+    /**
+     * Print the text to the screen.
+     */
+    private static void print(String text){
+        System.out.println(text);
+    }
+}

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -511,7 +511,15 @@
     </resources>
 
     <plugins>
-
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+            <configuration>
+                <executable>java</executable>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
 		<plugin>
 			<inherited>true</inherited>
 			<groupId>org.sakaiproject.maven.plugins</groupId>


### PR DESCRIPTION
Thanks to OpenCollab ZA for the patch.

This makes way for filesystems other than local (or mapped) disk, such
as OpenStack Swift.

A new interface is added, FileSystemHandler, along with extracting the
default file implementation. I made a few fixes to update the patch and
clean up a few stylistic things to fit into the kernel code better, but
there are no name or design changes.

All tests are passing and I have verified that DB and the local file backend are working as usual. The next step will be to test out the alternate backend implementation for Swift and verify if OpenCollab has made any adjustments since this patch was supplied.