### PR TITLE
SAK-28084 Add back in the check it’s not a GET.

### DIFF
--- a/authz/authz-tool/tool/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
+++ b/authz/authz-tool/tool/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
@@ -546,6 +546,11 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 	{
 		SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
 
+		if (!"POST".equals(data.getRequest().getMethod())) {
+			M_log.warn("PermissionsAction.doSave: user did not submit with a POST! IP=" + data.getRequest().getRemoteAddr());
+			return;
+		}
+
 		// only save the view realm's roles
 		AuthzGroup edit = (AuthzGroup) state.getAttribute(STATE_VIEW_REALM_EDIT);
 		if (edit == null)


### PR DESCRIPTION
This shouldn’t have been removed during the initial work as it stops someone changing permissions with a GET.