### PR TITLE
SAK-29645 opportunities for lost user (input) data when creating/editing/saving an 'invalid' group

### DIFF
--- a/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/impl/SiteManageGroupHandler.java
+++ b/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/impl/SiteManageGroupHandler.java
@@ -1,13 +1,12 @@
 package org.sakaiproject.site.tool.helper.managegroup.impl;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.Vector;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -41,10 +40,10 @@ import uk.org.ponder.messageutil.TargettedMessageList;
 public class SiteManageGroupHandler {
 	
     /** Our log (commons). */
-    private static Log M_log = LogFactory.getLog(SiteManageGroupHandler.class);
+    private static final Log M_log = LogFactory.getLog(SiteManageGroupHandler.class);
    
     private Collection<Member> groupMembers;
-    private GroupComparator groupComparator = new GroupComparator();
+    private final GroupComparator groupComparator = new GroupComparator();
 	
     public Site site = null;
     public SiteService siteService = null;
@@ -53,7 +52,6 @@ public class SiteManageGroupHandler {
     public SessionManager sessionManager = null;
     public ServerConfigurationService serverConfigurationService;
     private List<Group> groups = null;
-    private Set unhideables = null;
     public String memberList = "";
     public boolean update = false;
     public boolean done = false;
@@ -61,18 +59,8 @@ public class SiteManageGroupHandler {
     public String[] selectedGroupMembers = new String[]{};
     public String[] selectedSiteMembers = new String[]{};
     
-    private String NULL_STRING = "";
-    
-    private final String TOOL_CFG_FUNCTIONS = "functions.require";
-    private final String TOOL_CFG_MULTI = "allowMultiple";
-    private final String SITE_UPD = "site.upd";
     private final String HELPER_ID = "sakai.tool.helper.id";
-    private final String GROUP_ADD = "group.add";
     private final String GROUP_DELETE = "group.delete";
-    private final String GROUP_RENAME = "group.rename";
-    private final String GROUP_SHOW = "group.show";
-    private final String GROUP_HIDE = "group.hide";
-    private final String SITE_REORDER = "group.reorder";
     private final String SITE_RESET = "group.reset";
 
     // Tool session attribute name used to schedule a whole page refresh.
@@ -133,12 +121,16 @@ public class SiteManageGroupHandler {
 	 */
 	public void resetParams()
 	{
-		id = "";
-		title = "";
-		description ="";
-		deleteGroupIds=new String[]{};
-		selectedGroupMembers = new String[]{};
-	    selectedSiteMembers = new String[]{};
+		// SAK-29645 - preserve user input
+		if( messages.size() == 0 )
+		{
+			id = "";
+			title = "";
+			description ="";
+			deleteGroupIds=new String[]{};
+			selectedGroupMembers = new String[]{};
+			selectedSiteMembers = new String[]{};
+		}
 	}
 	 
     /**
@@ -150,14 +142,14 @@ public class SiteManageGroupHandler {
             init();
         }
         if (update) {
-            groups = new Vector<Group>();
+            groups = new ArrayList<>();
             if (site != null)
             {   
                // only show groups created by WSetup tool itself
                Collection allGroups = (Collection) site.getGroups();
                for (Iterator gIterator = allGroups.iterator(); gIterator.hasNext();) {
                   Group gNext = (Group) gIterator.next();
-                  String gProp = gNext.getProperties().getProperty(gNext.GROUP_PROP_WSETUP_CREATED);
+                  String gProp = gNext.getProperties().getProperty(Group.GROUP_PROP_WSETUP_CREATED);
                   if (gProp != null && gProp.equals(Boolean.TRUE.toString())) {
                      groups.add(gNext);
                   }
@@ -194,14 +186,14 @@ public class SiteManageGroupHandler {
             
             } catch (IdUnusedException e) {
                 // The siteId we were given was bogus
-                e.printStackTrace();
+                M_log.warn( e );
             }
         }
         title = "";
 
         if (groupMembers == null)
         {
-        	groupMembers = new Vector<Member>();
+        	groupMembers = new ArrayList<>();
         }
     }
     
@@ -217,7 +209,7 @@ public class SiteManageGroupHandler {
     
     public List<Participant> getSiteParticipant(Group group)
     {
-    	List<Participant> rv = new Vector<Participant>();
+    	List<Participant> rv = new ArrayList<>();
     	if (site != null)
     	{
     		String siteId = site.getId();
@@ -257,6 +249,7 @@ public class SiteManageGroupHandler {
     /**
      * Allows the Cancel button to return control to the tool calling this helper
      *
+     * @return status
      */
     public String processCancel() {
     	// reset the warning messages
@@ -271,6 +264,7 @@ public class SiteManageGroupHandler {
     /**
      * Cancel out of the current action and go back to main view
      * 
+     * @return status
      */
     public String processBack() {
     	// reset the warning messages
@@ -286,13 +280,8 @@ public class SiteManageGroupHandler {
                 EventTrackingService.newEvent(SITE_RESET, "/site/" + site.getId(), false));
 
         } 
-        catch (IdUnusedException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } 
-        catch (PermissionException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+        catch (IdUnusedException | PermissionException e) {
+            M_log.warn( e );
         }
 
         return "";
@@ -307,7 +296,7 @@ public class SiteManageGroupHandler {
     	// reset the warning messages
     	resetTargettedMessageList();
     	
-        Group group = null;
+        Group group;
         
         id = StringUtils.trimToNull(id);
         
@@ -343,7 +332,7 @@ public class SiteManageGroupHandler {
 		{
 			// adding a new group
 	        group= site.addGroup();
-	        group.getProperties().addProperty(group.GROUP_PROP_WSETUP_CREATED, Boolean.TRUE.toString());
+	        group.getProperties().addProperty(Group.GROUP_PROP_WSETUP_CREATED, Boolean.TRUE.toString());
 		}
 		
 		if (group != null)
@@ -351,7 +340,7 @@ public class SiteManageGroupHandler {
 			group.setTitle(title);
             group.setDescription(description);   
             
-            boolean found = false;
+            boolean found;
             // remove those no longer included in the group
 			Set members = group.getMembers();
 			String[] membersSelected = memberList.split("##");
@@ -371,24 +360,24 @@ public class SiteManageGroupHandler {
 				}
 			}
 
-			// add those seleted members
-			for (int i = 0; i < membersSelected.length; i++) {
-				String memberId = membersSelected[i];
-				memberId = StringUtils.trimToNull(memberId);
-				if (memberId != null && group.getUserRole(memberId) == null) {
-					Role r = site.getUserRole(memberId);
-					Member m = site.getMember(memberId);
-					Role memberRole = m != null ? m.getRole() : null;
-					// for every member added through the "Manage
-					// Groups" interface, he should be defined as
-					// non-provided
-					// get role first from site definition. 
-					// However, if the user is inactive, getUserRole would return null; then use member role instead
-					group.addMember(memberId, r != null ? r.getId()
-							: memberRole != null? memberRole.getId() : "", m != null ? m.isActive() : true,
-							false);
-				}
-			}
+            // add those seleted members
+            for( String memberId : membersSelected )
+            {
+                memberId = StringUtils.trimToNull(memberId);
+                if (memberId != null && group.getUserRole(memberId) == null) {
+                    Role r = site.getUserRole(memberId);
+                    Member m = site.getMember(memberId);
+                    Role memberRole = m != null ? m.getRole() : null;
+                    // for every member added through the "Manage
+                    // Groups" interface, he should be defined as
+                    // non-provided
+                    // get role first from site definition.
+                    // However, if the user is inactive, getUserRole would return null; then use member role instead
+                    group.addMember(memberId, r != null ? r.getId()
+                                              : memberRole != null? memberRole.getId() : "", m != null ? m.isActive() : true,
+                                              false);
+                }
+            }
 	            
     		// save the changes
     		try
@@ -397,11 +386,7 @@ public class SiteManageGroupHandler {
     			// reset the form params
     			resetParams();
 	        } 
-	        catch (IdUnusedException e) {
-	        	M_log.warn(this + ".processAddGroup: cannot find site " + site.getId(), e);
-	            return null;
-	        } 
-	        catch (PermissionException e) {
+	        catch (IdUnusedException | PermissionException e) {
 	        	M_log.warn(this + ".processAddGroup: cannot find site " + site.getId(), e);
 	            return null;
 	        }
@@ -425,14 +410,14 @@ public class SiteManageGroupHandler {
     	}
     	else
     	{
-    		List<Group> groups = new Vector<Group>();
+    		List<Group> groups = new ArrayList<>();
     		
-	    	for (int i = 0; i < deleteGroupIds.length; i++) {
-	    		String groupId = deleteGroupIds[i];
-	    		//
-	    		Group g = site.getGroup(groupId);
-	    		groups.add(g);
-	    	}
+            for( String groupId : deleteGroupIds )
+            {
+                //
+                Group g = site.getGroup(groupId);
+                groups.add(g);
+            }
 	    	return "confirm";
     	}
     }
@@ -444,13 +429,13 @@ public class SiteManageGroupHandler {
     	
     	if (site != null)
     	{
-	    	for (int i = 0; i < deleteGroupIds.length; i++) {
-		    	String groupId = deleteGroupIds[i];
-		    	Group g = site.getGroup(groupId);
-				if (g != null) {
-					site.removeGroup(g);
-				}
-			}
+            for( String groupId : deleteGroupIds )
+            {
+                Group g = site.getGroup(groupId);
+                if (g != null) {
+                    site.removeGroup(g);
+                }
+            }
 			try {
 				siteService.save(site);
 			} catch (IdUnusedException e) {
@@ -500,15 +485,14 @@ public class SiteManageGroupHandler {
 	
 	public List<Group> getSelectedGroups()
 	{
-		List<Group> rv = new Vector<Group>();
+		List<Group> rv = new ArrayList<>();
 		if (deleteGroupIds != null && deleteGroupIds.length > 0 && site != null)
 		{
-			for (int i = 0; i<deleteGroupIds.length; i++)
-			{
-				String groupId = deleteGroupIds[i];
-				Group g = site.getGroup(groupId);
-				rv.add(g);
-			}
+            for( String groupId : deleteGroupIds )
+            {
+                Group g = site.getGroup(groupId);
+                rv.add(g);
+            }
 		}
 		return rv;
 	}
@@ -534,4 +518,3 @@ public class SiteManageGroupHandler {
       }
    }
 }
-

--- a/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/rsf/GroupEditProducer.java
+++ b/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/rsf/GroupEditProducer.java
@@ -1,9 +1,10 @@
 package org.sakaiproject.site.tool.helper.managegroup.rsf;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -47,7 +48,7 @@ import uk.org.ponder.rsf.viewstate.ViewParamsReporter;
 public class GroupEditProducer implements ViewComponentProducer, ActionResultInterceptor, ViewParamsReporter {
 
 	/** Our log (commons). */
-	private static Log M_log = LogFactory.getLog(GroupEditProducer.class);
+	private static final Log M_log = LogFactory.getLog(GroupEditProducer.class);
 	
     public SiteManageGroupHandler handler;
     public static final String VIEW_ID = "GroupEdit";
@@ -83,7 +84,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
     	// description for group
     	String groupDescription = null;
     	// member list for group
-    	Collection<Member> groupMembers = new Vector<Member>();
+    	Set<Member> groupMembers = new HashSet<>();
     	
     	UIForm groupForm = UIForm.make(arg0, "groups-form");
 
@@ -92,15 +93,19 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
     	 {
     		 try
     		 {
-    			 g = siteService.findGroup(id);
-    			 groupId = g.getId();
-    			 groupTitle = g.getTitle();
-    			 groupDescription = g.getDescription();
-    			 groupMembers = g.getMembers();
+    			 // SAK-29645 - preserve user input
+    			 if( handler.messages.size() == 0 )
+    			 {
+    				 g = siteService.findGroup(id);
+    				 groupId = g.getId();
+    				 groupTitle = g.getTitle();
+    				 groupDescription = g.getDescription();
+    				 groupMembers = g.getMembers();
+    			 }
     		 }
     		 catch (Exception e)
     		 {
-    			 M_log.debug(this + "fillComponents: cannot get group id=" + id);
+    			 M_log.debug(this + "fillComponents: cannot get group id=" + id, e);
     		 }
     	 }
     	 else
@@ -116,7 +121,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
          UIOutput.make(groupForm, "instructions", messageLocator.getMessage("editgroup.instruction", new Object[]{addUpdateButtonName}));
          
          UIOutput.make(groupForm, "group_title_label", messageLocator.getMessage("group.title"));
-         UIInput titleTextIn = UIInput.make(groupForm, "group_title", "#{SiteManageGroupHandler.title}",groupTitle);
+         UIInput.make(groupForm, "group_title", "#{SiteManageGroupHandler.title}",groupTitle);
 		 
 		
 		 UIMessage groupDescrLabel = UIMessage.make(arg0, "group_description_label", "group.description"); 
@@ -128,46 +133,47 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
 		 UIOutput.make(groupForm, "membership_group_label", messageLocator.getMessage("editgroup.grouplist"));
 		 
 		 // for the site members list
-		 Collection siteMembers= handler.getSiteParticipant(g);
-		 String[] siteMemberLabels = new String[siteMembers.size()];
-		 String[] siteMemberValues = new String[siteMembers.size()];
-		 UISelect siteMember = UISelect.makeMultiple(groupForm,"siteMembers",siteMemberValues,siteMemberLabels,"#{SiteManageGroupHandler.selectedSiteMembers}", new String[] {});
+		 List<Participant> siteMembers= handler.getSiteParticipant(g);
+		 List<String> siteMemberLabels = new ArrayList<>();
+		 List<String> siteMemberValues = new ArrayList<>();
 		 
-		 int i =0;
 		 Iterator<Participant> sIterator = new SortedIterator(siteMembers.iterator(), new SiteComparator(SiteConstants.SORTED_BY_PARTICIPANT_NAME, Boolean.TRUE.toString()));
-	     for (; sIterator.hasNext();i++){
+	     while( sIterator.hasNext() ){
 	        	Participant p = (Participant) sIterator.next();
 	        	// not in the group yet
 	        	if (g == null || g.getMember(p.getUniqname()) == null)
 	        	{
-					siteMemberLabels[i] = p.getName() + " (" + p.getDisplayId() + ")";
-					siteMemberValues[i] = p.getUniqname();
+					siteMemberLabels.add( p.getName() + " (" + p.getDisplayId() + ")" );
+					siteMemberValues.add( p.getUniqname() );
 	        	}
 	        }
-	     
+
+         UISelect.makeMultiple( groupForm, "siteMembers", siteMemberValues.toArray( new String[siteMemberValues.size()]), 
+                                siteMemberLabels.toArray( new String[siteMemberLabels.size()]), "#{SiteManageGroupHandler.selectedSiteMembers}", new String[] {} );
+
 	     // for the group members list
-		 String[] groupMemberLabels = new String[groupMembers.size()];
-		 String[] groupMemberValues = new String[groupMembers.size()];
-		 UISelect groupMember = UISelect.make(groupForm,"groupMembers",groupMemberValues,groupMemberLabels,null);
-		 i =0;
+		 List<String> groupMemberLabels = new ArrayList<>();
+		 List<String> groupMemberValues = new ArrayList<>();
 		 Iterator<Member> gIterator = new SortedIterator(groupMembers.iterator(), new SiteComparator(SiteConstants.SORTED_BY_MEMBER_NAME, Boolean.TRUE.toString()));
-	     for (; gIterator.hasNext();i++){
+	     while( gIterator.hasNext() ){
 	        	Member p = (Member) gIterator.next();
 	        	String userId = p.getUserId();
 	        	try
 	        	{
 	        		User u = userDirectoryService.getUser(userId);
-	        		groupMemberLabels[i] = u.getSortName() + " (" + u.getDisplayId() + ")";
+	        		groupMemberLabels.add( u.getSortName() + " (" + u.getDisplayId() + ")" );
+                    groupMemberValues.add( userId );
 	        	}
 	        	catch (Exception e)
 	        	{
-	        		M_log.debug(this + ":fillComponents: cannot find user " + userId);
+	        		M_log.debug(this + ":fillComponents: cannot find user " + userId, e);
 	        		// need to remove the group member
 	        		groupMembers.remove(p);
 	        	}
-				groupMemberValues[i] = userId;
 	        }
-	        
+
+	     UISelect.make( groupForm, "groupMembers", groupMemberValues.toArray( new String[groupMemberValues.size()]), 
+                        groupMemberLabels.toArray( new String[groupMemberLabels.size()]), null );
 	     UICommand.make(groupForm, "save", addUpdateButtonName, "#{SiteManageGroupHandler.processAddGroup}");
 
          UICommand.make(groupForm, "cancel", messageLocator.getMessage("editgroup.cancel"), "#{SiteManageGroupHandler.processBack}");
@@ -180,8 +186,8 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
          //process any messages
          tml = handler.messages;
          if (tml.size() > 0) {
- 			for (i = 0; i < tml.size(); i ++ ) {
- 				UIBranchContainer errorRow = UIBranchContainer.make(arg0,"error-row:", Integer.valueOf(i).toString());
+ 			for (int i = 0; i < tml.size(); i ++ ) {
+ 				UIBranchContainer errorRow = UIBranchContainer.make(arg0,"error-row:", Integer.toString(i));
  				TargettedMessage msg = tml.messageAt(i);
 		    	if (msg.args != null ) 
 		    	{
@@ -204,19 +210,10 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
         return params;
     }
 
-    // old and busted
-//    public List reportNavigationCases() {
-//        List togo = new ArrayList();
-//        togo.add(new NavigationCase("success", new SimpleViewParameters(GroupListProducer.VIEW_ID)));
-//    	togo.add(new NavigationCase("cancel", new SimpleViewParameters(GroupListProducer.VIEW_ID)));
-//        return togo;
-//    }
-
     // new hotness
     public void interceptActionResult(ARIResult result, ViewParameters incoming, Object actionReturn) {
         if ("success".equals(actionReturn) || "cancel".equals(actionReturn)) {
             result.resultingView = new SimpleViewParameters(GroupListProducer.VIEW_ID);
         }
     }
-
 }

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupEditProducer.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupEditProducer.java
@@ -1,8 +1,7 @@
 package org.sakaiproject.site.tool.helper.managegroupsectionrole.rsf;
 
-import java.util.Collection;
-import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,21 +9,18 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Vector;
+import org.apache.commons.lang.StringUtils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.Role;
-import org.sakaiproject.exception.IdUnusedException;
-import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.tool.helper.managegroupsectionrole.impl.SiteManageGroupSectionRoleHandler;
 import org.sakaiproject.site.util.Participant;
 import org.sakaiproject.site.util.SiteComparator;
 import org.sakaiproject.site.util.SiteConstants;
-import org.sakaiproject.util.SortedIterator;
 import org.sakaiproject.util.SortedIterator;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
@@ -45,17 +41,13 @@ import uk.org.ponder.rsf.components.UISelect;
 import uk.org.ponder.rsf.components.UIDeletionBinding;
 import uk.org.ponder.rsf.components.decorators.UICSSDecorator;
 import uk.org.ponder.rsf.components.decorators.UILabelTargetDecorator;
-import uk.org.ponder.rsf.components.decorators.UITooltipDecorator;
-import uk.org.ponder.rsf.evolvers.FormatAwareDateInputEvolver;
 import uk.org.ponder.rsf.flow.ARIResult;
 import uk.org.ponder.rsf.flow.ActionResultInterceptor;
-import uk.org.ponder.rsf.flow.jsfnav.NavigationCase;
 import uk.org.ponder.rsf.view.ComponentChecker;
 import uk.org.ponder.rsf.view.ViewComponentProducer;
 import uk.org.ponder.rsf.viewstate.SimpleViewParameters;
 import uk.org.ponder.rsf.viewstate.ViewParameters;
 import uk.org.ponder.rsf.viewstate.ViewParamsReporter;
-import uk.org.ponder.stringutil.StringList;
 
 /**
  * 
@@ -65,10 +57,10 @@ import uk.org.ponder.stringutil.StringList;
 public class GroupEditProducer implements ViewComponentProducer, ActionResultInterceptor, ViewParamsReporter{
 
 	/** Our log (commons). */
-	private static Log M_log = LogFactory.getLog(GroupEditProducer.class);
+	private static final Log M_log = LogFactory.getLog(GroupEditProducer.class);
 	
-	private String SECTION_PREFIX = "Section: ";
-	private String ROLE_PREFIX = "Role: ";
+	private static final String SECTION_PREFIX = "Section: ";
+	private static final String ROLE_PREFIX = "Role: ";
 	
     public SiteManageGroupSectionRoleHandler handler;
     public static final String VIEW_ID = "GroupEdit";
@@ -104,7 +96,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
     	// description for group
     	String groupDescription = null;
     	// member list for group
-    	Collection<Member> groupMembers = new Vector<Member>();
+    	Set<Member> groupMembers = new HashSet<>();
     	// group provider id
     	String groupProviderId = null;
     	// list of group role provider ids
@@ -117,41 +109,45 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
     	 {
     		 try
     		 {
-    			 g = siteService.findGroup(id);
-    			 groupId = g.getId();
-    			 groupTitle = g.getTitle();
-    			 groupDescription = g.getDescription();
-    			 handler.allowViewMembership = Boolean.valueOf(g.getProperties().getProperty(g.GROUP_PROP_VIEW_MEMBERS));
-    			 groupMembers = g.getMembers();
-    			 groupProviderId = g.getProviderGroupId();
-    			 groupRoleProviderRoles = handler.getGroupProviderRoles(g);
-    			 String joinableSet = g.getProperties().getProperty(g.GROUP_PROP_JOINABLE_SET);
-    			 if(joinableSet != null && !"".equals(joinableSet.trim())){
-    				 handler.joinableSetName = joinableSet;
-    				 handler.joinableSetNameOrig = joinableSet;
-    				 handler.joinableSetNumOfMembers = g.getProperties().getProperty(g.GROUP_PROP_JOINABLE_SET_MAX);
-    				 handler.allowPreviewMembership = Boolean.valueOf(g.getProperties().getProperty(g.GROUP_PROP_JOINABLE_SET_PREVIEW));
-    				 //set unjoinable.  Since you can't change this value at the group edit page, all groups will have the same
-    				 //value in the set.  Find another group in the same set (if exist) and set it to the same value.
-    				 for(Group group : handler.site.getGroups()){
-    		        		String joinableSetName = group.getProperties().getProperty(group.GROUP_PROP_JOINABLE_SET);
-    		        		if(joinableSetName != null && joinableSetName.equals(joinableSet)){
-    		        			//we only need to find the first one since all are the same
-    		        			handler.unjoinable = Boolean.valueOf(group.getProperties().getProperty(g.GROUP_PROP_JOINABLE_UNJOINABLE));
-    		        			break;
-    		        		}
+    			 // SAK-29645
+    			 if( handler.messages.size() == 0 )
+    			 {
+    				 g = siteService.findGroup(id);
+    				 groupId = g.getId();
+    				 groupTitle = g.getTitle();
+    				 groupDescription = g.getDescription();
+    				 handler.allowViewMembership = Boolean.valueOf(g.getProperties().getProperty(Group.GROUP_PROP_VIEW_MEMBERS));
+    				 groupMembers = g.getMembers();
+    				 groupProviderId = g.getProviderGroupId();
+    				 groupRoleProviderRoles = handler.getGroupProviderRoles(g);
+    				 String joinableSet = g.getProperties().getProperty(Group.GROUP_PROP_JOINABLE_SET);
+    				 if(joinableSet != null && !"".equals(joinableSet.trim())){
+    					 handler.joinableSetName = joinableSet;
+    					 handler.joinableSetNameOrig = joinableSet;
+    					 handler.joinableSetNumOfMembers = g.getProperties().getProperty(Group.GROUP_PROP_JOINABLE_SET_MAX);
+    					 handler.allowPreviewMembership = Boolean.valueOf(g.getProperties().getProperty(Group.GROUP_PROP_JOINABLE_SET_PREVIEW));
+    					 //set unjoinable.  Since you can't change this value at the group edit page, all groups will have the same
+    					 //value in the set.  Find another group in the same set (if exist) and set it to the same value.
+    					 for(Group group : handler.site.getGroups()){
+    			        		String joinableSetName = group.getProperties().getProperty(Group.GROUP_PROP_JOINABLE_SET);
+    			        		if(joinableSetName != null && joinableSetName.equals(joinableSet)){
+    			        			//we only need to find the first one since all are the same
+    			        			handler.unjoinable = Boolean.valueOf(group.getProperties().getProperty(Group.GROUP_PROP_JOINABLE_UNJOINABLE));
+    			        			break;
+    			        		}
+    					 }
+    				 }else{
+    					 handler.joinableSetName = "";
+    					 handler.joinableSetNameOrig = "";
+    					 handler.joinableSetNumOfMembers = "";
+    					 handler.allowPreviewMembership = false;
+    					 handler.unjoinable = false;
     				 }
-    			 }else{
-    				 handler.joinableSetName = "";
-    				 handler.joinableSetNameOrig = "";
-    				 handler.joinableSetNumOfMembers = "";
-    				 handler.allowPreviewMembership = false;
-    				 handler.unjoinable = false;
     			 }
     		 }
     		 catch (Exception e)
     		 {
-    			 M_log.debug(this + "fillComponents: cannot get group id=" + id);
+    			 M_log.debug(this + "fillComponents: cannot get group id=" + id, e);
     		 }
     	 }
     	 else
@@ -168,7 +164,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
          UIOutput.make(groupForm, "instructions", messageLocator.getMessage("editgroup.instruction", new Object[]{addUpdateButtonName}));
          
          UIOutput.make(groupForm, "group_title_label", messageLocator.getMessage("group.title"));
-         UIInput titleTextIn = UIInput.make(groupForm, "group_title", "#{SiteManageGroupSectionRoleHandler.title}",groupTitle);
+         UIInput.make(groupForm, "group_title", "#{SiteManageGroupSectionRoleHandler.title}",groupTitle);
 		 
 		
 		 UIMessage groupDescrLabel = UIMessage.make(groupForm, "group_description_label", "group.description"); 
@@ -181,16 +177,16 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
 		 
 		 //Joinable Set:
 		 UIMessage joinableSetLabel = UIMessage.make(groupForm, "group_joinable_set_label", "group.joinable.set");
-		 List<String> joinableSetValuesSet = new ArrayList<String>();
+		 List<String> joinableSetValuesSet = new ArrayList<>();
 		 for(Group group : handler.site.getGroups()){
-			 String joinableSet = group.getProperties().getProperty(group.GROUP_PROP_JOINABLE_SET);
+			 String joinableSet = group.getProperties().getProperty(Group.GROUP_PROP_JOINABLE_SET);
 			 if(joinableSet != null && !joinableSetValuesSet.contains(joinableSet)){
 				 joinableSetValuesSet.add(joinableSet);
 			 }
 		 }
 		 Collections.sort(joinableSetValuesSet);
-		 List<String> joinableSetValues = new ArrayList<String>();
-		 List<String> joinableSetNames = new ArrayList<String>();
+		 List<String> joinableSetValues = new ArrayList<>();
+		 List<String> joinableSetNames = new ArrayList<>();
 		 joinableSetValues.add("");
 		 joinableSetNames.add(messageLocator.getMessage("none"));
 		 joinableSetValues.addAll(joinableSetValuesSet);
@@ -204,7 +200,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
 		 //joinable div:
 		 UIBranchContainer joinableDiv = UIBranchContainer.make(groupForm, "joinable-set-div:");
 		 if(handler.joinableSetName == null || "".equals(handler.joinableSetName)){
-			 Map<String, String> hidden = new HashMap<String, String>();
+			 Map<String, String> hidden = new HashMap<>();
 			 hidden.put("display", "none");
 			 joinableDiv.decorate(new UICSSDecorator(hidden));
 		 }
@@ -224,66 +220,61 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
 		 List<String> siteRosters= handler.getSiteRosters(g);
 		 List<Role> siteRoles= handler.getSiteRoles(g);
 		 List<Participant> siteMembers= handler.getSiteParticipant(g);
-		 int totalListSize = siteRosters.size() + siteRoles.size() + siteMembers.size();
-		 String[] siteMemberLabels = new String[totalListSize];
-		 String[] siteMemberValues = new String[totalListSize];
-		 UISelect siteMember = UISelect.makeMultiple(groupForm,"siteMembers",siteMemberValues,siteMemberLabels,"#{SiteManageGroupSectionRoleHandler.selectedSiteMembers}", new String[] {});
-		 
-		 int i =0;
+		 List<String> siteMemberLabels = new ArrayList<>();
+		 List<String> siteMemberValues = new ArrayList<>();
+		 List<String> membersSelected;
+		 if( handler.memberList != null && handler.memberList.length() > 0 )
+		 {
+			 membersSelected = Arrays.asList( handler.memberList.split( "##" ) );
+		 }
+		 else
+		 {
+			 membersSelected = new ArrayList<>();
+		 }
+
 		 // add site roster
 		 for (String roster:siteRosters)
 		 {
 			 // not include in the group yet
-			 if (groupProviderId == null || !groupProviderId.contains(roster))
+			 if ((groupProviderId == null || !groupProviderId.contains(roster)) && !membersSelected.contains( roster ))
 			 {
-				 siteMemberLabels[i] = SECTION_PREFIX + roster;
-				 siteMemberValues[i] = roster;
-				 i++;
+				 siteMemberLabels.add( SECTION_PREFIX + roster );
+				 siteMemberValues.add( roster );
 			 }
 		 }
 		 // add site role
 		 for (Role role:siteRoles)
 		 {
 			 // not include in the group yet
-			 if (groupRoleProviderRoles == null || !groupRoleProviderRoles.contains(role.getId()))
+			 if ((groupRoleProviderRoles == null || !groupRoleProviderRoles.contains(role.getId())) && !membersSelected.contains( role.getId() ))
 			 {
-				 siteMemberLabels[i] = ROLE_PREFIX + role.getId();
-				 siteMemberValues[i] = role.getId();
-				 i++;
+				 siteMemberLabels.add( ROLE_PREFIX + role.getId() );
+				 siteMemberValues.add( role.getId() );
 			 }
 		 }
 		 // add site members to the list
 		 Iterator<Participant> sIterator = new SortedIterator(siteMembers.iterator(), new SiteComparator(SiteConstants.SORTED_BY_PARTICIPANT_NAME, Boolean.TRUE.toString()));
-	     for (; sIterator.hasNext();i++){
+	     while( sIterator.hasNext() ){
 	        	Participant p = (Participant) sIterator.next();
 	        	// not in the group yet
-	        	if (g == null || g.getMember(p.getUniqname()) == null)
+	        	if ((g == null || g.getMember(p.getUniqname()) == null) && !membersSelected.contains( p.getUniqname() ))
 	        	{
-					siteMemberLabels[i] = p.getName() + " (" + p.getDisplayId() + ")";
-					siteMemberValues[i] = p.getUniqname();
+					siteMemberLabels.add( p.getName() + " (" + p.getDisplayId() + ")" );
+					siteMemberValues.add( p.getUniqname() );
 	        	}
 	        }
-	     
-	     
+
+	     UISelect.makeMultiple( groupForm, "siteMembers", siteMemberValues.toArray( new String[siteMemberValues.size()] ), 
+	     	     	     	     siteMemberLabels.toArray( new String[siteMemberLabels.size()] ), 
+	     	     	     	     "#{SiteManageGroupSectionRoleHandler.selectedSiteMembers}", new String[] {} );
+
 	     /********************** for the group members list **************************/
-	     // rosters
 	     List<String> groupRosters = handler.getGroupRosters(g);
-	     if (groupRosters != null)
-	     {
-	    	 totalListSize = groupRosters.size();
-	     }
-	     // roles
 	     List<String> groupProviderRoles = handler.getGroupProviderRoles(g);
-	     if (groupProviderRoles != null)
-	     {
-	    	 totalListSize += groupProviderRoles.size();
-	     }
-	     // group members
-	     List<Member> groupMembersCopy = new Vector<Member>();
+	     List<Member> groupMembersCopy = new ArrayList<>();
 	     groupMembersCopy.addAll(groupMembers);
-	     for (Iterator<Member> gItr=groupMembersCopy.iterator(); gItr.hasNext();){
-        	Member p = (Member) gItr.next();
-        	
+	     for( Member p : groupMembersCopy )
+	     {
         	// exclude those user with provided roles and rosters
         	String userId = p.getUserId();
         	try{
@@ -296,28 +287,23 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
         	}
         	catch (Exception e)
         	{
-        		M_log.debug(this + "fillInComponent: cannot find user with id " + userId);
+        		M_log.debug(this + "fillInComponent: cannot find user with id " + userId, e);
         		// need to remove the group member
         		groupMembers.remove(p);
         	}
 	     }
-	     if (groupMembers != null)
-	     {
-	    	 totalListSize +=groupMembers.size();
-	     }
-	     
-		 String[] groupMemberLabels = new String[totalListSize];
-		 String[] groupMemberValues = new String[totalListSize];
-		 UISelect groupMember = UISelect.make(groupForm,"groupMembers",groupMemberValues,groupMemberLabels,null);
-		 i =0;
+
+		 // SAK-29645
+		 Set<String> groupMemberLabels = new HashSet<>();
+		 Set<String> groupMemberValues = new HashSet<>();
+
 		 // add the rosters first
 		 if (groupRosters != null)
 		 {
 			 for (String groupRoster:groupRosters)
 			 {
-				 groupMemberLabels[i] = SECTION_PREFIX + groupRoster;
-				 groupMemberValues[i] = groupRoster;
-				 i++;
+				 groupMemberLabels.add( SECTION_PREFIX + groupRoster );
+				 groupMemberValues.add( groupRoster );
 			 }
 		 }
 		 // add the roles next
@@ -325,31 +311,71 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
 		 {
 			 for (String groupProviderRole:groupProviderRoles)
 			 {
-				 groupMemberLabels[i] = ROLE_PREFIX + groupProviderRole;
-				 groupMemberValues[i] = groupProviderRole;
-				 i++;
+				 groupMemberLabels.add( ROLE_PREFIX + groupProviderRole );
+				 groupMemberValues.add( groupProviderRole );
 			 }
 		 }
 		 // add the members last
 		 if (groupMembers != null)
 		 {
 			 Iterator<Member> gIterator = new SortedIterator(groupMembers.iterator(), new SiteComparator(SiteConstants.SORTED_BY_MEMBER_NAME, Boolean.TRUE.toString()));
-			 for (; gIterator.hasNext();i++){
+			 while( gIterator.hasNext() ){
 				 Member p = (Member) gIterator.next();
 				 String userId = p.getUserId();
 				 try
 				 {
 					 User u = userDirectoryService.getUser(userId);
-					 groupMemberLabels[i] = u.getSortName() + " (" + u.getDisplayId() + ")";
+					 groupMemberLabels.add( u.getSortName() + " (" + u.getDisplayId() + ")" );
+					 groupMemberValues.add( userId );
 				 }
 				 catch (Exception e)
 				 {
-					 M_log.debug(this + ":fillComponents: cannot find user " + userId);
+					 M_log.debug(this + ":fillComponents: cannot find user " + userId, e);
 				 }
-				 groupMemberValues[i] = userId;
 			 }
 		 }
-	        
+
+        // SAK-29645 - preserve user selected values
+        if( !membersSelected.isEmpty() )
+        {
+            siteRosters = handler.getSiteRosters( null );
+            List<String> siteRoleIDs = handler.getSiteRoleIds();
+            for( String memberID : membersSelected )
+            {
+                // Selected roster...
+                if( siteRosters.contains( memberID ) )
+                {
+                    groupMemberLabels.add( SECTION_PREFIX + memberID );
+                    groupMemberValues.add( memberID );
+                }
+
+                // Selected role...
+                else if( siteRoleIDs.contains( memberID ) )
+                {
+                    groupMemberLabels.add( ROLE_PREFIX + memberID );
+                    groupMemberValues.add( memberID );
+                }
+
+                // Selected member...
+                else if( groupMembers != null )
+                {
+                    sIterator = new SortedIterator(siteMembers.iterator(), new SiteComparator(SiteConstants.SORTED_BY_PARTICIPANT_NAME, Boolean.TRUE.toString()));
+                    while( sIterator.hasNext() )
+                    {
+                        Participant p = (Participant) sIterator.next();
+                        String userID = p.getUniqname();
+                        if( StringUtils.isNotBlank( userID ) && userID.equals( memberID ) )
+                        {
+                            groupMemberLabels.add( p.getName() + " (" + p.getDisplayId() + ")" );
+                            groupMemberValues.add( userID );
+                        }
+                    }
+                }
+            }
+        }
+
+         UISelect.make( groupForm, "groupMembers", groupMemberValues.toArray( new String[groupMemberValues.size()] ),
+                                                groupMemberLabels.toArray( new String[groupMemberLabels.size()] ), null );
     	 UICommand.make(groupForm, "save", addUpdateButtonName, "#{SiteManageGroupSectionRoleHandler.processAddGroup}");
 
          UICommand cancel = UICommand.make(groupForm, "cancel", messageLocator.getMessage("editgroup.cancel"), "#{SiteManageGroupSectionRoleHandler.processBack}");
@@ -363,8 +389,8 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
          //process any messages
          tml = handler.messages;
          if (tml.size() > 0) {
- 			for (i = 0; i < tml.size(); i ++ ) {
- 				UIBranchContainer errorRow = UIBranchContainer.make(arg0,"error-row:", Integer.valueOf(i).toString());
+ 			for (int i = 0; i < tml.size(); i ++ ) {
+ 				UIBranchContainer errorRow = UIBranchContainer.make(arg0,"error-row:", Integer.toString(i));
  				TargettedMessage msg = tml.messageAt(i);
 		    	if (msg.args != null ) 
 		    	{
@@ -393,5 +419,4 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
             result.resultingView = new SimpleViewParameters(GroupListProducer.VIEW_ID);
         }
     }
-
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29645

"When creating/editing a group with invalid data (duplicate group name, etc), the page refreshes with the appropriate feedback message, but any changes the user made to the form fields are discarded. The result is empty form fields for a new group, or the previously saved data for an existing group.

After validation failure, the user's input should be preserved so they don't have to key it all out again."