### PR TITLE
SAK-29867 Correct the view course grade permission check to not conflict with existing permission checks

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GraderPermission.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GraderPermission.java
@@ -1,5 +1,9 @@
 package org.sakaiproject.service.gradebook.shared;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * The list of permissions that can be assigned to a grader
  */
@@ -15,6 +19,18 @@ public enum GraderPermission {
 	@Override
 	public String toString() {
 		return this.name().toLowerCase();
+	}
+	
+	/**
+	 * Helper to get the view and grade permissions as a list
+	 * Used in a few places
+	 * @return
+	 */
+	public static List<String> getStandardPermissions() {
+		List<String> rval = new ArrayList<>();
+		rval.add(GraderPermission.VIEW.toString());
+		rval.add(GraderPermission.GRADE.toString());
+		return rval;
 	}
 
 }

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GraderPermission.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GraderPermission.java
@@ -1,7 +1,6 @@
 package org.sakaiproject.service.gradebook.shared;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
@@ -24,6 +24,7 @@ package org.sakaiproject.component.gradebook;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -32,8 +33,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.HibernateException;
@@ -50,6 +51,7 @@ import org.sakaiproject.service.gradebook.shared.ConflictingCategoryNameExceptio
 import org.sakaiproject.service.gradebook.shared.GradebookNotFoundException;
 import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
+import org.sakaiproject.service.gradebook.shared.GraderPermission;
 import org.sakaiproject.service.gradebook.shared.StaleObjectModificationException;
 import org.sakaiproject.tool.gradebook.AbstractGradeRecord;
 import org.sakaiproject.tool.gradebook.Assignment;
@@ -68,7 +70,6 @@ import org.sakaiproject.tool.gradebook.facades.Authn;
 import org.sakaiproject.tool.gradebook.facades.EventTrackingService;
 import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
-
 import org.sakaiproject.component.api.ServerConfigurationService;
 
 /**
@@ -1116,7 +1117,7 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
     	return (List)getHibernateTemplate().execute(hc);    	
     }
 
-    public List getPermissionsForUserForCategory(final Long gradebookId, final String userId, final List cateIds) throws IllegalArgumentException
+    public List<Permission> getPermissionsForUserForCategory(final Long gradebookId, final String userId, final List cateIds) throws IllegalArgumentException
     {
     	if(gradebookId == null || userId == null)
     		throw new IllegalArgumentException("Null parameter(s) in BaseHibernateManager.getPermissionsForUserForCategory");
@@ -1141,16 +1142,17 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
     	}
     }
 
-    public List getPermissionsForUserAnyCategory(final Long gradebookId, final String userId) throws IllegalArgumentException
+    public List<Permission> getPermissionsForUserAnyCategory(final Long gradebookId, final String userId) throws IllegalArgumentException
     {
     	if(gradebookId == null || userId == null)
     		throw new IllegalArgumentException("Null parameter(s) in BaseHibernateManager.getPermissionsForUserAnyCategory");
 
     	HibernateCallback hc = new HibernateCallback() {
     		public Object doInHibernate(Session session) throws HibernateException {
-    			Query q = session.createQuery("from Permission as perm where perm.gradebookId=:gradebookId and perm.userId=:userId and perm.categoryId is null");
+    			Query q = session.createQuery("from Permission as perm where perm.gradebookId=:gradebookId and perm.userId=:userId and perm.categoryId is null and perm.function in (:functions)");
     			q.setLong("gradebookId", gradebookId);
     			q.setString("userId", userId);
+    			q.setParameterList("functions", GraderPermission.getStandardPermissions());
 
     			return q.list();
     		}
@@ -1158,16 +1160,17 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
     	return (List)getHibernateTemplate().execute(hc);
     }
 
-    public List getPermissionsForUserAnyGroup(final Long gradebookId, final String userId) throws IllegalArgumentException
+    public List<Permission> getPermissionsForUserAnyGroup(final Long gradebookId, final String userId) throws IllegalArgumentException
     {
     	if(gradebookId == null || userId == null)
     		throw new IllegalArgumentException("Null parameter(s) in BaseHibernateManager.getPermissionsForUserAnyGroup");
 
     	HibernateCallback hc = new HibernateCallback() {
     		public Object doInHibernate(Session session) throws HibernateException {
-    			Query q = session.createQuery("from Permission as perm where perm.gradebookId=:gradebookId and perm.userId=:userId and perm.groupId is null");
+    			Query q = session.createQuery("from Permission as perm where perm.gradebookId=:gradebookId and perm.userId=:userId and perm.groupId is null and perm.function in (:functions)");
     			q.setLong("gradebookId", gradebookId);
     			q.setString("userId", userId);
+    			q.setParameterList("functions", GraderPermission.getStandardPermissions());
 
     			return q.list();
     		}


### PR DESCRIPTION


The addition of the view_course_grade permission needs the other permission checks to be tweaked so that they specifically test for the permission they desire.

This is because the methods getPermissionsForUserAnyCategory and getPermissionsForUserAnyGroup check for any category/group that have null values, and assume that the user has permission, however the view_course_grade permission check explicitly sets null values for its fields as it doesn't apply to a specific category or group.

So this change will adjust those two methods to check for the view and grade permission explicitly. The permission checks where categories/groups are specified are unaffected.
