### PR TITLE
SAK-29161 Now users can see a list of softly deleted sites in Worksite setup

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2228,23 +2228,51 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
   	return Double.valueOf(assignmentScore).toString();
   }
 
-  public String getAssignmentScoreString(final String gradebookUid, final Long gbItemId, String studentUid) 
+  public String getAssignmentScoreString(final String gradebookUid, final Long gbItemId, final String studentUid) 
   throws GradebookNotFoundException, AssessmentNotFoundException
   {
+		final boolean studentRequestingOwnScore = authn.getUserUid().equals(studentUid);
+	  
 		if (gradebookUid == null || gbItemId == null || studentUid == null) {
 			throw new IllegalArgumentException("null parameter passed to getAssignmentScore");
-		}
-		
-		Assignment assignment = (Assignment)getHibernateTemplate().execute(new HibernateCallback() {
-			public Object doInHibernate(Session session) throws HibernateException {
-				return getAssignmentWithoutStats(gradebookUid, gbItemId, session);
-			}
-		});
-		if (assignment == null) {
-			throw new AssessmentNotFoundException("There is no assignment with the gbItemId " + gbItemId);
-		}
-		
-		return getAssignmentScoreString(gradebookUid, assignment.getName(), studentUid);
+		}	
+
+	  	Double assignmentScore = (Double)getHibernateTemplate().execute(new HibernateCallback() {
+	  		public Object doInHibernate(Session session) throws HibernateException {
+	  			Assignment assignment = getAssignmentWithoutStats(gradebookUid, gbItemId, session);
+	  			if (assignment == null) {
+	  				throw new AssessmentNotFoundException("There is no assignment with id " + gbItemId + " in gradebook " + gradebookUid);
+	  			}
+
+	  			if (!studentRequestingOwnScore && !isUserAbleToViewItemForStudent(gradebookUid, gbItemId, studentUid)) {
+	  				log.error("AUTHORIZATION FAILURE: User " + getUserUid() + " in gradebook " + gradebookUid + " attempted to retrieve grade for student " + studentUid + " for assignment " + assignment.getName());
+	  				throw new SecurityException("You do not have permission to perform this operation");
+	  			}
+
+	  			// If this is the student, then the assignment needs to have
+	  			// been released.
+	  			if (studentRequestingOwnScore && !assignment.isReleased()) {
+	  				log.error("AUTHORIZATION FAILURE: Student " + getUserUid() + " in gradebook " + gradebookUid + " attempted to retrieve score for unreleased assignment " + assignment.getName());
+	  				throw new SecurityException("You do not have permission to perform this operation");					
+	  			}
+
+	  			AssignmentGradeRecord gradeRecord = getAssignmentGradeRecord(assignment, studentUid, session);
+	  			if (log.isDebugEnabled()) log.debug("gradeRecord=" + gradeRecord);
+	  			if (gradeRecord == null) {
+	  				return null;
+	  			} else {
+	  				return gradeRecord.getPointsEarned();
+	  			}
+	  		}
+	  	});
+	  	if (log.isDebugEnabled()) log.debug("returning " + assignmentScore);
+	  	
+	  	//TODO: when ungraded items is considered, change column to ungraded-grade 
+	  	//its possible that the assignment score is null
+	  	if (assignmentScore == null)
+	  		return null;
+	  	
+	  	return Double.valueOf(assignmentScore).toString();
   }
 
 	public void setAssignmentScoreString(final String gradebookUid, final String assignmentName, final String studentUid, final String score, final String clientServiceDescription) 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
@@ -728,7 +728,7 @@ public abstract class DbSiteService extends BaseSiteService
 				}
 			}
 			if (criteria != null) fieldCount += 1;
-			if ((type == SelectionType.JOINABLE) || (type == SelectionType.ACCESS) || (type == SelectionType.UPDATE) || (type == SelectionType.MEMBER)) fieldCount++;
+			if ((type == SelectionType.JOINABLE) || (type == SelectionType.ACCESS) || (type == SelectionType.UPDATE) || (type == SelectionType.MEMBER) || (type == SelectionType.DELETED)) fieldCount++;
 			if (propertyCriteria != null) fieldCount += (2 * propertyCriteria.size());
 			Object fields[] = null;
 			if (fieldCount > 0)


### PR DESCRIPTION
Despite having the correct permissions (site.visit.softly.deleted), users cannot see a list of softly deleted sites in Worksite setup therefore cannot restore them. This fixes the issue.


