### PR TITLE
SAK-20621 add syllabi attachments to site archive export

### DIFF
--- a/syllabus/components/src/webapp/WEB-INF/components.xml
+++ b/syllabus/components/src/webapp/WEB-INF/components.xml
@@ -66,6 +66,7 @@
 		<property name="contentHostingService">
 			<ref bean="org.sakaiproject.content.api.ContentHostingService" />
 		</property>
+		<property name="entityManager"><ref bean="org.sakaiproject.entity.api.EntityManager"/></property>
 	</bean>
 
 	<bean id="FixPublicSyllabusAttachmentsJob"

--- a/syllabus/syllabus-api/src/java/org/sakaiproject/api/app/syllabus/SyllabusData.java
+++ b/syllabus/syllabus-api/src/java/org/sakaiproject/api/app/syllabus/SyllabusData.java
@@ -109,9 +109,9 @@ public interface SyllabusData
    */
   public void setSyllabusItem(SyllabusItem syllabusItem);
   
-  public Set getAttachments();
+  public Set<SyllabusAttachment> getAttachments();
   
-  public void setAttachments(Set attachments);
+  public void setAttachments(Set<SyllabusAttachment> attachments);
   
   /**
    * @return Returns the syllabus' start time

--- a/syllabus/syllabus-api/src/java/org/sakaiproject/api/app/syllabus/SyllabusManager.java
+++ b/syllabus/syllabus-api/src/java/org/sakaiproject/api/app/syllabus/SyllabusManager.java
@@ -71,7 +71,7 @@ public interface SyllabusManager
 
   public void removeSyllabusAttachSyllabusData(final SyllabusData syllabusData, final SyllabusAttachment syllabusAttach);
 
-  public Set getSyllabusAttachmentsForSyllabusData(final SyllabusData syllabusData);
+  public Set<SyllabusAttachment> getSyllabusAttachmentsForSyllabusData(final SyllabusData syllabusData);
 
   public SyllabusAttachment getSyllabusAttachment(final String syllabusAttachId);
   

--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusManagerImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusManagerImpl.java
@@ -729,7 +729,7 @@ public class SyllabusManagerImpl extends HibernateDaoSupport implements Syllabus
           return new TreeSet();
         }
       };             
-      return (Set) getHibernateTemplate().execute(hcb);     
+      return (Set<SyllabusAttachment>) getHibernateTemplate().execute(hcb);
     }
   }  
 


### PR DESCRIPTION
Currently if you use the Admin Workspace -> Site Archive, the syllabus body HTML will be part of the XML export but the attachments will not be included.