### PR TITLE
SAK-29855 SAM-2218 - Some ideas for setting initial focus a11y

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/site.vm
@@ -179,5 +179,9 @@
         #parse("/vm/morpheus/includeGoogleTagManager.vm")
 
         ${includeExtraHead}
+        <script>
+            //Setup initial page focus
+            ${d}PBJQ(document).ready(setInitialFocus());
+        </script>
     </body>
 </html>

--- a/reference/library/src/webapp/js/headscripts.js
+++ b/reference/library/src/webapp/js/headscripts.js
@@ -741,3 +741,15 @@ function modalDialogWidth() {
 	if ( dWidth < 300 ) dWidth = 300; // Should not happen
 	return Math.round(dWidth);
 }
+
+//Funtion to try to improve a11y by changing where the focus is. I don't see setFocus ever called by anything
+function setInitialFocus() {
+    var errorMsg = $('table.messageSamigo');
+    if (errorMsg.length !=0) {
+        errorMsg.focus()
+        return;
+    }
+    //Default focus
+    $('.portletBody').find ('input:visible:first').focus();
+
+}


### PR DESCRIPTION
I'm putting this up for review. This seems like a long standing issue (back from SAK-7131) that nobody has resolved. It currently has a special case in there for messageSamigo which is an important message that Samigo wants the user to focus on. 

There's a method in headscripts setFocus(elements) that's been in there since revision 1, but it looks like the only thing it _might_ have been used for were velocity tools and I don't even see exactly when/if those are calling it. 

I think it could be nice if the tool could adjust where the focus would be so we don't have a dozen special cases here, though since this should only change where the tab key starts from and where the screen readers start reading from, it seems like the impact is low. 

Also I can tell from the code and debugging that it is calling it, but I can't see any visible changes, though the tab order seems to be _better_. Any thoughts?
