### PR TITLE
SAK-29720 group filter can reveal identities for anonymous assignments on the instructor submission list UI

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -163,7 +163,7 @@
 			<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
 			## show the view by group choice when there is at least one group defined
 			#if (!$assignment.isGroup())
-				#if ($!groups.hasNext())
+				#if (!$value_CheckAnonymousGrading.equals("true") && $!groups.hasNext())
 					<div class="navPanel">
 						<div class="viewNav">
 							<label for="view">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29720

The submission list for an anonymous assignment can be filtered by group. This allows you to infer identities by controlling group membership. This filter should be hidden/not rendered for anonymous assignments.