### PR TITLE
SAK-29284 Use features in Maven 3.3.1 to reduce setup.

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xms168m -Xmx1536m -XX:NewSize=64m -Djava.awt.headless=true


### PR DESCRIPTION
Maven 3.3.1 allows MAVEN_OPTS to effectively come from the project source code. This means that developers have one less thing to configure when setting up their build.

On most developer machine the heap space options shouldn’t be needed as typically the JVM will limit it’s heap to 1/4 of physical memory, but it’s worth setting because some people may be compiling under VMs with much more limited memory constrains.

The permgen options aren’t included here as they are no longer supported under JDK 8 which is now required for master.