### PR TITLE
SAK-29859 avoid NPE error when there is a LTI tool with site id associated with it

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -3125,31 +3125,10 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		{
 			siteId = ref.getContext();
 		}
-		// id may be null in format of /group/<site_id>, which leads to null value for the reference context field
-		if (siteId == null && ToolManager.getCurrentPlacement() != null)
+		else
 		{
 			siteId = ToolManager.getCurrentPlacement().getContext();
 		}
-		
-		if (siteId == null)
-		{
-			// if the siteId is still null
-			//// find the site root collection id
-			org.sakaiproject.content.api.ContentHostingService contentService = ContentHostingService.getInstance();
-			String collectionId = id;
-			String containingCollectionId = ContentHostingService.getContainingCollectionId(id);
-			// containingCollectionId becomes "/group/" when checking against the root level collection
-			while (!contentService.COLLECTION_SITE.equals(containingCollectionId))
-			{
-				collectionId = containingCollectionId;
-				containingCollectionId = contentService.getContainingCollectionId(collectionId);
-			}
-			// now the collectionId should be the id of root collection, and is of format /group/site_id
-			siteId = collectionId.replace(contentService.COLLECTION_SITE, "");
-			// remove the trailing "/"
-			siteId = siteId.replace(Entity.SEPARATOR, "");
-		}
-		
 		Collection<ContentPermissions> permissions = new ArrayList<ContentPermissions>();
 		if(ContentHostingService.isCollection(id))
 		{

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -3125,10 +3125,31 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		{
 			siteId = ref.getContext();
 		}
-		else
+		// id may be null in format of /group/<site_id>, which leads to null value for the reference context field
+		if (siteId == null && ToolManager.getCurrentPlacement() != null)
 		{
 			siteId = ToolManager.getCurrentPlacement().getContext();
 		}
+		
+		if (siteId == null)
+		{
+			// if the siteId is still null
+			//// find the site root collection id
+			org.sakaiproject.content.api.ContentHostingService contentService = ContentHostingService.getInstance();
+			String collectionId = id;
+			String containingCollectionId = ContentHostingService.getContainingCollectionId(id);
+			// containingCollectionId becomes "/group/" when checking against the root level collection
+			while (!contentService.COLLECTION_SITE.equals(containingCollectionId))
+			{
+				collectionId = containingCollectionId;
+				containingCollectionId = contentService.getContainingCollectionId(collectionId);
+			}
+			// now the collectionId should be the id of root collection, and is of format /group/site_id
+			siteId = collectionId.replace(contentService.COLLECTION_SITE, "");
+			// remove the trailing "/"
+			siteId = siteId.replace(Entity.SEPARATOR, "");
+		}
+		
 		Collection<ContentPermissions> permissions = new ArrayList<ContentPermissions>();
 		if(ContentHostingService.isCollection(id))
 		{

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3815,9 +3815,10 @@ public class SiteAction extends PagedResourceActionII {
 				String ltiToolId = toolMap.get("id").toString();
 				String siteId = StringUtils.trimToNull((String) toolMap.get(m_ltiService.LTI_SITE_ID));
 				toolMap.put("selected", linkedLtiContents.containsKey(ltiToolId));
-				if ( siteId == null || siteId.equals(site.getId()) )
+				if ( siteId == null || (siteId != null && siteId.equals(site.getId())))
 				{
-					// only show the system-range lti tools or tools for current site
+					// only show the system-range lti tools (siteId = null)
+					// or site-range lti tools for current site (siteId != null), and current siteId equals to current site's id
 					ltiTools.put(ltiToolId, toolMap);
 				}
 			}

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3815,7 +3815,7 @@ public class SiteAction extends PagedResourceActionII {
 				String ltiToolId = toolMap.get("id").toString();
 				String siteId = StringUtils.trimToNull((String) toolMap.get(m_ltiService.LTI_SITE_ID));
 				toolMap.put("selected", linkedLtiContents.containsKey(ltiToolId));
-				if ( siteId == null || (siteId != null && siteId.equals(site.getId())))
+				if ( siteId == null || (site != null && siteId.equals(site.getId())))
 				{
 					// only show the system-range lti tools (siteId = null)
 					// or site-range lti tools for current site (siteId != null), and current siteId equals to current site's id


### PR DESCRIPTION
This is only a problem when

1. admin using Worksite Setup tool within !admin site;

and 

2. there is at least one LTI tool with siteId associated with it.