### PR TITLE
SAK-29757 assignment's grading notification emails need some improvements

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -903,9 +903,9 @@ content_review.accepted.types.delimiter=,
 content_review.accepted.types.lparen=(
 content_review.accepted.types.rparen=)
 
-noti.releaseresubmission.subject.content=Assignment submission has been corrected
-noti.releaseresubmission.text=Your submission to assignment "{0}" has been corrected and it allows resubmissions until the due date. Please go to {1} to view details.
-noti.releaseresubmission.noresubmit.text=Your submission to assignment "{0}" has been corrected. Please go to {1} to view details.
+noti.releaseresubmission.subject.content=Assignment submission has been graded
+noti.releaseresubmission.text=Your submission to assignment "{0}" has been graded and it allows resubmissions until the due date. Please go to {1} to view details.
+noti.releaseresubmission.noresubmit.text=Your submission to assignment "{0}" has been graded. Please go to {1} to view details.
 
 send.submission.releasereturn.email.options=Released Resubmission Notification Email Options:
 send.submission.releasereturn.email.none=Do not send notification email to student when the grade is released and resubmission is available

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -104,6 +104,7 @@ import java.util.zip.ZipOutputStream;
 
 //Export to excel
 import java.text.DecimalFormat;
+import org.sakaiproject.entitybroker.DeveloperHelperService;
 
 /**
  * <p>
@@ -168,6 +169,11 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 	private SecurityService securityService = null;
 	public void setSecurityService(SecurityService securityService){
 		this.securityService = securityService;
+	}
+
+	private DeveloperHelperService developerHelperService = null;
+	public void setDeveloperHelperService( DeveloperHelperService developerHelperService ) {
+		this.developerHelperService = developerHelperService;
 	}
 
 	String newline = "<br />\n";
@@ -2958,7 +2964,8 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		buffer.append(rb.getString("noti.site.title") + " " + siteTitle + newline);
 		buffer.append(rb.getString("noti.site.url") + " <a href=\""+ siteUrl+ "\">" + siteUrl + "</a>"+ newline);
 		// notification text
-		buffer.append(rb.getFormattedMessage("noti.releasegrade.text", new String[]{a.getTitle(), siteTitle}));
+		String linkToToolInSite = "<a href=\"" + developerHelperService.getToolViewURL( "sakai.assignment.grades", null, null, null ) + "\">" + siteTitle + "</a>";
+		buffer.append(rb.getFormattedMessage("noti.releasegrade.text", new String[]{a.getTitle(), linkToToolInSite}));
 		
 		return buffer.toString();
 	}
@@ -2987,11 +2994,13 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		if (s.getSubmitterIds() != null && s.getSubmitterIds().size() > 0) {
 		    userId = (String) s.getSubmitterIds().get(0);
 		}
+
+		String linkToToolInSite = "<a href=\"" + developerHelperService.getToolViewURL( "sakai.assignment.grades", null, null, null ) + "\">" + siteTitle + "</a>";
 		if (canSubmit(context,a,userId)) {
-		    buffer.append(rb.getFormattedMessage("noti.releaseresubmission.text", new String[]{a.getTitle(), siteTitle}));
+		    buffer.append(rb.getFormattedMessage("noti.releaseresubmission.text", new String[]{a.getTitle(), linkToToolInSite}));
 		}
 		else {
-		    buffer.append(rb.getFormattedMessage("noti.releaseresubmission.noresubmit.text", new String[]{a.getTitle(), siteTitle}));
+		    buffer.append(rb.getFormattedMessage("noti.releaseresubmission.noresubmit.text", new String[]{a.getTitle(), linkToToolInSite}));
 		}
 	 		
 	 	return buffer.toString();

--- a/assignment/assignment-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/assignment/assignment-impl/pack/src/webapp/WEB-INF/components.xml
@@ -26,6 +26,7 @@
  		<property name="autoDdl"><value>${auto.ddl}</value></property>
  		<property name="assignmentPeerAssessmentService"><ref bean="org.sakaiproject.assignment.api.AssignmentPeerAssessmentService"/></property>
  		<property name="securityService"><ref bean="org.sakaiproject.authz.api.SecurityService"/></property>
+ 		<property name="developerHelperService"><ref bean="org.sakaiproject.entitybroker.DeveloperHelperService"/></property>
  		
  		
  		<!--<property name="contentReviewService"><ref bean="org.sakaiproject.contentreview.service.ContentReviewService"/></property>-->


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29757

When a student gets a notification that their assignment has been graded it looks like this:

> Site Title: Project Site 017B
> Site ID: d3e634a6-73cc-4194-8c71-bbfeb5bdc74f
> 
> Your submission to assignment "Asn B" has been corrected. Please go to Project Site 017B to view details.`

Provide a link to the assignments tool in the site, and change the strange phrase "has been corrected" to "has been graded".

These changes also apply to the emails when resubmissions are allowed, and the email a student gets to notify them that a grade has been released.