### PR TITLE
SAK-29745 clicking the 'cancel' button on the assignments 'download all' or 'upload all' still displays the link to download

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -875,7 +875,7 @@ reorder.fail.valid.message=A number smaller than # please!
 
 ## the url used by download all process
 download_url_reminder = You have chosen to download student submissions. If you encountered a problem downloading all submissions, click on the following link:
-download_url_link_label = Download all link
+download_url_link_label = Download
 allPurpose_save = Save
 allPurpose_cancel = Cancel
 

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -15416,38 +15416,14 @@ public class AssignmentAction extends PagedResourceActionII
 	    }
 	    return retVal;
 	}
-
-	/**
-	 * 
-	 * @return
-	 */
-	public void doDownload_upload_all(RunData data)
-	{
-		SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
-		ParameterParser params = data.getParameters();
-		String flow = params.getString("flow");
-		if ("upload".equals(flow))
-		{
-			// upload
-			doUpload_all(data);
-		}
-		else if ("download".equals(flow))
-		{
-			// upload
-			doDownload_all(data);
-		}
-		else if ("cancel".equals(flow))
-		{
-			// cancel
-			doCancel_download_upload_all(data);
-		}
-	}
 	
 	public void doDownload_all(RunData data)
 	{
 		SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
-		
 		state.setAttribute(STATE_MODE, MODE_INSTRUCTOR_GRADE_ASSIGNMENT);
+		ParameterParser params = data.getParameters();
+		String downloadUrl = params.getString("downloadUrl");
+		state.setAttribute(STATE_DOWNLOAD_URL, downloadUrl);
 	}
 	
 	public void doUpload_all(RunData data)
@@ -16317,9 +16293,6 @@ public class AssignmentAction extends PagedResourceActionII
 	{
 		SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
 		state.setAttribute(STATE_MODE, MODE_INSTRUCTOR_GRADE_ASSIGNMENT);
-		ParameterParser params = data.getParameters();
-		String downloadUrl = params.getString("downloadUrl");
-		state.setAttribute(STATE_DOWNLOAD_URL, downloadUrl);
 		cleanUploadAllContext(state);
 	}
 	

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_uploadAll.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_uploadAll.vm
@@ -181,15 +181,15 @@
 			<p class="act">
 			#if ($download)
 				#set($alertMessage = $tlang.getString('downloadall.alert.choose.element'))
-				#set($actionString="#toolLinkParam($action 'doCancel_download_upload_all' 'flow=cancel')")
+				#set($actionString="#toolLinkParam($action 'doDownload_all')")
 				<input type="button" name="downloadButton" id="downloadButton"  accesskey="d" class="active"
 						onclick="invokeDownloadUrl('$accessPointUrl', '$actionString', '$alertMessage', '$contextString', '$viewString', '$searchString', '$showSubmissionByFilterSearchOnly');" value="$tlang.getString('downloadall.button.download')" />
 			#else
 				<input type="button" name="uploadButton" id="uploadButton"  accesskey="s" class="active"
-						onclick="ASN.disableControls();ASN.showSpinner('downloadUploadSpinner');document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doDownload_upload_all' 'flow=upload')'; submitform('uploadAllForm');" value="$tlang.getString('uploadall.button.upload')" />
+						onclick="ASN.disableControls();ASN.showSpinner('downloadUploadSpinner');document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doUpload_all')'; submitform('uploadAllForm');" value="$tlang.getString('uploadall.button.upload')" />
 			#end	
 					<input type="button" name="cancelButton" id="cancelButton"  accesskey="x"
-						onclick="ASN.disableControls();ASN.showSpinner('downloadUploadSpinner');document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doCancel_download_upload_all' 'flow=cancel')'; submitform('uploadAllForm');" value="$tlang.getString('gen.can')" />
+						onclick="ASN.disableControls();ASN.showSpinner('downloadUploadSpinner');document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doCancel_download_upload_all')'; submitform('uploadAllForm');" value="$tlang.getString('gen.can')" />
 					<img id="downloadUploadSpinner" class="spinner" src="/library/image/indicator.gif" />
 		</p>
 		</div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29745

Steps to reproduce:

    go to Assignments
    create an assignment
    click the Grade link from the table for that assignment
    click the Download All link or the Upload All link
    click the Cancel button

You'll get the following message:

    You have chosen to download student submissions. If you encountered a problem downloading all submissions, click on the following link:

    Download all link

This is wrong because you've cancelled. The message appears when you click Download as expected, but it shouldn't when you click Cancel (especially Cancel from the Upload page).