### PR TITLE
SAK-29758 assignments -> grade report -> filter by name/id/email doesn't work in mixed (anonymous and regular assignments) scenarios

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4860,10 +4860,10 @@ public class AssignmentAction extends PagedResourceActionII
 		List submissions = prepPage( state );
 		context.put("submissions", submissions);
 
+		List<SubmitterSubmission> allSubmissions = (List) state.getAttribute(STATE_PAGEING_TOTAL_ITEMS);
 		boolean hasAtLeastOneAnonAssigment = false;
-		for( Object obj : submissions )
+		for( SubmitterSubmission submission : allSubmissions )
 		{
-			SubmitterSubmission submission = (SubmitterSubmission) obj;
 			Assignment assignment = submission.getSubmission().getAssignment();
 			if( AssignmentService.getInstance().assignmentUsesAnonymousGrading( assignment ) )
 			{

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -46,7 +46,7 @@
 		<div class="navPanel">
 			<div class="viewNav">
 			<br />
-			#if ($!groups.hasNext() || !$hasAtLeastOneAnonAssignment)
+			#if (!$hasAtLeastOneAnonAssignment)
 			<form name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
 			<input type="hidden" name="option" id="option" value="x" />
 			<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
@@ -72,7 +72,6 @@
 				<p />
 				#end
 
-				#if( !$hasAtLeastOneAnonAssignment )
 				<label for="$form_search" class="skip">$tlang.getString("search")</label>
 				<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
 					name="search" id="search" type="text" class="searchField" size="20" />
@@ -82,7 +81,6 @@
 				#end
 				<img id="userFilterSpinner" class="spinner" src="/library/image/indicator.gif" />
 				<p />
-				#end
 
 				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 			</form>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29758

In a site where you have a mix of both anonymous and regular assignments:

1) go to Assignments -> Grade Report
2) type the name/id/email of any student in the list into the filter text box
3) click the 'Find' button
4) form submits, page refreshes, filter is not applied and the filter text box is now gone

The problem is that the code to determine if there's an anonymous assignment (and conditionally not render the filter and group selection) is only checking the assignments on the current page. It should rather be checking the entire collection of submissions for all assignments.