### PR TITLE
SAK-29248 Add API method to allow retrieving a sorted list of gradebook assignments

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -199,7 +199,14 @@ public interface GradebookService {
 	 * @return Returns a list of Assignment objects describing the assignments
 	 *         that are currently defined in the given gradebook.
 	 */
-	public List getAssignments(String gradebookUid)
+	public List<Assignment> getAssignments(String gradebookUid)
+			throws GradebookNotFoundException;
+	
+	/**
+	 * @return Returns a list of Assignment objects describing the assignments
+	 *         that are currently defined in the given gradebook, sorted by the given sort type.
+	 */
+	public List<Assignment> getAssignments(String gradebookUid, SortType sortBy)
 			throws GradebookNotFoundException;
 
 	/**

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/SortType.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/SortType.java
@@ -1,0 +1,20 @@
+package org.sakaiproject.service.gradebook.shared;
+
+/**
+ * Represents the different ways an (internal) Assignment can be sorted
+ * 
+ * @author Steve Swinsburg (steve.swinsburg@gmail.com)
+ *
+ */
+public enum SortType {
+
+	SORT_BY_NONE, //no explicit sorting
+	SORT_BY_DATE,
+	SORT_BY_NAME,
+	SORT_BY_MEAN,
+	SORT_BY_POINTS,
+	SORT_BY_RELEASED,
+	SORT_BY_COUNTED,
+	SORT_BY_EDITOR,
+	SORT_BY_SORTING; //default
+}

--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/Assignment.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/Assignment.java
@@ -38,15 +38,18 @@ import org.sakaiproject.service.gradebook.shared.GradebookService;
  */
 public class Assignment extends GradableObject {
 
-    public static String SORT_BY_DATE = "dueDate";
-    public static String SORT_BY_NAME = "name";
-    public static String SORT_BY_MEAN = "mean";
-    public static String SORT_BY_POINTS = "pointsPossible";
-    public static String SORT_BY_RELEASED ="released";
-    public static String SORT_BY_COUNTED = "counted";
-    public static String SORT_BY_EDITOR = "gradeEditor";
-    public static String SORT_BY_SORTING = "sorting";
-    public static String DEFAULT_SORT = SORT_BY_SORTING;
+	/**
+	 * use the SortType enum instead. This remains only for the gradebook tool
+	 */
+	@Deprecated public static String SORT_BY_DATE = "dueDate";
+	@Deprecated public static String SORT_BY_NAME = "name";
+	@Deprecated public static String SORT_BY_MEAN = "mean";
+	@Deprecated public static String SORT_BY_POINTS = "pointsPossible";
+	@Deprecated public static String SORT_BY_RELEASED ="released";
+	@Deprecated public static String SORT_BY_COUNTED = "counted";
+	@Deprecated public static String SORT_BY_EDITOR = "gradeEditor";
+	@Deprecated public static String SORT_BY_SORTING = "sorting";
+	@Deprecated public static String DEFAULT_SORT = SORT_BY_SORTING;
     
     public static String item_type_points = "Points";
     public static String item_type_percentage = "Percentage";

--- a/gradebook/app/business/src/java/org/sakaiproject/tool/gradebook/business/impl/GradebookManagerHibernateImpl.java
+++ b/gradebook/app/business/src/java/org/sakaiproject/tool/gradebook/business/impl/GradebookManagerHibernateImpl.java
@@ -75,6 +75,8 @@ import org.sakaiproject.thread_local.cover.ThreadLocalManager;
 
 /**
  * Manages Gradebook persistence via hibernate.
+ * 
+ * Note that many of these methods are duplicates of those in the gradebook service API code.
  */
 public abstract class GradebookManagerHibernateImpl extends GradebookServiceHibernateImpl
         implements GradebookManager {


### PR DESCRIPTION
Add a SortType enum class and deprecate the strings in the internal Assignment class, but leave them in as they are used in the GB tool and has its own sorting. Wire up the sorting for the service.

https://jira.sakaiproject.org/browse/SAK-29248