### PR TITLE
SAK-29714 : Removing JQuery mobile js to fix the errors due to conflict with JQuery UI

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/site.vm
@@ -113,12 +113,7 @@
                 setupSiteNav();
                 ## Moved IE aria label code to sakai.portal.ie.js // SAK-22308 	
             });
-			// Code to not enable jquery mobile ajax
-			${d}PBJQ(document).on("mobileinit", function() {
-				${d}PBJQ.mobile.ajaxEnabled = false;
-				${d}PBJQ.mobile.autoInitializePage = false;
-				${d}PBJQ.mobile.pushStateEnabled = false;
-			});
+			
         </script>
 
         <script>
@@ -140,7 +135,6 @@
         ${d}PBJQ(document).ready(portal_check_pnotify);
     #end
         </script>
-        <script src="${pageScriptPath}jquery/jquerymobile/1.4.5/jquery.mobile.min.js$!{portalCDNQuery}"></script>
 
         <!--[if lt IE 9]>
         <script src="${pageSkinRepo}/${pageSkin}/js/ie/sakai.portal.ie.js$!{portalCDNQuery}"></script>

--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -237,12 +237,6 @@ $PBJQ(document).ready(function(){
 
   });
 
- // Swipe left on header to open more sites tab.
-  $PBJQ('.Mrphs-topHeader').on("swipeleft",function(e){
-	e.preventDefault();
-      return dhtml_view_sites();
-  });
-
   // Open all Sites with mobile view 	
    $PBJQ(".js-toggle-sites-nav", "#skipNav").on("click", dhtml_view_sites);
   

--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
@@ -34,7 +34,3 @@ $PBJQ(document).ready(function(){
 // Remove toogle sites nav on Skip nav to More sites view @TODO need to clean this toggleSitesNav code since it is not used anymore
 //$PBJQ(".js-toggle-sites-nav", "#skipNav").on("click", toggleSitesNav);
 $PBJQ(".js-toggle-tools-nav", "#skipNav").on("click", toggleToolsNav);
-
-// Swipe left handlers to the more sites tab.
-$PBJQ('.Mrphs-topHeader').on("swiperight",toggleToolsNav);
-


### PR DESCRIPTION
SAK-29714 : Removing JQuery mobile js which is added to provide handle swipe event in mobile view to open tool and sites drawers,  due to conflict with JQuery UI it is breaking other functionality around sakai. 