### PR TITLE
SAK-29596 Fix external-calendar tests on Windows

### DIFF
--- a/external-calendaring-service/impl/src/test/org/sakaiproject/calendaring/mocks/MockSakaiProxy.java
+++ b/external-calendaring-service/impl/src/test/org/sakaiproject/calendaring/mocks/MockSakaiProxy.java
@@ -48,7 +48,7 @@ public class MockSakaiProxy implements SakaiProxy {
 
 	@Override
 	public String getCalendarFilePath() {
-		return "/tmp";
+		return System.getProperty("java.io.tmpdir");
 	}
 
 	@Override


### PR DESCRIPTION
/tmp was assumed to to be somewhere to create temp files but on Windows this doesn’t exist so the tests were failing. Switched to use the standard way of finding the tmp directory with the system property which works everywhere.