### PR TITLE
KNL-1256 - Lower BaseAuthzGroup logging level

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
@@ -645,7 +645,9 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
                         permissions.add(rf.function);
                         roles.add(rf.role);
                     }
-                    M_log.info("Changed permissions for roles (" + roles + ") in " + azGroup.getId() + ": " + permissions);
+                    if (M_log.isDebugEnabled()) {
+                        M_log.debug("Changed permissions for roles (" + roles + ") in " + azGroup.getId() + ": " + permissions);
+                    }
                 }
                 ((SakaiSecurity) securityService()).notifyRealmChanged(azGroup.getId(), roles, permissions);
             } catch (Exception e) {


### PR DESCRIPTION
I don't feel like this log message is very useful in a normal case anymore and on the demo it creates a lot of useless messages currently when the DelegatedAccessSampleDataLoader (and some of our other jobs) manipulates the roles on nightlies when demo is true. 