### PR TITLE
KNL-1361 Add the ability to promote a sakai property by adding @Syste…

### DIFF
--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -7,6 +7,8 @@
 ## Local properties files (sakai,local,security) will override kernel.properties and default.sakai.properties
 # tests depend on this value being set and not changing
 kernel.test.key=kernel
+# KNL-1361 - Add support for system-scoped properties
+system.test.key@SystemProperty=sakai
 
 # Default: localhost
 #serverId=SAKAI1

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/BasicConfigurationService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/BasicConfigurationService.java
@@ -85,6 +85,7 @@ public class BasicConfigurationService implements ServerConfigurationService, Ap
 
     private static final String SAKAI_LOCALES_KEY = "locales";
     private static final String SAKAI_LOCALES_MORE = "locales.more"; // default is blank/null
+    private static final String SAKAI_SYSTEM_PROPERTY_SUFFIX = "@SystemProperty";
 
 
     /**********************************************************************************************************************************************************************************************************************************************************
@@ -854,6 +855,14 @@ public class BasicConfigurationService implements ServerConfigurationService, Ap
             for (Enumeration<Object> e = p.keys(); e.hasMoreElements(); /**/) {
                 String name = (String) e.nextElement();
                 String value = p.getProperty(name);
+		// KNL-1361 - Add support for system-scoped properties
+		if ( name != null && name.endsWith(SAKAI_SYSTEM_PROPERTY_SUFFIX) && 
+			name.length() > SAKAI_SYSTEM_PROPERTY_SUFFIX.length() ) {
+			name = name.substring(0,name.length()-SAKAI_SYSTEM_PROPERTY_SUFFIX.length());
+			System.setProperty(name, value);
+			M_log.info("Promoted to system property: "+name);
+			continue;
+		}
                 ConfigItemImpl ci = new ConfigItemImpl(name, value, source);
                 this.addConfigItem(ci, source);
             }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/component/test/ConfigurationLoadingTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/component/test/ConfigurationLoadingTest.java
@@ -72,6 +72,8 @@ public class ConfigurationLoadingTest extends SakaiKernelTestBase {
 		// Check that the test sakai-configuration.xml and sakai.properties files have been loaded.
 		Assert.assertTrue(serverConfigurationService.getString("loadedTomcatSakaiProperties").equals("true"));
 		Assert.assertTrue(serverConfigurationService.getString("kernel.test.key").equals("kernel"));
+		// KNL-1361 - Add support for system-scoped properties
+		Assert.assertTrue(System.getProperty("system.test.key").equals("sakai"));
 		ITestComponent testComponent = (ITestComponent)getService(ITestComponent.class.getName());
 		Assert.assertTrue(testComponent.getOverrideString1().equals("nondefault"));
 		Assert.assertTrue(testComponent.getPlaceholderString1().equals("nondefault"));


### PR DESCRIPTION
In order to set a System-wide property, we add the suffix of "@SystemProperty" to
the property in the sakai.properties file:

kernel.test.key=kernel
system.test.key@SystemProperty=sakai

Once this is done, any Java code anywhere in the Sakai JVM can do

System.getProperty("system.test.key")