### PR TITLE
SAK-29548 make search field default text into true placeholder text

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4092,7 +4092,7 @@ public class AssignmentAction extends PagedResourceActionII
 			String view = (String)state.getAttribute(VIEW_SUBMISSION_LIST_OPTION);
 			context.put("view", view);
 			
-			context.put("searchString", state.getAttribute(VIEW_SUBMISSION_SEARCH)!=null?state.getAttribute(VIEW_SUBMISSION_SEARCH): rb.getString("search_student_instruction"));
+			context.put("searchString", state.getAttribute(VIEW_SUBMISSION_SEARCH) != null ? state.getAttribute(VIEW_SUBMISSION_SEARCH) : "");
 
 			
 			// access point url for zip file download
@@ -4254,11 +4254,7 @@ public class AssignmentAction extends PagedResourceActionII
 		supplementItemIntoContext(state, context, assignment, null);
 		
 		// search context
-		String searchString = (String) state.getAttribute(STATE_SEARCH);
-		if (searchString == null)
-		{
-			searchString = rb.getString("search_student_instruction");
-		}
+		String searchString = (String) state.getAttribute(STATE_SEARCH) != null ? (String) state.getAttribute(STATE_SEARCH) : "";
 		context.put("searchString", searchString);
 		
 		context.put("form_search", FORM_SEARCH);
@@ -4757,12 +4753,6 @@ public class AssignmentAction extends PagedResourceActionII
 		String search = (String) state.getAttribute(VIEW_SUBMISSION_SEARCH);
 		Boolean searchFilterOnly = (state.getAttribute(SUBMISSIONS_SEARCH_ONLY) != null && ((Boolean) state.getAttribute(SUBMISSIONS_SEARCH_ONLY)) ? Boolean.TRUE:Boolean.FALSE);
 
-		// Don't search for "Name, ID, or Email" literally
-		if (search != null && search.equals(rb.getString("search_student_instruction")))
-		{
-			search = null;
-		}
-
 		// get the realm and its member
 		List studentMembers = new ArrayList();
 		List assignments = AssignmentService.getListAssignmentsForContext(contextString);
@@ -4807,7 +4797,7 @@ public class AssignmentAction extends PagedResourceActionII
 		context.put("userService", UserDirectoryService.getInstance());
 		context.put("viewGroup", state.getAttribute(VIEW_SUBMISSION_LIST_OPTION));
 
-		context.put("searchString", state.getAttribute(VIEW_SUBMISSION_SEARCH)!=null?state.getAttribute(VIEW_SUBMISSION_SEARCH): rb.getString("search_student_instruction"));
+		context.put("searchString", state.getAttribute(VIEW_SUBMISSION_SEARCH) != null ? state.getAttribute(VIEW_SUBMISSION_SEARCH) : "");
 		context.put("showSubmissionByFilterSearchOnly", state.getAttribute(SUBMISSIONS_SEARCH_ONLY) != null && ((Boolean) state.getAttribute(SUBMISSIONS_SEARCH_ONLY)) ? Boolean.TRUE:Boolean.FALSE);
 		
 		if (AssignmentService.getAllowGroupAssignments()) {
@@ -4895,7 +4885,7 @@ public class AssignmentAction extends PagedResourceActionII
 		
 		// get current site
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
-		context.put("searchString", state.getAttribute(VIEW_SUBMISSION_SEARCH)!=null?state.getAttribute(VIEW_SUBMISSION_SEARCH): rb.getString("search_student_instruction"));
+		context.put("searchString", state.getAttribute(VIEW_SUBMISSION_SEARCH) != null ? state.getAttribute(VIEW_SUBMISSION_SEARCH) : "");
 
 		String view = (String)state.getAttribute(VIEW_SUBMISSION_LIST_OPTION);
 		context.put("view", state.getAttribute(VIEW_SUBMISSION_LIST_OPTION));
@@ -14106,12 +14096,6 @@ public class AssignmentAction extends PagedResourceActionII
 			String search = (String) state.getAttribute(VIEW_SUBMISSION_SEARCH);
 			Boolean searchFilterOnly = (state.getAttribute(SUBMISSIONS_SEARCH_ONLY) != null && ((Boolean) state.getAttribute(SUBMISSIONS_SEARCH_ONLY)) ? Boolean.TRUE:Boolean.FALSE);
 
-			// Don't search for "Name, ID, or Email" literally
-			if (search != null && search.equals(rb.getString("search_student_instruction")))
-			{
-				search = null;
-			}
-
 		    Boolean has_multiple_groups_for_user = false;
 		    List submissions = new ArrayList();
 
@@ -14209,11 +14193,6 @@ public class AssignmentAction extends PagedResourceActionII
 			String aRef = (String) state.getAttribute(EXPORT_ASSIGNMENT_REF);
 			Boolean searchFilterOnly = (state.getAttribute(SUBMISSIONS_SEARCH_ONLY) != null && ((Boolean) state.getAttribute(SUBMISSIONS_SEARCH_ONLY)) ? Boolean.TRUE:Boolean.FALSE);
 
-			// Don't search for "Name, ID, or Email" literally
-			if (search != null && search.equals(rb.getString("search_student_instruction")))
-			{
-				search = null;
-			}
 			
 			try {
 			    if (AssignmentService.getAssignment(aRef).isGroup()) {

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -189,7 +189,8 @@
 			#if (!$value_CheckAnonymousGrading.equals("true"))
 				<p>
 					<label for="$form_search" class="skip">$tlang.getString("search_students")</label>
-					<input value="$validator.escapeHtml($searchString)" name="search" id="search" type="text" class="searchField"  size="20" />
+					<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
+						name="search" id="search" type="text" class="searchField" size="20" />
 					<input type="button" value="$tlang.getString('search')" onclick="ASN.applySearchFilter('search');" />
 						#if (($!searchString) && (!$searchString.equals("")))
 							<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="ASN.applySearchFilter('clearSearch');" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -74,7 +74,8 @@
 
 				#if( !$hasAtLeastOneAnonAssignment )
 				<label for="$form_search" class="skip">$tlang.getString("search")</label>
-				<input value="$validator.escapeHtml($searchString)" name="search" id="search" type="text" class="searchField"  size="20" />
+				<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
+					name="search" id="search" type="text" class="searchField" size="20" />
 				<input type="button" value="$tlang.getString('search')" onclick="ASN.applySearchFilter('search');" />
 				#if (($!searchString) && (!$searchString.equals("")))
 					<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="ASN.applySearchFilter('clearSearch');" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -91,7 +91,8 @@
 
 					#if( !$hasAtLeastOneAnonAssignment )
 					<label for="$form_search" class="skip">$tlang.getString("search")</label>
-					<input value="$validator.escapeHtml($searchString)" name="search" id="search" type="text" class="searchField"  size="20" />
+					<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
+						name="search" id="search" type="text" class="searchField" size="20" />
 					<input type="button" value="$tlang.getString('search')" onclick="ASN.applySearchFilter( 'search', true );" />
 					#if (($!searchString) && (!$searchString.equals("")))
 						<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="ASN.applySearchFilter( 'clearSearch', true );" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29548

Currently the default value of the search fields is actually a value, rather than a placeholder. This is annoying for the users, who have to manually clear out the placeholder text before typing their desired search value.

Also, having the default as a value text requires server side code to detect and abort actually searching for the default text.

This PR turns the default text into a true HTML5 placeholder attribute text.