### PR TITLE
SAK-29226 Use the standard maven plugins.

### DIFF
--- a/sitestats/pom.xml
+++ b/sitestats/pom.xml
@@ -200,33 +200,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <!-- Build -->
-  <build>
-    <plugins>
-      <!-- maven-surefire-report-plugin 2.8+ requires maven-site-plugin 2.1+ -->
-      <plugin>
-        <inherited>true</inherited>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>2.1</version>
-      </plugin>
-      <!-- Downgrade surefireplugin version due to build error. -->
-      <plugin>
-        <inherited>true</inherited>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <systemPropertyVariables>
-            <!-- Pass through important service-integration test properties. -->
-            <maven.tomcat.home>${maven.tomcat.home}</maven.tomcat.home>
-            <test.sakai.home>${test.sakai.home}</test.sakai.home>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <!-- Reporting (mvn site) -->
   <reporting>
     <plugins>

--- a/sitestats/sitestats-impl/pom.xml
+++ b/sitestats/sitestats-impl/pom.xml
@@ -292,7 +292,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.6</version>
                         <configuration>
                             <includes>
                                 <include>**/*Test.java</include>


### PR DESCRIPTION
The newer(standard) maven plugins seem to work fine, and surefire will show the stack trace by default of the failed test on the console. This means when the CI server fails you can see where it failed.