### PR TITLE
SAK-29730 too many decimal places warning is shown twice

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11727,10 +11727,9 @@ public class AssignmentAction extends PagedResourceActionII
 							// the preview grade process might already scaled up the grade by "factor"
 							if (!((String) state.getAttribute(STATE_MODE)).equals(MODE_INSTRUCTOR_PREVIEW_GRADE_SUBMISSION))
 							{
-								validPointGrade(state, grade, factor);
-								
 								if (state.getAttribute(STATE_MESSAGE) == null)
 								{
+									validPointGrade(state, grade, factor);
 									int maxGrade = a.getContent().getMaxGradePoint();
 									try
 									{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29730

Steps to reproduce:

1) set sakai.property to use two (or more) decimal places: assignment.grading.decimals=2
2) create a new assignment graded by points
3) go to grade a student
4) enter a grade with more decimal places than you set the sakai.property to
5) save
6) notice the warning at the top of the page repeats itself:

"Alert: Please use only 2 decimal place(s) for the grade field. Please use only 2 decimal place(s) for the grade field."