### PR TITLE
SAK-29890 Fix the bug by removing duplicates when getting the list of…

### DIFF
--- a/edu-services/gradebook-service/api/pom.xml
+++ b/edu-services/gradebook-service/api/pom.xml
@@ -17,4 +17,11 @@
     <properties>
         <deploy.target>shared</deploy.target>
     </properties>
+    
+    <dependencies>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+		</dependency>
+    </dependencies>
 </project>

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/Assignment.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/Assignment.java
@@ -24,11 +24,13 @@ package org.sakaiproject.service.gradebook.shared;
 import java.io.Serializable;
 import java.util.Date;
 
+import org.apache.commons.lang.builder.CompareToBuilder;
+
 /**
  * JavaBean to hold data associated with a Gradebook assignment.
  * The Course Grade is not considered an assignment.
  */
-public class Assignment implements Serializable {
+public class Assignment implements Serializable, Comparable<Assignment> {
 	private static final long serialVersionUID = 1L;
 
     private String name;
@@ -228,6 +230,13 @@ public class Assignment implements Serializable {
 
 	public void setCategoryId(Long categoryId) {
 		this.categoryId = categoryId;
+	}
+	
+	@Override
+	public int compareTo(Assignment o) {
+		return new CompareToBuilder()
+	       .append(this.id, o.id)
+	       .toComparison();
 	}
 
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -1308,7 +1310,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
   throws GradebookNotFoundException {
 
 	  List<Assignment> viewableAssignments = new ArrayList<>();
-	  List<org.sakaiproject.service.gradebook.shared.Assignment> assignmentsToReturn = new ArrayList<>();
+	  SortedSet<org.sakaiproject.service.gradebook.shared.Assignment> assignmentsToReturn = new TreeSet<>();
 
 	  Gradebook gradebook = getGradebook(gradebookUid);
 
@@ -1325,12 +1327,12 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			  // if this gradebook has categories enabled, we need to check for category-specific restrictions
 
 			  if (gradebook.getCategory_type() == GradebookService.CATEGORY_TYPE_NO_CATEGORY) {
-				  assignmentsToReturn = getAssignments(gradebookUid);
+				  assignmentsToReturn.addAll(getAssignments(gradebookUid));
 			  } else {
 
 				  String userUid = getUserUid();
 				  if (getGradebookPermissionService().getPermissionForUserForAllAssignment(gradebook.getId(), userUid)) {
-					  assignmentsToReturn = getAssignments(gradebookUid);
+					  assignmentsToReturn.addAll(getAssignments(gradebookUid));
 				  }
 
 				  // categories are enabled, so we need to check the category restrictions
@@ -1381,7 +1383,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		  }
 	  }
 
-	  return assignmentsToReturn;
+	  return new ArrayList<>(assignmentsToReturn);
 
   }
   


### PR DESCRIPTION
When a TA is granted multiple permission rules that provide overlap for a given category, the category's items are duplicated in the TA's view.

E.g., TA is granted "View" access to ALL categories in the Gradebook, but "Grade" access to only 1 category (let's call it "Homework"). When the TA views the GB, they will see all of the items in "Homework" twice. 

**Investigation**

The bug is a long standing one in `GradebookService.getViewableAssignmentsForCurrentUser`.

Under the above settings, the assignment list is duplicated.

This is because the checks will satisfy BOTH:
`if (getGradebookPermissionService().getPermissionForUserForAllAssignment(gradebook.getId(), userUid)) {
	 assignmentsToReturn = getAssignments(gradebookUid);
 }
`
*and* the following iteration of assignments within categories, which then adds more assignments to the `assignmentsToReturn` variable. 

This is proven by stepping through this method with a debugger from access of both Gradebook and GradebookNG, and a watch on `assignmentsToReturn`. If there are two assignments, it will end up with 4. 
Gradebook must be then removing duplicates which is dumb, the list should have just been reduced in the first place.
