### PR TITLE
SAK-29804 assignments -> update disableControls JavaScript to include links by name attribute

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/js/assignments.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/assignments.js
@@ -556,7 +556,7 @@ ASN.toggleElements = function( elements, disabled )
 };
 
 // SAK-29314
-ASN.disableControls = function( escape )
+ASN.disableControls = function( escape, linkName )
 {
     // Clone and disable all drop downs (disable the clone, hide the original)
     var dropDowns = ASN.nodeListToArray( document.getElementsByTagName( "select" ) );
@@ -614,6 +614,18 @@ ASN.disableControls = function( escape )
         if( links[i] !== null )
         {
             ASN.disableLink( links[i] );
+        }
+    }
+
+    if( linkName !== null )
+    {
+        var links = ASN.nodeListToArray( document.getElementsByName( linkName ) );
+        for( i = 0; i < links.length; i++ )
+        {
+            if( links[i] !== null )
+            {
+                ASN.disableLink( links[i] );
+            }
         }
     }
 };

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -57,7 +57,7 @@
 					<input type="hidden" name="eventSubmit_doView" value="view" />
 					<label for="view">$tlang.getString("gen.view2")</label>
 					<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-					<select name="view" id="view" size="1" tabindex="3" onchange="ASN.disableControls();ASN.showSpinner( 'viewSpinner' );document.viewFormList.submit();">
+					<select name="view" id="view" size="1" tabindex="3" onchange="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'viewSpinner' );document.viewFormList.submit();">
 						<option value="lisofass1" >$!tlang.getString('lisofass1')</option>
 						<option value="lisofass2" selected="selected" >$!tlang.getString('lisofass2')</option>
 					</select>
@@ -74,7 +74,7 @@
 						</div>
  						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
 
- 						<select id="viewgroup" name="viewgroup" size="1" tabindex="3" onchange="ASN.disableControls();ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
+ 						<select id="viewgroup" name="viewgroup" size="1" tabindex="3" onchange="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
 
 							#if (!$showSubmissionByFilterSearchOnly)
 								<option value="all" #if($!viewGroup.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
@@ -144,12 +144,12 @@
 							<td headers="studentname" class="specialLink">	
 								<h4>
 								#if (!$studentListShowSet.contains($member.Id))
-									<a href="#" onclick="ASN.disableControls();ASN.showSpinner( 'userSpinner_$member.Id' );location='#toolLinkParam("AssignmentAction" "doShow_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
-											title="$tlang.getString("stulistsunbm.shostuass")">
+									<a href="#" onclick="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'userSpinner_$member.Id' );location='#toolLinkParam("AssignmentAction" "doShow_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
+											title="$tlang.getString("stulistsunbm.shostuass")" name="studentLink" >
 										<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("stulistsunbm.shostuass")" width="13" height="13" border="0" />
 								#else 
-									<a href="#" onclick="ASN.disableControls();ASN.showSpinner( 'userSpinner_$member.Id' );location='#toolLinkParam("AssignmentAction" "doHide_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
-											title="$tlang.getString("stulistsunbm.hidstuass")">
+									<a href="#" onclick="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'userSpinner_$member.Id' );location='#toolLinkParam("AssignmentAction" "doHide_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
+											title="$tlang.getString("stulistsunbm.hidstuass")" name="studentLink" >
 										<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("stulistsunbm.hidstuass")" width="13" height="13" border="0" />
 								#end
 										$submitterName
@@ -183,7 +183,7 @@
 												#if ($allowAddAssignment && $allowSubmitByInstructor)
 												#set( $spinnerID = "submitFor_" + $member.Id + "_" + $validator.escapeUrl($assignment.Reference) )
 												<div class="itemAction">
-													<a onclick="ASN.disableControls();ASN.showSpinner( '$spinnerID' );" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)&submitterId=$validator.escapeUrl($member.id)")">
+													<a onclick="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( '$spinnerID' );" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)&submitterId=$validator.escapeUrl($member.id)")">
 														$tlang.getString("submitforstudent")
 													</a>
 													<img id="$spinnerID" class="spinner" src="/library/image/indicator.gif" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -126,7 +126,7 @@ function duplicateLink(lnk) {
 						$tlang.getString("gen.view2")
 					</label>
 					<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-					<select id="view" name="view" size="1" tabindex="3" onchange="ASN.disableControls();ASN.showSpinner( 'viewSpinner' );document.viewForm.submit();">
+					<select id="view" name="view" size="1" tabindex="3" onchange="ASN.disableControls( null, 'asnActionLink' );ASN.showSpinner( 'viewSpinner' );document.viewForm.submit();">
 						<option value="lisofass1" #if($!view.equals('lisofass1'))selected="selected"#end >$!tlang.getString('lisofass1')</option>
 						<option value="lisofass2" #if($!view.equals('lisofass2'))selected="selected"#end >$!tlang.getString('lisofass2')</option>
 					</select>
@@ -152,23 +152,23 @@ function duplicateLink(lnk) {
 			#if ($pagesize != 0)
 				#if ($goFPButton == "true")
 					<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")" /></fieldset>
+						<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#else
 					<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" disabled="disabled" /></fieldset>
+						<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" disabled="disabled" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#end
 				#if ($goPPButton == "true")
 					<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getString('gen.previous') $pagesize" accesskey="p" /></fieldset>
+						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getString('gen.previous') $pagesize" accesskey="p" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#else
 					<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" disabled="disabled" /></fieldset>
+						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" disabled="disabled" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#end
@@ -186,23 +186,23 @@ function duplicateLink(lnk) {
 			#if ($pagesize != 0)
 				#if ($goNPButton == "true")
 					<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getString('gen.next') $pagesize" accesskey="n" /></fieldset>
+						<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getString('gen.next') $pagesize" accesskey="n" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#else
 					<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" disabled="disabled" /></fieldset>
+						<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" disabled="disabled" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#end
 				#if ($goLPButton == "true")
 					<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString('gen.last')" /></fieldset>
+						<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString('gen.last')" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#else
 					<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" disabled="disabled" /></fieldset>
+						<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" disabled="disabled" /></fieldset>
 						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 					</form>
 				#end
@@ -228,7 +228,6 @@ function duplicateLink(lnk) {
 							#end 
 						</a>
 					</th>
-                                        
 					#if ($!allowGradeSubmission)
 						<th id="$tlang.getString('gen.visible')">
 							#if (!$sortedBy.equalsIgnoreCase("$tlang.getString('gen.visible')"))
@@ -329,7 +328,7 @@ function duplicateLink(lnk) {
 				</tr>
 				#set ($assignmentCount = 0)
 				#foreach ($assignment in $assignments)
-                                        #set ($assignmentContent = $assignment.getContent())
+					#set ($assignmentContent = $assignment.getContent())
 					#set ($assignmentReference = $assignment.Reference)
 					#set($assignmentProperties=$!assignment.getProperties())
 					## all allow function results
@@ -368,12 +367,12 @@ function duplicateLink(lnk) {
 							<td headers="title">
 									#if (($!allowAddAssignment || $!allowUpdateAssignment || $!service.allowGradeSubmission($assignment.getReference())) && $!view.equals('lisofass1'))
 										<h4>
-                                                                                        #assignmentTitleIcon($assignment)
+											#assignmentTitleIcon($assignment)
 											## normal instructor view
 											#if ($assignment.draft && $!allowUpdateAssignment )
-												<a href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">
+												<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">
 											#else
-												<a href="#toolLinkParam("$action" "doView_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">
+												<a name="asnActionLink" href="#toolLinkParam("$action" "doView_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">
 											#end
 											#if ($!assignment.draft)
 												<span class="highlight">$tlang.getString("gen.dra2") </span>
@@ -387,8 +386,8 @@ function duplicateLink(lnk) {
 										</h4>
 										<div class="itemAction">
 											#set($prevAction=false)
-											#if ($!allowUpdateAssignment)#set($prevAction=true)<a href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
-											#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) | #else#set($prevAction=true)#end<a onclick="duplicateLink(this);return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("dupli") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
+											#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
+											#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) | #else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("dupli") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
 											#if ($taggable && $allowAddAssignment)
 												#foreach ($provider in $providers)
 													#set ($helperInfo = false)
@@ -400,14 +399,14 @@ function duplicateLink(lnk) {
 														#else
 															#set($prevAction=true)
 														#end
-															<a href="#toolLinkParam("$action" "doHelp_activity" "activityRef=$validator.escapeUrl($activity.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!helperInfo.description">$!helperInfo.name</a>
+															<a name="asnActionLink" href="#toolLinkParam("$action" "doHelp_activity" "activityRef=$validator.escapeUrl($activity.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!helperInfo.description">$!helperInfo.name</a>
 													#end
 												#end
 											#end
 											#if (!$assignment.draft && $!service.allowGradeSubmission($assignment.getReference()))#if($prevAction) | #end
 											#set ($gradeScale = $assignmentContent.getTypeOfGrade())
 											## show "view submissions" link for ungraded type of assignment
-												<a href="#" onclick="if(allowClick(this)){ASN.disableControls();ASN.showSpinner( 'viewSubmissionsSpinner_$assignmentReference' );window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")';}" >#if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end <span class="skip">: $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>
+												<a name="asnActionLink" href="#" onclick="if(allowClick(this)){ASN.disableControls( null, 'asnActionLink' );ASN.showSpinner( 'viewSubmissionsSpinner_$assignmentReference' );window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")';}" >#if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end <span class="skip">: $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>
 												<img id="viewSubmissionsSpinner_$assignmentReference" class="spinner" src="/library/image/indicator.gif" />
 											#end
 										</div>
@@ -423,20 +422,20 @@ function duplicateLink(lnk) {
 													#end
 												#end
 												## if not submitted or returned and still allowed to submit within the due time
-                                                                                                #assignmentTitleIcon($assignment)
-                                                                                                #if ($service.canSubmit($assignment.getContext(), $assignment))
+												#assignmentTitleIcon($assignment)
+												#if ($service.canSubmit($assignment.getContext(), $assignment))
 													## go to view submission page when (1) submission has been returned and allow for resubmit;(2)submission has not been posted yet.
-													<a href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">
+													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">
 												#else
-													<a href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submission.Reference)")">
+													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submission.Reference)")">
 												#end
-												$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>                                     
+												$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
 											#else
-                                                                                                #assignmentTitleIcon($assignment)
+												#assignmentTitleIcon($assignment)
 												$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))
 												#if ($!allowSubmit)
 													<div class="itemAction">
-														<a href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">
+														<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">
 															$tlang.getString("subasstudent")<span class="skip">: $validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</span>
 														</a>
 													</div>	
@@ -472,17 +471,17 @@ function duplicateLink(lnk) {
 													#if ($service.canSubmit($assignment.getContext(), $assignment))
 														## go to view submission page when (1) submission has been returned and allow for resubmit;(2)submission has not been posted yet.
 														<h4>#assignmentTitleIcon($assignment)
-                                                                                                                <a href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
-                                                                                                                </h4>
+															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
+														</h4>
 												#else
 														<h4>#assignmentTitleIcon($assignment)
-                                                                                                                <a href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submission.Reference)")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
-                                                                                                                </h4>														
+															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submission.Reference)")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
+														</h4>
 													#end
 												#else
-												 <h4>#assignmentTitleIcon($assignment)
-                                                                                                    <a href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
-                                                                                                 </h4>
+												<h4>#assignmentTitleIcon($assignment)
+													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a>
+												</h4>
 												#end
 												#if ($taggable && $allowAddAssignment)
 													<div class="itemAction">
@@ -497,7 +496,7 @@ function duplicateLink(lnk) {
 																#else
 																	#set($prevAction=true)
 																#end
-																<a href="#toolLinkParam("$action" "doHelp_activity" "activityRef=$validator.escapeUrl($activity.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!activityHelperInfo.description">$!activityHelperInfo.name</a>
+																<a name="asnActionLink" href="#toolLinkParam("$action" "doHelp_activity" "activityRef=$validator.escapeUrl($activity.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!activityHelperInfo.description">$!activityHelperInfo.name</a>
 															#end
 															#if ($!submission)
 																#set ($itemHelperInfo = false)
@@ -509,14 +508,14 @@ function duplicateLink(lnk) {
 																	#else
 																		#set($prevAction=true)
 																	#end
-																	<a href="#toolLinkParam("$action" "doHelp_item" "itemRef=$validator.escapeUrl($item.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!itemHelperInfo.description">$!itemHelperInfo.name</a>
+																	<a name="asnActionLink" href="#toolLinkParam("$action" "doHelp_item" "itemRef=$validator.escapeUrl($item.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!itemHelperInfo.description">$!itemHelperInfo.name</a>
 																#end
 															#end
 														#end
 													</div>
 												#end
 											#else
-												<a href="#toolLinkParam("AssignmentAction" "doView_assignment_as_student" "assignmentId=$assignment.Reference")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a></h4>
+												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_as_student" "assignmentId=$assignment.Reference")">$validator.escapeHtml($validator.limit($assignment.getTitle(), 40))</a></h4>
 											#end
 										#end
 										#set ($deleted = false)
@@ -576,7 +575,7 @@ function duplicateLink(lnk) {
 										$submission.getStatus()
 										#if ($submission.getSubmitted()) 
 											#if ($assignment.getDueTime() && $submission.getTimeSubmitted() && $submission.getTimeSubmitted().after($assignment.getDueTime()))
-                                            	<span class="highlight">$tlang.getString("gen.late2")</span>
+												<span class="highlight">$tlang.getString("gen.late2")</span>
 											#end
 										#end
 									#else
@@ -589,10 +588,9 @@ function duplicateLink(lnk) {
 							</td>
 							<td headers="dueDate">
 							#if ($assignmentContent.getHideDueDate() != "true" || $!allowUpdateAssignment)
-
-                                ##Instructors can still see the due date
-                                <span class="highlight">$!assignment.dueTime.toStringLocalFull()</span>
-                            #end
+								##Instructors can still see the due date
+								<span class="highlight">$!assignment.dueTime.toStringLocalFull()</span>
+							#end
 
 							</td>
 
@@ -615,7 +613,7 @@ function duplicateLink(lnk) {
 											#set($totalNumber = $ungradedNumber)
 										#end
 									#end
-									<a href="#" onclick="if(allowClick(this)){ASN.disableControls();ASN.showSpinner( 'viewSubmissionsSpinner2_$assignmentReference' );window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")';}" >
+									<a name="asnActionLink" href="#" onclick="if(allowClick(this)){ASN.disableControls( null, 'asnActionLink' );ASN.showSpinner( 'viewSubmissionsSpinner2_$assignmentReference' );window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")';}" >
 									<span class="skip"> #if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end : $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64)). </span> <span class="skip">$!tlang.getString("gen.subm2"): </span>$!totalNumber/<span class="skip">$!tlang.getString("ungra"): </span>$!ungradedNumber</a>
 									<img id="viewSubmissionsSpinner2_$assignmentReference" class="spinner" src="/library/image/indicator.gif" />
 								#end
@@ -714,7 +712,7 @@ function duplicateLink(lnk) {
 												#else
 													<!-- user hasn't started -->
 													$tlang.getString("peerassessment.notStarted")
-												#end												
+												#end
 											#end
 										#end
 									#else
@@ -765,7 +763,7 @@ function duplicateLink(lnk) {
 												#if($review.isSubmitted())
 													$tlang.getFormattedMessage("peerassessment.student", $reviewCount)&nbsp;<img src="/library/image/silk/accept.png"/>
 												#else
-													<a href="#toolLinkParam("$action" "doEdit_review" "assignmentId=$validator.escapeUrl($assignmentReference)&submissionId=$validator.escapeUrl($review.getSubmissionId())")">
+													<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_review" "assignmentId=$validator.escapeUrl($assignmentReference)&submissionId=$validator.escapeUrl($review.getSubmissionId())")">
 														$tlang.getFormattedMessage("peerassessment.student", $reviewCount)
 													</a>
 												#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29804

On the assignment list and assignment list by student you can effectively click links such as the grade, edit, student expand (list by student). This has the effect of duplicating the cloned controles (list by student) until the page is reloaded. On the main assignment list page, it has the effect that you're not sure where you'll be taken. Maybe it's the last thing you clicked? Maybe not. A simple solution is to update the JavaScript algorithm to 'disable' a set of links limited by the name attribute.