### PR TITLE
SAK-29356: Prompt students when they cancel out of a non-empty assignment submission

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -93,6 +93,7 @@ gen.attfprgra     = Attachments for grading
 gen.atttoret      = Attachments to Return with Grade
 gen.atttoret2      = Attachments to Return with Assignment
 gen.can           = Cancel
+gen.can.discard   = Your changes will be discarded. Are you sure you want to cancel?
 gen.clocli        = Close, click to open assignment instructions
 gen.closed        = Closed
 gen.creby         = Created by

--- a/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
@@ -1,0 +1,40 @@
+var ASN_SVS = {};
+
+/* For the cancel button - if the user made progress, we need them to confirm that they want to discard their progress */
+ASN_SVS.confirmDiscardOrSubmit = function(attachmentsModified)
+{
+	var inlineProgress = false;
+	var ckEditor = CKEDITOR.instances["$name_submission_text"];
+	if (ckEditor)
+	{
+		inlineProgress = CKEDITOR.instances["$name_submission_text"].checkDirty();
+	}
+	var showDiscardDialog = inlineProgress || attachmentsModified;
+	var submitPanel = document.getElementById("submitPanel");
+	var confirmationDialogue = document.getElementById("confirmationDialogue");
+	if (showDiscardDialog)
+	{
+		submitPanel.setAttribute('style', 'display:none;');
+		confirmationDialogue.removeAttribute('style');
+	}
+	else
+	{
+	cancelProceed();
+	}
+}
+
+ASN_SVS.cancelProceed = function()
+{
+	document.addSubmissionForm.onsubmit();
+	document.addSubmissionForm.option.value='cancel'; 
+	document.addSubmissionForm.submit(); 
+}
+
+ASN_SVS.undoCancel = function()
+{
+	var submitPanel = document.getElementById("submitPanel");
+	var confirmationDialogue = document.getElementById("confirmationDialogue");
+	submitPanel.removeAttribute('style');
+	confirmationDialogue.setAttribute('style', 'display:none;');
+}
+

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -88,7 +88,8 @@ function enableSubmitUnlessNoFile(checkForFile)
 	}
 }
 </script>
-
+## Include other javascript specific to this page
+<script type="text/javascript" src="/sakai-assignment-tool/js/studentViewSubmission.js"></script>
 
 <div class="portletBody">
 ## submission times
@@ -1158,7 +1159,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 						$tlang.getString("gen.youmus")
 					</p>
 				#end
-				<div
+				<div id="submitPanel"
 					#if ($!deleted.equalsIgnoreCase("true") || !$!canSubmit)
 					 class="act">
 						<input 
@@ -1167,7 +1168,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 							accesskey="x"
 							id="cancel" 
 							value="$tlang.getString("gen.don")"
-							onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='cancel'; document.addSubmissionForm.submit(); return false;"
+							onclick="ASN_SVS.confirmDiscardOrSubmit($!new_attachments); return false;"
 						/>
 					#else
 					 class="act messageInformation">
@@ -1222,7 +1223,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 								accesskey="x"
 								id="cancel" 
 								value="$tlang.getString("gen.can")"
-								onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='cancel'; document.addSubmissionForm.submit(); return false;"
+								onclick="ASN_SVS.confirmDiscardOrSubmit($!new_attachments); return false"
 							/>
 							#end
 
@@ -1233,6 +1234,11 @@ function enableSubmitUnlessNoFile(checkForFile)
                             #end
 					#end
 				<span id="submitnotif" style="visibility:hidden">$tlang.getString("gen.proces")</span>
+			</div>
+			<div id="confirmationDialogue" class="act messageInformation" style="display:none;">
+				$tlang.getString("gen.can.discard")
+				<input class="disableme" type="button" name="yes" accesskey="y" id="yes" value="$tlang.getString("gen.yes")" onclick="ASN_SVS.cancelProceed()" />
+				<input class="active" type="button" name="no" accesskey="n" id="no" value="$tlang.getString("gen.no")" onclick="ASN_SVS.undoCancel()" />
 			</div>
 		#else
 				#if ($submission.getGradeReleased() && $!submission.FeedbackText && ($submission.FeedbackText.length()>0))
@@ -1372,7 +1378,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 					accesskey="x"
 					id="cancel" 
 					value="$tlang.getString("gen.don")"
-					onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='cancel'; document.addSubmissionForm.submit(); return false;"
+					onclick="ASN_SVS.confirmDiscardOrSubmit($!new_attachments); return false;"
 				/>
 			</p>
 		#end


### PR DESCRIPTION
We've had at least one student who erroneously clicked cancel and believed they submitted their assignment. 
We need a prompt upon clicking cancel if: 
1) It's a new submission and the inline-text is non-empty or they uploaded at least one attachment 
2) It's a resubmission and the inline-text has changed or the list of attachments is not identical to their last submission.