### PR TITLE
SAK-27587: When content-review is enabled, block attachment if they are not acceptable with the content-review service

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -238,6 +238,7 @@ gen.thearecur2    = There are currently no submissions at this location.
 gen.theassall4    = This assignment allows submissions using both the text box below and attached documents. Type your submission in the box below and use the Browse button or the "select files" button to include other documents. <b>Save frequently while working</b>.
 gen.theassall6    = This assignment allows submissions using the text box below only. Type in your submission. <b>Save frequently while working</b>.
 gen.yoursubwill   = Your submission will be sent to {0} to be electronically reviewed for plagiarism.
+gen.onlythefoll   = Only the following file types will be accepted: {0}
 gen.theassinf     = The assignment info
 gen.title         = Title
 gen.view2         = View
@@ -719,6 +720,7 @@ review.exclude.matches.wordmax=Up to a Word Count of:
 review.exclude.matches.percentage=Percentage:
 review.exclude.matches.value_error=A value from 0-100 is required when excluding small matches for Turnitin.
 review.exclude.matches.header=Exclusion options:
+review.file.not.accepted=The file you have tried to upload is not accepted by {0}. Please upload a file that is one of the following types: {1}
 
 gen.sorbyreview = Sort by review
 gen.rev = TurnItIn
@@ -896,7 +898,10 @@ content_review.pending.info = This attachment has been submitted and is pending 
 
 content_review.error = An unknown error occurred. The originality review for this attachment is not available.
 content_review.error.createAssignment=An error with {0} has occurred while creating this assignment. {1} has saved the assignment in draft mode. Please try posting this assignment again later.
-content_review.note=<div><br /><em>NOTE:</em><ul><li>When submitting attachments, students should only use these file types: Word (.doc, .docx), PostScript (.ps), PDF (.pdf), HTML (.html), rich or plain text (.rtf, .txt).</li> <li>Students should always save files with the appropriate extension.</li> </ul></div>
+content_review.note=<div><br /><em>NOTE:</em><ul><li>When submitting attachments, students should only use these file types: {0}.</li> <li>Students should always save files with the appropriate extension.</li> </ul></div>
+content_review.accepted.types.delimiter=,
+content_review.accepted.types.lparen=(
+content_review.accepted.types.rparen=)
 
 noti.releaseresubmission.subject.content=Email notification for assignment with resubmissions allowed
 noti.releaseresubmission.text=Your submission to assignment "{0}" has been corrected and it allows resubmissions. Please go to {1} to view details.

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1464,6 +1465,11 @@ public class AssignmentAction extends PagedResourceActionII
 			if (assignment.getContent().getAllowReviewService())
 			{
 				context.put("plagiarismNote", rb.getFormattedMessage("gen.yoursubwill", contentReviewService.getServiceName()));
+				if (!contentReviewService.allowAllContent() && assignmentSubmissionTypeTakesAttachments(assignment))
+				{
+					context.put("plagiarismFileTypes", rb.getFormattedMessage("gen.onlythefoll", getContentReviewAcceptedFileTypesMessage()));
+					context.put("content_review_acceptedMimeTypes", getContentReviewAcceptedMimeTypes());
+				}
 			}
 			if (assignment.getContent().getTypeOfSubmission() == Assignment.NON_ELECTRONIC_ASSIGNMENT_SUBMISSION)
 			{
@@ -1685,6 +1691,61 @@ public class AssignmentAction extends PagedResourceActionII
 		}
 		return stripped;
 	}
+
+	/**
+	 * Get a list of accepted mime types suitable for an 'accept' attribute in an html file picker
+	 * @throws illegal argument exception if the assignment accepts all attachments
+	 */
+	private String getContentReviewAcceptedMimeTypes()
+	{
+		if (contentReviewService.allowAllContent())
+		{
+			throw new IllegalArgumentException("getContentReviewAcceptedMimeTypes invoked, but the content review service accepts all attachments");
+		}
+
+		StringBuilder mimeTypes = new StringBuilder();
+		Collection<SortedSet<String>> mimeTypesCollection = contentReviewService.getAcceptableExtensionsToMimeTypes().values();
+		String delimiter = "";
+		for (SortedSet<String> mimeTypesList : mimeTypesCollection)
+		{
+			for (String mimeType : mimeTypesList)
+			{
+				mimeTypes.append(delimiter).append(mimeType);
+				delimiter = ",";
+			}
+		}
+		return mimeTypes.toString();
+	}
+
+	/**
+	 * return true if the assignment's submission type takes attachments.
+	 * @throws IllegalArgumentException if assignment is null
+	 */
+	private boolean assignmentSubmissionTypeTakesAttachments(Assignment assignment)
+	{
+		if (assignment == null)
+		{
+			throw new IllegalArgumentException("assignmentSubmissionTypeTakesAttachments invoked with assignment = null");
+		}
+		
+		int submissionType = assignment.getContent().getTypeOfSubmission();
+
+		if (submissionType == Assignment.ATTACHMENT_ONLY_ASSIGNMENT_SUBMISSION)
+		{
+			return true;
+		}
+		if (submissionType == Assignment.TEXT_AND_ATTACHMENT_ASSIGNMENT_SUBMISSION)
+		{
+			return true;
+		}
+		if (submissionType == Assignment.SINGLE_ATTACHMENT_SUBMISSION)
+		{
+			return true;
+		}
+
+		return false;
+	}
+	
 
 	/**
 	 * build the student view of showing a group assignment error with eligible groups
@@ -2510,6 +2571,12 @@ public class AssignmentAction extends PagedResourceActionII
 		
 		// Keep the use review service setting
 		context.put("value_UseReviewService", state.getAttribute(NEW_ASSIGNMENT_USE_REVIEW_SERVICE));
+		if (!contentReviewService.allowAllContent())
+		{
+			String fileTypesMessage = getContentReviewAcceptedFileTypesMessage();
+			String contentReviewNote = rb.getFormattedMessage("content_review.note", new Object[]{fileTypesMessage});
+			context.put("content_review_note", contentReviewNote);
+		}
 		context.put("turnitin_forceSingleAttachment", ServerConfigurationService.getBoolean("turnitin.forceSingleAttachment", false));
 		context.put("value_AllowStudentView", state.getAttribute(NEW_ASSIGNMENT_ALLOW_STUDENT_VIEW) == null ? Boolean.toString(ServerConfigurationService.getBoolean("turnitin.allowStudentView.default", false)) : state.getAttribute(NEW_ASSIGNMENT_ALLOW_STUDENT_VIEW));
 		
@@ -2794,6 +2861,41 @@ public class AssignmentAction extends PagedResourceActionII
 		}
 		
 	} // setAssignmentFormContext
+
+	/**
+	 * Get a user facing String message represeting the list of file types that are accepted by the content review service
+	 * They appear in this form: PowerPoint (.pps, .ppt, .ppsx, .pptx), plain text (.txt), ...
+	 */
+	private String getContentReviewAcceptedFileTypesMessage()
+	{
+		StringBuilder sb = new StringBuilder();
+		Map<String, SortedSet<String>> fileTypesToExtensions = contentReviewService.getAcceptableFileTypesToExtensions();
+		// The delimiter is a comma. Commas still need to be internationalized (the arabic comma is not the english comma)
+		String i18nDelimiter = rb.getString("content_review.accepted.types.delimiter") + " ";
+		String i18nLParen = " " + rb.getString("content_review.accepted.types.lparen");
+		String i18nRParen = rb.getString("content_review.accepted.types.rparen");
+		String fDelimiter = "";
+		// don't worry about conjunctions; just separate with commas
+		for (Map.Entry<String, SortedSet<String>> entry : fileTypesToExtensions.entrySet())
+		{
+			String fileType = entry.getKey();
+			SortedSet<String> extensions = entry.getValue();
+			sb.append(fDelimiter).append(fileType).append(i18nLParen);
+			String eDelimiter = "";
+			for (String extension : extensions)
+			{
+				sb.append(eDelimiter).append(extension);
+				// optimized by java compiler
+				eDelimiter = i18nDelimiter;
+			}
+			sb.append(i18nRParen);
+			
+			// optimized by java compiler
+			fDelimiter = i18nDelimiter;
+		}
+
+		return sb.toString();
+	}
 
 	/**
 	 * how many gradebook items has been assoicated with assignment
@@ -16806,22 +16908,52 @@ public class AssignmentAction extends PagedResourceActionII
 						m_securityService.pushAdvisor(sa);
 						ContentResource attachment = m_contentHostingService.addAttachmentResource(resourceId, siteId, "Assignments", contentType, fileContentStream, props);
 						
+						Site s = null;
 						try
 						{
-							Reference ref = EntityManager.newReference(m_contentHostingService.getReference(attachment.getId()));
-							if (singleFileUpload && attachments.size() > 1)
+							s = SiteService.getSite(siteId);
+						}
+						catch (IdUnusedException iue)
+						{
+							M_log.warn(this + ":doAttachUpload: Site not found!" + iue.getMessage());
+						}
+
+						// Check if the file is acceptable with the ContentReviewService
+						boolean blockedByCRS = false;
+						if (allowReviewService && contentReviewService != null && contentReviewService.isSiteAcceptable(s))
+						{
+							String assignmentReference = (String) state.getAttribute(VIEW_SUBMISSION_ASSIGNMENT_REFERENCE);
+							Assignment a = getAssignment(assignmentReference, "doAttachUpload", state);
+							if (a.getContent().getAllowReviewService())
 							{
-								//SAK-26319	- the assignment type is 'single file upload' and the user has existing attachments, so they must be uploading a 'newSingleUploadedFile'
-								state.setAttribute("newSingleUploadedFile", ref);
-							}
-							else
-							{
-								attachments.add(ref);
+								if (!contentReviewService.isAcceptableContent(attachment))
+								{
+									addAlert(state, rb.getFormattedMessage("review.file.not.accepted", new Object[]{contentReviewService.getServiceName(), getContentReviewAcceptedFileTypesMessage()}));
+									blockedByCRS = true;
+									// TODO: delete the file? Could we have done this check without creating it in the first place?
+								}
 							}
 						}
-						catch(Exception ee)
+
+						if (!blockedByCRS)
 						{
-							M_log.warn(this + "doAttachUpload cannot find reference for " + attachment.getId() + ee.getMessage());
+							try
+							{
+								Reference ref = EntityManager.newReference(m_contentHostingService.getReference(attachment.getId()));
+								if (singleFileUpload && attachments.size() > 1)
+								{
+									//SAK-26319	- the assignment type is 'single file upload' and the user has existing attachments, so they must be uploading a 'newSingleUploadedFile'	--bbailla2
+									state.setAttribute("newSingleUploadedFile", ref);
+								}
+								else
+								{
+									attachments.add(ref);
+								}
+							}
+							catch(Exception ee)
+							{
+								M_log.warn(this + "doAttachUpload cannot find reference for " + attachment.getId() + ee.getMessage());
+							}
 						}
 						
 						state.setAttribute(ATTACHMENTS, attachments);

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -687,7 +687,10 @@ $(document).ready(function() {
 					</div>
 					<!-- Start TII custom options -->
 					#if($reviewServiceName.equals("Turnitin"))
-					$tlang.getString("content_review.note")
+
+					#if ($content_review_note)
+						$content_review_note
+					#end
 					$tlang.getString("review.submit.papers.repository")
 					<br/>
 					<div class="indnt1">

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -705,7 +705,12 @@ function enableSubmitUnlessNoFile(checkForFile)
 							#if ($plagiarismNote)
 								<p>
 									<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" class="assignmentRosette"/>
-									<em>$plagiarismNote</em>
+									<em>
+										$plagiarismNote
+										#if ($plagiarismFileTypes)
+											$plagiarismFileTypes
+										#end
+									</em>
 								</p>
 							#end
 							</p>
@@ -774,7 +779,12 @@ function enableSubmitUnlessNoFile(checkForFile)
 					#if ($plagiarismNote)
 						<p>
 							<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" class="assignmentRosette"/>
-							<em>$plagiarismNote</em>
+							<em>
+								$plagiarismNote
+								#if ($plagiarismFileTypes)
+									$plagiarismFileTypes
+								#end
+							</em>
 						</p>
 					#end
 					#if ($unsubmittableInline && ""!="$!value_submission_text")
@@ -855,7 +865,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 											</td>
 											<td>
 												<div id="clonableUploadW"> 
-													<input type="file" name="upload" class="upload" id="clonableUpload" onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUpload" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';submitform('addSubmissionForm');"/> 
+													<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUpload" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';submitform('addSubmissionForm');"/> 
 													<span id="submitnotifxxx" class="messageProgress" style="visibility:hidden">$tlang.getString("processmessage.file")</span>
 												</div>
 											</td>
@@ -895,7 +905,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 											<label for="upload">$tlang.getString("att.upl")</label>
 										</td>
 										<td>
-											<input type="file" name="upload" class="upload" id="clonableUpload" onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';submitform('addSubmissionForm');"/> 
+											<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';submitform('addSubmissionForm');"/> 
 											<span id="submitnotifxxx" class="messageProgress" style="visibility:hidden">$tlang.getString("processmessage.file")</span>
 											<input type="hidden" name="submissionFileCount" id="submissionFileCount" value="1"/>
 										</td>
@@ -970,7 +980,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 								<br>
 							#else
 								$tlang.getString("stuviewsubm.uploadnew")
-								<input type="file" name="upload" class="upload" id="clonableUpload" onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "")';submitform('addSubmissionForm');"/>
+								<input type="file" name="upload" class="upload" id="clonableUpload" #if ($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "")';submitform('addSubmissionForm');"/>
 								<span id="submitnotifxxx" class="messageProgress" style="visibility:hidden">$tlang.getString("processmessage.file")</span>
 								<span class="navIntraToolLink">
 									<input

--- a/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewService.java
+++ b/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewService.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.SortedSet;
 
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.site.api.Site;
@@ -202,14 +203,33 @@ public interface ContentReviewService {
 	 */
 	
 	public void resetUserDetailsLockedItems(String userId);
+
+	/**
+	 * Each content review implementation can either accept all files or reject unsupported file formats.
+	 * VeriCite for instance accepts files of any type; if content is in a format that cannot be checked for originality, it returns a score of 0.
+	 * However, TurnItIn reports errors when the file format cannot be checked for originality, so we need to block unsupported content.
+	 * @return whether all content is accepted by this content review service
+	 */
+	public boolean allowAllContent();
 	
 	/**
-	 * Is the content resource of an type that can be accepted by the service implementation
+	 * Is the content resource of a type that can be accepted by the service implementation
 	 * @param resource
 	 * @return
 	 */
 	public boolean isAcceptableContent(ContentResource resource);
 	
+	/**                                                                                                                                                                                                    
+	 * Gets a map of acceptable file extensions for this content-review service to their associated mime types (ie. ".rtf" -> ["text/rtf", "application,rtf"])                                             
+	 */                                                                                                                                                                                                    
+	public Map<String, SortedSet<String>> getAcceptableExtensionsToMimeTypes();                                                                                                                                 
+																																																		  
+	/**                                                                                                                                                                                                    
+	 * Gets a map of acceptable file types for this content-review service (as UI presentable names) to their associated file extensions (ie. "PowerPoint" -> [".ppt", ".pptx", ".pps", ".ppsx"])          
+	 * NB: This must always be implemented as a LinkedHashMap or equivalent; the order is expected to be preserved                                                                                         
+	 */                                                                                                                                                                                                    
+	public Map<String, SortedSet<String>> getAcceptableFileTypesToExtensions();
+
 	/**
 	 *  Can this site make use of the content review service
 	 * 

--- a/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
+++ b/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.SortedSet;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -252,11 +253,39 @@ public class ContentReviewFederatedServiceImpl implements ContentReviewService {
 		return null;
 	}
 
+	public boolean allowAllContent()
+	{
+		ContentReviewService provider = getSelectedProvider();
+		if (provider != null)
+			return provider.allowAllContent();
+		return true;
+	}
+
 	public boolean isAcceptableContent(ContentResource arg0) {
 		ContentReviewService provider = getSelectedProvider();
 		if (provider != null)
 			return provider.isAcceptableContent(arg0);
 		return false;
+	}
+
+	public Map<String, SortedSet<String>> getAcceptableExtensionsToMimeTypes()
+	{
+		ContentReviewService provider = getSelectedProvider();
+		if (provider != null)
+		{
+			return provider.getAcceptableExtensionsToMimeTypes();
+		}
+		return null;
+	}
+
+	public Map<String, SortedSet<String>> getAcceptableFileTypesToExtensions()
+	{
+		ContentReviewService provider = getSelectedProvider();
+		if (provider != null)
+		{
+			return provider.getAcceptableFileTypesToExtensions();
+		}
+		return null;
 	}
 
 	public boolean isSiteAcceptable(Site arg0) {


### PR DESCRIPTION
Currently, any type of file can be submitted to an assignment. If content-review is enabled, there are only a few types of files that can be accepted by the content-review service. 

All attachments submitted to a content-review enabled assignment should get content-reviewed. Do this by limiting the file types that are accepted. Inform users which types of files are accepted before they upload. 

Make the content-review service API provide the file types that are accepted.

NB: This should not be merged until TII-157's revised patch is applied (or else https://source.sakaiproject.org/contrib/turnitin/trunk/ will break due to content-review API changes)