### PR TITLE
SAK-29794 manual selection of checkboxes in user membership -> sitelist.jsp doesn't work

### DIFF
--- a/usermembership/tool/src/webapp/usermembership/sitelist.jsp
+++ b/usermembership/tool/src/webapp/usermembership/sitelist.jsp
@@ -68,7 +68,7 @@
             sortAscending="#{SiteListBean.sitesSortAscending}"
             rendered="#{SiteListBean.renderTable}" >
 			<h:column id="statusToggle">
-				<h:selectBooleanCheckbox value="#{row1.selected}" styleClass="chkStatus" onclick="USR_MEMBRSHP.checkEnableButtons();" />
+				<h:selectBooleanCheckbox value="#{row1.selected}" styleClass="chkStatus" onclick="this.value = this.checked; USR_MEMBRSHP.checkEnableButtons();" />
 			</h:column>
 			<h:column id="siteName">
 				<f:facet name="header">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29794

1) Select All
2) Deselect All
3) Manually select any number
4) Use any of the actions
5) Nothing happens because the backing bean thinks nothing is selected.

The problem is that the value attribute isn't being updated on click of the actual checkbox. When the form is loaded for the first time, all the checkboxes have a value="true". The select all/deselect all/invert selection JavaScript functions update the checked and value attributes accordingly. So you deselect all, and all the checkboxes have value="false". Then you go and manually select any number, but their value attribute remains false. So when you go to perform any of the actions, the backing bean thinks that none of the items are selected.

Adding some simple JavaScript to the onclick of the checkboxes themselves to update the value attribute solves the issue.