### PR TITLE
SAK-29549 Now able to hide connections in roster

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2608,6 +2608,10 @@
 # DEFAULT: true
 # roster_view_email=false
 
+# Hide connection information from picture view (default=false), Profile2 >=1.4
+# NOTE: If Profile2.connections.enabled is false, set accordingly.
+# roster_view_connections=true
+
 # Whether to allow site visit data to be displayed with each member
 # DEFAULT: false
 # roster.showVisits=true

--- a/roster2/src/java/org/sakaiproject/roster/api/SakaiProxy.java
+++ b/roster2/src/java/org/sakaiproject/roster/api/SakaiProxy.java
@@ -46,6 +46,7 @@ public interface SakaiProxy {
 	public final static Boolean DEFAULT_FIRST_NAME_LAST_NAME = false;
 	public final static Boolean DEFAULT_HIDE_SINGLE_GROUP_FILTER = false;
 	public final static Boolean DEFAULT_VIEW_EMAIL = true;
+	public final static Boolean DEFAULT_VIEW_CONNECTIONS = true;
 	public final static Boolean DEFAULT_VIEW_USER_DISPLAY_ID = true;
 	public final static Integer DEFAULT_ROSTER_STATE = 0;
 	
@@ -128,6 +129,14 @@ public interface SakaiProxy {
 	 * @return the value of the <code>roster_view_email</code> Sakai property.
 	 */
 	public Boolean getViewEmail(String siteId);
+
+	/**
+	 * Returns the value of the <code>roster_view_connections</code> Sakai property.
+	 * Note: if Profile2 connections (profile2.connections.enabled) is false, this
+	 * will also be automatically false.
+	 * @return the value of the <code>roster_view_connections</code> Sakai property.
+	 */
+	public Boolean getViewConnections();
 	
 	/**
 	 * Returns the value of the <code>roster.display.userDisplayId</code> Sakai property.

--- a/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -53,6 +53,7 @@ import org.sakaiproject.memory.api.Cache;
 import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.memory.api.SimpleConfiguration;
 import org.sakaiproject.profile2.logic.ProfileConnectionsLogic;
+import org.sakaiproject.profile2.util.ProfileConstants;
 import org.sakaiproject.roster.api.RosterEnrollment;
 import org.sakaiproject.roster.api.RosterFunctions;
 import org.sakaiproject.roster.api.RosterGroup;
@@ -260,6 +261,26 @@ public class SakaiProxyImpl implements SakaiProxy {
 			return hasUserSitePermission(getCurrentUserId(), RosterFunctions.ROSTER_FUNCTION_VIEWEMAIL, siteId);
 		}
 		return false;		
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public Boolean getViewConnections() {
+
+		Boolean view_connections = serverConfigurationService.getBoolean("roster_view_connections",
+				DEFAULT_VIEW_CONNECTIONS);
+
+		Boolean profile2_connections_enabled = serverConfigurationService.getBoolean("profile2.connections.enabled",
+				ProfileConstants.SAKAI_PROP_PROFILE2_CONNECTIONS_ENABLED);
+		Boolean profile2_menu_enabled = serverConfigurationService.getBoolean("profile2.menu.enabled",
+				ProfileConstants.SAKAI_PROP_PROFILE2_MENU_ENABLED);
+
+		if(!profile2_menu_enabled || !profile2_connections_enabled) {
+			view_connections = false;
+		}
+
+		return view_connections;
 	}
 	
 	/**

--- a/roster2/src/java/org/sakaiproject/roster/tool/RosterTool.java
+++ b/roster2/src/java/org/sakaiproject/roster/tool/RosterTool.java
@@ -122,6 +122,7 @@ public class RosterTool extends HttpServlet {
         request.setAttribute("viewEmail", sakaiProxy.getViewEmail());
 		request.setAttribute("superUser", sakaiProxy.isSuperUser());
 		request.setAttribute("siteMaintainer", sakaiProxy.isSiteMaintainer(sakaiProxy.getCurrentSiteId()));
+        request.setAttribute("viewConnections", sakaiProxy.getViewConnections());
 
         response.setContentType("text/html");
         request.getRequestDispatcher("/WEB-INF/bootstrap.jsp").include(request, response);	

--- a/roster2/src/webapp/WEB-INF/bootstrap.jsp
+++ b/roster2/src/webapp/WEB-INF/bootstrap.jsp
@@ -41,6 +41,7 @@
                 viewUserDisplayId: ${viewUserDisplayId},
                 officialPicturesByDefault: ${officialPicturesByDefault},
                 viewEmail: ${viewEmail},
+                viewConnections: ${viewConnections},
                 superUser: ${superUser},
                 siteMaintainer: ${siteMaintainer},
                 i18n: {}

--- a/roster2/src/webapp/js/roster.js
+++ b/roster2/src/webapp/js/roster.js
@@ -533,7 +533,7 @@
                 'currentUserId': roster.userId,
                 'viewOfficialPhoto': roster.currentUserPermissions.viewOfficialPhoto,
                 'viewSiteVisits': roster.currentUserPermissions.viewSiteVisits,
-                'viewConnections': (undefined != window.friendStatus)
+                'viewConnections': ((undefined != window.friendStatus) && roster.viewConnections)
             };
 
         var templateName = (enrollmentsMode) ? 'enrollments' : 'members';


### PR DESCRIPTION
A new sakai.property has been added, roster_view_connections,
which when false will hide the Connections button in the roster
view. The property's default is true, though it will be false
if profile2.connections.enabled is also false (also see
SAK-29267 & SAK-29408).

Jira ticket: https://jira.sakaiproject.org/browse/SAK-29549