### PR TITLE
SAK-29934: Add sakai.property to disable Forums Ranks feature - Phase1: disabling the Ranks page

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -9327,6 +9327,11 @@ public class DiscussionForumTool
 		this.rankBeanList.addAll(alist);
 	}
 
+	public boolean isRanksEnabled()
+	{
+		return ServerConfigurationService.getBoolean("msgcntr.forums.ranks.enable", true);
+	}
+
 	private static final String INSUFFICIENT_PRIVILEGES_TO_EDIT_RANKS = "cdfm_insufficient_privileges_ranks";
 	private static final String VIEW_RANK = "dfViewAllRanks";
 	private static final String ADD_RANK = "dfAddRank";

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionMessageBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionMessageBean.java
@@ -77,8 +77,12 @@ public class DiscussionMessageBean
   }
 
   public void setAuthorPostCount(String userEid) {
-    int authorCount = messageManager.findAuthoredMessageCountForStudent(userEid);
-    authorPostCount = authorCount;
+    // This is invoked a lot, but it's only relevant when a student has a rank.
+    if (authorRank != null)
+    {
+      int authorCount = messageManager.findAuthoredMessageCountForStudent(userEid);
+      authorPostCount = authorCount;
+    }
   }
 
   public int getAuthorPostCount() {

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/forumsOnly/dfForums.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/forumsOnly/dfForums.jsp
@@ -29,7 +29,7 @@ org.sakaiproject.tool.cover.SessionManager.getCurrentToolSession().
 	  <sakai:tool_bar_item value="#{msgs.cdfm_template_setting}" action="#{ForumTool.processActionTemplateSettings}" rendered="#{ForumTool.instructor}" />
 	  <sakai:tool_bar_item value="#{msgs.stat_list}" action="#{ForumTool.processActionStatistics}" rendered="#{ForumTool.instructor}" />
 	  <sakai:tool_bar_item value="#{msgs.cdfm_msg_pending_queue} #{msgs.cdfm_openb}#{ForumTool.numPendingMessages}#{msgs.cdfm_closeb}" action="#{ForumTool.processPendingMsgQueue}" rendered="#{ForumTool.displayPendingMsgQueue}" />
- 	  <sakai:tool_bar_item value="#{msgs.ranks}" action="#{ForumTool.processActionViewRanks}" rendered="#{ForumTool.instructor}" />
+ 	  <sakai:tool_bar_item value="#{msgs.ranks}" action="#{ForumTool.processActionViewRanks}" rendered="#{ForumTool.instructor && ForumTool.ranksEnabled}" />
 	  <sakai:tool_bar_item value="#{msgs.watch}" action="#{ForumTool.processActionWatch}" />
 
   </sakai:tool_bar>


### PR DESCRIPTION
Because of the performance issues (SAK-29654) with the new Forum Ranks feature that we got in Sakai 10 (SAK-24854), we had to create a property to disable the Ranks system to avoid our database from crashing under the hundreds of thousands of queries per hour and the millions of CPU-intensive buffers each hour attribute to the Ranks feature.
However, because of the lack of time over the summer, we decided to implement this property in two phases:
Phase 1 - disable the Ranks page from the UI so that instructors and maintainers cannot add Ranks (this ticket)
Phase 2 - disable the Ranks feature throughout the code (SAK-29936)
This ticket will contain the patch for Phase 1.