### PR TITLE
SAK-29754 - Problem with maven eclipse:eclipse and project references

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1789,6 +1789,16 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.10</version>
+        <!-- https://issues.apache.org/jira/browse/MECLIPSE-726 -->
+        <configuration>
+          <useProjectReferences>true</useProjectReferences>
+          <workspace>..</workspace>
+        </configuration>
+      </plugin>
+      <plugin>
         <inherited>true</inherited>
         <groupId>org.sakaiproject.maven.plugins</groupId>
         <artifactId>sakai</artifactId>


### PR DESCRIPTION
I'm putting a needs review label on this, the change is adding some options to the maven eclipse plugin when run. Does anyone else run this plugin and import a single tool into eclipse (without importing all of Sakai?) Has anyone else noticed this behavior change mentioned in the SAK?

https://confluence.sakaiproject.org/display/BOOT/Import+Sakai+source+into+Eclipse