### PR TITLE
SAK-29250 Strengthen wording of Turnitin alert

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -888,7 +888,14 @@ content_review.error.SUBMISSION_ERROR_RETRY_EXCEEDED_CODE = All attempts to subm
 content_review.pending.info = This attachment has been submitted and is pending review.
 
 content_review.error = An unknown error occurred. The originality review for this attachment is not available.
-content_review.error.createAssignment=An error with {0} has occurred while creating this assignment. {1} has saved the assignment in draft mode. Please try posting this assignment again later.
+
+content_review.error.createAssignment=An error with {0} has occurred while creating this assignment. {1} has saved the assignment in draft mode,\
+but Turnitin has identified a problem and the Originality Reports may not be returned. The problem may be due to the following:\
+<ul><li>Clash of assignment titles: If you have duplicated an assignment or used a similar title to one that exists in the Turnitin database, then rather create a brand new assignment with a new title.</li>\
+<li>Unauthorised site members: If anyone in the site has status 'Expired', or is an external user without having set their first name, surname, email address, either remove them, or ask them to set their personal details in My Dashboard > Account.</li>\
+</ul>\
++If this does not solve the problem, please contact {2}, giving the site URL and title of the assignment you are trying to create.
+
 content_review.note=<div><br /><em>NOTE:</em><ul><li>When submitting attachments, students should only use these file types: Word (.doc, .docx), PostScript (.ps), PDF (.pdf), HTML (.html), rich or plain text (.rtf, .txt).</li> <li>Students should always save files with the appropriate extension.</li> </ul></div>
 
 noti.releaseresubmission.subject.content=Email notification for assignment with resubmissions allowed

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -8936,14 +8936,15 @@ public class AssignmentAction extends PagedResourceActionII
         }
         try {
             contentReviewService.createAssignment(assign.getContext(), assignmentRef, opts);
-			return true;
+            return true;
         } catch (Exception e) {
             M_log.error(e);
-			String uiService = ServerConfigurationService.getString("ui.service", "Sakai");
-			String[] args = new String[]{contentReviewService.getServiceName(), uiService};
+            String uiService = ServerConfigurationService.getString("ui.service", "Sakai");
+            String supportEmail = ServerConfigurationService.getString("mail.support", null);
+            String[] args = new String[]{contentReviewService.getServiceName(), uiService, supportEmail};
             state.setAttribute("alertMessage", rb.getFormattedMessage("content_review.error.createAssignment", args));
         }
-		return false;
+        return false;
     }
 	
 


### PR DESCRIPTION
When this alert appears on saving an assignment, site owners tend to ignore it. Only later they contact us when TII reports fail to be generated:
"Alert: The assignment was saved, but Turnitin information was unable to be updated. Please try saving again."
Strengthen the wording so that they do something about it. 