### PR TITLE
SAK-29352: Checkboxes to allow individual students to resubmit have Iabels that read 'resubmisison'

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -803,7 +803,7 @@ allowResubmission.instruction = Select user(s) and apply the resubmission settin
 allowResubmission.groups.instruction = Select group(s) and apply the resubmission settings.
 allowResubmission.nouser = Please choose at least one user for setting the resubmission choices.
 allowResubmission.toggleall   = Select/unselect all to allow for resubmission
-allowResubmission.select.student = Allow resubmisison from 
+allowResubmission.select.student = Allow resubmission from 
 ## single file upload
 singleatt = Single Uploaded File only
 att.upl = Choose File: 


### PR DESCRIPTION
The message is:
allowResubmission.select.student = Allow resubmisison from

These labels have a class on them called 'skip', which pushes the labels offscreen to the left. So they don't display visually, but I believe they are picked up by screen readers. 