### PR TITLE
SAK-29310 Drag and Drop crashes because of Over-quota and Email Notifications

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -2175,9 +2175,11 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 			SiteEmailNotificationDragAndDrop sendnd = new SiteEmailNotificationDragAndDrop(site.getId());
 			sendnd.setDropboxFolder(item.isDropbox());
 			sendnd.setFileList((ArrayList<String>)(state.getAttribute(DRAGNDROP_FILENAME_REFERENCE_LIST)));
-			ne.setAction(sendnd);
-			sendnd.notify(ne,eventTrackingService.newEvent(eventResource, ContentHostingService.REFERENCE_ROOT+item.getId(), true, notificationPriority));
-			
+			// Notify when files were successfully added
+			if (sendnd.getFileList() != null && !sendnd.getFileList().isEmpty()) {			
+				ne.setAction(sendnd);
+				sendnd.notify(ne,eventTrackingService.newEvent(eventResource, ContentHostingService.REFERENCE_ROOT+item.getId(), true, notificationPriority));			
+			}
 			state.setAttribute(DRAGNDROP_FILENAME_REFERENCE_LIST, null);
 		} catch (IdUnusedException e) {
 			logger.warn("Somehow we couldn't find the site.", e);


### PR DESCRIPTION
When all files weren't successfully uploaded, DRAGNDROP_FILENAME_REFERENCE_LIST would be null and it would causes NPE.
With this changes, notify method will be invoked if any file were successfully added.
