### PR TITLE
SAK-29866 Remove unused categoryType param from GradebookPermissionService API calls

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookPermissionService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookPermissionService.java
@@ -14,11 +14,10 @@ public interface GradebookPermissionService
    * @param gradebookId Gradebook ID
    * @param userId grader ID
    * @param categoryList List of Category. (should be all categories for this gradebook)
-   * @param cateType gradebook category type
    * @throws IllegalArgumentException
    * @return List of categories
    */
-	public List<Long> getCategoriesForUser(Long gradebookId, String userId, List<Long> categoryIdList, int cateType) throws IllegalArgumentException;
+	public List<Long> getCategoriesForUser(Long gradebookId, String userId, List<Long> categoryIdList) throws IllegalArgumentException;
 	
 	/**
 	 * Returns viewable categorie id's for a user for a specific student
@@ -26,12 +25,11 @@ public interface GradebookPermissionService
 	 * @param userId
 	 * @param studentId
 	 * @param categories
-	 * @param cateType
 	 * @param sectionIds
 	 * @return
 	 * @throws IllegalArgumentException
 	 */
-	public List<Long> getCategoriesForUserForStudentView(Long gradebookId, String userId, String studentId, List<Long> categories, int cateType, List<String> sectionIds) throws IllegalArgumentException;
+	public List<Long> getCategoriesForUserForStudentView(Long gradebookId, String userId, String studentId, List<Long> categories, List<String> sectionIds) throws IllegalArgumentException;
 	
   /**
    * Get true/false value for current user which indicats if he has permission for all

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookPermissionServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookPermissionServiceImpl.java
@@ -30,13 +30,11 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 {
 	private SectionAwareness sectionAwareness;
 	
-	public List<Long> getCategoriesForUser(Long gradebookId, String userId, List<Long> categoryIdList, int cateType) throws IllegalArgumentException
+	public List<Long> getCategoriesForUser(Long gradebookId, String userId, List<Long> categoryIdList) throws IllegalArgumentException
 	{
 		if(gradebookId == null || userId == null)
 			throw new IllegalArgumentException("Null parameter(s) in GradebookPermissionServiceImpl.getCategoriesForUser");
-		if(cateType != GradebookService.CATEGORY_TYPE_ONLY_CATEGORY && cateType != GradebookService.CATEGORY_TYPE_WEIGHTED_CATEGORY)
-			throw new IllegalArgumentException("CategoryType must be CATEGORY_TYPE_ONLY_CATEGORY or CATEGORY_TYPE_WEIGHTED_CATEGORY in GradebookPermissionServiceImpl.getCategoriesForUser");
-
+		
 		List anyCategoryPermission = getPermissionsForUserAnyCategory(gradebookId, userId);
 		if(anyCategoryPermission != null && anyCategoryPermission.size() > 0 )
 		{
@@ -44,13 +42,6 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 		}
 		else
 		{
-//			List ids = new ArrayList();
-//			for(Iterator iter = categoryList.iterator(); iter.hasNext(); )
-//			{
-//				Category cate = (Category) iter.next();
-//				if(cate != null)
-//					ids.add(cate.getId());
-//			}
 
 			List<Long> returnCatIds = new ArrayList<Long>();
 			List<Permission> permList = getPermissionsForUserForCategory(gradebookId, userId, categoryIdList);
@@ -64,35 +55,13 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 			}
 			
 			return returnCatIds;
-			
-
-//			List filteredCates = new ArrayList();
-//			for(Iterator cateIter = categoryList.iterator(); cateIter.hasNext();)
-//			{
-//				Category cate = (Category) cateIter.next();
-//				if(cate != null)
-//				{
-//					for(Iterator iter = permList.iterator(); iter.hasNext();)
-//					{
-//						Permission perm = (Permission) iter.next();
-//						if(perm != null && perm.getCategoryId().equals(cate.getId()))
-//						{
-//							filteredCates.add(cate);
-//							break;
-//						}
-//					}
-//				}
-//			}
-//			return filteredCates;
 		}
 	}
 	
-	public List<Long> getCategoriesForUserForStudentView(Long gradebookId, String userId, String studentId, List<Long> categoriesIds, int cateType, List<String> sectionIds) throws IllegalArgumentException
+	public List<Long> getCategoriesForUserForStudentView(Long gradebookId, String userId, String studentId, List<Long> categoriesIds, List<String> sectionIds) throws IllegalArgumentException
 	{
 		if(gradebookId == null || userId == null || studentId == null)
 			throw new IllegalArgumentException("Null parameter(s) in GradebookPermissionServiceImpl.getCategoriesForUser");
-		if(cateType != GradebookService.CATEGORY_TYPE_ONLY_CATEGORY && cateType != GradebookService.CATEGORY_TYPE_WEIGHTED_CATEGORY)
-			throw new IllegalArgumentException("CategoryType must be CATEGORY_TYPE_ONLY_CATEGORY or CATEGORY_TYPE_WEIGHTED_CATEGORY in GradebookPermissionServiceImpl.getCategoriesForUser");
 		
 		List<Long> returnCategoryList = new ArrayList<Long>();
 		//Map categoryMap = new HashMap();  // to keep the elements unique
@@ -104,14 +73,6 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 		{
 			return returnCategoryList;
 		}
-		
-//		Map categoryIdCategoryMap = new HashMap();
-//		for (Iterator catIter = categories.iterator(); catIter.hasNext();) {
-//			Category cat = (Category) catIter.next();
-//			if (cat != null) {
-//				categoryIdCategoryMap.put(cat.getId(), cat);
-//			}
-//		}
 		
 		List<String> studentSections = new ArrayList<String>();
 		
@@ -134,9 +95,6 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 				}else{
 					returnCategoryList.add(catId);
 				}
-		//		Category cat = (Category)categoryIdCategoryMap.get(catId);
-		//		if (cat != null)
-//					categoryMap.put(cat, null);
 			}
 		}
 		

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -1340,7 +1340,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 					  for (Category category : (List<Category>) allCategories) {
 						  catIds.add(category.getId());
 					  }
-					  List<Long> viewableCategorieIds = getGradebookPermissionService().getCategoriesForUser(gradebook.getId(), userUid, catIds, gradebook.getCategory_type());
+					  List<Long> viewableCategorieIds = getGradebookPermissionService().getCategoriesForUser(gradebook.getId(), userUid, catIds);
 					  List<Category> viewableCategories = new ArrayList<Category>();
 					  for (Category category : (List<Category>) allCategories) {
 						  if(viewableCategorieIds.contains(category.getId())){

--- a/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/AssignmentDetailsBean.java
+++ b/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/AssignmentDetailsBean.java
@@ -326,7 +326,7 @@ public class AssignmentDetailsBean extends EnrollmentTableBean {
         				for (Category category : (List<Category>) categoryList) {
         					catIds.add(category.getId());
         				}
-        				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds, getGradebook().getCategory_type());
+        				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds);
         				List<Category> tmpCatList = new ArrayList<Category>();
         				for (Category category : (List<Category>) categoryList) {
         					if(viewableCats.contains(category.getId())){

--- a/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/GradebookDependentBean.java
+++ b/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/GradebookDependentBean.java
@@ -278,7 +278,7 @@ public abstract class GradebookDependentBean extends InitializableBean {
     					for (Category category : (List<Category>) categoryList) {
     						catIds.add(category.getId());
     					}
-    					List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds, getGradebook().getCategory_type());
+    					List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds);
     					List<Category> viewableCategories = new ArrayList<Category>();
     					for (Category category : (List<Category>) categoryList) {
     						if(viewableCats.contains(category.getId())){

--- a/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/OverviewBean.java
+++ b/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/OverviewBean.java
@@ -139,7 +139,7 @@ public class OverviewBean extends GradebookDependentBean implements Serializable
 				for (Category category : (List<Category>) categoryList) {
 					catIds.add(category.getId());
 				}
-				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds, getGradebook().getCategory_type());
+				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds);
 				List<Category> tmpCatList = new ArrayList<Category>();
 				for (Category category : (List<Category>) categoryList) {
 					if(viewableCats.contains(category.getId())){

--- a/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/RosterBean.java
+++ b/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/RosterBean.java
@@ -259,7 +259,7 @@ public class RosterBean extends EnrollmentTableBean implements Serializable, Pag
 				for (Category category : categories) {
 					catIds.add(category.getId());
 				}
-				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds, getGradebook().getCategory_type());
+				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds);
 				List<Category> tmpCatList = new ArrayList<Category>();
 				for (Category category : categories) {
 					if(viewableCats.contains(category.getId())){
@@ -937,7 +937,7 @@ public class RosterBean extends EnrollmentTableBean implements Serializable, Pag
 				for (Category category : (List<Category>) categoriesFilter) {
 					catIds.add(category.getId());
 				}
-				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds, getGradebook().getCategory_type());
+				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUser(getGradebookId(), getUserUid(), catIds);
 				List<Category> tmpCatList = new ArrayList<Category>();
 				for (Category category : (List<Category>) categoriesFilter) {
 					if(viewableCats.contains(category.getId())){

--- a/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/ViewByStudentBean.java
+++ b/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/ViewByStudentBean.java
@@ -622,7 +622,7 @@ public class ViewByStudentBean extends EnrollmentTableBean implements Serializab
     				for (Category category : (List<Category>) categoryList) {
     					catIds.add(category.getId());
     				}
-    				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUserForStudentView(getGradebookId(), getUserUid(), studentUid, catIds, getGradebook().getCategory_type(), getViewableSectionIds());
+    				List<Long> viewableCats = getGradebookPermissionService().getCategoriesForUserForStudentView(getGradebookId(), getUserUid(), studentUid, catIds, getViewableSectionIds());
     				List<Category> tmpCatList = new ArrayList<Category>();
     				for (Category category : (List<Category>) categoryList) {
     					if(viewableCats.contains(category.getId())){


### PR DESCRIPTION
The methods `getCategoriesForUser` and `getCategoriesForUserForStudentView` accept a category type parameter but it is unused.
There is also a bunch of commented out code associated with it. This will be removed to make this API simpler to use and easier to modify.