### PR TITLE
portal.error.showdetail is incorrectly documented.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -840,8 +840,8 @@
 
 # Certain institutions consider Sakai error messages as overly verbose, revealing technical information that is not relevant to the user (e.g., stack traces, SQL error messages, etc.).  
 # You can limit such disclosures by setting portal.error.showdetail to false.
-# DEFAULT: true
-# portal.error.showdetail=false
+# DEFAULT: false
+# portal.error.showdetail=true
 
 # Filter properties when performing a site export
 # To exclude properties with the string 'secret' or 'password' in the resulting site.xml file.


### PR DESCRIPTION
The default in the code is false (not to show stack traces to users), but 
it is currently documented as false. This updates the documentation to
follow the code.

