### PR TITLE
Profile2: Now able to hide sub-menu & social items in profile

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2349,25 +2349,55 @@
 # profile2.profile.change.email.enabled=false
 # profile2.profile.change.email.eid=admin
 
+# Enable/disable the profile menu feature? (true/false)
+# Disabling the menu, hides all the profile menu tabs
+# This setting overrides the following properties:
+#   profile2.gallery.enabled
+#   profile2.connection.enabled
+#   profile2.messaging.enabled
+#   profile2.search.enabled
+#   profile2.privacy.enabled
+#   profile2.preference.enabled
+# profile2.menu.enabled=true
+
 # Enable/disable the gallery feature? (true/false)
 # DEFAULT: true
 # profile2.gallery.enabled=true
+
+# Enable/disable the connections feature? (true/false)
+# If Connections are disabled, than messaging is also disabled as
+# messages may only be sent to connections.
+# DEFAULT: true
+# profile2.connection.enabled=true
 
 # Enable/disable the messaging feature? (true/false)
 # DEFAULT: true
 # profile2.messaging.enabled=true
 
-# Enable/Disable the connections options (true/false)
-# DEFAULT: true
-# profile2.connections.enabled=false
-
 # Enable/disable the friend search options (true/false)
 # DEFAULT: true
-# profile2.search.enabled=false
+# profile2.search.enabled=true
+
+# Enable/disable the privacy feature? (true/false)
+# Be sure to set global privacy settings as desired if this is disabled.
+# DEFAULT: true
+# profile2.privacy.enabled=true
+
+# Enable/disable the preferences tab? (true/false)
+# DEFAULT: true
+# profile2.preference.enabled=true
 
 # Allow status updates and display? (true/false)
 # DEFAULT: true
-# profile2.profile.status.enabled=false
+# profile2.profile.status.enabled=true
+
+# Enable/dsiable the myKudos feature? (true/false)
+# DEFAULT: true
+# profile2.myKudos.enabled=true
+
+# Enable/disable the online status feature (true/false)
+# This feature shows if you are currently logged in.
+# profile2.onlineStatus.enabled=true
 
 # Should users profiles be linked in forum posts? (true/false)
 # Works in conjunction with *msgcntr.forums.showProfileInfo* and *msgcntr.messages.showProfileInfo*

--- a/profile2/api/src/java/org/sakaiproject/profile2/logic/SakaiProxy.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/logic/SakaiProxy.java
@@ -26,36 +26,36 @@ import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.user.api.User;
 /**
  * An interface for abstracting Sakai specific parts away from the main logic.
- * 
+ *
  * @author Steve Swinsburg (s.swinsburg@lancaster.ac.uk)
  *
  */
 public interface SakaiProxy {
-	
+
 	/**
 	 * Get current siteid
 	 * @return
 	 */
 	public String getCurrentSiteId();
-	
+
 	/**
 	 * Get current user id
 	 * @return
 	 */
 	public String getCurrentUserId();
-	
+
 	/**
 	 * Get current user
 	 * @return
 	 */
 	public User getCurrentUser();
-	
+
 	/**
 	 * Convert internal userid to eid (jsmith26)
 	 * @return
 	 */
 	public String getUserEid(String userId);
-	
+
 	/**
 	 * Convert eid to internal userid
 	 * @return
@@ -67,51 +67,51 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public String getUserDisplayName(String userId);
-	
+
 	/**
 	 * Get firstname of a given userid (internal id)
 	 * @return
 	 */
 	public String getUserFirstName(String userId);
-	
+
 	/**
 	 * Get lastname of a given userid (internal id)
 	 * @return
 	 */
 	public String getUserLastName(String userId);
-	
+
 	/**
 	 * Get email address for a given userid (internal id)
 	 * @return
 	 */
 	public String getUserEmail(String userId);
-	
+
 	/**
 	 * Check if a user with the given internal id (ie 6ec73d2a-b4d9-41d2-b049-24ea5da03fca) exists
 	 * @param userId
 	 * @return
 	 */
 	public boolean checkForUser(String userId);
-	
+
 	/**
 	 * Check if a user with the given eid (ie jsmith26) exists
 	 * @param userId
 	 * @return
 	 */
 	public boolean checkForUserByEid(String eid);
-	
+
 	/**
 	 * Is the current user a superUser? (anyone in admin realm)
 	 * @return
 	 */
 	public boolean isSuperUser();
-	
+
 	/**
 	 * Is the current user the admin user? (ie 'admin')
 	 * @return
 	 */
 	public boolean isAdminUser();
-	
+
 	/**
 	 * Is the current user a superUser and are they performing an action on another user's profile?
 	 * @param userId - userId of other user
@@ -124,14 +124,14 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public String getUserType(String userId);
-	
+
 	/**
 	 * Get a user
 	 * @param userId internal user id
 	 * @return
 	 */
 	public User getUserById(String userId);
-	
+
 	/**
 	 * Get the User object for the given userId.
 	 * <p>This will not log errors so that we can quietly use it to check if a User exists for a given profile,
@@ -140,7 +140,7 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public User getUserQuietly(String userId);
-	
+
 	/**
 	 * Get the title of the current tool. If no current tool is set, returns 'Profile'.
 	 * @return
@@ -153,21 +153,21 @@ public interface SakaiProxy {
 	 * @return List<User>
 	 */
 	public List<User> getUsers(List<String> userUuids);
-	
+
 	/**
 	 * Get a list of uuids for each of the given Users
 	 * @param users		Users
 	 * @return List<String> of uuids
 	 */
 	public List<String> getUuids(List<User> users);
-	
+
 	/**
 	 * Get a SakaiPerson for a user
 	 * @param userId
 	 * @return
 	 */
 	public SakaiPerson getSakaiPerson(String userId);
-	
+
 	/**
 	 * Get a SakaiPerson Jpeg photo for a user. Checks UserMutableType record first, then goes for SystemMutableType if none.
 	 * <p>Returns null if nothing found.
@@ -175,7 +175,7 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public byte[] getSakaiPersonJpegPhoto(String userId);
-	
+
 	/**
 	 * Get a SakaiPerson image URL for a user. Checks UserMutableType record first, then goes for SystemMutableType if none.
 	 * <p>Returns null if nothing found.
@@ -183,7 +183,7 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public String getSakaiPersonImageUrl(String userId);
-	
+
 	/**
 	 * Get a SakaiPerson prototype if they don't have a profile.
 	 * <p>This is not persistable so should only be used for temporary views.
@@ -192,7 +192,7 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public SakaiPerson getSakaiPersonPrototype();
-	
+
 	/**
 	 * Create a new persistable SakaiPerson object for a user
 	 * @param userId
@@ -204,50 +204,50 @@ public interface SakaiProxy {
 	 * Update a SakaiPerson object in the db.
 	 * <p>If you are doing this from the UI you should use the {@link ProfileLogic.updateUserProfile} method instead
 	 * as it will also handle any email notifications that may be required.
-	 * 
+	 *
 	 * <p>We keep this because for direct actions like converting profiles etc we dont need email notifications.
-	 *  
+	 *
 	 * @param sakaiPerson
 	 * @return
 	 */
 	public boolean updateSakaiPerson(SakaiPerson sakaiPerson);
-	
+
 	/**
 	 * Get the maximum filesize that can be uploaded (profile2.picture.max=2)
 	 * @return
 	 */
 	public int getMaxProfilePictureSize();
-		
+
 	/**
 	 * Returns the gallery resource path for the specified user and image.
-	 * 
+	 *
 	 * @param userId the ID of the user.
 	 * @param imageId the ID of the image.
 	 * @return the gallery resource path for the specified user and image.
 	 */
 	public String getProfileGalleryImagePath(String userId, String imageId);
-	
+
 	/**
 	 * Returns the gallery resource path for the specified user and thumbnail.
-	 * 
+	 *
 	 * @param userId the ID of the user.
 	 * @param imageId the ID of the thumbnail.
 	 * @return the gallery resource path for the specified user and image.
 	 */
 	public String getProfileGalleryThumbnailPath(String userId, String thumbnailId);
-	
+
 	/**
 	 * Get the location for a profileImage given the user and type
-	 * 
+	 *
 	 * @param userId
 	 * @param type
 	 * @return
 	 */
 	public String getProfileImageResourcePath(String userId, int type);
-	
+
 	/**
 	 * Save a file to CHS
-	 * 
+	 *
 	 * @param fullResourceId
 	 * @param userId
 	 * @param fileName
@@ -256,23 +256,23 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public boolean saveFile(String fullResourceId, String userId, String fileName, String mimeType, byte[] fileData);
-		
+
 	/**
 	 * Retrieve a resource from ContentHosting with byte[] and mimetype
 	 *
 	 * @param resourceId	the full resourceId of the file
 	 */
 	public MimeTypeByteArray getResource(String resourceId);
-	
+
 	/**
 	 * Removes the specified resource.
-	 * 
+	 *
 	 * @param resourceId the ID of the resource to remove.
 	 * @return <code>true</code> if the resource is successfully removed,
-	 * <code>false</code> if the remove operation fails. 
+	 * <code>false</code> if the remove operation fails.
 	 */
 	public boolean removeResource(String resourceId);
-	
+
 	/**
 	 * Search UserDirectoryService for users that match in name or email.
 	 *
@@ -280,7 +280,7 @@ public interface SakaiProxy {
 	 * @return a List of User objects
 	 */
 	public List<User> searchUsers(String search);
-	
+
 	/**
 	 * Search UserDirectoryService for externally provided users that match in name or email.
 	 *
@@ -288,28 +288,28 @@ public interface SakaiProxy {
 	 * @return a List of User objects
 	 */
 	public List<User> searchExternalUsers(String search);
-	
-	
+
+
 	/**
 	 * Post an event to Sakai
-	 * 
+	 *
 	 * @param event			name of event
 	 * @param reference		reference
 	 * @param modify		true if something changed, false if just access
-	 * 
+	 *
 	 */
 	public void postEvent(String event,String reference,boolean modify);
 
 	/**
 	 * Send an email message. The message should be ready to go as is. The message will be formatted with
 	 * mime boundaries, html escaped then sent.
-	 * 
+	 *
 	 * @param userId	userId to send the message to
 	 * @param subject	subject of message
 	 * @param message	complete with newlines and any links.
 	 */
 	public void sendEmail(String userId, String subject, String message);
-	
+
 	/**
 	 * Sends an email to a list of users using the email template and replacement values supplied
 	 * @param users			list of userIds to send to - already cleaned up for their email preferences
@@ -317,7 +317,7 @@ public interface SakaiProxy {
 	 * @parem replacementValues	Map of values that are substituted into the placeholders in the email template.
 	 */
 	public void sendEmail(List<String> userIds, String emailTemplateKey, Map<String,String> replacementValues);
-	
+
 	/**
 	 * Sends an email to a single user using the email template and replacement values supplied
 	 * @param user			userId to send to - already cleaned up for their email preferences
@@ -326,80 +326,80 @@ public interface SakaiProxy {
 	 */
 	public void sendEmail(String userId, String emailTemplateKey, Map<String,String> replacementValues);
 
-	
+
 	/**
 	 * Get the name of this Sakai installation (ie Sakai@Lancs)
 	 * @return
 	 */
 	public String getServiceName();
-	
+
 	/**
 	 * Gets the portalUrl configuration parameter (ie http://sakai.lancs.ac.uk/portal)
 	 * Will not work outside of /portal context (ie won't work from an entityprovider)
 	 * @return
 	 */
 	public String getPortalUrl();
-	
+
 	/**
 	 * Gets the serverUrl configuration parameter (http://sakai.lancs.ac.uk:8080)
 	 * @return
 	 */
 	public String getServerUrl();
-	
+
 	/**
 	 * Get the DNS name of this Sakai server (ie sakai.lancs.ac.uk)
 	 * @return
 	 */
 	public String getServerName();
-	
+
 	/**
 	 * Get the URL to the current user's my workspace
 	 * @return
 	 */
 	public String getUserHomeUrl();
-	
+
 	/**
 	 * Gets the portal path, generally /portal unless override in sakai.properties
 	 * @return
 	 */
 	public String getPortalPath();
-	
+
 	/**
-	 * Are we using the normal /portal? 
+	 * Are we using the normal /portal?
 	 * Deep links are broken in xsl-portal, so we need a workaround to drop the toolstate param.
 	 * See PRFL-264
 	 * @return
 	 */
 	public boolean isUsingNormalPortal();
-	
+
 	/**
 	 * Gets the full portal url by adding getServerUrl() and getPortalPath() together
 	 * This WILL work outside the portal context so safe to use from an entityprovider
 	 * @return
 	 */
 	public String getFullPortalUrl();
-	
+
 	/**
 	 * Updates a user's email address
 	 * If the user is a provided user (ie from LDAP) this will probably fail
 	 * so only internal accounts can be updated.
-	 * 
+	 *
 	 * @param userId	uuid of the user
-	 * @param email	
+	 * @param email
 	 */
 	public void updateEmailForUser(String userId, String email);
-	
+
 	/**
 	 * Updates a user's name
 	 * If the user is a provided user (ie from LDAP) this will probably fail
 	 * so only internal accounts can be updated.
-	 * 
+	 *
 	 * @param userId	uuid of the user
-	 * @param email	
+	 * @param email
 	 */
 	public void updateNameForUser(String userId, String firstName, String lastName);
-	
-	
+
+
 	/**
 	 * Creates a direct URL to a user's profile page on their My Workspace
 	 * Any other parameters supplied in string are appended and encoded.
@@ -408,114 +408,105 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public String getDirectUrlToUserProfile(String userId, String extraParams);
-	
+
 	/**
 	 * Check if a user is allowed to update their account. The User could come from LDAP
 	 * so updates not allowed. This will check if any updates are allowed.
-	 * 
+	 *
 	 * Note userDirectoryService.allowUpdateUserEmail etc are NOT the right methods to use
 	 * as they don't check if account updates are allowed, just if the user doing the update is allowed.
-	 * 
+	 *
 	 * @param userId
 	 * @return
 	 */
 	public boolean isAccountUpdateAllowed(String userId);
-	
+
 	/**
 	 * Is the profile2.profile.business.enabled flag set in sakai.properties? If
 	 * not set, defaults to <code>false</code>.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.profile.business.enabled flag
 	 *         is set, otherwise returns <code>false</code>.
 	 */
 	public boolean isBusinessProfileEnabled();
-	
+
 	/**
 	 * Is the profile2.wall.enabled flag set in sakai.properties? If not set,
 	 * defaults to <code>false</code>.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.wall.enabled flag is set,
 	 *         otherwise returns <code>false</code>.
 	 */
 	public boolean isWallEnabledGlobally();
-	
+
 	/**
 	 * Is the profile2.wall.default flag set in sakai.properties? If not set,
 	 * defaults to <code>false</code>.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.wall.default flag is set,
 	 *         otherwise returns <code>false</code>.
 	 */
 	public boolean isWallDefaultProfilePage();
-	
+
 	/**
 	 * Is the profile2.convert flag set in sakai.properties?
 	 * If not set, defaults to false
-	 * 
-	 * <p>This will convert profiles from the original Profile tool in Sakai, to Profile2 format. 
+	 *
+	 * <p>This will convert profiles from the original Profile tool in Sakai, to Profile2 format.
 	 * Any images that were uploaded via various methods will be placed into Sakai's ContentHostingSystem
 	 * and thumbnails generated for use in various parts of Profile2.</p>
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isProfileConversionEnabled();
-	
+
 	/**
 	 * Is the profile2.import flag set in sakai.properties?
 	 * If not set, defaults to false
-	 * 
+	 *
 	 * <p>This will import profiles from a csv file specified by the profile2.import.csv property</p>
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isProfileImportEnabled();
-	
+
 	/**
 	 * Get the path to the CSV file to import, specified by the profile2.import.csv property
-	 * 
+	 *
 	 * @return
 	 */
 	public String getProfileImportCsvPath();
-	
-	
+
+
 	/**
 	 * Is the profile2.integration.twitter.enabled flag set in sakai.properties?
 	 * If not set, defaults to true
-	 * 
+	 *
 	 * <p>Depending on this setting, the UI will allow a user to input their Twitter settings
 	 * and their status updates will be sent to Twitter.</p>
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isTwitterIntegrationEnabledGlobally();
-	
+
 	/**
-	 * 
+	 *
 	 * Get the profile2.integration.twitter.source parameter
 	 *
 	 * See here:
 	 * http://bugs.sakaiproject.org/confluence/display/PROFILE/Profile2
 	 */
 	public String getTwitterSource();
-	
+
 	/**
 	 * Is the profile2.gallery.enabled flag set in sakai.properties?
 	 * If not set, default to <code>true</code>.
-	 * 
+	 *
 	 * @return the status of the profile2.gallery.enabled flag in sakai.properties.
 	 * Returns <code>true</code> by default.
 	 */
 	public boolean isProfileGalleryEnabledGlobally();
-	
-	/**
-	 * Is the profile2.messaging.enabled flag set in sakai.properties?
-	 * If not set, default to <code>true</code>.
-	 * 
-	 * @return the status of the profile2.messaging.enabled flag in sakai.properties.
-	 * Returns <code>true</code> by default.
-	 */
-	public boolean isMessagingEnabledGlobally();
-	
+
 	/**
 	 * Is the profile2.search.enabled flag set in sakai.properties?
 	 * If not set, default to <code>true</code>.
@@ -537,38 +528,38 @@ public interface SakaiProxy {
 	/**
 	 * Is the profile2.picture.change.enabled flag set in sakai.properties?
 	 * If not set, defaults to true
-	 * 
-	 * <p>Depending on this setting, users will be able to upload their own image. 
+	 *
+	 * <p>Depending on this setting, users will be able to upload their own image.
 	 * This can be useful to disable for institutions which may provide official photos for students.</p>
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isProfilePictureChangeEnabled();
-	
+
 	/**
 	 * Get the profile2.picture.type setting in sakai.properties
 	 * <p>Possible values for the sakai property are 'upload', 'url', 'official' and 'gravatar'.
 	 * If not set, defaults to 'upload'.</p>
-	 * <p>This returns an int which matches one of: ProfileConstants.PICTURE_SETTING_UPLOAD, 
+	 * <p>This returns an int which matches one of: ProfileConstants.PICTURE_SETTING_UPLOAD,
 	 * ProfileConstants.PICTURE_SETTING_URL, ProfileConstants.PICTURE_SETTING_OFFICIAL,
 	 * ProfileConstants.PICTURE_SETTINGS_GRAVATAR.</p>
-	 * 
+	 *
 	 * <p>Depending on this setting, Profile2 will decide how it retrieves a user's profile image, and the method by which
 	 * users can add their own image. ie by uploading their own image, providing a URL, not at all (for official), or creating a gravatar URL</p>
-	 * 
+	 *
 	 * @return
 	 */
 	public int getProfilePictureType();
-	
-	
-	
+
+
+
 	/**
 	 * Gets the profile2.profile.entity.set.academic list of properties that should be used in the academic profile view.
 	 * Returns default list of ProfileConstants.ENTITY_SET_ACADEMIC if none.
 	 * @return
 	 */
 	public List<String> getAcademicEntityConfigurationSet();
-	
+
 	/**
 	 * Gets the profile2.profile.entity.set.minimal list of properties that should be used in the minimal profile view.
 	 * Returns default list of ProfileConstants.ENTITY_SET_MINIMAL if none.
@@ -578,51 +569,51 @@ public interface SakaiProxy {
 
 	/**
 	 * Convenience method to ensure the given userId(eid or internal id) is returned as a valid uuid.
-	 * 
+	 *
 	 * <p>External integrations must pass input through this method, where the input can be either form,
 	 * since all data is keyed on the internal user id.
-	 * 
+	 *
 	 * @param userId
 	 * @return uuid or null
 	 */
 	public String ensureUuid(String userId);
-	
+
 	/**
 	 * Convenience method to check if the user making a request is the same as the current user
 	 * @param userUuid	uuid to check against current user
-	 * @return	
+	 * @return
 	 */
 	public boolean currentUserMatchesRequest(String userUuid);
-	
+
 	/**
 	 * Is the profile2.privacy.change.enabled flag set in sakai.properties?
 	 * If not set, defaults to true
 	 * <p>
-	 * 
+	 *
 	 * Allows an institution to lock down privacy changes as some things need to be never changed.
 	 * Generally should coupled with the sakai.properties that override the default privacy settings
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isPrivacyChangeAllowedGlobally();
-	
-	
+
+
 	/**
 	 * Gets the set of sakai.properties that can override the built in defaults. This is then called
 	 * when a default privacy record is requested and the values used preferentially.
-	 * 
+	 *
 	 * Note that mostly the value is an Integer but for some values its a Boolean, ie checkboxes
-	 * 
+	 *
 	 * @return
 	 */
 	public HashMap<String, Object> getOverriddenPrivacySettings();
-	
+
 	/**
 	 * Gets the profile2.invisible.users List for user's that should never show in searches or connection lists
 	 * @return
 	 */
 	public List<String> getInvisibleUsers();
-	
+
 	/**
 	 * Gets the list of usertypes from profile2.allowed.connection.usertypes.TYPE.
 	 * <p>This defines what user types can connect to each other. The <b>requestingUserType</b> is appended to the property string
@@ -634,7 +625,7 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public boolean isConnectionAllowedBetweenUserTypes(String requestingUserType, String targetUserType);
-	
+
 	/**
 	 * Toggle a profile's locked status.
 	 * @param userId
@@ -642,105 +633,105 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public boolean toggleProfileLocked(String userId, boolean locked);
-	
+
 	/**
 	 * Is profile2.official.image.enabled true? If so, allow use of this image and preference.
 	 * @return
 	 */
 	public boolean isOfficialImageEnabledGlobally();
-	
+
 	/**
 	 * Checks if the conditions are appropriate for a user to be able to select whether to use the official
 	 * image or an alternate of their choice
 	 * @return
 	 */
 	public boolean isUsingOfficialImageButAlternateSelectionEnabled();
-	
+
 	/**
 	 * Gets the value of the profile2.official.image.source attribute from sakai.properties.
 	 * If not set, defaults to ProfileConstants.OFFICIAL_SETTING_DEFAULT
-	 * 
+	 *
 	 * This should be specified if profile2.picture.type=official
-	 * 
+	 *
 	 * @return
 	 */
 	public String getOfficialImageSource();
-	
+
 	/**
 	 * Gets the value of the profile2.official.image.directory attribute from sakai.properties.
 	 * If not set, defaults to /official-photos
-	 * 
+	 *
 	 * This should be specified if profile2.picture.type=official
-	 * 
+	 *
 	 * @return The root directory where official images are stored
 	 */
 	public String getOfficialImagesDirectory();
-	
+
 	/**
 	 * Get the value of the profile2.official.image.directory.pattern attribute from sakai.properties.
 	 * If not set, defaults to TWO_DEEP.
-	 * 
+	 *
 	 * <br />
 	 * Options:
 	 * <ul>
-	 * <li>ONE_DEEP = first letter of a user's eid, then a slash, then the eid suffixed by '.jpg'. 
+	 * <li>ONE_DEEP = first letter of a user's eid, then a slash, then the eid suffixed by '.jpg'.
 	 * For example BASEDIR/a/adrian.jpg, BASEDIR/s/steve.jpg</li>
-	 * <li>TWO_DEEP = first letter of a user's eid, then a slash, then the second letter of the eid 
-	 * followed by a slash and finally the eid suffixed by '.jpg'. 
+	 * <li>TWO_DEEP = first letter of a user's eid, then a slash, then the second letter of the eid
+	 * followed by a slash and finally the eid suffixed by '.jpg'.
 	 * For example BASEDIR/a/d/adrian.jpg, BASEDIR/s/t/steve.jpg</li>
 	 * <li>ALL_IN_ONE = all files in the one directory.
 	 * For example BASEDIR/adrian.jpg, BASEDIR/steve.jpg</li>
 	 * </ul>
-	 * 
+	 *
 	 * This is optional but if you have your images on the filesystem in a pattern that isnt default, you need to set a pattern.
 	 * @return
 	 */
 	public String getOfficialImagesFileSystemPattern();
-	
+
 	/**
 	 * Gets the value of the profile2.official.image.attribute from sakai.properties
 	 * If not set, defaults to ProfileConstants.USER_PROPERTY_JPEG_PHOTO
-	 * 
+	 *
 	 * This should be specified if profile2.official.image.source=provided
 	 *
 	 * @return
 	 */
 	public String getOfficialImageAttribute();
-	
+
 	/**
 	 * Get a UUID from the IdManager
 	 * @return
 	 */
 	public String createUuid();
-	
+
 	/**
 	 * Does the user have a current Sakai session
 	 * @param userUuid	user to check
 	 * @return	true/false
-	 */ 
+	 */
 	public boolean isUserActive(String userUuid);
-	
+
 	/**
 	 * Get the list of users with active Sakai sessions, given the supplied list of userIds.
 	 * @param userUuids		List of users to check
 	 * @return	List of userUuids that have active Sakai sessions
 	 */
 	public List<String> getActiveUsers(List<String> userUuids);
-	
+
 	/**
 	 * Get the last event time for the user.
 	 * @param userUuid		user to check
 	 * @return	Long of time in milliseconds since epoch, or null if no event.
 	 */
 	public Long getLastEventTimeForUser(String userUuid);
-	
+
 	/**
 	 * Get the last event time for each of the given users
 	 * @param userUuids		users to check
 	 * @return	Map of userId to Long of time in milliseconds since epoch, or null if no event.
 	 */
 	public Map<String, Long> getLastEventTimeForUsers(List<String> userUuids);
-	
+
 	/**
 	 * Generic method to get a configuration parameter from sakai.properties
 	 * @param key	key of property
@@ -748,15 +739,15 @@ public interface SakaiProxy {
 	 * @return	value or default if none
 	 */
 	public String getServerConfigurationParameter(String key, String def);
-	
-	
+
+
 	/**
 	 * Check if specified site is a My Workspace site
 	 * @param siteId id of site
 	 * @return true if site is a My Workspace site, false otherwise.
 	 */
 	public boolean isUserMyWorkspace(String siteId);
-	
+
 	/**
 	 * Generic method to check if user has permission in site
 	 * @param userId userId of user to check permission
@@ -765,24 +756,24 @@ public interface SakaiProxy {
 	 * @return
 	 */
 	public boolean isUserAllowedInSite(String userId, String permission, String siteId);
-	
+
 	/**
 	 * Check if the given siteid is valid
 	 * @param siteId
 	 * @return
 	 */
 	public boolean checkForSite(String siteId);
-	
+
 	/**
 	 * Get the profile2.search.maxSearchResults value from sakai.properties
 	 */
 	public int getMaxSearchResults();
-	
+
 	/**
 	 * Get the profile2.search.maxSearchResultsPerPage value from sakai.properties
 	 */
 	public int getMaxSearchResultsPerPage();
-	
+
 	/**
 	 * Is profile2.gravatar.image.enabled true? If so, allow use of this image and preference.
 	 * @return
@@ -791,143 +782,242 @@ public interface SakaiProxy {
 
 	/**
 	 * Does user have site.add permission?
-	 * 
+	 *
 	 * @return <code>true</code> if user allowed to create worksites, else <code>false</code>.
 	 */
 	public boolean isUserAllowedAddSite(String userUuid);
-	
+
 	/**
 	 * Add a new site.
-	 * 
+	 *
 	 * @param id the id of the site.
 	 * @param type the type of the site e.g. project.
 	 * @return a reference to the new site or <code>null</code> if there is a problem creating the site.
 	 */
 	public Site addSite(String id, String type);
-	
+
 	/**
 	 * Save an existing site.
-	 * 
+	 *
 	 * @param site a reference to the site to save.
 	 * @return <code>true</code> if successful, otherwise <code>false</code>.
 	 */
 	public boolean saveSite(Site site);
-	
+
 	/**
 	 * Return a reference to the specified site.
-	 * 
+	 *
 	 * @param siteId
 	 * @return a reference to the specified site.
 	 */
 	public Site getSite(String siteId);
-	
+
 	/**
 	 * Return all user sites for the current user (i.e. worksites that the user has at least 'access' permission to).
-	 * 
+	 *
 	 * @return all user sites for the current user.
 	 */
 	public List<Site> getUserSites();
-	
+
 	/**
 	 * Returns a reference to the specified Sakai tool.
-	 * 
+	 *
 	 * @param id the id of the tool required.
 	 * @return a reference to the specified Sakai tool or <code>null</code> if a
 	 *         reference cannot be obtained.
 	 */
 	public Tool getTool(String id);
-	
+
 	/**
 	 * Returns a list of the tool types required for the specified site type.
-	 * 
+	 *
 	 * @param category the type of site e.g. 'project'
 	 * @return a list of the tool types required for the specified site type
 	 */
 	public List<String> getToolsRequired(String category);
-	
+
 	/**
 	 * Is the profile2.integration.google.enabled flag set to true in sakai.properties?
 	 * If not set, defaults to false
-	 * 
+	 *
 	 * <p>Depending on this setting, the UI will allow a user to add their Google account.
 	 * For institutions to use this there additional setup required.</p>
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isGoogleIntegrationEnabledGlobally();
-	
+
 	/**
 	 * Helper to check if the current user is logged in
 	 * @return
 	 */
 	public boolean isLoggedIn();
-	
+
 	/**
-	 * Is the profile2.profile.fields.enabled flag set in sakai.properties? 
+	 * Is the profile2.profile.fields.enabled flag set in sakai.properties?
 	 * If not set, defaults to true.
-	 * 
+	 *
 	 * <p>This setting controls the display of the profile fields.
-	 * 
-	 * @return true or false. 
+	 *
+	 * @return true or false.
 	 */
 	public boolean isProfileFieldsEnabled();
-	
+
 	/**
-	 * Is the profile2.profile.status.enabled flag set in sakai.properties? 
+	 * Is the profile2.profile.status.enabled flag set in sakai.properties?
 	 * If not set, defaults to true.
-	 * 
+	 *
 	 * <p>This setting controls the display of the profile status section.
-	 * 
-	 * @return true or false. 
+	 *
+	 * @return true or false.
 	 */
 	public boolean isProfileStatusEnabled();
 
 	/**
-	 * Is the profile2.profile.social.enabled flag set in sakai.properties? 
+	 * Is the profile2.profile.social.enabled flag set in sakai.properties?
 	 * If not set, defaults to true.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.profile.social.enabled flag
 	 *         is set, otherwise returns <code>false</code>.
 	 */
 	public boolean isSocialProfileEnabled();
 
 	/**
-	 * Is the profile2.profile.interests.enabled flag set in sakai.properties? 
+	 * Is the profile2.profile.interests.enabled flag set in sakai.properties?
 	 * If not set, defaults to true.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.profile.interests.enabled flag
 	 *         is set, otherwise returns <code>false</code>.
 	 */
 	public boolean isInterestsProfileEnabled();
 
 	/**
-	 * Is the profile2.profile.staff.enabled flag set in sakai.properties? 
+	 * Is the profile2.profile.staff.enabled flag set in sakai.properties?
 	 * If not set, defaults to true.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.profile.staff.enabled flag
 	 *         is set, otherwise returns <code>false</code>.
 	 */
 	public boolean isStaffProfileEnabled();
 
 	/**
-	 * Is the profile2.profile.student.enabled flag set in sakai.properties? 
+	 * Is the profile2.profile.student.enabled flag set in sakai.properties?
 	 * If not set, defaults to true.
-	 * 
+	 *
 	 * @return <code>true</code> if the profile2.profile.student.enabled flag
 	 *         is set, otherwise returns <code>false</code>.
 	 */
 	public boolean isStudentProfileEnabled();
-	
-	
+
+
 	/**
 	 * Is the profile2.import.images flag set in sakai.properties?
 	 * If not set, defaults to false
-	 * 
-	 * <p>If enabled then at startup profile 2 will attempt to download any profile URLs set 
+	 *
+	 * <p>If enabled then at startup profile 2 will attempt to download any profile URLs set
 	 * and upload them as profile images.
 	 * </p>
-	 * 
+	 *
 	 * @return true or false
 	 */
 	public boolean isProfileImageImportEnabled();
+
+	/**
+	* Is the profile2.menu.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the profile sub-sections will be displayed.
+	* This setting controls the display of the profile sub-sections:
+	*				* Messaging						* Privacy
+	*				* Gallery							* Preferences
+	*				* Search							* Messaging
+	*				* Connections
+	* </p>
+	*
+	* @return <code>true</code> if the profile2.menu.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isMenuEnabledGlobally();
+
+	/**
+	* Is the profile2.connection.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the connection feature will be available.</p>
+	*
+	* @return <code>true</code> if the profile2.connection.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isConnectionEnabledGlobally();
+
+	/**
+	* Is the profile2.messaging.enabled flag set in sakai.properties?
+	* If not set, default to true, as long as profile2.connection.enabled is true.
+	*
+	* <p>If enabled, the messaging feature will be enabled. Though, Messaging
+	* depends on Connections, thus if ConnectionsEnabled == false, Messaging will
+	* also be false. </p>
+	*
+	* @return the status of the profile2.messaging.enabled flag in sakai.properties.
+	* Returns true by default.
+	*/
+	public boolean isMessagingEnabledGlobally();
+
+	/**
+	* Is the profile2.search.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the ability to search for people in profile
+	* will be available. </p>
+	*
+	* @return <code>true</code> if the profile2.search.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isSearchEnabledGlobally();
+
+	/**
+	* Is the profile2.privacy.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the ability to modify one's privacy settings in profile
+	* will be available. Set profile2.privacy.default.x appropriately if disabled </p>
+	*
+	* @return <code>true</code> if the profile2.privacy.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isPrivacyEnabledGlobally();
+
+	/**
+	* Is the profile2.preference.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the ability to modify one's preferences within profile
+	* will be available. </p>
+	*
+	* @return <code>true</code> if the profile2.preference.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isPreferenceEnabledGlobally();
+
+	/**
+	* Is the profile2.myKudos.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the Kudos feature will be displayed.</p>
+	*
+	* @return <code>true</code> if the profile2.myKudos.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isMyKudosEnabledGlobally();
+
+	/**
+	* Is the profile2.onlineStatus.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, an online indicator will be present when viewing a profile. </p>
+	*
+	* @return <code>true</code> if the profile2.onlineStatus.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isOnlineStatusEnabledGlobally();
 }

--- a/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
@@ -17,7 +17,7 @@ package org.sakaiproject.profile2.util;
 
 /**
  * Class to hold static constants for Profile2, like defaults etc.
- * 
+ *
  * @author Steve Swinsburg (s.swinsburg@lancaster.ac.uk)
  *
  */
@@ -26,43 +26,43 @@ public class ProfileConstants {
 	/*
 	 * CONNECTIONS
 	 */
-	
+
 	//number of friends to show in friends feed
-	public static final int MAX_FRIENDS_FEED_ITEMS = 6; 
-	
+	public static final int MAX_FRIENDS_FEED_ITEMS = 6;
+
 	//relationship type
 	public static final int RELATIONSHIP_FRIEND = 1;
 	//public static final int RELATIONSHIP_COLLEAGUE = 2;
-	
+
 	//connection status
 	public static final int CONNECTION_NONE = 0;
 	public static final int CONNECTION_REQUESTED = 1;
 	public static final int CONNECTION_INCOMING = 2;
 	public static final int CONNECTION_CONFIRMED = 3;
 
-	
+
 	/*
 	 * IMAGE
 	 */
-	
+
 	//default if not specified in sakai.properties as profile.picture.max (megs)
-	public static final int MAX_IMAGE_UPLOAD_SIZE = 2; 
-	
+	public static final int MAX_IMAGE_UPLOAD_SIZE = 2;
+
 	//one side will be scaled to this if larger. 200 is large enough
-	public static final int MAX_IMAGE_XY = 200; 	
-	
-	//one side will be scaled to this if larger. 
-	public static final int MAX_THUMBNAIL_IMAGE_XY = 100; 	
-    
+	public static final int MAX_IMAGE_XY = 200;
+
+	//one side will be scaled to this if larger.
+	public static final int MAX_THUMBNAIL_IMAGE_XY = 100;
+
 	//directories in content hosting that these images live in
 	//also used by ProfileImageExternal
-	public static final int PROFILE_IMAGE_MAIN = 1;		
+	public static final int PROFILE_IMAGE_MAIN = 1;
 	public static final int PROFILE_IMAGE_THUMBNAIL = 2;
 	public static final int PROFILE_IMAGE_AVATAR = 3;
-	
+
 	//should images be marked up in a way that a browser can cache them?
 	public static final boolean PROFILE_IMAGE_CACHE = true;
-	
+
 	//gallery-related constants
 	public static final String GALLERY_IMAGE_MAIN = "images";
 	public static final String GALLERY_IMAGE_THUMBNAILS = "thumbnails";
@@ -72,14 +72,14 @@ public class ProfileConstants {
 	public static final int MAX_GALLERY_FILE_UPLOADS = 10;
 	public static final int MAX_GALLERY_IMAGES_PER_PAGE = 12; //max before pager kicks in
 
-	
+
 	//default images for certain things
 	public static final String UNAVAILABLE_IMAGE = "images/no_image.gif";
 	public static final String UNAVAILABLE_IMAGE_THUMBNAIL = "/profile2-tool/images/no_image_thumbnail.gif";
 	public static final String UNAVAILABLE_IMAGE_FULL = "/profile2-tool/images/no_image.gif";
 	public static final String CLOSE_IMAGE = "/library/image/silk/cross.png";
 	public static final String INFO_IMAGE = "/library/image/silk/information.png";
-	
+
 	public static final String RSS_IMG = "/library/image/silk/feed.png";
 	public static final String ACCEPT_IMG = "/library/image/silk/accept.png";
 	public static final String ADD_IMG = "/library/image/silk/add.png";
@@ -87,7 +87,7 @@ public class ProfileConstants {
 	public static final String DELETE_IMG = "/library/image/silk/delete.png";
 	public static final String CROSS_IMG = "/library/image/silk/cross.png";
 	public static final String CROSS_IMG_LOCAL = "images/cross.png";
-	
+
 	public static final String AWARD_NORMAL_IMG = "/library/image/silk/medal_silver_1.png";
 	public static final String AWARD_BRONZE_IMG = "/library/image/silk/award_star_bronze_3.png";
 	public static final String AWARD_SILVER_IMG = "/library/image/silk/award_star_silver_3.png";
@@ -97,7 +97,7 @@ public class ProfileConstants {
 	public static final String ONLINE_STATUS_OFFLINE_IMG = "/library/image/silk/bullet_black.png";
 	public static final String ONLINE_STATUS_AWAY_IMG = "/library/image/silk/bullet_yellow.png";
 
-	
+
 	//profile picture settings for use in API and tool and their values for sakai.properties
 	//and the default if not specified or invalid one specified
 	public static final int PICTURE_SETTING_UPLOAD = 1;
@@ -109,27 +109,27 @@ public class ProfileConstants {
 	public static final int PICTURE_SETTING_GRAVATAR = 4;
 	//n.b a gravatar is not an enforceable setting, hence no property here. it is purely a choice.
 	//it can be disabled in sakai.properties if required.
-	
+
 	public static final int PICTURE_SETTING_DEFAULT = PICTURE_SETTING_UPLOAD;
-	
+
 	// if using official photo, where does that image come from?
-	// can be url, provider or filesystem. 
+	// can be url, provider or filesystem.
 	public static final String OFFICIAL_IMAGE_SETTING_URL = "url";
 	public static final String OFFICIAL_IMAGE_SETTING_PROVIDER = "provider";
 	public static final String OFFICIAL_IMAGE_SETTING_FILESYSTEM = "filesystem";
-	
+
 	public static final String OFFICIAL_IMAGE_SETTING_DEFAULT = OFFICIAL_IMAGE_SETTING_URL;
 
 	//the property that an external provider may set into the user properties for the jpegPhoto field.
 	public static final String USER_PROPERTY_JPEG_PHOTO = "jpegPhoto";
-	
+
 	//gravatar base URL
 	public static final String GRAVATAR_BASE_URL = "http://www.gravatar.com/avatar/";
 
     // Defines the name of the blank image, the one a user gets when nothing else is available
     public static final String BLANK = "blank";
-	
-	
+
+
 	/*
 	 * SEARCH
 	 */
@@ -160,26 +160,26 @@ public class ProfileConstants {
 	public static final boolean DEFAULT_SHOW_GALLERY_FEED_SETTING = true;
 	public static final boolean DEFAULT_GRAVATAR_SETTING = false;
 	public static final boolean DEFAULT_SHOW_ONLINE_STATUS_SETTING = true;
-	
-	
+
+
 	/*
 	 * PRIVACY
 	 */
-	
+
 	//setup the profile privacy values (2 is only used in strict mode, 3 is only used in super strict mode)
-	public static final int PRIVACY_OPTION_EVERYONE = 0; 
-	public static final int PRIVACY_OPTION_ONLYFRIENDS = 1; 
-	public static final int PRIVACY_OPTION_ONLYME = 2; 
-	public static final int PRIVACY_OPTION_NOBODY = 3; 
-	
+	public static final int PRIVACY_OPTION_EVERYONE = 0;
+	public static final int PRIVACY_OPTION_ONLYFRIENDS = 1;
+	public static final int PRIVACY_OPTION_ONLYME = 2;
+	public static final int PRIVACY_OPTION_NOBODY = 3;
+
 	//these values are used when creating a default privacy record for a user
-	public static final int DEFAULT_PRIVACY_OPTION_PROFILEIMAGE = PRIVACY_OPTION_EVERYONE; 
-	public static final int DEFAULT_PRIVACY_OPTION_BASICINFO = PRIVACY_OPTION_EVERYONE; 
+	public static final int DEFAULT_PRIVACY_OPTION_PROFILEIMAGE = PRIVACY_OPTION_EVERYONE;
+	public static final int DEFAULT_PRIVACY_OPTION_BASICINFO = PRIVACY_OPTION_EVERYONE;
 	public static final int DEFAULT_PRIVACY_OPTION_CONTACTINFO = PRIVACY_OPTION_EVERYONE;
-	public static final int DEFAULT_PRIVACY_OPTION_PERSONALINFO = PRIVACY_OPTION_EVERYONE; 
-	public static final int DEFAULT_PRIVACY_OPTION_SEARCH = PRIVACY_OPTION_EVERYONE; 
-	public static final int DEFAULT_PRIVACY_OPTION_MYFRIENDS = PRIVACY_OPTION_EVERYONE; 
-	public static final int DEFAULT_PRIVACY_OPTION_MYSTATUS = PRIVACY_OPTION_EVERYONE; 
+	public static final int DEFAULT_PRIVACY_OPTION_PERSONALINFO = PRIVACY_OPTION_EVERYONE;
+	public static final int DEFAULT_PRIVACY_OPTION_SEARCH = PRIVACY_OPTION_EVERYONE;
+	public static final int DEFAULT_PRIVACY_OPTION_MYFRIENDS = PRIVACY_OPTION_EVERYONE;
+	public static final int DEFAULT_PRIVACY_OPTION_MYSTATUS = PRIVACY_OPTION_EVERYONE;
 	public static final int DEFAULT_PRIVACY_OPTION_MYPICTURES = PRIVACY_OPTION_EVERYONE;
 	public static final int DEFAULT_PRIVACY_OPTION_MESSAGES = PRIVACY_OPTION_ONLYFRIENDS;
 	public static final int DEFAULT_PRIVACY_OPTION_BUSINESSINFO = PRIVACY_OPTION_EVERYONE;
@@ -191,11 +191,11 @@ public class ProfileConstants {
 	public static final int DEFAULT_PRIVACY_OPTION_ONLINESTATUS = PRIVACY_OPTION_EVERYONE;
 
 	public static final boolean DEFAULT_BIRTHYEAR_VISIBILITY = true;
-	
+
 	/*
 	 * DEFAULT SAKAI PROPERTIES
 	 */
-	
+
 	public static final String SAKAI_PROP_INVISIBLE_USERS = "postmaster"; //string, comma separated
 	public static final char SAKAI_PROP_LIST_SEPARATOR = ','; //char used to separate multi value lists
 	public static final String SAKAI_PROP_SERVICE_NAME = "Sakai"; //ui.service
@@ -219,82 +219,90 @@ public class ProfileConstants {
 	public static final boolean SAKAI_PROP_PROFILE2_PROFILE_FIELDS_ENABLED = true; //profile2.profile.fields.enabled
 	public static final boolean SAKAI_PROP_PROFILE2_PROFILE_STATUS_ENABLED = true; //profile2.profile.status.enabled
 	public static final boolean SAKAI_PROP_PROFILE2_IMPORT_IMAGES_ENABLED = false; // profile2.import.images
+	public static final boolean SAKAI_PROP_PROFILE2_MENU_ENABLED = true; //profile2.menu.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_CONNECTION_ENABLED = true; //profile2.connection.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_MESSAGING_ENABLED = true; //profile2.messaging.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_SEARCH_ENABLED = true; //profile2.search.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_PRIVACY_ENABLED = true; //profile2.privacy.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_PREFERENCE_ENABLED = true; //profile2.preference.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_MY_KUDOS_ENABLED = true; //profile2.myKudos.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_ONLINE_STATUS_ENABLED = true; //profile2.onlineStatus.enabled
 
 
-	
+
 	/*
 	 * MESSAGING
 	 */
 	//max number of connections that can be shown in an autocomplete search that match the criteria
 	public static final int MAX_CONNECTIONS_PER_SEARCH = 15;
-	
+
 	//default subject if none supplied
 	public static final String DEFAULT_PRIVATE_MESSAGE_SUBJECT = "(no subject)";
-	
+
 	//max number of messages to show per page
 	public static final int MAX_MESSAGES_PER_PAGE = 15;
-	
+
 	//date format display for messages
 	public static final String MESSAGE_DISPLAY_DATE_FORMAT = "dd MMMM 'at' HH:mm";
-	
+
 	//max length of the preview of a message
 	public static final int MESSAGE_PREVIEW_MAX_LENGTH = 150;
-	
-	
+
+
 	/*
 	 * MISC
 	 */
-	
+
 	//date format display
-	public static final String DEFAULT_DATE_FORMAT = "dd MMMM yyyy"; 
+	public static final String DEFAULT_DATE_FORMAT = "dd MMMM yyyy";
 	public static final String DEFAULT_DATE_FORMAT_HIDE_YEAR = "dd MMMM";
-	
+
 	//max number of connections to show per page
 	public static final int MAX_CONNECTIONS_PER_PAGE = 15;
-	
+
 	//record limits used in searchUsers (could we combine with above?)
-	public static final int FIRST_RECORD = 1;		
+	public static final int FIRST_RECORD = 1;
 	public static final int MAX_RECORDS = 99;
-	
+
 	//tool id
 	public static final String TOOL_ID = "sakai.profile2";
-		
+
 	//email constants
 	public static final String EMAIL_NEWLINE = "<br />\n";
-	
+
 	/*
 	 * TABS
 	 */
 	public static final String TAB_COOKIE = "profile2-tab";
 	public static final int TAB_INDEX_PROFILE = 0;
 	public static final int TAB_INDEX_WALL = 1;
-	
+
 	/*
-	 * WALL 
+	 * WALL
 	 */
 	public static final int WALL_ITEM_TYPE_EVENT = 0;
 	public static final int WALL_ITEM_TYPE_STATUS = 1;
 	public static final int WALL_ITEM_TYPE_POST = 2;
-	
+
 	//date format display for wall items and wall comments
 	public static final String WALL_DISPLAY_DATE_FORMAT = "dd MMMMM, HH:mm";
-	
+
 	// TODO possible candidates for sakai.properties
 	public static final int MAX_WALL_ITEMS_SAVED_PER_USER = 30;
 	public static final int MAX_WALL_ITEMS_PER_PAGE = 10;
-	
+
 	/*
 	 * EVENTS
 	 */
-	
-	//this is so granular so we can get good reports on what and how much is being used 
+
+	//this is so granular so we can get good reports on what and how much is being used
 	public static final String EVENT_PROFILE_VIEW_OWN = "profile.view.own";
 	public static final String EVENT_PROFILE_VIEW_OTHER = "profile.view.other";
 	public static final String EVENT_PROFILE_IMAGE_CHANGE_UPLOAD = "profile.image.change.upload";
 	public static final String EVENT_PROFILE_IMAGE_CHANGE_URL = "profile.image.change.url";
 	public static final String EVENT_PROFILE_IMAGE_UPLOAD = "profile.image.upload";
 	public static final String EVENT_PROFILE_NEW = "profile.new";
-		
+
 	public static final String EVENT_PROFILE_INFO_UPDATE = "profile.info.update";
 	public static final String EVENT_PROFILE_CONTACT_UPDATE = "profile.contact.update";
 	public static final String EVENT_PROFILE_INTERESTS_UPDATE = "profile.interests.update";
@@ -302,7 +310,7 @@ public class ProfileConstants {
 	public static final String EVENT_PROFILE_STUDENT_UPDATE = "profile.student.update";
 	public static final String EVENT_PROFILE_SOCIAL_NETWORKING_UPDATE = "profile.socialnetworking.update";
 	public static final String EVENT_PROFILE_BUSINESS_UPDATE = "profile.business.update";
-	
+
 	public static final String EVENT_FRIEND_REQUEST = "profile.friend.request";
 	public static final String EVENT_FRIEND_CONFIRM = "profile.friend.confirm";
 	public static final String EVENT_FRIEND_IGNORE = "profile.friend.ignore";
@@ -310,48 +318,48 @@ public class ProfileConstants {
 
 	public static final String EVENT_PRIVACY_NEW = "profile.privacy.new";
 	public static final String EVENT_PRIVACY_UPDATE = "profile.privacy.update";
-	
+
 	public static final String EVENT_FRIENDS_VIEW_OWN = "profile.friends.view.own";
 	public static final String EVENT_FRIENDS_VIEW_OTHER = "profile.friends.view.other";
 
 	public static final String EVENT_SEARCH_BY_NAME = "profile.search.name";
 	public static final String EVENT_SEARCH_BY_INTEREST = "profile.search.interest";
-	
+
 	public static final String EVENT_PREFERENCES_NEW = "profile.prefs.new";
 	public static final String EVENT_PREFERENCES_UPDATE = "profile.prefs.update";
 
 	public static final String EVENT_STATUS_UPDATE = "profile.status.update";
 	public static final String EVENT_TWITTER_UPDATE = "profile.twitter.update";
-	
+
 	public static final String EVENT_MESSAGE_SENT = "profile.message.sent";
-	
+
 	public static final String EVENT_GALLERY_IMAGE_UPLOAD = "profile.gallery.image.upload";
-	
-	
+
+
 	/*
 	 * ENTITY
 	 */
-	
+
 	//custom entity types
 	public static final int ENTITY_PROFILE_FULL = 0;
 	public static final int ENTITY_PROFILE_MINIMAL = 1;
 	public static final int ENTITY_PROFILE_ACADEMIC = 2;
-	
+
 	//entity set defaults
 	public static final String ENTITY_SET_ACADEMIC = "displayName,imageUrl";
 	public static final String ENTITY_SET_MINIMAL = "displayName,statusMessage,statusDate";
-	
+
 	//entity css
 	public static final String ENTITY_CSS_PROFILE = "/profile2-tool/css/profile2-profile-entity.css";
-	
+
 	//max length of the personal summary in the formatted profile
 	public static final String FORMATTED_PROFILE_SUMMARY_MAX_LENGTH = "1000"; //profile2.formatted.profile.summary.max
-	
-	
+
+
 	/*
 	 * EMAIL TEMPLATING
 	 */
-	
+
 	public static final String EMAIL_TEMPLATE_KEY_MESSAGE_NEW = "profile2.messageNew";
 	public static final String EMAIL_TEMPLATE_KEY_MESSAGE_REPLY = "profile2.messageReply";
 	public static final String EMAIL_TEMPLATE_KEY_CONNECTION_REQUEST = "profile2.connectionRequest";
@@ -362,11 +370,11 @@ public class ProfileConstants {
 	public static final String EMAIL_TEMPLATE_KEY_WALL_STATUS_NEW = "profile2.wallStatusNew";
 	public static final String EMAIL_TEMPLATE_KEY_WORKSITE_NEW = "profile2.worksiteNew";
 	public static final String EMAIL_TEMPLATE_KEY_PROFILE_CHANGE_NOTIFICATION = "profile2.profileChangeNotification";
-	
+
 	/*
 	 * DIRECT LINKS
 	 */
-	
+
 	public static final String ENTITY_BROKER_PREFIX = "/direct";
 	public static final String LINK_ENTITY_PREFIX = "/my";
 	public static final String LINK_ENTITY_PROFILE = "/profile";
@@ -387,27 +395,27 @@ public class ProfileConstants {
 	/*
 	 * ONLINE STATUS
 	 */
-	
+
 	public static final int ONLINE_STATUS_OFFLINE = 0;
 	public static final int ONLINE_STATUS_ONLINE = 1;
 	public static final int ONLINE_STATUS_AWAY = 2;
 
 	public static final long ONLINE_INACTIVITY_INTERVAL = 5000000; // 5 minutes between events  = online -> away
-	
+
 	/*
 	 * PERMISSIONS
 	 */
-	
+
 	public static final String ROSTER_VIEW_PHOTO = "roster.viewofficialphoto";
 	public static final String ROSTER_VIEW_EMAIL = "roster.viewemail";
-	
-	
+
+
 	/*
 	 * INTEGRATIONS
 	 */
 	public static final String GOOGLE_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 	public static final String GOOGLE_DOCS_SCOPE = "https://docs.google.com/feeds/";
 
-	
-	
+
+
 }

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/SakaiProxyImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/SakaiProxyImpl.java
@@ -69,35 +69,35 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 
 /**
  * Implementation of SakaiProxy for Profile2.
- * 
+ *
  * @author Steve Swinsburg (s.swinsburg@lancaster.ac.uk)
  *
  */
 public class SakaiProxyImpl implements SakaiProxy {
 
 	private static final Logger log = Logger.getLogger(SakaiProxyImpl.class);
-    
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getCurrentSiteId(){
 		return toolManager.getCurrentPlacement().getContext();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getCurrentUserId() {
 		return sessionManager.getCurrentSessionUserId();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public User getCurrentUser() {
 		return userDirectoryService.getCurrentUser();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -110,7 +110,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return eid;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -137,7 +137,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return name;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -150,7 +150,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return email;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -163,7 +163,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return email;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -176,7 +176,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return email;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -186,13 +186,13 @@ public class SakaiProxyImpl implements SakaiProxy {
 			u = userDirectoryService.getUser(userId);
 			if (u != null) {
 				return true;
-			} 
+			}
 		} catch (UserNotDefinedException e) {
 			log.info("User with id: " + userId + " does not exist : " + e.getClass() + " : " + e.getMessage());
 		}
 		return false;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -202,20 +202,20 @@ public class SakaiProxyImpl implements SakaiProxy {
 			u = userDirectoryService.getUserByEid(eid);
 			if (u != null) {
 				return true;
-			} 
+			}
 		} catch (UserNotDefinedException e) {
 			log.info("User with eid: " + eid + " does not exist : " + e.getClass() + " : " + e.getMessage());
 		}
 		return false;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isSuperUser() {
 		return securityService.isSuperUser();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -223,15 +223,15 @@ public class SakaiProxyImpl implements SakaiProxy {
 		return StringUtils.equals(sessionManager.getCurrentSessionUserId(), UserDirectoryService.ADMIN_ID);
 	}
 
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isSuperUserAndProxiedToUser(String userId) {
 		return (isSuperUser() && !StringUtils.equals(userId, getCurrentUserId()));
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -244,7 +244,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return type;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -255,11 +255,11 @@ public class SakaiProxyImpl implements SakaiProxy {
 		} catch (UserNotDefinedException e) {
 			log.info("User with id: " + userId + " does not exist : " + e.getClass() + " : " + e.getMessage());
 		}
-		
+
 		return u;
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -273,7 +273,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		return u;
 	}
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -284,14 +284,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 		else
 			return "Profile";
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public List<User> getUsers(List<String> userIds) {
 		return userDirectoryService.getUsers(userIds);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -303,14 +303,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 		return uuids;
 	}
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public SakaiPerson getSakaiPerson(String userId) {
-		
+
 		SakaiPerson sakaiPerson = null;
-		
+
 		try {
 			sakaiPerson = sakaiPersonManager.getSakaiPerson(userId, sakaiPersonManager.getUserMutableType());
 		} catch (Exception e) {
@@ -318,15 +318,15 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return sakaiPerson;
 	}
-  
+
 	/**
  	* {@inheritDoc}
  	*/
 	public byte[] getSakaiPersonJpegPhoto(String userId) {
-		
+
 		SakaiPerson sakaiPerson = null;
 		byte[] image = null;
-    
+
 		try {
 			//try normal user type
 			sakaiPerson = sakaiPersonManager.getSakaiPerson(userId, sakaiPersonManager.getUserMutableType());
@@ -340,21 +340,21 @@ public class SakaiProxyImpl implements SakaiProxy {
 					image = sakaiPerson.getJpegPhoto();
 				}
 			}
-			
+
 		} catch (Exception e) {
 			log.error("SakaiProxy.getSakaiPersonJpegPhoto(): Couldn't get SakaiPerson Jpeg photo for: " + userId + " : " + e.getClass() + " : " + e.getMessage());
 		}
 		return image;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getSakaiPersonImageUrl(String userId) {
-		
+
 		SakaiPerson sakaiPerson = null;
 		String url = null;
-    
+
 		try {
 			//try normal user type
 			sakaiPerson = sakaiPersonManager.getSakaiPerson(userId, sakaiPersonManager.getUserMutableType());
@@ -368,20 +368,20 @@ public class SakaiProxyImpl implements SakaiProxy {
 					url = sakaiPerson.getPictureUrl();
 				}
 			}
-			
+
 		} catch (Exception e) {
 			log.error("SakaiProxy.getSakaiPersonImageUrl(): Couldn't get SakaiPerson image URL for: " + userId + " : " + e.getClass() + " : " + e.getMessage());
 		}
 		return url;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public SakaiPerson getSakaiPersonPrototype() {
-		
+
 		SakaiPerson sakaiPerson = null;
-		
+
 		try {
 			sakaiPerson = sakaiPersonManager.getPrototype();
 		} catch (Exception e) {
@@ -389,14 +389,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return sakaiPerson;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public SakaiPerson createSakaiPerson(String userId) {
-		
+
 		SakaiPerson sakaiPerson = null;
-		
+
 		try {
 			sakaiPerson = sakaiPersonManager.create(userId, sakaiPersonManager.getUserMutableType());
 		} catch (Exception e) {
@@ -406,14 +406,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 	}
 
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean updateSakaiPerson(SakaiPerson sakaiPerson) {
 		//the save is void, so unless it throws an exception, its ok (?)
 		//I'd prefer a return value from sakaiPersonManager. this wraps it.
-		
+
 		try {
 			sakaiPersonManager.save(sakaiPerson);
 			return true;
@@ -423,16 +423,16 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return false;
 	}
-	
-	
-	
+
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public int getMaxProfilePictureSize() {
 		return serverConfigurationService.getInt("profile2.picture.max", ProfileConstants.MAX_IMAGE_UPLOAD_SIZE);
 	}
-	
+
 	private String getProfileGalleryPath(String userId) {
 		String slash = Entity.SEPARATOR;
 
@@ -452,7 +452,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 	 * {@inheritDoc}
 	 */
 	public String getProfileGalleryImagePath(String userId, String imageId) {
-		
+
 		StringBuilder path = new StringBuilder(getProfileGalleryPath(userId));
 
 		path.append(ProfileConstants.GALLERY_IMAGE_MAIN);
@@ -473,14 +473,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 
 		return path.toString();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getProfileImageResourcePath(String userId, int type) {
-		
+
 		String slash = Entity.SEPARATOR;
-		
+
 		StringBuilder path = new StringBuilder();
 		path.append(slash);
 		path.append("private");
@@ -492,25 +492,25 @@ public class SakaiProxyImpl implements SakaiProxy {
 		path.append(type);
 		path.append(slash);
 		path.append(ProfileUtils.generateUuid());
-		
+
 		return path.toString();
-		
+
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean saveFile(String fullResourceId, String userId, String fileName, String mimeType, byte[] fileData) {
-		
+
 		ContentResourceEdit resource = null;
 		boolean result = true;
-		
+
 		try {
-			
+
 			enableSecurityAdvisor();
-			
+
 			try {
-								
+
 				resource = contentHostingService.addResource(fullResourceId);
 				resource.setContentType(mimeType);
 				resource.setContent(fileData);
@@ -532,7 +532,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 				log.error("SakaiProxy.saveFile(): failed: " + e.getClass() + " : " + e.getMessage());
 				result = false;
 			}
-			
+
 		} catch (Exception e) {
 			log.error("SakaiProxy.saveFile():" + e.getClass() + ":" + e.getMessage());
 			result = false;
@@ -540,21 +540,21 @@ public class SakaiProxyImpl implements SakaiProxy {
 			disableSecurityAdvisor();
 		}
 		return result;
-		
+
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public MimeTypeByteArray getResource(String resourceId) {
-		
+
 		MimeTypeByteArray mtba = new MimeTypeByteArray();
-		
+
 		if(StringUtils.isBlank(resourceId)) {
 			return null;
 		}
-		
+
 		try {
 			enableSecurityAdvisor();
 			try {
@@ -575,24 +575,24 @@ public class SakaiProxyImpl implements SakaiProxy {
 		finally	{
 			disableSecurityAdvisor();
 		}
-		
+
 		return null;
 	}
-	
-	
-	
+
+
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public boolean removeResource(String resourceId) {
-		
+
 		boolean result = false;
-		
+
 		try {
 			enableSecurityAdvisor();
 
 			contentHostingService.removeResource(resourceId);
-			
+
 			result = true;
 		} catch (Exception e) {
 			log.error("SakaiProxy.removeResource() failed for resourceId "
@@ -601,42 +601,42 @@ public class SakaiProxyImpl implements SakaiProxy {
 		} finally {
 			disableSecurityAdvisor();
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public List<User> searchUsers(String search) {
 		return userDirectoryService.searchUsers(search, ProfileConstants.FIRST_RECORD, ProfileConstants.MAX_RECORDS);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public List<User> searchExternalUsers(String search) {
 		return userDirectoryService.searchExternalUsers(search, ProfileConstants.FIRST_RECORD, ProfileConstants.MAX_RECORDS);
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public void postEvent(String event,String reference,boolean modify) {
 		eventTrackingService.post(eventTrackingService.newEvent(event,reference,modify));
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public void sendEmail(final String userId, final String subject, String message) {
-		
+
 		class EmailSender {
 			private String userId;
 			private String subject;
 			private String message;
-			
+
 			public final String MULTIPART_BOUNDARY = "======sakai-multi-part-boundary======";
 			public final String BOUNDARY_LINE = "\n\n--"+MULTIPART_BOUNDARY+"\n";
 			public final String TERMINATION_LINE = "\n\n--"+MULTIPART_BOUNDARY+"--\n\n";
@@ -657,21 +657,21 @@ public class SakaiProxyImpl implements SakaiProxy {
 
 					//get User to send to
 					User user = userDirectoryService.getUser(userId);
-					
+
 					if (StringUtils.isBlank(user.getEmail())){
 						log.error("SakaiProxy.sendEmail() failed. No email for userId: " + userId);
 						return;
 					}
-					
+
 					//do it
 					emailService.sendToUsers(Collections.singleton(user), getHeaders(user.getEmail(), subject), formatMessage(subject, message));
-					
+
 					log.info("Email sent to: " + userId);
 				} catch (UserNotDefinedException e) {
 					log.error("SakaiProxy.sendEmail() failed for userId: " + userId + " : " + e.getClass() + " : " + e.getMessage());
 				}
 			}
-			
+
 			/** helper methods for formatting the message */
 			private String formatMessage(String subject, String message) {
 				StringBuilder sb = new StringBuilder();
@@ -685,10 +685,10 @@ public class SakaiProxyImpl implements SakaiProxy {
 				sb.append(message);
 				sb.append(HTML_END);
 				sb.append(TERMINATION_LINE);
-				
+
 				return sb.toString();
 			}
-			
+
 			private String htmlPreamble(String subject) {
 				StringBuilder sb = new StringBuilder();
 				sb.append("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
@@ -698,10 +698,10 @@ public class SakaiProxyImpl implements SakaiProxy {
 				sb.append(subject);
 				sb.append("</title></head>\n");
 				sb.append("<body>\n");
-				
+
 				return sb.toString();
 			}
-			
+
 			private List<String> getHeaders(String emailTo, String subject){
 				List<String> headers = new ArrayList<String>();
 				headers.add("MIME-Version: 1.0");
@@ -711,10 +711,10 @@ public class SakaiProxyImpl implements SakaiProxy {
 				if (StringUtils.isNotBlank(emailTo)) {
 					headers.add("To: " + emailTo);
 				}
-				
+
 				return headers;
 			}
-			
+
 			private String getFrom(){
 				StringBuilder sb = new StringBuilder();
 				sb.append("From: ");
@@ -722,44 +722,44 @@ public class SakaiProxyImpl implements SakaiProxy {
 				sb.append(" <");
 				sb.append(serverConfigurationService.getString("setup.request", "no-reply@" + getServerName()));
 				sb.append(">");
-				
+
 				return sb.toString();
 			}
-			
+
 			private String formatSubject(String subject) {
 				StringBuilder sb = new StringBuilder();
 				sb.append("Subject: ");
 				sb.append(subject);
-				
+
 				return sb.toString();
 			}
-			
-			
+
+
 		}
-		
+
 		//instantiate class to format, then send the mail
 		new EmailSender(userId, subject, message).send();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public void sendEmail(List<String> userIds, final String emailTemplateKey, final Map<String,String> replacementValues) {
-		
+
 		//get list of Users
 		final List<User> users = new ArrayList<User>(getUsers(userIds));
-		
+
 		//only ever use one thread whether sending to one user or many users
 		Thread sendMailThread = new Thread() {
-			
+
 			public void run() {
 				//get the rendered template for each user
 				RenderedTemplate template = null;
-				
+
 				for(User user : users) {
 					log.info("SakaiProxy.sendEmail() attempting to send email to: " + user.getId());
-					try { 
-						template = emailTemplateService.getRenderedTemplateForUser(emailTemplateKey, user.getReference(), replacementValues); 
+					try {
+						template = emailTemplateService.getRenderedTemplateForUser(emailTemplateKey, user.getReference(), replacementValues);
 						if (template == null) {
 							log.error("SakaiProxy.sendEmail() no template with key: " + emailTemplateKey);
 							return;	//no template
@@ -769,7 +769,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 						log.error("SakaiProxy.sendEmail() error retrieving template for user: " + user.getId() + " with key: " + emailTemplateKey + " : " + e.getClass() + " : " + e.getMessage());
 						continue; //try next user
 					}
-					
+
 					//send
 					sendEmail(user.getId(), template.getRenderedSubject(), template.getRenderedHtmlMessage());
 				}
@@ -777,7 +777,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		};
 		sendMailThread.start();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -786,33 +786,33 @@ public class SakaiProxyImpl implements SakaiProxy {
 	}
 
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getServerName() {
 		return serverConfigurationService.getServerName();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getPortalUrl() {
 		return serverConfigurationService.getPortalUrl();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getServerUrl() {
 		return serverConfigurationService.getServerUrl();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getFullPortalUrl() {
-		return getServerUrl() + getPortalPath(); 
+		return getServerUrl() + getPortalPath();
 	}
 
 	/**
@@ -821,7 +821,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 	public String getPortalPath() {
 		return serverConfigurationService.getString("portalPath", "/portal");
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -836,14 +836,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 		return serverConfigurationService.getUserHomeUrl();
 	}
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getServiceName() {
 		return serverConfigurationService.getString("ui.service", ProfileConstants.SAKAI_PROP_SERVICE_NAME);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -853,15 +853,15 @@ public class SakaiProxyImpl implements SakaiProxy {
 			userEdit = userDirectoryService.editUser(userId);
 			userEdit.setEmail(email);
 			userDirectoryService.commitEdit(userEdit);
-			
+
 			log.info("User email updated for: " + userId);
 		}
-		catch (Exception e) {  
+		catch (Exception e) {
 			log.error("SakaiProxy.updateEmailForUser() failed for userId: " + userId + " : " + e.getClass() + " : " + e.getMessage());
 		}
 	}
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -872,39 +872,39 @@ public class SakaiProxyImpl implements SakaiProxy {
 			userEdit.setFirstName(firstName);
 			userEdit.setLastName(lastName);
 			userDirectoryService.commitEdit(userEdit);
-			
+
 			log.info("User name details updated for: " + userId);
 		}
-		catch (Exception e) {  
+		catch (Exception e) {
 			log.error("SakaiProxy.updateNameForUser() failed for userId: " + userId + " : " + e.getClass() + " : " + e.getMessage());
 		}
 	}
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getDirectUrlToUserProfile(final String userId, final String extraParams) {
 		String portalUrl = getFullPortalUrl();
 		String siteId = getUserMyWorkspace(userId);
-		
+
 		ToolConfiguration toolConfig = getFirstInstanceOfTool(siteId, ProfileConstants.TOOL_ID);
 		if(toolConfig == null) {
 			//if the user doesn't have the Profile2 tool installed in their My Workspace,
 			log.warn("SakaiProxy.getDirectUrlToUserProfile() failed to find " + ProfileConstants.TOOL_ID + " installed in My Workspace for userId: " + userId);
-			
+
 			//just return a link to their My Workspace
 			StringBuilder url = new StringBuilder();
 			url.append(portalUrl);
 			url.append("/site/");
 			url.append(siteId);
 			return url.toString();
-			
+
 		}
-		
+
 		String pageId = toolConfig.getPageId();
 		String placementId = toolConfig.getId();
-				
+
 		try {
 			StringBuilder url = new StringBuilder();
 			url.append(portalUrl);
@@ -919,18 +919,18 @@ public class SakaiProxyImpl implements SakaiProxy {
 				url.append("=");
 				url.append(URLEncoder.encode(extraParams,"UTF-8"));
 			}
-		
+
 			return url.toString();
 		}
 		catch(Exception e) {
 			log.error("SakaiProxy.getDirectUrl():" + e.getClass() + ":" + e.getMessage());
 			return null;
 		}
-		
+
 	}
 
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -954,7 +954,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 				"profile2.profile.business.enabled",
 				ProfileConstants.SAKAI_PROP_PROFILE2_PROFILE_BUSINESS_ENABLED);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -997,34 +997,34 @@ public class SakaiProxyImpl implements SakaiProxy {
 	public boolean isWallEnabledGlobally() {
 		return serverConfigurationService.getBoolean(
 				"profile2.wall.enabled",
-				ProfileConstants.SAKAI_PROP_PROFILE2_WALL_ENABLED);		
+				ProfileConstants.SAKAI_PROP_PROFILE2_WALL_ENABLED);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public boolean isWallDefaultProfilePage() {
 		return serverConfigurationService.getBoolean(
 				"profile2.wall.default",
-				ProfileConstants.SAKAI_PROP_PROFILE2_WALL_DEFAULT);	
+				ProfileConstants.SAKAI_PROP_PROFILE2_WALL_DEFAULT);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isProfileConversionEnabled() {
 		return serverConfigurationService.getBoolean("profile2.convert", ProfileConstants.SAKAI_PROP_PROFILE2_CONVERSION_ENABLED);
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isProfileImageImportEnabled() {
 		return serverConfigurationService.getBoolean("profile2.import.images", ProfileConstants.SAKAI_PROP_PROFILE2_IMPORT_IMAGES_ENABLED);
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -1032,40 +1032,37 @@ public class SakaiProxyImpl implements SakaiProxy {
 		return serverConfigurationService.getBoolean("profile2.import", ProfileConstants.SAKAI_PROP_PROFILE2_IMPORT_ENABLED);
 
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getProfileImportCsvPath() {
 		return serverConfigurationService.getString("profile2.import.csv", null);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isTwitterIntegrationEnabledGlobally() {
 		return serverConfigurationService.getBoolean("profile2.integration.twitter.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_TWITTER_INTEGRATION_ENABLED);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getTwitterSource() {
 		return serverConfigurationService.getString("profile2.integration.twitter.source", ProfileConstants.SAKAI_PROP_PROFILE2_TWITTER_INTEGRATION_SOURCE);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isProfileGalleryEnabledGlobally() {
-		return serverConfigurationService.getBoolean("profile2.gallery.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_GALLERY_ENABLED);
-	}
-	
-	/**
- 	* {@inheritDoc}
- 	*/
-	public boolean isMessagingEnabledGlobally() {
-		return serverConfigurationService.getBoolean("profile2.messaging.enabled", true);
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.gallery.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_GALLERY_ENABLED);
+		}
 	}
 
 	/**
@@ -1092,13 +1089,13 @@ public class SakaiProxyImpl implements SakaiProxy {
 		// return user type specific setting, defaulting to global one
 		return serverConfigurationService.getBoolean("profile2.picture.change." + userType + ".enabled", globallyEnabled);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public int getProfilePictureType() {
 		String pictureType = serverConfigurationService.getString("profile2.picture.type", ProfileConstants.PICTURE_SETTING_UPLOAD_PROP);
-				
+
 		//if 'upload'
 		if(pictureType.equals(ProfileConstants.PICTURE_SETTING_UPLOAD_PROP)) {
 			return ProfileConstants.PICTURE_SETTING_UPLOAD;
@@ -1113,47 +1110,47 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		//gravatar is not an enforceable setting, hence no block here. it is purely a user preference.
 		//but can be disabled
-		
+
 		//otherwise return default
 		else {
 			return ProfileConstants.PICTURE_SETTING_DEFAULT;
 		}
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public List<String> getAcademicEntityConfigurationSet() {
-		
+
 		String configuration = serverConfigurationService.getString("profile2.profile.entity.set.academic", ProfileConstants.ENTITY_SET_ACADEMIC);
 		String[] parameters = StringUtils.split(configuration, ',');
-		
+
 		List<String> tempList = Arrays.asList(parameters);
 		List<String> list = new ArrayList<String>(tempList);
-		
+
 		return list;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public List<String> getMinimalEntityConfigurationSet() {
 		String configuration = serverConfigurationService.getString("profile2.profile.entity.set.minimal", ProfileConstants.ENTITY_SET_MINIMAL);
 		String[] parameters = StringUtils.split(configuration, ',');
-		
+
 		List<String> tempList = Arrays.asList(parameters);
 		List<String> list = new ArrayList<String>(tempList);
-		
+
 		return list;
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String ensureUuid(String userId) {
-		
+
 		//check for userId
 		try {
 			User u = userDirectoryService.getUser(userId);
@@ -1163,7 +1160,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		} catch (UserNotDefinedException e) {
 			//do nothing, this is fine, cotninue to next check
 		}
-		
+
 		//check for eid
 		try {
 			User u = userDirectoryService.getUserByEid(userId);
@@ -1173,41 +1170,41 @@ public class SakaiProxyImpl implements SakaiProxy {
 		} catch (UserNotDefinedException e) {
 			//do nothing, this is fine, continue
 		}
-		
+
 		log.error("User: " + userId + " could not be found in any lookup by either id or eid");
 		return null;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean currentUserMatchesRequest(String userUuid) {
-		
+
 		//get current user
 		String currentUserUuid = getCurrentUserId();
-		
+
 		//check match
 		if(StringUtils.equals(currentUserUuid, userUuid)) {
 			return true;
 		}
-		
+
 		return false;
 	}
 
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isPrivacyChangeAllowedGlobally() {
 		return serverConfigurationService.getBoolean("profile2.privacy.change.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PRIVACY_CHANGE_ENABLED);
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public HashMap<String, Object> getOverriddenPrivacySettings() {
-		
+
 		HashMap<String, Object> props = new HashMap<String, Object>();
 		props.put("profileImage", serverConfigurationService.getInt("profile2.privacy.default.profileImage", ProfileConstants.DEFAULT_PRIVACY_OPTION_PROFILEIMAGE));
 		props.put("basicInfo", serverConfigurationService.getInt("profile2.privacy.default.basicInfo", ProfileConstants.DEFAULT_PRIVACY_OPTION_BASICINFO));
@@ -1228,7 +1225,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 
 		return props;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -1236,31 +1233,31 @@ public class SakaiProxyImpl implements SakaiProxy {
 		String config = serverConfigurationService.getString("profile2.invisible.users", ProfileConstants.SAKAI_PROP_INVISIBLE_USERS);
 		return ProfileUtils.getListFromString(config, ProfileConstants.SAKAI_PROP_LIST_SEPARATOR);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isConnectionAllowedBetweenUserTypes(String requestingUserType, String targetUserType) {
-		
+
 		if(isSuperUser()){
 			return true;
 		}
-		
+
 		String configuration = serverConfigurationService.getString("profile2.allowed.connection.usertypes." + requestingUserType);
 		if(StringUtils.isBlank(configuration)) {
 			return true;
 		}
-		
+
 		String[] values = StringUtils.split(configuration, ',');
 		List<String> valueList = Arrays.asList(values);
 
 		if(valueList.contains(targetUserType)){
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -1275,70 +1272,70 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return false;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isOfficialImageEnabledGlobally() {
 		return serverConfigurationService.getBoolean("profile2.official.image.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_OFFICIAL_IMAGE_ENABLED);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isUsingOfficialImageButAlternateSelectionEnabled() {
-		
-		if(isOfficialImageEnabledGlobally() && 
+
+		if(isOfficialImageEnabledGlobally() &&
 			getProfilePictureType() != ProfileConstants.PICTURE_SETTING_OFFICIAL &&
 			isProfilePictureChangeEnabled()) {
 			return true;
 		}
 		return false;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getOfficialImageSource() {
 		return serverConfigurationService.getString("profile2.official.image.source", ProfileConstants.OFFICIAL_IMAGE_SETTING_DEFAULT);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getOfficialImagesDirectory() {
 		return serverConfigurationService.getString("profile2.official.image.directory", "/official-photos");
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getOfficialImagesFileSystemPattern() {
 		return serverConfigurationService.getString("profile2.official.image.directory.pattern", "TWO_DEEP");
 	}
-	
-	
+
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getOfficialImageAttribute() {
 		return serverConfigurationService.getString("profile2.official.image.attribute", ProfileConstants.USER_PROPERTY_JPEG_PHOTO);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String createUuid() {
 		return idManager.createUuid();
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isUserActive(String userUuid) {
 		return activityService.isUserActive(userUuid);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -1352,28 +1349,28 @@ public class SakaiProxyImpl implements SakaiProxy {
 	public Long getLastEventTimeForUser(String userUuid) {
 		return activityService.getLastEventTimeForUser(userUuid);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public Map<String, Long> getLastEventTimeForUsers(List<String> userUuids) {
 		return activityService.getLastEventTimeForUsers(userUuids);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public String getServerConfigurationParameter(String key, String def) {
 		return serverConfigurationService.getString(key, def);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean isUserMyWorkspace(String siteId) {
 		return siteService.isUserSite(siteId);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -1390,14 +1387,14 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return false;
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
 	public boolean checkForSite(String siteId) {
 		return siteService.siteExists(siteId);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1415,7 +1412,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 				"profile2.search.maxSearchResultsPerPage",
 				ProfileConstants.DEFAULT_MAX_SEARCH_RESULTS_PER_PAGE);
 	}
-	
+
 	/**
  	* {@inheritDoc}
  	*/
@@ -1429,7 +1426,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 	public boolean isUserAllowedAddSite(String userUuid) {
 		return siteService.allowAddSite(userUuid);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1444,10 +1441,10 @@ public class SakaiProxyImpl implements SakaiProxy {
 		} catch (PermissionException e) {
 			e.printStackTrace();
 		}
-		
+
 		return site;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1463,7 +1460,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		}
 		return true;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1475,49 +1472,49 @@ public class SakaiProxyImpl implements SakaiProxy {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public List<Site> getUserSites() {
 		return siteService.getSites(SelectionType.ACCESS, null, null, null, SortType.TITLE_ASC, null);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public Tool getTool(String id) {
 		return toolManager.getTool(id);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public List<String> getToolsRequired(String category) {
 		return serverConfigurationService.getToolsRequired(category);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public boolean isGoogleIntegrationEnabledGlobally() {
 		return serverConfigurationService.getBoolean("profile2.integration.google.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_GOOGLE_INTEGRATION_ENABLED);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public boolean isLoggedIn() {
 		return StringUtils.isNotBlank(getCurrentUserId());
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public boolean isProfileFieldsEnabled() {
 		return serverConfigurationService.getBoolean("profile2.profile.fields.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PROFILE_FIELDS_ENABLED);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -1525,10 +1522,86 @@ public class SakaiProxyImpl implements SakaiProxy {
 		return serverConfigurationService.getBoolean("profile2.profile.status.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PROFILE_STATUS_ENABLED);
 
 	}
-	
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isMenuEnabledGlobally() {
+		return serverConfigurationService.getBoolean("profile2.menu.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_MENU_ENABLED);
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isConnectionEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.connection.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_CONNECTION_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isMessagingEnabledGlobally() {
+		if(isConnectionEnabledGlobally()) {
+			return serverConfigurationService.getBoolean("profile2.messaging.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_MESSAGING_ENABLED);
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isSearchEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.search.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_SEARCH_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isPrivacyEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.privacy.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PRIVACY_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isPreferenceEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.preference.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PREFERENCE_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isMyKudosEnabledGlobally() {
+		return serverConfigurationService.getBoolean("profile2.myKudos.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_MY_KUDOS_ENABLED);
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isOnlineStatusEnabledGlobally() {
+		return serverConfigurationService.getBoolean("profile2.onlineStatus.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_ONLINE_STATUS_ENABLED);
+	}
+
 	// PRIVATE METHODS FOR SAKAIPROXY
-	
-	
+
+
 	/**
 	 * Setup a security advisor for this transaction
 	 */
@@ -1546,21 +1619,21 @@ public class SakaiProxyImpl implements SakaiProxy {
 	private void disableSecurityAdvisor(){
 		securityService.popAdvisor();
 	}
-	
+
 	/**
 	 * Gets the siteId of the given user's My Workspace
 	 * Generally ~userId but may not be
-	 * 
+	 *
 	 * @param userId
 	 * @return
 	 */
 	private String getUserMyWorkspace(String userId) {
 		return siteService.getUserSiteId(userId);
 	}
-		
+
 	/**
 	 * Gets the ToolConfiguration of a page in a site containing a given tool
-	 * 
+	 *
 	 * @param siteId	siteId
 	 * @param toolId	toolId ie sakai.profile2
 	 * @return
@@ -1574,66 +1647,66 @@ public class SakaiProxyImpl implements SakaiProxy {
 			return null;
 		}
 	}
-	
-	
+
+
 	/**
 	 * init
 	 */
 	public void init() {
 		log.info("Profile2 SakaiProxy init()");
-		
+
 		//process the email templates
 		//the list is injected via Spring
 		emailTemplateService.processEmailTemplates(emailTemplates);
-		
+
 	}
 
-	
-	
+
+
 	@Setter
 	private ToolManager toolManager;
-	
+
 	@Setter
 	private SecurityService securityService;
-	
+
 	@Setter
 	private SessionManager sessionManager;
-	
+
 	@Setter
 	private SiteService siteService;
-	
+
 	@Setter
 	private UserDirectoryService userDirectoryService;
-	
+
 	@Setter
 	private SakaiPersonManager sakaiPersonManager;
-	
+
 	@Setter
 	private ContentHostingService contentHostingService;
-	
+
 	@Setter
 	private EventTrackingService eventTrackingService;
-	
+
 	@Setter
 	private EmailService emailService;
-	
+
 	@Setter
 	private ServerConfigurationService serverConfigurationService;
-	
+
 	@Setter
 	private EmailTemplateService emailTemplateService;
-	
+
 	@Setter
 	private IdManager idManager;
-	
+
 	@Setter
 	private ActivityService activityService;
-	
+
 
 	//INJECT OTHER RESOURCES
 	@Setter
 
 	private ArrayList<String> emailTemplates;
-	
-	
+
+
 }

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/BasePage.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/BasePage.java
@@ -49,41 +49,41 @@ import org.sakaiproject.profile2.util.ProfileUtils;
 
 public class BasePage extends WebPage implements IHeaderContributor {
 
-	private static final Logger log = Logger.getLogger(BasePage.class); 
-	
+	private static final Logger log = Logger.getLogger(BasePage.class);
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.SakaiProxy")
 	protected SakaiProxy sakaiProxy;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileLogic")
 	protected ProfileLogic profileLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfilePreferencesLogic")
 	protected ProfilePreferencesLogic preferencesLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfilePrivacyLogic")
 	protected ProfilePrivacyLogic privacyLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileConnectionsLogic")
 	protected ProfileConnectionsLogic connectionsLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileMessagingLogic")
 	protected ProfileMessagingLogic messagingLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileImageLogic")
 	protected ProfileImageLogic imageLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileKudosLogic")
 	protected ProfileKudosLogic kudosLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileExternalIntegrationLogic")
 	protected ProfileExternalIntegrationLogic externalIntegrationLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileWallLogic")
 	protected ProfileWallLogic wallLogic;
-	
+
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfileSearchLogic")
 	protected ProfileSearchLogic searchLogic;
-	
+
 	Link<Void> myPicturesLink;
 	Link<Void> myProfileLink;
 	Link<Void> myFriendsLink;
@@ -91,22 +91,22 @@ public class BasePage extends WebPage implements IHeaderContributor {
 	Link<Void> myPrivacyLink;
 	Link<Void> searchLink;
 	Link<Void> preferencesLink;
-	
-	
+
+
 	public BasePage() {
 		//super();
-		
+
 		log.debug("BasePage()");
-		
+
 		//set Locale - all pages will inherit this.
 		setUserPreferredLocale();
-		
+
 		//PRFL-791 set base HTML lang attribute
-		add(new LocaleAwareHtmlTag("html")); 
-		
+		add(new LocaleAwareHtmlTag("html"));
+
 		//get currentUserUuid
 		String currentUserUuid = sakaiProxy.getCurrentUserId();
-		
+
     	//profile link
     	myProfileLink = new Link<Void>("myProfileLink") {
 			private static final long serialVersionUID = 1L;
@@ -116,8 +116,13 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		myProfileLink.add(new Label("myProfileLabel",new ResourceModel("link.my.profile")));
 		myProfileLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.profile.tooltip")));
+
+		if(!sakaiProxy.isMenuEnabledGlobally()) {
+			myProfileLink.setVisible(false);
+		}
+
 		add(myProfileLink);
-		
+
 		//my pictures link
 		myPicturesLink = new Link<Void>("myPicturesLink") {
 			private static final long serialVersionUID = 1L;
@@ -135,8 +140,8 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		}
 
 		add(myPicturesLink);
-		
-		
+
+
 		//my friends link
     	myFriendsLink = new Link<Void>("myFriendsLink") {
 			private static final long serialVersionUID = 1L;
@@ -146,7 +151,7 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		myFriendsLink.add(new Label("myFriendsLabel",new ResourceModel("link.my.friends")));
 		myFriendsLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.friends.tooltip")));
-		
+
 		//get count of new connection requests
 		int newRequestsCount = connectionsLogic.getConnectionRequestsForUserCount(currentUserUuid);
 		Label newRequestsLabel = new Label("newRequestsLabel", new Model<Integer>(newRequestsCount));
@@ -156,10 +161,13 @@ public class BasePage extends WebPage implements IHeaderContributor {
 			newRequestsLabel.setVisible(false);
 		}
 
-		myFriendsLink.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
+		if(!sakaiProxy.isConnectionEnabledGlobally()) {
+			myFriendsLink.setVisible(false);
+		}
+
 		add(myFriendsLink);
-		
-		
+
+
 		//messages link
     	myMessagesLink = new Link<Void>("myMessagesLink") {
 			private static final long serialVersionUID = 1L;
@@ -169,7 +177,7 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		myMessagesLink.add(new Label("myMessagesLabel",new ResourceModel("link.my.messages")));
 		myMessagesLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.messages.tooltip")));
-		
+
 		//get count of new messages grouped by thread
 		int newMessagesCount = messagingLogic.getThreadsWithUnreadMessagesCount(currentUserUuid);
 		Label newMessagesLabel = new Label("newMessagesLabel", new Model<Integer>(newMessagesCount));
@@ -178,12 +186,12 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		if(newMessagesCount == 0) {
 			newMessagesLabel.setVisible(false);
 		}
-		
+
 		if (!sakaiProxy.isMessagingEnabledGlobally()) {
 			myMessagesLink.setVisible(false);
 		}
 		add(myMessagesLink);
-		
+
 
 		//privacy link
     	myPrivacyLink = new Link<Void>("myPrivacyLink") {
@@ -194,9 +202,14 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		myPrivacyLink.add(new Label("myPrivacyLabel",new ResourceModel("link.my.privacy")));
 		myPrivacyLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.privacy.tooltip")));
+
+		if(!sakaiProxy.isPrivacyEnabledGlobally()) {
+			myPrivacyLink.setVisible(false);
+		}
+
 		add(myPrivacyLink);
-		
-		
+
+
 		//search link
     	searchLink = new Link<Void>("searchLink") {
 			private static final long serialVersionUID = 1L;
@@ -207,11 +220,13 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		searchLink.add(new Label("searchLabel",new ResourceModel("link.my.search")));
 		searchLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.search.tooltip")));
 
-		searchLink.setVisible(sakaiProxy.isSearchEnabledGlobally());
+		if(!sakaiProxy.isSearchEnabledGlobally()) {
+			searchLink.setVisible(false);
+		}
 
 		add(searchLink);
-		
-		
+
+
 		//preferences link
     	preferencesLink = new Link<Void>("preferencesLink") {
 			private static final long serialVersionUID = 1L;
@@ -221,9 +236,13 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		preferencesLink.add(new Label("preferencesLabel",new ResourceModel("link.my.preferences")));
 		preferencesLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.preferences.tooltip")));
+
+		if(!sakaiProxy.isPreferenceEnabledGlobally()) {
+			preferencesLink.setVisible(false);
+		}
 		add(preferencesLink);
-			
-		
+
+
 		//rss link
 		/*
 		ContextImage icon = new ContextImage("icon",new Model(ProfileImageManager.RSS_IMG));
@@ -236,51 +255,32 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		icon.setVisible(true);
 		add(rssLink);
 		*/
-		
-    }
-	
-	
-	
-	
-	
-	
-	
 
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+    }
+
+
 	//Style it like a Sakai tool
 	public void renderHead(IHeaderResponse response) {
-		
+
 		//get the Sakai skin header fragment from the request attribute
 		HttpServletRequest request = getWebRequestCycle().getWebRequest().getHttpServletRequest();
 		response.renderString((String)request.getAttribute("sakai.html.head"));
 		response.renderOnLoadJavascript("setMainFrameHeight( window.name )");
-		
+
 		//Tool additions (at end so we can override if required)
 		response.renderString("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />");
 		response.renderCSSReference("css/profile2.css");
 		response.renderJavascriptReference("javascript/profile2.js");
-		
+
 	}
-	
+
 	/* disable caching
-	protected void setHeaders(WebResponse response) { 
-		response.setHeader("Pragma", "no-cache"); 
-		response.setHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store"); 
-    } 
+	protected void setHeaders(WebResponse response) {
+		response.setHeader("Pragma", "no-cache");
+		response.setHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store");
+    }
 	*/
-	
+
 	/**
 	 * Allow overrides of the user's locale
 	 */
@@ -289,36 +289,36 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		log.debug("User preferred locale: " + locale);
 		getSession().setLocale(locale);
 	}
-	
+
 	/**
 	 * Allow Pages to set the title
 	 * @param model
 	 */
 	/*
-	protected void setPageTitle(IModel model) {  
-		get("pageTitle").setDefaultModel(model);  
-	} 
-	*/ 
-	
-	/** 
+	protected void setPageTitle(IModel model) {
+		get("pageTitle").setDefaultModel(model);
+	}
+	*/
+
+	/**
 	 * Disable a page nav link (PRFL-468)
 	 */
 	protected void disableLink(Link<Void> l) {
 		l.add(new AttributeAppender("class", new Model<String>("current"), " "));
 		l.setEnabled(false);
 	}
-	
+
 	/**
 	 * Set the cookie that stores the current tab index.
-	 * 
+	 *
 	 * @param tabIndex the current tab index.
 	 */
 	protected void setTabCookie(int tabIndex) {
-		
+
 		Cookie tabCookie = new Cookie(ProfileConstants.TAB_COOKIE, "" + tabIndex);
 		// don't persist indefinitely
 		tabCookie.setMaxAge(-1);
 		getWebRequestCycle().getWebResponse().addCookie(tabCookie);
 	}
-	
+
 }

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPreferences.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPreferences.java
@@ -51,59 +51,59 @@ public class MyPreferences extends BasePage{
 
 	private CheckBox officialImage;
 	private CheckBox gravatarImage;
-	
+
 	private boolean officialImageEnabled;
 	private boolean gravatarEnabled;
-	
+
 	public MyPreferences() {
-		
+
 		log.debug("MyPreferences()");
-		
+
 		disableLink(preferencesLink);
-		
+
 		//get current user
 		final String userUuid = sakaiProxy.getCurrentUserId();
 
 		//get the prefs record for this user from the database, or a default if none exists yet
 		profilePreferences = preferencesLogic.getPreferencesRecordForUser(userUuid, false);
-		
+
 		//if null, throw exception
 		if(profilePreferences == null) {
 			throw new ProfilePreferencesNotDefinedException("Couldn't retrieve preferences record for " + userUuid);
 		}
-		
+
 		//get email address for this user
 		String emailAddress = sakaiProxy.getUserEmail(userUuid);
 		//if no email, set a message into it fo display
 		if(emailAddress == null || emailAddress.length() == 0) {
 			emailAddress = new ResourceModel("preferences.email.none").getObject();
 		}
-		
-				
+
+
 		Label heading = new Label("heading", new ResourceModel("heading.preferences"));
 		add(heading);
-		
+
 		//feedback for form submit action
 		final Label formFeedback = new Label("formFeedback");
 		formFeedback.setOutputMarkupPlaceholderTag(true);
 		final String formFeedbackId = formFeedback.getMarkupId();
 		add(formFeedback);
-		
-				
+
+
 		//create model
 		CompoundPropertyModel<ProfilePreferences> preferencesModel = new CompoundPropertyModel<ProfilePreferences>(profilePreferences);
-		
-		//setup form		
+
+		//setup form
 		Form<ProfilePreferences> form = new Form<ProfilePreferences>("form", preferencesModel);
 		form.setOutputMarkupId(true);
-		
-	
+
+
 		//EMAIL SECTION
-		
+
 		//email settings
 		form.add(new Label("emailSectionHeading", new ResourceModel("heading.section.email")));
 		form.add(new Label("emailSectionText", new StringResourceModel("preferences.email.message", null, new Object[] { emailAddress })).setEscapeModelStrings(false));
-	
+
 		//on/off labels
 		form.add(new Label("prefOn", new ResourceModel("preference.option.on")));
 		form.add(new Label("prefOff", new ResourceModel("preference.option.off")));
@@ -120,7 +120,7 @@ public class MyPreferences extends BasePage{
 		emailRequests.add(requestsOff);
 		emailRequests.add(new Label("requestsLabel", new ResourceModel("preferences.email.requests")));
 		form.add(emailRequests);
-		
+
 		//updater
 		emailRequests.add(new AjaxFormChoiceComponentUpdatingBehavior() {
 			private static final long serialVersionUID = 1L;
@@ -128,7 +128,10 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
+		//visibility for request emails
+		emailRequests.setVisible(sakaiProxy.isConnectionEnabledGlobally());
+
 		//confirm emails
 		final RadioGroup<Boolean> emailConfirms = new RadioGroup<Boolean>("confirmEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "confirmEmailEnabled"));
 		Radio confirmsOn = new Radio<Boolean>("confirmsOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -141,7 +144,7 @@ public class MyPreferences extends BasePage{
 		emailConfirms.add(confirmsOff);
 		emailConfirms.add(new Label("confirmsLabel", new ResourceModel("preferences.email.confirms")));
 		form.add(emailConfirms);
-		
+
 		//updater
 		emailConfirms.add(new AjaxFormChoiceComponentUpdatingBehavior() {
 			private static final long serialVersionUID = 1L;
@@ -149,7 +152,10 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
+		//visibility for confirm emails
+		emailConfirms.setVisible(sakaiProxy.isConnectionEnabledGlobally());
+
 		//new message emails
 		final RadioGroup<Boolean> emailNewMessage = new RadioGroup<Boolean>("messageNewEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "messageNewEmailEnabled"));
 		Radio messageNewOn = new Radio<Boolean>("messageNewOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -162,7 +168,7 @@ public class MyPreferences extends BasePage{
 		emailNewMessage.add(messageNewOff);
 		emailNewMessage.add(new Label("messageNewLabel", new ResourceModel("preferences.email.message.new")));
 		form.add(emailNewMessage);
-		
+
 		//updater
 		emailNewMessage.add(new AjaxFormChoiceComponentUpdatingBehavior() {
 			private static final long serialVersionUID = 1L;
@@ -170,9 +176,9 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		emailNewMessage.setVisible(sakaiProxy.isMessagingEnabledGlobally());
-		
+
 		//message reply emails
 		final RadioGroup<Boolean> emailReplyMessage = new RadioGroup<Boolean>("messageReplyEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "messageReplyEmailEnabled"));
 		Radio messageReplyOn = new Radio<Boolean>("messageReplyOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -185,7 +191,7 @@ public class MyPreferences extends BasePage{
 		emailReplyMessage.add(messageReplyOff);
 		emailReplyMessage.add(new Label("messageReplyLabel", new ResourceModel("preferences.email.message.reply")));
 		form.add(emailReplyMessage);
-		
+
 		//updater
 		emailReplyMessage.add(new AjaxFormChoiceComponentUpdatingBehavior() {
 			private static final long serialVersionUID = 1L;
@@ -193,9 +199,9 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		emailReplyMessage.setVisible(sakaiProxy.isMessagingEnabledGlobally());
-		
+
 		// new wall item notification emails
 		final RadioGroup<Boolean> wallItemNew = new RadioGroup<Boolean>("wallItemNewEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "wallItemNewEmailEnabled"));
 		Radio wallItemNewOn = new Radio<Boolean>("wallItemNewOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -208,7 +214,7 @@ public class MyPreferences extends BasePage{
 		wallItemNew.add(wallItemNewOff);
 		wallItemNew.add(new Label("wallItemNewLabel", new ResourceModel("preferences.email.wall.new")));
 		form.add(wallItemNew);
-		
+
 		//updater
 		wallItemNew.add(new AjaxFormChoiceComponentUpdatingBehavior() {
 			private static final long serialVersionUID = 1L;
@@ -216,7 +222,10 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
+		//visibility for wall items
+		wallItemNew.setVisible(sakaiProxy.isWallEnabledGlobally());
+
 		// added to new worksite emails
 		final RadioGroup<Boolean> worksiteNew = new RadioGroup<Boolean>("worksiteNewEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "worksiteNewEmailEnabled"));
 		Radio worksiteNewOn = new Radio<Boolean>("worksiteNewOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -229,7 +238,7 @@ public class MyPreferences extends BasePage{
 		worksiteNew.add(worksiteNewOff);
 		worksiteNew.add(new Label("worksiteNewLabel", new ResourceModel("preferences.email.worksite.new")));
 		form.add(worksiteNew);
-		
+
 		//updater
 		worksiteNew.add(new AjaxFormChoiceComponentUpdatingBehavior() {
 			private static final long serialVersionUID = 1L;
@@ -237,8 +246,8 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-        
-		
+
+
 		// TWITTER SECTION
 
 		//headings
@@ -246,12 +255,12 @@ public class MyPreferences extends BasePage{
 		twitterSectionHeadingContainer.add(new Label("twitterSectionHeading", new ResourceModel("heading.section.twitter")));
 		twitterSectionHeadingContainer.add(new Label("twitterSectionText", new ResourceModel("preferences.twitter.message")));
 		form.add(twitterSectionHeadingContainer);
-		
+
 		//panel
 		if(sakaiProxy.isTwitterIntegrationEnabledGlobally()) {
 			form.add(new AjaxLazyLoadPanel("twitterPanel"){
 				private static final long serialVersionUID = 1L;
-	
+
 				@Override
 				public Component getLazyLoadComponent(String markupId) {
 					return new TwitterPrefsPane(markupId, userUuid);
@@ -261,13 +270,13 @@ public class MyPreferences extends BasePage{
 			form.add(new EmptyPanel("twitterPanel"));
 			twitterSectionHeadingContainer.setVisible(false);
 		}
-		
-		
+
+
 		// IMAGE SECTION
 		//only one of these can be selected at a time
 		WebMarkupContainer is = new WebMarkupContainer("imageSettingsContainer");
 		is.setOutputMarkupId(true);
-				
+
 		// headings
 		is.add(new Label("imageSettingsHeading", new ResourceModel("heading.section.image")));
 		is.add(new Label("imageSettingsText", new ResourceModel("preferences.image.message")));
@@ -288,23 +297,23 @@ public class MyPreferences extends BasePage{
 		officialImage.add(new AjaxFormComponentUpdatingBehavior("onchange") {
 			private static final long serialVersionUID = 1L;
 			protected void onUpdate(AjaxRequestTarget target) {
-				
+
 				//set gravatar to false since we can't have both active
 				gravatarImage.setModelObject(false);
 				if(gravatarEnabled) {
 					target.addComponent(gravatarImage);
-				}				
-            	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
-            }
-        });
+				}
+      	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
+      }
+    });
 		is.add(officialImageContainer);
-		
+
 		//if using official images but alternate choice isn't allowed, hide this section
 		if(!officialImageEnabled) {
 			profilePreferences.setUseOfficialImage(false); //set the model false to clear data as well (doesnt really need to do this but we do it to keep things in sync)
 			officialImageContainer.setVisible(false);
 		}
-				
+
 		//gravatar
 		//checkbox
 		WebMarkupContainer gravatarContainer = new WebMarkupContainer("gravatarContainer");
@@ -318,35 +327,36 @@ public class MyPreferences extends BasePage{
 		gravatarImage.add(new AjaxFormComponentUpdatingBehavior("onchange") {
 			private static final long serialVersionUID = 1L;
 			protected void onUpdate(AjaxRequestTarget target) {
-				
+
 				//set gravatar to false since we can't have both active
 				officialImage.setModelObject(false);
 				if(officialImageEnabled) {
 					target.addComponent(officialImage);
 				}
-            	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
-            }
-        });
+      	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
+      }
+    });
 		is.add(gravatarContainer);
-		
+
 		//if gravatar's are disabled, hide this section
 		if(!gravatarEnabled) {
 			profilePreferences.setUseGravatar(false); //set the model false to clear data as well (doesnt really need to do this but we do it to keep things in sync)
 			gravatarContainer.setVisible(false);
 		}
-		
+
 		//if official image disabled and gravatar disabled, hide the entire container
 		if(!officialImageEnabled && !gravatarEnabled) {
 			is.setVisible(false);
 		}
-		
+
 		form.add(is);
 
-		
+
 		// WIDGET SECTION
 		WebMarkupContainer ws = new WebMarkupContainer("widgetSettingsContainer");
 		ws.setOutputMarkupId(true);
-		
+		int visibleWidgetCount = 0;
+
 		//widget settings
 		ws.add(new Label("widgetSettingsHeading", new ResourceModel("heading.section.widget")));
 		ws.add(new Label("widgetSettingsText", new ResourceModel("preferences.widget.message")));
@@ -360,7 +370,7 @@ public class MyPreferences extends BasePage{
 		kudosContainer.add(kudosSetting);
 		//tooltip
 		kudosContainer.add(new IconWithClueTip("kudosToolTip", ProfileConstants.INFO_IMAGE, new ResourceModel("preferences.widget.kudos.tooltip")));
-		
+
 
 		//updater
 		kudosSetting.add(new AjaxFormComponentUpdatingBehavior("onchange") {
@@ -370,7 +380,13 @@ public class MyPreferences extends BasePage{
             }
         });
 		ws.add(kudosContainer);
-		
+		if(sakaiProxy.isMyKudosEnabledGlobally()) {
+			visibleWidgetCount++;
+		} else {
+			kudosContainer.setVisible(false);
+		}
+
+
 		//gallery feed
 		WebMarkupContainer galleryFeedContainer = new WebMarkupContainer("galleryFeedContainer");
 		galleryFeedContainer.add(new Label("galleryFeedLabel", new ResourceModel("preferences.widget.gallery")));
@@ -380,7 +396,7 @@ public class MyPreferences extends BasePage{
 		galleryFeedContainer.add(galleryFeedSetting);
 		//tooltip
 		galleryFeedContainer.add(new IconWithClueTip("galleryFeedToolTip", ProfileConstants.INFO_IMAGE, new ResourceModel("preferences.widget.gallery.tooltip")));
-		
+
 		//updater
 		galleryFeedSetting.add(new AjaxFormComponentUpdatingBehavior("onchange") {
 			private static final long serialVersionUID = 1L;
@@ -389,9 +405,13 @@ public class MyPreferences extends BasePage{
             }
         });
 		ws.add(galleryFeedContainer);
-		galleryFeedContainer.setVisible(sakaiProxy.isProfileGalleryEnabledGlobally());
-		
-		
+		if(sakaiProxy.isProfileGalleryEnabledGlobally()) {
+        visibleWidgetCount++;
+    } else {
+        galleryFeedContainer.setVisible(false);
+    }
+
+
 		//online status
 		WebMarkupContainer onlineStatusContainer = new WebMarkupContainer("onlineStatusContainer");
 		onlineStatusContainer.add(new Label("onlineStatusLabel", new ResourceModel("preferences.widget.onlinestatus")));
@@ -401,7 +421,7 @@ public class MyPreferences extends BasePage{
 		onlineStatusContainer.add(onlineStatusSetting);
 		//tooltip
 		onlineStatusContainer.add(new IconWithClueTip("onlineStatusToolTip", ProfileConstants.INFO_IMAGE, new ResourceModel("preferences.widget.onlinestatus.tooltip")));
-		
+
 		//updater
 		onlineStatusSetting.add(new AjaxFormComponentUpdatingBehavior("onchange") {
 			private static final long serialVersionUID = 1L;
@@ -409,57 +429,65 @@ public class MyPreferences extends BasePage{
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		ws.add(onlineStatusContainer);		
-		
+		ws.add(onlineStatusContainer);
+
+		if(sakaiProxy.isOnlineStatusEnabledGlobally()){
+        visibleWidgetCount++;
+    } else {
+        onlineStatusContainer.setVisible(false);
+    }
+
+    // Hide widget container if nothing to show
+    if(visibleWidgetCount == 0) {
+        ws.setVisible(false);
+    }
+
 		form.add(ws);
-		
+
 		//submit button
 		IndicatingAjaxButton submitButton = new IndicatingAjaxButton("submit", form) {
 			private static final long serialVersionUID = 1L;
 			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
-				
+
 				//get the backing model
 				ProfilePreferences profilePreferences = (ProfilePreferences) form.getModelObject();
-				
+
 				formFeedback.setDefaultModel(new ResourceModel("success.preferences.save.ok"));
 				formFeedback.add(new AttributeModifier("class", true, new Model<String>("success")));
-				
+
 				//save
 				if(preferencesLogic.savePreferencesRecord(profilePreferences)) {
 					formFeedback.setDefaultModel(new ResourceModel("success.preferences.save.ok"));
 					formFeedback.add(new AttributeModifier("class", true, new Model<String>("success")));
-					
+
 					//post update event
 					sakaiProxy.postEvent(ProfileConstants.EVENT_PREFERENCES_UPDATE, "/profile/"+userUuid, true);
-					
+
 				} else {
 					formFeedback.setDefaultModel(new ResourceModel("error.preferences.save.failed"));
-					formFeedback.add(new AttributeModifier("class", true, new Model<String>("alertMessage")));	
+					formFeedback.add(new AttributeModifier("class", true, new Model<String>("alertMessage")));
 				}
-				
+
 				//resize iframe
 				target.appendJavascript("setMainFrameHeight(window.name);");
-				
+
 				//PRFL-775 - set focus to feedback message so it is announced to screenreaders
 				target.appendJavascript("$('#" + formFeedbackId + "').focus();");
-				
+
 				target.addComponent(formFeedback);
             }
-			
-			
+
+
 		};
 		submitButton.setModel(new ResourceModel("button.save.settings"));
 		submitButton.setDefaultFormProcessing(false);
 		form.add(submitButton);
-		
+
         add(form);
-		
+
 	}
-	
-	
-	
-	
+
+
+
+
 }
-
-
-

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPrivacy.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPrivacy.java
@@ -46,95 +46,95 @@ public class MyPrivacy extends BasePage {
 
 	private static final Logger log = Logger.getLogger(MyPrivacy.class);
 	private transient ProfilePrivacy profilePrivacy;
-		
+
 	public MyPrivacy() {
-		
+
 		log.debug("MyPrivacy()");
 
 		disableLink(myPrivacyLink);
-		
+
 		//get current user
 		final String userUuid = sakaiProxy.getCurrentUserId();
 
 		//get the privacy record for this user from the database, or a default if none exists
 		profilePrivacy = privacyLogic.getPrivacyRecordForUser(userUuid, false);
-		
+
 		//if null, throw exception
 		if(profilePrivacy == null) {
 			throw new ProfilePrivacyNotDefinedException("Couldn't retrieve privacy record for " + userUuid);
 		}
-		
+
 		Label heading = new Label("heading", new ResourceModel("heading.privacy"));
 		add(heading);
-		
+
 		Label infoLocked = new Label("infoLocked");
 		infoLocked.setOutputMarkupPlaceholderTag(true);
 		infoLocked.setVisible(false);
 		add(infoLocked);
-		
+
 		//feedback for form submit action
 		final Label formFeedback = new Label("formFeedback");
 		formFeedback.setOutputMarkupPlaceholderTag(true);
 		final String formFeedbackId = formFeedback.getMarkupId();
 		add(formFeedback);
-		
-		
-		
+
+
+
 		//create model
 		CompoundPropertyModel<ProfilePrivacy> privacyModel = new CompoundPropertyModel<ProfilePrivacy>(profilePrivacy);
-		
-		//setup form		
+
+		//setup form
 		Form<ProfilePrivacy> form = new Form<ProfilePrivacy>("form", privacyModel);
 		form.setOutputMarkupId(true);
-		
-		
+
+
 		//setup LinkedHashMap of privacy options for strict things
 		final LinkedHashMap<Integer, String> privacySettingsStrict = new LinkedHashMap<Integer, String>();
 		privacySettingsStrict.put(ProfileConstants.PRIVACY_OPTION_EVERYONE, new StringResourceModel("privacy.option.everyone", this,null).getString());
 		privacySettingsStrict.put(ProfileConstants.PRIVACY_OPTION_ONLYFRIENDS, new StringResourceModel("privacy.option.onlyfriends", this,null).getString());
 		privacySettingsStrict.put(ProfileConstants.PRIVACY_OPTION_ONLYME, new StringResourceModel("privacy.option.onlyme", this,null).getString());
-		
+
 		//model that wraps our options
 		IModel dropDownModelStrict = new Model() {
 			public ArrayList<Integer> getObject() {
 				 return new ArrayList(privacySettingsStrict.keySet());
-			} 
+			}
 		};
-		
+
 		//setup LinkedHashMap of privacy options for more relaxed things
 		final LinkedHashMap<Integer, String> privacySettingsRelaxed = new LinkedHashMap<Integer, String>();
 		privacySettingsRelaxed.put(ProfileConstants.PRIVACY_OPTION_EVERYONE, new StringResourceModel("privacy.option.everyone", this,null).getString());
 		privacySettingsRelaxed.put(ProfileConstants.PRIVACY_OPTION_ONLYFRIENDS, new StringResourceModel("privacy.option.onlyfriends", this,null).getString());
-		
+
 		//model that wraps our options
 		IModel dropDownModelRelaxed = new Model() {
 			public ArrayList<Integer> getObject() {
 				 return new ArrayList(privacySettingsRelaxed.keySet());
-			} 
+			}
 		};
-		
+
 		//setup LinkedHashMap of privacy options for super duper strict things!
 		final LinkedHashMap<Integer, String> privacySettingsSuperStrict = new LinkedHashMap<Integer, String>();
 		privacySettingsSuperStrict.put(ProfileConstants.PRIVACY_OPTION_ONLYFRIENDS, new StringResourceModel("privacy.option.onlyfriends", this,null).getString());
 		privacySettingsSuperStrict.put(ProfileConstants.PRIVACY_OPTION_NOBODY, new StringResourceModel("privacy.option.nobody", this,null).getString());
-		
+
 		//model that wraps our options
 		IModel dropDownModelSuperStrict = new Model() {
 			public ArrayList<Integer> getObject() {
 				 return new ArrayList(privacySettingsSuperStrict.keySet());
-			} 
+			}
 		};
-		
+
 		//when using DDC with a compoundPropertyModel we use this constructor: DDC<T>(String,IModel<List<T>>,IChoiceRenderer<T>)
 		//and the ID of the DDC field maps to the field in the CompoundPropertyModel
-		
+
 		//the AjaxFormComponentUpdatingBehavior is to allow the DDC and checkboxes to fadeaway any error/success message
 		//that might be visible since the form has changed and it needs to be submitted again for it to take effect
-		
+
 		//profile image privacy
 		WebMarkupContainer profileImageContainer = new WebMarkupContainer("profileImageContainer");
 		profileImageContainer.add(new Label("profileImageLabel", new ResourceModel("privacy.profileimage")));
-		DropDownChoice profileImageChoice = new DropDownChoice("profileImage", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));             
+		DropDownChoice profileImageChoice = new DropDownChoice("profileImage", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));
 		profileImageChoice.setMarkupId("imageprivacyinput");
 		profileImageChoice.setOutputMarkupId(true);
 		profileImageContainer.add(profileImageChoice);
@@ -147,9 +147,9 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
-		
-		
+
+
+
 		//basicInfo privacy
 		WebMarkupContainer basicInfoContainer = new WebMarkupContainer("basicInfoContainer");
 		basicInfoContainer.add(new Label("basicInfoLabel", new ResourceModel("privacy.basicinfo")));
@@ -166,7 +166,7 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		//contactInfo privacy
 		WebMarkupContainer contactInfoContainer = new WebMarkupContainer("contactInfoContainer");
 		contactInfoContainer.add(new Label("contactInfoLabel", new ResourceModel("privacy.contactinfo")));
@@ -183,7 +183,7 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		//staffInfo privacy
 		WebMarkupContainer staffInfoContainer = new WebMarkupContainer("staffInfoContainer");
 		staffInfoContainer.add(new Label("staffInfoLabel", new ResourceModel("privacy.staffinfo")));
@@ -200,7 +200,7 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		//studentInfo privacy
 		WebMarkupContainer studentInfoContainer = new WebMarkupContainer("studentInfoContainer");
 		studentInfoContainer.add(new Label("studentInfoLabel", new ResourceModel("privacy.studentinfo")));
@@ -217,7 +217,7 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		//businesInfo privacy
 		WebMarkupContainer businessInfoContainer = new WebMarkupContainer("businessInfoContainer");
 		businessInfoContainer.add(new Label("businessInfoLabel", new ResourceModel("privacy.businessinfo")));
@@ -234,9 +234,9 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		businessInfoContainer.setVisible(sakaiProxy.isBusinessProfileEnabled());
-		
+
 		//socialNetworkingInfo privacy
 		WebMarkupContainer socialNetworkingInfoContainer = new WebMarkupContainer("socialNetworkingInfoContainer");
 		socialNetworkingInfoContainer.add(new Label("socialNetworkingInfoLabel", new ResourceModel("privacy.socialinfo")));
@@ -253,8 +253,8 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
-		
+
+
 		//personalInfo privacy
 		WebMarkupContainer personalInfoContainer = new WebMarkupContainer("personalInfoContainer");
 		personalInfoContainer.add(new Label("personalInfoLabel", new ResourceModel("privacy.personalinfo")));
@@ -271,7 +271,7 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		//birthYear privacy
 		WebMarkupContainer birthYearContainer = new WebMarkupContainer("birthYearContainer");
 		birthYearContainer.add(new Label("birthYearLabel", new ResourceModel("privacy.birthyear")));
@@ -288,7 +288,7 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-				
+
 		//myFriends privacy
 		WebMarkupContainer myFriendsContainer = new WebMarkupContainer("myFriendsContainer");
 		myFriendsContainer.add(new Label("myFriendsLabel", new ResourceModel("privacy.myfriends")));
@@ -305,7 +305,9 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
+		myFriendsContainer.setVisible(sakaiProxy.isConnectionEnabledGlobally());
+
 		//myStatus privacy
 		WebMarkupContainer myStatusContainer = new WebMarkupContainer("myStatusContainer");
 		myStatusContainer.add(new Label("myStatusLabel", new ResourceModel("privacy.mystatus")));
@@ -322,11 +324,13 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
+		myStatusContainer.setVisible(sakaiProxy.isProfileStatusEnabled());
+
 		// gallery privacy
 		WebMarkupContainer myPicturesContainer = new WebMarkupContainer("myPicturesContainer");
 		myPicturesContainer.add(new Label("myPicturesLabel", new ResourceModel("privacy.mypictures")));
-		DropDownChoice myPicturesChoice = new DropDownChoice("myPictures", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));             
+		DropDownChoice myPicturesChoice = new DropDownChoice("myPictures", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));
 		myPicturesChoice.setMarkupId("picturesprivacyinput");
 		myPicturesChoice.setOutputMarkupId(true);
 		myPicturesContainer.add(myPicturesChoice);
@@ -338,13 +342,13 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		myPicturesContainer.setVisible(sakaiProxy.isProfileGalleryEnabledGlobally());
-		
+
 		// messages privacy
 		WebMarkupContainer messagesContainer = new WebMarkupContainer("messagesContainer");
 		messagesContainer.add(new Label("messagesLabel", new ResourceModel("privacy.messages")));
-		DropDownChoice messagesChoice = new DropDownChoice("messages", dropDownModelSuperStrict, new HashMapChoiceRenderer(privacySettingsSuperStrict));             
+		DropDownChoice messagesChoice = new DropDownChoice("messages", dropDownModelSuperStrict, new HashMapChoiceRenderer(privacySettingsSuperStrict));
 		messagesChoice.setMarkupId("messagesprivacyinput");
 		messagesChoice.setOutputMarkupId(true);
 		messagesContainer.add(messagesChoice);
@@ -356,13 +360,13 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
 		messagesContainer.setVisible(sakaiProxy.isMessagingEnabledGlobally());
-		
+
 		// kudos privacy
 		WebMarkupContainer myKudosContainer = new WebMarkupContainer("myKudosContainer");
 		myKudosContainer.add(new Label("myKudosLabel", new ResourceModel("privacy.mykudos")));
-		DropDownChoice kudosChoice = new DropDownChoice("myKudos", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));             
+		DropDownChoice kudosChoice = new DropDownChoice("myKudos", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));
 		kudosChoice.setMarkupId("kudosprivacyinput");
 		kudosChoice.setOutputMarkupId(true);
 		myKudosContainer.add(kudosChoice);
@@ -374,11 +378,13 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
+
+		myKudosContainer.setVisible(sakaiProxy.isMyKudosEnabledGlobally());
+
 		// wall privacy
 		WebMarkupContainer myWallContainer = new WebMarkupContainer("myWallContainer");
 		myWallContainer.add(new Label("myWallLabel", new ResourceModel("privacy.mywall")));
-		DropDownChoice myWallChoice = new DropDownChoice("myWall", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));             
+		DropDownChoice myWallChoice = new DropDownChoice("myWall", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));
 		myWallChoice.setMarkupId("wallprivacyinput");
 		myWallChoice.setOutputMarkupId(true);
 		myWallContainer.add(myWallChoice);
@@ -392,11 +398,11 @@ public class MyPrivacy extends BasePage {
         });
 		myWallContainer.setVisible(sakaiProxy.isWallEnabledGlobally());
 
-		
+
 		// online status privacy
 		WebMarkupContainer onlineStatusContainer = new WebMarkupContainer("onlineStatusContainer");
 		onlineStatusContainer.add(new Label("onlineStatusLabel", new ResourceModel("privacy.onlinestatus")));
-		DropDownChoice onlineStatusChoice = new DropDownChoice("onlineStatus", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));             
+		DropDownChoice onlineStatusChoice = new DropDownChoice("onlineStatus", dropDownModelRelaxed, new HashMapChoiceRenderer(privacySettingsRelaxed));
 		onlineStatusChoice.setMarkupId("onlinestatusprivacyinput");
 		onlineStatusChoice.setOutputMarkupId(true);
 		onlineStatusContainer.add(onlineStatusChoice);
@@ -408,8 +414,9 @@ public class MyPrivacy extends BasePage {
             	target.appendJavascript("$('#" + formFeedbackId + "').fadeOut();");
             }
         });
-		
-		
+
+		onlineStatusContainer.setVisible(sakaiProxy.isOnlineStatusEnabledGlobally());
+
 		//submit button
 		IndicatingAjaxButton submitButton = new IndicatingAjaxButton("submit", form) {
 			protected void onSubmit(AjaxRequestTarget target, Form form) {
@@ -417,28 +424,28 @@ public class MyPrivacy extends BasePage {
 				if(save(form)){
 					formFeedback.setDefaultModel(new ResourceModel("success.privacy.save.ok"));
 					formFeedback.add(new AttributeModifier("class", true, new Model<String>("success")));
-					
+
 					//post update event
 					sakaiProxy.postEvent(ProfileConstants.EVENT_PRIVACY_UPDATE, "/profile/"+userUuid, true);
 
 				} else {
 					formFeedback.setDefaultModel(new ResourceModel("error.privacy.save.failed"));
-					formFeedback.add(new AttributeModifier("class", true, new Model<String>("alertMessage")));	
+					formFeedback.add(new AttributeModifier("class", true, new Model<String>("alertMessage")));
 				}
-				
+
 				//resize iframe
 				target.appendJavascript("setMainFrameHeight(window.name);");
-				
+
 				//PRFL-775 - set focus to feedback message so it is announced to screenreaders
 				target.appendJavascript("$('#" + formFeedbackId + "').focus();");
-				
+
 				target.addComponent(formFeedback);
             }
 		};
 		submitButton.setModel(new ResourceModel("button.save.settings"));
 		submitButton.setOutputMarkupId(true);
 		form.add(submitButton);
-		
+
 		//cancel button
 		/*
 		AjaxFallbackButton cancelButton = new AjaxFallbackButton("cancel", new ResourceModel("button.cancel"), form) {
@@ -449,7 +456,7 @@ public class MyPrivacy extends BasePage {
         cancelButton.setDefaultFormProcessing(false);
         form.add(cancelButton);
 		*/
-		
+
 		if(!sakaiProxy.isPrivacyChangeAllowedGlobally()){
 			infoLocked.setDefaultModel(new ResourceModel("text.privacy.cannot.modify"));
 			infoLocked.setVisible(true);
@@ -467,20 +474,20 @@ public class MyPrivacy extends BasePage {
 			messagesChoice.setEnabled(false);
 			myWallChoice.setEnabled(false);
 			onlineStatusChoice.setEnabled(false);
-			
+
 			submitButton.setEnabled(false);
 			submitButton.setVisible(false);
-			
+
 			form.setEnabled(false);
 		}
-        
+
         add(form);
 	}
-	
-	
+
+
 	//called when the form is to be saved
 	private boolean save(Form<ProfilePrivacy> form) {
-		
+
 		//get the backing model - its elems have been updated with the form params
 		ProfilePrivacy profilePrivacy = (ProfilePrivacy) form.getModelObject();
 
@@ -491,10 +498,7 @@ public class MyPrivacy extends BasePage {
 			log.info("Couldn't save ProfilePrivacy for: " + profilePrivacy.getUserUuid());
 			return false;
 		}
-	
+
 	}
-	
+
 }
-
-
-

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyProfile.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyProfile.java
@@ -69,7 +69,7 @@ public class MyProfile extends BasePage {
 
 	private static final long serialVersionUID = 1L;
 	private static final Logger log = Logger.getLogger(MyProfile.class);
-	
+
 
 	/**
 	 * Default constructor if viewing own
@@ -81,16 +81,16 @@ public class MyProfile extends BasePage {
 		String userUuid = sakaiProxy.getCurrentUserId();
 		renderMyProfile(userUuid);
 	}
-	
+
 	/**
 	 * This constructor is called if we are viewing someone elses but in edit mode.
 	 * This will only be called if we were a superuser editing someone else's profile.
 	 * An additional catch is also in place.
-	 * @param userUuid		uuid of other user 
+	 * @param userUuid		uuid of other user
 	 */
 	public MyProfile(final String userUuid)   {
 		log.debug("MyProfile(" + userUuid +")");
-		
+
 		//double check only super users
 		if(!sakaiProxy.isSuperUser()) {
 			log.error("MyProfile: user " + sakaiProxy.getCurrentUserId() + " attempted to access MyProfile for " + userUuid + ". Redirecting...");
@@ -99,34 +99,34 @@ public class MyProfile extends BasePage {
 		//render for given user
 		renderMyProfile(userUuid);
 	}
-	
+
 	/**
 	 * Does the actual rendering of the page
 	 * @param userUuid
 	 */
 	private void renderMyProfile(final String userUuid) {
-		
+
 		//don't do this for super users viewing other people's profiles as otherwise there is no way back to own profile
 		if(!sakaiProxy.isSuperUserAndProxiedToUser(userUuid)) {
 			disableLink(myProfileLink);
 		}
-		
+
 		//add the feedback panel for any error messages
 		FeedbackPanel feedbackPanel = new FeedbackPanel("feedbackPanel");
 		add(feedbackPanel);
 		feedbackPanel.setVisible(false); //hide by default
-		
+
 		//get the prefs record, or a default if none exists yet
 		final ProfilePreferences prefs = preferencesLogic.getPreferencesRecordForUser(userUuid);
-		
+
 		//if null, throw exception
 		if(prefs == null) {
 			throw new ProfilePreferencesNotDefinedException("Couldn't create default preferences record for " + userUuid);
 		}
-		
+
 		//get SakaiPerson for this user
 		SakaiPerson sakaiPerson = sakaiProxy.getSakaiPerson(userUuid);
-		//if null, create one 
+		//if null, create one
 		if(sakaiPerson == null) {
 			log.warn("No SakaiPerson for " + userUuid + ". Creating one.");
 			sakaiPerson = sakaiProxy.createSakaiPerson(userUuid);
@@ -136,14 +136,14 @@ public class MyProfile extends BasePage {
 			}
 			//post create event
 			sakaiProxy.postEvent(ProfileConstants.EVENT_PROFILE_NEW, userUuid, true);
-		} 
-		
+		}
+
 		//post view event
 		sakaiProxy.postEvent(ProfileConstants.EVENT_PROFILE_VIEW_OWN, "/profile/"+userUuid, false);
 
 		//get some values from SakaiPerson or SakaiProxy if empty
 		//SakaiPerson returns NULL strings if value is not set, not blank ones
-	
+
 		//these must come from Account to keep it all in sync
 		//we *could* get a User object here and get the values.
 		String userDisplayName = sakaiProxy.getUserDisplayName(userUuid);
@@ -153,58 +153,58 @@ public class MyProfile extends BasePage {
 		*/
 
 		String userEmail = sakaiProxy.getUserEmail(userUuid);
-		
+
 		//create instance of the UserProfile class
 		//we then pass the userProfile in the constructor to the child panels
 		final UserProfile userProfile = new UserProfile();
-				
+
 		//get rest of values from SakaiPerson and setup UserProfile
 		userProfile.setUserUuid(userUuid);
-		
+
 		userProfile.setNickname(sakaiPerson.getNickname());
 		userProfile.setDateOfBirth(sakaiPerson.getDateOfBirth());
 		userProfile.setDisplayName(userDisplayName);
 		//userProfile.setFirstName(userFirstName);
 		//userProfile.setLastName(userLastName);
 		//userProfile.setMiddleName(sakaiPerson.getInitials());
-		
+
 		userProfile.setEmail(userEmail);
 		userProfile.setHomepage(sakaiPerson.getLabeledURI());
 		userProfile.setHomephone(sakaiPerson.getHomePhone());
 		userProfile.setWorkphone(sakaiPerson.getTelephoneNumber());
 		userProfile.setMobilephone(sakaiPerson.getMobile());
 		userProfile.setFacsimile(sakaiPerson.getFacsimileTelephoneNumber());
-		
+
 		userProfile.setDepartment(sakaiPerson.getOrganizationalUnit());
 		userProfile.setPosition(sakaiPerson.getTitle());
 		userProfile.setSchool(sakaiPerson.getCampus());
 		userProfile.setRoom(sakaiPerson.getRoomNumber());
-		
+
 		userProfile.setCourse(sakaiPerson.getEducationCourse());
 		userProfile.setSubjects(sakaiPerson.getEducationSubjects());
-		
+
 		userProfile.setStaffProfile(sakaiPerson.getStaffProfile());
 		userProfile.setAcademicProfileUrl(sakaiPerson.getAcademicProfileUrl());
 		userProfile.setUniversityProfileUrl(sakaiPerson.getUniversityProfileUrl());
 		userProfile.setPublications(sakaiPerson.getPublications());
-		
+
 		// business fields
 		userProfile.setBusinessBiography(sakaiPerson.getBusinessBiography());
 		userProfile.setCompanyProfiles(profileLogic.getCompanyProfiles(userUuid));
-		
+
 		userProfile.setFavouriteBooks(sakaiPerson.getFavouriteBooks());
 		userProfile.setFavouriteTvShows(sakaiPerson.getFavouriteTvShows());
 		userProfile.setFavouriteMovies(sakaiPerson.getFavouriteMovies());
 		userProfile.setFavouriteQuotes(sakaiPerson.getFavouriteQuotes());
 		userProfile.setPersonalSummary(sakaiPerson.getNotes());
-		
+
 		// social networking fields
 		SocialNetworkingInfo socialInfo = profileLogic.getSocialNetworkingInfo(userProfile.getUserUuid());
 		if(socialInfo == null){
 			socialInfo = new SocialNetworkingInfo();
 		}
 		userProfile.setSocialInfo(socialInfo);
-		
+
 		//PRFL-97 workaround. SakaiPerson table needs to be upgraded so locked is not null, but this handles it if not upgraded.
 		if(sakaiPerson.getLocked() == null) {
 			userProfile.setLocked(false);
@@ -213,17 +213,17 @@ public class MyProfile extends BasePage {
 			this.setLocked(sakaiPerson.getLocked());
 			userProfile.setLocked(this.isLocked());
 		}
-		
-	
+
+
 		//what type of picture changing method do we use?
 		int profilePictureType = sakaiProxy.getProfilePictureType();
-		
+
 		//change picture panel (upload or url depending on property)
 		final Panel changePicture;
-		
+
 		//render appropriate panel with appropriate constructor ie if superUser etc
 		if(profilePictureType == ProfileConstants.PICTURE_SETTING_UPLOAD) {
-			
+
 			if(sakaiProxy.isSuperUserAndProxiedToUser(userUuid)){
 				changePicture = new ChangeProfilePictureUpload("changePicture", userUuid);
 			} else {
@@ -238,7 +238,7 @@ public class MyProfile extends BasePage {
 		} else if (profilePictureType == ProfileConstants.PICTURE_SETTING_OFFICIAL) {
 			//cannot edit anything if using official images
 			changePicture = new EmptyPanel("changePicture");
-		} else {	
+		} else {
 			//no valid option for changing picture was returned from the Profile2 API.
 			log.error("Invalid picture type returned: " + profilePictureType);
 			changePicture = new EmptyPanel("changePicture");
@@ -246,51 +246,51 @@ public class MyProfile extends BasePage {
 		changePicture.setOutputMarkupPlaceholderTag(true);
 		changePicture.setVisible(false);
 		add(changePicture);
-		
+
 		//add the current picture
 		add(new ProfileImage("photo", new Model<String>(userUuid)));
-		
+
 		//change profile image button
 		AjaxLink<Void> changePictureLink = new AjaxLink<Void>("changePictureLink") {
 			private static final long serialVersionUID = 1L;
 
 			public void onClick(AjaxRequestTarget target) {
-				
+
 				//show the panel
 				changePicture.setVisible(true);
 				target.addComponent(changePicture);
-				
+
 				//resize iframe to fit it
 				target.appendJavascript("resizeFrame('grow');");
 			}
-						
+
 		};
 		changePictureLink.add(new Label("changePictureLabel", new ResourceModel("link.change.profile.picture")));
-		
+
 		//is picture changing disabled? (property, or locked)
 		if((!sakaiProxy.isProfilePictureChangeEnabled() || userProfile.isLocked()) && !sakaiProxy.isSuperUser()) {
 			changePictureLink.setEnabled(false);
 			changePictureLink.setVisible(false);
 		}
-		
+
 		//if using official images, is the user allowed to select an alternate?
 		//or have they specified the official image in their preferences.
 		if(sakaiProxy.isOfficialImageEnabledGlobally() && (!sakaiProxy.isUsingOfficialImageButAlternateSelectionEnabled() || prefs.isUseOfficialImage())) {
 			changePictureLink.setEnabled(false);
 			changePictureLink.setVisible(false);
 		}
-		
-		
+
+
 		add(changePictureLink);
-		
-		
+
+
 		/* SIDELINKS */
 		WebMarkupContainer sideLinks = new WebMarkupContainer("sideLinks");
 		int visibleSideLinksCount = 0;
-		
+
 		//ADMIN: ADD AS CONNECTION
 		if(sakaiProxy.isSuperUserAndProxiedToUser(userUuid)) {
-			
+
 			//init
 			boolean friend = false;
 			boolean friendRequestToThisPerson = false;
@@ -312,7 +312,7 @@ public class MyProfile extends BasePage {
 			if(!friend && !friendRequestToThisPerson) {
 				friendRequestFromThisPerson = connectionsLogic.isFriendRequestPending(userUuid, currentUserUuid);
 			}
-			
+
 			WebMarkupContainer addFriendContainer = new WebMarkupContainer("addFriendContainer");
 			final ModalWindow addFriendWindow = new ModalWindow("addFriendWindow");
 
@@ -326,7 +326,7 @@ public class MyProfile extends BasePage {
 			final Label addFriendLabel = new Label("addFriendLabel");
 			addFriendLink.add(addFriendLabel);
 			addFriendContainer.add(addFriendLink);
-			
+
 			//setup link/label and windows
 			if(friend) {
 				addFriendLabel.setDefaultModel(new ResourceModel("text.friend.confirmed"));
@@ -346,17 +346,17 @@ public class MyProfile extends BasePage {
 			}  else {
 				addFriendLabel.setDefaultModel(new StringResourceModel("link.friend.add.name", null, new Object[]{ nickname } ));
 	    		addFriendLink.add(new AttributeModifier("class", true, new Model<String>("icon connection-add")));
-				addFriendWindow.setContent(new AddFriend(addFriendWindow.getContentId(), addFriendWindow, friendActionModel, currentUserUuid, userUuid)); 
+				addFriendWindow.setContent(new AddFriend(addFriendWindow.getContentId(), addFriendWindow, friendActionModel, currentUserUuid, userUuid));
 			}
-			
+
 			sideLinks.add(addFriendContainer);
-		
-			//ADD FRIEND MODAL WINDOW HANDLER 
+
+			//ADD FRIEND MODAL WINDOW HANDLER
 			addFriendWindow.setWindowClosedCallback(new ModalWindow.WindowClosedCallback() {
 				private static final long serialVersionUID = 1L;
-	
+
 				public void onClose(AjaxRequestTarget target){
-	            	if(friendActionModel.isRequested()) { 
+	            	if(friendActionModel.isRequested()) {
 	            		//friend was successfully requested, update label and link
 	            		addFriendLabel.setDefaultModel(new ResourceModel("text.friend.requested"));
 	            		addFriendLink.add(new AttributeModifier("class", true, new Model<String>("instruction")));
@@ -365,16 +365,20 @@ public class MyProfile extends BasePage {
 	            	}
 	            }
 	        });
-			
+
 			add(addFriendWindow);
-		
-			visibleSideLinksCount++;
-			
-			
+
+			if(sakaiProxy.isConnectionEnabledGlobally()) {
+        visibleSideLinksCount++;
+      } else {
+        addFriendContainer.setVisible(false);
+      }
+
+
 			//ADMIN: LOCK/UNLOCK A PROFILE
 			WebMarkupContainer lockProfileContainer = new WebMarkupContainer("lockProfileContainer");
 			final Label lockProfileLabel = new Label("lockProfileLabel");
-			
+
 			final AjaxLink<Void> lockProfileLink = new AjaxLink<Void>("lockProfileLink") {
 				private static final long serialVersionUID = 1L;
 
@@ -395,27 +399,27 @@ public class MyProfile extends BasePage {
 	    			}
 				}
 			};
-			
+
 			//set init icon for locked
 			if(isLocked()){
 				lockProfileLink.add(new AttributeModifier("class", true, new Model<String>("icon locked")));
 			} else {
 				lockProfileLink.add(new AttributeModifier("class", true, new Model<String>("icon unlocked")));
 			}
-			
+
 			lockProfileLink.add(lockProfileLabel);
-					
+
 			//setup link/label and windows with special property based on locked status
 			lockProfileLabel.setDefaultModel(new ResourceModel("link.profile.locked." + isLocked()));
 			lockProfileLink.add(new AttributeModifier("title", true, new ResourceModel("text.profile.locked." + isLocked())));
-			
+
 			lockProfileContainer.add(lockProfileLink);
-			
+
 			sideLinks.add(lockProfileContainer);
-			
+
 			visibleSideLinksCount++;
 
-			
+
 		} else {
 			//blank components
 			WebMarkupContainer addFriendContainer = new WebMarkupContainer("addFriendContainer");
@@ -424,60 +428,60 @@ public class MyProfile extends BasePage {
 			}).add(new Label("addFriendLabel"));
 			sideLinks.add(addFriendContainer);
 			add(new WebMarkupContainer("addFriendWindow"));
-			
+
 			WebMarkupContainer lockProfileContainer = new WebMarkupContainer("lockProfileContainer");
 			lockProfileContainer.add(new AjaxLink("lockProfileLink") {
 				public void onClick(AjaxRequestTarget target) {}
 			}).add(new Label("lockProfileLabel"));
 			sideLinks.add(lockProfileContainer);
 		}
-		
-		
+
+
 		//hide entire list if no links to show
 		if(visibleSideLinksCount == 0) {
 			sideLinks.setVisible(false);
 		}
-		
+
 		add(sideLinks);
-		
-		
+
+
 		//status panel
 		Panel myStatusPanel = new MyStatusPanel("myStatusPanel", userProfile);
 		add(myStatusPanel);
-		
+
 		List<ITab> tabs = new ArrayList<ITab>();
-		
+
 		AjaxTabbedPanel tabbedPanel = new AjaxTabbedPanel("myProfileTabs", tabs) {
-			
+
 			private static final long serialVersionUID = 1L;
 
 			// overridden so we can add tooltips to tabs
 			@Override
 			protected WebMarkupContainer newLink(String linkId, final int index) {
 				WebMarkupContainer link = super.newLink(linkId, index);
-				
+
 				if (ProfileConstants.TAB_INDEX_PROFILE == index) {
 					link.add(new AttributeModifier("title", true,
 							new ResourceModel("link.tab.profile.tooltip")));
-					
+
 				} else if (ProfileConstants.TAB_INDEX_WALL == index) {
 					link.add(new AttributeModifier("title", true,
-							new ResourceModel("link.tab.wall.tooltip")));	
+							new ResourceModel("link.tab.wall.tooltip")));
 				}
 				return link;
 			}
 		};
-		
+
 		Cookie tabCookie = getWebRequestCycle().getWebRequest().getCookie(ProfileConstants.TAB_COOKIE);
-		
+
 		if (sakaiProxy.isProfileFieldsEnabled()) {
 			tabs.add(new AbstractTab(new ResourceModel("link.tab.profile")) {
-	
+
 				private static final long serialVersionUID = 1L;
-	
+
 				@Override
 				public Panel getPanel(String panelId) {
-	
+
 					setTabCookie(ProfileConstants.TAB_INDEX_PROFILE);
 					MyProfilePanelState panelState = new MyProfilePanelState();
 					panelState.showBusinessDisplay = sakaiProxy.isBusinessProfileEnabled();
@@ -487,12 +491,12 @@ public class MyProfile extends BasePage {
 					panelState.showStudentDisplay = sakaiProxy.isStudentProfileEnabled();
 					return new MyProfilePanel(panelId, userProfile,panelState);
 				}
-	
+
 			});
 		}
-		
+
 		if (true == sakaiProxy.isWallEnabledGlobally()) {
-			
+
 			tabs.add(new AbstractTab(new ResourceModel("link.tab.wall")) {
 
 				private static final long serialVersionUID = 1L;
@@ -508,13 +512,13 @@ public class MyProfile extends BasePage {
 					}
 				}
 			});
-			
+
 			if (true == sakaiProxy.isWallDefaultProfilePage() && null == tabCookie) {
-				
+
 				tabbedPanel.setSelectedTab(ProfileConstants.TAB_INDEX_WALL);
 			}
 		}
-		
+
 		if (null != tabCookie) {
 			try {
 				tabbedPanel.setSelectedTab(Integer.parseInt(tabCookie.getValue()));
@@ -522,34 +526,37 @@ public class MyProfile extends BasePage {
 				//do nothing. This will be thrown if the cookie contains a value > the number of tabs but thats ok.
 			}
 		}
-		
+
 		add(tabbedPanel);
-		
+
 		//kudos panel
 		add(new AjaxLazyLoadPanel("myKudos"){
 			private static final long serialVersionUID = 1L;
 
 			@Override
 			public Component getLazyLoadComponent(String markupId) {
-				if(prefs.isShowKudos()){
-										
+				if(sakaiProxy.isMyKudosEnabledGlobally() && prefs.isShowKudos()){
+
 					int score = kudosLogic.getKudos(userUuid);
 					if(score > 0) {
 						return new KudosPanel(markupId, userUuid, userUuid, score);
 					}
-				} 
+				}
 				return new EmptyPanel(markupId);
 			}
 		});
-		
-		
+
+
 		//friends feed panel for self - lazy loaded
 		add(new NotifyingAjaxLazyLoadPanel("friendsFeed") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
             public Component getLazyLoadComponent(String markupId) {
-            	return new FriendsFeed(markupId, userUuid, userUuid);
+							if(sakaiProxy.isConnectionEnabledGlobally()) {
+								return new FriendsFeed(markupId, userUuid, userUuid);
+							}
+							return new EmptyPanel(markupId);
             }
 
 			@Override
@@ -557,8 +564,8 @@ public class MyProfile extends BasePage {
 				response.renderOnDomReadyJavascript("resizeFrame('grow');");
 			}
         });
-        	
-        	
+
+
 		//gallery feed panel
 		add(new NotifyingAjaxLazyLoadPanel("galleryFeed") {
 			private static final long serialVersionUID = 1L;
@@ -577,10 +584,10 @@ public class MyProfile extends BasePage {
 			public void renderHead(IHeaderResponse response) {
 				response.renderOnDomReadyJavascript("resizeFrame('grow');");
 			}
-			
+
 		});
 	}
-	
+
 	private boolean locked;
 	public boolean isLocked() {
 		return locked;
@@ -588,5 +595,5 @@ public class MyProfile extends BasePage {
 	public void setLocked(boolean locked) {
 		this.locked = locked;
 	}
-	
+
 }

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MySearch.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MySearch.java
@@ -75,8 +75,8 @@ import org.sakaiproject.site.api.Site;
 public class MySearch extends BasePage {
 
 	private List<Person> results = new ArrayList<Person>();
-	private static final Logger log = Logger.getLogger(MySearch.class); 
-	
+	private static final Logger log = Logger.getLogger(MySearch.class);
+
 	private WebMarkupContainer numSearchResultsContainer;
 	private Label numSearchResults;
 	private WebMarkupContainer resultsContainer;
@@ -87,40 +87,40 @@ public class MySearch extends BasePage {
 	private CheckBox connectionsCheckBox;
 	private CheckBox worksiteCheckBox;
 	private DropDownChoice worksiteChoice;
-	
+
 	// Used independently of search history for current search, and
-	// transient because Cookie isn't serializable	 
+	// transient because Cookie isn't serializable
     private transient Cookie searchCookie = null;
-    
+
 	public MySearch() {
-		
+
 		log.debug("MySearch()");
-		
+
 		disableLink(searchLink);
-		
-		//check for current search cookie	 
+
+		//check for current search cookie
 		searchCookie = getWebRequestCycle().getWebRequest().getCookie(ProfileConstants.SEARCH_COOKIE);
-		
+
 		//setup model to store the actions in the modal windows
 		final FriendAction friendActionModel = new FriendAction();
-		
+
 		//get current user info
 		final String currentUserUuid = sakaiProxy.getCurrentUserId();
 		final String currentUserType = sakaiProxy.getUserType(currentUserUuid);
-		
+
 		/*
-		 * Combined search form 
+		 * Combined search form
 		 */
-		
+
 		//heading
 		Label searchHeading = new Label("searchHeading", new ResourceModel("heading.search"));
 		add(searchHeading);
-		
+
 		//setup form
-        final StringModel searchStringModel = new StringModel();        
+        final StringModel searchStringModel = new StringModel();
         Form<StringModel> searchForm = new Form<StringModel>("searchForm", new Model<StringModel>(searchStringModel));
         searchForm.setOutputMarkupId(true);
-        
+
         //search field
         searchForm.add(new Label("searchLabel", new ResourceModel("text.search.terms.label")));
         searchField = new TextField<String>("searchField", new PropertyModel<String>(searchStringModel, "string"));
@@ -129,8 +129,8 @@ public class MySearch extends BasePage {
         searchField.setOutputMarkupId(true);
         searchForm.add(searchField);
         searchForm.add(new IconWithClueTip("searchToolTip", ProfileConstants.INFO_IMAGE, new ResourceModel("text.search.terms.tooltip")));
-		
-        //by name or by interest radio group        
+
+        //by name or by interest radio group
 		searchTypeRadioGroup = new RadioGroup<String>("searchTypeRadioGroup");
 		// so we can repaint after clicking on search history links
 		searchTypeRadioGroup.setOutputMarkupId(true);
@@ -148,17 +148,19 @@ public class MySearch extends BasePage {
 		searchTypeRadioGroup.add(new Label("searchTypeNameLabel", new ResourceModel("text.search.byname.label")));
 		searchTypeRadioGroup.add(new Label("searchTypeInterestLabel", new ResourceModel("text.search.byinterest.label")));
 		searchForm.add(searchTypeRadioGroup);
-		
+
 		searchForm.add(new Label("connectionsLabel", new ResourceModel("text.search.include.connections")));
 		// model is true (include connections by default)
 		connectionsCheckBox = new CheckBox("connectionsCheckBox", new Model<Boolean>(true));
 		connectionsCheckBox.setMarkupId("includeconnectionsinput");
 		connectionsCheckBox.setOutputMarkupId(true);
+		//hide if connections disabled globally
+		connectionsCheckBox.setVisible(sakaiProxy.isConnectionEnabledGlobally());
 		searchForm.add(connectionsCheckBox);
-				
+
 		final List<Site> worksites = sakaiProxy.getUserSites();
 		final boolean hasWorksites = worksites.size() > 0;
-		
+
 		searchForm.add(new Label("worksiteLabel", new ResourceModel("text.search.include.worksite")));
 		// model is false (include all worksites by default)
 		worksiteCheckBox = new CheckBox("worksiteCheckBox", new Model<Boolean>(false));
@@ -166,16 +168,16 @@ public class MySearch extends BasePage {
 		worksiteCheckBox.setOutputMarkupId(true);
 		worksiteCheckBox.setEnabled(hasWorksites);
 		searchForm.add(worksiteCheckBox);
-		
+
 		final IModel<String> defaultWorksiteIdModel;
 		if (hasWorksites) {
 			defaultWorksiteIdModel = new Model<String>(worksites.get(0).getId());
 		} else {
 			defaultWorksiteIdModel = new ResourceModel("text.search.no.worksite");
 		}
-		
+
 		final LinkedHashMap<String, String> worksiteMap = new LinkedHashMap<String, String>();
-		
+
 		if (hasWorksites) {
 			for (Site worksite : worksites) {
 				worksiteMap.put(worksite.getId(), worksite.getTitle());
@@ -183,27 +185,27 @@ public class MySearch extends BasePage {
 		} else {
 			worksiteMap.put(defaultWorksiteIdModel.getObject(), defaultWorksiteIdModel.getObject());
 		}
-		
+
 		IModel worksitesModel = new Model() {
 
 			public ArrayList<String> getObject() {
 				return new ArrayList<String>(worksiteMap.keySet());
 			}
 		};
-		
+
 		worksiteChoice = new DropDownChoice("worksiteChoice", defaultWorksiteIdModel, worksitesModel, new HashMapChoiceRenderer(worksiteMap));
 		worksiteChoice.setMarkupId("worksiteselect");
 		worksiteChoice.setOutputMarkupId(true);
 		worksiteChoice.setNullValid(false);
 		worksiteChoice.setEnabled(hasWorksites);
 		searchForm.add(worksiteChoice);
-		
-		/* 
-		 * 
+
+		/*
+		 *
 		 * RESULTS
-		 * 
+		 *
 		 */
-		
+
 		//search results label/container
 		numSearchResultsContainer = new WebMarkupContainer("numSearchResultsContainer");
 		numSearchResultsContainer.setOutputMarkupPlaceholderTag(true);
@@ -211,7 +213,7 @@ public class MySearch extends BasePage {
 		numSearchResults.setOutputMarkupId(true);
 		numSearchResults.setEscapeModelStrings(false);
 		numSearchResultsContainer.add(numSearchResults);
-		
+
 		//clear results button
 		Form<Void> clearResultsForm = new Form<Void>("clearResults");
 		clearResultsForm.setOutputMarkupPlaceholderTag(true);
@@ -220,25 +222,25 @@ public class MySearch extends BasePage {
 			private static final long serialVersionUID = 1L;
 
 			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
-				
-				// clear cookie if present	 
-                if (null != searchCookie) {	 
-                        getWebRequestCycle().getWebResponse().clearCookie(searchCookie);	 
+
+				// clear cookie if present
+                if (null != searchCookie) {
+                        getWebRequestCycle().getWebResponse().clearCookie(searchCookie);
                 }
-                
+
 				//clear the fields, hide self, then repaint
                 searchField.clearInput();
                 searchField.updateModel();
-                				
+
 				numSearchResultsContainer.setVisible(false);
 				resultsContainer.setVisible(false);
 				clearButton.setVisible(false);
-				
+
 				target.addComponent(searchField);
 				target.addComponent(numSearchResultsContainer);
 				target.addComponent(resultsContainer);
 				target.addComponent(this);
-			}				
+			}
 		};
 		clearButton.setOutputMarkupPlaceholderTag(true);
 		if (null == searchCookie) {
@@ -247,9 +249,9 @@ public class MySearch extends BasePage {
 		clearButton.setModel(new ResourceModel("button.search.clear"));
 		clearResultsForm.add(clearButton);
 		numSearchResultsContainer.add(clearResultsForm);
-		
+
 		add(numSearchResultsContainer);
-		
+
 		// model to wrap search results
 		LoadableDetachableModel<List<Person>> resultsModel = new LoadableDetachableModel<List<Person>>(){
 			private static final long serialVersionUID = 1L;
@@ -257,28 +259,28 @@ public class MySearch extends BasePage {
 			protected List<Person> load() {
 				return results;
 			}
-		};	
-				
+		};
+
 		//container which wraps list
 		resultsContainer = new WebMarkupContainer("searchResultsContainer");
 		resultsContainer.setOutputMarkupPlaceholderTag(true);
 		if (null == searchCookie) {
 			resultsContainer.setVisible(false); //hide initially
 		}
-		
+
 		//connection window
 		final ModalWindow connectionWindow = new ModalWindow("connectionWindow");
-		
+
 		//search results
 		final PageableListView<Person> resultsListView = new PageableListView<Person>("searchResults",
 				resultsModel, sakaiProxy.getMaxSearchResultsPerPage()) {
-			
+
 			private static final long serialVersionUID = 1L;
 
 			protected void populateItem(final ListItem<Person> item) {
-		        
+
 		    	Person person = (Person)item.getModelObject();
-		    	
+
 		    	//get basic values
 		    	final String userUuid = person.getUuid();
 		    	final String displayName = person.getDisplayName();
@@ -287,7 +289,7 @@ public class MySearch extends BasePage {
 		    	//get connection status
 		    	int connectionStatus = connectionsLogic.getConnectionStatus(currentUserUuid, userUuid);
 		    	boolean friend = (connectionStatus == ProfileConstants.CONNECTION_CONFIRMED) ? true : false;
-		    	
+
 		    	//image wrapper, links to profile
 		    	Link<String> friendItem = new Link<String>("searchResultPhotoWrap") {
 					private static final long serialVersionUID = 1L;
@@ -295,14 +297,14 @@ public class MySearch extends BasePage {
 						setResponsePage(new ViewProfile(userUuid));
 					}
 				};
-				
+
 				//image
 				ProfileImage searchResultPhoto = new ProfileImage("searchResultPhoto", new Model<String>(userUuid));
 				searchResultPhoto.setSize(ProfileConstants.PROFILE_IMAGE_THUMBNAIL);
 				friendItem.add(searchResultPhoto);
-				
+
 				item.add(friendItem);
-		    	
+
 		    	//name and link to profile (if allowed or no link)
 		    	Link<String> profileLink = new Link<String>("searchResultProfileLink", new Model<String>(userUuid)) {
 					private static final long serialVersionUID = 1L;
@@ -317,10 +319,10 @@ public class MySearch extends BasePage {
 						}
 					}
 				};
-				
+
 				profileLink.add(new Label("searchResultName", displayName));
 		    	item.add(profileLink);
-		    	
+
 		    	//status component
 		    	ProfileStatusRenderer status = new ProfileStatusRenderer("searchResultStatus", person, "search-result-status-msg", "search-result-status-date") {
 		    		@Override
@@ -330,18 +332,18 @@ public class MySearch extends BasePage {
 		    	};
 				status.setOutputMarkupId(true);
 				item.add(status);
-		    	
-		    	
+
+
 		    	/* ACTIONS */
 				boolean isFriendsListVisible = privacyLogic.isActionAllowed(userUuid, currentUserUuid, PrivacyType.PRIVACY_OPTION_MYFRIENDS);
 				boolean isConnectionAllowed = sakaiProxy.isConnectionAllowedBetweenUserTypes(userType, currentUserType);
-		    	
+
 
 		    	//ADD CONNECTION LINK
 		    	final WebMarkupContainer c1 = new WebMarkupContainer("connectionContainer");
 		    	c1.setOutputMarkupId(true);
 
-				if(!isConnectionAllowed){
+				if(!isConnectionAllowed && !sakaiProxy.isConnectionEnabledGlobally()){
 					//add blank components - TODO turn this into an EmptyLink component
 					AjaxLink<Void> emptyLink = new AjaxLink<Void>("connectionLink"){
 						private static final long serialVersionUID = 1L;
@@ -354,42 +356,42 @@ public class MySearch extends BasePage {
 					//render the link
 			    	final Label connectionLabel = new Label("connectionLabel");
 					connectionLabel.setOutputMarkupId(true);
-					
+
 			    	final AjaxLink<String> connectionLink = new AjaxLink<String>("connectionLink", new Model<String>(userUuid)) {
 						private static final long serialVersionUID = 1L;
 						public void onClick(AjaxRequestTarget target) {
-							
+
 							//get this item, reinit some values and set content for modal
 					    	final String userUuid = (String)getModelObject();
-					    	connectionWindow.setContent(new AddFriend(connectionWindow.getContentId(), connectionWindow, friendActionModel, currentUserUuid, userUuid)); 
-							
-					    	// connection modal window handler 
+					    	connectionWindow.setContent(new AddFriend(connectionWindow.getContentId(), connectionWindow, friendActionModel, currentUserUuid, userUuid));
+
+					    	// connection modal window handler
 							connectionWindow.setWindowClosedCallback(new ModalWindow.WindowClosedCallback() {
 								private static final long serialVersionUID = 1L;
 								public void onClose(AjaxRequestTarget target){
-					            	if(friendActionModel.isRequested()) { 
+					            	if(friendActionModel.isRequested()) {
 					            		connectionLabel.setDefaultModel(new ResourceModel("text.friend.requested"));
 										add(new AttributeModifier("class", true, new Model<String>("instruction icon connection-request")));
 					            		setEnabled(false);
 					            		target.addComponent(c1);
 					            	}
 					            }
-					        });						
+					        });
 							//in preparation for the window being closed, update the text. this will only
 							//be put into effect if its a successful model update from the window close
 					    	//connectionLabel.setModel(new ResourceModel("text.friend.requested"));
 							//this.add(new AttributeModifier("class", true, new Model("instruction")));
 							//this.setEnabled(false);
 							//friendActionModel.setUpdateThisComponentOnSuccess(this);
-							
+
 							connectionWindow.show(target);
-							target.appendJavascript("fixWindowVertical();"); 
-			            	
+							target.appendJavascript("fixWindowVertical();");
+
 						}
 					};
-					
+
 					connectionLink.add(connectionLabel);
-					
+
 					//setup 'add connection' link
 					if(StringUtils.equals(userUuid, currentUserUuid)) {
 						connectionLabel.setDefaultModel(new ResourceModel("text.friend.self"));
@@ -402,7 +404,7 @@ public class MySearch extends BasePage {
 					} else if (connectionStatus == ProfileConstants.CONNECTION_REQUESTED) {
 						connectionLabel.setDefaultModel(new ResourceModel("text.friend.requested"));
 						connectionLink.add(new AttributeModifier("class", true, new Model<String>("instruction icon connection-request")));
-						connectionLink.setEnabled(false);					
+						connectionLink.setEnabled(false);
 					} else if (connectionStatus == ProfileConstants.CONNECTION_INCOMING) {
 						connectionLabel.setDefaultModel(new ResourceModel("text.friend.pending"));
 						connectionLink.add(new AttributeModifier("class", true, new Model<String>("instruction icon connection-request")));
@@ -413,14 +415,14 @@ public class MySearch extends BasePage {
 					connectionLink.setOutputMarkupId(true);
 					c1.add(connectionLink);
 				}
-				
+
 				item.add(c1);
-				
-				
+
+
 				//VIEW FRIENDS LINK
 				WebMarkupContainer c2 = new WebMarkupContainer("viewFriendsContainer");
 		    	c2.setOutputMarkupId(true);
-		    	
+
 		    	final AjaxLink<String> viewFriendsLink = new AjaxLink<String>("viewFriendsLink") {
 					private static final long serialVersionUID = 1L;
 					public void onClick(AjaxRequestTarget target) {
@@ -434,53 +436,53 @@ public class MySearch extends BasePage {
 				};
 				final Label viewFriendsLabel = new Label("viewFriendsLabel", new ResourceModel("link.view.friends"));
 				viewFriendsLink.add(viewFriendsLabel);
-				
+
 				//hide if not allowed
-				if(!isFriendsListVisible) {
+				if(!isFriendsListVisible && !sakaiProxy.isConnectionEnabledGlobally()) {
 					viewFriendsLink.setEnabled(false);
 					c2.setVisible(false);
 				}
 				viewFriendsLink.setOutputMarkupId(true);
 				c2.add(viewFriendsLink);
 				item.add(c2);
-				
+
 				WebMarkupContainer c3 = new WebMarkupContainer("emailContainer");
 		    	c3.setOutputMarkupId(true);
-		    	
+
 		    	ExternalLink emailLink = new ExternalLink("emailLink",
 						"mailto:" + person.getProfile().getEmail(),
 						new ResourceModel("profile.email").getObject());
-		    	
+
 				c3.add(emailLink);
-				
+
 				if (StringUtils.isBlank(person.getProfile().getEmail()) ||
 						false == privacyLogic.isActionAllowed(person.getUuid(), currentUserUuid, PrivacyType.PRIVACY_OPTION_CONTACTINFO)) {
 					c3.setVisible(false);
 				}
 				item.add(c3);
-				
+
 				WebMarkupContainer c4 = new WebMarkupContainer("websiteContainer");
 		    	c4.setOutputMarkupId(true);
-		    	
+
 		    	// TODO home page, university profile URL or academic/research URL (see PRFL-35)
 		    	ExternalLink websiteLink = new ExternalLink("websiteLink", person.getProfile()
 						.getHomepage(), new ResourceModel(
 						"profile.homepage").getObject()).setPopupSettings(new PopupSettings());
-		    	
+
 		    	c4.add(websiteLink);
-		    	
-				if (StringUtils.isBlank(person.getProfile().getHomepage()) || 
+
+				if (StringUtils.isBlank(person.getProfile().getHomepage()) ||
 						false == privacyLogic.isActionAllowed(person.getUuid(), currentUserUuid, PrivacyType.PRIVACY_OPTION_CONTACTINFO)) {
-					
+
 					c4.setVisible(false);
 				}
 				item.add(c4);
-				
+
 				// TODO personal, academic or business (see PRFL-35)
-				
+
 				if (true == privacyLogic.isActionAllowed(
 						person.getUuid(), currentUserUuid,  PrivacyType.PRIVACY_OPTION_BASICINFO)) {
-					
+
 					item.add(new Label("searchResultSummary",
 							StringUtils.abbreviate(ProfileUtils.stripHtml(
 									person.getProfile().getPersonalSummary()), 200)));
@@ -489,7 +491,7 @@ public class MySearch extends BasePage {
 				}
 		    }
 		};
-		
+
 		resultsListView.add(new MySearchCookieBehavior(resultsListView));
 		resultsContainer.add(resultsListView);
 
@@ -500,20 +502,20 @@ public class MySearch extends BasePage {
 		resultsContainer.add(searchResultsNavigator);
 
 		add(connectionWindow);
-		
+
 		//add results container
 		add(resultsContainer);
-		
+
 		/*
 		 * SEARCH HISTORY
 		 */
-		
+
 		final WebMarkupContainer searchHistoryContainer = new WebMarkupContainer("searchHistoryContainer");
 		searchHistoryContainer.setOutputMarkupPlaceholderTag(true);
-		
+
 		Label searchHistoryLabel = new Label("searchHistoryLabel", new ResourceModel("text.search.history"));
 		searchHistoryContainer.add(searchHistoryLabel);
-		
+
 		IModel<List<ProfileSearchTerm>> searchHistoryModel =  new LoadableDetachableModel<List<ProfileSearchTerm>>() {
 
 			private static final long serialVersionUID = 1L;
@@ -527,7 +529,7 @@ public class MySearch extends BasePage {
 					return searchHistory;
 				}
 			}
-			
+
 		};
 		ListView<ProfileSearchTerm> searchHistoryList = new ListView<ProfileSearchTerm>("searchHistoryList", searchHistoryModel) {
 
@@ -543,18 +545,18 @@ public class MySearch extends BasePage {
 					@Override
 					public void onClick(AjaxRequestTarget target) {
 						if (null != target) {
-														
+
 							// post view event
 							sakaiProxy.postEvent(ProfileConstants.EVENT_SEARCH_BY_NAME, "/profile/"+currentUserUuid, false);
-							
+
 							ProfileSearchTerm searchTerm = item.getModelObject();
 							// this will update its position in list
 							searchLogic.addSearchTermToHistory(currentUserUuid, searchTerm);
-							
+
 							searchStringModel.setString(searchTerm.getSearchTerm());
 							searchTypeRadioGroup.setModel(new Model<String>(searchTerm.getSearchType()));
 							connectionsCheckBox.setModel(new Model<Boolean>(searchTerm.isConnections()));
-							
+
 							if (null == searchTerm.getWorksite()) {
 								worksiteCheckBox.setModel(new Model<Boolean>(false));
 								worksiteChoice.setModel(new Model(defaultWorksiteIdModel));
@@ -562,14 +564,14 @@ public class MySearch extends BasePage {
 								worksiteCheckBox.setModel(new Model<Boolean>(true));
 								worksiteChoice.setModel(new Model(searchTerm.getWorksite()));
 							}
-							
+
 							setSearchCookie(searchTerm.getSearchType(), searchTerm.getSearchTerm(), searchTerm.getSearchPageNumber(), searchTerm.isConnections(), searchTerm.getWorksite());
-							
+
 							if (ProfileConstants.SEARCH_TYPE_NAME.equals(searchTerm.getSearchType())) {
-								
+
 								searchByName(resultsListView, searchResultsNavigator,
 										searchHistoryContainer, target, searchTerm.getSearchTerm(), searchTerm.isConnections(), searchTerm.getWorksite());
-								
+
 							} else if (ProfileConstants.SEARCH_TYPE_INTEREST.equals(searchTerm.getSearchType())) {
 
 								searchByInterest(resultsListView, searchResultsNavigator,
@@ -577,20 +579,20 @@ public class MySearch extends BasePage {
 							}
 						}
 					}
-					
+
 				};
 				link.add(new Label("previousSearchLabel", item.getModelObject().getSearchTerm()));
 				item.add(link);
 			}
 		};
-		
+
 		searchHistoryContainer.add(searchHistoryList);
 		add(searchHistoryContainer);
-		
+
 		if (null == searchLogic.getSearchHistory(currentUserUuid)) {
 			searchHistoryContainer.setVisible(false);
 		}
-		
+
 		//clear button
 		Form<Void> clearHistoryForm = new Form<Void>("clearHistory");
 		clearHistoryForm.setOutputMarkupPlaceholderTag(true);
@@ -599,20 +601,20 @@ public class MySearch extends BasePage {
 			private static final long serialVersionUID = 1L;
 
 			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
-				
+
 				searchLogic.clearSearchHistory(currentUserUuid);
-				
+
 				//clear the fields, hide self, then repaint
 				searchField.clearInput();
 				searchField.updateModel();
-								
+
 				searchHistoryContainer.setVisible(false);
 				clearHistoryButton.setVisible(false);
-				
+
 				target.addComponent(searchField);
 				target.addComponent(searchHistoryContainer);
 				target.addComponent(this);
-			}				
+			}
 		};
 		clearHistoryButton.setOutputMarkupPlaceholderTag(true);
 
@@ -622,32 +624,32 @@ public class MySearch extends BasePage {
 		clearHistoryButton.setModel(new ResourceModel("button.search.history.clear"));
 		clearHistoryForm.add(clearHistoryButton);
 		searchHistoryContainer.add(clearHistoryForm);
-		
+
 		/*
 		 * Combined search submit
 		 */
 		IndicatingAjaxButton searchSubmitButton = new IndicatingAjaxButton("searchSubmit", searchForm) {
-			
+
 			private static final long serialVersionUID = 1L;
 
 			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
-				
+
 				if(target != null) {
 					//get the model and text entered
 					StringModel model = (StringModel) form.getModelObject();
 					//PRFL-811 - dont strip this down, we will lose i18n chars.
 					//And there is no XSS risk since its only for the current user.
 					String searchText = model.getString();
-					
+
 					//get search type
 					String searchType = searchTypeRadioGroup.getModelObject();
-					
+
 					log.debug("MySearch search by " + searchType + ": " + searchText);
-					
+
 					if(StringUtils.isBlank(searchText)){
 						return;
 					}
-					
+
 					// save search terms
 					ProfileSearchTerm searchTerm = new ProfileSearchTerm();
 					searchTerm.setUserUuid(currentUserUuid);
@@ -658,22 +660,22 @@ public class MySearch extends BasePage {
 					searchTerm.setConnections(connectionsCheckBox.getModelObject());
 					// set to worksite or empty depending on value of checkbox
 					searchTerm.setWorksite((worksiteCheckBox.getModelObject() == true) ? worksiteChoice.getValue() : null);
-					
+
 					searchLogic.addSearchTermToHistory(currentUserUuid, searchTerm);
-					
+
 					// set cookie for current search (page 0 when submitting new search)
 					setSearchCookie(searchTerm.getSearchType(), URLEncoder.encode(searchTerm.getSearchTerm()), searchTerm.getSearchPageNumber(), searchTerm.isConnections(), searchTerm.getWorksite());
-					
+
 					if (ProfileConstants.SEARCH_TYPE_NAME.equals(searchType)) {
-						
+
 						searchByName(resultsListView, searchResultsNavigator, searchHistoryContainer, target, searchTerm.getSearchTerm(), searchTerm.isConnections(), searchTerm.getWorksite());
-						
+
 						//post view event
 						sakaiProxy.postEvent(ProfileConstants.EVENT_SEARCH_BY_NAME, "/profile/"+currentUserUuid, false);
 					} else if (ProfileConstants.SEARCH_TYPE_INTEREST.equals(searchType)) {
-						
+
 						searchByInterest(resultsListView, searchResultsNavigator, searchHistoryContainer, target, searchTerm.getSearchTerm(), searchTerm.isConnections(), searchTerm.getWorksite());
-						
+
 						//post view event
 						sakaiProxy.postEvent(ProfileConstants.EVENT_SEARCH_BY_INTEREST, "/profile/"+currentUserUuid, false);
 					}
@@ -683,20 +685,20 @@ public class MySearch extends BasePage {
 		searchSubmitButton.setModel(new ResourceModel("button.search.generic"));
 		searchForm.add(searchSubmitButton);
         add(searchForm);
-		                
+
         if (null != searchCookie) {
-        	
+
         	String searchString = getCookieSearchString(searchCookie.getValue());
         	searchStringModel.setString(searchString);
-        	
+
         	Boolean filterConnections = getCookieFilterConnections(searchCookie.getValue());
         	String worksiteId = getCookieFilterWorksite(searchCookie.getValue());
         	Boolean filterWorksite = (null == worksiteId) ? false : true;
-        	
+
     		connectionsCheckBox.setModel(new Model<Boolean>(filterConnections));
     		worksiteCheckBox.setModel(new Model<Boolean>(filterWorksite));
     		worksiteChoice.setModel(new Model((null == worksiteId) ? defaultWorksiteIdModel : worksiteId));
-    		
+
         	if (searchCookie.getValue().startsWith(ProfileConstants.SEARCH_TYPE_NAME)) {
         		searchTypeRadioGroup.setModel(new Model<String>(ProfileConstants.SEARCH_TYPE_NAME));
 				searchByName(resultsListView, searchResultsNavigator, searchHistoryContainer, null, searchString, filterConnections, worksiteId);
@@ -710,7 +712,7 @@ public class MySearch extends BasePage {
         	searchTypeRadioGroup.setModel(new Model<String>(ProfileConstants.SEARCH_TYPE_NAME));
         }
 	}
-	
+
 	// use null target when using cookie
 	private void searchByName(
 			final PageableListView<Person> resultsListView,
@@ -718,21 +720,21 @@ public class MySearch extends BasePage {
 			final WebMarkupContainer searchHistoryContainer,
 			AjaxRequestTarget target, String searchTerm, boolean connections,
 			String worksiteId) {
-						
+
 		//search both UDP and SakaiPerson for matches.
 		results = new ArrayList<Person>(searchLogic.findUsersByNameOrEmail(searchTerm, connections, worksiteId));
 		Collections.sort(results);
-		
+
 		int numResults = results.size();
 		int maxResults = sakaiProxy.getMaxSearchResults();
 		int maxResultsPerPage = sakaiProxy.getMaxSearchResultsPerPage();
-		
+
 		// set current page if previously-viewed search
 		int currentPage = getCurrentPageNumber();
-				
+
 		//show the label wrapper
 		numSearchResultsContainer.setVisible(true);
-		
+
 		//text
 		//Strip the chars for display purposes
 		String cleanedSearchTerm = ProfileUtils.stripAndCleanHtml(searchTerm);
@@ -760,7 +762,7 @@ public class MySearch extends BasePage {
 			resultsContainer.setVisible(true);
 			searchResultsNavigator.setVisible(false);
 		}
-		
+
 		if (null != target) {
 			//repaint components
 			target.addComponent(searchField);
@@ -778,7 +780,7 @@ public class MySearch extends BasePage {
 			target.appendJavascript("setMainFrameHeight(window.name);");
 		}
 	}
-	
+
 	// use null target when using cookie
 	private void searchByInterest(
 			final PageableListView<Person> resultsListView,
@@ -786,21 +788,21 @@ public class MySearch extends BasePage {
 			WebMarkupContainer searchHistoryContainer,
 			AjaxRequestTarget target, String searchTerm, boolean connections,
 			String worksiteId) {
-						
+
 		//search SakaiPerson for matches
 		results = new ArrayList<Person>(searchLogic.findUsersByInterest(searchTerm, connections, worksiteId));
 		Collections.sort(results);
-		
+
 		int numResults = results.size();
 		int maxResults = sakaiProxy.getMaxSearchResults();
 		int maxResultsPerPage = sakaiProxy.getMaxSearchResultsPerPage();
 
 		// set current page if previously-viewed search
 		int currentPage = getCurrentPageNumber();
-		
+
 		//show the label wrapper
 		numSearchResultsContainer.setVisible(true);
-		
+
 		//text
 		//Strip the chars for display purposes
 		String cleanedSearchTerm = ProfileUtils.stripAndCleanHtml(searchTerm);
@@ -828,7 +830,7 @@ public class MySearch extends BasePage {
 			resultsContainer.setVisible(true);
 			searchResultsNavigator.setVisible(false);
 		}
-		
+
 		if (null != target) {
 			//repaint components
 			target.addComponent(searchField);
@@ -846,7 +848,7 @@ public class MySearch extends BasePage {
 			target.appendJavascript("setMainFrameHeight(window.name);");
 		}
 	}
-	
+
 	private int getCurrentPageNumber() {
 		if (null == searchCookie) {
 			return 0;
@@ -854,13 +856,13 @@ public class MySearch extends BasePage {
 			return getCookiePageNumber();
 		}
 	}
-	
+
 	private int getCookiePageNumber() {
 		return Integer.parseInt(searchCookie.getValue().substring(
 			searchCookie.getValue().indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_PAGE_MARKER) + 1,
 			searchCookie.getValue().indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_SEARCH_MARKER)));
 	}
-	
+
 	private void updatePageNumber(int pageNumber, String cookieString) {
 		setSearchCookie(getCookieSearchType(cookieString),
 				getCookieSearchString(cookieString),
@@ -868,7 +870,7 @@ public class MySearch extends BasePage {
 				getCookieFilterConnections(cookieString),
 				getCookieFilterWorksite(cookieString));
 	}
-	
+
 	private void setSearchCookie(String searchCookieValuePrefix,
 			String searchText, int searchPageNumber, boolean connections,
 			String worksiteId) {
@@ -888,7 +890,7 @@ public class MySearch extends BasePage {
 		searchCookie.setMaxAge(-1);
 		getWebRequestCycle().getWebResponse().addCookie(searchCookie);
 	}
-	
+
 	private String getCookieSearchString(String cookieString) {
 		return URLDecoder.decode(cookieString.substring(cookieString.indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_SEARCH_MARKER) + 1));
 	}
@@ -896,21 +898,21 @@ public class MySearch extends BasePage {
 	private String getCookieSearchType(String cookieString) {
 		return cookieString.substring(0, cookieString.indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_CONNECTIONS_MARKER));
 	}
-	
+
 	private boolean getCookieFilterConnections(String cookieString) {
 		return Boolean.parseBoolean(
 				cookieString.substring(cookieString.indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_CONNECTIONS_MARKER) + 1,
 				cookieString.indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_WORKSITE_MARKER)));
 	}
-	
+
 	private String getCookieFilterWorksite(String cookieString) {
 		String worksiteId = cookieString.substring(cookieString.indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_WORKSITE_MARKER) + 1,
 				cookieString.indexOf(ProfileConstants.SEARCH_COOKIE_VALUE_PAGE_MARKER));
-		
+
 		return (true == worksiteId.equals("null") ? null : worksiteId);
 	}
-		         
-	// behaviour so we can set the current search cookie when the navigator page changes	 
+
+	// behaviour so we can set the current search cookie when the navigator page changes
 	private class MySearchCookieBehavior extends AbstractBehavior {
 
 		private static final long serialVersionUID = 1L;
@@ -928,5 +930,5 @@ public class MySearch extends BasePage {
 			}
 		}
 	}
-		
+
 }

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/ViewProfile.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/ViewProfile.java
@@ -60,45 +60,45 @@ import org.sakaiproject.user.api.User;
 public class ViewProfile extends BasePage {
 
 	private static final Logger log = Logger.getLogger(ViewProfile.class);
-	
+
 	public ViewProfile(final String userUuid, final String tab)   {
-				
+
 		log.debug("ViewProfile()");
 
 		//setup model to store the actions in the modal windows
 		final FriendAction friendActionModel = new FriendAction();
-		
+
 		//get current user info
 		User currentUser = sakaiProxy.getUserQuietly(sakaiProxy.getCurrentUserId());
 		final String currentUserId = currentUser.getId();
 		String currentUserType = currentUser.getType();
-		
+
 		//double check, if somehow got to own ViewPage, redirect to MyProfile instead
 		if(userUuid.equals(currentUserId)) {
 			log.warn("ViewProfile: user " + userUuid + " accessed ViewProfile for self. Redirecting...");
 			throw new RestartResponseException(new MyProfile());
 		}
-		
+
 		//check if super user, to grant editing rights to another user's profile
 		if(sakaiProxy.isSuperUser()) {
 			log.warn("ViewProfile: superUser " + currentUserId + " accessed ViewProfile for " + userUuid + ". Redirecting to allow edit.");
 			throw new RestartResponseException(new MyProfile(userUuid));
 		}
-		
+
 		//post view event
 		sakaiProxy.postEvent(ProfileConstants.EVENT_PROFILE_VIEW_OTHER, "/profile/"+userUuid, false);
-		
+
 		/* DEPRECATED via PRFL-24 when privacy was relaxed
 		if(!isProfileAllowed) {
 			throw new ProfileIllegalAccessException("User: " + currentUserId + " is not allowed to view profile for: " + userUuid);
 		}
 		*/
-			
+
 		//get some values from User
 		User user = sakaiProxy.getUserQuietly(userUuid);
 		String userDisplayName = user.getDisplayName();
 		String userType = user.getType();
-		
+
 		//init
 		final boolean friend;
 		boolean friendRequestToThisPerson = false;
@@ -111,87 +111,87 @@ public class ViewProfile extends BasePage {
 		if(!friend) {
 			friendRequestToThisPerson = connectionsLogic.isFriendRequestPending(currentUserId, userUuid);
 		}
-		
+
 		//if not friend and no friend request to this person, has a friend request been made from this person to the current user?
 		if(!friend && !friendRequestToThisPerson) {
 			friendRequestFromThisPerson = connectionsLogic.isFriendRequestPending(userUuid, currentUserId);
 		}
-		
+
 		//privacy checks
 		final ProfilePrivacy privacy = privacyLogic.getPrivacyRecordForUser(userUuid);
-		
+
 		boolean isFriendsListVisible = privacyLogic.isActionAllowed(userUuid, currentUserId, PrivacyType.PRIVACY_OPTION_MYFRIENDS);
 		boolean isKudosVisible = privacyLogic.isActionAllowed(userUuid, currentUserId, PrivacyType.PRIVACY_OPTION_MYKUDOS);
 		boolean isGalleryVisible = privacyLogic.isActionAllowed(userUuid, currentUserId, PrivacyType.PRIVACY_OPTION_MYPICTURES);
 		boolean isConnectionAllowed = sakaiProxy.isConnectionAllowedBetweenUserTypes(currentUserType, userType);
 		boolean isOnlineStatusVisible = privacyLogic.isActionAllowed(userUuid, currentUserId, PrivacyType.PRIVACY_OPTION_ONLINESTATUS);
-		
+
 		final ProfilePreferences prefs = preferencesLogic.getPreferencesRecordForUser(userUuid);
 
 		/* IMAGE */
 		add(new ProfileImage("photo", new Model<String>(userUuid)));
-		
+
 		/* NAME */
 		Label profileName = new Label("profileName", userDisplayName);
 		add(profileName);
-		
+
 		/* ONLINE PRESENCE INDICATOR */
-		if(prefs.isShowOnlineStatus() && isOnlineStatusVisible){
+		if(sakaiProxy.isOnlineStatusEnabledGlobally() && prefs.isShowOnlineStatus() && isOnlineStatusVisible){
 			add(new OnlinePresenceIndicator("online", userUuid));
 		} else {
 			add(new EmptyPanel("online"));
 		}
-		
+
 		/*STATUS PANEL */
 		if(sakaiProxy.isProfileStatusEnabled()) {
 			add(new ProfileStatusRenderer("status", userUuid, privacy, null, "tiny"));
 		} else {
 			add(new EmptyPanel("status"));
 		}
-		
+
 		/* TABS */
 		List<ITab> tabs = new ArrayList<ITab>();
-		
+
 		AjaxTabbedPanel tabbedPanel = new AjaxTabbedPanel("viewProfileTabs", tabs) {
-			
+
 			private static final long serialVersionUID = 1L;
 
 			// overridden so we can add tooltips to tabs
 			@Override
 			protected WebMarkupContainer newLink(String linkId, final int index) {
 				WebMarkupContainer link = super.newLink(linkId, index);
-				
+
 				if (ProfileConstants.TAB_INDEX_PROFILE == index) {
 					link.add(new AttributeModifier("title", true,
 							new ResourceModel("link.tab.profile.tooltip")));
-					
+
 				} else if (ProfileConstants.TAB_INDEX_WALL == index) {
 					link.add(new AttributeModifier("title", true,
-							new ResourceModel("link.tab.wall.tooltip")));	
+							new ResourceModel("link.tab.wall.tooltip")));
 				}
 				return link;
 			}
 		};
-		
+
 		Cookie tabCookie = getWebRequestCycle().getWebRequest().getCookie(ProfileConstants.TAB_COOKIE);
-		
+
 		if (sakaiProxy.isProfileFieldsEnabled()) {
 			tabs.add(new AbstractTab(new ResourceModel("link.tab.profile")) {
-	
+
 				private static final long serialVersionUID = 1L;
-	
+
 				@Override
 				public Panel getPanel(String panelId) {
-	
+
 					setTabCookie(ProfileConstants.TAB_INDEX_PROFILE);
 					return new ViewProfilePanel(panelId, userUuid, currentUserId,
 							privacy, friend);
 				}
 			});
 		}
-		
-		if (true == sakaiProxy.isWallEnabledGlobally()) {
-			
+
+		if (sakaiProxy.isWallEnabledGlobally()) {
+
 			tabs.add(new AbstractTab(new ResourceModel("link.tab.wall")) {
 
 				private static final long serialVersionUID = 1L;
@@ -203,14 +203,14 @@ public class ViewProfile extends BasePage {
 					return new ViewWallPanel(panelId, userUuid);
 				}
 			});
-			
-			if (true == sakaiProxy.isWallDefaultProfilePage() && null == tabCookie) {
-				
+
+			if (sakaiProxy.isWallDefaultProfilePage() && null == tabCookie) {
+
 				tabbedPanel.setSelectedTab(ProfileConstants.TAB_INDEX_WALL);
 			}
 		}
-		
-		
+
+
 		if (null != tab) {
 			tabbedPanel.setSelectedTab(Integer.parseInt(tab));
 		} else if (null != tabCookie) {
@@ -220,15 +220,15 @@ public class ViewProfile extends BasePage {
 				//do nothing. This will be thrown if the cookie contains a value > the number of tabs but thats ok.
 			}
 		}
-		
+
 		add(tabbedPanel);
-		
+
 		/* SIDELINKS */
 		WebMarkupContainer sideLinks = new WebMarkupContainer("sideLinks");
 		int visibleSideLinksCount = 0;
-		
+
 		WebMarkupContainer addFriendContainer = new WebMarkupContainer("addFriendContainer");
-		
+
 		//ADD FRIEND MODAL WINDOW
 		final ModalWindow addFriendWindow = new ModalWindow("addFriendWindow");
 
@@ -240,12 +240,12 @@ public class ViewProfile extends BasePage {
     			addFriendWindow.show(target);
 			}
 		};
-		
+
 		final Label addFriendLabel = new Label("addFriendLabel");
 		addFriendLink.add(addFriendLabel);
-		
+
 		addFriendContainer.add(addFriendLink);
-		
+
 		//setup link/label and windows
 		if(friend) {
 			addFriendLabel.setDefaultModel(new ResourceModel("text.friend.confirmed"));
@@ -264,17 +264,17 @@ public class ViewProfile extends BasePage {
 			addFriendLink.setEnabled(false);
 		}  else {
 			addFriendLabel.setDefaultModel(new StringResourceModel("link.friend.add.name", null, new Object[]{ user.getFirstName() } ));
-			addFriendWindow.setContent(new AddFriend(addFriendWindow.getContentId(), addFriendWindow, friendActionModel, currentUserId, userUuid)); 
+			addFriendWindow.setContent(new AddFriend(addFriendWindow.getContentId(), addFriendWindow, friendActionModel, currentUserId, userUuid));
 		}
 		sideLinks.add(addFriendContainer);
-		
-		
-		//ADD FRIEND MODAL WINDOW HANDLER 
+
+
+		//ADD FRIEND MODAL WINDOW HANDLER
 		addFriendWindow.setWindowClosedCallback(new ModalWindow.WindowClosedCallback() {
 			private static final long serialVersionUID = 1L;
 
 			public void onClose(AjaxRequestTarget target){
-            	if(friendActionModel.isRequested()) { 
+            	if(friendActionModel.isRequested()) {
             		//friend was successfully requested, update label and link
             		addFriendLabel.setDefaultModel(new ResourceModel("text.friend.requested"));
             		addFriendLink.add(new AttributeModifier("class", true, new Model<String>("instruction icon connection-request")));
@@ -283,48 +283,48 @@ public class ViewProfile extends BasePage {
             	}
             }
         });
-		
+		addFriendWindow.setVisible(sakaiProxy.isConnectionEnabledGlobally());
 		add(addFriendWindow);
-		
+
 		//hide connection link if not allowed
-		if(!isConnectionAllowed) {
+		if(!isConnectionAllowed && !sakaiProxy.isConnectionEnabledGlobally()) {
 			addFriendContainer.setVisible(false);
 		} else {
 			visibleSideLinksCount++;
 		}
-		
+
 		//hide entire list if no links to show
 		if(visibleSideLinksCount == 0) {
 			sideLinks.setVisible(false);
 		}
-		
+
 		add(sideLinks);
-		
-		
+
+
 		/* KUDOS PANEL */
-		if(isKudosVisible) {
+		if(sakaiProxy.isMyKudosEnabledGlobally() && isKudosVisible) {
 			add(new AjaxLazyLoadPanel("myKudos"){
 				private static final long serialVersionUID = 1L;
-	
+
 				@Override
 				public Component getLazyLoadComponent(String markupId) {
 					if(prefs.isShowKudos()){
-											
+
 						int score = kudosLogic.getKudos(userUuid);
 						if(score > 0) {
 							return new KudosPanel(markupId, userUuid, currentUserId, score);
 						}
-					} 
+					}
 					return new EmptyPanel(markupId);
 				}
 			});
 		} else {
 			add(new EmptyPanel("myKudos").setVisible(false));
 		}
-		
-		
+
+
 		/* FRIENDS FEED PANEL */
-		if(isFriendsListVisible) {
+		if(sakaiProxy.isConnectionEnabledGlobally() && isFriendsListVisible) {
 			add(new AjaxLazyLoadPanel("friendsFeed") {
 				private static final long serialVersionUID = 1L;
 
@@ -332,17 +332,17 @@ public class ViewProfile extends BasePage {
 	            public Component getLazyLoadComponent(String markupId) {
 	            	return new FriendsFeed(markupId, userUuid, currentUserId);
 	            }
-				
+
 	        });
 		} else {
 			add(new EmptyPanel("friendsFeed").setVisible(false));
 		}
-		
+
 		/* GALLERY FEED PANEL */
 		if (sakaiProxy.isProfileGalleryEnabledGlobally() && isGalleryVisible && prefs.isShowGalleryFeed()) {
 			add(new AjaxLazyLoadPanel("galleryFeed") {
 				private static final long serialVersionUID = 1L;
-	
+
 				@Override
 				public Component getLazyLoadComponent(String markupId) {
 					return new GalleryFeed(markupId, userUuid, currentUserId).setOutputMarkupId(true);
@@ -352,7 +352,7 @@ public class ViewProfile extends BasePage {
 			add(new EmptyPanel("galleryFeed").setVisible(false));
 		}
 	}
-	
+
 	/**
 	 * This constructor is called if we have a pageParameters object containing the userUuid as an id parameter
 	 * Just redirects to normal ViewProfile(String userUuid)
@@ -361,7 +361,7 @@ public class ViewProfile extends BasePage {
 	public ViewProfile(PageParameters parameters) {
 		this(parameters.getString(ProfileConstants.WICKET_PARAM_USERID), parameters.getString(ProfileConstants.WICKET_PARAM_TAB));
 	}
-	
+
 	public ViewProfile(final String userUuid) {
 		this(userUuid, null);
 	}


### PR DESCRIPTION
Messaging, Privacy, Preferences, Online Status, and my Kudos are now individually able to be hidden.
Messaging depends on Connections, so if connections are disabled, so is messaging. 

A global property, profile2.menu.enabled (default true), was created which overrides all the sub-menu items:
- profile2.gallery.enabled
- profile2.connection.enabled
- profile2.messaging.enabled
- profile2.search.enabled
- profile2.privacy.enabled
- profile2.preference.enabled

That is when profile2.menu.enabled is false, all the other values are ignored.

Sorry about all the whitespace changes. :disappointed_relieved: