### PR TITLE
SAK-29637: add ability to User Membership to bulk change status

### DIFF
--- a/usermembership/tool/src/bundle/org/sakaiproject/umem/tool/bundle/Messages.properties
+++ b/usermembership/tool/src/bundle/org/sakaiproject/umem/tool/bundle/Messages.properties
@@ -9,7 +9,7 @@ bar_input_search_title=Enter User Name, ID or Email Address to Search For.
 bar_search=Search
 bar_clear_search=Clear search
 instructions_userlist=Select a user from the search results to get site and group membership.
-instructions_sitelist=Site and group membership for selected user.
+instructions_sitelist=Site and group membership for the selected user.
 unauthorized=You are not authorized to use this tool. This incident will be reported.
 processing=Processing user memberships...
 no_enrollments=No users to display
@@ -53,3 +53,13 @@ user_type_none=(no type)
 user_auth_all=All
 user_auth_internal=Internal
 user_auth_external=External
+
+## SAK-29637
+set_to_inactive_button=Set Selected to Inactive
+set_to_active_button=Set Selected to Active
+invert_selection=Invert Selection
+select_all=Select All
+deselect_all=Deselect All
+export_selected_to_csv=Export Selected to CSV
+export_selected_to_excel=Export Selected to Excel
+actions_header=Actions

--- a/usermembership/tool/src/webapp/usermembership/css/usermembership.css
+++ b/usermembership/tool/src/webapp/usermembership/css/usermembership.css
@@ -3,8 +3,75 @@
 	text-align: left;
 	padding: 0px;
 }
+
 .right {
 	vertical-align: bottom;
 	text-align: right;
 	padding: 0px;
 }
+
+/* SAK-29637 */
+div#sitelistform\:headerContainer1, div#sitelistform\:headerContainer2 {
+	margin-top: 1em;
+}
+
+div.headerWrapper {
+	display: inline-block;
+	background-color: #EEE !important;
+	padding: 1em 1em 1em 0.5em;
+}
+
+div#sitelistform\:headerContainer1 span.collapsed, div#sitelistform\:headerContainer1 span.expanded,
+div#sitelistform\:headerContainer2 span.collapsed, div#sitelistform\:headerContainer2 span.expanded {
+	cursor: pointer;
+	padding-left: 13px;
+}
+
+div#sitelistform\:headerContainer1 span.collapsed, div#sitelistform\:headerContainer2 span.collapsed {
+	background: url('/library/image/sakai/expand.gif') no-repeat left !important;
+}
+
+div#sitelistform\:headerContainer1 span.expanded, div#sitelistform\:headerContainer2 span.expanded {
+	background: url('/library/image/sakai/collapse.gif') no-repeat left !important;
+}
+
+div#sitelistform\:actionContainer1, div#sitelistform\:actionContainer2 {
+	display: none;
+	background-color: #EEE;
+	padding: 1em;
+}
+
+div#sitelistform\:actionContainer1 div, div#sitelistform\:actionContainer2 div {
+	display: inline-block;
+}
+
+div#sitelistform\:actionContainer1 input, div#sitelistform\:actionContainer2 input {
+	display: block;
+	margin: 0.25em 0;
+	border: 0 !important;
+	background: 0 !important;
+	background-color: #EEE !important;
+	width: 100%;
+	text-align: left;
+	text-shadow: none !important;
+}
+
+div#sitelistform\:actionContainer1 input:hover:enabled, div#sitelistform\:actionContainer2 input:hover:enabled {
+	background-color: #CCC !important;
+}
+
+div#sitelistform\:actionContainer1 input:active:enabled, div#sitelistform\:actionContainer2 input:active:enabled {
+	background-color: #75B9C2 !important;
+	color: #FFF !important;
+	box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.15) inset !important;
+	text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.3) !important;
+}
+
+div#sitelistform\:actionContainer1 div.column2, div#sitelistform\:actionContainer1 div.column3,
+div#sitelistform\:actionContainer2 div.column2, div#sitelistform\:actionContainer2 div.column3 {
+	border-left: 2px solid #C8C8C8;
+	padding-left: 1em;
+	margin-left: 1em;
+	vertical-align: top;
+}
+/* end SAK-29637 */

--- a/usermembership/tool/src/webapp/usermembership/js/usermembership.js
+++ b/usermembership/tool/src/webapp/usermembership/js/usermembership.js
@@ -1,0 +1,56 @@
+var USR_MEMBRSHP = {};
+
+USR_MEMBRSHP.applyStateToCheckboxes = function( state )
+{
+    $( ".chkStatus" ).prop( "checked", state );
+    $( ".chkStatus" ).attr( "value", state );
+    USR_MEMBRSHP.checkEnableButtons();
+};
+
+USR_MEMBRSHP.checkEnableButtons = function()
+{
+    // Enable the buttons if any of the checkboxes are checked
+    var disabled = $( ".chkStatus:checked" ).length > 0 ? false : true;
+    $( "#sitelistform\\:setToInactive1" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:setToActive1" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:exportCsv1" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:exportXls1" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:setToInactive2" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:setToActive2" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:exportCsv2" ).prop( "disabled", disabled );
+    $( "#sitelistform\\:exportXls2" ).prop( "disabled", disabled );
+};
+
+USR_MEMBRSHP.invertSelection = function()
+{
+    // For each checkbox...
+    $( ".chkStatus" ).each( function()
+    {
+        // Invert it's selected state and value
+        var checked = $( this ).prop( "checked" );
+        $( this ).prop( "checked", !checked );
+        $( this ).attr( "value", !checked );
+    });
+
+    USR_MEMBRSHP.checkEnableButtons();
+};
+
+USR_MEMBRSHP.toggleActions = function( clickedElement )
+{
+    var specifier = clickedElement.parentElement.id === "sitelistform:headerContainer1" ? "1" : "2";
+    var span = $( "#sitelistform\\:actionHeader" + specifier );
+    if( span.attr( "class" ) === "collapsed" )
+    {
+        span.attr( "class", "expanded" );
+        $( "#sitelistform\\:actionContainer" + specifier ).show();
+        $( "#sitelistform\\:actionContainer" + specifier ).css( "display", "inline-flex" );
+    }
+    else
+    {
+        span.attr( "class", "collapsed" );
+        $( "#sitelistform\\:actionContainer" + specifier ).hide();
+        $( "#sitelistform\\:actionContainer" + specifier ).css( "display", "none" );
+    }
+
+    setMainFrameHeight( USR_MEMBRSHP.frameID );
+};

--- a/usermembership/tool/src/webapp/usermembership/sitelist.jsp
+++ b/usermembership/tool/src/webapp/usermembership/sitelist.jsp
@@ -1,3 +1,4 @@
+<%@ page import="org.sakaiproject.umem.tool.ui.SiteListBean"%>
 <%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
@@ -17,6 +18,14 @@
 
 <f:view>
 <sakai:view title="#{msgs.tool_title}">
+	<script type="text/javascript" src="/library/js/jquery/jquery-1.9.1.min.js"></script>
+	<script type="text/javascript" src="/sakai-usermembership-tool/usermembership/js/usermembership.js"></script>
+	<link href="/sakai-usermembership-tool/usermembership/css/usermembership.css" rel="stylesheet" type="text/css" media="all"></link>
+
+	<script>
+		USR_MEMBRSHP.frameID = "<%= SiteListBean.getFrameID() %>";
+	</script>
+
 	<%/*<sakai:flowState bean="#{SiteListBean}"/>*/%>
 	<h:outputText value="#{SiteListBean.initValues}"/>
 	
@@ -28,6 +37,27 @@
 		<h3><h:outputText value="#{msgs.title_sitelist} (#{SiteListBean.userDisplayId})"/></h3>
 		<sakai:instruction_message value="#{msgs.instructions_sitelist}" />
 
+		<t:div id="headerContainer1" rendered="#{SiteListBean.renderTable && !SiteListBean.emptySiteList}">
+			<t:div styleClass="headerWrapper" onclick="USR_MEMBRSHP.toggleActions( this );">
+				<h:outputText id="actionHeader1" styleClass="collapsed" value="#{msgs.actions_header}" />
+			</t:div>
+		</t:div>
+		<t:div id="actionContainer1" rendered="#{SiteListBean.renderTable && !SiteListBean.emptySiteList}">
+			<t:div styleClass="column1">
+				<h:commandButton type="button" title="#{msgs.select_all}" value="#{msgs.select_all}" onclick="USR_MEMBRSHP.applyStateToCheckboxes( true );" />
+				<h:commandButton type="button" title="#{msgs.deselect_all}" value="#{msgs.deselect_all}" onclick="USR_MEMBRSHP.applyStateToCheckboxes( false );" />
+				<h:commandButton type="button" title="#{msgs.invert_selection}" value="#{msgs.invert_selection}" onclick="USR_MEMBRSHP.invertSelection();" />
+			</t:div>
+			<t:div styleClass="column2">
+				<h:commandButton id="setToInactive1" actionListener="#{SiteListBean.setToInactive}" value="#{msgs.set_to_inactive_button}" disabled="true"/>
+				<h:commandButton id="setToActive1" actionListener="#{SiteListBean.setToActive}" value="#{msgs.set_to_active_button}" disabled="true" />
+			</t:div>
+			<t:div styleClass="column3">
+				<h:commandButton id="exportCsv1" actionListener="#{SiteListBean.exportAsCsv}" value="#{msgs.export_selected_to_csv}" disabled="true" />
+				<h:commandButton id="exportXls1" actionListener="#{SiteListBean.exportAsXls}" value="#{msgs.export_selected_to_excel}" disabled="true" />
+			</t:div>
+		</t:div>
+
 		<t:dataTable
 			value="#{SiteListBean.userSitesRows}"
 			var="row1"
@@ -35,6 +65,9 @@
 			sortColumn="#{SiteListBean.sitesSortColumn}"
             sortAscending="#{SiteListBean.sitesSortAscending}"
             rendered="#{SiteListBean.renderTable}" >
+			<h:column id="statusToggle">
+				<h:selectBooleanCheckbox value="#{row1.selected}" styleClass="chkStatus" onclick="USR_MEMBRSHP.checkEnableButtons();" />
+			</h:column>
 			<h:column id="siteName">
 				<f:facet name="header">
 		            <t:commandSortHeader columnName="siteName" immediate="true" arrow="true">
@@ -93,19 +126,36 @@
 			</h:column>
 		</t:dataTable>
 
-		<p class="instruction" style="margin-top: 40px;">
-			<h:outputText value="#{msgs.no_sitelist}" rendered="#{SiteListBean.emptySiteList}" />
-		</p>
-		
-		<br>
-		<t:div styleClass="act" rendered="#{SiteListBean.allowed}">
-			<h:commandButton id="userlist" action="#{SiteListBean.processActionBack}" value="#{msgs.back_button}" styleClass="active"/>
-			<h:commandButton id="exportCsv" actionListener="#{SiteListBean.exportAsCsv}" value="#{msgs.export_csv_button}" rendered="#{!SiteListBean.emptySiteList}" />
-			<h:commandButton id="exportXls" actionListener="#{SiteListBean.exportAsXls}" value="#{msgs.export_excel_button}" rendered="#{!SiteListBean.emptySiteList}" />
+		<h:panelGroup rendered="#{SiteListBean.emptySiteList}">
+			<p class="instruction" style="margin-top: 40px;">
+				<h:outputText value="#{msgs.no_sitelist}" />
+			</p>
+		</h:panelGroup>
+
+		<t:div id="headerContainer2" rendered="#{SiteListBean.renderTable && !SiteListBean.emptySiteList}" onclick="USR_MEMBRSHP.toggleActions( this );">
+			<t:div styleClass="headerWrapper">
+				<h:outputText id="actionHeader2" styleClass="collapsed" value="#{msgs.actions_header}" />
+			</t:div>
 		</t:div>
-	  	
+		<t:div id="actionContainer2" rendered="#{SiteListBean.renderTable && !SiteListBean.emptySiteList}">
+			<t:div styleClass="column1">
+				<h:commandButton type="button" title="#{msgs.select_all}" value="#{msgs.select_all}" onclick="USR_MEMBRSHP.applyStateToCheckboxes( true );" />
+				<h:commandButton type="button" title="#{msgs.deselect_all}" value="#{msgs.deselect_all}" onclick="USR_MEMBRSHP.applyStateToCheckboxes( false );" />
+				<h:commandButton type="button" title="#{msgs.invert_selection}" value="#{msgs.invert_selection}" onclick="USR_MEMBRSHP.invertSelection();" />
+			</t:div>
+			<t:div styleClass="column2">
+				<h:commandButton id="setToInactive2" actionListener="#{SiteListBean.setToInactive}" value="#{msgs.set_to_inactive_button}" disabled="true"/>
+				<h:commandButton id="setToActive2" actionListener="#{SiteListBean.setToActive}" value="#{msgs.set_to_active_button}" disabled="true" />
+			</t:div>
+			<t:div styleClass="column3">
+				<h:commandButton id="exportCsv2" actionListener="#{SiteListBean.exportAsCsv}" value="#{msgs.export_selected_to_csv}" disabled="true" />
+				<h:commandButton id="exportXls2" actionListener="#{SiteListBean.exportAsXls}" value="#{msgs.export_selected_to_excel}" disabled="true" />
+			</t:div>
+		</t:div>
 
+		<t:div styleClass="act">
+			<h:commandButton id="userlist" action="#{SiteListBean.processActionBack}" value="#{msgs.back_button}" styleClass="active"/>
+		</t:div>
 	</h:form>
-
 </sakai:view>
 </f:view>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29637

Please see the screenshots on the JIRA ticket.

"Add the ability to bulk toggle a users' membership status (active/inactive) via the User Membership tool.

This allows administrators the ability to change a users' membership across the board or in selective sites via the User Membership tool. Currently, the admin would have to visit each site and flip them manually, or use web services."