### PR TITLE
SAK-29776 improve performance of auto groups by roster

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -54,9 +54,6 @@ import uk.org.ponder.messageutil.TargettedMessage;
 import uk.org.ponder.messageutil.TargettedMessageList;
 import au.com.bytecode.opencsv.CSVReader;
 import java.util.Arrays;
-import org.sakaiproject.coursemanagement.api.CourseManagementService;
-import org.sakaiproject.coursemanagement.api.Membership;
-import org.sakaiproject.coursemanagement.api.exception.IdNotFoundException;
 
 /**
  * 
@@ -103,7 +100,6 @@ public class SiteManageGroupSectionRoleHandler {
     public String groupTitleUser = "";
     
     // SAK-29373
-    public CourseManagementService cms;
     public int rosterOptionAssign = OPTION_ASSIGN_BY_ROLES_OR_ROSTER;
     public boolean rosterGroupSplit = true;
     public String rosterNumToSplitGroup = "";
@@ -1084,26 +1080,17 @@ public class SiteManageGroupSectionRoleHandler {
         if( StringUtils.isNotBlank( groupTitle ) && StringUtils.isNotBlank( providerID ) )
         {
             Set<String> userSet = new HashSet<>();
-            try
+            List<AuthzGroup> realms = authzGroupService.getAuthzGroups( providerID, null );
+            for( AuthzGroup realm : realms )
             {
-                Set<Membership> sectionMembers = cms.getSectionMemberships( providerID );
-                for( Membership member : sectionMembers )
+                if( providerID.equals( realm.getProviderGroupId() ) )
                 {
-                    String userEID = member.getUserId();
-                    try
+                    Set<Member> members = realm.getMembers();
+                    for( Member member : members )
                     {
-                        String userID = userDirectoryService.getUserId( userEID );
-                        userSet.add( userID );
-                    }
-                    catch( UserNotDefinedException ex )
-                    {
-                        M_log.debug( this + ".createRandomGroupsForRoster: user not defined = " + userEID, ex );
+                        userSet.add( member.getUserId() );
                     }
                 }
-            }
-            catch( IdNotFoundException ex )
-            {
-                M_log.debug( this + ".createRandomGroupsForRoster: can't find section for provider ID = " + providerID, ex );
             }
 
             createRandomGroups( rosterGroupSplit, new ArrayList<>( userSet ), groupTitle, unit );

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/WEB-INF/requestContext.xml
@@ -51,7 +51,6 @@
     <property name="messages" ref="targettedMessageList" />
     <property name="httpServletRequest" ref="httpServletRequest" />
     <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
-    <property name="cms" ref="org.sakaiproject.coursemanagement.api.CourseManagementService" />
   </bean>
   
     <bean id="GroupDelProdcuer" 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29776

Improve the performance by cutting out the CMS and UserDirectoryService calls in favour of using the realm. This reduces code and eliminates the dependency on the CMS.