### PR TITLE
SAK-29802 group list select all/none is buggy; missing key error when click remove with no groups selected

### DIFF
--- a/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/rsf/GroupListProducer.java
+++ b/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/rsf/GroupListProducer.java
@@ -15,7 +15,6 @@ import org.sakaiproject.authz.api.GroupNotDefinedException;
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.Tool;
-import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.Validator;
 
@@ -189,7 +188,7 @@ public class GroupListProducer
  				if (tml.messageAt(i).args != null ) {
  					outString = messageLocator.getMessage(tml.messageAt(i).acquireMessageCode(),tml.messageAt(i).args[0]);
  				} else {
- 					outString = messageLocator.getMessage(tml.messageAt(i).acquireMessageCode());
+ 					outString = tml.messageAt(i).acquireMessageCode();
  				}
  				UIMessage.make(errorRow,"error",outString);
 			}

--- a/site-manage/site-manage-group-helper/tool/src/webapp/content/js/util.js
+++ b/site-manage/site-manage-group-helper/tool/src/webapp/content/js/util.js
@@ -15,8 +15,10 @@ function toggleCheckboxes( clickedElement )
 	for( i = 0; i < checkboxes.length; i++ )
 	{
 		checkboxes[i].checked = clickedElement.checked;
-		adjustCount( checkboxes[i], "removeCount", "delete-groups" );
+		adjustCount( checkboxes[i], "removeCount" );
 	}
+
+	checkEnableRemove();
 }
 
 function syncSelectAll()
@@ -33,24 +35,26 @@ function syncSelectAll()
 	}
 
 	document.getElementById( "selectAll" ).checked = allSelected;
+	checkEnableRemove();
 }
 
-function adjustCount(caller, countName, buttonName)
+function checkEnableRemove()
 {
-	var counter = document.getElementById(countName);
-	var button = document.getElementById(buttonName);
-	if(caller && caller.checked && caller.checked === true)
+	var button = document.getElementById( "delete-groups" );
+	if( button )
 	{
-		counter.value = parseInt(counter.value) + 1;
-	}
-	else
-	{
-		counter.value = parseInt(counter.value) - 1;
-	}
+		var anySelected = false;
+		var checkboxes = document.getElementsByName( "delete-group-selection" );
+		for( i = 0; i < checkboxes.length; i++ )
+		{
+			if( checkboxes[i].checked )
+			{
+				anySelected = true;
+				break;
+			}
+		}
 
-	if(button)
-	{
-		if(counter.value > 0)
+		if( anySelected )
 		{
 			button.disabled = false;
 			button.className='enabled active';
@@ -60,5 +64,18 @@ function adjustCount(caller, countName, buttonName)
 			button.disabled = true;
 			button.className='disabled';
 		}
+	}
+}
+
+function adjustCount(caller, countName)
+{
+	var counter = document.getElementById(countName);
+	if(caller && caller.checked && caller.checked === true)
+	{
+		counter.value = parseInt(counter.value) + 1;
+	}
+	else
+	{
+		counter.value = parseInt(counter.value) - 1;
 	}
 }

--- a/site-manage/site-manage-group-helper/tool/src/webapp/content/templates/GroupList.html
+++ b/site-manage/site-manage-group-helper/tool/src/webapp/content/templates/GroupList.html
@@ -51,7 +51,7 @@
 							<td rsf:id="group-size">Group Size</td>
 							<td>
 								<label rsf:id="delete-label" class="skip">Label for element</label>
-								<input rsf:id="group-select" title="Select to remove" type="checkbox" id="check-2" name="deleteGroup" value="" onclick="adjustCount(this, 'removeCount', 'delete-groups');syncSelectAll();" /> 
+								<input rsf:id="group-select" title="Select to remove" type="checkbox" id="check-2" name="deleteGroup" value="" onclick="adjustCount(this, 'removeCount');syncSelectAll();" />
 							</td>
 						</tr>
 					</tbody>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupListProducer.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupListProducer.java
@@ -213,7 +213,7 @@ public class GroupListProducer
  				if (tml.messageAt(i).args != null ) {
  					outString = messageLocator.getMessage(tml.messageAt(i).acquireMessageCode(),tml.messageAt(i).args[0]);
  				} else {
- 					outString = messageLocator.getMessage(tml.messageAt(i).acquireMessageCode());
+ 					outString = tml.messageAt(i).acquireMessageCode();
  				}
  				UIMessage.make(errorRow,"error",outString);
 			}

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/js/util.js
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/js/util.js
@@ -298,8 +298,10 @@ function toggleCheckboxes( clickedElement )
     for( i = 0; i < checkboxes.length; i++ )
     {
         checkboxes[i].checked = clickedElement.checked;
-        adjustCount( checkboxes[i], "removeCount", "delete-groups" );
+        adjustCount( checkboxes[i], "removeCount" );
     }
+
+    checkEnableRemove();
 }
 
 function syncSelectAll()
@@ -316,24 +318,26 @@ function syncSelectAll()
     }
 
     document.getElementById( "selectAll" ).checked = allSelected;
+    checkEnableRemove();
 }
 
-function adjustCount(caller, countName, buttonName)
+function checkEnableRemove()
 {
-    var counter = document.getElementById(countName);
-    var button = document.getElementById(buttonName);
-    if(caller && caller.checked && caller.checked === true)
+    var button = document.getElementById( "delete-groups" );
+    if( button )
     {
-        counter.value = parseInt(counter.value) + 1;
-    }
-    else
-    {
-        counter.value = parseInt(counter.value) - 1;
-    }
+        var anySelected = false;
+        var checkboxes = document.getElementsByName( "delete-group-selection" );
+        for( i = 0; i < checkboxes.length; i++ )
+        {
+            if( checkboxes[i].checked )
+            {
+                anySelected = true;
+                break;
+            }
+        }
 
-    if(button)
-    {
-        if(counter.value > 0)
+        if( anySelected )
         {
             button.disabled = false;
             button.className='enabled active';
@@ -360,5 +364,18 @@ function toggleGenPanel( clickedElement )
         div.className = "edit collapsed";
         $( div ).siblings().hide();
         resizeFrame( "shrink" );
+    }
+}
+
+function adjustCount(caller, countName)
+{
+    var counter = document.getElementById(countName);
+    if(caller && caller.checked && caller.checked === true)
+    {
+        counter.value = parseInt(counter.value) + 1;
+    }
+    else
+    {
+        counter.value = parseInt(counter.value) - 1;
     }
 }

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupList.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupList.html
@@ -57,7 +57,7 @@
 							<td rsf:id="group-members"></td>
 							<td>
 								<label rsf:id="delete-label" class="skip">Label for element</label>
-								<input rsf:id="group-select" title="Select to remove" type="checkbox" id="check-2" name="deleteGroup" value="" onclick="adjustCount(this, 'removeCount', 'delete-groups');syncSelectAll();" /> 
+								<input rsf:id="group-select" title="Select to remove" type="checkbox" id="check-2" name="deleteGroup" value="" onclick="adjustCount(this, 'removeCount');syncSelectAll();" />
 							</td>
 						</tr>
 					</tbody>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29802

If you select all, uncheck one box, then select all again, then select none, the Remove Checked button is still enabled.

If you press the button, you get a missing key error:

[missing key (mre): org.sakaiproject.site.tool.managegroupsectionrole.bundle.Messages Please choose at least one group to be deleted.]