### PR TITLE
SAK-29277 Hide Event's orgin when in the same site.

### DIFF
--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_viewList.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_viewList.vm
@@ -250,7 +250,7 @@
 																</tr>
 
 																#set ($calObj = $CalendarService.getCalendar($m.CalendarReference))
-																#if ($calObj.getContext() != $PortalService.CurrentSiteId )
+																#if ($calObj.getContext() != $Context )
 																<tr>
 																	<td>&nbsp;</td>
 																	#set ($siteDisplay = $SiteService.getSiteDisplay($calObj.getContext()))


### PR DESCRIPTION
When viewing a Schedule's events in list form, the site said event originates
from is displayed always. This change only displays the origin site when
viewing events from other sites. Thus when viewing a schedule's list of events within a site, the From: $CurrentSite is hidden.