### PR TITLE
SAM-2562: Retract date is taken into account only when late submissions are accepted

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -3194,6 +3194,9 @@ public class DeliveryBean
       return "error";
     }
 
+    boolean acceptLateSubmission = AssessmentAccessControlIfc.
+            ACCEPT_LATE_SUBMISSION.equals(publishedAssessment.getAssessmentAccessControl().getLateHandling());
+
     if (this.actionMode == PREVIEW_ASSESSMENT) {
 		  return "safeToProceed";
     }
@@ -3217,7 +3220,7 @@ public class DeliveryBean
     
     log.debug("check 2");
     // check 2: is it still available?
-    if (!isFromTimer && isRetracted(isSubmitForGrade)){
+    if (!isFromTimer && isRetracted(isSubmitForGrade) && acceptLateSubmission){
      return "isRetracted";
     }
     
@@ -3261,43 +3264,59 @@ public class DeliveryBean
     }
 
     log.debug("check 8");
-    // check 8: accept late submission?
-    boolean acceptLateSubmission = AssessmentAccessControlIfc.
-        ACCEPT_LATE_SUBMISSION.equals(publishedAssessment.getAssessmentAccessControl().getLateHandling());
-
-    // check 7: has dueDate arrived? if so, does it allow late submission?
+    // check 8: has dueDate arrived? if so, does it allow late submission?
     // If it is a timed assessment and "No Late Submission" and not during a Retake, always go through. Because in this case the
    	// assessment will be auto-submitted anyway - when time is up or when current date reaches due date (if the time limited is
    	// longer than due date,) for either case, we want to redirect to the normal "submision successful page" after submitting.
     if (pastDueDate()){
     	// If Accept Late and there is no submission yet, go through
-    	if (acceptLateSubmission && totalSubmissions == 0) {
-    		log.debug("Accept Late Submission && totalSubmissions == 0");
-    	}
-    	else {
-    		log.debug("take from bean: actualNumberRetake =" + actualNumberRetake);
-    		// Not during a Retake
-    		if (actualNumberRetake == numberRetake) {
-    			// When taking the assessment via URL (from LoginServlet), if pass due date, throw an error 
-    			if (isViaUrlLogin) {
+    	if (acceptLateSubmission){
+    		if(totalSubmissions == 0) {
+    			log.debug("Accept Late Submission && totalSubmissions == 0");
+    		}
+    		else {
+    			log.debug("take from bean: actualNumberRetake =" + actualNumberRetake);
+    			// Not during a Retake
+    			if (actualNumberRetake == numberRetake) {
     				return "noLateSubmission";
     			}
-    	    	// If No Late, this is a timed assessment, and not during a Retake, go through (see above reason)
-    			else if (!acceptLateSubmission && this.isTimedAssessment()) {
-    				log.debug("No Late Submission && timedAssessment"); 
+    			// During a Retake
+    			else if (actualNumberRetake == numberRetake - 1) {
+    				log.debug("actualNumberRetake == numberRetake - 1: through Retake");
     			}
+    			// Should not come to here
     			else {
-    				log.debug("noLateSubmission");
-        			return "noLateSubmission";
+    				log.error("Should NOT come to here - wrong actualNumberRetake or numberRetake");
     			}
     		}
-    		// During a Retake
-    		else if (actualNumberRetake == numberRetake - 1) {
-    			log.debug("actualNumberRetake == numberRetake - 1: through Retake");
-    		}
-    		// Should not come to here
-    		else {
-    			log.error("Should NOT come to here - wrong actualNumberRetake or numberRetake");
+    	} else {
+    		if(!isRetracted(isSubmitForGrade)){
+    			log.debug("take from bean: actualNumberRetake =" + actualNumberRetake);
+    			// Not during a Retake
+    			if (actualNumberRetake == numberRetake) {
+    				// When taking the assessment via URL (from LoginServlet), if pass due date, throw an error 
+    				if (isViaUrlLogin) {
+    					return "noLateSubmission";
+    				}
+    				// If No Late, this is a timed assessment, and not during a Retake, go through (see above reason)
+    				else if (this.isTimedAssessment()) {
+    					log.debug("No Late Submission && timedAssessment"); 
+    				}
+    				else {
+    					log.debug("noLateSubmission");
+    					return "noLateSubmission";
+    				}
+    			}
+    			// During a Retake
+    			else if (actualNumberRetake == numberRetake - 1) {
+    				log.debug("actualNumberRetake == numberRetake - 1: through Retake");
+    			}
+    			// Should not come to here
+    			else {
+    				log.error("Should NOT come to here - wrong actualNumberRetake or numberRetake");
+    			}    			
+    		} else {
+    		     return "isRetracted";
     		}
     	}
     }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/AuthorActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/AuthorActionListener.java
@@ -441,7 +441,7 @@ public class AuthorActionListener
 			  returnValue = false;
 		  }
 
-		  if (retractDate != null && retractDate.before(currentDate)) {
+		  if (acceptLateSubmission && retractDate != null && retractDate.before(currentDate)) {
 			  returnValue = false;
 		  }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
@@ -596,6 +596,7 @@ public class SelectActionListener
     Date startDate = f.getStartDate();
     Date retractDate = f.getRetractDate();
     Date dueDate = f.getDueDate();
+    boolean acceptLateSubmission = AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.equals(f.getLateHandling());
     
     if (!Integer.valueOf(1).equals(status)) {
     	return false;
@@ -605,7 +606,7 @@ public class SelectActionListener
     	return false;
     }
     
-    if (retractDate != null && retractDate.before(currentDate)) {
+    if (retractDate != null && retractDate.before(currentDate) && acceptLateSubmission) {
     	return false;
     }
     
@@ -613,9 +614,6 @@ public class SelectActionListener
     	return true;
     }
     
-    boolean acceptLateSubmission = AssessmentAccessControlIfc.
-        ACCEPT_LATE_SUBMISSION.equals(
-        f.getLateHandling());
     int maxSubmissionsAllowed = 9999;
     if ( (Boolean.FALSE).equals(f.getUnlimitedSubmissions())){
       maxSubmissionsAllowed = f.getSubmissionsAllowed().intValue();
@@ -634,28 +632,45 @@ public class SelectActionListener
     }
     
       //2. time to go through all the criteria
-    if (retractDate == null || retractDate.after(currentDate)) {
-    	if (startDate == null || startDate.before(currentDate)) {
-			if (dueDate != null && dueDate.before(currentDate)) {
-				if (acceptLateSubmission) {
-					if (totalSubmitted == 0) {
-						return true;
-					}
-				}
+    // Tests if dueDate has passed
+    if (dueDate != null && dueDate.before(currentDate)) {
+    	// DUE DATE HAS PASSED
+    	if (acceptLateSubmission) {
+    		// LATE SUBMISSION ARE HANDLED: The assessment is available in these situations:
+    		//    * Is the first submission
+    		//    * A retake has been granted 
+    		// (if late submission are handled, a previous test implies that retract date has not yet passed)
+			if (totalSubmitted == 0) {
+				returnValue = true;
+			} else {
 				int actualNumberRetake = 0;
 				if (actualNumberRetakeHash.get(f.getPublishedAssessmentId()) != null) {
 					actualNumberRetake = ((Integer) actualNumberRetakeHash.get(f.getPublishedAssessmentId())).intValue();
 				}
 				if (actualNumberRetake < numberRetake) {
 					returnValue = true;
+				} else {
+					returnValue = false;
 				}
 			}
-			else {
-				if (totalSubmitted < maxSubmissionsAllowed + numberRetake) {
+    	} else {
+    		// LATE SUBMISSION ARE NOT HANDLED: Test retract date and retakes
+    		if (retractDate == null || retractDate.after(currentDate)) {
+				int actualNumberRetake = 0;
+				if (actualNumberRetakeHash.get(f.getPublishedAssessmentId()) != null) {
+					actualNumberRetake = ((Integer) actualNumberRetakeHash.get(f.getPublishedAssessmentId())).intValue();
+				}
+				if (actualNumberRetake < numberRetake) {
 					returnValue = true;
+				} else {
+					returnValue = false;
 				}
-			}
-		}
+    		}
+    		else{
+	    		// Retract date has passed: Assessment is not available    		
+	    		returnValue = false;
+    		}
+    	}
 	}
 	else {
 		if (totalSubmitted < maxSubmissionsAllowed + numberRetake) {


### PR DESCRIPTION
The assessment is not available if retract date is in the past although the current date is between start date and due date. 
This PR solves the issue taking into account the retract date only when the instructor wants to accept late submissions once past the due date. 

The full behaviour is the next (it has not been modified):
When due date has passed and the retract date has not passed yet, the assessment will be available in this cases:
   + If late submission are handled:
            - The first submission 
               or 
            - When a retake has been granted

   + If late submission are not handled:
            - Only when a retake has been granted
    		