### PR TITLE
SAM-1947 Email notifications on Samigo submission

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3085,6 +3085,11 @@
 # samigo.questionprogress.answeredpath = /images/blackBubble15.png
 # samigo.questionprogress.markdpath = /images/questionMarkBubble15.png
 
+# SAM-1947 Email notifications on Samigo Submission
+# The from address for individual submission notifications
+# DEFAULT: no-reply@serverName
+# samigo.fromAddress=<SAMIGO_SMTP_FROM>
+
 #########################################
 # WORKSITE SETUP/SITE INFO
 #########################################

--- a/samigo/pom.xml
+++ b/samigo/pom.xml
@@ -23,6 +23,7 @@
 		<module>samigo-api</module>
 		<module>samigo-app</module>
 		<module>samigo-hibernate</module>
+		<module>samigo-impl</module>
 		<module>samigo-pack</module>
 		<module>samigo-qti</module>
 		<module>samigo-services</module>
@@ -80,6 +81,11 @@
             </dependency>
             <dependency>
                 <groupId>org.sakaiproject.samigo</groupId>
+                <artifactId>samigo-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.sakaiproject.samigo</groupId>
                 <artifactId>samigo-import</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -124,6 +130,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
     
     <reporting>
         <plugins>

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/SamigoETSProvider.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/SamigoETSProvider.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2015, The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.api;
+
+import org.sakaiproject.event.api.Event;
+
+
+import java.util.Map;
+
+public interface SamigoETSProvider {
+
+
+    void init();
+
+    void notify(String templateKey, Map<String, Object> notificationValues, Event event);
+}

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015, The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.util;
+
+import org.sakaiproject.event.api.NotificationService;
+
+/**
+ * Class to hold constants for Samigo, defaults, etc.
+ *
+ * Modeled after {@link org.sakaiproject.profile2.util.ProfileConstants}
+ *
+ * @author Leonardo Canessa ( lcanessa1 at udayton dot edu )
+ */
+public class SamigoConstants {
+    /*
+     * Email Templating
+     */
+    public static final     String      EMAIL_TEMPLATE_ASSESSMENT_SUBMITTED                 = "sam.assessmentSubmitted";
+    public static final     String      EMAIL_TEMPLATE_ASSESSMENT_SUBMITTED_FILE_NAME       = "template-assessmentSubmission.xml";
+    public static final     String      EMAIL_TEMPLATE_ASSESSMENT_AUTO_SUBMITTED            = "sam.assessmentAutoSubmitted";
+    public static final     String      EMAIL_TEMPLATE_ASSESSMENT_AUTO_SUBMITTED_FILE_NAME  = "template-assessmentAutoSubmission.xml";
+    public static final     String      EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED           = "sam.assessmentTimedSubmitted";
+    public static final     String      EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED_FILE_NAME = "template-assessmentTimedSubmission.xml";
+
+    /*
+     * Events
+     */
+    public static final     String      EVENT_ASSESSMENT_SUBMITTED                          = "sam.assessmentSubmitted";
+    public static final     String      EVENT_ASSESSMENT_AUTO_SUBMITTED                     = "sam.assessmentAutoSubmitted";
+    public static final     String      EVENT_ASSESSMENT_TIMED_SUBMITTED                    = "sam.assessmentTimedSubmitted";
+
+    /*
+     * Notification Types
+     */
+    public static final     String      NOTI_PREFS_TYPE_SAMIGO                              = "sakai:samigo";
+
+
+    /*
+     * Notification Defaults
+     */
+    public static final     int         NOTI_PREF_DEFAULT                                   = NotificationService.PREF_IMMEDIATE;
+    public static final     int         NOTI_EVENT_ASSESSMENT_SUBMITTED                     = NotificationService.NOTI_OPTIONAL;
+    public static final     int         NOTI_EVENT_ASSESSMENT_TIMED_SUBMITTED               = NotificationService.NOTI_OPTIONAL;
+}

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -94,11 +94,6 @@
                <version>1.2_15</version>
         </dependency>
 		<!-- end of JSF related version issue -->
-		        
-        <dependency>
-            <groupId>org.sakaiproject.kernel</groupId>
-            <artifactId>sakai-kernel-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-component-manager</artifactId>

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -117,6 +117,11 @@ unlimited_submission=Unlimited
 only=Only
 limited_submission=submissions allowed
 
+instructorNotification=Would you like to receive emails notifications when students submit this assessment?
+oneEmail=Yes - send me an email for every submission
+digestEmail=Yes - send me one email digest each day
+noEmail=No - I do not want to receive any emails
+
 auto_save=Autosave
 user_click_save=User must click "Save" button to save input
 save_automatically=All user input saved automatically

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -772,6 +772,14 @@ public class AssessmentSettingsBean
 	  }
   }
 
+  public String getInstructorNotification(){
+    return this.assessment.getInstructorNotification().toString();
+  }
+
+  public void setInstructorNotification(String notiEmail){
+    this.assessment.setInstructorNotification(Integer.valueOf(notiEmail));
+  }
+
   public String getSubmissionsAllowed() {
     return submissionsAllowed;
   }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -692,6 +692,15 @@ public class PublishedAssessmentSettingsBean
 	  }
   }
 
+  public String getInstructorNotification(){
+    return this.assessment.getInstructorNotification().toString();
+  }
+
+  public void setInstructorNotification(String notiEmail){
+    this.assessment.setInstructorNotification(Integer.valueOf(notiEmail));
+  }
+
+
   public String getSubmissionsAllowed() {
     return submissionsAllowed;
   }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -343,6 +343,8 @@ public class SaveAssessmentSettings
     assessment.setTitle( newTitle );
     assessment.updateAssessmentMetaData(SecureDeliveryServiceAPI.TITLE_DECORATION, titleDecoration );
 
+    assessment.setInstructorNotification(Integer.valueOf(assessmentSettings.getInstructorNotification()));
+
     // l. FINALLY: save the assessment
     assessmentService.saveAssessment(assessment);
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -190,7 +190,9 @@ implements ActionListener
 	    }
 	    assessment.setTitle( newTitle );
 	    assessment.updateAssessmentMetaData(SecureDeliveryServiceAPI.TITLE_DECORATION, titleDecoration );
-	    
+
+	    // Save Instructor Notification value
+	    assessment.setInstructorNotification(Integer.valueOf(assessmentSettings.getInstructorNotification()));
 	    
 	    // l. FINALLY: save the assessment
 	    assessmentService.saveAssessment(assessment);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/queue/delivery/SubmitTimedAssessmentThread.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/queue/delivery/SubmitTimedAssessmentThread.java
@@ -21,16 +21,13 @@
 
 package org.sakaiproject.tool.assessment.ui.queue.delivery;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.TimerTask;
-import java.util.List;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.event.cover.NotificationService;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.assessment.data.dao.assessment.EventLogData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAssessmentData;
@@ -122,7 +119,17 @@ public class SubmitTimedAssessmentThread extends TimerTask
 
             PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
             String siteId = publishedAssessmentService.getPublishedAssessmentOwner(ag.getPublishedAssessmentId());
-            EventTrackingService.post(EventTrackingService.newEvent("sam.assessment.thread_submit", "siteId=" + siteId + ", submissionId=" + ag.getAssessmentGradingId(), siteId, true, NotificationService.NOTI_REQUIRED));
+
+            EventTrackingService.post(EventTrackingService.newEvent("sam.assessment.thread_submit", "siteId=" + AgentFacade.getCurrentSiteId() + ", submissionId=" + ag.getAssessmentGradingId(), siteId, true, NotificationService.NOTI_REQUIRED));
+
+            Map<String, Object> notiValues = new HashMap<String, Object>();
+
+            notiValues.put("assessmentGradingID", ag.getAssessmentGradingId());
+            notiValues.put("userID", ag.getAgentId());
+            notiValues.put("submissionDate", submitDate.toString());
+            notiValues.put("publishedAssessmentID", ag.getPublishedAssessmentId());
+
+            EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_TIMED_SUBMITTED, notiValues.toString(), siteId, true, SamigoConstants.NOTI_EVENT_ASSESSMENT_TIMED_SUBMITTED));
             notifyGradebookByScoringType(ag, timedAG.getPublishedAssessment());
             log.debug("**** 4a. time's up, timeLeft+latency buffer reached, saved to DB");
             log.info("Submitted timed assessment assessmentId=" + eventLogData.getAssessmentId() + " userEid=" + eventLogData.getUserEid() + " siteId=" + siteId + ", submissionId=" + ag.getAssessmentGradingId());

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -301,6 +301,18 @@
     <h:outputLabel value="#{assessmentSettingsMessages.auto_submit}"/>
   </h:panelGroup>
 
+    <!-- SUBMISSION EMAILS -->
+    <h:panelGroup rendered="#{assessmentSettings.valueMap.submissionModel_isInstructorEditable==true}">
+        <h:outputLabel value="#{assessmentSettingsMessages.instructorNotification}" />
+        <f:verbatim><div class="tier1"></f:verbatim>
+        <h:selectOneRadio id="notificationEmailChoices" value="#{assessmentSettings.instructorNotification}" layout="pageDirection">
+            <f:selectItem itemValue="3" itemLabel="#{assessmentSettingsMessages.oneEmail}" />
+            <f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.digestEmail}" />
+            <f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.noEmail}" />
+        </h:selectOneRadio>
+        <f:verbatim></div></f:verbatim>
+    </h:panelGroup>
+
 <f:verbatim><div id="jqueryui-accordion-security"></f:verbatim><!-- This is sub-accordion for high security and submission message -->
 
   <!-- *** HIGH SECURITY *** -->

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -290,6 +290,18 @@
     <h:outputLabel value="#{assessmentSettingsMessages.auto_submit}"/>
   </h:panelGroup>
 
+    <!-- SUBMISSION EMAILS -->
+    <h:panelGroup rendered="#{publishedSettings.valueMap.submissionModel_isInstructorEditable==true}">
+        <h:outputLabel value="#{assessmentSettingsMessages.instructorNotification}" />
+        <f:verbatim><div class="tier1"></f:verbatim>
+        <h:selectOneRadio id="notificationEmailChoices" value="#{publishedSettings.instructorNotification}" layout="pageDirection">
+            <f:selectItem itemValue="3" itemLabel="#{assessmentSettingsMessages.oneEmail}" />
+            <f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.digestEmail}" />
+            <f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.noEmail}" />
+        </h:selectOneRadio>
+        <f:verbatim></div></f:verbatim>
+    </h:panelGroup>
+
 <f:verbatim><div id="jqueryui-accordion-security"></f:verbatim><!-- This is sub-accordion for high security and submission message -->
 
   <!-- *** HIGH SECURITY *** -->

--- a/samigo/samigo-cp/pom.xml
+++ b/samigo/samigo-cp/pom.xml
@@ -25,10 +25,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
-			<artifactId>sakai-kernel-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-component-manager</artifactId>
 		</dependency>
 		<dependency>

--- a/samigo/samigo-hibernate/pom.xml
+++ b/samigo/samigo-hibernate/pom.xml
@@ -28,10 +28,6 @@
             <artifactId>samigo-api</artifactId>
         </dependency>
 		<dependency>
-			<groupId>org.sakaiproject.kernel</groupId>
-			<artifactId>sakai-kernel-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 		</dependency>

--- a/samigo/samigo-impl/pom.xml
+++ b/samigo/samigo-impl/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sakaiproject.samigo</groupId>
+        <artifactId>samigo</artifactId>
+        <version>11-SNAPSHOT</version>
+    </parent>
+
+    <name>Samigo Impl</name>
+    <groupId>org.sakaiproject.samigo</groupId>
+    <artifactId>samigo-impl</artifactId>
+    <version>11-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-component-manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-storage-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>samigo-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>samigo-services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.message</groupId>
+            <artifactId>sakai-message-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.scheduler</groupId>
+            <artifactId>scheduler-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.emailtemplateservice</groupId>
+            <artifactId>emailtemplateservice-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jdom</groupId>
+            <artifactId>jdom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
@@ -1,0 +1,441 @@
+/**
+ * Copyright (c) 2015, The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.*;
+
+import lombok.Setter;
+import org.apache.commons.lang.StringUtils;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+import org.apache.log4j.Logger;
+
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.emailtemplateservice.model.EmailTemplate;
+import org.sakaiproject.emailtemplateservice.model.RenderedTemplate;
+import org.sakaiproject.emailtemplateservice.service.EmailTemplateService;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.event.api.Event;
+import org.sakaiproject.samigo.api.SamigoETSProvider;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
+import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
+import org.sakaiproject.user.api.*;
+import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.samigo.util.SamigoConstants;
+import org.sakaiproject.email.api.EmailService;
+import org.sakaiproject.email.api.DigestService;
+
+public class SamigoETSProviderImpl implements SamigoETSProvider {
+    private   static                Logger                      log                             = Logger.getLogger(SamigoETSProviderImpl.class);
+    private                         Map<String,String>          constantValues                  = new HashMap<String, String>();
+    private             final       String                      MULTIPART_BOUNDARY              = "======sakai-multi-part-boundary======";
+    private             final       String                      BOUNDARY_LINE                   = "\n\n--"+MULTIPART_BOUNDARY+"\n";
+    private             final       String                      TERMINATION_LINE                = "\n\n--"+MULTIPART_BOUNDARY+"--\n\n";
+    private             final       String                      MIME_ADVISORY                   = "This message is for MIME-compliant mail readers.";
+    private   static    final       String                      ADMIN                           = "admin";
+    private                         String                      fromAddress                     = "";
+
+    public      void                init                            () {
+        log.info("init()");
+
+        String samigoFromAddress                    = serverConfigurationService.getString("samigo.fromAddress");
+
+        if( samigoFromAddress == null || StringUtils.isBlank(samigoFromAddress)){
+            fromAddress                             = serverConfigurationService.getString("setup.request", "no-reply@" + serverConfigurationService.getServerName());
+        } else {
+            fromAddress                             = samigoFromAddress;
+        }
+
+        constantValues.put("localSakaiName" , serverConfigurationService.getString("ui.service", ""));
+        constantValues.put("localSakaiUrl"  , serverConfigurationService.getPortalUrl());
+
+        loadTemplate(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_SUBMITTED_FILE_NAME      , SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_SUBMITTED);
+        loadTemplate(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_AUTO_SUBMITTED_FILE_NAME , SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_AUTO_SUBMITTED);
+        loadTemplate(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED_FILE_NAME, SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED);
+    }
+
+    public      void                notify                          (String eventKey, Map<String, Object> notificationValues, Event event) {
+        log.debug("Notify, templateKey: " + eventKey + " event: " + event.toString());
+        if          (eventKey.equals(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED)){
+            handleAssessmentSubmitted(notificationValues, event);
+        } else if   (eventKey.equals(SamigoConstants.EVENT_ASSESSMENT_AUTO_SUBMITTED)){
+            handleAssessmentAutoSubmitted(notificationValues, event);
+        } else if   (eventKey.equals(SamigoConstants.EVENT_ASSESSMENT_TIMED_SUBMITTED)){
+            handleAssessmentTimedSubmitted(notificationValues, event);
+        }
+    }
+
+    private     void                handleAssessmentSubmitted       (Map<String, Object> notificationValues, Event event) {
+        log.debug("Assessment Submitted");
+        assessmentSubmittedHelper(notificationValues, event, 1);
+
+    }
+
+    private     void handleAssessmentAutoSubmitted(Map<String, Object> notificationValues, Event event){
+        log.debug("Assessment Auto Submitted");
+        assessmentSubmittedHelper(notificationValues, event, 2);
+    }
+
+    private     void handleAssessmentTimedSubmitted(Map<String, Object> notificationValues, Event event){
+        log.debug("Assessment Timed Submitted");
+        assessmentSubmittedHelper(notificationValues, event, 3);
+    }
+
+    /*
+     * assessmentSubmittedType is an int.
+     * 1 = Normal Submission
+     * 2 = Auto Submission
+     * 3 = Timer expired Submission
+     */
+    private     void                assessmentSubmittedHelper       (Map<String, Object> notificationValues, Event event, int assessmentSubmittedType){
+        log.debug("assessment Submitted helper, assessmentSubmittedType: " + assessmentSubmittedType);
+        String              priStr                  = Integer.toString(event.getPriority());
+        Map<String, String> replacementValues       = new HashMap<>(constantValues);
+        try {
+            User            user                    = userDirectoryService.getUser(notificationValues.get("userID").toString());
+
+            PublishedAssessmentService pubAssServ   = new PublishedAssessmentService();
+            PublishedAssessmentFacade  pubAssFac    = pubAssServ.getSettingsOfPublishedAssessment(notificationValues.get("publishedAssessmentID").toString());
+
+            String          siteID                  = pubAssFac.getOwnerSiteId();
+            /*
+             * siteName
+             * siteID
+             * userName
+             * userDisplayID
+             * assessmentTitle
+             * assessmentDueDate
+             * assessmentGradingID
+             * submissionDate
+             */
+            replacementValues.put("siteName"            , pubAssFac.getOwnerSite());
+            replacementValues.put("siteID"              , siteID);
+            replacementValues.put("userName"            , user.getDisplayName());
+            replacementValues.put("userDisplayID"       , user.getDisplayId());
+            replacementValues.put("assessmentTitle"     , pubAssFac.getTitle());
+            replacementValues.put("assessmentDueDate"   , pubAssFac.getDueDate() == null ? "" : pubAssFac.getDueDate().toString());
+            replacementValues.put("assessmentGradingID" , notificationValues.get("assessmentGradingID").toString());
+            replacementValues.put("submissionDate"      , notificationValues.get("submissionDate").toString());
+
+
+            RenderedTemplate rt                 = getRenderedTemplate(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_SUBMITTED , user, replacementValues);;
+            // Assume assessmentSubmittedType is 1 to ensure rt is initialized
+            if (assessmentSubmittedType == 2) {
+                rt = getRenderedTemplate(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_AUTO_SUBMITTED   , user, replacementValues);
+            } else if (assessmentSubmittedType == 3){
+                rt = getRenderedTemplate(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED  , user, replacementValues);
+            }
+
+            String body = getBody(rt);
+
+            notifyStudent(user, rt, body, priStr);
+            notifyInstructor(siteID, pubAssFac.getInstructorNotification(), rt, body, priStr);
+        } catch(UserNotDefinedException e){
+            log.warn("UserNotDefined: " + notificationValues.get("userID").toString() + " in sending samigo notification.");
+        }
+    }
+
+    private     void                notifyInstructor                (String siteID, Integer instructNoti , RenderedTemplate rt, String message,String priStr){
+        log.debug("notifyInstructor");
+
+        Map<User, Integer>  validUsers              = new HashMap<>();
+
+        try{
+            Site            site                    = siteService.getSite(siteID);
+            AuthzGroup      azGroup                 = authzGroupService.getAuthzGroup("/site/" + siteID);
+            Set<String>     siteUsersHasRole        = site.getUsersHasRole(azGroup.getMaintainRole());
+
+            for(String userString : siteUsersHasRole){
+                try{
+                    if(!userString.equals(ADMIN)) {
+                        User user = userDirectoryService.getUser(userString);
+
+                        Integer uPref = getUserPreferences(user, priStr);
+                        validUsers.put(user, uPref);
+                    }
+                } catch(UserNotDefinedException e){
+                    log.warn("Instructor '" + userString +"' not found in samigo notification.");
+                }
+            }
+        } catch(org.sakaiproject.exception.IdUnusedException e){
+            //Site not found
+            log.warn("Site '" + siteID + "' not found while sending instructor notifications for samigo submission.");
+            log.debug(e);
+        } catch(org.sakaiproject.authz.api.GroupNotDefinedException e){
+            // Realm not found
+            log.warn("AuthzGroup '/site/" + siteID + "' not found while sending instructor notifications for samigo submission");
+            log.debug(e);
+        }
+
+        List<User>          users                   = new ArrayList<>();
+        List<User>          immediateUsers          = new ArrayList<>();
+
+        if(validUsers.size() > 0){
+            users.addAll(validUsers.keySet());
+
+            List<String>        headers         = getHeaders(rt, users, constantValues.get("localSakaiName"), fromAddress);
+
+
+            for(Map.Entry<User, Integer> entry : validUsers.entrySet()){
+                User user = entry.getKey();
+                if(instructNoti == NotificationService.PREF_IMMEDIATE){
+                    immediateUsers.add(user);
+                } else if(instructNoti == NotificationService.PREF_DIGEST){
+                    log.debug("notifyInstructor + sendDigest + User: " + user.getDisplayName() + " rt: " + rt.getKey());
+                    digestService.digest(user.getId(), rt.getRenderedSubject(), rt.getRenderedMessage());
+                }
+            }
+
+            if(instructNoti == NotificationService.PREF_IMMEDIATE && !immediateUsers.isEmpty()) {
+                log.debug("notifyInstructor + send one email to Users: " + immediateUsers.toString() +" rt: " + rt.getKey());
+                emailService.sendToUsers(immediateUsers, headers, message);
+            }
+        }
+    }
+
+    private     void                notifyStudent                   (User user, RenderedTemplate rt, String message, String priStr){
+        log.debug("notifyStudent");
+        List<User>          users                   = new ArrayList<>();
+        users.add(user);
+
+        List<String>        headers                 = getHeaders(rt, users, constantValues.get("localSakaiName"), fromAddress);
+
+        int                 uSamEmailPref           = getUserPreferences(user, priStr);
+
+        if(uSamEmailPref == NotificationService.PREF_IMMEDIATE){
+            log.debug("notifyStudent + send one email + rt: " + rt.getKey());
+            emailService.sendToUsers(users, headers, message);
+        } else if (uSamEmailPref == NotificationService.PREF_DIGEST){
+            log.debug("notifyStudent + sendDigest + rt: " + rt.getKey());
+            digestService.digest(user.getId(), rt.getRenderedSubject(), rt.getRenderedMessage());
+        }
+    }
+
+    private     int                 getUserPreferences              (User user, String priStr){
+        log.debug("getUserPreferences User: " + user.getDisplayName());
+        int                 uSamEmailPref           = SamigoConstants.NOTI_PREF_DEFAULT;
+
+        Preferences         userPrefs               = preferencesService.getPreferences(user.getId());
+        ResourceProperties  props                   = userPrefs.getProperties(NotificationService.PREFS_TYPE + SamigoConstants.NOTI_PREFS_TYPE_SAMIGO);
+
+        try{
+            uSamEmailPref                           = (int) props.getLongProperty(priStr);
+        } catch (Exception e){
+            //User hasn't changed preference
+        }
+        log.debug("getUserPreferences: pref=" + uSamEmailPref);
+        return uSamEmailPref;
+    }
+
+    private     String              getBody                         (RenderedTemplate rt){
+        log.debug("getBody");
+        StringBuilder       body                = new StringBuilder();
+        body.append(MIME_ADVISORY);
+
+        if (rt.getRenderedMessage() != null) {
+            body.append(BOUNDARY_LINE);
+            body.append("Content-Type: text/plain; charset=UTF-8\n");
+            body.append(rt.getRenderedMessage());
+        }
+        if (rt.getRenderedHtmlMessage() != null) {
+            //append the HMTL part
+            body.append(BOUNDARY_LINE);
+            body.append("Content-Type: text/html; charset=UTF-8\n");
+            body.append(rt.getRenderedHtmlMessage());
+        }
+
+        body.append(TERMINATION_LINE);
+
+        return body.toString();
+    }
+
+    private     RenderedTemplate    getRenderedTemplate             (String templateName, User user, Map<String,String> replacementValues){
+        log.debug("getting template: " + templateName);
+        RenderedTemplate    template            = null;
+
+        try {
+            template = emailTemplateService.getRenderedTemplateForUser(templateName, user!=null?user.getReference():"", replacementValues);
+        }catch (Exception e) {
+            log.warn("Samigo Notification email template error. " + this + e.getMessage());
+        }
+
+        return template;
+    }
+
+
+    // Based on EmailTemplateService.sendRenderedMessages()
+    private     List<String>        getHeaders                      (RenderedTemplate rt, List<User> toAddress, String fromName, String fromEmail){
+        log.debug("getHeaders");
+        List<String>        headers             = new ArrayList<>();
+        //the template may specify a from address
+        if (StringUtils.isNotBlank(rt.getFrom())) {
+            headers.add("From: \"" + rt.getFrom() );
+        } else {
+            headers.add("From: \"" + fromName + "\" <" + fromEmail + ">" );
+        }
+        // Add a To: header of either the recipient (if only 1), or the sender (if multiple)
+        String              toName                  = fromName;
+        String              toEmail                 = fromEmail;
+
+        if (toAddress.size() == 1) {
+            User u = toAddress.get(0);
+            toName = u.getDisplayName();
+            toEmail = u.getEmail();
+        }
+
+        headers.add("To: \"" + toName + "\" <" + toEmail + ">" );
+
+        //SAK-21742 we need the rendered subject
+        headers.add("Subject: " + rt.getRenderedSubject());
+        headers.add("Content-Type: multipart/alternative; boundary=\"" + MULTIPART_BOUNDARY + "\"");
+        headers.add("Mime-Version: 1.0");
+        headers.add("Return-Path: <>");
+        headers.add("Auto-Submitted: auto-generated");
+
+        return headers;
+    }
+
+    // loadTemplate from ValidationLogicImpl.java
+    /**
+     * Load and register one or more email templates (contained in the given
+     * .xml file) with the email template service
+     *
+     * @param templateFileName - the name of the .xml file to load
+     * @param templateRegistrationString - the key (name) of the template to be saved to the service
+     */
+    @SuppressWarnings("unchecked")
+    private     void                loadTemplate                    (String templateFileName, String templateRegistrationString) {
+        log.info(this + " loading template " + templateFileName);
+
+        SecurityAdvisor yesMan = new SecurityAdvisor() {
+            public SecurityAdvice isAllowed( String userId, String function, String reference ) {
+                return SecurityAdvice.ALLOWED;
+            }
+        };
+
+        try {
+            // Push the yesMan SA on the stack and perform the necessary actions
+            securityService.pushAdvisor(yesMan);
+
+            // Load up the resource as an input stream
+            InputStream input = SamigoETSProviderImpl.class.getClassLoader().getResourceAsStream("" + templateFileName);
+            if ( input == null ) {
+                log.error( "Could not load resource from '" + templateFileName + "'. Skipping ..." );
+            } else {
+                // Parse the XML, get all the child templates
+                Document document = new SAXBuilder().build( input );
+                List<?> childTemplates = document.getRootElement().getChildren( "emailTemplate" );
+                Iterator<?> iter = childTemplates.iterator();
+
+                // Create and register a template with the service for each one found in the XML file
+                while ( iter.hasNext() ) {
+                    xmlToTemplate( (Element) iter.next(), templateRegistrationString );
+                }
+            }
+        } catch (Exception e) {
+            if( JDOMException.class.isInstance(e) || IOException.class.isInstance(e)) {
+                log.error("loadTemplate error: ", e);
+            }
+        } finally { // Pop the yesMan SA off the stack (remove elevated permissions)
+            securityService.popAdvisor(yesMan);
+        }
+    }
+
+    // xmlToTemplate from ValidationLogicImpl.java
+    private     void                xmlToTemplate                   (Element xmlTemplate, String key) {
+        String              subject                 = xmlTemplate.getChildText("subject");
+        String              body                    = xmlTemplate.getChildText("message");
+        String              bodyHtml                = xmlTemplate.getChildText("messagehtml");
+        String              locale                  = xmlTemplate.getChildText("locale");
+        String              localeLangTag           = xmlTemplate.getChildText("localeLangTag");
+        String              versionString           = xmlTemplate.getChildText("version");
+
+
+        if (emailTemplateService.getEmailTemplate(key, Locale.forLanguageTag(localeLangTag)) == null)
+        {
+            EmailTemplate template = new EmailTemplate();
+            template.setSubject(subject);
+            template.setMessage(body);
+            if (bodyHtml != null) {
+                String decodedHtml;
+                try {
+                    decodedHtml = URLDecoder.decode(bodyHtml, "utf8");
+                } catch (UnsupportedEncodingException e) {
+                    decodedHtml = bodyHtml;
+                    e.printStackTrace();
+                }
+                template.setHtmlMessage(decodedHtml);
+            }
+            template.setLocale(locale);
+            template.setKey(key);
+            template.setVersion(Integer.valueOf(versionString));//setVersion(versionString != null ? Integer.valueOf(versionString) : Integer.valueOf(0));	// set version
+            template.setOwner("admin");
+            template.setLastModified(new Date());
+            try {
+                this.emailTemplateService.saveTemplate(template);
+                log.info(this + " user notification template " + key + " added");
+            }catch (Exception e){
+                log.warn("Samigo notification xmlToTemplate error." + e);
+            }
+        }
+    }
+
+    @Setter
+    private                         ServerConfigurationService  serverConfigurationService;
+
+    @Setter
+    private                         UserDirectoryService        userDirectoryService;
+
+    @Setter
+    private                         EmailTemplateService        emailTemplateService;
+
+    @Setter
+    private                         PreferencesService          preferencesService;
+
+    @Setter
+    private                         EmailService                emailService;
+
+    @Setter
+    private                         DigestService               digestService;
+
+    @Setter
+    private                         NotificationService         notificationService;
+
+    @Setter
+    private                         SiteService                 siteService;
+
+    @Setter
+    private                         SessionManager              sessionManager;
+
+    @Setter
+    private                         SecurityService             securityService;
+
+    @Setter
+    private                         AuthzGroupService           authzGroupService;
+}

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoObserver.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoObserver.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2015, The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
+
+import lombok.Setter;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.sakaiproject.event.api.Event;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.samigo.util.SamigoConstants;
+
+public class SamigoObserver implements Observer {
+    private static final Logger log = Logger.getLogger(SamigoObserver.class);
+
+    public void init() {
+        log.info("init()");
+        eventTrackingService.addLocalObserver(this);
+    }
+
+    public void destroy(){
+        log.info("destroy");
+        eventTrackingService.deleteObserver(this);
+    }
+
+    public void update(Observable arg0, Object arg) {
+        if (!(arg instanceof Event)){
+            return;
+        }
+
+        Event event = (Event) arg;
+        String eventType = event.getEvent();
+
+        if(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED.equals(eventType)) {
+            log.debug("Assessment Submitted Event");
+            String hashMapString = event.getResource();
+            Map<String, Object> notiValues =  stringToHashMap(hashMapString);
+            samigoETSProvider.notify(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED, notiValues, event);
+        } else if(SamigoConstants.EVENT_ASSESSMENT_AUTO_SUBMITTED.equals(eventType)){
+            log.debug("Assessment Auto Submitted Event");
+            String hashMapString = event.getResource();
+            Map<String, Object> notiValues =  stringToHashMap(hashMapString);
+            samigoETSProvider.notify(SamigoConstants.EVENT_ASSESSMENT_AUTO_SUBMITTED, notiValues, event);
+        } else if(SamigoConstants.EVENT_ASSESSMENT_TIMED_SUBMITTED.equals(eventType)){
+            log.debug("Assessment Timed Submitted Event");
+            String hashMapString = event.getResource();
+            Map<String, Object> notiValues = stringToHashMap(hashMapString);
+            samigoETSProvider.notify(SamigoConstants.EVENT_ASSESSMENT_TIMED_SUBMITTED, notiValues, event);
+        }
+    }
+
+    /*
+     * stringToHashMap
+     * Derived from http://stackoverflow.com/a/26486046
+     */
+    private Map<String, Object> stringToHashMap(String hashMapString){
+        Map<String, Object> map = new HashMap<String, Object>();
+
+        hashMapString = StringUtils.substringBetween(hashMapString, "{", "}");           //remove curly brackets
+        String[] keyValuePairs = hashMapString.split(",");              //split the string to create key-value pairs
+
+        for(String pair : keyValuePairs)                        //iterate over the pairs
+        {
+            String[] entry = pair.split("=");                   //split the pairs to get key and value
+            String key = StringUtils.trim(entry[0]);
+            if(entry.length == 2) {
+                if (key.equals("assessmentGradingID") || key.equals("publishedAssessmentID")) {
+                    map.put(key, Long.valueOf(StringUtils.trim(entry[1])));
+                } else {
+                    map.put(key, String.valueOf(StringUtils.trim(entry[1])));          //add them to the hashmap and trim whitespaces
+                }
+            } else{
+                map.put(key, "");
+            }
+        }
+
+        return map;
+    }
+
+    @Setter
+    private EventTrackingService    eventTrackingService;
+
+    @Setter
+    private SamigoETSProviderImpl   samigoETSProvider;
+}

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/user/prefs/SamigoUserNotificationPreferencesRegistrationImpl.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/user/prefs/SamigoUserNotificationPreferencesRegistrationImpl.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015, The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.user.prefs;
+
+import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.UserNotificationPreferencesRegistrationImpl;
+
+public class SamigoUserNotificationPreferencesRegistrationImpl extends UserNotificationPreferencesRegistrationImpl {
+    public ResourceLoader getResourceLoader(String location) {
+        return new ResourceLoader(location);
+    }
+}

--- a/samigo/samigo-import/pom.xml
+++ b/samigo/samigo-import/pom.xml
@@ -20,10 +20,6 @@
     
 	<dependencies>
 		<dependency>
-			<groupId>org.sakaiproject.kernel</groupId>
-			<artifactId>sakai-kernel-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.sakaiproject.common</groupId>
 			<artifactId>archive-api</artifactId>
 		</dependency>

--- a/samigo/samigo-pack/pom.xml
+++ b/samigo/samigo-pack/pom.xml
@@ -29,10 +29,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
-			<artifactId>sakai-kernel-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-component-manager</artifactId>
 		</dependency>
 		<dependency>
@@ -59,7 +55,10 @@
 			<artifactId>jsr173</artifactId>
 			<version>1.0_api</version>
 		</dependency>
-
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>samigo-impl</artifactId>
+		</dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>samigo-qti</artifactId>
@@ -73,6 +72,13 @@
 				<directory>src/sql</directory>
 				<includes>
 					<include>**/*.sql</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/bundle</directory>
+				<includes>
+					<include>**/*.properties</include>
+					<include>**/*.xml</include>
 				</includes>
 			</resource>
 		</resources>

--- a/samigo/samigo-pack/src/bundle/samigo-noti-prefs.properties
+++ b/samigo/samigo-pack/src/bundle/samigo-noti-prefs.properties
@@ -1,0 +1,7 @@
+prefs_title = Tests & Quizzes
+# Do not remove prefs_description or prefs_title_override, check SAK-21078 for risk and code for reason
+prefs_description =
+prefs_title_override =
+prefs_opt3 = Send me an email confirmation each time I submit an assessment
+prefs_opt2 = Send me one email per day confirming all of my submissions
+prefs_opt1 = Do not send me any email confirmations

--- a/samigo/samigo-pack/src/bundle/template-assessmentAutoSubmission.xml
+++ b/samigo/samigo-pack/src/bundle/template-assessmentAutoSubmission.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<emailTemplates>
+    <emailTemplate>
+        <subject>Notification for assessment auto submission: ${siteName} - ${assessmentTitle}</subject>
+        <message>The following assessment auto submission was recorded by Isidore:
+
+    Site Title          : ${siteName}
+    Assessment          : ${assessmentTitle}
+
+    Student             : ${userName} (${userDisplayID})
+    Submission ID       : ${assessmentGradingID}
+    Submitted on        : ${submissionDate}
+
+    Assessment Due Date : ${assessmentDueDate}
+    Site ID             : ${siteID}
+
+---
+This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
+Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+        </message>
+        <messagehtml>&lt;pre&gt;
+The following assessment auto submission was recorded by Isidore:
+
+    Site Title          : ${siteName}
+    Assessment          : ${assessmentTitle}
+
+    Student             : ${userName} (${userDisplayID})
+    Submission ID       : ${assessmentGradingID}
+    Submitted Date      : ${submissionDate}
+
+    Assessment Due Date : ${assessmentDueDate}
+    Site ID             : ${siteID}
+
+---
+This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
+Control what email notifications you receive at My Workspace -&gt; Preferences -&gt; Notifications
+&lt;/pre&gt;
+        </messagehtml>
+        <version>1</version>
+        <owner>admin</owner>
+        <key>sam.assessmentAutoSubmitted</key>
+        <locale>en_US</locale>
+        <localeLangTag>en-US</localeLangTag>
+    </emailTemplate>
+</emailTemplates>

--- a/samigo/samigo-pack/src/bundle/template-assessmentSubmission.xml
+++ b/samigo/samigo-pack/src/bundle/template-assessmentSubmission.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<emailTemplates>
+    <emailTemplate>
+        <subject>Notification for assessment submission: ${siteName} - ${assessmentTitle}</subject>
+        <message>The following assessment submission was recorded by Isidore:
+
+    Site Title          : ${siteName}
+    Assessment          : ${assessmentTitle}
+
+    Student             : ${userName} (${userDisplayID})
+    Submission ID       : ${assessmentGradingID}
+    Submitted on        : ${submissionDate}
+
+    Assessment Due Date : ${assessmentDueDate}
+    Site ID             : ${siteID}
+
+---
+This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
+Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+        </message>
+        <messagehtml>&lt;pre&gt;
+The following assessment submission was recorded by Isidore:
+
+    Site Title          : ${siteName}
+    Assessment          : ${assessmentTitle}
+
+    Student             : ${userName} (${userDisplayID})
+    Submission ID       : ${assessmentGradingID}
+    Submitted Date      : ${submissionDate}
+
+    Assessment Due Date : ${assessmentDueDate}
+    Site ID             : ${siteID}
+
+---
+This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
+Control what email notifications you receive at My Workspace -&gt; Preferences -&gt; Notifications
+&lt;/pre&gt;
+        </messagehtml>
+        <version>1</version>
+        <owner>admin</owner>
+        <key>sam.assessmentSubmitted</key>
+        <locale>en_US</locale>
+        <localeLangTag>en-US</localeLangTag>
+    </emailTemplate>
+</emailTemplates>

--- a/samigo/samigo-pack/src/bundle/template-assessmentTimedSubmission.xml
+++ b/samigo/samigo-pack/src/bundle/template-assessmentTimedSubmission.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<emailTemplates>
+    <emailTemplate>
+        <subject>Notification for timed assessment submission: ${siteName} - ${assessmentTitle}</subject>
+        <message>The timer has expired and the following timed assessment has been automatically submitted:
+
+    Site Title          : ${siteName}
+    Assessment          : ${assessmentTitle}
+
+    Student             : ${userName} (${userDisplayID})
+    Submission ID       : ${assessmentGradingID}
+    Submitted on        : ${submissionDate}
+
+    Assessment Due Date : ${assessmentDueDate}
+    Site ID             : ${siteID}
+
+---
+This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
+Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+        </message>
+        <messagehtml>&lt;pre&gt;
+The timer has expired and the following timed assessment has been automatically submitted:
+
+    Site Title          : ${siteName}
+    Assessment          : ${assessmentTitle}
+
+    Student             : ${userName} (${userDisplayID})
+    Submission ID       : ${assessmentGradingID}
+    Submitted Date      : ${submissionDate}
+
+    Assessment Due Date : ${assessmentDueDate}
+    Site ID             : ${siteID}
+
+---
+This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
+Control what email notifications you receive at My Workspace -&gt; Preferences -&gt; Notifications
+&lt;/pre&gt;
+        </messagehtml>
+        <version>1</version>
+        <owner>admin</owner>
+        <key>sam.assessmentTimedSubmitted</key>
+        <locale>en_US</locale>
+        <localeLangTag>en-US</localeLangTag>
+    </emailTemplate>
+</emailTemplates>

--- a/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
+++ b/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
@@ -336,6 +336,59 @@
       </property>
    </bean>       	
 
+    <!-- Email Template Service Setup -->
+    <bean id="org.sakaiproject.samigo.api.SamigoETSProvider"
+          class="org.sakaiproject.samigo.impl.SamigoETSProviderImpl"
+          init-method="init"
+          singleton="true" >
+        <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
+        <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+        <property name="emailTemplateService" ref="org.sakaiproject.emailtemplateservice.service.EmailTemplateService"/>
+        <property name="emailService" ref="org.sakaiproject.email.api.EmailService"/>
+        <property name="digestService" ref="org.sakaiproject.email.api.DigestService"/>
+        <property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService"/>
+        <property name="notificationService" ref="org.sakaiproject.event.api.NotificationService"/>
+        <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+        <property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
+    </bean>
+
+    <bean id="org.sakaiproject.samigo.impl.SamigoObserver"
+          class="org.sakaiproject.samigo.impl.SamigoObserver"
+          init-method="init">
+        <property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService" />
+        <property name="samigoETSProvider" ref="org.sakaiproject.samigo.api.SamigoETSProvider" />
+    </bean>
+
+    <!-- Adds User Preference for Notifications -->
+    <bean id="org.sakaiproject.user.api.UserNotificationPreferencesRegistration.samigo"
+          parent="org.sakaiproject.user.api.UserNotificationPreferencesRegistration"
+          class="org.sakaiproject.samigo.user.prefs.SamigoUserNotificationPreferencesRegistrationImpl"
+          init-method="init" singleton="true">
+        <property name="bundleLocation"><value>samigo-noti-prefs</value></property>
+        <property name="sectionTitleBundleKey"><value>prefs_title</value></property>
+        <property name="sectionDescriptionBundleKey"><value>prefs_description</value></property>
+        <property name="overrideSectionTitleBundleKey"><value>prefs_title_override</value></property>
+        <property name="defaultValue"><value>3</value></property>
+        <property name="type"><value>sakai:samigo</value></property>
+        <property name="prefix"><value>samigo</value></property>
+        <property name="toolId"><value>sakai.samigo</value></property>
+        <property name="rawOptions">
+            <map>
+                <entry key="1"><value>prefs_opt1</value></entry>
+                <entry key="2"><value>prefs_opt2</value></entry>
+                <entry key="3"><value>prefs_opt3</value></entry>
+            </map>
+        </property>
+        <property name="overrideBySite"><value>false</value></property>
+        <property name="expandByDefault"><value>true</value></property>
+    </bean>
+
+
+
+
+
 </beans>
 
 

--- a/samigo/samigo-qti/pom.xml
+++ b/samigo/samigo-qti/pom.xml
@@ -29,10 +29,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
-			<artifactId>sakai-kernel-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-component-manager</artifactId>
 		</dependency>
         <dependency>

--- a/samigo/samigo-services/pom.xml
+++ b/samigo/samigo-services/pom.xml
@@ -33,10 +33,6 @@
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
-            <artifactId>sakai-kernel-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-component-manager</artifactId>
         </dependency>
         <dependency>

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -73,6 +73,7 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
 import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.site.cover.SiteService;
@@ -3430,6 +3431,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		boolean updateCurrentGrade = false;
 	    while (iter.hasNext()) {
 	    	updateCurrentGrade = false;
+            Map<String, Object> notiValues = new HashMap<String, Object>();
 	    	try{
 	    		adata = (AssessmentGradingData) iter.next();
 	    		adata.setHasAutoSubmissionRun(Boolean.TRUE);
@@ -3496,7 +3498,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     						AutoSubmitAssessmentsJob.safeEventLength("publishedAssessmentId=" + adata.getPublishedAssessmentId() + 
     								", assessmentGradingId=" + adata.getAssessmentGradingId()), true));
     				
+    				notiValues.put("publishedAssessmentID", adata.getPublishedAssessmentId());
+    				notiValues.put("assessmentGradingID", adata.getAssessmentGradingId());
+    				notiValues.put("userID", adata.getAgentId());
+    				notiValues.put("submissionDate", adata.getSubmittedDate());
+
+    				EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_AUTO_SUBMITTED, notiValues.toString(), AgentFacade.getCurrentSiteId(), false, SamigoConstants.NOTI_EVENT_ASSESSMENT_SUBMITTED));
     			}
+
 	    		lastPublishedAssessmentId = adata.getPublishedAssessmentId();
     			lastAgentId = adata.getAgentId();
 
@@ -3525,6 +3534,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     					}
     				}
     			}
+
     			adata = null;
 	    	}catch (Exception e) {
 	    		if(adata != null){

--- a/samigo/samlite-impl/pom.xml
+++ b/samigo/samlite-impl/pom.xml
@@ -65,9 +65,5 @@
 			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-kernel-util</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.sakaiproject.kernel</groupId>
-			<artifactId>sakai-kernel-api</artifactId>
-		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This adds email notifications on samigo submissions for the three kinds
of submissions:
* Manual submission
* Timer expires submission
* Auto Submit Job execution submission

A high level overview follows:

For each of the three submission types, a separate event is fired.
A local observer, SamigoObserver, monitors the events and passes the
appropriate events to the SamigoETSProvider.

This provider then handles the events and sends an email / digest depending
on the settings of the exam and user settings.

User settings exist under My Workspace -> Preferences -> Notifications.
These settings are only respected if you are a student taking the exam.

Each exam has its own individual notification settings, which are used when
sending a notification to an instructor. This means that an instructors
notifications are contolled by the individual exam's notification
settings.

The SamigoETSProider loads up email templates using the Email
Templating Service.