### PR TITLE
SAK-29408 Profile2: Now able to hide sub-menu & social items in profile

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2361,25 +2361,55 @@
 # profile2.profile.change.email.enabled=false
 # profile2.profile.change.email.eid=admin
 
+# Enable/disable the profile menu feature? (true/false)
+# Disabling the menu, hides all the profile menu tabs
+# This setting overrides the following properties:
+#   profile2.gallery.enabled
+#   profile2.connections.enabled
+#   profile2.messaging.enabled
+#   profile2.search.enabled
+#   profile2.privacy.enabled
+#   profile2.preference.enabled
+# profile2.menu.enabled=true
+
 # Enable/disable the gallery feature? (true/false)
 # DEFAULT: true
 # profile2.gallery.enabled=true
+
+# Enable/disable the connections feature? (true/false)
+# If Connections are disabled, than messaging is also disabled as
+# messages may only be sent to connections.
+# DEFAULT: true
+# profile2.connections.enabled=true
 
 # Enable/disable the messaging feature? (true/false)
 # DEFAULT: true
 # profile2.messaging.enabled=true
 
-# Enable/Disable the connections options (true/false)
-# DEFAULT: true
-# profile2.connections.enabled=false
-
 # Enable/disable the friend search options (true/false)
 # DEFAULT: true
-# profile2.search.enabled=false
+# profile2.search.enabled=true
+
+# Enable/disable the privacy feature? (true/false)
+# Be sure to set global privacy settings as desired if this is disabled.
+# DEFAULT: true
+# profile2.privacy.enabled=true
+
+# Enable/disable the preferences tab? (true/false)
+# DEFAULT: true
+# profile2.preference.enabled=true
 
 # Allow status updates and display? (true/false)
 # DEFAULT: true
-# profile2.profile.status.enabled=false
+# profile2.profile.status.enabled=true
+
+# Enable/dsiable the myKudos feature? (true/false)
+# DEFAULT: true
+# profile2.myKudos.enabled=true
+
+# Enable/disable the online status feature (true/false)
+# This feature shows if you are currently logged in.
+# profile2.onlineStatus.enabled=true
 
 # Should users profiles be linked in forum posts? (true/false)
 # Works in conjunction with *msgcntr.forums.showProfileInfo* and *msgcntr.messages.showProfileInfo*

--- a/profile2/api/src/java/org/sakaiproject/profile2/logic/SakaiProxy.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/logic/SakaiProxy.java
@@ -508,33 +508,6 @@ public interface SakaiProxy {
 	public boolean isProfileGalleryEnabledGlobally();
 	
 	/**
-	 * Is the profile2.messaging.enabled flag set in sakai.properties?
-	 * If not set, default to <code>true</code>.
-	 * 
-	 * @return the status of the profile2.messaging.enabled flag in sakai.properties.
-	 * Returns <code>true</code> by default.
-	 */
-	public boolean isMessagingEnabledGlobally();
-	
-	/**
-	 * Is the profile2.search.enabled flag set in sakai.properties?
-	 * If not set, default to <code>true</code>.
-	 * 
-	 * @return the status of the profile2.search.enabled flag in sakai.properties.
-	 * Returns <code>true</code> by default.
-	 */
-	public boolean isSearchEnabledGlobally();
-
-	/**
-	 * Is the profile2.connections.enabled flag set in sakai.properties?
-	 * If not set, default to <code>true</code>.
-	 * 
-	 * @return the status of the profile2.connections.enabled flag in sakai.properties.
-	 * Returns <code>true</code> by default.
-	 */
-	public boolean isConnectionsEnabledGlobally();
-
-	/**
 	 * Is the profile2.picture.change.enabled flag set in sakai.properties?
 	 * If not set, defaults to true
 	 * 
@@ -930,4 +903,103 @@ public interface SakaiProxy {
 	 * @return true or false
 	 */
 	public boolean isProfileImageImportEnabled();
+
+	/**
+	* Is the profile2.menu.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the profile sub-sections will be displayed.
+	* This setting controls the display of the profile sub-sections:
+	*	* Messaging		* Privacy
+	*	* Gallery		* Preferences
+	*	* Search		* Messaging
+	*	* Connections
+	* </p>
+	*
+	* @return <code>true</code> if the profile2.menu.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isMenuEnabledGlobally();
+
+	/**
+	* Is the profile2.connections.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the connection feature will be available.</p>
+	*
+	* @return <code>true</code> if the profile2.connections.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isConnectionsEnabledGlobally();
+
+	/**
+	* Is the profile2.messaging.enabled flag set in sakai.properties?
+	* If not set, default to true, as long as profile2.connections.enabled is true.
+	*
+	* <p>If enabled, the messaging feature will be enabled. Though, Messaging
+	* depends on Connections, thus if ConnectionsEnabled == false, Messaging will
+	* also be false. </p>
+	*
+	* @return the status of the profile2.messaging.enabled flag in sakai.properties.
+	* Returns true by default.
+	*/
+	public boolean isMessagingEnabledGlobally();
+
+	/**
+	* Is the profile2.search.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the ability to search for people in profile
+	* will be available. </p>
+	*
+	* @return <code>true</code> if the profile2.search.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isSearchEnabledGlobally();
+
+	/**
+	* Is the profile2.privacy.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the ability to modify one's privacy settings in profile
+	* will be available. Set profile2.privacy.default.x appropriately if disabled </p>
+	*
+	* @return <code>true</code> if the profile2.privacy.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isPrivacyEnabledGlobally();
+
+	/**
+	* Is the profile2.preference.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the ability to modify one's preferences within profile
+	* will be available. </p>
+	*
+	* @return <code>true</code> if the profile2.preference.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isPreferenceEnabledGlobally();
+
+	/**
+	* Is the profile2.myKudos.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, the Kudos feature will be displayed.</p>
+	*
+	* @return <code>true</code> if the profile2.myKudos.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isMyKudosEnabledGlobally();
+
+	/**
+	* Is the profile2.onlineStatus.enabled flag set in sakai.properties? If not set,
+	* defaults to true.
+	*
+	* <p>If enabled, an online indicator will be present when viewing a profile. </p>
+	*
+	* @return <code>true</code> if the profile2.onlineStatus.enabled flag is set,
+	*         otherwise returns <code>false</code>.
+	*/
+	public boolean isOnlineStatusEnabledGlobally();
 }

--- a/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
@@ -219,6 +219,14 @@ public class ProfileConstants {
 	public static final boolean SAKAI_PROP_PROFILE2_PROFILE_FIELDS_ENABLED = true; //profile2.profile.fields.enabled
 	public static final boolean SAKAI_PROP_PROFILE2_PROFILE_STATUS_ENABLED = true; //profile2.profile.status.enabled
 	public static final boolean SAKAI_PROP_PROFILE2_IMPORT_IMAGES_ENABLED = false; // profile2.import.images
+	public static final boolean SAKAI_PROP_PROFILE2_MENU_ENABLED = true; //profile2.menu.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_CONNECTIONS_ENABLED = true; //profile2.connections.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_MESSAGING_ENABLED = true; //profile2.messaging.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_SEARCH_ENABLED = true; //profile2.search.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_PRIVACY_ENABLED = true; //profile2.privacy.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_PREFERENCE_ENABLED = true; //profile2.preference.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_MY_KUDOS_ENABLED = true; //profile2.myKudos.enabled
+	public static final boolean SAKAI_PROP_PROFILE2_ONLINE_STATUS_ENABLED = true; //profile2.onlineStatus.enabled
 
 
 	

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/SakaiProxyImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/SakaiProxyImpl.java
@@ -1058,30 +1058,13 @@ public class SakaiProxyImpl implements SakaiProxy {
  	* {@inheritDoc}
  	*/
 	public boolean isProfileGalleryEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
 		return serverConfigurationService.getBoolean("profile2.gallery.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_GALLERY_ENABLED);
 	}
-	
-	/**
- 	* {@inheritDoc}
- 	*/
-	public boolean isMessagingEnabledGlobally() {
-		return serverConfigurationService.getBoolean("profile2.messaging.enabled", true);
 	}
 
-	/**
- 	* {@inheritDoc}
- 	*/
-	public boolean isSearchEnabledGlobally() {
-		return serverConfigurationService.getBoolean("profile2.search.enabled", true);
-	}
-
-	/**
- 	* {@inheritDoc}
- 	*/
-	public boolean isConnectionsEnabledGlobally() {
-		return serverConfigurationService.getBoolean("profile2.connections.enabled", true);
-	}
-	
 	/**
  	* {@inheritDoc}
  	*/
@@ -1526,6 +1509,82 @@ public class SakaiProxyImpl implements SakaiProxy {
 
 	}
 	
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isMenuEnabledGlobally() {
+		return serverConfigurationService.getBoolean("profile2.menu.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_MENU_ENABLED);
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isConnectionsEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.connections.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_CONNECTIONS_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isMessagingEnabledGlobally() {
+		if(isConnectionsEnabledGlobally()) {
+			return serverConfigurationService.getBoolean("profile2.messaging.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_MESSAGING_ENABLED);
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isSearchEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.search.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_SEARCH_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isPrivacyEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.privacy.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PRIVACY_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isPreferenceEnabledGlobally() {
+		if(!isMenuEnabledGlobally()){
+			return false;
+		} else {
+			return serverConfigurationService.getBoolean("profile2.preference.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_PREFERENCE_ENABLED);
+		}
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isMyKudosEnabledGlobally() {
+		return serverConfigurationService.getBoolean("profile2.myKudos.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_MY_KUDOS_ENABLED);
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public boolean isOnlineStatusEnabledGlobally() {
+		return serverConfigurationService.getBoolean("profile2.onlineStatus.enabled", ProfileConstants.SAKAI_PROP_PROFILE2_ONLINE_STATUS_ENABLED);
+	}
+
 	// PRIVATE METHODS FOR SAKAIPROXY
 	
 	

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/entityprovider/ProfileEntityProvider.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/entityprovider/ProfileEntityProvider.java
@@ -426,7 +426,7 @@ public class ProfileEntityProvider extends AbstractEntityProvider implements Cor
 			sb.append("</div>");
 		}
 		
-		if(!sakaiProxy.getCurrentUserId().equals(userProfile.getUserUuid())) {
+		if(sakaiProxy.isConnectionsEnabledGlobally() && !sakaiProxy.getCurrentUserId().equals(userProfile.getUserUuid())) {
 			
 			int connectionStatus = connectionsLogic.getConnectionStatus(sakaiProxy.getCurrentUserId(), userProfile.getUserUuid());
 		

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/BasePage.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/BasePage.java
@@ -121,6 +121,11 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		myProfileLink.add(new Label("myProfileLabel",new ResourceModel("link.my.profile")));
 		myProfileLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.profile.tooltip")));
+
+		if(!sakaiProxy.isMenuEnabledGlobally()) {
+			myProfileLink.setVisible(false);
+		}
+
 		add(myProfileLink);
 		
 		//my pictures link
@@ -161,7 +166,10 @@ public class BasePage extends WebPage implements IHeaderContributor {
 			newRequestsLabel.setVisible(false);
 		}
 
-		myFriendsLink.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
+		if(!sakaiProxy.isConnectionsEnabledGlobally()) {
+			myFriendsLink.setVisible(false);
+		}
+
 		add(myFriendsLink);
 		
 		
@@ -199,6 +207,11 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		myPrivacyLink.add(new Label("myPrivacyLabel",new ResourceModel("link.my.privacy")));
 		myPrivacyLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.privacy.tooltip")));
+
+		if(!sakaiProxy.isPrivacyEnabledGlobally()) {
+			myPrivacyLink.setVisible(false);
+		}
+
 		add(myPrivacyLink);
 		
 		
@@ -212,7 +225,9 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		searchLink.add(new Label("searchLabel",new ResourceModel("link.my.search")));
 		searchLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.search.tooltip")));
 
-		searchLink.setVisible(sakaiProxy.isSearchEnabledGlobally());
+		if(!sakaiProxy.isSearchEnabledGlobally()) {
+			searchLink.setVisible(false);
+		}
 
 		add(searchLink);
 		
@@ -226,6 +241,10 @@ public class BasePage extends WebPage implements IHeaderContributor {
 		};
 		preferencesLink.add(new Label("preferencesLabel",new ResourceModel("link.my.preferences")));
 		preferencesLink.add(new AttributeModifier("title", true, new ResourceModel("link.my.preferences.tooltip")));
+
+		if(!sakaiProxy.isPreferenceEnabledGlobally()) {
+			preferencesLink.setVisible(false);
+		}
 		add(preferencesLink);
 			
 		

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPreferences.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPreferences.java
@@ -129,6 +129,9 @@ public class MyPreferences extends BasePage{
             }
         });
 		
+		//visibility for request emails
+		emailRequests.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
+
 		//confirm emails
 		final RadioGroup<Boolean> emailConfirms = new RadioGroup<Boolean>("confirmEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "confirmEmailEnabled"));
 		Radio confirmsOn = new Radio<Boolean>("confirmsOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -150,6 +153,9 @@ public class MyPreferences extends BasePage{
             }
         });
 		
+		//visibility for confirm emails
+		emailConfirms.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
+
 		//new message emails
 		final RadioGroup<Boolean> emailNewMessage = new RadioGroup<Boolean>("messageNewEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "messageNewEmailEnabled"));
 		Radio messageNewOn = new Radio<Boolean>("messageNewOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -217,6 +223,9 @@ public class MyPreferences extends BasePage{
             }
         });
 		
+		//visibility for wall items
+		wallItemNew.setVisible(sakaiProxy.isWallEnabledGlobally());
+
 		// added to new worksite emails
 		final RadioGroup<Boolean> worksiteNew = new RadioGroup<Boolean>("worksiteNewEmailEnabled", new PropertyModel<Boolean>(preferencesModel, "worksiteNewEmailEnabled"));
 		Radio worksiteNewOn = new Radio<Boolean>("worksiteNewOn", new Model<Boolean>(Boolean.valueOf(true)));
@@ -346,6 +355,7 @@ public class MyPreferences extends BasePage{
 		// WIDGET SECTION
 		WebMarkupContainer ws = new WebMarkupContainer("widgetSettingsContainer");
 		ws.setOutputMarkupId(true);
+		int visibleWidgetCount = 0;
 		
 		//widget settings
 		ws.add(new Label("widgetSettingsHeading", new ResourceModel("heading.section.widget")));
@@ -370,6 +380,12 @@ public class MyPreferences extends BasePage{
             }
         });
 		ws.add(kudosContainer);
+		if(sakaiProxy.isMyKudosEnabledGlobally()) {
+			visibleWidgetCount++;
+		} else {
+			kudosContainer.setVisible(false);
+		}
+
 		
 		//gallery feed
 		WebMarkupContainer galleryFeedContainer = new WebMarkupContainer("galleryFeedContainer");
@@ -389,7 +405,11 @@ public class MyPreferences extends BasePage{
             }
         });
 		ws.add(galleryFeedContainer);
-		galleryFeedContainer.setVisible(sakaiProxy.isProfileGalleryEnabledGlobally());
+		if(sakaiProxy.isProfileGalleryEnabledGlobally()) {
+            visibleWidgetCount++;
+        } else {
+            galleryFeedContainer.setVisible(false);
+        }
 		
 		
 		//online status
@@ -411,6 +431,17 @@ public class MyPreferences extends BasePage{
         });
 		ws.add(onlineStatusContainer);		
 		
+		if(sakaiProxy.isOnlineStatusEnabledGlobally()){
+        visibleWidgetCount++;
+        } else {
+            onlineStatusContainer.setVisible(false);
+        }
+        
+        // Hide widget container if nothing to show
+        if(visibleWidgetCount == 0) {
+            ws.setVisible(false);
+        }
+
 		form.add(ws);
 		
 		//submit button

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPrivacy.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyPrivacy.java
@@ -306,6 +306,8 @@ public class MyPrivacy extends BasePage {
             }
         });
 		
+		myFriendsContainer.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
+
 		//myStatus privacy
 		WebMarkupContainer myStatusContainer = new WebMarkupContainer("myStatusContainer");
 		myStatusContainer.add(new Label("myStatusLabel", new ResourceModel("privacy.mystatus")));
@@ -323,6 +325,8 @@ public class MyPrivacy extends BasePage {
             }
         });
 		
+		myStatusContainer.setVisible(sakaiProxy.isProfileStatusEnabled());
+
 		// gallery privacy
 		WebMarkupContainer myPicturesContainer = new WebMarkupContainer("myPicturesContainer");
 		myPicturesContainer.add(new Label("myPicturesLabel", new ResourceModel("privacy.mypictures")));
@@ -375,6 +379,8 @@ public class MyPrivacy extends BasePage {
             }
         });
 		
+		myKudosContainer.setVisible(sakaiProxy.isMyKudosEnabledGlobally());
+
 		// wall privacy
 		WebMarkupContainer myWallContainer = new WebMarkupContainer("myWallContainer");
 		myWallContainer.add(new Label("myWallLabel", new ResourceModel("privacy.mywall")));
@@ -409,6 +415,7 @@ public class MyPrivacy extends BasePage {
             }
         });
 		
+		onlineStatusContainer.setVisible(sakaiProxy.isOnlineStatusEnabledGlobally());
 		
 		//submit button
 		IndicatingAjaxButton submitButton = new IndicatingAjaxButton("submit", form) {

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyProfile.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MyProfile.java
@@ -371,7 +371,11 @@ public class MyProfile extends BasePage {
 			
 			add(addFriendWindow);
 		
+			if(sakaiProxy.isConnectionsEnabledGlobally()) {
 			visibleSideLinksCount++;
+      } else {
+        addFriendContainer.setVisible(false);
+      }
 			
 			
 			//ADMIN: LOCK/UNLOCK A PROFILE
@@ -536,7 +540,7 @@ public class MyProfile extends BasePage {
 
 			@Override
 			public Component getLazyLoadComponent(String markupId) {
-				if(prefs.isShowKudos()){
+				if(sakaiProxy.isMyKudosEnabledGlobally() && prefs.isShowKudos()){
 										
 					int score = kudosLogic.getKudos(userUuid);
 					if(score > 0) {
@@ -554,7 +558,10 @@ public class MyProfile extends BasePage {
 
 			@Override
             public Component getLazyLoadComponent(String markupId) {
+							if(sakaiProxy.isConnectionsEnabledGlobally()) {
             	return new FriendsFeed(markupId, userUuid, userUuid);
+            }
+							return new EmptyPanel(markupId);
             }
 
 			@Override

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MySearch.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/MySearch.java
@@ -157,6 +157,8 @@ public class MySearch extends BasePage {
 		connectionsCheckBox = new CheckBox("connectionsCheckBox", new Model<Boolean>(true));
 		connectionsCheckBox.setMarkupId("includeconnectionsinput");
 		connectionsCheckBox.setOutputMarkupId(true);
+		//hide if connections disabled globally
+		connectionsCheckBox.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
 		searchForm.add(connectionsCheckBox);
 				
 		final List<Site> worksites = sakaiProxy.getUserSites();
@@ -345,7 +347,7 @@ public class MySearch extends BasePage {
 		    	final WebMarkupContainer c1 = new WebMarkupContainer("connectionContainer");
 		    	c1.setOutputMarkupId(true);
 
-				if(!isConnectionAllowed){
+				if(!isConnectionAllowed && !sakaiProxy.isConnectionsEnabledGlobally()){
 					//add blank components - TODO turn this into an EmptyLink component
 					AjaxLink<Void> emptyLink = new AjaxLink<Void>("connectionLink"){
 						private static final long serialVersionUID = 1L;
@@ -440,7 +442,7 @@ public class MySearch extends BasePage {
 				viewFriendsLink.add(viewFriendsLabel);
 				
 				//hide if not allowed
-				if(!isFriendsListVisible) {
+				if(!isFriendsListVisible && !sakaiProxy.isConnectionsEnabledGlobally()) {
 					viewFriendsLink.setEnabled(false);
 					c2.setVisible(false);
 				}

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/ViewProfile.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/ViewProfile.java
@@ -137,7 +137,7 @@ public class ViewProfile extends BasePage {
 		add(profileName);
 		
 		/* ONLINE PRESENCE INDICATOR */
-		if(prefs.isShowOnlineStatus() && isOnlineStatusVisible){
+		if(sakaiProxy.isOnlineStatusEnabledGlobally() && prefs.isShowOnlineStatus() && isOnlineStatusVisible){
 			add(new OnlinePresenceIndicator("online", userUuid));
 		} else {
 			add(new EmptyPanel("online"));
@@ -195,7 +195,7 @@ public class ViewProfile extends BasePage {
 			});
 		}
 		
-		if (true == sakaiProxy.isWallEnabledGlobally()) {
+		if (sakaiProxy.isWallEnabledGlobally()) {
 			
 			tabs.add(new AbstractTab(new ResourceModel("link.tab.wall")) {
 
@@ -209,7 +209,7 @@ public class ViewProfile extends BasePage {
 				}
 			});
 			
-			if (true == sakaiProxy.isWallDefaultProfilePage() && null == tabCookie) {
+			if (sakaiProxy.isWallDefaultProfilePage() && null == tabCookie) {
 				
 				tabbedPanel.setSelectedTab(ProfileConstants.TAB_INDEX_WALL);
 			}
@@ -288,11 +288,11 @@ public class ViewProfile extends BasePage {
             	}
             }
         });
-		
+		addFriendWindow.setVisible(sakaiProxy.isConnectionsEnabledGlobally());
 		add(addFriendWindow);
 		
 		//hide connection link if not allowed
-		if(!isConnectionAllowed) {
+		if(!isConnectionAllowed && !sakaiProxy.isConnectionsEnabledGlobally()) {
 			addFriendContainer.setVisible(false);
 		} else {
 			visibleSideLinksCount++;
@@ -307,7 +307,7 @@ public class ViewProfile extends BasePage {
 		
 		
 		/* KUDOS PANEL */
-		if(isKudosVisible) {
+		if(sakaiProxy.isMyKudosEnabledGlobally() && isKudosVisible) {
 			add(new AjaxLazyLoadPanel("myKudos"){
 				private static final long serialVersionUID = 1L;
 	
@@ -329,7 +329,7 @@ public class ViewProfile extends BasePage {
 		
 		
 		/* FRIENDS FEED PANEL */
-		if(isFriendsListVisible) {
+		if(sakaiProxy.isConnectionsEnabledGlobally() && isFriendsListVisible) {
 			add(new AjaxLazyLoadPanel("friendsFeed") {
 				private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Messaging, Privacy, Preferences, Online Status, and my Kudos are now individually able to be hidden.
Messaging depends on Connections, so if connections are disabled, so is messaging. 

A global property, profile2.menu.enabled (default true), was created which overrides all the sub-menu items:
- profile2.gallery.enabled
- profile2.connection.enabled
- profile2.messaging.enabled
- profile2.search.enabled
- profile2.privacy.enabled
- profile2.preference.enabled

That is when profile2.menu.enabled is false, all the other values are ignored.

~~Sorry about all the whitespace changes. :disappointed_relieved:~~

NOTE: I fIxed the merge issues which caused build to fail from PR https://github.com/sakaiproject/sakai/pull/549