### PR TITLE
SAK-29638: User tool fieldset width is limiting on create-blurb content

### DIFF
--- a/user/user-tool/tool/src/webapp/css/sakai-user-tool.css
+++ b/user/user-tool/tool/src/webapp/css/sakai-user-tool.css
@@ -140,7 +140,18 @@
 
 #user-create_edit fieldset
 {
-    width: 33em;
+    display:inline-block;
+}
+
+.createBlurb
+{
+    display:table;
+    width:33em;
+}
+
+.createBlurb p
+{
+    margin: 10px 0;
 }
 
 #useredit fieldset

--- a/user/user-tool/tool/src/webapp/vm/user/chef_users_create.vm
+++ b/user/user-tool/tool/src/webapp/vm/user/chef_users_create.vm
@@ -27,7 +27,7 @@ ${includeLatestJQuery}
 			</legend>
 			<div class="instruction">
 				#if ($createBlurb)
-					<div>$createBlurb</div>
+					<div class="createBlurb">$createBlurb</div>
 				#end
 				<span class="reqStarInline">*</span> $tlang.getString("usecre.instruc")
 			</div>


### PR DESCRIPTION
The New Account tool has a tool configuration property called 'create-blurb'. This allows the administrator to configure the tool with introductory text / html that is site specific. However, the width of the containing fieldset is a bit small. This should be widened to accommodate wide introductory text / html.