### PR TITLE
SAK-29339: Reduce calls to getNonInlineAttachments when resubmitting

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5959,12 +5959,15 @@ public class AssignmentAction extends PagedResourceActionII
 						sEdit.setAssignment(a);
 
 						// SAK-26322	--bbailla2
-						List nonInlineAttachments = getNonInlineAttachments(state, a);
-						if (nonInlineAttachments != null && a.getContent().getTypeOfSubmission() == 5)
+						if (a.getContent().getTypeOfSubmission() == 5)
 						{
-							//clear out inline attachments for content-review
-							//filter the attachment sin the state to exclude inline attachments (nonInlineAttachments, is a subset of what's currently in the state)
-							state.setAttribute(ATTACHMENTS, nonInlineAttachments);
+							List nonInlineAttachments = getNonInlineAttachments(state, a);
+							if (nonInlineAttachments != null)
+							{
+								//clear out inline attachments for content-review
+								//filter the attachments in the state to exclude inline attachments (nonInlineAttachments, is a subset of what's currently in the state)
+								state.setAttribute(ATTACHMENTS, nonInlineAttachments);
+							}
 						}
 
 						// add attachments


### PR DESCRIPTION
If we're using Single Uploaded File Only, we don't want to submit inline attachments from the previous submission. 

Currently, our code grabs the nonInlineAttachments, and then checks if we're using Single Uploaded File Only. It would be more efficient to first check if we're using Single Uploaded File Only, and then grab the nonInlineAttachments, so we won't be grabbing nonInlineAttachments if we don't need to on other submission types.