### PR TITLE
SAK-29780 error when deleting assignments

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -10268,13 +10268,13 @@ public class AssignmentAction extends PagedResourceActionII
 				
 				// remove related announcement if there is one
 				removeAnnouncement(state, pEdit);
-				
-				// we use to check "assignment.delete.cascade.submission" setting. But the implementation now is always remove submission objects when the assignment is removed.
-				// delete assignment and its submissions altogether
-				deleteAssignmentObjects(state, aEdit, true);
 
 				// remove from Gradebook
 				integrateGradebook(state, (String) ids.get (i), associateGradebookAssignment, "remove", null, null, -1, null, null, null, -1);
+
+				// we use to check "assignment.delete.cascade.submission" setting. But the implementation now is always remove submission objects when the assignment is removed.
+				// delete assignment and its submissions altogether
+				deleteAssignmentObjects(state, aEdit, true);
 			}
 		} // for
 

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
@@ -282,6 +282,13 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
         hibTempl.deleteAll(toBeDeleted);
         if (log.isInfoEnabled()) log.info("Deleted " + numberDeleted + " externally defined scores");
 
+        toBeDeleted = hibTempl.find( "from Comment as c where c.gradableObject = ?", asn );
+        hibTempl.deleteAll( toBeDeleted );
+        if( log.isInfoEnabled() )
+        {
+            log.info( "Deleted " + toBeDeleted.size() + " externally defined score comments" );
+        }
+
         // Delete the assessment.
 		hibTempl.flush();
 		hibTempl.clear();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29780

Deleting an assignment gives an error like:

> Alert: Can not find the assignment '/assignment/a/130370e6-a421-4dba-bf32-06df27a38820 /78fed328-2108-4ed7-9901-91f67bdf69dd'. Can not find the assignment '/assignment/a/130370e6-a421-4dba-bf32-06df27a38820/78fed328-2108-4ed7-9901-91f67bdf69dd'.

And leaves you on the delete page. The assignment is, however, deleted. A side effect of this bug is that assignments associated with gradebook items will not remove the gradebook item when the assignment is removed. It will leave orphaned gradebook items which cannot be deleted from the Gradebook tool.

The problem is the algorithm responsible for deleting all the data related to an assignment. It ran in the following order:

   1 delete calendar events associated with the assignment
   2 delete announcements associated with the assignment
   3 delete all submissions for the assignment, and the assignment itself
   4 delete the gradebook item associated with the assignment

However, because the assignment is actually deleted in the 3rd step, when it goes to check if it needs to delete any associated gradebook item(s), the code blows up because the assignment has already been deleted.

The solution is to swap items 3 and 4 so that the gradebook code is executed before the assignment is actually deleted.