### PR TITLE
SAK-29584 Ensure that a UUID is passed through when updating a popup.

### DIFF
--- a/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/Banner.java
+++ b/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/Banner.java
@@ -34,7 +34,6 @@ import static org.sakaiproject.pasystem.api.ValidationHelper.*;
  * A data object representing a banner.
  */
 public class Banner implements Comparable<Banner> {
-    @Getter
     private final String uuid;
     @Getter
     private final String message;
@@ -104,7 +103,11 @@ public class Banner implements Comparable<Banner> {
             return false;
         }
 
-        return uuid.equals(((Banner)obj).getUuid());
+        try {
+            return uuid.equals(((Banner)obj).getUuid());
+        } catch (MissingUuidException e) {
+            return false;
+        }
     }
 
     public int hashCode() {
@@ -116,6 +119,14 @@ public class Banner implements Comparable<Banner> {
      */
     public int getSeverityScore() {
         return type.ordinal();
+    }
+
+    public String getUuid() throws MissingUuidException {
+        if (this.uuid == null) {
+            throw new MissingUuidException("No UUID has been set for this banner");
+        }
+
+        return this.uuid;
     }
 
     /**

--- a/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/MissingUuidException.java
+++ b/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/MissingUuidException.java
@@ -1,0 +1,31 @@
+/**********************************************************************************
+ *
+ * Copyright (c) 2015 The Sakai Foundation
+ *
+ * Original developers:
+ *
+ *   New York University
+ *   Payten Giles
+ *   Mark Triggs
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.pasystem.api;
+
+public class MissingUuidException extends Exception {
+    public MissingUuidException(String msg) {
+        super(msg);
+    }
+}

--- a/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/Popup.java
+++ b/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/Popup.java
@@ -32,8 +32,6 @@ import static org.sakaiproject.pasystem.api.ValidationHelper.*;
  * A data object representing a popup.
  */
 public class Popup {
-
-    @Getter
     private final String uuid;
     @Getter
     private String descriptor;
@@ -85,6 +83,15 @@ public class Popup {
      */
     public static Popup create(String uuid, String descriptor, long startTime, long endTime, boolean isOpenCampaign, String template) {
         return new Popup(uuid, descriptor, startTime, endTime, isOpenCampaign, template);
+    }
+
+
+    public String getUuid() throws MissingUuidException {
+        if (this.uuid == null) {
+            throw new MissingUuidException("No UUID has been set for this popup");
+        }
+
+        return this.uuid;
     }
 
     /**

--- a/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/forms/BannerForm.java
+++ b/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/forms/BannerForm.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.Data;
 import org.sakaiproject.pasystem.api.Banner;
 import org.sakaiproject.pasystem.api.Errors;
+import org.sakaiproject.pasystem.api.MissingUuidException;
 
 /**
  * Maps to and from the banner HTML form and a banner data object.
@@ -51,15 +52,19 @@ public class BannerForm extends BaseForm {
     }
 
     public static BannerForm fromBanner(Banner existingBanner) {
-        String uuid = existingBanner.getUuid();
+        try {
+            String uuid = existingBanner.getUuid();
 
-        return new BannerForm(uuid,
-                existingBanner.getMessage(),
-                existingBanner.getHosts(),
-                existingBanner.getStartTime(),
-                existingBanner.getEndTime(),
-                existingBanner.isActive(),
-                existingBanner.getType());
+            return new BannerForm(uuid,
+                    existingBanner.getMessage(),
+                    existingBanner.getHosts(),
+                    existingBanner.getStartTime(),
+                    existingBanner.getEndTime(),
+                    existingBanner.isActive(),
+                    existingBanner.getType());
+        } catch (MissingUuidException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static BannerForm fromRequest(String uuid, HttpServletRequest request) {

--- a/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/forms/PopupForm.java
+++ b/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/forms/PopupForm.java
@@ -33,6 +33,7 @@ import lombok.Data;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.sakaiproject.pasystem.api.Errors;
 import org.sakaiproject.pasystem.api.PASystem;
+import org.sakaiproject.pasystem.api.MissingUuidException;
 import org.sakaiproject.pasystem.api.Popup;
 import org.sakaiproject.pasystem.api.TemplateStream;
 import org.sakaiproject.pasystem.tool.handlers.CrudHandler;
@@ -68,15 +69,19 @@ public class PopupForm extends BaseForm {
     }
 
     public static PopupForm fromPopup(Popup existingPopup, PASystem paSystem) {
-        String uuid = existingPopup.getUuid();
-        List<String> assignees = paSystem.getPopups().getAssignees(uuid);
+        try {
+            String uuid = existingPopup.getUuid();
+            List<String> assignees = paSystem.getPopups().getAssignees(uuid);
 
-        return new PopupForm(uuid, existingPopup.getDescriptor(),
-                existingPopup.getStartTime(),
-                existingPopup.getEndTime(),
-                existingPopup.isOpenCampaign(),
-                assignees,
-                Optional.empty());
+            return new PopupForm(uuid, existingPopup.getDescriptor(),
+                    existingPopup.getStartTime(),
+                    existingPopup.getEndTime(),
+                    existingPopup.isOpenCampaign(),
+                    assignees,
+                    Optional.empty());
+        } catch (MissingUuidException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static PopupForm fromRequest(String uuid, HttpServletRequest request) {
@@ -141,6 +146,6 @@ public class PopupForm extends BaseForm {
     }
 
     public Popup toPopup() {
-        return Popup.create(descriptor, startTime, endTime, isOpenCampaign);
+        return Popup.create(uuid, descriptor, startTime, endTime, isOpenCampaign);
     }
 }


### PR DESCRIPTION
Previously, modifications to an existing popup would not persist.

Modified the call to .getUUID to throw an exception if a UUID value was
missing where one was expected, and modified callers to deal with this.
The tool should fail more loudly in the future, while the code that
integrates with the portal should swallow errors and log to avoid
interrupting the user's session.