### PR TITLE
SAM-2616 Retract date is disabled when late submission are not accepted

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -85,6 +85,7 @@
           lockdownMarkForReview(navVal);
           showHideReleaseGroups();
           checkUncheckTimeBox();
+          checkLastHandling();
         });
       </script>
 
@@ -266,7 +267,7 @@
     <h:outputText value="#{assessmentSettingsMessages.late_accept}" />
     <h:panelGrid columns="4" border="0" columnClasses="alignBottom">
       <f:verbatim>&nbsp;&nbsp;</f:verbatim>
-      <h:selectOneRadio id="lateHandling" value="#{publishedSettings.lateHandling}"  layout="pageDirection">
+      <h:selectOneRadio id="lateHandling" onclick="checkLastHandling();" value="#{publishedSettings.lateHandling}"  layout="pageDirection">
         <f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.no_late}"/>
         <f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.yes_late}"/>
       </h:selectOneRadio>


### PR DESCRIPTION
The retract date enabled/disabled behaviour has been unified in both cases (working and published copies)