### PR TITLE
SAK-29328 - Major refactor of LTI2 utility code to allow toolproxy inspection

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -664,13 +664,14 @@ public interface LTIService {
 		"launch:url:label=bl_launch:maxlength=1024:allowed=true",
 		"consumerkey:text:label=bl_consumerkey:allowed=true:maxlength=1024",
 		"secret:text:label=bl_secret:allowed=true:maxlength=1024",
-		"resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin",
+		"resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin:only=lti2",
 		"xmlimport:text:hidden=true:maxlength=1M",
 		// LTI 2.x settings
 		"settings:text:hidden=true:maxlength=1M",
-		"enabled_capability:text:hidden=true:maxlength=1M:role=admin",
 		// Sakai LTI 1.x extension settings (see SAK-25621)
 		"settings_ext:text:hidden=true:maxlength=1M",
+		// LTI Content-Item (see SAK-29328)
+		"contentitem:text:label=bl_contentitem:rows=5:cols=25:maxlength=1M:role=admin",
 		"placement:text:hidden=true:maxlength=256", 
 		"placementsecret:text:hidden=true:maxlength=512",
 		"oldplacementsecret:text:hidden=true:maxlength=512",
@@ -686,13 +687,13 @@ public interface LTIService {
 		"SITE_ID:text:maxlength=99:role=admin",
 		"title:text:label=bl_title:required=true:maxlength=1024",
 		"allowtitle:radio:label=bl_allowtitle:choices=disallow,allow",
+		"fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
 		"pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
 		"allowpagetitle:radio:label=bl_allowpagetitle:choices=disallow,allow",
-		"fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
 		"description:textarea:label=bl_description:maxlength=4096",
 		"status:radio:label=bl_status:choices=enable,disable",
 		"visible:radio:label=bl_visible:choices=visible,stealth:role=admin",
-		"resource_handler:text:label=bl_resource_handler:maxlength=1024:only=lti2",
+		"resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin:only=lti2",
 		"deployment_id:integer:hidden=true",
 		"lti2_launch:header:fields=launch,consumerkey,secret:only=lti2",
 		"launch:url:label=bl_launch:maxlength=1024:required=true",
@@ -711,6 +712,7 @@ public interface LTIService {
 		"allowroster:checkbox:label=bl_allowroster",
 		"allowsettings:checkbox:label=bl_allowsettings",
 		"allowlori:checkbox:label=bl_allowlori",
+		"allowcontentitem:checkbox:label=bl_allowcontentitem",
 		"newpage:radio:label=bl_newpage:choices=off,on,content",
 		"debug:radio:label=bl_debug:choices=off,on,content",
 		// LTI 1.x user-entered custom
@@ -719,9 +721,9 @@ public interface LTIService {
 		"settings:text:hidden=true:maxlength=1M",
 		// LTI 2.x tool-registration time parameters
 		"parameter:textarea:label=bl_parameter:rows=5:cols=25:maxlength=16384:only=lti2",
-		"enabled_capability:textarea:label=bl_enabled_capability:rows=5:cols=25:maxlength=16384:only=lti2",
+		"tool_proxy_binding:textarea:label=bl_tool_proxy_binding:maxlength=2M:only=lti2:hide=insert:role=admin",
 		"allowcustom:checkbox:label=bl_allowcustom",
-		"xmlimport:text:hidden=true:maxlength=1M",
+		"xmlimport:textarea:hidden=true:maxlength=1M",
 		"splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384",
 		"created_at:autodate", 
 		"updated_at:autodate" };
@@ -746,6 +748,7 @@ public interface LTIService {
 		"allowroster:checkbox:label=bl_allowroster",
 		"allowsettings:checkbox:label=bl_allowsettings",
 		"allowlori:checkbox:label=bl_allowlori",
+		"allowcontentitem:checkbox:label=bl_allowcontentitem",
 		"lti2_internal:header:fields=reg_launch,reg_key,reg_secret,reg_password,consumerkey,secret,reg_profile:hide=insert",
 		"reg_launch:url:label=bl_reg_launch:maxlength=1024:role=admin",
 		"reg_key:text:label=bl_reg_key:maxlength=1024:hide=insert:role=admin",
@@ -754,7 +757,7 @@ public interface LTIService {
 		"consumerkey:text:label=bl_consumerkey:maxlength=1024:hide=insert",
 		"secret:text:label=bl_secret:maxlength=1024:hide=insert",
 		"new_secret:text:label=bl_secret:maxlength=1024:hide=insert",
-		"reg_profile:textarea:label=bl_reg_profile:maxlength=1M:hide=insert:role=admin",
+		"reg_profile:textarea:label=bl_reg_profile:maxlength=2M:hide=insert:role=admin",
 		"settings:text:hidden=true:maxlength=1M",   // This is "custom" in the JSON
 		"created_at:autodate", 
 		"updated_at:autodate" };
@@ -784,7 +787,7 @@ public interface LTIService {
 	static final String LTI_ALLOWTITLE =	"allowtitle";
 	static final String LTI_PAGETITLE =    	"pagetitle";
 	static final String LTI_ALLOWPAGETITLE =	"allowpagetitle";
-	static final String LTI_FA_ICON =    	"fa_icon";
+	static final String LTI_FA_ICON =       "fa_icon";
 	static final String LTI_PLACEMENT =    "placement";
 	static final String LTI_DESCRIPTION = "description";
 	static final String LTI_STATUS = 	"status";
@@ -805,8 +808,10 @@ public interface LTIService {
 	static final String LTI_ALLOWROSTER = "allowroster";
 	static final String LTI_ALLOWSETTINGS = "allowsettings";
 	static final String LTI_ALLOWLORI = "allowlori";
+	static final String LTI_ALLOWCONTENTITEM = "allowcontentitem";
 	static final String LTI_SETTINGS = "settings";
 	static final String LTI_SETTINGS_EXT = "settings_ext";
+	static final String LTI_CONTENTITEM = "contentitem";
 	static final String LTI_NEWPAGE =	"newpage";
 	static final String LTI_DEBUG =	"debug";
 	static final String LTI_CUSTOM = 	"custom";
@@ -832,8 +837,9 @@ public interface LTIService {
 	static final String LTI_REG_ACK = "reg_ack";
 	static final String LTI_REG_PASSWORD = "reg_password";
 	static final String LTI_PARAMETER = "parameter";
-	static final String LTI_REG_PROFILE = "reg_profile";
-	static final String LTI_ENABLED_CAPABILITY = "enabled_capability";
+	static final String LTI_REG_PROFILE = "reg_profile"; // A.k.a tool_proxy
+	// A subset of a tool_proxy with only a single resource_handler
+	static final String LTI_TOOL_PROXY_BINDING = "tool_proxy_binding";
 	// End of BLTI-230 - LTI 2.0
 
 }

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -41,6 +41,8 @@ import org.imsglobal.lti2.LTI2Constants;
 import org.imsglobal.lti2.LTI2Vars;
 import org.imsglobal.lti2.LTI2Caps;
 import org.imsglobal.lti2.LTI2Util;
+import org.imsglobal.lti2.LTI2Messages;
+import org.imsglobal.lti2.ToolProxyBinding;
 import org.imsglobal.lti2.objects.ToolConsumer;
 
 import org.sakaiproject.lti.api.LTIService;
@@ -831,12 +833,12 @@ public class SakaiBLTIUtil {
 		LTI2Util.addCustomToLaunch(ltiProps, custom);
 
 		// Check which kind of signing we are supposed to do
-		String enabled_capability = (String) content.get("enabled_capability");
-		if ( enabled_capability == null ) {
-			enabled_capability = (String) tool.get("enabled_capability");
-		}
+		String tool_proxy_binding = (String) tool.get("tool_proxy_binding");
+		ToolProxyBinding toolProxyBinding = new ToolProxyBinding(tool_proxy_binding);
+		
+		if ( toolProxyBinding.enabledCapability( LTI2Messages.BASIC_LTI_LAUNCH_REQUEST, 
+			LTI2Caps.OAUTH_HMAC256) ) {
 
-		if ( LTI2Util.enabledCapability(enabled_capability, LTI2Caps.OAUTH_HMAC256) ) {
 			ltiProps.put(OAuth.OAUTH_SIGNATURE_METHOD,"HMAC-SHA256");
 			M_log.debug("Launching with SHA256 Signing");
 		}
@@ -884,7 +886,6 @@ public class SakaiBLTIUtil {
 		setProperty(ltiProps, BasicLTIConstants.LAUNCH_PRESENTATION_RETURN_URL, serverUrl + "/portal/tool/"+placementId+"?panel=PostRegister&id="+deployKey);
 
 		int debug = getInt(tool.get(LTIService.LTI_DEBUG));
-		debug = 1;
 
 		M_log.debug("ltiProps="+ltiProps);
 

--- a/basiclti/basiclti-docs/resources/docs/sakai-api-test/tp.php
+++ b/basiclti/basiclti-docs/resources/docs/sakai-api-test/tp.php
@@ -238,7 +238,6 @@ foreach($tc_capabilities as $capability) {
     // promote these up to the top level capabilities
     if ( "OAuth.splitSecret" == $capability || "OAuth.hmac-sha256" == $capability ) {
         $tp_profile->enabled_capability[] = $capability;
-        continue;
     }
 
     if ( in_array($capability, $tp_profile->tool_profile->resource_handler[0]->message[0]->enabled_capability) ) continue;

--- a/basiclti/basiclti-impl/src/bundle/ltiservice.properties
+++ b/basiclti/basiclti-impl/src/bundle/ltiservice.properties
@@ -67,6 +67,7 @@ bl_allowoutcomes=Allow External Tool to return grades
 bl_allowroster=Provide Roster to External Tool
 bl_allowsettings=Allow External Tool to store setting data
 bl_allowlori=Allow External Tool to access Lessons API
+bl_allowcontentitem=Allow External Tool to configure itself (IMS Content-Item)
 bl_allowlinkselection=Allow External Tool to Send Links
 bl_allowassessmentselection=Allow External Tool to be an assessment
 bl_allowcoursenavigation=Allow External Tool to be in course navigation
@@ -79,6 +80,7 @@ bl_launchurl=Actual Launch Url
 bl_resource_handler=Resource Handler
 bl_parameter=Launch Parameters
 bl_enabled_capability=Enabled Capabilities
+bl_contentitem=Enabled Capabilities
 
 bl_version=LTI Version
 bl_version_lti1=LTI 1.x Tool
@@ -95,6 +97,7 @@ bl_reg_key=LTI 2.x Registration Key
 bl_reg_password=LTI 2.x Registration Secret
 bl_reg_parameters=LTI 2.x Tool Launch Parameters
 bl_reg_profile=LTI 2.x Registration Profile
+bl_tool_proxy_binding=LTI 2.x Tool Registration Profile
 
 error.id.not.found = Cannot find LTI tool id.
 error.maintain.link = Must be site maintainer to manage LTI tool links

--- a/basiclti/basiclti-util/src/java/org/imsglobal/lti2/LTI2Constants.java
+++ b/basiclti/basiclti-util/src/java/org/imsglobal/lti2/LTI2Constants.java
@@ -66,6 +66,33 @@ public class LTI2Constants {
 	public static final String GRADE_TYPE_DECIMAL = "decimal";
 	public static final String COMMENT = "comment";
 	public static final String RESULTSCORE = "resultScore";
+	public static final String TOOL_PROXY = "tool_proxy";
+	public static final String TOOL_PROXY_BINDING = "tool_proxy_binding";
+	public static final String RESOURCE_HANDLER = "resource_handler";
+	public static final String ICON_INFO = "icon_info";
+	public static final String PARAMETER = "parameter";
+	public static final String DESCRIPTION = "description";
+
+	public static final String TOOL_PROFILE = "tool_profile";
+	public static final String MESSAGE = "message";
+	public static final String MESSAGE_TYPE = "message_type";
+	public static final String ICON_STYLE = "icon_style";
+	public static final String DEFAULT_LOCATION = "default_location";
+	public static final String PATH = "path";
+	public static final String GUID = "guid";
+	public static final String PRODUCT_INSTANCE = "product_instance";
+	public static final String PRODUCT_INFO = "product_info";
+	public static final String PRODUCT_NAME = "product_name";
+	public static final String DEFAULT_VALUE = "default_value";
+	public static final String PRODUCT_FAMILY = "product_family";
+	public static final String CODE = "code";
+	public static final String VENDOR = "vendor";
+	public static final String BASE_URL_CHOICE = "base_url_choice";
+	public static final String SECURE_BASE_URL = "secure_base_url";
+	public static final String RESOURCE_TYPE = "resource_type";
+	public static final String SHORT_NAME = "short_name";
+	public static final String DEFAULT_BASE_URL = "default_base_url";
+	public static final String RESOURCE_NAME = "resource_name";
 
 	/**
 	 * Utility array useful for validating property names when building launch

--- a/basiclti/basiclti-util/src/java/org/imsglobal/lti2/LTI2Messages.java
+++ b/basiclti/basiclti-util/src/java/org/imsglobal/lti2/LTI2Messages.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 IMS GLobal Learning Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * 
+ */
+package org.imsglobal.lti2;
+
+/**
+ * A class to capture the names of the valid LTI 2.0 capabilities
+ *
+ * Taken from: http://www.imsglobal.org/lti/ltiv2p0/uml/purl.imsglobal.org/vocab/lti/v2/capability/index.html
+ */
+
+public class LTI2Messages {
+
+	public static final String BASIC_LTI_LAUNCH_REQUEST = "basic-lti-launch-request";
+
+	public static final String TOOLPROXY_RE_REGISTRATION_REQUEST = "ToolProxyReregistrationRequest";
+
+	public static final String CONTENT_ITEM_SELECTION_REQUEST = "ContentItemSelectionRequest";
+
+}

--- a/basiclti/basiclti-util/src/java/org/imsglobal/lti2/ToolProxy.java
+++ b/basiclti/basiclti-util/src/java/org/imsglobal/lti2/ToolProxy.java
@@ -1,0 +1,441 @@
+/*
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2015 IMS GLobal Learning Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.imsglobal.lti2;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.HashMap;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.imsglobal.basiclti.BasicLTIUtil;
+import org.imsglobal.lti2.objects.Service_offered;
+import org.imsglobal.lti2.objects.StandardServices;
+import org.imsglobal.lti2.objects.ToolConsumer;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
+import static org.imsglobal.lti2.LTI2Util.getArray;
+import static org.imsglobal.lti2.LTI2Util.getObject;
+import static org.imsglobal.lti2.LTI2Util.getString;
+
+public class ToolProxy {
+
+	// We use the built-in Java logger because this code needs to be very generic
+	private static Logger M_log = Logger.getLogger(ToolProxy.class.toString());
+
+	private JSONObject toolProxy = null;
+
+	/**
+	 * We check for the fields essential for the class to operate here.
+	 */
+	public ToolProxy(String tool_proxy)
+	{
+		if ( tool_proxy == null || tool_proxy.trim().length() < 1 ) {
+			throw new java.lang.RuntimeException("Cannot initialize with empty string");
+		}
+		Object prox = JSONValue.parse(tool_proxy);
+		if ( prox != null && prox instanceof JSONObject ) {
+			toolProxy = (JSONObject) prox;
+		} else {
+			throw new java.lang.RuntimeException("tool proxy is wrong type "+prox.getClass().getName());
+		}
+
+		JSONObject tp = getToolProfile();
+		if ( tp == null ) {
+			throw new java.lang.RuntimeException("A tool_proxy must include a tool_profile");
+		}
+	}
+
+	/**
+	 * Return a string
+	 */
+	public String toString()
+	{
+		return toolProxy.toString();
+	}
+
+	/**
+	 * Retrieve the parsed tool_proxy
+	 */
+	public JSONObject getToolProxy()
+	{
+		return toolProxy;
+	}
+
+	/**
+	 * Retrieve the tool_profile from the tool_proxy
+	 */
+	public JSONObject getToolProfile()
+	{
+		return getObject(toolProxy, LTI2Constants.TOOL_PROFILE);
+	}
+
+	/**
+	 * Retrieve the security_contract from the tool_proxy
+	 */
+	public JSONObject getSecurityContract()
+	{
+		return getObject(toolProxy, LTI2Constants.SECURITY_CONTRACT);
+	}
+
+	/**
+	 * Retrieve the custom from the tool_proxy
+	 */
+	public JSONObject getCustom()
+	{
+		return getObject(toolProxy, LTI2Constants.CUSTOM);
+	}
+
+	/**
+	 * Retrieve the resource_handlers from a tool_profile
+	 */
+	public JSONArray getResourceHandlers()
+	{
+		return getArray(getToolProfile(), LTI2Constants.RESOURCE_HANDLER);
+	}
+
+	/**
+	 * Retrieve a particular message type from an individual tool_profile
+	 * 
+	 * @param String resourceHandler - JSONObject for the resource_handler
+	 * @param String messageType - Which message type you are looking for
+	 */
+	public JSONObject getMessageOfType(JSONObject resourceHandler, String messageType)
+	{
+	       if ( resourceHandler == null || messageType == null || messageType.length() < 1 ) {
+			return null;
+		}
+
+		JSONArray messages = getArray(resourceHandler, LTI2Constants.MESSAGE);
+		if ( messages == null ) return null;
+		for ( Object m : messages ) {
+			if ( ! (m instanceof JSONObject) ) return null;
+			JSONObject message = (JSONObject) m;
+			String message_type = getString(message,LTI2Constants.MESSAGE_TYPE);
+			if ( message_type == null ) continue;
+			if ( message_type.equals(messageType) ) return message;
+		}
+		return null;
+	}
+
+	/**
+	 * Check if a particular capability is enabled
+	 * 
+	 * @param String resourceHandler - JSONObject for the resource_handler
+	 * @param String messageType - Which message type you are looking for
+	 * @param String capability - The capability to look for
+	 */
+	public boolean enabledCapability(JSONObject resourceHandler, String messageType, String capability)
+	{
+		JSONObject message = getMessageOfType(resourceHandler, messageType);
+		JSONArray enabled_capability = getArray(message, LTI2Constants.ENABLED_CAPABILITY);
+		return enabled_capability.contains(capability);
+	}
+
+	/**
+	 * Extract an icon path by icon_style from an icon_info string
+	 * 
+	 * @param String resourceHandler - JSONObject for the resource_handler
+	 * @param String icon_style - The style to look for
+	 */
+	public String getIconPath(JSONObject resourceHandler, String icon_style) {
+		JSONArray icon_info = getArray(resourceHandler, LTI2Constants.ICON_INFO);
+		if ( icon_info == null ) return null;
+
+		for (Object m : icon_info) {
+			if ( ! ( m instanceof JSONObject) ) continue;
+			JSONObject jm = (JSONObject) m;
+			JSONArray icon_styles = getArray(jm, LTI2Constants.ICON_STYLE);
+			if ( icon_styles == null ) continue;
+			if ( ! icon_styles.contains(icon_style) ) continue;
+			JSONObject default_location = getObject(jm, LTI2Constants.DEFAULT_LOCATION);
+			if ( default_location == null ) continue;
+			String default_location_path = getString(default_location,LTI2Constants.PATH);
+			if ( default_location_path == null ) continue;
+			return default_location_path;
+		}
+		return null;
+	}
+
+	/**
+	 * Validate our tool_services against a tool consumer
+	 */
+	public String validateServices(ToolConsumer consumer) 
+	{
+		// Mostly to catch casting errors from bad JSON
+		try {
+			JSONObject security_contract = (JSONObject) toolProxy.get(LTI2Constants.SECURITY_CONTRACT);
+			if ( security_contract == null  ) {
+				return "JSON missing security_contract";
+			}
+			JSONArray tool_services = (JSONArray) security_contract.get(LTI2Constants.TOOL_SERVICE);
+
+			List<Service_offered> services_offered = consumer.getService_offered();
+
+			if ( tool_services != null ) for (Object o : tool_services) {
+				JSONObject tool_service = (JSONObject) o;
+				String json_service = (String) tool_service.get(LTI2Constants.SERVICE);
+
+				boolean found = false;
+				for (Service_offered service : services_offered ) {
+					String service_id = service.get_id();
+					if ( service_id.equals(json_service) ) {
+						found = true;
+						break;
+					}
+				}
+				if ( ! found ) return "Service not allowed: "+json_service;
+			}
+			return null;
+		}
+		catch (Exception e) {
+			return "Exception:"+ e.getLocalizedMessage();
+		}
+	}
+
+	/**
+	 * Validate enabled_capabilities agains our ToolConsumer
+	 */
+
+	public String validateCapabilities(ToolConsumer consumer) 
+	{
+		List<Properties> theTools = new ArrayList<Properties> ();
+		Properties info = new Properties();
+
+		// Mostly to catch casting errors from bad JSON
+		try {
+			String retval = parseToolProfile(theTools, info);
+			if ( retval != null )  return retval;
+
+			if ( theTools.size() < 1 ) return "No tools found in profile";
+
+			// Check all the capabilities requested by all the tools comparing against consumer
+			List<String> capabilities = consumer.getCapability_offered();
+			for ( Properties theTool : theTools ) {
+				String ec = (String) theTool.get(LTI2Constants.ENABLED_CAPABILITY);
+				JSONArray enabled_capability = (JSONArray) JSONValue.parse(ec);
+				if ( enabled_capability != null ) for (Object o : enabled_capability) {
+					ec = (String) o;
+					if ( capabilities.contains(ec) ) continue;
+					return "Capability not permitted="+ec;
+				}
+			}
+			return null;
+		}
+		catch (Exception e ) {
+			return "Exception:"+ e.getLocalizedMessage();
+		}
+	}
+
+	/**
+	 * Parse a provider profile with lots of error checking...
+	 */
+	public String parseToolProfile(List<Properties> theTools, Properties info)
+	{
+		try {
+			return parseToolProfileInternal(theTools, info);
+		} catch (Exception e) {
+			M_log.warning("Internal error parsing tool proxy\n"+toolProxy.toString());
+			e.printStackTrace();
+			return "Internal error parsing tool proxy:"+e.getLocalizedMessage();
+		}
+	}
+
+	/**
+	 * Parse a provider profile with lots of error checking...
+	 */
+	@SuppressWarnings("unused")
+	private String parseToolProfileInternal(List<Properties> theTools, Properties info)
+	{
+		Object o = null;
+
+		JSONObject tool_profile = getToolProfile();
+		if ( tool_profile == null  ) {
+			return "JSON missing tool_profile";
+		}
+	
+		JSONObject product_instance = (JSONObject) tool_profile.get(LTI2Constants.PRODUCT_INSTANCE);
+		if ( product_instance == null  ) {
+			return "JSON missing product_instance";
+		}
+
+		String instance_guid = (String) product_instance.get(LTI2Constants.GUID);
+		if ( instance_guid == null  ) {
+			return "JSON missing product_info / guid";
+		}
+		info.put("instance_guid",instance_guid);
+
+		JSONObject product_info = (JSONObject) product_instance.get(LTI2Constants.PRODUCT_INFO);
+		if ( product_info == null  ) {
+			return "JSON missing product_info";
+		}
+
+		// Look for required fields
+		JSONObject product_name = getObject(product_info,LTI2Constants.PRODUCT_NAME);
+		String productTitle = getString(product_name,LTI2Constants.DEFAULT_VALUE);
+		JSONObject description = getObject(product_info,LTI2Constants.DESCRIPTION);
+		String productDescription = getString(description,LTI2Constants.DEFAULT_VALUE);
+
+		JSONObject product_family = getObject(product_info,LTI2Constants.PRODUCT_FAMILY);
+		String productCode = getString(product_family,LTI2Constants.CODE);
+		JSONObject product_vendor = getObject(product_family,LTI2Constants.VENDOR);
+		description = getObject(product_vendor,LTI2Constants.DESCRIPTION);
+		String vendorDescription = getString(description,LTI2Constants.DEFAULT_VALUE);
+		String vendorCode = getString(product_vendor,LTI2Constants.CODE);
+
+		if ( productTitle == null || productDescription == null ) {
+			return "JSON missing product_name or description ";
+		}
+		if ( productCode == null || vendorCode == null || vendorDescription == null ) {
+			return "JSON missing product code, vendor code or description";
+		}
+
+		info.put("product_name", productTitle);
+		info.put("description", productDescription);  // Backwards compatibility
+		info.put("product_description", productDescription);
+		info.put("product_code", productCode);
+		info.put("vendor_code", vendorCode);
+		info.put("vendor_description", vendorDescription);
+
+		JSONArray base_url_choices = getArray(tool_profile,LTI2Constants.BASE_URL_CHOICE);
+		if ( base_url_choices == null  ) {
+			return "JSON missing base_url_choices";
+		}
+
+		String secure_base_url = null;
+		String default_base_url = null;
+		for ( Object i : base_url_choices ) {
+			JSONObject url_choice = (JSONObject) i;
+			secure_base_url = (String) url_choice.get(LTI2Constants.SECURE_BASE_URL);
+			default_base_url = (String) url_choice.get(LTI2Constants.DEFAULT_BASE_URL);
+		}
+		
+		String launch_url = secure_base_url;
+		if ( launch_url == null ) launch_url = default_base_url;
+		if ( launch_url == null ) {
+			return "Unable to determine launch URL";
+		}
+
+		JSONArray resource_handlers = getResourceHandlers();
+		if ( resource_handlers == null  ) {
+			return "JSON missing resource_handlers";
+		}
+
+		// Loop through resource handlers, read, and check for errors
+		for(Object i : resource_handlers ) {
+			JSONObject resource_handler = (JSONObject) i;
+			JSONObject resource_type_json = (JSONObject) resource_handler.get(LTI2Constants.RESOURCE_TYPE);
+			String resource_type_code = (String) resource_type_json.get(LTI2Constants.CODE);
+			if ( resource_type_code == null ) {
+				return "JSON missing resource_type code";
+			}
+
+			JSONArray messages = getArray(resource_handler, LTI2Constants.MESSAGE);
+			if ( messages == null ) {
+				return "JSON missing resource_handler / message";
+			}
+
+			JSONObject titleObject = (JSONObject) resource_handler.get(LTI2Constants.RESOURCE_NAME);
+			String title = titleObject == null ? null : (String) titleObject.get(LTI2Constants.DEFAULT_VALUE);
+			if ( title == null || titleObject == null ) {
+				return "JSON missing resource_handler / resource_name / default_value";
+			}
+
+			JSONObject buttonObject = (JSONObject) resource_handler.get(LTI2Constants.SHORT_NAME);
+			String button = buttonObject == null ? null : (String) buttonObject.get(LTI2Constants.DEFAULT_VALUE);
+		
+			JSONObject descObject = (JSONObject) resource_handler.get(LTI2Constants.DESCRIPTION);
+			String resourceDescription = getString(descObject, LTI2Constants.DEFAULT_VALUE);
+
+			// Simplify the icon data structure
+			JSONArray iconInfo = getArray(resource_handler,LTI2Constants.ICON_INFO);
+
+			String path = null;
+			JSONArray parameter = null;
+			JSONArray enabled_capability = null; 
+			for ( Object m : messages ) {
+				JSONObject message = (JSONObject) m;
+				String message_type = (String) message.get(LTI2Constants.MESSAGE_TYPE);
+				if ( ! "basic-lti-launch-request".equals(message_type) ) continue;
+				if ( path != null ) {
+					return "A resource_handler cannot have more than one basic-lti-launch-request message RT="+resource_type_code;
+				}
+				path = (String) message.get(LTI2Constants.PATH);
+				if ( path == null ) {
+					return "A basic-lti-launch-request message must have a path RT="+resource_type_code;
+				} 
+				parameter = getArray(message,LTI2Constants.PARAMETER);
+				enabled_capability = getArray(message, LTI2Constants.ENABLED_CAPABILITY);
+			}
+
+			// Ignore everything except launch handlers
+			if ( path == null ) continue;
+
+			// Check the URI
+			String thisLaunch = launch_url;
+			thisLaunch = thisLaunch + path;
+			try {
+				URL url = new URL(thisLaunch);
+			} catch ( Exception e ) {
+				return "Bad launch URL="+thisLaunch;
+			}
+
+			// Passed all the tests...  Lets keep it...
+			Properties theTool = new Properties();
+
+			theTool.put("resource_type", resource_type_code); // Backwards compatibility
+			theTool.put("resource_type_code", resource_type_code);
+			if ( title == null ) title = productTitle;
+			if ( title != null ) theTool.put("title", title);
+			if ( button != null ) theTool.put("button", button);
+			if ( resourceDescription == null ) resourceDescription = productDescription;
+			if ( resourceDescription != null ) theTool.put("description", resourceDescription);
+			if ( parameter != null ) theTool.put(LTI2Constants.PARAMETER, parameter.toString());
+			if ( iconInfo != null ) theTool.put(LTI2Constants.ICON_INFO,iconInfo.toString());
+			theTool.put(LTI2Constants.ENABLED_CAPABILITY, enabled_capability.toString());
+			theTool.put("launch", thisLaunch);
+			if ( secure_base_url != null ) theTool.put("secure_base_url", secure_base_url);
+			if ( default_base_url != null ) theTool.put("default_base_url", default_base_url);
+
+			// Turn the tool_proxy into a tool_proxy_binding by having a single 
+			// resource_handler that is the one that corresponds to this tool.
+                        ToolProxy local_tool_proxy = new ToolProxy(toolProxy.toString());
+			JSONObject local_tool_profile = local_tool_proxy.getToolProfile();
+			local_tool_profile.remove(LTI2Constants.RESOURCE_HANDLER);
+			JSONArray handlers = new JSONArray ();
+			handlers.add(resource_handler);
+			local_tool_profile.put(LTI2Constants.RESOURCE_HANDLER, handlers);
+
+			// With a single resource handler it is now a TPB
+			ToolProxyBinding tool_proxy_binding = new ToolProxyBinding(local_tool_proxy.toString());
+			theTool.put(LTI2Constants.TOOL_PROXY_BINDING, tool_proxy_binding.toString());
+			theTools.add(theTool);
+		}
+		return null;  // All good
+	}
+
+}

--- a/basiclti/basiclti-util/src/java/org/imsglobal/lti2/ToolProxyBinding.java
+++ b/basiclti/basiclti-util/src/java/org/imsglobal/lti2/ToolProxyBinding.java
@@ -1,0 +1,115 @@
+/*
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2015 IMS GLobal Learning Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.imsglobal.lti2;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.HashMap;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.imsglobal.basiclti.BasicLTIUtil;
+import org.imsglobal.lti2.objects.Service_offered;
+import org.imsglobal.lti2.objects.StandardServices;
+import org.imsglobal.lti2.objects.ToolConsumer;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
+import static org.imsglobal.lti2.LTI2Util.getArray;
+import static org.imsglobal.lti2.LTI2Util.getObject;
+import static org.imsglobal.lti2.LTI2Util.getString;
+
+public class ToolProxyBinding extends ToolProxy {
+
+	// We use the built-in Java logger because this code needs to be very generic
+	private static Logger M_log = Logger.getLogger(ToolProxyBinding.class.toString());
+
+	private JSONObject resourceHandler = null;
+
+	public ToolProxyBinding(String tool_proxy_binding)
+	{
+		super(tool_proxy_binding);
+
+		// Sanity-check the number of resource_handler (s)
+		JSONArray ja = getResourceHandlers();
+		if ( ja == null || ja.size() != 1 ) {
+			throw new java.lang.RuntimeException("A ToolProxyBinding must have exactly one resource_handler");
+		}
+		Object rh = ja.get(0);
+
+		if ( ! (rh instanceof JSONObject ) ) {
+			throw new java.lang.RuntimeException("resource handler is wrong type "+rh.getClass().getName());
+		}
+		resourceHandler = (JSONObject) rh;
+	}
+
+	/**
+	 * Retrieve the tool_proxy_binding
+	 */
+	public JSONObject getToolProxyBinding()
+	{
+		return getToolProxy();
+	}
+
+	/**
+	 * Retrieve the (single) resource_type from a tool_profile (binding)
+	 */
+	public JSONObject getResourceHandler()
+	{
+		return this.resourceHandler;
+	}
+
+	/**
+	 * Retrieve a particular message type from an individual tool_profile
+	 * 
+	 * @param String messageType - Which message type you are looking for
+	 */
+	public JSONObject getMessageOfType(String messageType)
+	{
+		return getMessageOfType(resourceHandler, messageType);
+	}
+
+	/**
+	 * Check if a particular capability is enabled
+	 * 
+	 * @param String messageType - Which message type you are looking for
+	 * @param String capability - The capability to look for
+	 */
+	public boolean enabledCapability(String messageType, String capability)
+	{
+		return enabledCapability(resourceHandler, messageType, capability);
+	}
+
+	/**
+	 * Extract an icon path by icon_style from an icon_info string
+	 * 
+	 * @param String icon_style - The style to look for
+	 */
+	public String getIconPath(String icon_style) {
+		return getIconPath(resourceHandler, icon_style);
+	}
+
+}


### PR DESCRIPTION

As we go forward with ContentItem and other LTI 2.x services, we will
need to increasingly look at the ToolProxy and ToolProxyBinding structures
so this pulls that utility code into two new classes and refactors the rest
of the code to use those utility classes.