### PR TITLE
SAK-29768 Remove unused codehaus plugin repository.

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -241,13 +241,6 @@
       </releases>
     </pluginRepository>
     <pluginRepository>
-      <id>codehaus plugin repository</id>
-      <url>https://nexus.codehaus.org/content/repositories/releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </pluginRepository>
-    <pluginRepository>
       <id>Sakai Plugin Repo</id>
       <url>http://source.sakaiproject.org/maven2</url>
       <releases>


### PR DESCRIPTION
The codehaus plugin repository isn’t needed any more and currently it’s causing build problems, so we should just drop it.