### PR TITLE
SAK-29359: Join site page doesn't consider account type limitations

### DIFF
--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -87,9 +87,11 @@ pda_subsite = (Sub Site)
 join_title = Joinable Site
 join_instr = You are not currently a member of the site:
 join_question = Would you like to join the site?
+join_restricted = This site has limited access. You cannot join the site with your current account. Contact the site's owner for more information.
 
 yes = Yes
 no = No
+return = Return to My Workspace
 
 pc_title = Chat
 pc_chat_close = Close this chat

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/JoinHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/JoinHandler.java
@@ -81,8 +81,16 @@ public class JoinHandler extends BasePortalHandler
 				SiteService.getInstance().join(site.getId());
 				sendToSite(res, site);
 			} else {
-				// The user didn't opt to join so show the error.
-				portal.doError(req, res, session, Portal.ERROR_SITE);
+				// The user didn't opt to join
+				Site myWorkspace = portal.getSiteHelper().getMyWorkspace(session);
+				if (myWorkspace != null)
+				{
+					sendToSite(res, myWorkspace);
+				}
+				else
+				{
+					portal.doError(req, res, session, Portal.ERROR_SITE);
+				}
 			}
 		}
 		catch (IdUnusedException e) {
@@ -128,6 +136,10 @@ public class JoinHandler extends BasePortalHandler
 					PortalRenderContext context = portal.startPageContext(siteType, title, skin, req);
 					context.put("currentSite", portal.getSiteHelper().convertSiteToMap(req, site, null, site.getId(), null, false, false, false, false, null, true));
 					context.put("uiService", serviceName);
+					
+					boolean restrictedByAccountType = !SiteService.getInstance().isAllowedToJoin(siteId);
+					context.put("restrictedByAccountType", restrictedByAccountType);
+					
 					portal.sendResponse(context, res, "join", "text/html");
 					return;
 				}

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/join.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/join.vm
@@ -37,13 +37,21 @@
                             </td>
                         </tr>
                         <tr>
+                        #if (!${restrictedByAccountType})
                             <td>${rloader.getString("join_question")}</td>
+                        #else
+                            <td>${rloader.getString("join_restricted")}</td>
+                        #end
                         </tr>
                         <tr>
                             <td>
                                 <form method="POST">
+                                #if (!${restrictedByAccountType})
                                     <input type="submit" name="join" value="${rloader.getString("yes")}">
                                     <input type="submit" name="reject" value="${rloader.getString("no")}">
+                                #else
+                                    <input type="submit" name="return" value="${rloader.getString("return")}" class="active"/>
+                                #end
                                 </form>
                             </td>
                         </tr>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29359

When visiting a joinable site you are not a member of, a page appears asking if you would like to join. However, with certain properties enabled, joinability can be limited by account type. If a user tries to join but doesn't have the right account type, they will just hit Site Unavailable.

Linked PR will present a message to users that they will not actually be able to join the site, with an option to return to My Workspace. The PR will also adjust the behaviour of the "No thanks" option to direct the user to My Workspace instead of Site Unavailable.