### PR TITLE
SAK-29263: Errors in the content tool (Resources) are not displayed in UI

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -8328,21 +8328,28 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		{
 			pipe.setErrorEncountered(true);
 			pipe.setErrorMessage(trb.getString("alert.noperm"));
+			addAlert(pipe.getErrorMessage());
 			logger.warn("PermissionException " + e);
 		}
 		catch (IdUnusedException e)
 		{
 			pipe.setErrorEncountered(true);
+			pipe.setErrorMessage(trb.getString("alert.unknown"));
+			addAlert(pipe.getErrorMessage());
 			logger.warn("IdUnusedException ", e);
 		}
 		catch (TypeException e)
 		{
 			pipe.setErrorEncountered(true);
+			pipe.setErrorMessage(trb.getString("alert.unknown"));
+			addAlert(pipe.getErrorMessage());
 			logger.warn("TypeException ", e);
 		}
 		catch (InUseException e)
 		{
 			pipe.setErrorEncountered(true);
+			pipe.setErrorMessage(trb.getString("alert.unknown"));
+			addAlert(pipe.getErrorMessage());
 			logger.warn("InUseException ", e);
 		}
 		catch (OverQuotaException e)


### PR DESCRIPTION
Error message for permissions was set, but not alerted.
I change it to invoke the addAlert method with the error message.
When message is not set, I set the message "alert.unknown".