### PR TITLE
SAK-29532 Update Syllabus redirect URL to new site id when copying a site if needed

### DIFF
--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
@@ -1175,14 +1175,19 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer, 
 							.getSite(toContext).getTitle());
 					SyllabusItem toSyItem = syllabusManager
 							.getSyllabusItemByContextId(toPage);
+					String redirectUrl = fromSyllabusItem.getRedirectURL();
+					if (redirectUrl.indexOf(fromContext) != -1)
+					{
+							redirectUrl = redirectUrl.replaceAll(fromContext, toContext);
+					}
 					if (toSyItem == null) 
 					{
 						toSyItem = syllabusManager.createSyllabusItem(
 								UserDirectoryService.getCurrentUser().getId(),
-								toPage, fromSyllabusItem.getRedirectURL());
+								toPage, redirectUrl);
 					}
 					else if (fromSyllabusItem.getRedirectURL() !=null) {
-	                    toSyItem.setRedirectURL(fromSyllabusItem.getRedirectURL());
+	                    toSyItem.setRedirectURL(redirectUrl);
 	                    syllabusManager.saveSyllabusItem(toSyItem);
 	                }
 


### PR DESCRIPTION
If Syllabus redirect url points to a resource from the site, when
duplicating that url needs to be changed to point the same resource from
the destination site.