### PR TITLE
LSNBLDR-507 Fix mvn eclipse:eclipse on windows

### DIFF
--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -247,11 +247,11 @@
                   <resources>
                     <resource>
                       <directory>${src1}/webapp/WEB-INF</directory>
-                      <targetPath>${project.build.directory}/lessonbuilder-tool-${project.version}/WEB-INF</targetPath>
+                      <targetPath>${sakai.build.directory}/lessonbuilder-tool-${project.version}/WEB-INF</targetPath>
                     </resource>
                     <resource>
                       <directory>${src2}/webapp/WEB-INF</directory>
-                      <targetPath>${project.build.directory}/lessonbuilder-tool-${project.version}/WEB-INF</targetPath>
+                      <targetPath>${sakai.build.directory}/lessonbuilder-tool-${project.version}/WEB-INF</targetPath>
                     </resource>
                   </resources>
                 </configuration>


### PR DESCRIPTION
The problems is that project.build.directory is a full path to the build directory and on windows this includes the drive letter. This causes the maven eclipse plugin to fail. Switching to sakai.build.directory which is just a relative path means this always works.