### PR TITLE
SAM-2569 - File upload type isn't working

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/InitMimeTypes.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/InitMimeTypes.java
@@ -43,7 +43,7 @@ public class InitMimeTypes extends HttpServlet{
 
   public void init (ServletConfig config) throws ServletException {
     super.init(config);
-    String path = config.getServletContext().getRealPath("WEB-INF/mime.types");
+    String path = config.getServletContext().getRealPath("/WEB-INF/mime.types");
     log.debug("**** mimetypes path="+path);
     MimetypesFileTypeMap mimeTypeMap = null;
     FileInputStream input = null;


### PR DESCRIPTION
I thought this might have been a deprecated method, but seems like it was just a missing initial slash when trying to initialize the mime.types. http://stackoverflow.com/a/536260

Weird error though. Maybe could use some better debug messages. The only thing that was coming up up is.

2015-05-27 03:33:57,619  WARN localhost-startStop-1 org.sakaiproject.tool.assessment.ui.servlet.InitMimeTypes - 