### PR TITLE
KNL-1083: Content Hosting comparators are incompatible with java 7

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentHostingComparator.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/ContentHostingComparator.java
@@ -102,27 +102,27 @@ public class ContentHostingComparator implements Comparator
 		{
 			Entity entity1 = (Entity) o1;
 			Entity entity2 = (Entity) o2;
-			String str1 = entity1.getProperties().getProperty(property);
-			String str2 = entity2.getProperties().getProperty(property);
+			Integer rank1 = null;
+			Integer rank2 = null;
 
-			if(str1 == null || str2 == null)
-			{
-				// ignore -- default to a different sort
+			try {
+				rank1 = new Integer(entity1.getProperties().getProperty(property));
+			} catch (NumberFormatException e) { /* ignore, rank1 will be null */ }
+
+			try {
+				rank2 = new Integer(entity2.getProperties().getProperty(property));
+			} catch (NumberFormatException e) { /* ignore, rank2 will be null */ }
+
+			// Priorities can be null if a resource or collection was created before priorities were
+			// introduced. Sort null priorities to the bottom.
+			if (rank1 != null && rank2 != null) {
+				return m_ascending ? rank1.compareTo(rank2) : rank2.compareTo(rank1);
 			}
-			else
-			{
-				try
-				{
-					Integer rank1 = new Integer(str1);
-					Integer rank2 = new Integer(str2);
-					return m_ascending ? rank1.compareTo(rank2) : rank2.compareTo(rank1) ;
-				}
-				catch(NumberFormatException e)
-				{
-					// ignore -- default to a different sort
-				}
-			}
-			// if unable to do a priority sort, sort by title
+
+			if (rank1 != null) { return m_ascending ? -1 : 1; }
+			if (rank2 != null) { return m_ascending ? 1 : -1; }
+			
+			// If priorities are null for both items, fall back to display name sort.
 			property = ResourceProperties.PROP_DISPLAY_NAME;
 		}
 		
@@ -172,11 +172,8 @@ public class ContentHostingComparator implements Comparator
 		catch (Exception ignore)
 		{
 		}
-
-		// do a formatted interpretation - case insensitive
-		if (o1 == null) return -1;
-		if (o2 == null) return +1;
 		
+		// do a formatted interpretation - case insensitive
 		int rv = 0;
 		if (m_smart_sort) {
 			rv = compareLikeMacFinder( 

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/test/SortTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/test/SortTest.java
@@ -160,5 +160,33 @@ public class SortTest extends TestCase {
 		 */
 		assertTrue(c.comparerLocalSensitive("A1", "A184467440737095516160") < 0);
 	}
+
+	public void testPrioritySorts() {
+		ContentHostingComparator c = new ContentHostingComparator(ResourceProperties.PROP_CONTENT_PRIORITY, true, false);
+
+		MockContentResource priority10 = new MockContentResource("test", "itema");
+		priority10.getPropertiesEdit().addProperty(ResourceProperties.PROP_CONTENT_PRIORITY, "10");
+
+		MockContentResource priorityNull = new MockContentResource("test", "itemb");
+		MockContentResource diffPriorityNull = new MockContentResource("test", "iteme");
+
+		MockContentResource priority1 = new MockContentResource("test", "itemc");
+		MockContentResource diffPriority1 = new MockContentResource("test", "itemd");
+		priority1.getPropertiesEdit().addProperty(ResourceProperties.PROP_CONTENT_PRIORITY, "1");
+		diffPriority1.getPropertiesEdit().addProperty(ResourceProperties.PROP_CONTENT_PRIORITY, "1");
+
+		assertEquals(1, c.compare(priorityNull, priority10));
+		assertEquals(1, c.compare(priorityNull, priority1));
+		assertEquals(-1, c.compare(priority1, priority10));
+		assertEquals(0, c.compare(priority1, diffPriority1));
+		assertTrue(c.compare(priorityNull, diffPriorityNull) < 0);
+
+		c = new ContentHostingComparator(ResourceProperties.PROP_CONTENT_PRIORITY, false, false);
+		assertEquals(-1, c.compare(priorityNull, priority10));
+		assertEquals(-1, c.compare(priorityNull, priority1));
+		assertEquals(1, c.compare(priority1, priority10));
+		assertEquals(0, c.compare(priority1, diffPriority1));
+		assertTrue(c.compare(priorityNull, diffPriorityNull) > 0);
+	}
 	
 }


### PR DESCRIPTION
This should fix the error in resources related to item sorting. If the priorities on a resource or collection is null then you can run into a situation where a > b, b > c, and c > a. The solution is to treat null priority as 0. This will cause these items to sort to the top which we think is appropriate because the only way the priority can be null on a resource is if it was created before priorities were introduced.