### PR TITLE
SAK-29269 Hide non-assignable roles

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/AuthzGroupService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/AuthzGroupService.java
@@ -487,6 +487,13 @@ public interface AuthzGroupService extends EntityProducer
      * @return List containing the currently registered AuthzGroupAdvisors
      */
     public List<AuthzGroupAdvisor> getAuthzGroupAdvisors();
+
+    /**
+     * Check if the supplied role can be assigned to a user.
+     * @param roleId The role ID to check.
+     * @return <code>true</code> if the role can be assigned to a user.
+     */
+    public boolean isRoleAssignable(String roleId);
 	
 	/**
 	 * Get a nice display name for role. 

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteParticipantHelper.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteParticipantHelper.java
@@ -596,6 +596,9 @@ public class SiteParticipantHelper {
 		// Loop through all the roles for this site type
 		for( Role role : allRolesForSiteType )
 		{
+			if (!authzGroupService.isRoleAssignable(role.getId())) {
+				continue;
+			}
 			// If the user is an admin, or if the properties weren't found (empty set), just add the role to the list
 			if( securityService.isSuperUser() || restrictedRoles.isEmpty() )
 			{


### PR DESCRIPTION
Non-assignable roles, such as .anon and .auth, are now hidden during
participant addition.