### PR TITLE
SAK-29455 add API method to get grading events

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -23,6 +23,7 @@ package org.sakaiproject.service.gradebook.shared;
 
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -707,4 +708,12 @@ public interface GradebookService {
 	 */
 	public void updateAssignmentOrder(final String gradebookUid, final Long assignmentId, final Integer order);
 
+	 /**
+     * Gets the grading events for the given student and the given assignment
+     * @param studentId
+     * @param assignmentId
+     * @return List of GradingEvent objects.
+     */
+    @SuppressWarnings("rawtypes")
+	public List getGradingEvents(final String studentId, final long assignmentId);
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2676,9 +2676,9 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
         HibernateCallback hc = new HibernateCallback() {
             @Override
             public Object doInHibernate(Session session) throws HibernateException, SQLException {
-                Query q = session.createQuery("from GradingEvent as ge where ge.studentId=:studentId and ge.gradableObject=:assignmentId");
+                Query q = session.createQuery("from GradingEvent as ge where ge.studentId=:studentId and ge.gradableObject.id=:assignmentId");
                 q.setParameter("studentId", studentId);
-                q.setParameter("assignmentId", assignmentId, Hibernate.entity(GradableObject.class));
+                q.setParameter("assignmentId", assignmentId);
                 return q.list();
             }
         };


### PR DESCRIPTION
The getGradingEventsForStudent method which returns a list of grading events for a student, currently exists only in the gradebook tool. To use this outside of the gradebook it needs to be present in the API.