### PR TITLE
SAK-29830 - CKEditor plugins aren't working full screen

### DIFF
--- a/reference/library/src/webapp/editor/ckeditor.launch.js
+++ b/reference/library/src/webapp/editor/ckeditor.launch.js
@@ -218,12 +218,14 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
 
           var onShow = dialogDefinition.onShow;
           dialogDefinition.onShow = function() {
-              var pos = findPos(e.editor.container.$);
-              this.move(this.getPosition().x, pos[1]);
+              var result;
               if (typeof onShow !== 'undefined' && typeof onShow.call === 'function') {
-                  var result = onShow.call(this);
-                  return result;
+                  result = onShow.call(this);
               }
+              var pos = findPos(e.editor.container.$);
+              //SAK-29830 - On some pages it was moving too far down the pages, on others it was still moving too far. This fix is intended to cut that significantly.
+              this.move(this.getPosition().x, pos[1]*0.25);
+              return result;
           }
 
           if ( dialogName == 'link' )


### PR DESCRIPTION
This commit has two changes. This makes the re-position code happen after calling the "onShow" of the method (which some actually re-position the plugin) and it also positons the dialog only 25% of the height of the box, which was sometimes a problem when maximizing the dialog in some places. This is all just a temporary hack for iFrames that hopefully can go away in 11.