### PR TITLE
SAK-29891 Add API method to get category average scores as a student

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -722,11 +722,24 @@ public interface GradebookService {
     /**
      * Calculate a student's score for a category given the category definition and grades for that student.
      * 
+     * Note that this cannot be run as a student due to permission checks. 
+     * Use {@link GradebookService#calculateCategoryScore(List, String)} if in context of a student.
+     * 
      * @param category category to perform the calculations for
      * @param gradeMap map of assignmentId to grade, to use for the calculations
      * @return percentage or null if no calculations were made
      */
     Double calculateCategoryScore(CategoryDefinition category, Map<Long,String> gradeMap);
+    
+    /**
+     * Calculate the category score given the viewable assignments and grades for that student.
+     * 
+     * @param categoryId id of category, used for validation that the assignments and grades match
+     * @param assignments list of assignments the student can view
+     * @param gradeMap map of assignmentId to grade, to use for the calculations
+     * @return percentage or null if no calculations were made
+     */
+    Double calculateCategoryScore(final Long categoryId, final List<Assignment> viewableAssignments, final Map<Long,String> gradeMap);
 
     /**
      * Get the course grade for a student

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2708,15 +2708,24 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 	
 	@Override
 	public Double calculateCategoryScore(CategoryDefinition category, Map<Long,String> gradeMap) {
+		List<org.sakaiproject.service.gradebook.shared.Assignment> assignments = category.getAssignmentList();
+		return calculateCategoryScore(category.getId(), assignments, gradeMap);
+	}
+	
+	@Override
+	public Double calculateCategoryScore(Long categoryId, List<org.sakaiproject.service.gradebook.shared.Assignment> assignments, Map<Long,String> gradeMap) {
 		
 		int numScored = 0;
 		int numOfAssignments = 0;
 		BigDecimal totalEarned = new BigDecimal("0");
 		BigDecimal totalPossible = new BigDecimal("0");
 		
-		List<org.sakaiproject.service.gradebook.shared.Assignment> assignments = category.getAssignmentList();
-		
 		for(org.sakaiproject.service.gradebook.shared.Assignment assignment: assignments) {
+			
+			if(categoryId != assignment.getCategoryId()){
+				log.error("Category id: " + categoryId + " did not match assignment categoryId: " + assignment.getCategoryId());
+				return null;
+			}
 			
 			Long assignmentId = assignment.getId();
 			
@@ -2748,6 +2757,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
     	BigDecimal mean = totalEarned.divide(new BigDecimal(numScored), GradebookService.MATH_CONTEXT).divide((totalPossible.divide(new BigDecimal(numOfAssignments), GradebookService.MATH_CONTEXT)), GradebookService.MATH_CONTEXT).multiply(new BigDecimal("100"));    	
     	return Double.valueOf(mean.doubleValue());
 	}
+	
 
 	@Override
 	public org.sakaiproject.service.gradebook.shared.CourseGrade getCourseGradeForStudent(String gradebookUid, String userUuid) {


### PR DESCRIPTION
The current method to get the category average is geared around an instructor. It doesn't work for a student due to the call to get the assignment list form the categorydefinition, and fails permission checks.

This ticket will add a new method to allow a student to get this info.

https://jira.sakaiproject.org/browse/SAK-29891
