### PR TITLE
Revert "SAM-2544: Provide better error messaging when selected groups fo...

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages.properties
@@ -39,7 +39,6 @@ entire_site=Entire Site
 # bjones86 - OWL-1146
 selected_groups=Selected Groups
 selected_group=Selected Group
-no_selected_groups_error=Students are not able to take this assessment because the groups it was released to have been deleted. You must publish a new copy of this assessment.
 
 header_last_modified=Last Modified
 header_last_modified_date=Modified Date

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex.jsp
@@ -410,10 +410,9 @@ $(document).ready(function() {
       
         <t:div rendered="#{publishedAssessment.releaseTo eq 'Selected Groups'}">
             <t:div id="groupsHeader" onclick="#{publishedAssessment.groupCount gt 0 ? 'toggleGroups( this );' : ''}" styleClass="#{publishedAssessment.groupCount ge 1 ? 'collapse' : 'alertMessage'}">
-                <h:outputText value="#{publishedAssessment.groupCount} " rendered ="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount gt 0}" />
-                <h:outputText value="#{authorFrontDoorMessages.selected_groups} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount gt 1}"/>
+                <h:outputText value="#{publishedAssessment.groupCount} " rendered ="#{publishedAssessment.releaseTo eq 'Selected Groups'}" />
+                <h:outputText value="#{authorFrontDoorMessages.selected_groups} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and (publishedAssessment.groupCount gt 1 or publishedAssessment.groupCount eq 0)}"/>
                 <h:outputText value="#{authorFrontDoorMessages.selected_group} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount eq 1}"/>
-                <h:outputText value="#{authorFrontDoorMessages.no_selected_groups_error}" rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount eq 0}"/>
             </t:div>
             <t:div id="groupsPanel" style="display: none;">
                 <t:dataList layout="unorderedList" value="#{publishedAssessment.releaseToGroupsList}" var="group">


### PR DESCRIPTION
Reverts sakaiproject/sakai#433

Paul, I'm still only ever seeing the '0 Selected Groups' message rather than the newly introduced one. Let's take another look at this tomorrow.