### PR TITLE
SAK-29138: add option to use student's roster title instead of site title

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -79,6 +79,15 @@
 #
 # portal.google.universal_analytics_id=UA-XXXXXX-XX
 
+# SAK-29138 - If set to true, portal will use student's enrolled section title (of preferred type, see below)
+# rather than the site's title for the course site tab, page (browser tab) title, and tool header title
+# DEFAULT: false
+# portal.use.sectionTitle=true
+
+# SAK-29138 - Determines the preferred section type to use when a student is enrolled in multiple sections in the same site
+# DEFAULT: LEC
+# portal.use.sectionTitle.preferredCategory=TUT
+
 # ########################################################################
 # GATEWAY SITE
 # ########################################################################

--- a/edu-services/cm-service/cm-api/api/pom.xml
+++ b/edu-services/cm-service/cm-api/api/pom.xml
@@ -19,7 +19,12 @@
     <properties>
         <deploy.target>shared</deploy.target>
     </properties>
-    <dependencies />
+    <dependencies>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-api</artifactId>
+        </dependency>
+    </dependencies>
     <reports />
     <build>
         <resources>

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/pom.xml
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/pom.xml
@@ -116,8 +116,14 @@
 			<version>1.4</version>
 			<scope>test</scope>
 		</dependency>
-
-
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+		</dependency>
 	</dependencies>
 	<reports />
 	<build>

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SiteTitleAdvisorCMS.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SiteTitleAdvisorCMS.java
@@ -1,0 +1,148 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2008 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.coursemanagement.impl;
+
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.coursemanagement.api.CourseManagementService;
+import org.sakaiproject.coursemanagement.api.Section;
+import org.sakaiproject.coursemanagement.api.exception.IdNotFoundException;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteTitleAdvisor;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.user.api.UserNotDefinedException;
+
+/**
+ * SAK-29138 - Default implementation of SiteTitleAdvisor, used to retrieve the 
+ * site or section title conditionally.
+ * 
+ * @author bjones86
+ */
+public class SiteTitleAdvisorCMS implements SiteTitleAdvisor
+{
+    // Services
+    private final transient Log log = LogFactory.getLog( getClass() );
+    @Getter @Setter private static UserDirectoryService uds;
+    @Getter @Setter private static SecurityService ss;
+    @Getter @Setter private static CourseManagementService cms;
+    @Getter @Setter private static ServerConfigurationService scs;
+    @Getter @Setter private static AuthzGroupService azgs;
+
+    // Constants
+    private static final String DEFAULT_PREFERRED_CAT = "LEC";
+    private static final String SITE_UPDATE_PERMISSION = "site.upd";
+    private static final String CM_STUDENT_ROLE_KEY = "S";
+
+    // sakai.properties
+    private static final String SAK_PROP_PORTAL_USE_SECTION_TITLE = "portal.use.sectionTitle";
+    private static final String SAK_PROP_PORTAL_USE_SEC_TITLE_PREFERRED_CAT = "portal.use.sectionTitle.preferredCategory";
+    private static boolean portalUseSectionTitle;
+    private static String portalUseSecTitlePreferredCategory;
+
+    /**
+     * Initialization
+     */
+    public void init()
+    {
+        portalUseSectionTitle = scs.getBoolean( SAK_PROP_PORTAL_USE_SECTION_TITLE, false );
+        portalUseSecTitlePreferredCategory = scs.getString( SAK_PROP_PORTAL_USE_SEC_TITLE_PREFERRED_CAT, DEFAULT_PREFERRED_CAT );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getUserSpecificSiteTitle( Site site, String userID )
+    {
+        // Short circuit - only continue if sakai.property set to true
+        if( portalUseSectionTitle )
+        {
+            // Get the user by the ID supplied
+            User currentUser = null;
+            if( StringUtils.isNotBlank( userID ) )
+            {
+                try
+                {
+                    currentUser = uds.getUser( userID );
+                }
+                catch( UserNotDefinedException ex )
+                {
+                    log.warn( "Can't find user with ID = " + userID, ex );
+                }
+            }
+
+            // If we couldn't get the user, try to get the 'current' user
+            if( currentUser == null )
+            {
+                currentUser = uds.getCurrentUser();
+            }
+
+            // Short circuit - only continue if user is not null and user does not have the site.upd permission in the given site
+            if( currentUser != null && !ss.unlock( currentUser, SITE_UPDATE_PERMISSION, site.getReference() ) )
+            {
+                // Short circuit - only continue if there are more than one provider ID (cross listed site)
+                Set<String> providerIDs = azgs.getProviderIds( site.getReference() );
+                if( CollectionUtils.isNotEmpty( providerIDs ) )
+                {
+                    // Get the current user's section membership/role map
+                    Map<String, String> sectionRoles = cms.findSectionRoles( currentUser.getEid() );
+
+                    // Iterate over the section IDs for the site; find the first matching section ID
+                    for( String sectionID : providerIDs )
+                    {
+                        // If the user is enrolled in the current section of the site AND is a student
+                        String sectionRole = sectionRoles.get( sectionID );
+                        if( CM_STUDENT_ROLE_KEY.equals( sectionRole ) )
+                        {
+                            try
+                            {
+                                // If the section is of the preferred type, use the section title instead of the site title
+                                Section section = cms.getSection( sectionID );
+                                if( portalUseSecTitlePreferredCategory.equals( section.getCategory() ) )
+                                {
+                                    return section.getTitle();
+                                }
+                            }
+                            catch( IdNotFoundException ex )
+                            {
+                                log.warn( "SiteTitleAdvisorCMS.getSiteOrSectionTitle: section not found " + sectionID, ex );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // If the section title could not be found, the algorithm hit one of the short circuits,
+        // sakai property not set or set to false, or didn't find section or preferred type; use default behaviour
+        return site.getTitle();
+    }
+}

--- a/edu-services/cm-service/cm-impl/hibernate-pack/src/webapp/WEB-INF/components.xml
+++ b/edu-services/cm-service/cm-impl/hibernate-pack/src/webapp/WEB-INF/components.xml
@@ -168,5 +168,17 @@
    </bean>
 -->
 
+    <!-- SAK-29138 - SiteTitleAdvisor default impl registration -->
+    <bean id="org.sakaiproject.site.api.SiteTitleAdvisor"
+        class="org.sakaiproject.coursemanagement.impl.SiteTitleAdvisorCMS"
+        init-method="init"
+        singleton="true">
+        <property name="uds" ref="org.sakaiproject.user.api.UserDirectoryService" />
+        <property name="ss" ref="org.sakaiproject.authz.api.SecurityService" />
+        <property name="cms" ref="org.sakaiproject.coursemanagement.api.CourseManagementService" />
+        <property name="scs" ref="org.sakaiproject.component.api.ServerConfigurationService" />
+        <property name="azgs" ref="org.sakaiproject.authz.api.AuthzGroupService" />
+    </bean>
+
  </beans>
 

--- a/kernel/api/src/main/java/org/sakaiproject/authz/cover/AuthzGroupService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/cover/AuthzGroupService.java
@@ -109,10 +109,10 @@ public class AuthzGroupService
 		return service.getAuthzGroupIds(providerId);
 	}
 
-	public Set getProviderIds(String authzGroupId)
+	public static Set<String> getProviderIds(String authzGroupId)
 	{
 		org.sakaiproject.authz.api.AuthzGroupService service = getInstance();
-		if (service == null) return new HashSet();
+		if (service == null) return new HashSet<>();
 		
 		return service.getProviderIds(authzGroupId);
 	}

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -1203,4 +1203,17 @@ public interface SiteService extends EntityProducer
 	 */
 	public String getParentSite(String siteId);
 
+	/**
+	 * Given a site and a user ID, return the appropriate site or section title for the user.
+	 * 
+	 * SAK-29138 - Takes into account 'portal.use.sectionTitle' sakai.property; 
+	 * if set to true, this method will return the title of the section the current 
+	 * user is enrolled in for the site (if it can be found). Otherwise, it will 
+	 * return the site title (default behaviour).
+	 * 
+	 * @param site the site in question
+	 * @param userID the ID of the current user
+	 * @return the site or section title
+	 */
+	public String getUserSpecificSiteTitle( Site site, String userID );
 } 

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteTitleAdvisor.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteTitleAdvisor.java
@@ -1,0 +1,45 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2008 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.site.api;
+
+/**
+ * SAK-29138 - Portal, user and site-manage tools will optionally (if an implementation is
+ * present) use this to conditionally display the site or section title in the UI.
+ * 
+ * @author bjones86
+ */
+public interface SiteTitleAdvisor
+{
+    /**
+	 * Given a site and a user ID, return the appropriate site or section title for the user.
+	 * 
+	 * SAK-29138 - Takes into account 'portal.use.sectionTitle' sakai.property; 
+	 * if set to true, this method will return the title of the section the current 
+	 * user is enrolled in for the site (if it can be found). Otherwise, it will 
+	 * return the site title (default behaviour).
+	 * 
+	 * @param site the site in question
+	 * @param userID the ID of the current user
+	 * @return the site or section title
+	 */
+	public String getUserSpecificSiteTitle( Site site, String userID );
+}

--- a/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
@@ -24,8 +24,6 @@ package org.sakaiproject.site.cover;
 import java.util.List;
 
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.db.api.SqlReader;
-import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 
 /**
@@ -544,5 +542,25 @@ public class SiteService
 		if (service == null) return null;
 
 		return service.getSiteTypeStrings(param0);
+	}
+
+	/**
+	 * Given a site and a user ID, return the appropriate site or section title for the user.
+	 * 
+	 * SAK-29138 - Takes into account 'portal.use.sectionTitle' sakai.property; 
+	 * if set to true, this method will return the title of the section the current 
+	 * user is enrolled in for the site (if it can be found). Otherwise, it will 
+	 * return the site title (default behaviour).
+	 * 
+	 * @param site the site in question
+	 * @param userID the ID of the current user
+	 * @return the site or section title
+	 */
+	public static String getUserSpecificSiteTitle( Site site, String userID )
+	{
+		org.sakaiproject.site.api.SiteService service = getInstance();
+		if (service == null) return null;
+
+		return service.getUserSpecificSiteTitle( site, userID );
 	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
@@ -1361,7 +1361,7 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 		 * @param authzGroupId The ID of the AuthzGroup
 		 * @return The Set (String) of provider IDs
 		 */
-		public Set getProviderIds(String authzGroupId);
+		public Set<String> getProviderIds(String authzGroupId);
 
 		/**
 		 * Get the AuthzGroup IDs associated with a provider ID.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -57,8 +57,8 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class DbAuthzGroupService extends BaseAuthzGroupService implements Observer
 {
-	/** To avoide the dreaded ORA-01795 and the like, we need to limit to <100 the items in each in(?, ?, ...) clause, connecting them with ORs. */
-	protected final static int MAX_IN_CLAUSE = 99;
+	/** To avoide the dreaded ORA-01795 and the like, we need to limit to <1000 the items in each in(?, ?, ...) clause, connecting them with ORs. */
+	protected final static int MAX_IN_CLAUSE = 999;
 	/** Our log (commons). */
 	private static Log M_log = LogFactory.getLog(DbAuthzGroupService.class);
 	/** All the event functions we know exist on the db. */
@@ -506,7 +506,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 	 */
 	protected String orInClause(int size, String field)
 	{
-		// Note: to avoide the dreaded ORA-01795 and the like, we need to limit to <100 the items in each in(?, ?, ...) clause, connecting them with
+		// Note: to avoide the dreaded ORA-01795 and the like, we need to limit to <1000 the items in each in(?, ?, ...) clause, connecting them with
 		// ORs -ggolden
 		int ors = size / MAX_IN_CLAUSE;
 		int leftover = size - (ors * MAX_IN_CLAUSE);
@@ -1109,15 +1109,15 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 		/**
 		 * {@inheritDoc}
 		 */
-		public Set getProviderIds(String authzGroupId)
+		public Set<String> getProviderIds(String authzGroupId)
 		{
 			String statement = dbAuthzGroupSql.getSelectRealmProviderId1Sql();
 			List results = sqlService().dbRead(statement, new Object[] {authzGroupId}, null);
 			if (results == null)
 			{
-				return new HashSet();
+				return new HashSet<>();
 			}
-			return new HashSet(results);
+			return new HashSet<>(results);
 		}
 
 		/**

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
@@ -22,7 +22,6 @@
 package org.sakaiproject.authz.impl;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * database methods.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -56,6 +56,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
+import org.sakaiproject.component.cover.ComponentManager;
 
 /**
  * <p>
@@ -116,6 +117,9 @@ public abstract class BaseSiteService implements SiteService, Observer
         
     /** sfoster9@uwo.ca - A delegate class to contain the join methods **/
     protected JoinSiteDelegate joinSiteDelegate;
+
+	/** SAK-29138 - a site title advisor **/
+	protected SiteTitleAdvisor m_siteTitleAdvisor;
 
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * Abstractions, etc.
@@ -489,6 +493,9 @@ public abstract class BaseSiteService implements SiteService, Observer
             // sfoster9@uwo.ca
             // assign a new JoinSiteDelegate to handle the join methods; provide it services from this class
             joinSiteDelegate = new JoinSiteDelegate( this, securityService(), userDirectoryService() );
+			
+			// SAK-29138
+			m_siteTitleAdvisor = (SiteTitleAdvisor) ComponentManager.get( SiteTitleAdvisor.class );
 		}
 		catch (Exception t)
 		{
@@ -3489,4 +3496,18 @@ public abstract class BaseSiteService implements SiteService, Observer
 		return parentId;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getUserSpecificSiteTitle( Site site, String userID )
+	{
+		if( m_siteTitleAdvisor != null )
+		{
+			return m_siteTitleAdvisor.getUserSpecificSiteTitle( site, userID );
+		}
+		else
+		{
+			return site.getTitle();
+		}
+	}
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
@@ -24,17 +24,13 @@ package org.sakaiproject.site.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
 
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.db.api.SqlService;
-import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entity.api.EntityManager;
-import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.id.api.IdManager;
 import org.sakaiproject.javax.PagingPosition;
@@ -45,8 +41,6 @@ import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.tool.api.ActiveToolManager;
 import org.sakaiproject.tool.api.SessionManager;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 /**
  * <p>
@@ -174,5 +168,11 @@ public class SiteServiceTest extends DbSiteService
 	public List<String> getSiteIds(SelectionType type, Object ofType, String criteria, Map<String, String> propertyCriteria, SortType sort, PagingPosition page, boolean requireDescription, String userId)
 	{
 		return new ArrayList<String>(0);
+	}
+
+	@Override
+	public String getUserSpecificSiteTitle( Site site, String userID )
+	{
+		return null;
 	}
 }

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalSiteHelper.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalSiteHelper.java
@@ -99,7 +99,19 @@ public interface PortalSiteHelper
 			String currentSiteId, String myWorkspaceSiteId, boolean includeSummary,
 			boolean expandSite, boolean resetTools, boolean doPages,
 			String toolContextPath, boolean loggedIn);
-	
+
+	/**
+	 * SAK-29138 - Get the site or section title for the current user for the current site.
+	 * Takes into account 'portal.use.sectionTitle' sakai.property; if set to true,
+	 * this method will return the title of the section the current user is enrolled
+	 * in for the site (if it can be found). Otherwise, it will return the site
+	 * title (default behaviour)
+	 * 
+	 * @param site the site in question
+	 * @return the site or section title
+	 */
+	String getUserSpecificSiteTitle( Site site );
+
 	/**
 	 * Generates a SiteView object from the current request and location
 	 * @param view

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -58,7 +58,6 @@ import org.sakaiproject.pasystem.api.PASystem;
 import org.sakaiproject.portal.api.Editor;
 import org.sakaiproject.portal.api.PageFilter;
 import org.sakaiproject.portal.api.Portal;
-import org.sakaiproject.portal.api.PortalService;
 import org.sakaiproject.portal.api.PortalChatPermittedHelper;
 import org.sakaiproject.portal.api.PortalHandler;
 import org.sakaiproject.portal.api.PortalRenderContext;
@@ -93,7 +92,6 @@ import org.sakaiproject.portal.charon.handlers.ToolResetHandler;
 import org.sakaiproject.portal.charon.handlers.WorksiteHandler;
 import org.sakaiproject.portal.charon.handlers.WorksiteResetHandler;
 import org.sakaiproject.portal.charon.handlers.XLoginHandler;
-import org.sakaiproject.portal.charon.site.PortalSiteHelperImpl;
 import org.sakaiproject.portal.render.api.RenderResult;
 import org.sakaiproject.portal.render.cover.ToolRenderService;
 import org.sakaiproject.portal.util.ErrorReporter;
@@ -130,6 +128,8 @@ import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.sakaiproject.portal.api.PortalService;
+import org.sakaiproject.portal.charon.site.PortalSiteHelperImpl;
 
 
 /**
@@ -511,7 +511,8 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		String title = ServerConfigurationService.getString("ui.service","Sakai");
 		if (site != null)
 		{
-			title = title + ":" + site.getTitle();
+			// SAK-29138
+			title = title + ":" + siteHelper.getUserSpecificSiteTitle( site );
 			if (placement != null) title = title + " : " + placement.getTitle();
 		}
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/JoinHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/JoinHandler.java
@@ -131,7 +131,10 @@ public class JoinHandler extends BasePortalHandler
 				{
 					String siteType = portal.calcSiteType(site.getId());
 					String serviceName = ServerConfigurationService.getString("ui.service", "Sakai");
-					String title = serviceName+ " : "+ site.getTitle();
+					
+					// SAK-29138
+					String title = serviceName + " : "+ portal.getSiteHelper().getUserSpecificSiteTitle( site );
+					
 					String skin = site.getSkin();
 					PortalRenderContext context = portal.startPageContext(siteType, title, skin, req);
 					context.put("currentSite", portal.getSiteHelper().convertSiteToMap(req, site, null, site.getId(), null, false, false, false, false, null, true));

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
@@ -21,7 +21,6 @@
 
 package org.sakaiproject.portal.charon.handlers;
 
-import java.util.Locale;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -157,9 +156,9 @@ public class PageHandler extends BasePortalHandler
 			return;
 		}
 
-		// form a context sensitive title
+		// SAK-29138 - form a context sensitive title
 		String title = ServerConfigurationService.getString("ui.service","Sakai") + " : "
-				+ site.getTitle() + " : " + page.getTitle();
+				+ portal.getSiteHelper().getUserSpecificSiteTitle( site ) + " : " + page.getTitle();
 
 		String siteType = portal.calcSiteType(site.getId());
 		// start the response

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -23,11 +23,9 @@ package org.sakaiproject.portal.charon.handlers;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Locale;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -36,19 +34,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Cookie;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.authz.api.SecurityAdvisor;
-import org.sakaiproject.authz.cover.AuthzGroupService;
 import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.thread_local.cover.ThreadLocalManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.entity.api.ResourceProperties;
-import org.sakaiproject.entity.api.ResourcePropertiesEdit;
-import org.sakaiproject.entity.cover.EntityManager;
 import org.sakaiproject.event.api.Event;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
@@ -61,7 +55,6 @@ import org.sakaiproject.portal.api.SiteView;
 import org.sakaiproject.portal.api.StoredState;
 import org.sakaiproject.portal.charon.site.AllSitesViewImpl;
 import org.sakaiproject.tool.api.Tool;
-import org.sakaiproject.tool.api.ToolException;
 import org.sakaiproject.tool.api.ToolSession;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.site.api.Site;
@@ -80,7 +73,6 @@ import org.sakaiproject.util.Web;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.portal.util.URLUtils;
 import org.sakaiproject.portal.util.ToolUtils;
-import org.sakaiproject.portal.util.PortalUtils;
 import org.sakaiproject.portal.util.ByteArrayServletResponse;
 import org.sakaiproject.util.Validator;
 
@@ -374,9 +366,9 @@ public class SiteHandler extends WorksiteHandler
 		// clear the last page visited
 		session.removeAttribute(Portal.ATTR_SITE_PAGE + siteId);
 
-		// form a context sensitive title
+		// SAK-29138 - form a context sensitive title
 		String title = ServerConfigurationService.getString("ui.service","Sakai") + " : "
-				+ site.getTitle();
+				+ portal.getSiteHelper().getUserSpecificSiteTitle( site );
 
 		// Lookup the page in the site - enforcing access control
 		// business rules

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/ToolHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/ToolHandler.java
@@ -199,7 +199,7 @@ public class ToolHandler extends BasePortalHandler
 
 			// form a context sensitive title
 			String title = ServerConfigurationService.getString("ui.service","Sakai") + " : "
-				+ site.getTitle() + " : " + siteTool.getTitle();
+				+ portal.getSiteHelper().getUserSpecificSiteTitle( site ) + " : " + siteTool.getTitle();
 
 			PortalRenderContext rcontext = portal.startPageContext(siteType, title, 
 				siteTool.getSkin(), req);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/WorksiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/WorksiteHandler.java
@@ -22,7 +22,6 @@
 package org.sakaiproject.portal.charon.handlers;
 
 import java.io.IOException;
-import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,7 +30,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.component.cover.ServerConfigurationService;
-import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.Portal;
@@ -42,7 +40,6 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.ToolException;
-import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.portal.util.URLUtils;
 
 /**
@@ -153,9 +150,9 @@ public class WorksiteHandler extends PageHandler
 		// store the last page visited
 		session.setAttribute(Portal.ATTR_SITE_PAGE + siteId, page.getId());
 
-		// form a context sensitive title
+		// SAK-29138 - form a context sensitive title
 		String title = ServerConfigurationService.getString("ui.service","Sakai") + " : "
-				+ site.getTitle() + " : " + page.getTitle();
+				+ portal.getSiteHelper().getUserSpecificSiteTitle( site ) + " : " + page.getTitle();
 
 		// start the response
 		String siteType = portal.calcSiteType(siteId);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
@@ -31,10 +31,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.sakaiproject.authz.api.AuthzGroup;
-import org.sakaiproject.authz.api.Role;
-import org.sakaiproject.authz.cover.AuthzGroupService;
-import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.exception.IdUnusedException;
@@ -47,7 +43,6 @@ import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.user.api.PreferencesService;
-import org.sakaiproject.user.cover.UserDirectoryService;
 
 import org.sakaiproject.util.Web;
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -45,7 +45,6 @@ import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.tool.cover.SessionManager;
-import org.sakaiproject.user.cover.PreferencesService;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
@@ -330,6 +329,15 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	public String getUserSpecificSiteTitle( Site site )
+	{
+		String retVal = SiteService.getUserSpecificSiteTitle( site, UserDirectoryService.getCurrentUser().getId() );
+		return Web.escapeHtml( FormattedText.makeShortenedText( retVal, null, null, null ) );
+	}
+
+	/**
 	 * Explode a site into a map suitable for use in the map
 	 * 
 	 * @see org.sakaiproject.portal.api.PortalSiteHelper#convertSiteToMap(javax.servlet.http.HttpServletRequest,
@@ -343,7 +351,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			String toolContextPath, boolean loggedIn)
 	{
 		if (s == null) return null;
-		Map<String, Object> m = new HashMap<String, Object>();
+		Map<String, Object> m = new HashMap<>();
 
 		// In case the effective is different than the actual site
 		String effectiveSite = getSiteEffectiveId(s);
@@ -355,10 +363,12 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		m.put("isMyWorkspace", Boolean.valueOf(myWorkspaceSiteId != null
 				&& (s.getId().equals(myWorkspaceSiteId) || effectiveSite
 						.equals(myWorkspaceSiteId))));
-		String fullTitle = s.getTitle();
-		String titleStr = FormattedText.makeShortenedText(fullTitle, null, null, null);
-		m.put("siteTitle", Web.escapeHtml(titleStr));
-		m.put("fullTitle", Web.escapeHtml(fullTitle));
+		
+		// SAK-29138
+		String siteTitle = getUserSpecificSiteTitle( s );
+		m.put( "siteTitle", siteTitle );
+		m.put( "fullTitle", siteTitle );
+		
 		m.put("siteDescription", s.getHtmlDescription());
 
 		if ( s.getShortDescription() !=null && s.getShortDescription().trim().length()>0 ){
@@ -389,13 +399,13 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			List<Site> pwd = getPwd(s, ourParent);
 			if (pwd != null)
 			{
-				List<Map> l = new ArrayList<Map>();
+				List<Map> l = new ArrayList<>();
 				for (int i = 0; i < pwd.size(); i++)
 				{
 					Site site = pwd.get(i);
 					// System.out.println("PWD["+i+"]="+site.getId()+"
 					// "+site.getTitle());
-					Map<String, Object> pm = new HashMap<String, Object>();
+					Map<String, Object> pm = new HashMap<>();
 					pm.put("siteTitle", Web.escapeHtml(site.getTitle()));
 					pm.put("siteUrl", siteUrl + Web.escapeUrl(getSiteEffectiveId(site)));
 					l.add(pm);

--- a/site-manage/site-manage-tool/tool/src/bundle/membership.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/membership.properties
@@ -50,5 +50,8 @@ mb.list.select=To operate the combo box, first press Alt+Down Arrow to open it, 
 mb.list.of=of
 mb.nosd=No short site description has been provided
 
-# bjones86 - SAK-24423 - joinable site settings - membership tool messages
+# SAK-24423 - joinable site settings - membership tool messages
 mb.join.notAllowed = This site has limited access. You cannot join the site with your current account. Contact the site's owner for more information.
+
+# SAK-29138
+mb.sections = Roster(s)

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MembershipAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MembershipAction.java
@@ -23,7 +23,9 @@ package org.sakaiproject.site.tool;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import org.sakaiproject.cheftool.Context;
@@ -33,6 +35,9 @@ import org.sakaiproject.cheftool.RunData;
 import org.sakaiproject.cheftool.VelocityPortlet;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.coursemanagement.api.CourseManagementService;
+import org.sakaiproject.coursemanagement.api.Section;
+import org.sakaiproject.coursemanagement.api.exception.IdNotFoundException;
 import org.sakaiproject.event.api.SessionState;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.InUseException;
@@ -40,6 +45,7 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.javax.PagingPosition;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.cover.SiteService;
+import org.sakaiproject.site.util.SiteParticipantHelper;
 import org.sakaiproject.site.util.SiteTextEditUtil;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
@@ -73,6 +79,7 @@ public class MembershipAction extends PagedResourceActionII
 	private static UserAuditRegistration userAuditRegistration = (UserAuditRegistration) ComponentManager.get("org.sakaiproject.userauditservice.api.UserAuditRegistration.membership");
 	private static UserAuditService userAuditService = (UserAuditService) ComponentManager.get(UserAuditService.class);
 	private static UserDirectoryService userDirectoryService = (UserDirectoryService) ComponentManager.get(UserDirectoryService.class);
+	private static final CourseManagementService cms = (CourseManagementService) ComponentManager.get( CourseManagementService.class );
 
 	/*
 	 * (non-Javadoc)
@@ -229,6 +236,43 @@ public class MembershipAction extends PagedResourceActionII
 			}
 			*/
 			context.put("unjoinableSites", unjoinableSites);
+
+			// SAK-29138
+			Map<String, String> siteGroupsMap = new HashMap<>();
+			Map<String, String> sectionRoles = cms.findSectionRoles( userDirectoryService.getCurrentUser().getEid() );
+			for( Object obj : unjoinableSites )
+			{
+				Site site = (Site) obj;
+				List<String> providerIDs = SiteParticipantHelper.getProviderCourseList( site.getId() );
+				StringBuilder sectionTitles = new StringBuilder();
+				for( String providerID : providerIDs )
+				{
+					// If the user isn't enrolled in this section, skip it
+					if( !sectionRoles.keySet().contains( providerID ) )
+					{
+						continue;
+					}
+
+					if( sectionTitles.length() != 0 )
+					{
+						sectionTitles.append( ", " );
+					}
+
+					try
+					{
+						Section section = cms.getSection( providerID );
+						sectionTitles.append( section.getTitle() );
+					}
+					catch( IdNotFoundException ex )
+					{
+						Log.warn( "MembershipAction.buildMainPanelContext: cannot find section " + providerID, ex.getMessage() );
+					}
+				}
+				
+				siteGroupsMap.put( site.getId(), sectionTitles.toString() );
+			}
+			context.put( "siteGroupsMap", siteGroupsMap );
+
 			context.put("tlang", rb);
 
 			context.put("SiteService", SiteService.getInstance());

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership.vm
@@ -133,6 +133,10 @@
 							#end
 						</a>
 					</th>
+
+					## SAK-29138
+					<th id="sections">$tlang.getString("mb.sections")</th>
+
 					<th id="description">$tlang.getString("gen.description")</th>
 				</tr>
 				<tbody>
@@ -145,18 +149,23 @@
 								## don't show unjoin link if (1) unjoin is disabled for all sites; (2) unjoin is disabled for current site type
 								#if(!$disableUnjoinSelection && !($!siteType && $!disableUnjoinSiteTypes.contains($!siteType)) && $SiteService.allowUnjoinSite($site.Id))
 									<input title="$tlang.getString('mb.unjointitle') $validator.escapeHtml($site.Title)" type="checkbox" id="check-$rowCount" name="itemReference" value="$validator.escapeUrl($site.Id)" class="joinable"/>
-								#end						
+								#end
 							</td>	
 	
 							<td headers="worksite" style="white-space:nowrap" class="attach" id="mcstR-$rowCount">
 								<h4><a href="$site.Url" target="_top" title="$tlang.getString('mb.gotosite') $validator.escapeHtml($site.Title)">$validator.escapeHtml($site.Title)</a></h4>
 							</td>
+
+							<td headers="sections">
+								$siteGroupsMap.get( $site.getId() )
+							</td>
+
 							<td headers="description mcstR-$rowCount" class="specialLink">
 								#if ($validator.escapeHtml($site.Description) != '')
 									$!membershipTextEdit.doPlainTextAndLimit($site.Description,65,"...")
 									<span class="itemAction"><a class="getSiteDesc" id="$site.Id" href="#">$tlang.getString("list.desc.more")</a></span>
 								#end
-					    </td>
+						</td>
 						</tr>
 					#end
 				</tbody>	

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/perf/mock/MockSiteService.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/perf/mock/MockSiteService.java
@@ -524,4 +524,9 @@ public class MockSiteService implements SiteService {
 		return null;
 	}
 
+	@Override
+	public String getUserSpecificSiteTitle( Site site, String userID )
+	{
+		return null;
+	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29138

There has been an ongoing request at our institution to put the current user's section/roster name into the course site tab rather than the actual site's name. When site's are crosslisted, it can become confusing for users to determine which site they need to navigate to in order to complete an assignment, test, etc.

If the student is in section/roster 005, but the course site's name is of section/roster 001 of the same course, it may not be obvious to the user that they are indeed the same site. This can result in missed assignments, etc., as well as frustration for the professor(s) dealing with answering student inquiries regarding this.

The linked PR introduces a sakai.property to control this behaviour. Default is set to 'false'; only if set to true will the section/roster title replace the site title for student users enrolled in course sites with multiple sections/rosters. When set to true, student users will see their section/roster title in the course site tab, the page (browser tab) title, and the tool header title (the parts Portal is responsible for). It also introduces another sakai.property to define the 'preferred' type of section/roster title to use, which defaults to "LEC" (lecture) sections. This covers the scenario where the student is enrolled in multiple sections/rosters in the same site. For example, they may be enrolled in both a LEC and a TUT section/roster; so by default the LEC section/roster title would be used.

The algorithm will fall back (short circuit) to the default behaviour of using the site's title if any of the following conditions are true:

* if the sakai.property is set to false
* if there is no currently logged in user
* if there are <= 1 sections/rosters in the site
* if the section/roster object could not be found or the user is not enrolled in an section/roster of the preferred 'type'

This PR also introduces a new column in the "My Current Sites" table of the "Membership" tool located in My Workspace, that lists which sections/rosters the user is enrolled in for any of the given sites. It also ensures that the Preferences tool displays the site or roster title consistently, based on the sakai.properties.

There is also a deficiency in kernel regarding ORA-01745 (Oracle maximum elements in an IN clause) which is addressed by this PR. Previously, the limit of elements in an Oracle IN clause was hard-coded to 99, rather than 999 (DbAuthzGroupService.java).

The sakai.properties introduced (with defaults) are:

portal.use.sectionTitle=false
portal.use.sectionTitle.preferredCategory=LEC