### PR TITLE
KNL-1364 Allow deploy of the MySQL Connector/J JAR

### DIFF
--- a/kernel/deploy/common/pom.xml
+++ b/kernel/deploy/common/pom.xml
@@ -56,5 +56,26 @@
         <artifactId>slf4j-api</artifactId>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>1.1.9</version>
+    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <!-- This profile isn't active by default, as we can't bundle the JAR due to license restrictions
+           but if you build with the mysql profile active then the JAR will get downloaded and deployed into
+           tomcat without you having to copy it seperately. -->
+      <id>mysql</id>
+      <dependencies>
+        <dependency>
+          <groupId>mysql</groupId>
+          <artifactId>mysql-connector-java</artifactId>
+          <version>5.1.35</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
If you activate the mysql maven profile (mvn -P mysql install sakai:deploy) when deploying Sakai into Tomcat the MySQL JAR will be copied into place. This makes it easier for new developers as there’s one less step to get a working copy of Sakai up.

It’s disabled by default as we can’t bind or distribute the JAR due to license conflicts.