### PR TITLE
SAM-2547 Copying questions to shared pool fails

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -197,7 +197,7 @@ public class QuestionPoolBean implements Serializable
   public QuestionPoolDataModel getCopyQpools()
   {
 //	  if (qpDataModelCopy == null) {
-		  buildTreeCopy();
+		  buildTree();
 		  setQpDataModelByLevelCopy(getSortCopyPoolProperty(), getSortCopyPoolAscending());
 //	  }
 	  log.debug("getCopyQpools()");


### PR DESCRIPTION
It will be used 'buildTree' instead of 'buildTreeCopy'.