### PR TITLE
SAK-26124 Add support for searching by AID to LDAP.

### DIFF
--- a/providers/component/src/webapp/WEB-INF/jldap-beans.xml
+++ b/providers/component/src/webapp/WEB-INF/jldap-beans.xml
@@ -154,6 +154,13 @@
 		<!-- property name="maxResultSize">
 		  <value>1000</value>
 		</property -->
+
+		<!-- Optional. Require a different ID for login. This allows you to have one ID for logins
+		     and another EID which is used when looking up course/group information.
+		     Defaults to false -->
+		<!-- property name="enableAid">
+		  <value>true</value>
+		</property -->
 		
 		<!-- Optional. Defaults to an instance of 
 		edu.amc.sakai.user.SimpleLdapAttributeMapper -->
@@ -211,6 +218,7 @@
 		AttributeMappingConstants.DEFAULT_ATTR_MAPPINGS. -->
 		<!-- property name="attributeMappings">
 			<map>
+				<entry key="aid"><value>krb5PrincipalName</value></entry>
 				<entry key="login"><value>cn</value></entry>         
 				<entry key="firstName"><value>givenName</value></entry> 
 				<entry key="preferredFirstName"><value>preferredName</value></entry>

--- a/providers/jldap/src/java/edu/amc/sakai/user/AttributeMappingConstants.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/AttributeMappingConstants.java
@@ -38,6 +38,11 @@ public abstract class AttributeMappingConstants {
 	public static final String LOGIN_ATTR_MAPPING_KEY = "login";
 	
 	/** Key into {@link #DEFAULT_ATTR_MAPPINGS} representing the logical
+	 * name of a user entry's authentication (aka Sakai "AID") attribute
+	 */
+	public static final String AUTHENTICATION_ATTR_MAPPING_KEY = "aid";
+	
+	/** Key into {@link #DEFAULT_ATTR_MAPPINGS} representing the logical
 	 * name of a user entry's given name attribute
 	 */
 	public static final String FIRST_NAME_ATTR_MAPPING_KEY = "firstName";
@@ -70,6 +75,11 @@ public abstract class AttributeMappingConstants {
 	 * the physical name of a user entry's login (aka Sakai "EID") attribute
 	 */
 	public static final String DEFAULT_LOGIN_ATTR = "cn";
+	
+	/** Default value in {@link #DEFAULT_ATTR_MAPPINGS} representing
+	 * the physical name of a user entry's authentication (aka Sakai "AID") attribute
+	 */
+	public static final String DEFAULT_AUTHENTICATION_ATTR = "dn";
 	
 	/** Default value in {@link #DEFAULT_ATTR_MAPPINGS} representing
 	 * the physical name of a user entry's given name attribute
@@ -106,6 +116,7 @@ public abstract class AttributeMappingConstants {
 	static {
 		
 		DEFAULT_ATTR_MAPPINGS.put(LOGIN_ATTR_MAPPING_KEY, DEFAULT_LOGIN_ATTR);
+		DEFAULT_ATTR_MAPPINGS.put(AUTHENTICATION_ATTR_MAPPING_KEY, DEFAULT_AUTHENTICATION_ATTR);
 		DEFAULT_ATTR_MAPPINGS.put(FIRST_NAME_ATTR_MAPPING_KEY, DEFAULT_FIRST_NAME_ATTR);
 		DEFAULT_ATTR_MAPPINGS.put(PREFERRED_FIRST_NAME_ATTR_MAPPING_KEY, DEFAULT_PREFERRED_FIRST_NAME_ATTR);
 		DEFAULT_ATTR_MAPPINGS.put(LAST_NAME_ATTR_MAPPING_KEY, DEFAULT_LAST_NAME_ATTR);

--- a/providers/jldap/src/java/edu/amc/sakai/user/LdapAttributeMapper.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/LdapAttributeMapper.java
@@ -63,6 +63,14 @@ public interface LdapAttributeMapper {
 	public String getFindUserByEidFilter(String eid);
 
 	/**
+	 * Output a filter string for searching the directory with
+	 * the specified user aid as a key.
+	 * @param aid a user authentication id.
+	 * @return an LDAP search filter
+	 */
+	public String getFindUserByAidFilter(String aid);
+	
+	/**
 	 * Maps attribites from the specified <code>LDAPEntry</code> onto
 	 * a {@link LdapUserData}.
 	 * 

--- a/providers/jldap/src/java/edu/amc/sakai/user/LdapConnectionManagerConfig.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/LdapConnectionManagerConfig.java
@@ -233,4 +233,9 @@ public interface LdapConnectionManagerConfig {
 	 * @param maxResultSize The maximum number of results to ever get back from LDAP.
 	 */
 	public void setMaxResultSize(int maxResultSize);
+
+	/**
+	 * @param enable If <code>true</code> then perform searches for users by Authentication ID.
+	 */
+	public void setEnableAid(boolean enable);
 }

--- a/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapAttributeMapper.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapAttributeMapper.java
@@ -172,6 +172,12 @@ public class SimpleLdapAttributeMapper implements LdapAttributeMapper {
 		}
 	}
 
+	public String getFindUserByAidFilter(String aid) {
+		String eidAttr = 
+			attributeMappings.get(AttributeMappingConstants.AUTHENTICATION_ATTR_MAPPING_KEY);
+		return eidAttr + "=" + escapeSearchFilterTerm(aid);
+	}
+
 	/**
 	 * Performs {@link LDAPEntry}-to-{@Link LdapUserData} attribute
      * mappings. Assigns the given {@link LDAPEntry}'s DN to the


### PR DESCRIPTION
The JLDAP User Directory Provider now supports searching by authentication ID.
Although this class implements the methods out of the interface by default the
method doesn’t do anything. You need to enable AID searching.