### PR TITLE
SAK-29553 Removing obsolete mobile and OSP related code from portal

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -780,25 +780,9 @@
 # DEFAULT: false
 # eb.membership.admin.site.changes.allowed=true
 
-# Show the mobile link
-# DEFAULT: false
-# portal.add.mobile.link=false
-
 # Put the application in portlet JSR-168 testmode
 # DEFAULT: null (false)
 # portal.allow.test168=true
-
-# Portal minimization preferences
-# DEFAULT: true
-# portal.allow.auto.minimize=false
-
-# Allows the ability to minimize the navigation of top logo. 
-# DEFAULT: false
-# portal.allow.minimize.navigation=true
-
-# Allows the ability to minimize the tools where only the icons display. 
-# DEFAULT: true
-# portal.allow.minimize.tools=false
 
 # Property to disable setting the HttpOnly attribute on the cookie (if false)
 # DEFAULT: true (enabled)

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -87,11 +87,6 @@
                 <version>${sakai.velocity.version}</version>
             </dependency> 
 			<dependency>
-				<groupId>au.com.flyingkite</groupId>
-				<artifactId>mobiledetect</artifactId>
-				<version>1.1.0</version>
-			</dependency>
-			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>1.8.5</version>

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/Portal.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/Portal.java
@@ -76,11 +76,6 @@ public interface Portal
 	public static final String ATTR_SITE_PAGE = "sakai.portal.site.";
 
 	/**
-	 * Session variable passing a maximized URL between a portlet and the portal
-	 */
-	public static final String ATTR_MAXIMIZED_URL = "sakai:maximized-url";
-
-	/**
 	 * The default portal name is none is specified.
 	 */
 	public static final String DEFAULT_PORTAL_CONTEXT = "charon";
@@ -112,17 +107,6 @@ public interface Portal
 	 * as they are being placed in the context.
 	 */
 	public static final String JSR_168_PRE_RENDER = "sakai:portlet-pre-render";
-
-	/**
-	 * Tool property used to indicate if a tool prefers a maximized view
-	 * with minimal portal navigation.
-	 */
-	public static final String PREFER_MAXIMIZE = "sakai:prefer-maximize";
-	
-	/**
-	 * Name of cookie that is set to signal that the user wants us to start minimized
-	 */
-	public static final String SAKAI_NAV_MINIMIZED = "sakai_nav_minimized";
 
 	/**
 	 * Tool property to allow the enabling/disabling of the direct url linking UI
@@ -372,13 +356,6 @@ public interface Portal
 	 * @return
 	 */
 	ServletContext getServletContext();
-
-	/**
-         * Look at the user agent and add Mobile Browser related material to 
-	 * the context.
-	 */
- 	void setupMobileDevice(HttpServletRequest req, PortalRenderContext rcontext);
-
 
 	/**
 	 * Return the sub sites below a particular site

--- a/portal/portal-charon/charon/src/webapp/scripts/portalscripts.js
+++ b/portal/portal-charon/charon/src/webapp/scripts/portalscripts.js
@@ -1,52 +1,7 @@
 /* Script for pop-up dhtml more tabs implementation 
- * uses jQueryPBJQ library
+ * uses jQuery library
  */
 
-// SAK-20576 - the following wae pulled from includeStandardHead.vm so the declaration of 'portal' is available to OSP Portal
-// SAK-16484 Allow Javascript to easily get at user details.
-// SAK-13987, SAK-16162, SAK-19132 - Portal Logout Timer
-var portal = {
-    "loggedIn": false,
-    "portalPath": "/portal",
-    "loggedOutUrl": "/portal/logout",
-    "user": {
-        "id": "",
-        "eid": ""
-    },
-    "timeoutDialog" : {
-        "enabled": true,
-        "seconds": 60 * 60
-    },
-    "toggle" : {
-        "allowauto": true,
-        "tools": true,
-        "sitenav": true
-    }
-};
-
-/*
-   SAK-20576
-   This method can be called by any portal implementation to set the login status information for
-   the current user
- */
-function setLoginStatus (loggedIn, portalPath, loggedOutUrl, userId, userEid)
-{
-    portal["loggedIn"] = loggedIn;
-    portal["portalPath"] = portalPath;
-    portal["loggedOutUrl"] = loggedOutUrl;
-    portal["user"]["id"] = userId;
-    portal["user"]["eid"] = userEid;
-}
-
-/*
-   SAK-20576
-   This method can be called by any portal implementation to set the timeout configuration
- */
-function setTimeoutInfo (timeoutDialogEnabled, timeoutDialogWarningSeconds)
-{
-    portal["timeoutDialog"]["enabled"] = timeoutDialogEnabled;
-    portal["timeoutDialog"]["seconds"] = timeoutDialogWarningSeconds;
-}
 
 /* dhtml_more_tabs
  * displays the More Sites div 
@@ -240,37 +195,6 @@ function show_timeout_alert(min) {
 		$PBJQ("body").append(dialog);
 		$PBJQ('#timeout_alert_body').css('top', (f_scrollTop() + 100) + "px");
 	}
-}
-
-// The official way for a tool to request minimized navigation
-function portalMaximizeTool() {
-        if ( ! ( portal.toggle.sitenav || portal.toggle.tools ) ) return;
-        if ( ! portal.toggle.allowauto ) return;
-        sakaiMinimizeNavigation();
-}
-
-function sakaiMinimizeNavigation() {
-        if ( ! ( portal.toggle.sitenav || portal.toggle.tools ) ) return;
-	if (portal.toggle.sitenav) {
-		$PBJQ('#portalContainer').addClass('sakaiMinimizeSiteNavigation')
-	}
-	if (portal.toggle.tools){
-		$PBJQ('#container').addClass('sakaiMinimizePageNavigation');	
-	}
-	$PBJQ('#toggleToolMax').hide();
-	$PBJQ('#toggleNormal').css({'display':'block'});
-}
-
-function sakaiRestoreNavigation() {
-        if ( ! ( portal.toggle.sitenav || portal.toggle.tools ) ) return;
-	if (portal.toggle.sitenav) {
-		$PBJQ('#portalContainer').removeClass('sakaiMinimizeSiteNavigation')
-	}
-	if (portal.toggle.tools){
-		$PBJQ('#container').removeClass('sakaiMinimizePageNavigation');	
-	}
-	$PBJQ('#toggleToolMax').show();
-	$PBJQ('#toggleNormal').css({'display':'none'});
 }
 
 function updatePresence() {

--- a/portal/portal-charon/charon/src/webapp/scripts/portalscripts.js
+++ b/portal/portal-charon/charon/src/webapp/scripts/portalscripts.js
@@ -48,17 +48,6 @@ function setTimeoutInfo (timeoutDialogEnabled, timeoutDialogWarningSeconds)
     portal["timeoutDialog"]["seconds"] = timeoutDialogWarningSeconds;
 }
 
-/*
-   SAK-20576
-   This method can be called by any portal implementation to set various UI state properties
- */
-function setUIToggleState (portal_allow_auto_minimize, portal_allow_minimize_tools, portal_allow_minimize_navigation)
-{
-    portal["toggle"]["allowauto"] = portal_allow_auto_minimize;
-    portal["toggle"]["tools"] = portal_allow_minimize_tools;
-    portal["toggle"]["sitenav"] = portal_allow_minimize_navigation;
-}
-
 /* dhtml_more_tabs
  * displays the More Sites div 
  * note the technique of recasting the function after initalization

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -107,10 +107,6 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-			<groupId>au.com.flyingkite</groupId>
-			<artifactId>mobiledetect</artifactId>
-		</dependency>
-        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
         </dependency>

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -476,7 +476,6 @@ public class SiteHandler extends WorksiteHandler
 			}
 		}
 
-
 		// Include the buffered content if we have it
 		if ( BC instanceof Map ) {
 			if ( req.getMethod().equals("POST") ) {
@@ -490,19 +489,6 @@ public class SiteHandler extends WorksiteHandler
 			Map<String,String> bufferMap = (Map<String,String>) BC;
 			rcontext.put("responseHead", (String) bufferMap.get("responseHead"));
 			rcontext.put("responseBody", (String) bufferMap.get("responseBody"));
-		}
-
-
-		// Have we been requested to display minimized and are we logged in?
-		if (session.getUserId() != null ) {
-			Cookie c = portal.findCookie(req, portal.SAKAI_NAV_MINIMIZED);
-                        String reqParm = req.getParameter(portal.SAKAI_NAV_MINIMIZED);
-                	String minStr = ServerConfigurationService.getString("portal.allow.auto.minimize","true");
-                	if ( c != null && "true".equals(c.getValue()) ) {
-				rcontext.put(portal.SAKAI_NAV_MINIMIZED, Boolean.TRUE);
-			} else if ( reqParm != null &&  "true".equals(reqParm) && ! "false".equals(minStr) ) {
-				rcontext.put(portal.SAKAI_NAV_MINIMIZED, Boolean.TRUE);
-			}
 		}
 
 		rcontext.put("siteId", siteId);


### PR DESCRIPTION
Now that we have a responsive portal, things like:

PREFER_MAXIMIZE
SAKAI_NAV_MINIMIZED
portal.add.mobile.link
sakai:maximized-url
portal.allow.auto.minimize / portal_allow_auto_minimize
portal.allow.minimize.navigation

Also remove code/data in portalscripts.js that were just there for OSP portal in SAK-20576 that are now obsolete and can be removed.