### PR TITLE
SAK-29260 - Assignment decimal point moved on scoring

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -10893,6 +10893,9 @@ public class AssignmentAction extends PagedResourceActionII
 				// permissions
 				doPermissions(data);
 			}
+			else if ("new".equals(option)) {
+			    doNew_assignment(data,null);
+			}
 			else if ("returngrade".equals(option))
 			{
 					// return grading

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -59,7 +59,7 @@ function handleReportsTriangleDisclosure(btn)
 		#if ($allowAddAssignment)
 			#set($prevAction=true)
 			<li class="firstToolBarItem">
-				<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
+				<span><a href="#" title = "$!tlang.getString('new')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='new';document.getElementById('view').value='new';document.gradeForm.submit();return false;">$!tlang.getString("new")</a></span>
 			</li>
 		#end
 		<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>


### PR DESCRIPTION
Changed the link for the add assignment to match up with the others and perform a submit on the page. Looks like it fixes the bug and improves the error message returned if you try to submit without leaving. You have to hit the add button twice, but that's how all the buttons work.