### PR TITLE
SAK-29695 Hide/show Additional Access elements

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1000,6 +1000,7 @@
 #org.sakaiproject.api.privacy.PrivacyManager.PrivacyQueryCache.queryGetPrivacy
 #org.sakaiproject.authz.api.SecurityService.cache
 #org.sakaiproject.authz.impl.DbAuthzGroupService.realmRoleGroupCache
+
 #org.sakaiproject.calendar.impl.BaseExternalCacheSubscriptionService.institutional
 #org.sakaiproject.calendar.impl.BaseExternalCacheSubscriptionService.user
 #org.sakaiproject.citation.api.SearchManager.metasearchSessionManagerCache
@@ -4034,6 +4035,12 @@
 # realm.allowed.roles=access
 # # For each role a list of permissions that can be changed.
 # realm.allowed.access=annc.read,poll.vote
+
+# SAK-29695
+# Should the .auth role be assignable to a realm? Defaults to false.
+# sitemanage.grant.auth=true
+# Should the .anon role be assignable to a realm? Defaults to false.
+# sitemanage.grant.anon=true
 
 # #####
 # SAK-27743 Quartz job to seed sites, users, and resources

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2678,6 +2678,9 @@ public class SiteAction extends PagedResourceActionII {
 			List publicChangeableSiteTypes = (List) state
 					.getAttribute(STATE_PUBLIC_CHANGEABLE_SITE_TYPES);
 
+			context.put("authAllowed", ServerConfigurationService.getBoolean("sitemanage.grant.auth", false));
+			context.put("anonAllowed", ServerConfigurationService.getBoolean("sitemanage.grant.anon", false));
+
 			if (site != null) {
 				// editing existing site
 				context.put("site", site);

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -196,6 +196,7 @@
 			</label>
 		</p>
 		</fieldset>
+		#if ($!authAllowed || $!anonAllowed)
         <fieldset>
 			<legend>
 				<h4>$tlang.getString("ediacc.addit")</h4>
@@ -205,15 +206,20 @@
  				<input name="access" value="members" type="radio" id="access_members" #if($access == "members")checked="true"#end>
  				<label for="access_members">$tlang.getString("ediacc.noextra")</label>
  			</p>
+			#if ($!authAllowed)
  			<p class="checkbox indnt1">
  				<input name="access" value="authenticated" type="radio" id="access_authenticated"  #if($access == "authenticated")checked="true"#end>
  				<label for="access_authenticated">$tlang.getString("ediacc.auth")</label>
  			</p>
+			#end
+			#if ($!anonAllowed)
  			<p class="checkbox indnt1">
  				<input name="access" value="anonymous" type="radio" id="access_anonymous" #if($access == "anonymous")checked="true"#end>
  				<label for="access_anonymous">$tlang.getString("ediacc.anon")</label>
  			</p>
-        </fieldset>
+			#end
+		</fieldset>
+		#end
 		## site visibility
 		<fieldset>
 		<legend>


### PR DESCRIPTION
SiteAction now checks two properties, sitemanage.grant.anon/auth to determine whether anon and
auth roles are permitted.