### PR TITLE
SAK-29519 Mark the cloud content beans as lazy.

### DIFF
--- a/cloud-content/pack/src/webapp/WEB-INF/components.xml
+++ b/cloud-content/pack/src/webapp/WEB-INF/components.xml
@@ -2,13 +2,13 @@
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 
 <beans>
-
+  <!-- These beans are lazy inited as they won't startup unless correctly configured -->
   <bean id="org.sakaiproject.content.api.FileSystemHandler.swift" class="coza.opencollab.sakai.cloudcontent.SwiftFileSystemHandler"
-        init-method="init" destroy-method="destroy">
+        init-method="init" destroy-method="destroy" lazy-init="true">
   </bean>
 
   <bean id="org.sakaiproject.content.api.FileSystemHandler.blobstore" class="coza.opencollab.sakai.cloudcontent.BlobStoreFileSystemHandler"
-        init-method="init" destroy-method="destroy">
+        init-method="init" destroy-method="destroy" lazy-init="true">
   </bean>
 
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,7 @@
                 <module>citations</module>
                 <module>common</module>
                 <module>config</module>
-                <!--
                 <module>cloud-content</module>
-                -->
                 <module>content</module>
                 <module>content-review</module>
                 <module>courier</module>
@@ -137,9 +135,7 @@
                 <module>clogdashboardintegration</module>
                 <module>common</module>
                 <module>config</module>
-                <!--
                 <module>cloud-content</module>
-                -->
                 <module>content</module>
                 <module>content-review</module>
                 <module>courier</module>


### PR DESCRIPTION
The cloud-content Spring beans require configuration to work and spring will create then even if they are not used by any other beans. To prevent them being created and failing the startup we set them to be lazily inited.