### PR TITLE
SAM-2523:Checks autosubmit property in sakai.properties before setting retractDate to dueDate

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -169,8 +169,11 @@ public class ConfirmPublishAssessmentListener
     // if late submissions not allowed and late submission date is null, set late submission date to due date
     if (assessmentSettings.getLateHandling() != null && AssessmentAccessControlIfc.NOT_ACCEPT_LATE_SUBMISSION.toString().equals(assessmentSettings.getLateHandling()) &&
     		retractDate == null && dueDate != null && assessmentSettings.getAutoSubmit()) {
-    	retractDate = dueDate;
-    	assessmentSettings.setRetractDate(dueDate);
+    	boolean autoSubmitEnabled = ServerConfigurationService.getBoolean("samigo.autoSubmit.enabled", false);
+    	if (autoSubmitEnabled) {
+    		retractDate = dueDate;
+    		assessmentSettings.setRetractDate(dueDate);
+    	}
     }
     // if auto-submit is enabled, make sure late submission date is set
     if (assessmentSettings.getAutoSubmit() && retractDate == null) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -288,7 +288,10 @@ implements ActionListener
 	    // if late submissions not allowed and late submission date is null, set late submission date to due date
 	    if (assessmentSettings.getLateHandling() != null && AssessmentAccessControlIfc.NOT_ACCEPT_LATE_SUBMISSION.equals(assessmentSettings.getLateHandling()) &&
 	    		retractDate == null && dueDate != null && assessmentSettings.getAutoSubmit()) {
-	    	assessmentSettings.setRetractDate(dueDate);
+	    	boolean autoSubmitEnabled = ServerConfigurationService.getBoolean("samigo.autoSubmit.enabled", false);
+	    	if (autoSubmitEnabled) {
+	    		assessmentSettings.setRetractDate(dueDate);
+	    	}
 	    }
 
 	    // if auto-submit is enabled, make sure late submission date is set


### PR DESCRIPTION
The checking of the 'samigo.autoSubmit.enabled' property is needed to assure that the autosubmit feature is enabled.