### PR TITLE
LSNBLDR-485 Have content served through lessons wrapped.

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ContentFilterService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ContentFilterService.java
@@ -1,0 +1,18 @@
+package org.sakaiproject.content.api;
+
+/**
+ * This is a service that holds all the ContentFilters and allows streams to be filtered.
+ * It's exposed as a service so that tools serving up thier own content can do it in the
+ * same way as the kernel.
+ * @see ContentFilter
+ */
+public interface ContentFilterService {
+
+    /**
+     * This applies all the filters defined to the supplied content resource.
+     * @param resource The content resource to wrap cannot be <code>null</code>.
+     * @return A new content resource wrapped up or if the original resource if no filters apply.
+     */
+    ContentResource wrap(ContentResource resource);
+
+}

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
@@ -71,11 +71,7 @@
               <entry key="oracle" ><ref bean="org.sakaiproject.content.impl.ContentServiceSqlOracle" /></entry>
            </map>
         </property>
-        <property name="outputFilters">
-          <list>
-            <ref bean="org.sakaiproject.content.impl.HtmlPageFilter"/>
-          </list>
-        </property>
+        <property name="contentFilterService" ref="org.sakaiproject.content.api.ContentFilterService"/>
     </bean>
 
     <bean id="org.sakaiproject.content.impl.CollectionAccessFormatter"
@@ -114,6 +110,15 @@
         <property name="extensionFile"><value>content_type_extensions.properties</value></property>
         -->
 	</bean>
+
+    <bean id="org.sakaiproject.content.api.ContentFilterService"
+          class="org.sakaiproject.content.impl.ContentFilterServiceImpl">
+        <property name="outputFilters">
+            <list>
+                <ref bean="org.sakaiproject.content.impl.HtmlPageFilter"/>
+            </list>
+        </property>
+    </bean>
 
 	<bean id="org.sakaiproject.content.api.ContentResourceFilter.base"
 			class="org.sakaiproject.content.impl.BaseExtensionResourceFilter">

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -83,19 +83,7 @@ import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.conditions.api.ConditionService;
-import org.sakaiproject.content.api.ContentCollection;
-import org.sakaiproject.content.api.ContentCollectionEdit;
-import org.sakaiproject.content.api.ContentEntity;
-import org.sakaiproject.content.api.ContentFilter;
-import org.sakaiproject.content.api.ContentHostingHandler;
-import org.sakaiproject.content.api.ContentHostingService;
-import org.sakaiproject.content.api.ContentResource;
-import org.sakaiproject.content.api.ContentResourceEdit;
-import org.sakaiproject.content.api.ContentTypeImageService;
-import org.sakaiproject.content.api.GroupAwareEdit;
-import org.sakaiproject.content.api.GroupAwareEntity;
-import org.sakaiproject.content.api.ResourceType;
-import org.sakaiproject.content.api.ResourceTypeRegistry;
+import org.sakaiproject.content.api.*;
 import org.sakaiproject.content.api.GroupAwareEntity.AccessMode;
 import org.sakaiproject.content.api.providers.SiteContentAdvisor;
 import org.sakaiproject.content.api.providers.SiteContentAdvisorProvider;
@@ -279,8 +267,6 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 
 	/** Optional set of folders just within the m_bodyPath to distribute files among. */
 	protected String[] m_bodyVolumes = null;
-	
-	protected List<ContentFilter> m_outputFilters = Collections.emptyList();
 
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * Constructors, Dependencies and their setter methods
@@ -485,6 +471,21 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 	{
 		m_collectionAccessFormatter = service;
 	}
+
+	/** Dependency: ContentFilterService */
+	protected ContentFilterService m_contentFilterService;
+
+	/**
+	 * Dependency: ContentFilterService.
+	 *
+	 * @param service
+	 *        The ContentFilterService.
+	 */
+	public void setContentFilterService(ContentFilterService service)
+	{
+		m_contentFilterService = service;
+	}
+
 
 	/**
 	 * Set the site quota.
@@ -841,12 +842,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		this.convertToContextQueryForCollectionSize = convertToContextQueryForCollectionSize;
 	}
 
-	public void setOutputFilters(List<ContentFilter> outputFilters)
-	{
-		this.m_outputFilters = outputFilters;
-	}
 
-	
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * Init and Destroy
 	 *********************************************************************************************************************************************************************************************************************************************************/
@@ -6859,11 +6855,8 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 		
 		// Wrap up the resource if we need to.
-		for (ContentFilter filter: m_outputFilters)
-		{
-			resource = filter.wrap(resource);
-		}
-		
+		resource = m_contentFilterService.wrap(resource);
+
 		// Set some headers to tell browsers to revalidate and check for updated files
 		res.addHeader("Cache-Control", "must-revalidate, private");
 		res.addHeader("Expires", "-1");

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentFilterServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentFilterServiceImpl.java
@@ -1,0 +1,31 @@
+package org.sakaiproject.content.impl;
+
+import org.sakaiproject.content.api.ContentFilter;
+import org.sakaiproject.content.api.ContentFilterService;
+import org.sakaiproject.content.api.ContentResource;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A simple implementation of the output filtering.
+ */
+public class ContentFilterServiceImpl implements ContentFilterService {
+
+    protected List<ContentFilter> m_outputFilters = Collections.emptyList();
+
+    public void setOutputFilters(List<ContentFilter> outputFilters)
+    {
+        this.m_outputFilters = outputFilters;
+    }
+
+    @Override
+    public ContentResource wrap(ContentResource resource) {
+        // Wrap up the resource if we need to.
+        for (ContentFilter filter: m_outputFilters)
+        {
+            resource = filter.wrap(resource);
+        }
+        return resource;
+    }
+}

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderAccessService.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderAccessService.java
@@ -54,6 +54,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 
+import org.sakaiproject.content.api.ContentFilterService;
 import org.sakaiproject.memory.api.SimpleConfiguration;
 import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.cover.TimeService;
@@ -188,6 +189,12 @@ public class LessonBuilderAccessService {
 	}
 
 	LessonEntity assignmentEntity = null;
+
+	ContentFilterService contentFilterService;
+
+	public void setContentFilterService(ContentFilterService s) {
+		contentFilterService = s;
+	}
 
 	public void setAssignmentEntity(Object e) {
 		assignmentEntity = (LessonEntity) e;
@@ -600,6 +607,9 @@ public class LessonBuilderAccessService {
 					    throw new EntityCopyrightException(resource.getReference());
 					}  
 					try {
+						// Wrap it in any filtering needed.
+						resource = contentFilterService.wrap(resource);
+
 					    // following cast is redundant is current kernels, but is needed for Sakai 2.6.1
 						long len = (long)resource.getContentLength();
 						String contentType = resource.getContentType();

--- a/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -265,6 +265,7 @@ simplePageBean.peerEvalAllowSelfGrade
     <property name="contentHostingService"><ref bean="org.sakaiproject.content.api.ContentHostingService"/></property>
     <property name="eventTrackingService"><ref bean="org.sakaiproject.event.api.EventTrackingService"/></property>
     <property name="sessionManager"><ref bean="org.sakaiproject.tool.api.SessionManager"/></property>
+    <property name="contentFilterService"><ref bean="org.sakaiproject.content.api.ContentFilterService"/></property>
 
     <property name="messageLocator" ref="messageLocator"/>
     <property name="toolManager" ref="org.sakaiproject.tool.api.ActiveToolManager" />


### PR DESCRIPTION
When content is served through /access/content it can be modified on the fly be filters. One existing filter is a HTML top/tailer that adds on a header/footer to a HTML fragment. Content served through /access/lessonbuilder wasn’t getting processed in the same way.

To fix this I extracted out a service to the filter definitions are common across the whole service and exposed the collection of filters as a service so that tools outside the kernel can call it.