### PR TITLE
SAK-29614: Send an acknowledgement email after a successful password reset

### DIFF
--- a/reset-pass/account-validator-impl/src/bundle/acknowledge_passwordReset.xml
+++ b/reset-pass/account-validator-impl/src/bundle/acknowledge_passwordReset.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<emailTemplates>
+<emailTemplate>
+<subject>${localSakaiName}: Your password has been changed successfully</subject>
+<message>Your password for ${localSakaiName} has been changed successfully. If you did not change your password, please contact ${emailSupport}
+</message>
+<locale></locale>
+</emailTemplate>
+</emailTemplates>

--- a/reset-pass/account-validator-impl/src/java/org/sakaiproject/accountvalidator/logic/impl/ValidationLogicImpl.java
+++ b/reset-pass/account-validator-impl/src/java/org/sakaiproject/accountvalidator/logic/impl/ValidationLogicImpl.java
@@ -85,6 +85,7 @@ public class ValidationLogicImpl implements ValidationLogic {
 	private static final String TEMPLATE_KEY_PASSWORDRESET = "validate.passwordreset";
 	private static final String TEMPLATE_KEY_DELETED = "validate.deleted";
 	private static final String TEMPLATE_KEY_REQUEST_ACCOUNT = "validate.requestAccount";
+	private static final String TEMPLATE_KEY_ACKNOWLEDGE_PASSWORD_RESET = "acknowledge.passwordReset";
 	
 	private static final int VALIDATION_PERIOD_MONTHS = -36;
 	private static Log log = LogFactory.getLog(ValidationLogicImpl.class);
@@ -100,6 +101,7 @@ public class ValidationLogicImpl implements ValidationLogic {
 		loadTemplate("validate_newPassword.xml", TEMPLATE_KEY_PASSWORDRESET);
 		loadTemplate("validate_deleted.xml", TEMPLATE_KEY_DELETED);
 		loadTemplate("validate_requestAccount.xml", TEMPLATE_KEY_REQUEST_ACCOUNT);
+		loadTemplate("acknowledge_passwordReset.xml", TEMPLATE_KEY_ACKNOWLEDGE_PASSWORD_RESET);
 		
 		//seeing the GroupProvider is optional we need to load it here
 		if (groupProvider == null) {

--- a/reset-pass/account-validator-tool/pom.xml
+++ b/reset-pass/account-validator-tool/pom.xml
@@ -42,6 +42,10 @@
 		<groupId>org.sakaiproject.entitybroker</groupId>
         <artifactId>entitybroker-utils</artifactId>
       </dependency>
+      <dependency>
+      	<groupId>org.sakaiproject.emailtemplateservice</groupId>
+      	<artifactId>emailtemplateservice-api</artifactId>
+      </dependency>
       
       <dependency>
         <groupId>org.sakaiproject.kernel</groupId>

--- a/reset-pass/account-validator-tool/src/webapp/WEB-INF/requestContext.xml
+++ b/reset-pass/account-validator-tool/src/webapp/WEB-INF/requestContext.xml
@@ -74,6 +74,7 @@
 		<property name="developerHelperService" ref="org.sakaiproject.entitybroker.DeveloperHelperService"/>
 		<property name="messageLocator" ref="messageLocator"/>
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+		<property name="emailTemplateService" ref="org.sakaiproject.emailtemplateservice.service.EmailTemplateService" />
 	</bean>
 	
 	<bean name="claimLocator" class="org.sakaiproject.accountvalidator.tool.otp.ClaimLocator" >


### PR DESCRIPTION
It's good practice to send an ack email after a successful password reset. Make reset-pass send out an email such as the following:
"Your password in ui.service has been changed successfully. If you did not change your password, please contact mail.support"