### PR TITLE
SAK-29773 user membership active/inactive toggle has problems with non-provided students in provided sites

### DIFF
--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
@@ -657,7 +657,7 @@ public class SiteListBean {
 					{
 						String roleID = site.getMember( userId ).getRole().getId();
 						AuthzGroup realm = authzGroupService.getAuthzGroup( realmID );
-						boolean isProvided = StringUtils.isNotBlank( realm.getProviderGroupId() );
+						boolean isProvided = realm.getMember( userId ).isProvided();
 						realm.addMember( userId, roleID, active, isProvided );
 						authzGroupService.save( realm );
 					}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29773

If you have a non-provided student in a provided site (added manually rather than in the roster), the User Membership tool will fail to flip the user to active/inactive. It will rather remove the enrolment for that site for the user.

The problem is with the provided check only checking if the site has a provider ID, rather than checking if the user is provided in the realm.