### PR TITLE
SAK-29665 modifying to send internal Sakai user id instead of eid 

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeAnalytics.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeAnalytics.vm
@@ -34,8 +34,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '${googleUniversalAnalyticsId}', 'auto');
-        ga('create', '${googleUniversalAnalyticsId}', { 'userId': portal.user.eid });
+        ga('create', '${googleUniversalAnalyticsId}', { 'userId': portal.user.id });
         ga('send', 'pageview');
     </script>
 


### PR DESCRIPTION
per Google:

"The USER_ID value should be a unique, persistent, and non-personally identifiable
string identifier that represents a user or signed-in account across devices."