### PR TITLE
NOJIRA Increasing our memory to maven.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# travis-ci currently has Maven 3.2 which doesn't read our .mvn folder
+# and https://github.com/travis-ci/travis-ci/issues/4613 means we can't set MAVEN_OPTS directly
+before_install: echo "MAVEN_OPTS='-Xms168m -Xmx1536m -XX:NewSize=64m -Djava.awt.headless=true'" > ~/.mavenrc
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
travis-ci.org is currently still using maven 3.2 which doesn't read the .mvn folder for JVM options.
JVMs typically limit themselves to 1/4 of the available memory which on travis-ci is 3Gb so we're only getting about 768MB of available heap which is causing intermittent build failures.