### PR TITLE
SAK-29823 site type title not editable sakai.property not being obeyed

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -161,7 +161,7 @@ function submitRemoveSection(index){
                 <span class="reqStar">*</span>
 				$tlang.getString("sitediinf.sittit")
 			</label>
-			#if (!$!existingSite || $!siteTitleEditable)
+			#if ($siteTitleEditable)
 				<input type="text" name="title" id="title" size="20" maxlength="$!titleMaxLength" value="$validator.escapeHtml($!title)" />
 			#else
 				$validator.escapeHtml($!title)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29823

After stepping through the code in debug mode, the properties are actually loaded properly. The problem is the implementation in the velocity template.

Whoever updated the property and loading code didn't check the velocity template to see how it was implemented to obey the property. The conditional was effectively the opposite of what it needs to be:

> #if (!$!existingSite || $!siteTitleEditable)

The code shouldn't care if the site exists already or not, we want it to obey the property regardless. Also, it shouldn't be rendering the input field if the site title is NOT editable; it should only render it if it IS editable:

> #if ($siteTitleEditable)