### PR TITLE
SAK-29388 Error in pages that contains double Column Layout

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
@@ -257,6 +257,9 @@ public class PageHandler extends BasePortalHandler
 				for (Iterator i = tools.iterator(); i.hasNext();)
 				{
 					ToolConfiguration placement = (ToolConfiguration) i.next();
+					boolean thisTool = portal.getSiteHelper().allowTool(site,
+								placement);
+					if (!thisTool) continue; // Skip this tool if not allowed
 					Map m = portal.includeTool(res, req, placement);
 					if (m != null)
 					{


### PR DESCRIPTION
I have done the same at the second column that the first one, ask if the tool is alowed to the participant's rol.
To reproduce the issue, you need a page that has Double Column Layout. The problem is only present in the tools from the second column. Those tools should have a permission in the 'Function required' configuration.
Then, one of the site participants has a role without a permission that is used for one of the tools as 'Function required'.
When accessing the site, the user gets the error showed in the screenshot
with title "HOME" has a Double Column Layout. One participant of the site with rol that don´t have permissions of function required in a tool in the second column