### PR TITLE
SAK-29777 assignment list 'remove selected' button should not have class='active' when disabled

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/js/assignments.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/assignments.js
@@ -808,6 +808,7 @@ ASN.checkEnableRemove = function()
     }
 
     document.getElementById( "btnRemove" ).disabled = !selected;
+    document.getElementById( "btnRemove" ).className = (selected ? "active" : "" );
 };
 
 ASN.doReorderAction = function( action )

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -819,7 +819,7 @@ function duplicateLink(lnk) {
 			</table>
 			#if ($!allowRemoveAssignment && $!view.equals('lisofass1'))
 				<p class="act">
-					<input type="submit" id="btnRemove" class="active" name="eventSubmit_doDelete_confirm_assignment" value="$tlang.getString("removeSelected")" accesskey="s" disabled="disabled" />
+					<input type="submit" id="btnRemove" name="eventSubmit_doDelete_confirm_assignment" value="$tlang.getString("removeSelected")" accesskey="s" disabled="disabled" />
 				</p>
 			#end
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29777

Currently in some browsers, when the button is disabled, you can still click on it and get an animation of sorts. This is because the 'active' class is still applied on the button.

The JavaScript to enable/disable the button based on assignment selection should also be adding/removing the 'active' class from the button as well.
