### PR TITLE
SAK-29346: Add logging to some important swallowed exceptions in BaseAssignmentService

### DIFF
--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -2233,6 +2233,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		catch(IdUnusedException iue)
 		{
 			// A bit terminal, this.
+			M_log.error("addSubmission called with unknown assignmentId: " + assignmentId);
 		}
 
 		// SAK-21525
@@ -4633,7 +4634,12 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 
                         			commitEdit(s);
                         			// clear the permission
-                        		} finally {
+                        		} 
+                        		catch (Exception e)
+                        		{
+                        			M_log.warn("getSubmitterGroupList: exception thrown while creating empty submission for group who has not submitted: " + e.getMessage());
+                        		}
+                        		finally {
                         			securityService.popAdvisor(securityAdvisor);
                         		}
 	                        }
@@ -4811,6 +4817,10 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 									commitEdit(s);
 									rv.put(u, s);
 								}
+							}
+							catch (Exception e)
+							{
+								M_log.warn("getSubmitterMap: exception thrown while creating empty submission for student who has not submitted: " + e.getMessage());
 							}
 							finally
 							{


### PR DESCRIPTION
There are a couple blocks in BaseAssignmentService that do important tasks, and should an exception be thrown, it currently does nothing. Add logging in the catch statements.