### PR TITLE
SAK-29803 group membership is too sticky when creating new groups

### DIFF
--- a/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/impl/SiteManageGroupHandler.java
+++ b/site-manage/site-manage-group-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroup/impl/SiteManageGroupHandler.java
@@ -130,6 +130,7 @@ public class SiteManageGroupHandler {
 			deleteGroupIds=new String[]{};
 			selectedGroupMembers = new String[]{};
 			selectedSiteMembers = new String[]{};
+			memberList = new String();
 		}
 	}
 	 

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -205,6 +205,7 @@ public class SiteManageGroupSectionRoleHandler {
             selectedSiteMembers = new String[]{};
             selectedRosters = new HashMap<>();
             selectedRoles = new HashMap<>();
+            memberList = new String();
 
             optionAssign=OPTION_ASSIGN_BY_ROLES_OR_ROSTER;
             groupSplit = true;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29803

If you create a group and then create another, the second group is pre-populated with the previous group's members.

memberList needs to be re-initialized in the resetParams() function.
