### PR TITLE
SAK-29417: Inherit title and descriptions in Course Management

### DIFF
--- a/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/AbstractNamedCourseManagementObjectCmImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/AbstractNamedCourseManagementObjectCmImpl.java
@@ -59,4 +59,12 @@ public abstract class AbstractNamedCourseManagementObjectCmImpl
 			.append(getDescription())
 			.toString();
 	}
+
+	protected boolean isTitleEmpty() {
+		return title == null || title.length() == 0;
+	}
+
+	protected boolean isDescriptionEmpty() {
+		return description == null || description.length() == 0;
+	}
 }

--- a/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/CourseOfferingCmImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/CourseOfferingCmImpl.java
@@ -138,4 +138,22 @@ public class CourseOfferingCmImpl extends CrossListableCmImpl
 	public void setStatus(String status) {
 		this.status = status;
 	}
+
+	@Override
+	public String getTitle() {
+		if (isTitleEmpty() && canonicalCourse != null) {
+			return canonicalCourse.getTitle();
+		}
+
+		return title;
+	}
+
+	@Override
+	public String getDescription() {
+		if (isDescriptionEmpty() && canonicalCourse != null) {
+			return canonicalCourse.getDescription();
+		}
+
+		return description;
+	}
 }

--- a/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/EnrollmentSetCmImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/EnrollmentSetCmImpl.java
@@ -79,4 +79,22 @@ public class EnrollmentSetCmImpl extends AbstractNamedCourseManagementObjectCmIm
 		this.officialInstructors = officialInstructors;
 	}
 	
+	@Override
+	public String getTitle() {
+		if (isTitleEmpty() && courseOffering != null) {
+			return courseOffering.getTitle();
+		}
+
+		return title;
+	}
+
+	@Override
+	public String getDescription() {
+		if (isDescriptionEmpty() && courseOffering != null) {
+			return courseOffering.getDescription();
+		}
+
+		return description;
+	}
+
 }

--- a/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/SectionCmImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/java/org/sakaiproject/coursemanagement/impl/SectionCmImpl.java
@@ -101,4 +101,22 @@ public class SectionCmImpl extends AbstractMembershipContainerCmImpl
         public void setMaxSize(Integer maxSize) {
 	    this.maxSize = maxSize;
 	}
+
+	@Override
+	public String getTitle() {
+		if (isTitleEmpty() && enrollmentSet != null) {
+			return enrollmentSet.getTitle();
+		}
+
+		return title;
+	}
+
+	@Override
+	public String getDescription() {
+		if (isDescriptionEmpty() && enrollmentSet != null) {
+			return enrollmentSet.getDescription();
+		}
+
+		return description;
+	}
 }

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -81,7 +81,8 @@
     <kernel.hibernate.annotations.version>3.2.0.Final</kernel.hibernate.annotations.version>
     <kernel.hibernate.jpa.version>1.0.1.Final</kernel.hibernate.jpa.version>
     <!-- Standard dependency versions -->
-    <sakai.commons.lang.version>2.5</sakai.commons.lang.version>
+    <sakai.commons.lang.version>2.6</sakai.commons.lang.version>
+    <sakai.commons.lang3.version>3.4</sakai.commons.lang3.version>
     <sakai.commons-logging.version>1.2</sakai.commons-logging.version>
     <sakai.commons.fileupload.version>1.3.1</sakai.commons.fileupload.version>
     <sakai.ehcache.groupId>net.sf.ehcache</sakai.ehcache.groupId>
@@ -517,7 +518,7 @@
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <version>${sakai.commons.lang.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -536,6 +537,12 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.8</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${sakai.commons.lang3.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Titles and descriptions will be inherited as follows:
CanonicalCourse -> CourseOffering -> EnrollmentSet -> Section

Inheritance will only happen if title/description is null or empty.