### PR TITLE
Use more accurate variable name for window name.

### DIFF
--- a/reference/library/src/webapp/js/headscripts.js
+++ b/reference/library/src/webapp/js/headscripts.js
@@ -34,9 +34,9 @@ function inIframe () {
 	}
 }
 
-function openWindow(url, title, options)
+function openWindow(url, name, options)
 {
-	var win = top.window.open(url, title.replace(/[ -]+/g, ''), options);
+	var win = top.window.open(url, name.replace(/[ -]+/g, ''), options);
 	win.focus();
 	return win;
 }


### PR DESCRIPTION
The second argument to openWindow() is the name of the window that should
be opened, however at the moment it’s called title which is very misleading
as it is actually the window name and not the title.

https://developer.mozilla.org/en-US/docs/Web/API/Window/open