### PR TITLE
KNL-1221 Add support for expanding zip file which is not encoded with

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -481,6 +481,13 @@
 # DEFAULT: true
 # content.zip.compress.enabled=true
 
+# KNL-1221 Charsets used to expand zip file name.
+# No matter set or not, UTF-8 will be tested. 
+# The sample is used in simplified Chinese envirnoment.
+# DEFAULT: (not set, and UTF-8 will be used)
+# content.zip.expand.charsets.count=1
+# content.zip.expand.charsets.1=GBK
+
 # Enable creation of Web Content tools from resources, on by default.
 # DEFAULT: true
 # content.make.site.page=true

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -490,7 +490,7 @@ public class ZipContentUtil {
 	}
 	
 	private List<String> getZipCharsets() {
-		String[] charsetConfig = ServerConfigurationService.getStrings("content.zip.charset");
+		String[] charsetConfig = ServerConfigurationService.getStrings("content.zip.expand.charsets");
 		if (charsetConfig == null) {
 			charsetConfig = new String[0];
 		}


### PR DESCRIPTION
If the charset which zip used is not UTF-8, Sakai cannot expand it in content tool. This patch will allow administrator to add extra charsets in sakai.properties.
There is a test zip file in the according JIRA ticket.