### PR TITLE
SAK-29561 - Upgrade BasicLTIUtil and tests to support SHA256 signing

### DIFF
--- a/basiclti/basiclti-docs/resources/docs/sakai-api-test/lms.php
+++ b/basiclti/basiclti-docs/resources/docs/sakai-api-test/lms.php
@@ -103,6 +103,9 @@ echo('<input type="submit" onclick="javascript:lmsdataToggle();return false;" va
   $checked = '';
   if ( $iframe ) $checked = 'checked';
   echo("<br/>Launch in iFrame: <input type=\"checkbox\" name=\"iframe\" $checked $disabled value=\"true\">\n");
+  $sha256 = isset($_REQUEST["sha256"]) && $_REQUEST["sha256"] == "true";
+  if ( $sha256 ) $checked = 'checked';
+  echo("<br/>Sign with SHA256: <input type=\"checkbox\" name=\"sha256\" $checked $disabled value=\"true\">\n");
   echo("</fieldset><p>");
   echo("<fieldset><legend>Launch Data</legend>\n");
   foreach ($lmsdata as $k => $val ) {
@@ -138,6 +141,10 @@ addCustom($parms, array(
 
 if ( (isset($_REQUEST["cert_num"]) && $secret != "secret" ) || 
       isset($_POST['launch']) || isset($_POST['debug']) ) {
+
+if ( $sha256 ) {
+    $parms['oauth_signature_method'] = 'HMAC-SHA256';
+}
 
 $parms = signParameters($parms, $endpoint, "POST", $key, $secret, 
 "Finish Launch", $tool_consumer_instance_guid, $tool_consumer_instance_description);

--- a/basiclti/basiclti-docs/resources/docs/sakai-api-test/util/OAuth.php
+++ b/basiclti/basiclti-docs/resources/docs/sakai-api-test/util/OAuth.php
@@ -88,6 +88,33 @@ class OAuthSignatureMethod_HMAC_SHA1 extends OAuthSignatureMethod {
 
 }
 
+class OAuthSignatureMethod_HMAC_SHA256 extends OAuthSignatureMethod {
+  function get_name() {
+    return "HMAC-SHA256";
+  }
+
+  public function build_signature($request, $consumer, $token) {
+    global $OAuth_last_computed_signature;
+    $OAuth_last_computed_signature = false;
+
+    $base_string = $request->get_signature_base_string();
+    $request->base_string = $base_string;
+
+    $key_parts = array(
+      $consumer->secret,
+      ($token) ? $token->secret : ""
+    );
+
+    $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
+    $key = implode('&', $key_parts);
+
+    $computed_signature = base64_encode(hash_hmac('sha256', $base_string, $key, true));
+    $OAuth_last_computed_signature = $computed_signature;
+    return $computed_signature;
+  }
+
+}
+
 class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
   public function get_name() {
     return "PLAINTEXT";

--- a/basiclti/basiclti-util/src/java/net/oauth/OAuth.java
+++ b/basiclti/basiclti-util/src/java/net/oauth/OAuth.java
@@ -52,6 +52,7 @@ public class OAuth {
     public static final String OAUTH_CALLBACK = "oauth_callback";
 
     public static final String HMAC_SHA1 = "HMAC-SHA1";
+    public static final String HMAC_SHA256 = "HMAC-SHA256";
     public static final String RSA_SHA1 = "RSA-SHA1";
 
     /**

--- a/basiclti/basiclti-util/src/java/net/oauth/signature/HMAC_SHA256.java
+++ b/basiclti/basiclti-util/src/java/net/oauth/signature/HMAC_SHA256.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2007 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.oauth.signature;
+
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import net.oauth.OAuth;
+import net.oauth.OAuthException;
+
+/**
+ * @author John Kristian
+ * @author Charles Severance - Added SHA256
+ */
+class HMAC_SHA256 extends OAuthSignatureMethod {
+
+    @Override
+    protected String getSignature(String baseString) throws OAuthException {
+        try {
+            String signature = base64Encode(computeSignature(baseString));
+            return signature;
+        } catch (GeneralSecurityException e) {
+            throw new OAuthException(e);
+        } catch (UnsupportedEncodingException e) {
+            throw new OAuthException(e);
+        }
+    }
+
+    @Override
+    protected boolean isValid(String signature, String baseString)
+    throws OAuthException {
+        try {
+            byte[] expected = computeSignature(baseString);
+            byte[] actual = decodeBase64(signature);
+            return Arrays.equals(expected, actual);
+        } catch (GeneralSecurityException e) {
+            throw new OAuthException(e);
+        } catch (UnsupportedEncodingException e) {
+            throw new OAuthException(e);
+        }
+    }
+
+    private byte[] computeSignature(String baseString)
+            throws GeneralSecurityException, UnsupportedEncodingException {
+        SecretKey key = null;
+        synchronized (this) {
+            if (this.key == null) {
+                String keyString = OAuth.percentEncode(getConsumerSecret())
+                        + '&' + OAuth.percentEncode(getTokenSecret());
+                byte[] keyBytes = keyString.getBytes(ENCODING);
+                this.key = new SecretKeySpec(keyBytes, MAC_NAME);
+            }
+            key = this.key;
+        }
+        Mac mac = Mac.getInstance(MAC_NAME);
+        mac.init(key);
+        byte[] text = baseString.getBytes(ENCODING);
+        return mac.doFinal(text);
+    }
+
+    /** ISO-8859-1 or US-ASCII would work, too. */
+    private static final String ENCODING = OAuth.ENCODING;
+
+    private static final String MAC_NAME = "HmacSHA256";
+
+    private SecretKey key = null;
+
+    @Override
+    public void setConsumerSecret(String consumerSecret) {
+        synchronized (this) {
+            key = null;
+        }
+        super.setConsumerSecret(consumerSecret);
+    }
+
+    @Override
+    public void setTokenSecret(String tokenSecret) {
+        synchronized (this) {
+            key = null;
+        }
+        super.setTokenSecret(tokenSecret);
+    }
+
+}

--- a/basiclti/basiclti-util/src/java/net/oauth/signature/OAuthSignatureMethod.java
+++ b/basiclti/basiclti-util/src/java/net/oauth/signature/OAuthSignatureMethod.java
@@ -266,6 +266,7 @@ public abstract class OAuthSignatureMethod {
 	private static final Map<String, Class> NAME_TO_CLASS = new ConcurrentHashMap<String, Class>();
     static {
         registerMethodClass("HMAC-SHA1", HMAC_SHA1.class);
+        registerMethodClass("HMAC-SHA256", HMAC_SHA256.class);
         registerMethodClass("PLAINTEXT", PLAINTEXT.class);
         registerMethodClass("RSA-SHA1", RSA_SHA1.class);
         registerMethodClass("HMAC-SHA1" + _ACCESSOR, HMAC_SHA1.class);

--- a/basiclti/basiclti-util/src/java/org/imsglobal/basiclti/BasicLTIUtil.java
+++ b/basiclti/basiclti-util/src/java/org/imsglobal/basiclti/BasicLTIUtil.java
@@ -660,18 +660,34 @@ public class BasicLTIUtil {
 	 * @param oauth_consumer_key
 	 * @param oauth_consumer_secret
 	 */
-	public static String getOAuthURL(String method, String url, String oauth_consumer_key, String oauth_secret)
+	public static String getOAuthURL(String method, String url, 
+		String oauth_consumer_key, String oauth_secret)
+	{
+		return getOAuthURL(method, url, oauth_consumer_key, oauth_secret, null);
+	}
+
+	/** 
+         * getOAuthURL - Form a GET request signed by OAuth
+	 * @param method
+	 * @param url
+	 * @param oauth_consumer_key
+	 * @param oauth_consumer_secret
+	 * @param signature
+	 */
+	public static String getOAuthURL(String method, String url, 
+		String oauth_consumer_key, String oauth_secret, String signature)
 	{
 		OAuthMessage om = new OAuthMessage(method, url, null);
 		om.addParameter(OAuth.OAUTH_CONSUMER_KEY, oauth_consumer_key);
-		om.addParameter(OAuth.OAUTH_SIGNATURE_METHOD, OAuth.HMAC_SHA1);
+		if ( signature == null ) signature = OAuth.HMAC_SHA1;
+		om.addParameter(OAuth.OAUTH_SIGNATURE_METHOD, signature);
 		om.addParameter(OAuth.OAUTH_VERSION, "1.0");
 		om.addParameter(OAuth.OAUTH_TIMESTAMP, new Long((new Date().getTime()) / 1000).toString());
 		om.addParameter(OAuth.OAUTH_NONCE, UUID.randomUUID().toString());
 
 		OAuthConsumer oc = new OAuthConsumer(null, oauth_consumer_key, oauth_secret, null);
 		try {
-		    OAuthSignatureMethod osm = OAuthSignatureMethod.newMethod(OAuth.HMAC_SHA1, new OAuthAccessor(oc));
+		    OAuthSignatureMethod osm = OAuthSignatureMethod.newMethod(signature, new OAuthAccessor(oc));
 		    osm.sign(om);
 		    url = OAuth.addParameters(url, om.getParameters());
 		    return url;


### PR DESCRIPTION
This should be back ported to 10.x - it is independent of Sakai's LTI functionality as it is just library code.