### PR TITLE
SAK-29611 - Some 'softly deleted' translation keys are duplicated

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1187,14 +1187,6 @@ ltiTools.external = External Tools:
 ltiTools.usage = (Used in {0} sites)
 ltiTools.custom.instruction = Please enter the information for external tools
 
-# soft site deletes
-softly.deleted.already=One or more of the sites you selected are already marked for deletion and have been removed from your selection.
-sitegen.sitedel.remov.soft = Softly Deleting Site...
-sitegen.sitedel.soft = This site will be marked for deletion and will be purged as per the schedule set by your System Administrator. Participants will no longer be able to access the site, however the contents of the site will be preserved in case it needs to be restored.
-sitegen.sitedel.you.soft = You have selected the following site for soft deletion:
-sitegen.sitedel.you2.soft=You have selected the following sites for soft deletion:
-sitegen.sitedel.softly.delete = Mark for deletion
-
 # tool grouping
 tool.group.default=General
 


### PR DESCRIPTION
Some 'softly deleted' translation keys are duplicated