### PR TITLE
KNL-1373 Add generics support to the ComponentManager.

### DIFF
--- a/kernel/component-manager/src/main/java/org/sakaiproject/component/api/ComponentManager.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/component/api/ComponentManager.java
@@ -39,9 +39,9 @@ public interface ComponentManager
 	 * 
 	 * @param iface
 	 *        The interface Class.
-	 * @return a component instance, or null if not found.
+	 * @return a component instance the type of the class, or null if not found.
 	 */
-	Object get(Class iface);
+	<T> T get(Class<T> iface);
 
 	/**
 	 * Find a component that is registered to provide this interface.

--- a/kernel/component-manager/src/main/java/org/sakaiproject/component/cover/ComponentManager.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/component/cover/ComponentManager.java
@@ -113,7 +113,7 @@ public class ComponentManager {
 		return m_componentManager;
 	}
 
-	public static Object get(Class iface) {
+	public static <T> T get(Class<T> iface) {
 		return getInstance().get(iface);
 	}
 

--- a/kernel/component-manager/src/main/java/org/sakaiproject/component/impl/SpringCompMgr.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/component/impl/SpringCompMgr.java
@@ -48,7 +48,7 @@ import org.springframework.context.ConfigurableApplicationContext;
  * ApplicationContext.
  * </p>
  * <p>
- * See the {@link org.sakaiproject.api.kernel.component.ComponentManager}interface
+ * See the {@link org.sakaiproject.component.api.ComponentManager}interface
  * for details.
  * </p>
  */
@@ -214,8 +214,8 @@ public class SpringCompMgr implements ComponentManager {
 	/**
 	 * {@inheritDoc}
 	 */
-	public Object get(Class iface) {
-		Object component = null;
+	public <T> T get(Class<T> iface) {
+		T component = null;
 
 		try {
 			component = m_ac.getBean(iface.getName(), iface);


### PR DESCRIPTION
This means you don’t have to cast when supplying a class to the component manager that you would like an instance of.