### PR TITLE
SAK-26327 remove indexes that are impossible because of column length

### DIFF
--- a/rwiki/rwiki-model/src/java/uk/ac/cam/caret/sakai/rwiki/model/RWiki.hbm.xml
+++ b/rwiki/rwiki-model/src/java/uk/ac/cam/caret/sakai/rwiki/model/RWiki.hbm.xml
@@ -91,7 +91,7 @@
 		<property name="content" not-null="false" type="materialized_clob" />
 		-->
 		<!-- enough for about 400 pages, dont want to use a clob here -->
-		<property name="referenced" not-null="false" length="4000" index="irwikihistory_ref" />
+		<property name="referenced" not-null="false" length="4000" />
 		<!-- the user that edited this page. -->
 		<!-- when versioning is on, the last entry is the last updated -->
 		<!-- the first entry is the creator -->
@@ -140,7 +140,7 @@
 	-->
 
     <!-- enough for about 400 pages, dont want to use a clob here -->
-	<property name="referenced" not-null="false" length="4000" index="irwikiobject_ref" />
+	<property name="referenced" not-null="false" length="4000" />
 
 	<!-- the user that edited this page. -->
 	<!-- when versioning is on, the last entry is the last updated -->

--- a/shortenedurl/api/src/java/org/sakaiproject/shortenedurl/hbm/RandomisedUrl.hbm.xml
+++ b/shortenedurl/api/src/java/org/sakaiproject/shortenedurl/hbm/RandomisedUrl.hbm.xml
@@ -16,7 +16,7 @@
 		
 		<!-- KEY is a reserved SQL keyword, so it's TINY -->
 		<property name="key" column="TINY" type="string" not-null="true" index="KEY_INDEX" />
-		<property name="url" column="URL" type="string" length="4000" not-null="true" index="URL_INDEX" />
+		<property name="url" column="URL" type="string" length="4000" not-null="true" />
 		
 	</class>
 	


### PR DESCRIPTION
These indexes will all cause stacktraces when starting Sakai with auto.ddl enabled. It's impossible to put an index on a 4000 char column in MySQL:

"By default, an index key for a single-column index can be up to 767 bytes. "

http://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html