### PR TITLE
SAK-29430: Assignment falsely appears to be submitted when accept until date has passed and instructor viewed submissions

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -69,7 +69,7 @@ function handleReportsTriangleDisclosure(btn)
 						<span class="highlight"> - $tlang.getString("gen.returned")</span>
                         #elseif (!$submission.getSubmitted())
                                 <span class="highlight"> - $submission.getStatus() </span>
-			#elseif (!$!nonElectronicType)
+			#elseif (!$!nonElectronicType && $!submission.isUserSubmission())
 				<span class="highlight"> - $tlang.getString("gen.subm4")</span>
 			#end
 		</h3>


### PR DESCRIPTION
Steps to reproduce:
1) Create assignment, set the accept until date in the past (or in the future and wait for it to pass)
2) View the submissions, don't grade
3) As as a student, view the assignment
Symptom: Beside the assignment title, it says in red "- Submitted". This is false.
The isUserSubmission property is not being respected.