### PR TITLE
Add Javadoc to m_toolsRequired.

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/ToolConfigurationService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/ToolConfigurationService.java
@@ -41,9 +41,12 @@ public class ToolConfigurationService {
 
     private Map<String, List<String>> m_toolGroupSelected = new HashMap<>();
 
+    /**
+     * Required tools - map keyed by category to List of tool id strings.
+     */
     private Map<String, List<String>> m_toolsRequired = new HashMap<>();
     /**
-     * default tools - map keyed by category of List of tool id strings.
+     * default tools - map keyed by category to List of tool id strings.
      */
     private Map<String, List<String>> m_defaultTools = new HashMap<>();
     /**


### PR DESCRIPTION
ToolConfigurationService was missing JavaDoc about one of it's private members.