### PR TITLE
SAK-29395 allow extra credit flag to be updated

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -771,6 +771,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				assignment.setName(assignmentDefinition.getName().trim());
 				assignment.setPointsPossible(assignmentDefinition.getPoints());
 				assignment.setReleased(assignmentDefinition.isReleased());
+				assignment.setExtraCredit(assignmentDefinition.isExtraCredit());
 				updateAssignment(assignment, session);
 				return null;
 			}


### PR DESCRIPTION
The conversion from Assignment bean to Assignment DTO in the gradebook service exposes the extra credit flag. However the conversion from DTO back to bean when updating the assignment does not include the extra credit flag so you can never update this flag. This PR restores balance in the universe.
