### PR TITLE
SAK-25903 Update to released reflectutils.

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -116,7 +116,7 @@
     <sakairsf.components.version>11-SNAPSHOT</sakairsf.components.version>
     <sakairsf.version>11-SNAPSHOT</sakairsf.version>
     <generic-dao.version>0.9.18</generic-dao.version>
-    <reflectutils.version>0.9.20-SNAPSHOT</reflectutils.version>
+    <reflectutils.version>0.9.20</reflectutils.version>
     <!-- Sakai modules that are versioned separately -->
     <!-- lessonbuilder tool pom depends on msgcntr ver prop. Need to add a profile to the LB tool pom to mark change between 10.x master and earlier versions -->
     <sakai.msgcntr.version>11-SNAPSHOT</sakai.msgcntr.version> 


### PR DESCRIPTION
Now that there's a released version we should use that to improve the stability of the build and reduce the number of checks for artifacts maven makes.