### PR TITLE
SAK-29570 enrollment check for user deletion misses unpublished sites

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -901,6 +901,8 @@ public interface SiteService extends EntityProducer
 	 * This is a convenience and performance wrapper for getSites, because there are many places that need
 	 * the complete list of sites for the current user, and getSites is unnecessarily verbose in that case.
 	 * Because the semantics of this call are specific, it can also be optimized by the implementation.
+	 * 
+	 * Unpublished sites are not included; use getSites(boolean, boolean) to control if unpublished sites are included or not.
 	 *
 	 * The sites returned follow the same semantics as those from
 	 * {@link #getSites(SelectionType, Object, String, Map, SortType, PagingPosition) getSites}.
@@ -917,6 +919,8 @@ public interface SiteService extends EntityProducer
 	 * This is a convenience and performance wrapper for getSites, because there are many places that need
 	 * the complete list of sites for the current user, and getSites is unnecessarily verbose in that case.
 	 * Because the semantics of this call are specific, it can also be optimized by the implementation.
+	 * 
+	 * Unpublished sites are not included; use getSites(boolean, boolean) to control if unpublished sites are included or not.
 	 *
 	 * The sites returned follow the same semantics as those from
 	 * {@link #getSites(SelectionType, Object, String, Map, SortType, PagingPosition) getSites}.
@@ -927,9 +931,26 @@ public interface SiteService extends EntityProducer
 	List<Site> getUserSites(boolean requireDescription);
 
 	/**
+	 * Access a list of sites that the current user can visit, sorted by title, optionally requiring descriptions.
+	 *
+	 * This is a convenience and performance wrapper for getSites, because there are many places that need
+	 * the complete list of sites for the current user, and getSites is unnecessarily verbose in that case.
+	 * Because the semantics of this call are specific, it can also be optimized by the implementation.
+	 *
+	 * The sites returned follow the same semantics as those from
+	 * {@link #getSites(SelectionType, Object, String, Map, SortType, PagingPosition) getSites}.
+	 *
+	 * @param requireDescription when true, full descriptions will be included; when false, full descriptions may be omitted.
+	 * @param includeUnpublishedSites when true, unpublished sites will be included; when false, unpublished sites will be omitted.
+	 * @return A List<Site> of those sites the current user can access.
+	 */
+	List<Site> getUserSites(boolean requireDescription, boolean includeUnpublishedSites);
+
+	/**
 	 * Access a list of sites that the specified user can visit, sorted by title, optionally requiring descriptions.
 	 *
-	 * This is a convenience and performance wrapper for getSites.
+	 * This is a convenience and performance wrapper for getSites. Unpublished sites are not included;
+	 * use getSites(boolean, String, boolean) to control if unpublished sites are included or not.
 	 *
 	 * The sites returned follow the same semantics as those from
 	 * {@link #getSites(SelectionType, Object, String, Map, SortType, PagingPosition, boolean, String) getSites}.
@@ -939,6 +960,23 @@ public interface SiteService extends EntityProducer
 	 * @return A List<Site> of those sites the current user can access.
 	 */
 	List<Site> getUserSites(boolean requireDescription, String userId);
+
+	/**
+	 * Access a list of sites that the specified user can visit, sorted by title, optionally requiring descriptions.
+	 *
+	 * This is a convenience and performance wrapper for getSites.
+	 * 
+	 * Unpublished sites are not included; use getSites(String, boolean) to control if unpublished sites are included or not.
+	 *
+	 * The sites returned follow the same semantics as those from
+	 * {@link #getSites(SelectionType, Object, String, Map, SortType, PagingPosition, boolean, String) getSites}.
+	 *
+	 * @param requireDescription when true, full descriptions will be included; when false, full descriptions may be omitted.
+	 * @param userID the returned sites will be those which can be accessed by the user with this internal ID. Uses the current user if null.
+	 * @param includeUnpublishedSites when true, unpublished sites will be included; when false, unpublished sites will be omitted.
+	 * @return A List<Site> of those sites the current user can access.
+	 */
+	List<Site> getUserSites(boolean requireDescription, String userID, boolean includeUnpublishedSites);
 
 	/**
 	 * Access a list of Site objects that meet specified criteria.

--- a/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
@@ -24,8 +24,6 @@ package org.sakaiproject.site.cover;
 import java.util.List;
 
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.db.api.SqlReader;
-import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 
 /**
@@ -450,6 +448,14 @@ public class SiteService
 		if (service == null) return null;
 
 		return service.getUserSites(requireDescription);
+	}
+
+	public static List<Site> getUserSites( boolean requireDescription, boolean includeUnpublishedSites )
+	{
+		org.sakaiproject.site.api.SiteService service = getInstance();
+		if( service == null ) return null;
+
+		return service.getUserSites( requireDescription, includeUnpublishedSites );
 	}
 
 	public static java.util.List getSites(org.sakaiproject.site.api.SiteService.SelectionType param0, java.lang.Object param1,

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/perf/mock/MockSiteService.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/perf/mock/MockSiteService.java
@@ -24,6 +24,18 @@ public class MockSiteService implements SiteService {
 	}
 
 	@Override
+	public List<Site> getUserSites( boolean requireDescription, boolean includeUnpublishedSites )
+	{
+		return null;
+	}
+
+	@Override
+	public List<Site> getUserSites( boolean requireDescription, String userID, boolean includeUnpublishedSites )
+	{
+		return null;
+	}
+
+	@Override
 	public boolean willArchiveMerge() {
 		// TODO Auto-generated method stub
 		return false;

--- a/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -671,7 +671,7 @@ public class UsersAction extends PagedResourceActionII
 		if (unenrollFirst)
 		{
 			SiteService siteService = (SiteService)ComponentManager.get(SiteService.class);
-			List<Site> sites = siteService.getUserSites(false, user.getId());
+			List<Site> sites = siteService.getUserSites(false, user.getId(), true);
 			if (sites != null && !sites.isEmpty())
 			{
 				// there are sites to unenroll from, present this to the user


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29570

"Unenrollment message does not appear or is not accurate if all/some of the user's memberships are in unpublished sites.

This makes use of the new SelectionType.MEMBER introduced in KNL-1023."