### PR TITLE
SAK-29429: Single Uploaded File Only says 'Don't forget to save or submit!', but there is no save option

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -1229,6 +1229,8 @@ function enableSubmitUnlessNoFile(checkForFile)
 
                             #if ($submitted && ($submissionType == 2 || $submissionType == 5) && !$!new_attachments)
                                 <span class="messageInformation">$tlang.getString("stuviewsubm.modifytoresubmit")</span>
+                            #elseif ($submissionType == 5)
+                                <span class="messageInformation">$tlang.getString("stuviewsubm.reminder")</span>
                             #else
                                 <span class="messageInformation">$tlang.getString("stuviewsubm.submitreminder")</span>
                             #end


### PR DESCRIPTION
If an assignment accepts Single Uploaded File Only, the student's options are 'Submit' and 'Cancel', yet it prompts "Don't forget to save or submit!". It should simply say "Don't forget to submit!" in this case.