### PR TITLE
SAK-29312 show message making it clear that instructor submitted on behalf of student

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -317,6 +317,8 @@ listsub.grasub    = Grade submission
 listsub.nosub     = No Submission
 listsub.sorbyrel  = Sort by Released
 listsub.sorbysub  = Sort by Submission Times
+listsub.submitted.by = by
+listsub.submitted.on.behalf = on behalf of
 
 new = Add
 new.title = Add new assignment

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5698,8 +5698,8 @@ public class AssignmentAction extends PagedResourceActionII
 				// SAK-23817: return to the Assignments List by Student
 				state.setAttribute(FROM_VIEW, MODE_INSTRUCTOR_VIEW_STUDENTS_ASSIGNMENT);
 				try {
-					u = UserDirectoryService.getUser(studentId);
 					submitter = u;
+					u = UserDirectoryService.getUser(studentId);
 				} catch (UserNotDefinedException ex1) {
 					M_log.warn("Unable to find user with ID [" + studentId + "]");
 					submitter = null;

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -673,7 +673,8 @@
 						#set($gusers = $submission.getSubmitters())
 					#else
 						#set($siteUser = $userSubmission.User)
-						#set($submitterName=$!siteUser.sortName)
+						#set($submitterSortName=$!siteUser.sortName) 
+						#set($submitterName=$!submitterSortName) 
 						#set($submitterDisplayId=$!siteUser.getDisplayId())
 					#end
 					#set($submitterId = $!siteUser.getId())
@@ -797,7 +798,7 @@
 										$tlang.getString("listsub.nosub")
 									#end
 									#if ($!submittedBy) 
-									<br />by $!submittedBy.sortName
+									<br /> $tlang.getString("listsub.submitted.by") $!submittedBy.sortName ($tlang.getString("listsub.submitted.on.behalf") $validator.escapeHtml($submitterSortName))
 									#end
 							</td>
 							<td headers="status">

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -194,7 +194,10 @@
 													#set ($submitterId = false)
 													#set ($submitterId = $!submission.getProperties().getProperty("submitted_user_id"))
 													#if ($!submitterId)
-														<br />by $userService.getUser($submitterId).getDisplayName()
+														<br />$tlang.getString("listsub.submitted.by") $userService.getUser($submitterId).getDisplayName()
+														#if( $member.getDisplayId() != $submitterId )
+															($tlang.getString("listsub.submitted.on.behalf") $validator.escapeHtml($member.sortName))
+														#end
 													#end
 												#elseif ($!submission.TimeSubmitted.toStringLocalFull())
 													$tlang.getString("gen.subm4") $tlang.getString("submitted.date.redacted")


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29312

If you submit on behalf of a student, the assignment list by student view will only show that there is a submission for the user, rather than saying it was submitted on behalf of the student. To avoid confusion for users, it will now say "by <submitting user> (on behalf of <student>)". Also applies to the maintainer's list of submissions for a given assignment.

There are two lines swapped in AssignmentAction to keep track of the submitting user. Previously, the 'submitting user' would always be overwritten by the user being submitted for. 