### PR TITLE
SAK-29355 Keep “bad” URL in error site.

### DIFF
--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalService.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalService.java
@@ -73,6 +73,11 @@ public interface PortalService
 	public static final String SAKAI_CONTROLLING_PORTAL = "sakai-controlling-portal";
 
 	/**
+	 * The Site ID that the user was originally trying to access when they hit the error.
+	 */
+	String SAKAI_PORTAL_ORIGINAL_SITEID = "SAKAI_PORTAL_ORIGINAL_SITEID";
+
+	/**
 	 * ste the state of the portal reset flag.
 	 * 
 	 * @param state

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -154,60 +154,15 @@ public class SiteHandler extends WorksiteHandler
 		{
 			// This is part of the main portal so we simply remove the attribute
 			session.setAttribute(PortalService.SAKAI_CONTROLLING_PORTAL, null);
+			// site might be specified
+			String siteId = null;
+			if (parts.length >= 3)
+			{
+				siteId = parts[2];
+			}
 			try
 			{
-				// site might be specified
-				String siteId = null;
-				if (parts.length >= 3)
-				{
-					siteId = parts[2];
-				}
-				
-				// recognize an optional page/pageid
-				String pageId = null;
-				String toolId = null;
-
-				// may also have the tool part, so check that length is 5 or greater.
-				if ((parts.length >= 5) && (parts[3].equals("page")))
-				{
-					pageId = parts[4];
-				}
-
-				// Tool resetting URL - clear state and forward to the real tool
-				// URL
-				// /portal/site/site-id/tool-reset/toolId
-				// 0 1 2 3 4
-				if ((siteId != null) && (parts.length == 5) && (parts[3].equals("tool-reset")))
-				{
-					toolId = parts[4];
-					String toolUrl = req.getContextPath() + "/site/" + siteId + "/tool"
-						+ Web.makePath(parts, 4, parts.length);
-					String queryString = Validator.generateQueryString(req);
-					if (queryString != null)
-					{
-						toolUrl = toolUrl + "?" + queryString;
-					}
-					portalService.setResetState("true");
-					res.sendRedirect(toolUrl);
-					return RESET_DONE;
-				}
-
-				// may also have the tool part, so check that length is 5 or greater.
-				if ((parts.length >= 5) && (parts[3].equals("tool")))
-				{
-					toolId = parts[4];
-				}
-
-				String commonToolId = null;
-				
-				if(parts.length == 4)
-				{
-					commonToolId = parts[3];
-				}
-
-				doSite(req, res, session, siteId, pageId, toolId, commonToolId, parts,
-						req.getContextPath() + req.getServletPath());
-				return END;
+				return doGet(parts, req, res, session, siteId);
 			}
 			catch (Exception ex)
 			{
@@ -218,6 +173,60 @@ public class SiteHandler extends WorksiteHandler
 		{
 			return NEXT;
 		}
+	}
+
+	/**
+	 * This extra method is so that we can pass in a different siteId to the one in the URL.
+	 * @see #doGet(String[], HttpServletRequest, HttpServletResponse, Session, String)
+	 */
+	public int doGet(String[] parts, HttpServletRequest req, HttpServletResponse res,
+					 Session session, String siteId) throws IOException, ToolException {
+
+		// recognize an optional page/pageid
+		String pageId = null;
+		String toolId = null;
+
+		// may also have the tool part, so check that length is 5 or greater.
+		if ((parts.length >= 5) && (parts[3].equals("page")))
+		{
+			pageId = parts[4];
+		}
+
+		// Tool resetting URL - clear state and forward to the real tool
+		// URL
+		// /portal/site/site-id/tool-reset/toolId
+		// 0 1 2 3 4
+		if ((siteId != null) && (parts.length == 5) && (parts[3].equals("tool-reset")))
+		{
+			toolId = parts[4];
+			String toolUrl = req.getContextPath() + "/site/" + siteId + "/tool"
+					+ Web.makePath(parts, 4, parts.length);
+			String queryString = Validator.generateQueryString(req);
+			if (queryString != null)
+			{
+				toolUrl = toolUrl + "?" + queryString;
+			}
+			portalService.setResetState("true");
+			res.sendRedirect(toolUrl);
+			return RESET_DONE;
+		}
+
+		// may also have the tool part, so check that length is 5 or greater.
+		if ((parts.length >= 5) && (parts[3].equals("tool")))
+		{
+			toolId = parts[4];
+		}
+
+		String commonToolId = null;
+
+		if(parts.length == 4)
+		{
+			commonToolId = parts[3];
+		}
+
+		doSite(req, res, session, siteId, pageId, toolId, commonToolId, parts,
+				req.getContextPath() + req.getServletPath());
+		return END;
 	}
 
 	public void doSite(HttpServletRequest req, HttpServletResponse res, Session session,

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/SiteNeighbourhoodServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/SiteNeighbourhoodServiceImpl.java
@@ -40,9 +40,11 @@ import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.portal.api.PortalService;
 import org.sakaiproject.portal.api.SiteNeighbourhoodService;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.thread_local.api.ThreadLocalManager;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.user.api.PreferencesService;
@@ -68,6 +70,8 @@ public class SiteNeighbourhoodServiceImpl implements SiteNeighbourhoodService
 	private ServerConfigurationService serverConfigurationService;
 	
 	private AliasService aliasService;
+
+	private ThreadLocalManager threadLocalManager;
 	
 	/** Should all site aliases have a prefix */
 	private boolean useAliasPrefix = false;
@@ -527,14 +531,26 @@ public class SiteNeighbourhoodServiceImpl implements SiteNeighbourhoodService
 		this.userDirectoryService = userDirectoryService;
 	}
 
+	public void setThreadLocalManager(ThreadLocalManager threadLocalManager)
+	{
+		this.threadLocalManager = threadLocalManager;
+	}
+
 	public String lookupSiteAlias(String id, String context)
 	{
+		// TODO Constant extraction
+		if ("/site/!error".equals(id)) {
+			Object originalId =  threadLocalManager.get(PortalService.SAKAI_PORTAL_ORIGINAL_SITEID);
+			if (originalId instanceof String) {
+				return (String)originalId;
+			}
+		}
+		List<Alias> aliases = aliasService.getAliases(id);
 		if (!useSiteAliases)
 		{
 			return null;
 		}
-		List<Alias> aliases = aliasService.getAliases(id);
-		if (aliases.size() > 0) 
+		if (aliases.size() > 0)
 		{
 			if (aliases.size() > 1 && log.isInfoEnabled())
 			{

--- a/portal/portal-service-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/portal/portal-service-impl/pack/src/webapp/WEB-INF/components.xml
@@ -32,6 +32,7 @@
 	       <property name="userDirectoryService" ><ref bean="org.sakaiproject.user.api.UserDirectoryService" /></property>
 	       <property name="serverConfigurationService" ><ref bean="org.sakaiproject.component.api.ServerConfigurationService" /></property>
 	       <property name="aliasService"><ref bean="org.sakaiproject.alias.api.AliasService" /></property>
+         <property name="threadLocalManager"><ref bean="org.sakaiproject.thread_local.api.ThreadLocalManager" /></property>
     </bean>
     
     <bean id="org.sakaiproject.portal.service.AliasingSiteAdvisor"


### PR DESCRIPTION
This allows a tool running in the error site to know the URL that the user was having problems accessing, rather than have all the URLs just include the error site ID.

A simpler option would have been to use the Sakai session but this would have meant error handling wouldn't have with multiple windows and it would have bloated the size of the session.