### PR TITLE
SAK-29737 dummy text appears to user on Site Info -> Page Order

### DIFF
--- a/site-manage/pageorder/tool/src/bundle/org/sakaiproject/tool/pageorder/bundle/Messages.properties
+++ b/site-manage/pageorder/tool/src/bundle/org/sakaiproject/tool/pageorder/bundle/Messages.properties
@@ -34,7 +34,7 @@ success_enabled={0} is now enabled for normal users
 success_changed={0} was changed to {1}
 success_reset=Page title was reset to {0}
 
-error_pageid=A valid 'pageId' is required
+error_pageid=A valid 'page ID' is required
 
 welcome=Changes to the page ordering will not take effect until you click 'Save'. Editing, Hiding, or Deleting a Page takes place immediately. Pressing either the Save or Cancel buttons returns you to the Main Site Info Tool Page.
 warning=Warning: Hiding tools does not prevent access to the tool items through direct links. To make the tool items inaccessible via direct links, the permissions must be adjusted within the relevant tool.

--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageDelProducer.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageDelProducer.java
@@ -2,7 +2,6 @@ package org.sakaiproject.site.tool.helper.order.rsf;
 
 import org.sakaiproject.site.tool.helper.order.impl.SitePageEditHandler;
 
-import uk.org.ponder.messageutil.MessageLocator;
 import uk.org.ponder.rsf.components.UIBranchContainer;
 import uk.org.ponder.rsf.components.UIContainer;
 import uk.org.ponder.rsf.components.UIMessage;
@@ -18,24 +17,22 @@ import uk.org.ponder.rsf.viewstate.ViewParamsReporter;
  *
  */
 public class PageDelProducer implements ViewComponentProducer, ViewParamsReporter {
-    
+
     public static final String VIEW_ID = "PageDel";
-    public MessageLocator messageLocator;
-    public SitePageEditHandler handler;      
-    
-    public String getViewID() {    
+    public SitePageEditHandler handler;
+
+    public String getViewID() {
         return VIEW_ID;
     }
 
     public void fillComponents(UIContainer tofill, ViewParameters viewParams, ComponentChecker arg2) {
         PageEditViewParameters params = (PageEditViewParameters) viewParams;
 
-        UIBranchContainer mode = null;
+        UIBranchContainer mode;
  
         if (params.pageId == null) {
             mode = UIBranchContainer.make(tofill, "mode-failed:");
-            UIOutput.make(mode, "message", messageLocator
-                    .getMessage("error_pageid"));
+            UIMessage.make(mode, "message", "error_pageid");
         }
         else {
             try {
@@ -50,7 +47,7 @@ public class PageDelProducer implements ViewComponentProducer, ViewParamsReporte
             }
         }
     }
-    
+
     public ViewParameters getViewParameters() {
         return new PageEditViewParameters();
     }

--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageEditProducer.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageEditProducer.java
@@ -1,5 +1,7 @@
 package org.sakaiproject.site.tool.helper.order.rsf;
 
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
@@ -31,7 +33,7 @@ public class PageEditProducer implements ViewComponentProducer, ViewParamsReport
     public void fillComponents(UIContainer tofill, ViewParameters paramso, ComponentChecker arg2) {
         PageEditViewParameters params = (PageEditViewParameters) paramso;
 
-        UIBranchContainer mode = null;
+        UIBranchContainer mode;
 
         if (params.pageId != null) {
             if (params.newTitle != null) {
@@ -51,7 +53,7 @@ public class PageEditProducer implements ViewComponentProducer, ViewParamsReport
                      UIMessage.make(mode, "message", "success_reset", new Object[] {newTitle});
                   }
                }
-               catch (Exception e) {
+               catch (IdUnusedException | PermissionException e) {
                   ErrorUtil.renderError(tofill, e);
                }
             }
@@ -111,7 +113,7 @@ public class PageEditProducer implements ViewComponentProducer, ViewParamsReport
                           new Object[] {oldTitle});
                     }
                 } 
-                catch (Exception e) {
+                catch (IdUnusedException | PermissionException e) {
                   ErrorUtil.renderError(tofill, e);
                }
             }
@@ -122,9 +124,8 @@ public class PageEditProducer implements ViewComponentProducer, ViewParamsReport
             UIMessage.make(mode, "message", "error_pageid");
         }
     }
-    
+
     public ViewParameters getViewParameters() {
         return new PageEditViewParameters();
     }
-
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29737

When in Site Info -> Page Order, if you try to delete a tool that somehow has a null page ID, you will get the hardcoded text from the markup file, rather than the actual error message that should be displayed ("A valid 'page ID' is required").

We're not sure how the page IDs are null, but we have seen this happen in production. I have been able to recreate the scenario using a debugger to make the page ID null to satisfy the code path to generate the error message.

The problem is two fold:

1) it's populating a UIOutput component instead of a UIMessage component; this subsequently fails to find the text of the given message bundle key. This results in an NPE in the logs and the hard-coded text from the markup file being displayed to the end user
2) unnecessarily using a MessageLocator object