### PR TITLE
SAK-29586 Force to disable video chat when using IExplorer

### DIFF
--- a/portal/portal-charon/charon/src/webapp/scripts/chat.js
+++ b/portal/portal-charon/charon/src/webapp/scripts/chat.js
@@ -241,6 +241,8 @@
         if (portal.chat.video.enabled) {
             if (portal.chat.debug) console.debug('Setting up the video chat bar ...');
             this.setupVideoChatBar(peerUUID, !portal.chat.video.webrtc.isVideoEnabled() || !portal.chat.video.hasRemoteVideoAgent(peerUUID), minimised);
+        } else {
+            this.setupVideoChatBar(peerUUID, true, minimised);
         }
 
         return false;

--- a/portal/portal-charon/charon/src/webapp/scripts/videocall.js
+++ b/portal/portal-charon/charon/src/webapp/scripts/videocall.js
@@ -9,6 +9,7 @@
 
     var msiePattern = /.*MSIE ((\d+).\d+).*/
     if ( msiePattern.test(navigator.userAgent) ) {
+        portal.chat.video.enabled=false;
         return;
     }
 


### PR DESCRIPTION
That prevents from executing videocall methods on IE that were causing errors.