### PR TITLE
SAK-29257 Allow sitestats update manager to be monitored over JMX

### DIFF
--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/StatsUpdateManager.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/StatsUpdateManager.java
@@ -163,7 +163,7 @@ public interface StatsUpdateManager {
 	public long getResetTime();
 	
 	/** Get the total time ellapsed, in milliseconds, since start */
-	public long getTotalTimeEllapsedSinceReset();
+	public long getTotalTimeElapsedSinceReset();
 	
 	/** Get the average number of events processed per second */
 	public double getNumberOfEventsProcessedPerSec();

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/StatsUpdateManagerMXBean.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/StatsUpdateManagerMXBean.java
@@ -1,0 +1,21 @@
+package org.sakaiproject.sitestats.api;
+
+/**
+ * Interface for exporting to JMX.
+ * This needs to be in the API so that it is accessible to the correct classloaders.
+ */
+public interface StatsUpdateManagerMXBean {
+    long getNumberOfEventsProcessed();
+
+    long getTotalTimeInEventProcessing();
+
+    long getResetTime();
+
+    long getTotalTimeElapsedSinceReset();
+
+    double getNumberOfEventsProcessedPerSec();
+
+    double getNumberOfEventsGeneratedPerSec();
+
+    long getAverageTimeInEventProcessingPerEvent();
+}

--- a/sitestats/sitestats-impl/src/bundle/site-stats-components.xml
+++ b/sitestats/sitestats-impl/src/bundle/site-stats-components.xml
@@ -80,15 +80,15 @@
 	</bean>
 	<!-- Transaction proxy: StatsManager -->
 	<bean id="org.sakaiproject.sitestats.api.StatsManagerTransactionProxyFactoryBean"
-		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">		
+		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="@{sitestats.db}SitestatsTransactionManager" />
 		<property name="target" ref="org.sakaiproject.sitestats.api.StatsManager"/>
 		<property name="transactionAttributes">
 			<props><prop key="*">PROPAGATION_REQUIRED</prop></props>
 		</property>
 	</bean>
-	
-	
+
+
 	<!-- EventRegistryService ______________________________________________________________________________ -->
 	<bean id="org.sakaiproject.sitestats.api.event.EventRegistryService"
 		class="org.sakaiproject.sitestats.impl.event.EventRegistryServiceImpl"
@@ -203,7 +203,6 @@
 	<bean id="org.sakaiproject.sitestats.api.StatsUpdateManager"
 		class="org.sakaiproject.sitestats.impl.StatsUpdateManagerImpl"
 		singleton="true"
-		lazy-init="true"
 		init-method="init"
 		destroy-method="destroy">
 		
@@ -233,14 +232,14 @@
 	</bean>
 	<!-- Transaction proxy: StatsUpdateManager -->
 	<bean id="org.sakaiproject.sitestats.api.StatsUpdateManagerTransactionProxyFactoryBean"
-		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">		
+		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="@{sitestats.db}SitestatsTransactionManager" />
 		<property name="target" ref="org.sakaiproject.sitestats.api.StatsUpdateManager"/>
 		<property name="transactionAttributes">
 			<props><prop key="*">PROPAGATION_REQUIRED</prop></props>
 		</property>
 	</bean>
-	
+
 
 	<!-- ServerWideReportManager ____________________________________________________________________________ -->
 	<bean id="org.sakaiproject.sitestats.api.ServerWideReportManager"
@@ -344,6 +343,29 @@
             <props><prop key="*">PROPAGATION_REQUIRED</prop></props>
         </property>
     </bean>
+
+	<bean id="org.sakaiproject.sitestats.impl.MBeanExporter"
+		  class="org.springframework.jmx.export.MBeanExporter" lazy-init="false">
+		<property name="beans">
+			<map>
+				<entry key="org.sakaiproject.sitestats.api:name=StatsUpdateManager"
+					   value-ref="org.sakaiproject.sitestats.api.StatsUpdateManager"/>
+			</map>
+		</property>
+		<!-- This doesn't work because it detects both the original bean and it's Transaction Proxy -->
+		<!--
+		<property name="autodetectModeName" value="AUTODETECT_MBEAN"/>
+		<property name="namingStrategy">
+			<bean class="org.springframework.jmx.export.naming.KeyNamingStrategy">
+				<property name="mappings">
+					<props>
+						<prop key="org.sakaiproject.sitestats.api.StatsUpdateManager">org.sakaiproject.sitestats.api:name=StatsUpdateManager</prop>
+					</props>
+				</property>
+			</bean>
+		</property>
+		 -->
+	</bean>
 
 
 	<!-- Hibernate objects api-impl mapping _________________________________________________________________________________________ -->

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -398,7 +398,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 		return resetTime;
 	}
 	
-	public long getTotalTimeEllapsedSinceReset() {
+	public long getTotalTimeElapsedSinceReset() {
 		return System.currentTimeMillis() - resetTime;
 	}
 	
@@ -411,7 +411,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 	}
 	
 	public double getNumberOfEventsGeneratedPerSec() {
-		double ellapsed = (double) getTotalTimeEllapsedSinceReset();
+		double ellapsed = (double) getTotalTimeElapsedSinceReset();
 		if(ellapsed > 0) {
 			return Util.round((double)totalEventsProcessed / (ellapsed/1000), 3);
 		}else{
@@ -433,7 +433,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 			sb.append("SiteStats Event aggregation metrics summary:\n");
 			sb.append("\t\tNumber of total events processed: ").append(getNumberOfEventsProcessed()).append("\n");
 			sb.append("\t\tReset/init time: ").append(new Date(getResetTime())).append("\n");
-			sb.append("\t\tTotal time ellapsed since reset: ").append(getTotalTimeEllapsedSinceReset()).append(" ms\n");
+			sb.append("\t\tTotal time ellapsed since reset: ").append(getTotalTimeElapsedSinceReset()).append(" ms\n");
 			sb.append("\t\tTotal time spent processing events: ").append(getTotalTimeInEventProcessing()).append(" ms\n");
 			sb.append("\t\tNumber of events processed per sec: ").append(getNumberOfEventsProcessedPerSec()).append("\n");
 			sb.append("\t\tNumber of events genereated in Sakai per sec: ").append(getNumberOfEventsGeneratedPerSec()).append("\n");
@@ -442,7 +442,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 			sb.append("\t\tIdle: ").append(isIdle());
 		}else{
 			sb.append("#Events processed: ").append(getNumberOfEventsProcessed()).append(", ");
-			sb.append("Time ellapsed since reset: ").append(getTotalTimeEllapsedSinceReset()).append(" ms, ");
+			sb.append("Time ellapsed since reset: ").append(getTotalTimeElapsedSinceReset()).append(" ms, ");
 			sb.append("Time spent processing events: ").append(getTotalTimeInEventProcessing()).append(" ms, ");
 			sb.append("#Events processed/sec: ").append(getNumberOfEventsProcessedPerSec()).append(", ");
 			sb.append("Avg. Time/event: ").append(getAverageTimeInEventProcessingPerEvent()).append(" ms, ");

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -53,17 +53,7 @@ import org.sakaiproject.event.api.UsageSessionService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
-import org.sakaiproject.sitestats.api.EventStat;
-import org.sakaiproject.sitestats.api.JobRun;
-import org.sakaiproject.sitestats.api.ResourceStat;
-import org.sakaiproject.sitestats.api.ServerStat;
-import org.sakaiproject.sitestats.api.SiteActivity;
-import org.sakaiproject.sitestats.api.SitePresence;
-import org.sakaiproject.sitestats.api.SiteVisits;
-import org.sakaiproject.sitestats.api.StatsManager;
-import org.sakaiproject.sitestats.api.StatsUpdateManager;
-import org.sakaiproject.sitestats.api.UserStat;
-import org.sakaiproject.sitestats.api.Util;
+import org.sakaiproject.sitestats.api.*;
 import org.sakaiproject.sitestats.api.event.EventRegistryService;
 import org.sakaiproject.sitestats.api.event.ToolInfo;
 import org.sakaiproject.sitestats.api.parser.EventParserTip;
@@ -74,7 +64,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 /**
  * @author <a href="mailto:nuno@ufp.pt">Nuno Fernandes</a>
  */
-public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runnable, StatsUpdateManager, Observer {
+public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runnable, StatsUpdateManager, Observer, StatsUpdateManagerMXBean {
 	private Log								LOG									= LogFactory.getLog(StatsUpdateManagerImpl.class);
 	private final static String				PRESENCE_SUFFIX						= "-presence";
 	private final static int				PRESENCE_SUFFIX_LENGTH				= PRESENCE_SUFFIX.length();
@@ -386,22 +376,27 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 		resetTime = System.currentTimeMillis();
 	}
 	
+	@Override
 	public long getNumberOfEventsProcessed() {
 		return totalEventsProcessed;
 	}
 	
+	@Override
 	public long getTotalTimeInEventProcessing() {
 		return totalTimeInEventProcessing;
 	}
 	
+	@Override
 	public long getResetTime() {
 		return resetTime;
 	}
-	
+
+	@Override
 	public long getTotalTimeElapsedSinceReset() {
 		return System.currentTimeMillis() - resetTime;
 	}
 	
+	@Override
 	public double getNumberOfEventsProcessedPerSec() {
 		if(totalTimeInEventProcessing > 0) {
 			return Util.round((double)totalEventsProcessed / ((double)totalTimeInEventProcessing/1000), 3);
@@ -410,6 +405,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 		}
 	}
 	
+	@Override
 	public double getNumberOfEventsGeneratedPerSec() {
 		double ellapsed = (double) getTotalTimeElapsedSinceReset();
 		if(ellapsed > 0) {
@@ -419,6 +415,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 		}
 	}
 	
+	@Override
 	public long getAverageTimeInEventProcessingPerEvent() {
 		if(totalEventsProcessed > 0) {
 			return totalTimeInEventProcessing / totalEventsProcessed;

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsMetricsEntityProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsMetricsEntityProvider.java
@@ -80,7 +80,7 @@ public class SiteStatsMetricsEntityProvider extends AbstractEntityProvider imple
 		Map<String,Object> map = new HashMap<String, Object>();
 		map.put("Number_of_total_events_processed", statsUpdateManager.getNumberOfEventsProcessed());
 		map.put("Reset_or_Init_time", (new Date(statsUpdateManager.getResetTime()).toString()) + "( " + statsUpdateManager.getResetTime() + " ms)");
-		map.put("Total_time_ellapsed_since_reset", statsUpdateManager.getTotalTimeEllapsedSinceReset() + " ms");
+		map.put("Total_time_ellapsed_since_reset", statsUpdateManager.getTotalTimeElapsedSinceReset() + " ms");
 		map.put("Total_time_spent_processing_events", statsUpdateManager.getTotalTimeInEventProcessing() + " ms");
 		map.put("Number_of_events_processed_per_sec", statsUpdateManager.getNumberOfEventsProcessedPerSec());
 		map.put("Number_of_events_generated_in_Sakai_per_sec", statsUpdateManager.getNumberOfEventsGeneratedPerSec());
@@ -114,7 +114,7 @@ public class SiteStatsMetricsEntityProvider extends AbstractEntityProvider imple
 	
 	@EntityCustomAction(action = "get-time-ellapsed-since-reset", viewKey = EntityView.VIEW_LIST)
 	public ActionReturn getTimeEllapsedSinceReset(Search search, Map<String, Object> params) {
-		return new ActionReturn(statsUpdateManager.getTotalTimeEllapsedSinceReset());
+		return new ActionReturn(statsUpdateManager.getTotalTimeElapsedSinceReset());
 	}
 	
 	@EntityCustomAction(action = "get-time-spent-processing-events", viewKey = EntityView.VIEW_LIST)


### PR DESCRIPTION
Done in 2 commits so it's clear which was just correcting a typo in a method name and which actually adds the JMX support.