### PR TITLE
SAK-29564 Build error on windows in reference/library

### DIFF
--- a/reference/library/pom.xml
+++ b/reference/library/pom.xml
@@ -131,6 +131,24 @@
 									</resources>
 								</configuration>
 							</execution>
+							<execution>
+								<id>copy-fonts-css</id>
+								<phase>generate-resources</phase>
+								<goals>
+									<goal>copy-resources</goal>
+								</goals>
+								<configuration>
+									<outputDirectory>${basedir}/src/webapp/skin/${sakai.skin.target}/font-awesome/</outputDirectory>
+									<resources>
+										<resource>
+											<directory>src/${sakai.skin.source}/fonts/</directory>
+											<includes>
+												<include>*.css</include>
+											</includes>
+										</resource>
+									</resources>
+								</configuration>
+							</execution>
 						</executions>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
Build is broken in windows because an error with JRuby and font-awesome compass generation.