### PR TITLE
SAK-29825 New service to set the gradebook grading scales.

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookFrameworkService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookFrameworkService.java
@@ -22,6 +22,8 @@
 package org.sakaiproject.service.gradebook.shared;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This service is meant to be used by the framework which manages the Gradebook
@@ -78,5 +80,32 @@ public interface GradebookFrameworkService {
      *	The UID of the grading scale to use as the default for new gradebooks.
 	 */
 	public void setDefaultGradingScale(String uid);
+
+	/**
+	 *
+	 *	returns all the Available Grading Scales in the system.
+	 */
+	public List getAvailableGradingScales();
+
+	/**
+	 * Adds a new grade scale to an existing gradebook.
+	 *
+	 * @param scaleUuid
+	 *   The Uuid of the scale we want to be added to the gradebook
+	 * @param gradebook
+	 *   The gradebook with GradeMappings where we will add the grading scale.
+	 *
+	 */
+	public void saveGradeMappingToGradebook(String scaleUuid, String gradebookUid);
+
+
+	/**
+	 * Update a grademapping with new values.
+	 *
+	 * @param gradeMapping
+	 *   The gradeMApping to update.
+	 *
+	 */
+	public void updateGradeMapping(Long gradeMappingId, Map<String, Double> gradeMap);
 
 }

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -23,6 +23,7 @@ package org.sakaiproject.service.gradebook.shared;
 
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.util.Set;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -772,7 +773,7 @@ public interface GradebookService {
 	 */
 	@SuppressWarnings("rawtypes")
 	List getViewableSections(String gradebookUid);
-	
+
 	/**
 	 * Update the settings for this gradebook
 	 * 
@@ -781,4 +782,11 @@ public interface GradebookService {
 	 */
 	void updateGradebookSettings(String gradebookUid, GradebookInformation gbInfo);
 
+	/**
+	 * Return the gradebook but with the GradeMappings. The normal getGradebook(siteId)
+	 * doesn't return the GradeMapping.
+	 * @param gradebookId
+	 * @return a gradebook with all the GradeMappings.
+	 */
+	public Set getGradebookGradeMappings(Long gradebookId);
 }

--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradingScale.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradingScale.java
@@ -23,10 +23,13 @@
 package org.sakaiproject.tool.gradebook;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.sakaiproject.service.gradebook.shared.GradingScaleDefinition;
 
 public class GradingScale implements Serializable, Comparable {
 	private Long id;
@@ -97,4 +100,25 @@ public class GradingScale implements Serializable, Comparable {
         return new ToStringBuilder(this).
             append(getUid()).toString();
     }
+
+	public GradingScaleDefinition toGradingScaleDefinition(){
+		GradingScaleDefinition scaleDef = new GradingScaleDefinition();
+		scaleDef.setUid(this.getUid());
+		scaleDef.setName(this.getName());
+		Map<String, Double> mapBottomPercents = this.getDefaultBottomPercents();
+		List<Object> defaultBottomPercents = new ArrayList<>();
+		List<String> grades = new ArrayList<>();
+		Iterator mapBottomPercentsIter = mapBottomPercents.entrySet().iterator();
+		while (mapBottomPercentsIter.hasNext()) {
+			Map.Entry pair = (Map.Entry)mapBottomPercentsIter.next();
+			defaultBottomPercents.add(pair.getValue());
+			grades.add(pair.getKey().toString());
+			mapBottomPercentsIter.remove();
+		}
+		scaleDef.setGrades(grades);
+		scaleDef.setDefaultBottomPercents(defaultBottomPercents);
+		return scaleDef;
+	}
+
+
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3079,6 +3079,17 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		this.gradebookPermissionService = gradebookPermissionService;
 	}
 
-	
+	@Override
+	public Set getGradebookGradeMappings(final Long gradebookId) {
+		return (Set)getHibernateTemplate().execute(new HibernateCallback() {
+			@Override
+			public Set doInHibernate(Session session) throws HibernateException {
+				Gradebook gradebook = (Gradebook)session.load(Gradebook.class, gradebookId);
+				Hibernate.initialize(gradebook.getGradeMappings());
+				return gradebook.getGradeMappings();
+			}
+		});
+	}
+
 	
 }

--- a/webservices/cxf/pom.xml
+++ b/webservices/cxf/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>gradebook-service-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.sakaiproject.edu-services.gradebook</groupId>
+            <artifactId>gradebook-service-hibernate</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sakaiproject.msgcntr</groupId>
             <artifactId>messageforums-api</artifactId>
         </dependency>

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiGradebook.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiGradebook.java
@@ -1,0 +1,198 @@
+package org.sakaiproject.webservices;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.service.gradebook.shared.GradingScaleDefinition;
+import org.sakaiproject.tool.api.Session;
+
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+
+
+
+import org.sakaiproject.service.gradebook.shared.GradebookFrameworkService;
+
+import org.sakaiproject.tool.gradebook.GradingScale;
+import org.sakaiproject.tool.gradebook.GradeMapping;
+import org.sakaiproject.tool.gradebook.Gradebook;
+import org.sakaiproject.site.api.SiteService.SelectionType;
+import org.sakaiproject.site.api.SiteService.SortType;
+
+/**
+ * Created by: Diego del Blanco, SCRIBA
+ * Date: 9/18/15
+ */
+@WebService
+@SOAPBinding(style = SOAPBinding.Style.RPC, use = SOAPBinding.Use.LITERAL)
+public class SakaiGradebook extends AbstractWebService {
+    private static final Log LOG = LogFactory.getLog(SakaiGradebook.class);
+
+    protected GradebookFrameworkService gradebookFrameworkService;
+
+    @WebMethod(exclude = true)
+    public void setGradebookFrameworkService(GradebookFrameworkService gradebookFrameworkService) {
+        this.gradebookFrameworkService = gradebookFrameworkService;
+    }
+
+
+    @WebMethod
+    @Path("/createOrUpdateGradeScale")
+    @Produces("text/plain")
+    @GET
+    public String createOrUpdateGradeScale(
+            @WebParam(name = "sessionid", partName = "sessionid") @QueryParam("sessionid") String sessionid,
+            @WebParam(name = "scaleUuid", partName = "scaleUuid") @QueryParam("scaleUuid") String scaleUuid,
+            @WebParam(name = "scaleName", partName = "scaleName") @QueryParam("scaleName") String scaleName,
+            @WebParam(name = "grades", partName = "grades") @QueryParam("grades") String[] grades,
+            @WebParam(name = "percents", partName = "percents") @QueryParam("percents") String[] percents,
+            @WebParam(name = "updateOld", partName = "updateOld") @QueryParam("updateOld") boolean updateOld,
+            @WebParam(name = "updateOnlyNotCustomized", partName = "updateOnlyNotCustomized") @QueryParam("updateOnlyNotCustomized") boolean updateOnlyNotCustomized) {
+
+        Session session = establishSession(sessionid);
+        Map defaultBottomPercentsOld = new HashMap(); //stores the old default values, to check if a gradeSet is customized or not.
+
+        if (!securityService.isSuperUser()) {
+            LOG.warn("NonSuperUser trying to change Gradebook Scales: " + session.getUserId());
+            throw new RuntimeException("NonSuperUser trying to change Gradebook Scales: " + session.getUserId());
+        }
+
+        try {
+            boolean isUpdate = false;
+
+            //In the case it is called as a restful service we need to read correctly the parameters
+            if (percents[0].endsWith("}") && percents[0].startsWith("{") && grades[0].endsWith("}") && grades[0].startsWith("{")) {
+                grades = grades[0].substring(1, grades[0].length() - 1).split(",");
+                percents = percents[0].substring(1, percents[0].length() - 1).split(",");
+            }
+
+            //Get all the scales
+            List<GradingScale> gradingScales = gradebookFrameworkService.getAvailableGradingScales();
+
+            List<GradingScaleDefinition> gradingScaleDefinitions= new ArrayList<>();
+            //The API returns GradingScales, but needs GradingScalingDefinitions, so we'll need to convert them.
+
+            //Compare the UID of the scale to check if we need to update ot create a new one
+            for (Iterator iter = gradingScales.iterator(); iter.hasNext();) {
+                GradingScale gradingScale = (GradingScale)iter.next();
+                GradingScaleDefinition gradingScaleDefintion = gradingScale.toGradingScaleDefinition();
+                if (gradingScaleDefintion.getUid().equals(scaleUuid)) {   //If it is an update...
+
+                    //Store the previous default values to compare later if updateOnlyNotCustomized=true
+                    Iterator gradesIterOld = gradingScaleDefintion.getGrades().iterator();
+                    Iterator defaultBottomPercentsIterOld = gradingScaleDefintion.getDefaultBottomPercents().iterator();
+                    while (gradesIterOld.hasNext() && defaultBottomPercentsIterOld.hasNext()) {
+                        String gradeOld = (String)gradesIterOld.next();
+                        Double valueOld = (Double)defaultBottomPercentsIterOld.next();
+                        defaultBottomPercentsOld.put(gradeOld, valueOld);
+                    }
+                    // Set the new Values
+                    gradingScaleDefintion.setName(scaleName);
+                    gradingScaleDefintion.setGrades(Arrays.asList(grades));
+                    gradingScaleDefintion.setDefaultBottomPercents(Arrays.asList(percents));
+                    isUpdate=true;
+                }
+                gradingScaleDefinitions.add(gradingScaleDefintion); //always add the Scale
+            }
+
+            if (!isUpdate) {   //If it is not an update we create the scale and add it.
+                GradingScaleDefinition scale = new GradingScaleDefinition();
+                scale.setUid(scaleUuid);
+                scale.setName(scaleName);
+                scale.setGrades(Arrays.asList(grades));
+                scale.setDefaultBottomPercents(Arrays.asList(percents));
+                gradingScaleDefinitions.add(scale);//always add the Scale
+            }
+
+            //Finally we update all the scales
+            gradebookFrameworkService.setAvailableGradingScales(gradingScaleDefinitions);
+
+            // Now we need to add this scale to ALL the actual gradebooks if it is new,
+            // and if not new, then update (if updateOld=true) the values in the ALL the old gradebooks.
+            // Seems that there is not any service that returns the full list of all the gradebooks,
+            // but with the siteid we can call gradebookService.isGradebookDefined(siteId)
+            // and know if the site has gradebook or not, and use gradebookService.getGradebook(siteId); to
+            // have all of them.
+
+            List<String> siteList = siteService.getSiteIds(SelectionType.NON_USER, null, null, null, SortType.NONE, null);
+
+            for (String siteId : siteList) {
+                if (gradebookService.isGradebookDefined(siteId)){
+                    //If the site has gradebook then we
+                    Gradebook gradebook = (Gradebook)gradebookService.getGradebook(siteId);
+                    String gradebookUid=gradebook.getUid();
+                    Long gradebookId=gradebook.getId();
+
+                    if (!isUpdate) { //If it is new then we need to add the scale to every actual gradebook in the list
+                            gradebookFrameworkService.saveGradeMappingToGradebook(scaleUuid, gradebookUid);
+                            LOG.debug("SakaiGradebook: Adding the new scale " + scaleUuid + " in gradebook: " + gradebook.getUid());
+
+                    }else{ //If it is not new, then update the actual gradebooks with the new values ONLY if updateOld is true
+                        if (updateOld)  {
+                            Set<GradeMapping> gradeMappings =gradebookService.getGradebookGradeMappings(gradebookId);
+                                for (Iterator iter2 = gradeMappings.iterator(); iter2.hasNext();) {
+                                    GradeMapping gradeMapping = (GradeMapping)iter2.next();
+                                    if (gradeMapping.getGradingScale().getUid().equals(scaleUuid)){
+                                        if (updateOnlyNotCustomized){ //We will only update the ones that teachers have not customized
+                                            if (mapsAreEqual(defaultBottomPercentsOld, gradeMapping.getGradeMap())){
+                                                LOG.debug("SakaiGradebook:They are equals " + gradebook.getUid());
+                                                gradeMapping.setDefaultValues();
+                                            }else{
+                                                LOG.debug("SakaiGradebook:They are NOT equals " + gradebook.getUid());
+                                            }
+                                        }else{
+                                            gradeMapping.setDefaultValues();
+                                        }
+                                        LOG.debug("SakaiGradebook: updating gradeMapping" + gradeMapping.getName());
+                                        gradebookFrameworkService.updateGradeMapping(gradeMapping.getId(),gradeMapping.getGradeMap());
+                                    }
+                                }
+
+                        }
+                    }
+
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("SakaiGradebook: createOrUpdateGradeScale: Error attempting to manage a gradescale " + e.getClass().getName() + " : " + e.getMessage());
+            e.printStackTrace();
+            return e.getClass().getName() + " : " + e.getMessage();
+        }
+        return "success";
+    }
+
+    public boolean mapsAreEqual(Map<String, Double> mapA, Map<String, Double> mapB) {
+
+        try{
+            for (String k : mapB.keySet())
+            {
+                LOG.debug("SakaiGradebook:Comparing the default old value:" + mapA.get(k) + " with actual value:" + mapB.get(k));
+                if (!(mapA.get(k).compareTo(mapB.get(k))==0)) {
+                    return false;
+                }
+            }
+            for (String y : mapA.keySet())
+            {
+                if (!mapB.containsKey(y)) {
+                    LOG.debug("SakaiGradebook:Key not found comparing, so they are different:" + !mapB.containsKey(y));
+                    return false;
+                }
+            }
+        } catch (NullPointerException np) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/webservices/cxf/src/resources/applicationContext.xml
+++ b/webservices/cxf/src/resources/applicationContext.xml
@@ -86,6 +86,12 @@
         </jaxrs:serviceBeans>
     </jaxrs:server>
 
+    <jaxrs:server id="SakaiGradebookRS" address="/rest/gradebook">
+        <jaxrs:serviceBeans>
+            <ref bean="org.sakaiproject.webservices.SakaiGradebook"/>
+        </jaxrs:serviceBeans>
+    </jaxrs:server>
+
     <jaxws:endpoint id="SakaiJob"
                     implementor="#org.sakaiproject.webservices.SakaiJob"
                     address="/soap/job"/>
@@ -134,6 +140,10 @@
                     implementor="#org.sakaiproject.webservices.Activity"
                     address="/soap/activity"/>
 
+    <jaxws:endpoint id="SakaiGradebook"
+                    implementor="#org.sakaiproject.webservices.SakaiGradebook"
+                    address="/soap/gradebook"/>
+
     <bean id="org.sakaiproject.webservices.AbstractWebService" class="org.sakaiproject.webservices.AbstractWebService" init-method="init">
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
         <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
@@ -178,5 +188,8 @@
     <bean id="org.sakaiproject.webservices.SakaiConfiguration" class="org.sakaiproject.webservices.SakaiConfiguration" init-method="init" parent="org.sakaiproject.webservices.AbstractWebService" />
      <bean id="org.sakaiproject.webservices.Activity" class="org.sakaiproject.webservices.Activity" init-method="init" parent="org.sakaiproject.webservices.AbstractWebService">
          <property name="eventQueryService" ref="org.sakaiproject.event.api.EventQueryService"/>
+     </bean>
+    <bean id="org.sakaiproject.webservices.SakaiGradebook" class="org.sakaiproject.webservices.SakaiGradebook" init-method="init" parent="org.sakaiproject.webservices.AbstractWebService" >
+        <property name="gradebookFrameworkService" ref="org.sakaiproject.service.gradebook.GradebookFrameworkService"/>
     </bean>
 </beans>


### PR DESCRIPTION
SAK-29825 New service to set the gradebook grading scales. 

This time without the SQLService, only using the edu-services/gradebook services. 

Sample call:

http://SERVERNAME/sakai-ws/rest/gradebook/createOrUpdateGradeScale?sessionid=THESESSIONID&scaleUuid=27&scaleName=newscale&grades={eee,bbb,ccc}&percents={69,31,12}&updateOld=true&updateOnlyNotCustomized=true

updateOld=true updates the old values in the actual gradebooks. It depens of updateOnlyNotCustomized=true if it updates all of them or only the ones that has never been customized by instructors.
updateOld false only update the scale definition, but not the actual gradebooks.
