### PR TITLE
SAK-29759 Permissions helper -> 'Undo Changes' link should be a button

### DIFF
--- a/authz/authz-tool/tool/src/webapp/css/authz.css
+++ b/authz/authz-tool/tool/src/webapp/css/authz.css
@@ -23,3 +23,7 @@
 a.noPointers, input.noPointers {
     pointer-events: none;
 }
+
+div#groupSelector {
+    margin-top: 0.5em;
+}

--- a/authz/authz-tool/tool/src/webapp/js/authz.js
+++ b/authz/authz-tool/tool/src/webapp/js/authz.js
@@ -40,12 +40,6 @@ $(document).ready(function(){
         $("input").not('[disabled]').prop("checked", false).change();
         e.preventDefault();
     });
-    $('#restdef').click(function(e){
-        $("input").prop("checked", false);
-        $(".defaultSelected input").prop("checked", true).change();
-        e.preventDefault();
-    });
-    
 });
 
 var AUTHZ = {};
@@ -94,17 +88,6 @@ AUTHZ.disableControls = function( escape )
     for( i = 0; i < buttons.length; i++ )
     {
         AUTHZ.disableButton( "", buttons[i] );
-    }
-
-    // Get the download/upload links
-    var undoAll = document.getElementById( "restdef" );
-    var links = [undoAll];
-    for( i = 0; i < links.length; i++ )
-    {
-        if( links[i] !== null )
-        {
-            AUTHZ.disableLink( links[i] );
-        }
     }
 };
 

--- a/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
+++ b/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
@@ -48,7 +48,8 @@
 		#end
 		## end if there are any groups at all			
 		<div class="actionItem itemAction" style="float:left;padding-top:.5em">
-			<a id="restdef" href="#">$thelp.getString("per.lis.restoredef")</a>
+			<input type="button" value="$thelp.getString("per.lis.restoredef")" onclick="AUTHZ.disableControls();AUTHZ.showSpinner( 'undoSpinner' );window.location.reload();" />
+			<img id="undoSpinner" class="spinner" src="/library/image/indicator.gif" />
 		</div>
 	</div>
 	


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29759


In the permissions helper UI, the "Undo Changes" link should be a button; links perform navigation to a new interface whereas buttons perform an action on the current page.