### PR TITLE
SAK-29703 Remove grey for Samigo preview message

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -467,7 +467,6 @@ a.hideDivision {
 	width: 80%;
 	font-size: 1em;
 	clear: both;
-	color: grey;
 	margin: 5px 0;
 	padding: 5px 5px 5px 25px;
 }


### PR DESCRIPTION
On the Samigo preview view there is a message presented on the top and bottom of the page in grey stating "Assessment Preview - This is an example student view of this assessment ". The color set for this item is web grey (#808080).

Standard web grey does not contrast enough to be WCAG compliant. Removed the color definition all together so the message inherits the standard page colour (black by default).

The message could be made a more distinctive colour but the fact that it's at the top and bottom of the page and bordered already makes it pretty distinct.

See https://jira.sakaiproject.org/browse/SAK-29703 