### PR TITLE
SAK-29286 - Fix javadocs for java 8

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -63,6 +63,10 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
+                <configuration>
+                  <additionalparam>-Xdoclint:none</additionalparam>
+                  <failOnError>false</failOnError>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -188,13 +188,17 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.7</version>
+            <version>2.10.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
                 <goals>
                   <goal>jar</goal>
                 </goals>
+                <configuration>
+                  <additionalparam>-Xdoclint:none</additionalparam>
+                  <failOnError>false</failOnError>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -1570,7 +1574,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
+          <version>2.10.3</version>
           <configuration>
             <debug>false</debug>
             <links>
@@ -1582,6 +1586,8 @@
             <verbose>false</verbose>
             <minmemory>256m</minmemory>
             <maxmemory>2048m</maxmemory>
+            <additionalparam>-Xdoclint:none</additionalparam>
+            <failOnError>false</failOnError>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This looks like it produces a nearly complete javadoc. There are a few errors during the generation so I'm adding <failOnError>false</failOnError> so we could look into those and fix them, but I didn't see too many. There are a lot of warnings too.

Also upgraded to the latest version.
