### PR TITLE
SAK-29845 course grade calc error

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookPermissionServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookPermissionServiceImpl.java
@@ -1293,7 +1293,7 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 		for(PermissionDefinition def: permissionDefinitions) {
 			
 			if(!StringUtils.equalsIgnoreCase(def.getFunction(), GraderPermission.GRADE.toString()) && !StringUtils.equalsIgnoreCase(def.getFunction(), GraderPermission.VIEW.toString()) && !StringUtils.equalsIgnoreCase(def.getFunction(), GraderPermission.VIEW_COURSE_GRADE.toString())) {
-				throw new IllegalArgumentException("Invalid function for permission definition");
+				throw new IllegalArgumentException("Invalid function for permission definition: " + def.getFunction());
 			}
 			
 			Permission permission = new Permission();

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2720,27 +2720,24 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			Long assignmentId = assignment.getId();
 			
 			String grade = gradeMap.get(assignmentId);
-			
-			//update total points possible and number of assignments to be counted in the calculations
+						
+			//only update the variables for the calculation if:
+			// 1. the assignment has points to be assigned
+			// 2. its not extra credit
+			// 3. there is a grade for the student 
 			if(assignment.getPoints() != null && !assignment.isExtraCredit() && StringUtils.isNotBlank(grade)) {
 				totalPossible = totalPossible.add(new BigDecimal(assignment.getPoints().toString()));
 				numOfAssignments++;
+				numScored++;
 			}
 			
 			//sanitise grade
-			
 			if(StringUtils.isBlank(grade)) {
 				grade = "0";
 			}
 			
 			//update total points earned
 			totalEarned = totalEarned.add(new BigDecimal(grade));
-			
-			
-			if(!assignment.isExtraCredit()){
-				numScored++;
-			}
-			
 		}
 		
     	if (numScored == 0 || numOfAssignments == 0 || totalPossible.doubleValue() == 0) {

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2718,7 +2718,17 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		for(org.sakaiproject.service.gradebook.shared.Assignment assignment: assignments) {
 			
 			Long assignmentId = assignment.getId();
+			
 			String grade = gradeMap.get(assignmentId);
+			
+			//update total points possible and number of assignments to be counted in the calculations
+			if(assignment.getPoints() != null && !assignment.isExtraCredit() && StringUtils.isNotBlank(grade)) {
+				totalPossible = totalPossible.add(new BigDecimal(assignment.getPoints().toString()));
+				numOfAssignments++;
+			}
+			
+			//sanitise grade
+			
 			if(StringUtils.isBlank(grade)) {
 				grade = "0";
 			}
@@ -2726,11 +2736,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			//update total points earned
 			totalEarned = totalEarned.add(new BigDecimal(grade));
 			
-			//update total points possible and number of assignments
-			if(assignment.getPoints() != null && !assignment.isExtraCredit()) {
-				totalPossible = totalPossible.add(new BigDecimal(assignment.getPoints().toString()));
-				numOfAssignments++;
-			}
+			
 			if(!assignment.isExtraCredit()){
 				numScored++;
 			}


### PR DESCRIPTION
From: https://github.com/steveswinsburg/gradebookNG/issues/196

Category subtotal percentages (within the subtotal columns/student summary/student view and when calculated in the Course Grade) are reflecting null values, calculating them as 0's.

E.g., A category contains two items, each worth 100 pts. Student receives a 90/100 on one item, with no value supplied to the second. Category subtotal should display as 90% (90/100), but is instead displaying as 45% (90/200).

GB1 ignores null values in order to give subtotal/course grade calculations based solely off of entered grades.

https://jira.sakaiproject.org/browse/SAK-29845
