### PR TITLE
SAK-29719 add API method to get viewable sections and groups

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -23,7 +23,6 @@ package org.sakaiproject.service.gradebook.shared;
 
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -735,4 +734,13 @@ public interface GradebookService {
      * @return The CourseGrade for the student
      */
 	CourseGrade getCourseGradeForStudent(String gradebookUid, String userUuid);
+	
+	/**
+	 * Get a list of CourseSections that the current user has access to in the given gradebook.
+	 * This is a combination of sections and groups and is permission filtered.
+	 * @param gradebookUid
+	 * @return list of CourseSection objects.
+	 */
+	@SuppressWarnings("rawtypes")
+	List getViewableSections(String gradebookUid);
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2775,6 +2775,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		}
 		return rval;
 	}
+	
+	@Override
+	public List<CourseSection> getViewableSections(String gradebookUid) {
+		return this.getAuthz().getViewableSections(gradebookUid);
+	}
 
 	
 	public void setEventTrackingService(EventTrackingService eventTrackingService) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29719

Add API method to get visible course sections and groups for the current user. This applies the permission filtering that is configured in gradebook.

This is already inside the gradebook and needs to be exposed as an API so it can be used elsewhere, particularly in subsequent permission calls that require this list.
