### PR TITLE
SAK-29369 - Unpublished, softly deleted sites dont appear in the list of Softly Deleted sites in Worksite setup

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -293,7 +293,7 @@ public interface SiteService extends EntityProducer
 		public static final SelectionType MEMBER = new SelectionType("member", true, true, false, true);
 		
 		/** Get my deleted sites. */
-		public static final SelectionType DELETED = new SelectionType("deleted", true, true, true, false);
+		public static final SelectionType DELETED = new SelectionType("deleted", true, true, false, false);
 
 		/** Get any deleted sites, normally used by admin or purge job. */
 		public static final SelectionType ANY_DELETED = new SelectionType("anyDeleted", false, false, false, false);


### PR DESCRIPTION
Unpublished, softly deleted sites dont appear in the list of Softly Deleted sites in Worksite setup