### PR TITLE
SAM-2601: Questions do not copy when copying question pool

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
@@ -463,7 +463,7 @@ public class QuestionPoolFacadeQueries
         Iterator j = itemList.iterator();
         while (j.hasNext()) {
           ItemData itemData = (ItemData) j.next();
-          h.put(itemData.getItemIdString(), itemData);
+          h.put(itemData.getItemId(), itemData);
         }
         ArrayList itemArrayList = new ArrayList();
         Iterator i = questionPoolItems.iterator();


### PR DESCRIPTION
References to question pool item ids were changed from String to Long in 10.5. Line 472 tries to get from the hash using Long item id, but it was inserted as a String, so no questions were being added to the QuestionPool.