### PR TITLE
SAK-29663 log exceptions using ERROR instead of WARN

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -978,7 +978,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		}
 		catch (NullPointerException e)
 		{
-			M_log.warn(this+".buildMainPanelContext ", e);
+			M_log.error(this+".buildMainPanelContext ", e);
 		}
 
 		// get the current channel ID from state object or prolet initial parameter
@@ -1116,7 +1116,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		}
 		catch (PermissionException error)
 		{
-			M_log.warn(this+".buildMainPanelContext ", error);
+			M_log.error(this+".buildMainPanelContext ", error);
 		}
 		catch (IdUnusedException error)
 		{
@@ -4011,7 +4011,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			}
 			catch (ParseException e)
 			{
-				M_log.warn(this + " Cannot init RuleBasedCollator. Will use the default Collator instead.", e);
+				M_log.error(this + " Cannot init RuleBasedCollator. Will use the default Collator instead.", e);
 			}
 		}
 		// the criteria - asc
@@ -4938,7 +4938,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		catch (Exception e)
 		{
 			addAlert(sstate, rb.getString("java.alert.unknown"));
-			M_log.warn(this+".doOptionsUpdate", e);
+			M_log.error(this+".doOptionsUpdate", e);
 		}
 		
 		// We're omitting processing of the "showAnnouncementBody" since these
@@ -5041,7 +5041,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		}
 		catch (Exception e)
 		{
-			M_log.warn( this + ".processFormattedTextFromBrowser ", e);
+			M_log.error( this + ".processFormattedTextFromBrowser ", e);
 			return strFromBrowser;
 		}
 	}
@@ -5214,7 +5214,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		}
 		catch (Exception e)
 		{
-			M_log.warn(this+ ".getState", e);
+			M_log.error(this+ ".getState", e);
 		}
 
 		return null;
@@ -5278,7 +5278,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		}
 		catch (Exception e)
 		{
-			M_log.warn("", e);
+			M_log.error("", e);
 		}
 
 	} // releaseState

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -1703,12 +1703,12 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		    }
 		    catch (PermissionException e)
 		    {
-		        M_log.warn("getCalendar: The current user does not have permission to access " +
+		        M_log.error("getCalendar: The current user does not have permission to access " +
 		                "the calendar for context: " + contextId, e);
 		    }
 		    catch (Exception ex)
 		    {
-		        M_log.warn("getCalendar: Unknown exception occurred retrieving calendar for site: " + contextId, ex);
+		        M_log.error("getCalendar: Unknown exception occurred retrieving calendar for site: " + contextId, ex);
 		        calendar = null;
 		    }
 		}
@@ -2517,11 +2517,11 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		}
 		catch (IdUnusedException e)
 		{
-			M_log.warn(" commitEdit(), submissionId=" + submissionRef, e);
+			M_log.error(" commitEdit(), submissionId=" + submissionRef, e);
 		}
 		catch (PermissionException e)
 		{
-			M_log.warn(" commitEdit(), submissionId=" + submissionRef, e);
+			M_log.error(" commitEdit(), submissionId=" + submissionRef, e);
 		}
 
 	} // commitEdit(Submission)

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4171,7 +4171,7 @@ public class AssignmentAction extends PagedResourceActionII
 								u = UserDirectoryService.getUser(item.getAssessorUserId());
 								reviewersMap.put(item.getAssessorUserId(), u);
 							} catch (UserNotDefinedException e) {
-								M_log.warn(e.getMessage(), e);
+								M_log.error(e.getMessage(), e);
 							}
 						}
 					}
@@ -4547,7 +4547,7 @@ public class AssignmentAction extends PagedResourceActionII
 						User reviewer = UserDirectoryService.getUser(peerAssessmentItem.getAssessorUserId());
 						context.put("reviewer", reviewer);
 					} catch (UserNotDefinedException e) {
-						M_log.warn(e.getMessage(), e);
+						M_log.error(e.getMessage(), e);
 					}
 				}else{
 					context.put("view_only", false);
@@ -7552,7 +7552,7 @@ public class AssignmentAction extends PagedResourceActionII
 								}
 							}
 						} catch (IdUnusedException | PermissionException e) {
-							M_log.warn(e);
+							M_log.error(e);
 						}
 						
 						validPointGrade(state, gradePoints, scaleFactor);

--- a/content/content-impl-providers/impl/src/java/org/sakaiproject/content/providers/BaseEventDelayHandler.java
+++ b/content/content-impl-providers/impl/src/java/org/sakaiproject/content/providers/BaseEventDelayHandler.java
@@ -124,7 +124,7 @@ public class BaseEventDelayHandler implements EventDelayHandler, ScheduledInvoca
 						}
 						catch (SQLException se)
 						{
-							LOG.warn("Error trying to build event on read", se);
+							LOG.error("Error trying to build event on read", se);
 						}
 						return e;
 					}

--- a/content/content-types/src/java/org/sakaiproject/content/types/FileUploadType.java
+++ b/content/content-types/src/java/org/sakaiproject/content/types/FileUploadType.java
@@ -203,7 +203,7 @@ public class FileUploadType extends BaseResourceType
 			try {
 					contentHostingService.expandZippedResource(reference.getId());
 			} catch (Exception e) {
-				LOG.warn("Exception extracting zip content", e);
+				LOG.error("Exception extracting zip content", e);
 			}
 		}
 		

--- a/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
+++ b/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
@@ -175,7 +175,7 @@ public class SakaiBasicDataSource extends HikariDataSource
                 } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
                     // TODO Auto-generated catch block
                     String message = "driverClass not specified, might not be able to load the driver'";
-                    M_log.warn(message, e);
+                    M_log.error(message, e);
                 }
             }
         }
@@ -189,7 +189,7 @@ public class SakaiBasicDataSource extends HikariDataSource
         catch (Exception t)
         {
             String message = "Cannot load JDBC driver class '" + driverClassName + "'";
-            M_log.warn(message, t);
+            M_log.error(message, t);
             throw new SQLException(message,t);
         }
     }

--- a/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
+++ b/kernel/api/src/main/java/org/sakaiproject/hikaricp/jdbc/pool/SakaiBasicDataSource.java
@@ -175,7 +175,7 @@ public class SakaiBasicDataSource extends HikariDataSource
                 } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
                     // TODO Auto-generated catch block
                     String message = "driverClass not specified, might not be able to load the driver'";
-                    M_log.error(message, e);
+                    M_log.info(message, e);
                 }
             }
         }

--- a/kernel/api/src/main/java/org/sakaiproject/tomcat/jdbc/pool/SakaiBasicDataSource.java
+++ b/kernel/api/src/main/java/org/sakaiproject/tomcat/jdbc/pool/SakaiBasicDataSource.java
@@ -144,7 +144,7 @@ public class SakaiBasicDataSource extends DataSource
 			catch (Throwable t)
 			{
 				String message = "Cannot load JDBC driver class '" + driverClassName + "'";
-				M_log.warn(message, t);
+				M_log.error(message, t);
 				throw new SQLException(message,t);
 			}
 		}

--- a/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
@@ -504,17 +504,17 @@ public class RequestFilter implements Filter
 				}
 				catch (RuntimeException t)
 				{
-					M_log.warn("", t);
+					M_log.error("", t);
 					throw t;
 				}
 				catch (IOException ioe)
 				{
-					M_log.warn("", ioe);
+					M_log.error("", ioe);
 					throw ioe;
 				}
 				catch (ServletException se)
 				{
-					M_log.warn(se.getMessage(), se);
+					M_log.error(se.getMessage(), se);
 					throw se;
 				}
 				finally

--- a/kernel/component-manager/src/main/java/org/sakaiproject/component/impl/SpringCompMgr.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/component/impl/SpringCompMgr.java
@@ -165,7 +165,7 @@ public class SpringCompMgr implements ComponentManager {
 					M_log.fatal("Shutting down JVM");
 					System.exit(1);
 				} else {
-					M_log.warn(e.getMessage(), e);
+					M_log.error(e.getMessage(), e);
 				}
 			}
 		}
@@ -225,7 +225,7 @@ public class SpringCompMgr implements ComponentManager {
 				M_log.debug("get(" + iface.getName() + "): " + e, e);
 			}
 		} catch (Exception e) {
-			M_log.warn("get(" + iface.getName() + "): ", e);
+			M_log.error("get(" + iface.getName() + "): ", e);
 		}
 
 		return component;
@@ -245,7 +245,7 @@ public class SpringCompMgr implements ComponentManager {
 				M_log.debug("get(" + ifaceName + "): " + e, e);
 			}
 		} catch (Exception e) {
-			M_log.warn("get(" + ifaceName + "): ", e);
+			M_log.error("get(" + ifaceName + "): ", e);
 		}
 
 		return component;

--- a/kernel/component-manager/src/main/java/org/sakaiproject/util/ComponentsLoader.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/util/ComponentsLoader.java
@@ -115,7 +115,7 @@ public class ComponentsLoader
 			}
 		}
 		catch (Exception e) {
-			M_log.warn("load: exception: " + e, e);
+			M_log.error("load: exception: " + e, e);
 		}
 	}
 
@@ -185,7 +185,7 @@ public class ComponentsLoader
 		}
 		catch (Exception e)
 		{
-			M_log.warn("loadComponentPackage: exception loading: " + xml + " : " + e, e);
+			M_log.error("loadComponentPackage: exception loading: " + xml + " : " + e, e);
 		}
 		finally
 		{

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -955,7 +955,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 		catch (Exception t)
 		{
-			M_log.warn("init(): ", t);
+			M_log.error("init(): ", t);
 		}
 
 		this.m_useSmartSort = m_serverConfigurationService.getBoolean("content.smartSort", true);
@@ -2662,7 +2662,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("removeCollection(): closed ContentCollectionEdit", e);
+			M_log.error("removeCollection(): closed ContentCollectionEdit", e);
 			return;
 		}
 
@@ -2764,7 +2764,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 		catch (InconsistentException e)
 		{
-			M_log.warn("removeCollection():", e);
+			M_log.error("removeCollection():", e);
 		}
 		finally
 		{
@@ -2790,7 +2790,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("commitCollection(): closed ContentCollectionEdit", e);
+			M_log.error("commitCollection(): closed ContentCollectionEdit", e);
 			return;
 		}
 
@@ -2967,17 +2967,17 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				{
 					// If change of groups is consistent in superfolder, this should not occur here
 					m_storage.cancelResource(edit);
-					M_log.warn("verifyGroups(): ", e);
+					M_log.error("verifyGroups(): ", e);
 				} 
 				catch (PermissionException e) 
 				{
 					// If user has permission to change groups in superfolder, this should not occur here
 					m_storage.cancelResource(edit);
-					M_log.warn("verifyGroups(): ", e);
+					M_log.error("verifyGroups(): ", e);
 				} 
 				catch (ServerOverloadException e) 
 				{
-					M_log.warn("verifyGroups(): ", e);
+					M_log.error("verifyGroups(): ", e);
 				}
 			}
 			else
@@ -3000,13 +3000,13 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				{
 					// If change of groups is consistent in superfolder, this should not occur here
 					m_storage.cancelCollection(edit);
-					M_log.warn("verifyGroups(): ", e);
+					M_log.error("verifyGroups(): ", e);
 				} 
 				catch (PermissionException e) 
 				{
 					// If user has permission to change groups in superfolder, this should not occur here
 					m_storage.cancelCollection(edit);
-					M_log.warn("verifyGroups(): ", e);
+					M_log.error("verifyGroups(): ", e);
 				}
 			}
 		}
@@ -3025,7 +3025,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("cancelCollection(): closed ContentCollectionEdit", e);
+			M_log.error("cancelCollection(): closed ContentCollectionEdit", e);
 			return;
 		}
 
@@ -3072,23 +3072,23 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 			}
 			catch (IdUnusedException e)
 			{
-				M_log.warn("failed to removed canceled collection child", e);
+				M_log.error("failed to removed canceled collection child", e);
 			}
 			catch (TypeException e)
 			{
-				M_log.warn("failed to removed canceled collection child", e);
+				M_log.error("failed to removed canceled collection child", e);
 			}
 			catch (PermissionException e)
 			{
-				M_log.warn("failed to removed canceled collection child", e);
+				M_log.error("failed to removed canceled collection child", e);
 			}
 			catch (InUseException e)
 			{
-				M_log.warn("failed to removed canceled collection child", e);
+				M_log.error("failed to removed canceled collection child", e);
 			}
 			catch (ServerOverloadException e)
 			{
-				M_log.warn("failed to removed canceled collection child", e);
+				M_log.error("failed to removed canceled collection child", e);
 			}
 		}
 	}
@@ -4479,7 +4479,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("removeResource(): closed ContentResourceEdit", e);
+			M_log.error("removeResource(): closed ContentResourceEdit", e);
 			return;
 		}
 
@@ -4563,7 +4563,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("removeDeletedResource(): closed ContentResourceEdit", e);
+			M_log.error("removeDeletedResource(): closed ContentResourceEdit", e);
 			return;
 		}
 
@@ -4730,7 +4730,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				}
 				catch (IOException e)
 				{
-					M_log.warn("Failed to close when saving deleted content stream.", e);
+					M_log.error("Failed to close when saving deleted content stream.", e);
 				}
 			}
 		}
@@ -5916,7 +5916,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("commitResource(): closed ContentResourceEdit", e);
+			M_log.error("commitResource(): closed ContentResourceEdit", e);
 			return;
 		}
 		
@@ -6167,7 +6167,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("commitResourceEdit(): closed ContentResourceEdit", e);
+			M_log.error("commitResourceEdit(): closed ContentResourceEdit", e);
 			return;
 		}
 
@@ -6298,7 +6298,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (!edit.isActiveEdit())
 		{
 			Exception e = new Exception();
-			M_log.warn("cancelResource(): closed ContentResourceEdit", e);
+			M_log.error("cancelResource(): closed ContentResourceEdit", e);
 			return;
 		}
 
@@ -7951,7 +7951,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		catch (Exception any)
 		{
 			results.append("import interrputed: " + any.toString() + "\n");
-			M_log.warn("mergeContent(): exception: ", any);
+			M_log.error("mergeContent(): exception: ", any);
 		}
 
 		return results.toString();
@@ -8006,25 +8006,25 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 						}
 					} catch (InUseException e6) {
 						// TODO Auto-generated catch block
-						M_log.warn(this + thisKey, e6);
+						M_log.error(this + thisKey, e6);
 					}catch (PermissionException e1) {
-						M_log.warn(this + thisKey, e1);
+						M_log.error(this + thisKey, e1);
 					} catch (IdUnusedException e2) {
-						M_log.warn(this + thisKey, e2);
+						M_log.error(this + thisKey, e2);
 					} catch (TypeException e3) {
-						M_log.warn(this + thisKey, e3);
+						M_log.error(this + thisKey, e3);
 					} 
 	
 				}
 			}
 		} catch (PermissionException e1) {
-			M_log.warn(this + thisKey, e1);
+			M_log.error(this + thisKey, e1);
 		} catch (IdUnusedException e2) {
-			M_log.warn(this + thisKey, e2);
+			M_log.error(this + thisKey, e2);
 		} catch (TypeException e3) {
-			M_log.warn(this + thisKey, e3);
+			M_log.error(this + thisKey, e3);
 		} catch (ServerOverloadException e4) {
-			M_log.warn(this + thisKey, e4);
+			M_log.error(this + thisKey, e4);
 		}
 		
 	}
@@ -8087,28 +8087,28 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				}
 				catch (IdUnusedException eee)
 				{
-					M_log.warn(this + toContext, eee);
+					M_log.error(this + toContext, eee);
 				}
 				catch (TypeException eee)
 				{
-					M_log.warn(this + toContext, eee);
+					M_log.error(this + toContext, eee);
 				}
 			}
 			catch(IdUsedException ee)
 			{
-				M_log.warn(this + toContext, ee);
+				M_log.error(this + toContext, ee);
 			}
 			catch(IdInvalidException ee)
 			{
-				M_log.warn(this + toContext, ee);
+				M_log.error(this + toContext, ee);
 			}
 			catch (PermissionException ee)
 			{
-				M_log.warn(this + toContext, ee);
+				M_log.error(this + toContext, ee);
 			}
 			catch (InconsistentException ee)
 			{
-				M_log.warn(this + toContext, ee);
+				M_log.error(this + toContext, ee);
 			}
 			finally
 			{
@@ -8120,11 +8120,11 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 		catch (TypeException e)
 		{
-			M_log.warn(this + toContext, e);
+			M_log.error(this + toContext, e);
 		}
 		catch (PermissionException e)
 		{
-			M_log.warn(this + toContext, e);
+			M_log.error(this + toContext, e);
 		}
 
 		if (toCollection != null)
@@ -8538,15 +8538,15 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				+ StringUtil.limit(r.getProperties().getPropertyFormatted(ResourceProperties.PROP_DESCRIPTION), 30);
 			}
 		} catch (PermissionException e) {
-			M_log.warn("PermissionEception:", e);
+			M_log.error("PermissionEception:", e);
 		} catch (IdUnusedException e) {
-			M_log.warn("IdUnusedException:", e);
+			M_log.error("IdUnusedException:", e);
 		} catch (EntityPropertyNotDefinedException e) {
-			M_log.warn("EntityPropertyNotDefinedException:", e);
+			M_log.error("EntityPropertyNotDefinedException:", e);
 		} catch (EntityPropertyTypeException e) {
-			M_log.warn("EntityPropertyTypeException:", e);
+			M_log.error("EntityPropertyTypeException:", e);
 		} catch (TypeException e) {
-			M_log.warn("TypeException:", e);
+			M_log.error("TypeException:", e);
 		}
 		return rv;
 	}
@@ -8842,7 +8842,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				}
 				catch (IOException e)
 				{
-					M_log.warn("IOException ", e);
+					M_log.error("IOException ", e);
 				}
 			}
 
@@ -8854,7 +8854,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				}
 				catch (IOException e)
 				{
-					M_log.warn("IOException ", e);
+					M_log.error("IOException ", e);
 				}
 			}
 		}
@@ -9364,7 +9364,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 			try {
 				siteType = m_siteService.getSite(siteId).getType();
 			} catch (IdUnusedException e) {
-				M_log.warn("Quota calculation could not find the site '"+ siteId + "' to determine the type.", M_log.isDebugEnabled()?e:null);
+				M_log.error("Quota calculation could not find the site '"+ siteId + "' to determine the type.", e);
 			}
 
 			// use this quota unless we have one more specific
@@ -9441,7 +9441,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		// if we cannot, give up
 		catch (Exception any)
 		{
-			M_log.warn("generateCollections: " + any.getMessage(), any);
+			M_log.error("generateCollections: " + any.getMessage(), any);
 		}
 
 	} // generateCollections
@@ -11819,27 +11819,27 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					catch(TypeException e)
 					{
 						// TODO Auto-generated catch block
-						M_log.warn("TypeException",e);
+						M_log.error("TypeException",e);
 					} 
 					catch (IdUnusedException e) 
 					{
 						// TODO Auto-generated catch block
-						M_log.warn("IdUnusedException",e);
+						M_log.error("IdUnusedException",e);
 					} 
 					catch (PermissionException e) 
 					{
 						// TODO Auto-generated catch block
-						M_log.warn("PermissionException",e);
+						M_log.error("PermissionException",e);
 					} 
 					catch (InUseException e) 
 					{
 						// TODO Auto-generated catch block
-						M_log.warn("InUseException",e);
+						M_log.error("InUseException",e);
 					} 
 					catch (ServerOverloadException e) 
 					{
 						// TODO Auto-generated catch block
-						M_log.warn("ServerOverloadException",e);
+						M_log.error("ServerOverloadException",e);
 					}
 				}
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -474,7 +474,7 @@ public class DbContentService extends BaseContentService
         }
         catch (Exception t)
         {
-            M_log.warn("init(): ", t);
+            M_log.error("init(): ", t);
         }
 
         //testResourceByTypePaging();
@@ -549,13 +549,13 @@ public class DbContentService extends BaseContentService
                         }
                         catch(Exception e)
                         {
-                            M_log.warn("TEMPORARY LOG MESSAGE WITH STACK TRACE: Failed to create all resources; ch1 = " + ch1, e);
+                            M_log.error("TEMPORARY LOG MESSAGE WITH STACK TRACE: Failed to create all resources; ch1 = " + ch1, e);
                         }
                     }
                 }
                 catch(Exception e)
                 {
-                    M_log.warn("TEMPORARY LOG MESSAGE WITH STACK TRACE: Failed to create all collections; ch = " + ch, e);
+                    M_log.error("TEMPORARY LOG MESSAGE WITH STACK TRACE: Failed to create all collections; ch = " + ch, e);
                 }
             }
 
@@ -1084,7 +1084,7 @@ public class DbContentService extends BaseContentService
                 }
 
             } catch (SQLException e) {
-                M_log.warn("Unable to get database statement: " + e, e);
+                M_log.error("Unable to get database statement: " + e, e);
             } finally {
                 cleanup(connection, statement, rs, selectStatement, updateStatement);
             }
@@ -1172,28 +1172,28 @@ public class DbContentService extends BaseContentService
                     rs.close();
                 }
             } catch (SQLException ex) {
-                M_log.warn("Failed to close resultset: " + ex, ex);
+                M_log.error("Failed to close resultset: " + ex, ex);
             }
             try {
                 if (statement != null) {
                     statement.close();
                 }
             } catch (SQLException ex) {
-                M_log.warn("Failed to close statement: " + ex, ex);
+                M_log.error("Failed to close statement: " + ex, ex);
             }
             try {
                 if (selectStatement != null) {
                     selectStatement.close();
                 }
             } catch (SQLException ex) {
-                M_log.warn("Failed to close selectStatement: " + ex, ex);
+                M_log.error("Failed to close selectStatement: " + ex, ex);
             }
             try {
                 if (updateStatement != null) {
                     updateStatement.close();
                 }
             } catch (SQLException ex) {
-                M_log.warn("Failed to close updateStatement: " + ex, ex);
+                M_log.error("Failed to close updateStatement: " + ex, ex);
             }
             m_sqlService.returnConnection(connection);
         }
@@ -1698,7 +1698,7 @@ public class DbContentService extends BaseContentService
             }
             catch(Exception e)
             {
-                M_log.warn("sql == " + sql, e);
+                M_log.error("sql == " + sql, e);
             }
 
         }
@@ -1852,7 +1852,7 @@ public class DbContentService extends BaseContentService
                         cancelResource(edit);
                         ServerOverloadException e = new ServerOverloadException(message);
                         // may be overkill, but let's make sure stack trace gets to log
-                        M_log.warn(message, e);
+                        M_log.error(message, e);
                         throw e;
                     }
                     if(isInsideIndividualDropbox(edit.getId()))
@@ -2084,7 +2084,7 @@ public class DbContentService extends BaseContentService
 					   cancelResource(edit);
 					   ServerOverloadException e = new ServerOverloadException(message);
 					   // may be overkill, but let's make sure stack trace gets to log
-					   M_log.warn(message, e);
+					   M_log.error(message, e);
 					   throw e;
 				   }
 
@@ -2332,7 +2332,7 @@ public class DbContentService extends BaseContentService
             catch (IOException e)
             {
                 // If we have a non-zero body length and reading failed, it is an error worth of note
-                M_log.warn("Failed to read resource: " + resource.getId() + " len: " + ((BaseResourceEdit) resource).m_contentLength, e);
+                M_log.error("Failed to read resource: " + resource.getId() + " len: " + ((BaseResourceEdit) resource).m_contentLength, e);
                 throw new ServerOverloadException("Failed to read resource body", e);
             }
         }
@@ -2428,7 +2428,7 @@ public class DbContentService extends BaseContentService
             catch (IOException e)
             {
                 // TODO Auto-generated catch block
-                M_log.warn("IOException ", e);
+                M_log.error("IOException ", e);
             }
             finally
             {
@@ -2441,7 +2441,7 @@ public class DbContentService extends BaseContentService
                     catch (IOException e)
                     {
                         // TODO Auto-generated catch block
-                        M_log.warn("IOException ", e);
+                        M_log.error("IOException ", e);
                     }
                 }
             }
@@ -2482,7 +2482,7 @@ public class DbContentService extends BaseContentService
             }
             catch (IOException e)
             {
-                M_log.warn("IOException", e);
+                M_log.error("IOException", e);
                 return false;
             }
         }
@@ -2803,7 +2803,7 @@ public class DbContentService extends BaseContentService
         }
         catch (Exception e)
         {
-            M_log.warn("escapeResourceName: ", e);
+            M_log.error("escapeResourceName: ", e);
             return id;
         }
     }
@@ -3307,7 +3307,7 @@ public class DbContentService extends BaseContentService
             }
             catch(Exception e)
             {
-                M_log.warn("ContextAndFilesizeReader.readSqlResultRecord() failed. result skipped", e);
+                M_log.error("ContextAndFilesizeReader.readSqlResultRecord() failed. result skipped", e);
             }
 
             return null;

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
@@ -438,7 +438,7 @@ public class BasicEmailService implements EmailService
 		}
 		catch (MessagingException e)
 		{
-			M_log.warn("Email.sendMail: exception: " + e.getMessage(), e);
+			M_log.error("Email.sendMail: exception: " + e.getMessage(), e);
 		}
 	}
 
@@ -934,7 +934,7 @@ public class BasicEmailService implements EmailService
 			addresses = send(msg,true);
 		}
 		catch (MessagingException e) {
-			M_log.warn("Email.sendMail: exception: " + e.getMessage(), e);
+			M_log.error("Email.sendMail: exception: " + e.getMessage(), e);
 		}
 		return addresses;
 	}
@@ -1046,7 +1046,7 @@ public class BasicEmailService implements EmailService
 		} catch (MessagingException e) {
 			// Just log it, if user doesn't want it thrown
 			if (messagingException == false) {
-				M_log.warn("Email.sendMail: exception: " + e.getMessage(), e);
+				M_log.error("Email.sendMail: exception: " + e.getMessage(), e);
 			} else {
 				throw e;
 			}
@@ -1668,12 +1668,12 @@ public class BasicEmailService implements EmailService
 			 } 
 			 catch (MessagingException e) 
 			 {
-				  M_log.warn("Email.MyMessage: exception: " + e, e);
+				  M_log.error("Email.MyMessage: exception: " + e, e);
 				  addHeaderLine(header);
 			 } 
 			 catch (UnsupportedEncodingException e)
 			 {
-				  M_log.warn("Email.MyMessage: exception: " + e, e);
+				  M_log.error("Email.MyMessage: exception: " + e, e);
 				  addHeaderLine(header);
 			 }
 		} 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/UsageSessionServiceAdaptor.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/UsageSessionServiceAdaptor.java
@@ -227,7 +227,7 @@ public abstract class UsageSessionServiceAdaptor implements UsageSessionService
 		}
 		catch (Exception t)
 		{
-			M_log.warn("init(): ", t);
+			M_log.error("init(): ", t);
 		}
 		setUsageSessionServiceSql(sqlService().getVendor());
 		
@@ -321,9 +321,9 @@ public abstract class UsageSessionServiceAdaptor implements UsageSessionService
 					String hashedSessionId = byteArray2Hex(digest);					
 					s.setAttribute(SAKAI_CSRF_SESSION_ATTRIBUTE, hashedSessionId);
 				} catch (NoSuchAlgorithmException e) {
-					M_log.warn("Failed to create a hashed session id for use as CSRF token because no SHA-256 support", e);
+					M_log.error("Failed to create a hashed session id for use as CSRF token because no SHA-256 support", e);
 				} catch (UnsupportedEncodingException e) {
-					M_log.warn("Failed to create a hashed session id for use as CSRF token because could not get UTF-8 bytes of session id", e);
+					M_log.error("Failed to create a hashed session id for use as CSRF token because could not get UTF-8 bytes of session id", e);
 				}
 				
 				// set as the current session
@@ -769,7 +769,7 @@ public abstract class UsageSessionServiceAdaptor implements UsageSessionService
 				}
 				catch (Exception e)
 				{
-					M_log.warn("unBindAttributeValue: unbinding exception: ", e);
+					M_log.error("unBindAttributeValue: unbinding exception: ", e);
 				}
 			}
 		}
@@ -793,7 +793,7 @@ public abstract class UsageSessionServiceAdaptor implements UsageSessionService
 				}
 				catch (Exception e)
 				{
-					M_log.warn("bindAttributeValue: unbinding exception: ", e);
+					M_log.error("bindAttributeValue: unbinding exception: ", e);
 				}
 			}
 		}
@@ -1060,7 +1060,7 @@ public abstract class UsageSessionServiceAdaptor implements UsageSessionService
 				totalSessionsCount = counts.get(0);
 			}
 		} catch (Exception e) {
-			M_log.warn("Could not get count of sessions.", e);
+			M_log.error("Could not get count of sessions.", e);
 		}
 		return totalSessionsCount;
 	}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -499,7 +499,7 @@ public abstract class BaseSiteService implements SiteService, Observer
 		}
 		catch (Exception t)
 		{
-			M_log.warn(".init(): ", t);
+			M_log.error(".init(): ", t);
 		}
 	}
 
@@ -1309,7 +1309,7 @@ public abstract class BaseSiteService implements SiteService, Observer
 		}
 		catch (Exception e)
 		{
-			M_log.warn(".addSite(): error copying realm", e);
+			M_log.error(".addSite(): error copying realm", e);
 		}
 
 		// clear the site's notification id in properties
@@ -2506,7 +2506,7 @@ public abstract class BaseSiteService implements SiteService, Observer
 				}
 				catch (Exception t)
 				{
-					M_log.warn("Error encountered while notifying ContextObserver of Site Change", t);
+					M_log.error("Error encountered while notifying ContextObserver of Site Change", t);
 				}
 			}
 		}
@@ -2542,7 +2542,7 @@ public abstract class BaseSiteService implements SiteService, Observer
 				}
 				catch (Exception t)
 				{
-					M_log.warn("Error encountered while notifying ContextObserver of Site Change", t);
+					M_log.error("Error encountered while notifying ContextObserver of Site Change", t);
 				}
 			}
 		}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -600,7 +600,7 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		}
 		catch (Exception t)
 		{
-			M_log.warn("init(): ", t);
+			M_log.error("init(): ", t);
 		}
 	}
 
@@ -1212,7 +1212,7 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		// check for closed edit
 		if (!user.isActiveEdit())
 		{
-			M_log.warn("commitEdit(): closed UserEdit", new Exception());
+			M_log.error("commitEdit(): closed UserEdit", new Exception());
 			return;
 		}
 
@@ -1254,7 +1254,7 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 			}
 			catch (Exception e)
 			{
-				M_log.warn("cancelEdit(): closed UserEdit", e);
+				M_log.error("cancelEdit(): closed UserEdit", e);
 			}
 			return;
 		}
@@ -1564,7 +1564,7 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		// check for closed edit
 		if (!user.isActiveEdit())
 		{
-			M_log.warn("removeUser(): closed UserEdit", new Exception());
+			M_log.error("removeUser(): closed UserEdit", new Exception());
 			return;
 		}
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -372,7 +372,7 @@ public class FormattedTextImpl implements FormattedText
                 } catch (ScanException e) {
                     // this will match the legacy behavior
                     val = "";
-                    M_log.warn("processFormattedText: Failure during scan of input html: " + e, e);
+                    M_log.error("processFormattedText: Failure during scan of input html: " + e, e);
                 } catch (PolicyException e) {
                     // this is an unrecoverable failure
                     throw new RuntimeException("Unable to access the antiSamy policy file: "+e, e);
@@ -388,7 +388,7 @@ public class FormattedTextImpl implements FormattedText
             // We catch all exceptions here because doing so will usually give the user the
             // opportunity to work around the issue, rather than causing a tool stack trace
 
-            M_log.warn("Unexpected error processing text", e);
+            M_log.error("Unexpected error processing text", e);
             formattedTextErrors.append(getResourceLoader().getString("unknown_error_markup") + "\n");
             val = null;
         }
@@ -581,7 +581,7 @@ public class FormattedTextImpl implements FormattedText
         }
         catch (Exception e)
         {
-            M_log.warn("Validator.escapeHtml: ", e);
+            M_log.error("Validator.escapeHtml: ", e);
             return "";
         }
     }
@@ -625,7 +625,7 @@ public class FormattedTextImpl implements FormattedText
                 hrefTitle = matcher.group();
             }
         } catch (Exception e) {
-            M_log.warn("FormattedText.processAnchor ", e);
+            M_log.error("FormattedText.processAnchor ", e);
         }
 
         if (hrefTarget != null) {
@@ -683,13 +683,13 @@ public class FormattedTextImpl implements FormattedText
             // TODO call encodeUnicode in other process routine
             html = encodeUnicode(source);
         } catch (Exception e) {
-            M_log.warn("FormattedText.processEscapedHtml encodeUnicode(source):"+e, e);
+            M_log.error("FormattedText.processEscapedHtml encodeUnicode(source):"+e, e);
         }
         try {
             // to use the FormattedText functions
             html = unEscapeHtml(html);
         } catch (Exception e) {
-            M_log.warn("FormattedText.processEscapedHtml unEscapeHtml(Html):"+e, e);
+            M_log.error("FormattedText.processEscapedHtml unEscapeHtml(Html):"+e, e);
         }
 
         return processFormattedText(html, new StringBuilder());
@@ -996,7 +996,7 @@ public class FormattedTextImpl implements FormattedText
         }
         catch (Exception e)
         {
-            M_log.warn("escapeJavascript: ", e);
+            M_log.error("escapeJavascript: ", e);
             return value;
         }
     }
@@ -1056,7 +1056,7 @@ public class FormattedTextImpl implements FormattedText
         }
         catch (UnsupportedEncodingException e)
         {
-            M_log.warn("Validator.escapeUrl: ", e);
+            M_log.error("Validator.escapeUrl: ", e);
             return "";
         }
     }
@@ -1217,7 +1217,7 @@ public class FormattedTextImpl implements FormattedText
 		try {
 			nbFormat = NumberFormat.getNumberInstance(new ResourceLoader().getLocale());
 		} catch (Exception e) {
-			M_log.warn("Error while retrieving local number format, using default ", e);
+			M_log.error("Error while retrieving local number format, using default ", e);
 		}
 		if (maxFractionDigits!=null) nbFormat.setMaximumFractionDigits(maxFractionDigits);
 		if (minFractionDigits!=null) nbFormat.setMinimumFractionDigits(minFractionDigits);

--- a/providers/jldap/src/java/edu/amc/sakai/user/JLDAPDirectoryProvider.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/JLDAPDirectoryProvider.java
@@ -487,7 +487,7 @@ public class JLDAPDirectoryProvider implements UserDirectoryProvider, LdapConnec
 					}
 					resolvedEntry = getUserByEid(eid, null);
 				} catch ( InvalidEmailAddressException e ) {
-					M_log.warn("findUserByEmail(): Attempted to look up user at an invalid email address [" + email + "]", e);
+					M_log.error("findUserByEmail(): Attempted to look up user at an invalid email address [" + email + "]", e);
 					useStdFilter = true; // fall back to std processing, we cant derive an EID from this addr
 				}
 			}

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -774,7 +774,7 @@ public class SiteManageGroupSectionRoleHandler {
     			resetParams();
 	        } 
 	        catch (IdUnusedException | PermissionException e) {
-	        	M_log.warn(this + ".processAddGroup: cannot find site " + site.getId(), e);
+	        	M_log.error(this + ".processAddGroup: cannot find site " + site.getId(), e);
 	            return null;
 	        }
     	}
@@ -808,7 +808,7 @@ public class SiteManageGroupSectionRoleHandler {
                 }
                 catch (Exception e)
                 {
-                    M_log.warn( e );
+                    M_log.error( e );
                 }
             }
 	    	return "confirm";
@@ -833,10 +833,10 @@ public class SiteManageGroupSectionRoleHandler {
 				siteService.save(site);
 			} catch (IdUnusedException e) {
 				messages.addMessage(new TargettedMessage("editgroup.site.notfound.alert","cannot find site"));
-				M_log.warn(this + ".processDeleteGroups: Problem of saving site after group removal: site id =" + site.getId(), e);
+				M_log.error(this + ".processDeleteGroups: Problem of saving site after group removal: site id =" + site.getId(), e);
 			} catch (PermissionException e) {
 				messages.addMessage(new TargettedMessage("editgroup.site.permission.alert","not allowed to find site"));
-				M_log.warn(this + ".processDeleteGroups: Permission problem of saving site after group removal: site id=" + site.getId(), e);
+				M_log.error(this + ".processDeleteGroups: Permission problem of saving site after group removal: site id=" + site.getId(), e);
 			}
 	    	
 	    }
@@ -1049,7 +1049,7 @@ public class SiteManageGroupSectionRoleHandler {
                 resetParams();
             } 
             catch (IdUnusedException | PermissionException e) {
-                M_log.warn(this + ".processAutoCreateGroup: cannot find site " + site.getId(), e);
+                M_log.error(this + ".processAutoCreateGroup: cannot find site " + site.getId(), e);
                 return null;
             }
         }

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/job/SeedSitesAndUsersJob.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/job/SeedSitesAndUsersJob.java
@@ -137,9 +137,9 @@ public class SeedSitesAndUsersJob implements Job {
 				collection = createCollection(collectionName);
 				contentHostingService.commitCollection((ContentCollectionEdit) collection);
 			} catch (TypeException te) {
-				log.warn("seedData, wrong collection type: ", te);
+				log.error("seedData, wrong collection type: ", te);
             } catch (PermissionException pe) {
-    			log.warn("seedData, collection permission: ", pe);
+    			log.error("seedData, collection permission: ", pe);
             }
 			
 			if (collection != null) {
@@ -159,11 +159,11 @@ public class SeedSitesAndUsersJob implements Job {
 					resourceEdit.setContentType("text/plain");
 					contentHostingService.commitResource(resourceEdit, NotificationService.NOTI_NONE);
 				} catch (Exception e) {
-					log.warn("seedData, cannot add resource: " + collectionName + fileName + ".txt", e);
+					log.error("seedData, cannot add resource: " + collectionName + fileName + ".txt", e);
 				}
 				totalBytes += rawFile.length;
 			} else {
-				log.warn("seedData, could not get collection: " + collectionName);
+				log.error("seedData, could not get collection: " + collectionName);
 				break;
 			}
 		}
@@ -193,13 +193,13 @@ public class SeedSitesAndUsersJob implements Job {
 			collectionEdit = contentHostingService.addCollection(collectionName);
 			collectionEdit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME, "searchdata");
 		} catch (IdUsedException iue) {
-			log.warn("createCollection, existing collection: ", iue);
+			log.error("createCollection, existing collection: ", iue);
 		} catch (IdInvalidException iie) {
-			log.warn("createCollection, invalid collection id: ", iie);
+			log.error("createCollection, invalid collection id: ", iie);
 		} catch (PermissionException pe) {
-			log.warn("createCollection, collection permission: ", pe);
+			log.error("createCollection, collection permission: ", pe);
 		} catch (InconsistentException ie) {
-			log.warn("createCollection, collection inconsistent: ", ie);
+			log.error("createCollection, collection inconsistent: ", ie);
 		}
 		return collectionEdit;
 	}
@@ -255,12 +255,12 @@ public class SeedSitesAndUsersJob implements Job {
 			try {
 	            user = userDirectoryService.addUser(null, eid, faker.name().firstName(), lastName, eid + "@nowhere.com", faker.letterify("???????"), userType, null);
             } catch (UserIdInvalidException uiue) {
-            	log.warn("createUsers, invalid userId: ", uiue);
+            	log.error("createUsers, invalid userId: ", uiue);
             } catch (UserAlreadyDefinedException uade) {
-            	log.warn("createUsers, already exists: ", uade);
+            	log.error("createUsers, already exists: ", uade);
             	user = createUser(userType);
             } catch (UserPermissionException upe) {
-            	log.warn("createUsers, permission: ", upe);
+            	log.error("createUsers, permission: ", upe);
             }
 			
 		return user;
@@ -283,9 +283,9 @@ public class SeedSitesAndUsersJob implements Job {
 			try {
 				siteService.save(site);
 			} catch (IdUnusedException iue) {
-				log.warn("createEnrollments, site doesn't exist:", iue);
+				log.error("createEnrollments, site doesn't exist:", iue);
 			} catch (PermissionException pe) {
-				log.warn("createEnrollments, site save permission:", pe);
+				log.error("createEnrollments, site save permission:", pe);
 			}
 		}
 	}

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2403,7 +2403,7 @@ public class SiteAction extends PagedResourceActionII {
 				}
 				
 			} catch (Exception e) {
-				M_log.warn(this + " buildContextForTemplate chef_site-siteInfo-list.vm ", e);
+				M_log.error(this + " buildContextForTemplate chef_site-siteInfo-list.vm ", e);
 			}
 
 			roles = getRoles(state);
@@ -4315,7 +4315,7 @@ public class SiteAction extends PagedResourceActionII {
 			// in the properties file, use 1 MB as a default
 			max_file_size_mb = "1";
 			max_bytes = 1024 * 1024;
-			M_log.warn(this + ".doUpload_Mtrl_Frm_File: wrong setting of content.upload.max = " + max_file_size_mb, e);
+			M_log.error(this + ".doUpload_Mtrl_Frm_File: wrong setting of content.upload.max = " + max_file_size_mb, e);
 		}
 		if (fileFromUpload == null) {
 			// "The user submitted a file to upload but it was too big!"
@@ -4351,10 +4351,10 @@ public class SiteAction extends PagedResourceActionII {
 				fileInput = new ResetOnCloseInputStream(tempFile);
 			}
 			catch (FileNotFoundException fnfe) {
-				M_log.warn("FileNotFoundException creating temp import file",fnfe);
+				M_log.error("FileNotFoundException creating temp import file",fnfe);
 			}
 			catch (IOException ioe) {
-				M_log.warn("IOException creating temp import file",ioe);
+				M_log.error("IOException creating temp import file",ioe);
 			}
 			finally {
 				IOUtils.closeQuietly(fileInputStream);
@@ -4768,7 +4768,7 @@ public class SiteAction extends PagedResourceActionII {
 					userWorkspaceSite = SiteService.getSite(SiteService
 							.getUserSiteId(userId));
 				} catch (IdUnusedException e) {
-					M_log.warn(this + "sizeResources, template index = 0: Cannot find user "
+					M_log.error(this + "sizeResources, template index = 0: Cannot find user "
 							+ SessionManager.getCurrentSessionUserId()
 							+ "'s My Workspace site.", e);
 				}
@@ -4916,7 +4916,7 @@ public class SiteAction extends PagedResourceActionII {
 					userWorkspaceSite = SiteService.getSite(SiteService
 							.getUserSiteId(userId));
 				} catch (IdUnusedException e) {
-					M_log.warn(this + "readResourcesPage template index = 0 :Cannot find user " + SessionManager.getCurrentSessionUserId() + "'s My Workspace site.", e);
+					M_log.error(this + "readResourcesPage template index = 0 :Cannot find user " + SessionManager.getCurrentSessionUserId() + "'s My Workspace site.", e);
 				}
 				String view = (String) state.getAttribute(STATE_VIEW_SELECTED);
 				if (view != null) {
@@ -5213,10 +5213,10 @@ public class SiteAction extends PagedResourceActionII {
 						SiteService.removeSite(site);
 						M_log.debug("Removed site: " + site.getId());
 					} catch (IdUnusedException e) {
-						M_log.warn(this +".doSite_delete_confirmed - IdUnusedException " + id, e);
+						M_log.error(this +".doSite_delete_confirmed - IdUnusedException " + id, e);
 						addAlert(state, rb.getFormattedMessage("java.couldnt", new Object[]{site_title,id}));
 					} catch (PermissionException e) {
-						M_log.warn(this + ".doSite_delete_confirmed -  PermissionException, site " + site_title + "(" + id + ").", e);
+						M_log.error(this + ".doSite_delete_confirmed -  PermissionException, site " + site_title + "(" + id + ").", e);
 						addAlert(state, rb.getFormattedMessage("java.dontperm", new Object[]{site_title}));
 					}
 				} else {
@@ -5478,7 +5478,7 @@ public class SiteAction extends PagedResourceActionII {
 			}catch (Exception e) {  
 				// should never happened, as the list of templates are generated
 				// from existing sites
-				M_log.warn(this + ".doSite_type" + e.getClass().getName(), e);
+				M_log.error(this + ".doSite_type" + e.getClass().getName(), e);
 				state.removeAttribute(STATE_TEMPLATE_SITE);
 			}
 			
@@ -5645,7 +5645,7 @@ public class SiteAction extends PagedResourceActionII {
 								UserDirectoryService.getUserByEid(eid);
 							} catch (UserNotDefinedException e) {
 								addAlert(state, rb.getFormattedMessage("java.validAuthor", new Object[]{ServerConfigurationService.getString("officialAccountName")}));
-								M_log.warn(this + ".doManual_add_course: cannot find user with eid=" + eid, e);
+								M_log.error(this + ".doManual_add_course: cannot find user with eid=" + eid, e);
 							}
 						}
 					}
@@ -6803,12 +6803,12 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				AliasService.removeAlias(aliasId);
 			} catch ( PermissionException e ) {
 				addAlert(state, rb.getFormattedMessage("java.delalias", new Object[]{aliasId}));
-				M_log.warn(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.delalias", new Object[]{aliasId}), e);
+				M_log.error(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.delalias", new Object[]{aliasId}), e);
 			} catch ( IdUnusedException e ) {
 				// no problem
 			} catch ( InUseException e ) {
 				addAlert(state, rb.getFormattedMessage("java.delalias", new Object[]{aliasId}) + rb.getFormattedMessage("java.alias.locked", new Object[]{aliasId}));
-				M_log.warn(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.delalias", new Object[]{aliasId}) + rb.getFormattedMessage("java.alias.locked", new Object[]{aliasId}), e);
+				M_log.error(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.delalias", new Object[]{aliasId}) + rb.getFormattedMessage("java.alias.locked", new Object[]{aliasId}), e);
 	 			}
 	 		}
 		for ( String aliasId : aliasIdsToAdd ) {
@@ -6816,13 +6816,13 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				AliasService.setAlias(aliasId, siteReference);
 			} catch ( PermissionException e ) {
 				addAlert(state, rb.getString("java.addalias") + " ");
-				M_log.warn(this + ".setSiteReferenceAliases: " + rb.getString("java.addalias"), e);
+				M_log.error(this + ".setSiteReferenceAliases: " + rb.getString("java.addalias"), e);
 			} catch ( IdInvalidException e ) {
 				addAlert(state, rb.getFormattedMessage("java.alias.isinval", new Object[]{aliasId}));
-				M_log.warn(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.alias.isinval", new Object[]{aliasId}), e);
+				M_log.error(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.alias.isinval", new Object[]{aliasId}), e);
 			} catch ( IdUsedException e ) {
 				addAlert(state, rb.getFormattedMessage("java.alias.exists", new Object[]{aliasId}));
-				M_log.warn(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.alias.exists", new Object[]{aliasId}), e);
+				M_log.error(this + ".setSiteReferenceAliases: " + rb.getFormattedMessage("java.alias.exists", new Object[]{aliasId}), e);
 			}
 		}
 	}
@@ -6885,7 +6885,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				realmEdit.setProviderGroupId(providerRealm);
 				AuthzGroupService.save(realmEdit);
 			} catch (GroupNotDefinedException e) {
-				M_log.warn(this + ".updateCourseSiteSections: IdUnusedException, not found, or not an AuthzGroup object", e);
+				M_log.error(this + ".updateCourseSiteSections: IdUnusedException, not found, or not an AuthzGroup object", e);
 				addAlert(state, rb.getString("java.realm"));
 			}
 			catch (AuthzPermissionException e)
@@ -7815,7 +7815,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						}
 						catch (Exception e)
 						{
-							M_log.warn(this + ".doMenu_siteinfo_addClass: " + e.getMessage() + site.getId(), e);
+							M_log.error(this + ".doMenu_siteinfo_addClass: " + e.getMessage() + site.getId(), e);
 						}
 						found=true;
 					}
@@ -7836,7 +7836,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			}
 			catch (Exception e)
 			{
-				M_log.warn(this + ".doMenu_siteinfo_addClass: " + e.getMessage() + termEid, e);
+				M_log.error(this + ".doMenu_siteinfo_addClass: " + e.getMessage() + termEid, e);
 			}
 		}
 		else
@@ -8302,7 +8302,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			state.setAttribute(STATE_SITE_TYPE, type);
 
 		} catch (IdUnusedException e) {
-			M_log.warn(this + ".getReviseSite: " +  e.toString() + " site id = " + siteId, e);
+			M_log.error(this + ".getReviseSite: " +  e.toString() + " site id = " + siteId, e);
 		}
 
 		// one site has been selected
@@ -8637,7 +8637,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 								}
 							}
 						} catch (UserNotDefinedException e) {
-							M_log.warn(this + ".doUpdate_participant: IdUnusedException " + rId + ". ", e);
+							M_log.error(this + ".doUpdate_participant: IdUnusedException " + rId + ". ", e);
 							if (("admins".equals(showOrphanedMembers) && SecurityService.isSuperUser()) || ("maintainers".equals(showOrphanedMembers))) {
 								Member userMember = realmEdit.getMember(rId);
 								if (userMember != null) {
@@ -8704,10 +8704,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				}
 			} catch (GroupNotDefinedException e) {
 				addAlert(state, rb.getString("java.problem2"));
-				M_log.warn(this + ".doUpdate_participant: IdUnusedException " + s.getTitle() + "(" + realmId + "). ", e);
+				M_log.error(this + ".doUpdate_participant: IdUnusedException " + s.getTitle() + "(" + realmId + "). ", e);
 			} catch (AuthzPermissionException e) {
 				addAlert(state, rb.getString("java.changeroles"));
-				M_log.warn(this + ".doUpdate_participant: PermissionException " + s.getTitle() + "(" + realmId + "). ", e);
+				M_log.error(this + ".doUpdate_participant: PermissionException " + s.getTitle() + "(" + realmId + "). ", e);
 			}
 		}
 
@@ -8775,7 +8775,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						}
 						catch (Exception ee)
 						{
-							M_log.warn(this + ".doUpdate_related_group_participants: " + ee.getMessage() + g.getId(), ee);
+							M_log.error(this + ".doUpdate_related_group_participants: " + ee.getMessage() + g.getId(), ee);
 						}
 					}
 					
@@ -8785,7 +8785,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			}
 			catch (Exception e)
 			{
-				M_log.warn(this + ".doUpdate_related_group_participants: " + e.getMessage() + s.getId(), e);
+				M_log.error(this + ".doUpdate_related_group_participants: " + e.getMessage() + s.getId(), e);
 			}
 		}
 	}
@@ -9477,11 +9477,11 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 									
 									AuthzGroupService.save(realmEdit);
 								} catch (GroupNotDefinedException e) {
-									M_log.warn(this + ".actionForTemplate chef_siteinfo-duplicate: IdUnusedException, not found, or not an AuthzGroup object "+ realm, e);
+									M_log.error(this + ".actionForTemplate chef_siteinfo-duplicate: IdUnusedException, not found, or not an AuthzGroup object "+ realm, e);
 									addAlert(state, rb.getString("java.realm"));
 								} catch (AuthzPermissionException e) {
 									addAlert(state, this + rb.getString("java.notaccess"));
-									M_log.warn(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.notaccess"), e);
+									M_log.error(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.notaccess"), e);
 								}
 							
 							} catch (IdUnusedException e) {
@@ -9506,13 +9506,13 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 
 						} catch (IdInvalidException e) {
 							addAlert(state, rb.getString("java.siteinval"));
-							M_log.warn(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.siteinval") + " site id = " + newSiteId, e);
+							M_log.error(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.siteinval") + " site id = " + newSiteId, e);
 						} catch (IdUsedException e) {
 							addAlert(state, rb.getString("java.sitebeenused"));
-							M_log.warn(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.sitebeenused") + " site id = " + newSiteId, e);
+							M_log.error(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.sitebeenused") + " site id = " + newSiteId, e);
 						} catch (PermissionException e) {
 							addAlert(state, rb.getString("java.allowcreate"));
-							M_log.warn(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.allowcreate") + " site id = " + newSiteId, e);
+							M_log.error(this + ".actionForTemplate chef_siteinfo-duplicate: " + rb.getString("java.allowcreate") + " site id = " + newSiteId, e);
 						}
 					}
 				}
@@ -9702,7 +9702,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				}
 				catch (Exception e)
 				{
-					M_log.warn(this + ".actionForTemplate chef_siteinfo-addCourseConfirm: " +  e.getMessage() + site.getId(), e);
+					M_log.error(this + ".actionForTemplate chef_siteinfo-addCourseConfirm: " +  e.getMessage() + site.getId(), e);
 				}
 				
 				removeAddClassContext(state);
@@ -9783,10 +9783,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						}
 					}
 				} catch (GroupNotDefinedException e) {
-					M_log.warn(this + ".importSitesUsers: GroupNotDefinedException, " + fromSiteId + " not found, or not an AuthzGroup object", e);
+					M_log.error(this + ".importSitesUsers: GroupNotDefinedException, " + fromSiteId + " not found, or not an AuthzGroup object", e);
 					addAlert(state, rb.getString("java.cannotedit"));
 				} catch (IdUnusedException e) {
-					M_log.warn(this + ".importSitesUsers: IdUnusedException, " + fromSiteId + " not found, or not an AuthzGroup object", e);
+					M_log.error(this + ".importSitesUsers: IdUnusedException, " + fromSiteId + " not found, or not an AuthzGroup object", e);
 				
 				}
 			}
@@ -9798,10 +9798,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			AuthzGroupService.save(realm);
 			
 		} catch (GroupNotDefinedException e) {
-			M_log.warn(this + ".importSitesUsers: IdUnusedException, " + site.getTitle() + "(" + site.getId() + ") not found, or not an AuthzGroup object", e);
+			M_log.error(this + ".importSitesUsers: IdUnusedException, " + site.getTitle() + "(" + site.getId() + ") not found, or not an AuthzGroup object", e);
 			addAlert(state, rb.getString("java.cannotedit"));
 		} catch (AuthzPermissionException e) {
-			M_log.warn(this + ".importSitesUsers: PermissionException, user does not have permission to edit AuthzGroup object " + site.getTitle() + "(" + site.getId() + "). ", e);
+			M_log.error(this + ".importSitesUsers: PermissionException, user does not have permission to edit AuthzGroup object " + site.getTitle() + "(" + site.getId() + "). ", e);
 			addAlert(state, rb.getString("java.notaccess"));
 		}
 	}
@@ -10089,13 +10089,13 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 					AuthzGroupService.save(realmEdit1);
 				}
 			} catch (GroupNotDefinedException e) {
-				M_log.warn(this + ".updateCourseClasses: IdUnusedException, " + site.getTitle()
+				M_log.error(this + ".updateCourseClasses: IdUnusedException, " + site.getTitle()
 						+ "(" + realmId
 						+ ") not found, or not an AuthzGroup object", e);
 				addAlert(state, rb.getString("java.cannotedit"));
 				return;
 			} catch (AuthzPermissionException e) {
-				M_log.warn(this + ".updateCourseClasses: PermissionException, user does not have permission to edit AuthzGroup object "
+				M_log.error(this + ".updateCourseClasses: PermissionException, user does not have permission to edit AuthzGroup object "
 								+ site.getTitle() + "(" + realmId + "). ", e);
 				addAlert(state, rb.getString("java.notaccess"));
 				return;
@@ -10112,13 +10112,13 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				realmEdit2.setProviderGroupId(externalRealm);
 				AuthzGroupService.save(realmEdit2);
 			} catch (GroupNotDefinedException e) {
-				M_log.warn(this + ".updateCourseClasses: IdUnusedException, " + site.getTitle()
+				M_log.error(this + ".updateCourseClasses: IdUnusedException, " + site.getTitle()
 						+ "(" + realmId
 						+ ") not found, or not an AuthzGroup object", e);
 				addAlert(state, rb.getString("java.cannotclasses"));
 				return;
 			} catch (AuthzPermissionException e) {
-				M_log.warn(this
+				M_log.error(this
 								+ ".updateCourseClasses: PermissionException, user does not have permission to edit AuthzGroup object "
 								+ site.getTitle() + "(" + realmId + "). ", e);
 				addAlert(state, rb.getString("java.notaccess"));
@@ -10158,7 +10158,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			}
 			catch (Exception e)
 			{
-				M_log.warn(this + ".updateCourseClasses: cannot remove authzgroup : " + group.getReference(), e);
+				M_log.error(this + ".updateCourseClasses: cannot remove authzgroup : " + group.getReference(), e);
 			}
 		}
 
@@ -10175,7 +10175,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 								(List<SectionObject>) state.getAttribute(STATE_MANUAL_ADD_COURSE_FIELDS), 
 								"manual");
 			} catch (Exception e) {
-				M_log.warn(this +".updateCourseClasses:" + e.toString(), e);
+				M_log.error(this +".updateCourseClasses:" + e.toString(), e);
 			}
 		}
 		if (notifyClasses != null && notifyClasses.size() > 0) {
@@ -10183,7 +10183,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				// send out class access confirmation notifications
 				sendSiteNotification(state, getStateSite(state), notifyClasses);
 			} catch (Exception e) {
-				M_log.warn(this + ".updateCourseClasses:" + e.toString(), e);
+				M_log.error(this + ".updateCourseClasses:" + e.toString(), e);
 			}
 		}
 	} // updateCourseClasses
@@ -10404,7 +10404,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 					SiteService.getSite(id);
 					state.setAttribute(STATE_SITE_INSTANCE_ID, id);
 				} catch (IdUnusedException e) {
-					M_log.warn(this + ".updateSiteAttributes: IdUnusedException "
+					M_log.error(this + ".updateSiteAttributes: IdUnusedException "
 							+ siteInfo.getTitle() + "(" + id + ") not found", e);
 				}
 			}
@@ -10616,7 +10616,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			}
 			Collections.sort(roles);
 		} catch (GroupNotDefinedException e) {
-			M_log.warn( this + ".getRoles: IdUnusedException " + realmId, e);
+			M_log.error( this + ".getRoles: IdUnusedException " + realmId, e);
 		}
 		return roles;
 
@@ -10674,7 +10674,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				}
 				Collections.sort(roles);
 			} catch (GroupNotDefinedException e) {
-				M_log.warn( this + ".getRoles: IdUnusedException " + realmId, e);
+				M_log.error( this + ".getRoles: IdUnusedException " + realmId, e);
 			}
 		}
 		return roles;
@@ -10782,11 +10782,11 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 								AliasService.setAlias(alias,
 										channelReference);
 							} catch (IdUsedException exception) {
-								M_log.warn(this + ".saveFeatures setAlias IdUsedException:"+exception.getMessage()+" alias="+ alias + " channelReference="+channelReference, exception);
+								M_log.error(this + ".saveFeatures setAlias IdUsedException:"+exception.getMessage()+" alias="+ alias + " channelReference="+channelReference, exception);
 							} catch (IdInvalidException exception) {
-								M_log.warn(this + ".saveFeatures setAlias IdInvalidException:"+exception.getMessage()+" alias="+ alias + " channelReference="+channelReference, exception);
+								M_log.error(this + ".saveFeatures setAlias IdInvalidException:"+exception.getMessage()+" alias="+ alias + " channelReference="+channelReference, exception);
 							} catch (PermissionException exception) {
-								M_log.warn(this + ".saveFeatures setAlias PermissionException:"+exception.getMessage()+" alias="+ alias + " channelReference="+channelReference, exception);
+								M_log.error(this + ".saveFeatures setAlias PermissionException:"+exception.getMessage()+" alias="+ alias + " channelReference="+channelReference, exception);
 							}
 						}
 					}
@@ -10892,7 +10892,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 							String toolTitleText = rb.getString(SYNOPTIC_TOOL_TITLE_MAP.get(homeToolId));
 							addSynopticTool(page, homeToolId, toolTitleText, synopticToolIndex + ",1", synopticToolIndex++);
 						} catch (Exception e) {
-							M_log.warn(this + ".saveFeatures addSynotpicTool: " + e.getMessage() + " site id = " + site.getId() + " tool = " + homeToolId, e);
+							M_log.error(this + ".saveFeatures addSynotpicTool: " + e.getMessage() + " site id = " + site.getId() + " tool = " + homeToolId, e);
 						}
 					}
 					
@@ -11852,17 +11852,17 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				
 			} catch (IdUsedException e) {
 				addAlert(state, rb.getFormattedMessage("java.sitewithid.exists", new Object[]{id}));
-				M_log.warn(this + ".addNewSite: " + rb.getFormattedMessage("java.sitewithid.exists", new Object[]{id}), e);
+				M_log.error(this + ".addNewSite: " + rb.getFormattedMessage("java.sitewithid.exists", new Object[]{id}), e);
 				state.setAttribute(STATE_TEMPLATE_INDEX, params.getString("templateIndex"));
 				return;
 			} catch (IdInvalidException e) {
 				addAlert(state, rb.getFormattedMessage("java.sitewithid.notvalid", new Object[]{id}));
-				M_log.warn(this + ".addNewSite: " + rb.getFormattedMessage("java.sitewithid.notvalid", new Object[]{id}), e);
+				M_log.error(this + ".addNewSite: " + rb.getFormattedMessage("java.sitewithid.notvalid", new Object[]{id}), e);
 				state.setAttribute(STATE_TEMPLATE_INDEX, params.getString("templateIndex"));
 				return;
 			} catch (PermissionException e) {
 				addAlert(state, rb.getFormattedMessage("java.permission", new Object[]{id}));
-				M_log.warn(this + ".addNewSite: " + rb.getFormattedMessage("java.permission", new Object[]{id}), e);
+				M_log.error(this + ".addNewSite: " + rb.getFormattedMessage("java.permission", new Object[]{id}), e);
 				state.setAttribute(STATE_TEMPLATE_INDEX, params.getString("templateIndex"));
 				return;
 			}
@@ -11983,7 +11983,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			state.setAttribute(FORM_SITEINFO_URL_BASE, getSiteBaseUrl());
 			
 		} catch (Exception e) {
-			M_log.warn(this + ".sitePropertiesIntoState: " + e.getMessage(), e);
+			M_log.error(this + ".sitePropertiesIntoState: " + e.getMessage(), e);
 		}
 
 	} // sitePropertiesIntoState
@@ -13200,7 +13200,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			try {
 				template = SiteService.getSite(templateId);
 			} catch (Exception e) {
-				M_log.warn(this + ".addSiteTypeFeatures:" + e.getMessage() + templateId, e);
+				M_log.error(this + ".addSiteTypeFeatures:" + e.getMessage() + templateId, e);
 			}
 			if (template != null) {
 				// create a new site based on the template
@@ -13209,7 +13209,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 					// set site type
 					edit.setType(SiteTypeUtil.getTargetSiteType(template.getType()));
 				} catch (Exception e) {
-					M_log.warn(this + ".addSiteTypeFeatures:" + " add/edit site id=" + id, e);
+					M_log.error(this + ".addSiteTypeFeatures:" + " add/edit site id=" + id, e);
 				}
 	
 				// set the tab, etc.
@@ -13226,7 +13226,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 					try {
 						SiteService.save(edit);
 					} catch (Exception e) {
-						M_log.warn(this + ".addSiteTypeFeatures:" + " commitEdit site id=" + id, e);
+						M_log.error(this + ".addSiteTypeFeatures:" + " commitEdit site id=" + id, e);
 					}
 	
 					// now that the site and realm exist, we can set the email alias
@@ -13240,13 +13240,13 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						AliasService.setAlias(alias, channelReference);
 					} catch (IdUsedException ee) {
 						addAlert(state, rb.getFormattedMessage("java.alias.exists", new Object[]{alias}));
-						M_log.warn(this + ".addSiteTypeFeatures:" + rb.getFormattedMessage("java.alias.exists", new Object[]{alias}), ee);
+						M_log.error(this + ".addSiteTypeFeatures:" + rb.getFormattedMessage("java.alias.exists", new Object[]{alias}), ee);
 					} catch (IdInvalidException ee) {
 						addAlert(state, rb.getFormattedMessage("java.alias.isinval", new Object[]{alias}));
-						M_log.warn(this + ".addSiteTypeFeatures:" + rb.getFormattedMessage("java.alias.isinval", new Object[]{alias}), ee);
+						M_log.error(this + ".addSiteTypeFeatures:" + rb.getFormattedMessage("java.alias.isinval", new Object[]{alias}), ee);
 					} catch (PermissionException ee) {
 						addAlert(state, rb.getString("java.addalias"));
-						M_log.warn(this + ".addSiteTypeFeatures:" + SessionManager.getCurrentSessionUserId() + " does not have permission to add alias. ", ee);
+						M_log.error(this + ".addSiteTypeFeatures:" + SessionManager.getCurrentSessionUserId() + " does not have permission to add alias. ", ee);
 					}
 				}
 			}
@@ -13343,7 +13343,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						}
 					}
 				} catch (Throwable t) {
-					M_log.warn(this + ".transferCopyEntities: Error encountered while asking EntityTransfer to transferCopyEntities from: "
+					M_log.error(this + ".transferCopyEntities: Error encountered while asking EntityTransfer to transferCopyEntities from: "
 									+ fromContext + " to: " + toContext, t);
 				}
 			}
@@ -13446,7 +13446,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 							etRM.updateEntityReferences(toContext, transversalMap);
 						}
 					} catch (Throwable t) {
-						M_log.warn(
+						M_log.error(
 								"Error encountered while asking EntityTransfer to updateEntityReferences at site: "
 								+ toContext, t);
 					}
@@ -13481,7 +13481,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						}
 					}
 				} catch (Throwable t) {
-					M_log.warn(
+					M_log.error(
 							"Error encountered while asking EntityTransfer to transferCopyEntities from: "
 									+ fromContext + " to: " + toContext, t);
 				}
@@ -13766,7 +13766,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		try {
 			azgTemplate = AuthzGroupService.getAuthzGroup(azgId);
 		} catch (GroupNotDefinedException e) {
-			M_log.warn(this + ".getRolesAllowedToAttachSection: Could not find authz group " + azgId, e);
+			M_log.error(this + ".getRolesAllowedToAttachSection: Could not find authz group " + azgId, e);
 			return new HashSet();
 		}
 		Set roles = azgTemplate.getRolesIsAllowed("site.upd");
@@ -14864,7 +14864,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			}
 			catch (IOException e)
 			{
-				M_log.warn("Problem sending redirect to: "+ url,  e);
+				M_log.error("Problem sending redirect to: "+ url,  e);
 			}
 			return;
 		}
@@ -15267,7 +15267,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				quota = getSiteSpecificQuota(site);
 			}
 		} catch (IdUnusedException e) {
-			M_log.warn("Quota calculation could not find the site " + siteId
+			M_log.error("Quota calculation could not find the site " + siteId
 					+ "for site specific quota calculation",
 					M_log.isDebugEnabled() ? e : null);
 		}


### PR DESCRIPTION
By logging exceptions using ERROR, we can use log4j.properties to send exceptions to a centralized exception reporting system like Sentry.