### PR TITLE
SAK-29605: Button text on TransferMemberships form is inaccurate

### DIFF
--- a/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages.properties
+++ b/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages.properties
@@ -40,7 +40,7 @@ validate.loginexisting=Discard the account for {0} and transfer all new site mem
 validate.loginexisting.reset=Login with your other {0} account (it will be given access to the site(s) above).
 validate.loginexisting.transfer=To become a member of the site(s) above, log in with your existing {0} account.
 validate.loginexisting.accountReserved=The account reserved for {0} will be deleted. The account you have entered will become a member of the sites listed above.
-validate.loginexisting.transferMemberships=Accept invitation and log in
+validate.loginexisting.transferMemberships=Transfer memberships and log in
 validate.or=OR
 
 # bbailla2, bjones86 - SAK-24427


### PR DESCRIPTION
When you use the transfer memberships form, the button reads 'Activate your account and log in'. The account is actually being discarded, and your memberships are transferred to the account you are logging in with. Make the button text reflect this.