### PR TITLE
SAK-29407 Don’t fail where params undefined.

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/StrippedReportDef.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/StrippedReportDef.java
@@ -43,8 +43,14 @@ public class StrippedReportDef {
         this.title = reportDef.getTitle();
         this.description = reportDef.getDescription();
         ReportParams params = reportDef.getReportParams();
-        this.from = params.getWhenFrom().getTime();
-        this.to = params.getWhenTo().getTime();
+        // The report parameters might not all be defined and so there may not be a
+        // from / to value.
+        if (params.getWhenFrom() != null) {
+            this.from = params.getWhenFrom().getTime();
+        }
+        if (params.getWhenTo() != null) {
+            this.to = params.getWhenTo().getTime();
+        }
         this.toolIds = params.getWhatToolIds();
         this.eventIds = params.getWhatEventIds();
         this.resourceIds = params.getWhatResourceIds();


### PR DESCRIPTION
Reports defined earlier may not contain from/to dates so before copying
them we should check they aren’t null (to prevent NPE). The copying of
null fields is fine in other places.

It’s not practical to update the DB to ensure all fields are always defined.