### PR TITLE
Changes to send comments to Gradebook automatically. SAM-1597

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/ifc/GradebookServiceHelper.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/ifc/GradebookServiceHelper.java
@@ -63,6 +63,9 @@ public interface GradebookServiceHelper extends Serializable
   public void updateExternalAssessmentScores(Long publishedAssessmentId, final Map<String, Double> studentUidsToScores,
 		  GradebookExternalAssessmentService g) throws Exception;
   
+  public void updateExternalAssessmentComment(Long publishedAssessmentId, String studentUid, String comment, 
+		  GradebookExternalAssessmentService g) throws Exception;
+  
   public Long getExternalAssessmentCategoryId(String gradebookUId,
 		  String publishedAssessmentId, GradebookExternalAssessmentService g);
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
@@ -294,6 +294,22 @@ public void removeExternalAssessment(String gradebookUId,
 		  throw new Exception("Encountered an error in update ExternalAssessmentScore.");
 	  }
   }
+  
+  public void updateExternalAssessmentComment(Long publishedAssessmentId, String studentUid, String comment,
+          GradebookExternalAssessmentService g) throws Exception {
+	  boolean testErrorHandling=false;
+	  PublishedAssessmentService pubService = new PublishedAssessmentService();
+	  String gradebookUId = pubService.getPublishedAssessmentOwner(publishedAssessmentId);
+	  if (gradebookUId == null) {
+		  return;
+	  }	
+	  g.updateExternalAssessmentComment(gradebookUId, publishedAssessmentId.toString(), studentUid, comment);
+
+	  if (testErrorHandling){
+          throw new Exception("Encountered an error in update ExternalAssessmentComment.");
+	  }
+  }
+
 
 	public Long getExternalAssessmentCategoryId(String gradebookUId,
 			String publishedAssessmentId, GradebookExternalAssessmentService g) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -297,8 +297,22 @@ public class GradingService
       else{ // if new is different from old, include it for update
         AssessmentGradingData b = (AssessmentGradingData) o;
         if ((a.getFinalScore()!=null && b.getFinalScore()!=null) 
-            && !a.getFinalScore().equals(b.getFinalScore()))
-          l.add(a);
+            && !a.getFinalScore().equals(b.getFinalScore())) {
+            l.add(a);
+        }
+        // if scores are not modified but comments are added, include it for update
+        else if (a.getComments()!=null)
+        	{
+            	if (b.getComments()!=null)
+            	{
+                    if (!a.getComments().equals(b.getComments())) {
+                            l.add(a);
+                    }
+            	}
+            	else {
+                    l.add(a);
+            	}
+        	}
       }
     }
     return l;
@@ -1395,6 +1409,16 @@ public class GradingService
     if(!(MathUtils.equalsIncludingNaN(data.getFinalScore(), originalFinalScore, 0.0001))) {
     	data.setFinalScore(originalFinalScore);
     }
+    
+    try {
+        	Long publishedAssessmentId = data.getPublishedAssessmentId();
+        	String agent = data.getAgentId();
+        	String comment = data.getComments();
+        	gbsHelper.updateExternalAssessmentComment(publishedAssessmentId, agent, comment, g);
+    }
+    catch (Exception ex) {
+          log.warn("Error sending comments to gradebook: " + ex.getMessage());
+          }
     } else {
        if(log.isDebugEnabled()) log.debug("Not updating the gradebook.  toGradebook = " + toGradebook);
     }


### PR DESCRIPTION
With this modification, grader's comments are also sent to Gradebook tool besides scores. 
Students will see these comments in the associated item of Gradebook tool. 
Comments will be sent automatically if the option to send to Gradebook is selected, as currently happens with scores. 