### PR TITLE
SAM-2241 - Third try at this, seems like this is finally it

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -540,6 +540,8 @@ public class SubmitToGradingActionListener implements ActionListener {
 			} else { // itemGrading from new set doesn't exist, add to set in
 				// this case
 				// log.debug("**** SubmitToGrading: need add new item");
+				//a new item should always have the grading ID set to null
+				newItem.setItemGradingId(null);
 				newItem.setAgentId(adata.getAgentId());
 				updateItemGradingSet.add(newItem);
 			}
@@ -593,8 +595,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 		for (int m = 0; m < grading.size(); m++) {
 			ItemGradingData itemgrading = grading.get(m);
 			if (itemgrading.getItemGradingId() == null && (itemgrading.getReview() != null && itemgrading.getReview().booleanValue())  == true) {
-				adds.addAll(grading);
-				break;
+				adds.add(itemgrading);
 			} 
 		}
 		


### PR DESCRIPTION
Okay, it seems like the problem here was there was this code that was adding all of the mark for review items into the add set. It was even adding in the "special" items adding as a duplicate that it shouldn't have when it called an "addAll" here. 

This was a fix way back on SAM-1301 but it seems like it didn't account for the special case of rationales. I've tested this locally (also SAM-1301) and looks to work as expected.  I also added back in the change to SAM-2185.