### PR TITLE
SAK-29547 deal with null value of site id parsed from site root collection reference

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -3125,7 +3125,9 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		{
 			siteId = ref.getContext();
 		}
-		else
+		
+		// id may be in format of /group/<site_id>, which leads to null value for the reference context field
+		if (siteId == null)
 		{
 			siteId = ToolManager.getCurrentPlacement().getContext();
 		}


### PR DESCRIPTION
This is to avoid generate null value as site id. 