### PR TITLE
SAK-29322 upload resources using drag and drop does not obey file size and site quota limits properly

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -464,9 +464,6 @@
 # All quotas default to unlimited (0)
 
 # Set the maximum size for resources (content) in sites, does not affect the dropbox
-# OLD setting (still works but you should use the new one instead)
-# siteQuota@org.sakaiproject.content.api.ContentHostingService={value in KB}
-# NEW setting
 # DEFAULT: 0 (unlimited storage/no quota)
 # content.quota={value in KB}
 

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/AttachmentAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/AttachmentAction.java
@@ -136,7 +136,8 @@ public class AttachmentAction
 
 		if (state.getAttribute(FILE_UPLOAD_MAX_SIZE) == null)
 		{
-			state.setAttribute(FILE_UPLOAD_MAX_SIZE, ServerConfigurationService.getString("content.upload.max", "1"));
+			state.setAttribute(FILE_UPLOAD_MAX_SIZE, ServerConfigurationService.getString(ResourcesConstants.SAK_PROP_MAX_UPLOAD_FILE_SIZE, 
+																						  ResourcesConstants.DEFAULT_MAX_FILE_SIZE_STRING));
 		}
 
 		// make sure we have attachments

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
@@ -113,7 +113,6 @@ import org.sakaiproject.util.ParameterParser;
 import org.sakaiproject.util.Resource;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.StringUtil;
-import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.util.Validator;
 
 /**
@@ -1053,7 +1052,8 @@ public class FilePickerAction extends PagedResourceHelperAction
 
 		if (toolSession.getAttribute(STATE_FILE_UPLOAD_MAX_SIZE) == null)
 		{
-			toolSession.setAttribute(STATE_FILE_UPLOAD_MAX_SIZE, ServerConfigurationService.getString("content.upload.max", "1"));
+			toolSession.setAttribute(STATE_FILE_UPLOAD_MAX_SIZE, ServerConfigurationService.getString(ResourcesConstants.SAK_PROP_MAX_UPLOAD_FILE_SIZE, 
+																									  ResourcesConstants.DEFAULT_MAX_FILE_SIZE_STRING));
 		}
 		
 		return MODE_HELPER;

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -23,11 +23,9 @@ package org.sakaiproject.content.tool;
 
 import java.io.File;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.text.Format;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -119,7 +117,6 @@ import org.sakaiproject.exception.OverQuotaException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
-import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.SitePage;
@@ -144,22 +141,13 @@ import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.FileItem;
 import org.w3c.dom.Element;
 
-import java.io.PrintWriter;
-import java.io.IOException;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.sakaiproject.util.RequestFilter;
-import org.sakaiproject.thread_local.cover.ThreadLocalManager;
 import org.sakaiproject.api.app.scheduler.SchedulerManager;
 import org.sakaiproject.api.app.scheduler.JobBeanWrapper;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.quartz.JobExecutionContext;
 import org.quartz.JobDetail;
-import org.quartz.JobDataMap;
 import org.quartz.Trigger;
 
 /**
@@ -8398,7 +8386,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 
 		if (state.getAttribute(STATE_FILE_UPLOAD_MAX_SIZE) == null)
 		{
-			String uploadMax = ServerConfigurationService.getString("content.upload.max");
+			String uploadMax = ServerConfigurationService.getString(ResourcesConstants.SAK_PROP_MAX_UPLOAD_FILE_SIZE);
 			String uploadCeiling = ServerConfigurationService.getString("content.upload.ceiling");
 			
 			if(uploadMax == null && uploadCeiling == null)

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesConstants.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesConstants.java
@@ -1,0 +1,33 @@
+/**********************************************************************************
+ * $URL:	 $
+ * $Id:	$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2006, 2007, 2008, 2009 The Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.content.tool;
+
+public class ResourcesConstants
+{
+	// SAK-29332
+	public static final String SAK_PROP_MAX_UPLOAD_FILE_SIZE = "content.upload.max";
+	public static final String SAK_PROP_MASTER_SITE_QUOTA = "content.quota";
+	public static final String DEFAULT_MAX_FILE_SIZE_STRING = "20";
+	public static final String DEFAULT_SITE_QUOTA_STRING = "0";
+	public static final Long DEFAULT_MAX_FILE_SIZE = 20L;
+	public static final Long DEFAULT_SITE_QUOTA = 0L;
+}

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/content-components.xml
@@ -59,7 +59,7 @@
         <property name="bodyPath">                  <null/>                                     </property>
         <property name="bodyVolumes">               <null/>                                     </property>
         <property name="autoDdl">                   <value>${auto.ddl}</value>                  </property>
-        <property name="siteQuota">                 <value>1048576</value>                      </property>
+        <property name="siteQuota">                 <value>0</value>                            </property>
         <property name="availabilityChecksEnabled"> <value>true</value>                         </property>
         <property name="prioritySortEnabled">       <value>true</value>                         </property>
         <property name="useResourceTypeRegistry">   <value>true</value>                         </property>

--- a/rights/rights-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/rights/rights-impl/pack/src/webapp/WEB-INF/components.xml
@@ -12,7 +12,7 @@
 <!--
 		<property name="sqlService"><ref bean="org.sakaiproject.db.api.SqlService"/></property>
  		<property name="autoDdl"><value>${auto.ddl}</value></property>
- 		<property name="siteQuota"><value>1048576</value></property>
+ 		<property name="siteQuota"><value>0</value></property>
  		<property name="availabilityChecksEnabled"><value>true</value></property>
   		<property name="prioritySortEnabled"><value>true</value></property>
 -->


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29332

The current code has the following bugs:

1) if using the drag and drop upload and the site quota is set to unlimited, any file over the 1MB threshold will be reported as putting the user over the site quota

2) the code checks the deprecated siteQuota@... property, but not the new one (content.quota). This is the only remaining occurrence of the old siteQuota@... property. It should just be removed from both the default.sakai.properties and the referencing code

3) the code retrieves the quota and file size limit sakai.properties without providing default values. The result is that if these properties aren't set, the default limits will never be enforced

4) the advertised default value for site quota in default.sakai.properties is not respected due to 2 spring xml injection files specifying that the default value is 1048576KB (1GB). As a result, if you leave the sakai.property for this commented out, you would expect the site quota to be unlimited, but you will discover that the quota will actually be reported as 1GB. The Spring xml files should be specifying 0 instead of 1048576, for consistency with the advertised defaults in default.sakai.properties