### PR TITLE
SAK-21872: Citations copy/duplicate doesn't work as expected.

### DIFF
--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -2796,7 +2796,7 @@ public abstract class BaseCitationService implements CitationService
 				this.m_comparator = new MultipleKeyComparator( TITLE_AS_KEY, true );
 			}
 
-			set(other);
+			set(other, true);
 
 		}
 
@@ -3181,7 +3181,7 @@ public abstract class BaseCitationService implements CitationService
 				}
 				else
 				{
-					set((BasicCitationCollection) edit);
+					set((BasicCitationCollection) edit, false);
 				}
 			}
 
@@ -3191,7 +3191,7 @@ public abstract class BaseCitationService implements CitationService
 		 * copy
 		 * @param other
 		 */
-		protected void set(BasicCitationCollection other)
+		protected void set(BasicCitationCollection other, boolean isTemporary)
 		{
 			this.m_description = other.m_description;
 //			this.m_comparator = other.m_comparator;
@@ -3220,7 +3220,7 @@ public abstract class BaseCitationService implements CitationService
 				{
 					newCitation.copy(oldCitation);
 					newCitation.m_id = oldCitation.m_id;
-					newCitation.m_temporary = false;
+					newCitation.m_temporary = isTemporary;
 					this.saveCitation(newCitation);
 					this.add(newCitation);
 				}


### PR DESCRIPTION
The problem with copying/duplicating a reading list is that BaseCitationService.set(BasicCitationCollection) is called from both checkForUpdates() (which  reloads the BaseCitationCollection fresh from the database) and also from copy(BasicCitationCollection) (which is supposed to genuinely copy a BaseCitationCollection in the database). But set(BasicCitationCollection) never saves any new CITATION_CITATIONs because the citations are always explicitly set to temporary=false, i.e., they are already saved in the db (line 3223).

This change passes through 'temporary=true' to the set(BasicCitationCollection) method when it is called from the copy(BasicCitationCollection) method (and therefore saves CITATION_CITATIONs) and 'temporary=false' otherwise.
