### PR TITLE
SAK-29439 - Assignment tool: Limit assignment visibility options for assignments with group submission

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -216,6 +216,15 @@ $(document).ready(function() {
 			document.getElementById('resubmitNotification').style.display = 'none';
 		}
 	}
+
+	function toggleIsGroupSubmission(checked){
+		if (checked) {
+			$("#site").prop("disabled", true);
+			$("#groups").prop("checked", true).trigger("click");
+		} else {
+			$("#site").prop("disabled", false);
+		}
+	}
 </script>
 <script type="text/javascript">
 	focus_path = [ '$fField' ];
@@ -1103,7 +1112,7 @@ $(document).ready(function() {
 
                                  #if ($group_submissions_enabled)
                                     <p class="checkbox  indnt2">
-                            <input id="$name_CheckIsGroupSubmission" name="$name_CheckIsGroupSubmission" type="checkbox" value="1"
+                            <input id="$name_CheckIsGroupSubmission" name="$name_CheckIsGroupSubmission" type="checkbox" value="1" onclick="toggleIsGroupSubmission(this.checked);"
                             #if ($!value_CheckIsGroupSubmission.equals("1") && $!groupsList)
                                 checked="checked"
                                         #end
@@ -1139,7 +1148,9 @@ $(document).ready(function() {
                         <input type="radio" name="range" id="site" value="site" onclick="$('#groupTable').fadeOut('slow'); showOrHideAccessMessages( false ); resizeFrame();" 
                         #if( $!range == "site" || $selectedGroupsNotFound )
                             checked="checked"
-					#end
+                        #elseif ($!value_CheckIsGroupSubmission.equals("1") && $!groupsList)
+                            disabled="disabled"
+                        #end
                         />
                     #end
 					<label for="site">$tlang.getString("displayto.site")</label>


### PR DESCRIPTION
Hi @jonespm,

This PR delivers the behaviour as discussed with @jeffpasch from NYU:
-  In Assignments, when "Are submissions for a group?" is checked, the option of "display to site" should be grayed out, and "Display to selected groups" should be automatically selected.
- Then, if "Are submissions for a group" is unselected, "Display to selected groups" should remain selected (because assignments requiring individual submission can still be made visible to only certain groups), but "display to site" should then be ungrayed.

This patch introduces some Javascript to the new/edit assignment form to deliver the above behaviour.

Is there a process to ensure this change is backported to 10.x?  I'm happy to provide a compatible patch.

Thanks,
Payten