### PR TITLE
SAK-29711 add unofficial participants allows emails addresses with invalid domains to be invited to a site

### DIFF
--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -103,7 +103,7 @@ nonOfficialAccountSectionTitle = Non-official Participants
 nonOfficialAccountName=Guest
 nonOfficialAccountLabel=Email Address of Non-official Participant
 # DEFAULT: none (null)
-invalidNonOfficialAccountString=
+invalidEmailInIdAccountString=
 # Set to false to dis-allow non-official accounts. This value can be overriden by site-wide settings
 # DEFAULT: none (true)
 #nonOfficialAccount=

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -30,7 +30,6 @@ java.user = User
 java.username = ''{0}'' is not a valid username.
 java.notemailid = ''{0}'' is not an email id.
 java.emailaddress = ''{0}'' is not a valid email address.
-java.emailbaddomain = ''{0}'' has a domain that cannot be used for ''{1}''
 java.roletype = Please choose the role type.
 java.username.multiple = ''{0}'' matches multiple users in record. Please select from the following usernames: {1} 
 
@@ -100,6 +99,7 @@ officialAccountLabel=Official Email Address or Username
 nonOfficialAccountSectionTitle = Non-official Participants
 nonOfficialAccountName=Guest
 nonOfficialAccountLabel=Email Address of Non-official Participant
+nonOfficialAccount.invalidEmailDomain=Email addresses ending with "{0}" cannot be added as unofficial participants. Please try adding them as an official participant.
 
 confirm.name=Name
 confirm.id=Id

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
@@ -48,7 +48,7 @@ import uk.org.ponder.stringutil.StringList;
 public class AddProducer implements ViewComponentProducer, NavigationCaseReporter, DefaultView, ViewParamsReporter, ActionResultInterceptor {
 
 	/** Our log (commons). */
-	private static Log M_log = LogFactory.getLog(AddProducer.class);
+	private static final Log M_log = LogFactory.getLog(AddProducer.class);
 
     public SiteAddParticipantHandler handler;
     public static final String VIEW_ID = "Add";
@@ -172,7 +172,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 				TargettedMessage msg = targettedMessageList.messageAt(i);
 				if (msg.severity == TargettedMessage.SEVERITY_ERROR)
 				{
-					UIBranchContainer errorRow = UIBranchContainer.make(tofill,"error-row:", Integer.valueOf(i).toString());
+					UIBranchContainer errorRow = UIBranchContainer.make(tofill,"error-row:", Integer.toString(i));
 					
 			    	if (msg.args != null ) 
 			    	{
@@ -185,7 +185,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 				}
 				else if (msg.severity == TargettedMessage.SEVERITY_INFO)
 				{
-					UIBranchContainer errorRow = UIBranchContainer.make(tofill,"info-row:", Integer.valueOf(i).toString());
+					UIBranchContainer errorRow = UIBranchContainer.make(tofill,"info-row:", Integer.toString(i));
 						
 			    	if (msg.args != null ) 
 			    	{
@@ -211,7 +211,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
     }
     
     public List<NavigationCase> reportNavigationCases() {
-        List<NavigationCase> togo = new ArrayList<NavigationCase>();
+        List<NavigationCase> togo = new ArrayList<>();
         togo.add(new NavigationCase("sameRole", new SimpleViewParameters(SameRoleProducer.VIEW_ID)));
         togo.add(new NavigationCase("differentRole", new SimpleViewParameters(DifferentRoleProducer.VIEW_ID)));
         return togo;

--- a/site-manage/site-manage-participant-helper/src/webapp/WEB-INF/requestContext.xml
+++ b/site-manage/site-manage-participant-helper/src/webapp/WEB-INF/requestContext.xml
@@ -14,7 +14,6 @@
     <property name="notiProvider" ref="org.sakaiproject.sitemanage.api.UserNotificationProvider" />
     <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
     <property name="validationLogic" ref="org.sakaiproject.accountvalidator.logic.ValidationLogic"/>
-    <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
   </bean>
   
   <bean id="AddProducer"


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29711

"There is code behind the "Add Unofficial Participants" feature to disallow adding unofficial participants whose email addresses end with with any of the "invalid" domain suffixes defined in sakai.properties.

However, the property it obeys has been removed from default.sakai.properties (invalidNonOfficialAccountString), and there is now a new one that is being referenced from a few other tools (invalidEmailInIdAccountString).

The linked PR alters the code in site-manage to reference this newer property, rather than the old one that is no longer present in default.sakai.properties, so that all the tools are obeying a single property for invalid domain suffixes."