### PR TITLE
KNL-1272 - Implement hazelcast caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ sakai-demo.tar.gz
 sakai-demo.zip
 .directory
 .sass-cache
+*.DS_Store
+/bin

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/UserEdit.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/UserEdit.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.user.api;
 
 import org.sakaiproject.entity.api.Edit;
+import org.sakaiproject.time.api.Time;
 
 /**
  * <p>
@@ -120,5 +121,25 @@ public interface UserEdit extends User, Edit
 	 * Make the users eid unchangeable during the edit
 	 */
 	void restrictEditEid();
+
+  /**
+   * Set the last modified user id.
+   */
+  void setLastModifiedUserId(String id);
+
+  /**
+   * Set the last modified time
+   */
+  void setLastModifiedTime(Time lastModifiedTime);
+
+  /**
+   * Set the created user id
+   */
+  void setCreatedUserId(String id);
+
+  /**
+   * Set the creation time
+   */
+  void setCreatedTime(Time createdTime);
 	
 }

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/UserEditHelper.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/UserEditHelper.java
@@ -1,0 +1,75 @@
+/**********************************************************************************
+ * $URL: $
+ * $Id: $
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2008 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+package org.sakaiproject.user.api;
+
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.time.api.TimeService;
+import org.sakaiproject.util.api.FormattedText;
+import org.w3c.dom.Element;
+
+public interface UserEditHelper {
+
+    public void readProperties(UserEdit edit, ResourcePropertiesEdit props);
+
+    public User getAnonymousUser();
+
+    public String userReference(String id);
+
+    public String getAccessPoint(boolean relative);
+
+    public FormattedText formattedText();
+
+    public String encodePassword(String pw);
+
+    public boolean checkPassword(String pw1, String pw2);
+
+    public String getSortName(UserEdit user);
+
+    public String getUserDisplayId(UserEdit user);
+
+    public String getUserDisplayName(UserEdit user);
+
+    public String getDisplayName(UserEdit user);
+
+    public String getDisplayId(UserEdit user);
+    
+    public String cleanId(String id);
+
+    public String cleanEid(String eid);
+
+    public TimeService timeService();
+
+    public void addLiveProperties(UserEdit edit);
+
+    public void cancelEdit(UserEdit user);
+
+    public User getUser(String id) throws UserNotDefinedException;
+
+    public void init();
+
+    public void setLazyProperties(ResourcePropertiesEdit properties, User user);
+
+    void setLazyProperties(ResourcePropertiesEdit properties, boolean lazy);
+
+    public ResourcePropertiesEdit getResourcePropertiesEdit();
+
+    public ResourcePropertiesEdit getResourcePropertiesEdit(Element element);
+}

--- a/kernel/component-manager/src/main/java/org/sakaiproject/util/NoisierDefaultListableBeanFactory.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/util/NoisierDefaultListableBeanFactory.java
@@ -22,6 +22,7 @@
 
 package org.sakaiproject.util;
 
+import org.sakaiproject.util.serializable.SakaiCglibSubclassingInstantiationStrategy;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -41,6 +42,11 @@ public class NoisierDefaultListableBeanFactory extends
 		DefaultListableBeanFactory {
 
 	public static boolean noisyClose = true;
+
+  public NoisierDefaultListableBeanFactory() {
+    // We set this particular strategy because otherwise Spring uses a non-serializable object when processing the bytecode 
+    setInstantiationStrategy(new SakaiCglibSubclassingInstantiationStrategy());
+  }
 
 	public void preInstantiateSingletons() throws BeansException {
 		if (logger.isDebugEnabled()) {

--- a/kernel/component-manager/src/main/java/org/sakaiproject/util/serializable/SakaiCglibSubclassingInstantiationStrategy.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/util/serializable/SakaiCglibSubclassingInstantiationStrategy.java
@@ -1,0 +1,228 @@
+/**********************************************************************************
+ * $URL: $
+ * $Id: $
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2008 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+package org.sakaiproject.util.serializable;
+
+
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.support.LookupOverride;
+import org.springframework.beans.factory.support.MethodOverride;
+import org.springframework.beans.factory.support.MethodReplacer;
+import org.springframework.beans.factory.support.ReplaceOverride;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.beans.factory.support.SimpleInstantiationStrategy;
+import org.springframework.cglib.proxy.Callback;
+import org.springframework.cglib.proxy.CallbackFilter;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.MethodInterceptor;
+import org.springframework.cglib.proxy.MethodProxy;
+import org.springframework.cglib.proxy.NoOp;
+
+/**
+ * Largely a copy of the Spring 2.3.2 version of the original EXCEPT that we use a serializable form of the NoOp
+ * @see org.springframework.beans.factory.support.CglibSubclassingInstantiationStrategy
+ */
+public class SakaiCglibSubclassingInstantiationStrategy extends SimpleInstantiationStrategy {
+    /**
+     * Index in the CGLIB callback array for passthrough behavior,
+     * in which case the subclass won't override the original class.
+     */
+    private static final int PASSTHROUGH = 0;
+
+    /**
+     * Index in the CGLIB callback array for a method that should
+     * be overridden to provide method lookup.
+     */
+    private static final int LOOKUP_OVERRIDE = 1;
+
+    /**
+     * Index in the CGLIB callback array for a method that should
+     * be overridden using generic Methodreplacer functionality.
+     */
+    private static final int METHOD_REPLACER = 2;
+
+    @Override
+    protected Object instantiateWithMethodInjection(RootBeanDefinition beanDefinition, String beanName,
+            BeanFactory owner) {
+
+        // Must generate CGLIB subclass.
+        return new CglibSubclassCreator(beanDefinition, owner).instantiate(null, null);
+    }
+
+    @Override
+    protected Object instantiateWithMethodInjection(RootBeanDefinition beanDefinition, String beanName,
+            BeanFactory owner, Constructor ctor, Object[] args) {
+
+        return new CglibSubclassCreator(beanDefinition, owner).instantiate(ctor, args);
+    }
+
+    /**
+     * An inner class created for historical reasons to avoid external CGLIB dependency
+     * in Spring versions earlier than 3.2.
+     */
+    private static class CglibSubclassCreator implements Serializable {
+
+        private static final Log logger = LogFactory.getLog(CglibSubclassCreator.class);
+
+        private final RootBeanDefinition beanDefinition;
+
+        private final BeanFactory owner;
+
+        public CglibSubclassCreator(RootBeanDefinition beanDef, BeanFactory owner) {
+            this.beanDefinition = beanDef;
+            this.owner = owner;
+            //            this.beanDefinition = beanDef;
+            //            this.beanDefinition.setConstructorArgumentValues(new SakaiConstructorArgumentValues(beanDef
+            //                    .getConstructorArgumentValues()));
+            //            this.beanDefinition.setMethodOverrides(new SakaiMethodOverrides(beanDef.getMethodOverrides()));
+            //            // update the propertyValues - parse through the original list and then replace it with the revised version.
+            //            List<PropertyValue> revisedList = new ArrayList<PropertyValue>();
+            //            for (PropertyValue propertyValue : beanDef.getPropertyValues().getPropertyValueList()) {
+            //                revisedList.add(new SakaiPropertyValue(propertyValue));
+            //            }
+            //            // The getPropertyValueList method actually gives you a handle to the actual list used.
+            //            beanDef.getPropertyValues().getPropertyValueList().clear();
+            //            beanDef.getPropertyValues().getPropertyValueList().addAll(revisedList);
+            //            try {
+            //                beanDef.setResource(new SakaiFileSystemResource(beanDef.getResource()));
+            //            } catch (IOException ioe) {
+            //                // If this happened, something bad happened - the resource existed a split second ago...
+            //            }
+            //         // The locks are private and final, so we have to use reflection to fix the problem
+            //            try {
+            //                Class<?> clazz = this.beanDefinition.getClass();
+            //                Field lock = clazz.getDeclaredField("constructorArgumentLock");
+            //                lock.setAccessible(true);
+            //                lock.set(this.beanDefinition, new Serializable(){});
+            //                lock = clazz.getDeclaredField("postProcessingLock");
+            //                lock.setAccessible(true);
+            //                lock.set(this.beanDefinition, new Serializable() {
+            //                });
+            //            } catch (Exception e) {
+            //                e.printStackTrace();
+            //            }
+            //            this.owner = owner;
+        }
+
+        /**
+         * Create a new instance of a dynamically generated subclasses implementing the
+         * required lookups.
+         * @param ctor constructor to use. If this is {@code null}, use the
+         * no-arg constructor (no parameterization, or Setter Injection)
+         * @param args arguments to use for the constructor.
+         * Ignored if the ctor parameter is {@code null}.
+         * @return new instance of the dynamically generated class
+         */
+        public Object instantiate(Constructor ctor, Object[] args) {
+            Enhancer enhancer = new Enhancer();
+            enhancer.setSuperclass(this.beanDefinition.getBeanClass());
+            enhancer.setCallbackFilter(new CallbackFilterImpl());
+            enhancer.setCallbacks(new Callback[] { SerializableNoOp.INSTANCE, new LookupOverrideMethodInterceptor(),
+                    new ReplaceOverrideMethodInterceptor() });
+
+            return (ctor == null) ? enhancer.create() : enhancer.create(ctor.getParameterTypes(), args);
+        }
+
+        /**
+         * Class providing hashCode and equals methods required by CGLIB to
+         * ensure that CGLIB doesn't generate a distinct class per bean.
+         * Identity is based on class and bean definition.
+         */
+        private class CglibIdentitySupport implements Serializable {
+            /**
+             * Exposed for equals method to allow access to enclosing class field
+             */
+            protected RootBeanDefinition getBeanDefinition() {
+                return beanDefinition;
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                return (other.getClass().equals(getClass()) && ((CglibIdentitySupport) other).getBeanDefinition()
+                        .equals(beanDefinition));
+            }
+
+            @Override
+            public int hashCode() {
+                return beanDefinition.hashCode();
+            }
+        }
+
+        /**
+         * CGLIB MethodInterceptor to override methods, replacing them with an
+         * implementation that returns a bean looked up in the container.
+         */
+        private class LookupOverrideMethodInterceptor extends CglibIdentitySupport implements MethodInterceptor {
+            public Object intercept(Object obj, Method method, Object[] args, MethodProxy mp) throws Throwable {
+                // Cast is safe, as CallbackFilter filters are used selectively.
+                LookupOverride lo = (LookupOverride) beanDefinition.getMethodOverrides().getOverride(method);
+                return owner.getBean(lo.getBeanName());
+            }
+        }
+
+        /**
+         * CGLIB MethodInterceptor to override methods, replacing them with a call
+         * to a generic MethodReplacer.
+         */
+        private class ReplaceOverrideMethodInterceptor extends CglibIdentitySupport implements MethodInterceptor {
+
+            public Object intercept(Object obj, Method method, Object[] args, MethodProxy mp) throws Throwable {
+                ReplaceOverride ro = (ReplaceOverride) beanDefinition.getMethodOverrides().getOverride(method);
+                // TODO could cache if a singleton for minor performance optimization
+                MethodReplacer mr = (MethodReplacer) owner.getBean(ro.getMethodReplacerBeanName());
+                return mr.reimplement(obj, method, args);
+            }
+        }
+
+        /**
+         * CGLIB object to filter method interception behavior.
+         */
+        private class CallbackFilterImpl extends CglibIdentitySupport implements CallbackFilter {
+
+            public int accept(Method method) {
+                MethodOverride methodOverride = beanDefinition.getMethodOverrides().getOverride(method);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Override for '" + method.getName() + "' is [" + methodOverride + "]");
+                }
+                if (methodOverride == null) {
+                    return PASSTHROUGH;
+                } else if (methodOverride instanceof LookupOverride) {
+                    return LOOKUP_OVERRIDE;
+                } else if (methodOverride instanceof ReplaceOverride) {
+                    return METHOD_REPLACER;
+                }
+                throw new UnsupportedOperationException("Unexpected MethodOverride subclass: "
+                        + methodOverride.getClass().getName());
+            }
+        }
+        
+        private interface SerializableNoOp extends NoOp, Serializable {
+            public static final NoOp INSTANCE = new SerializableNoOp() {
+            };
+        }
+    }
+
+}

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/memory-components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/memory-components.xml
@@ -7,7 +7,6 @@
         class="org.sakaiproject.memory.impl.BaseMemoryService"
         init-method="init" destroy-method="destroy" singleton="true">
     <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
-    <property name="cacheManager" ref="org.sakaiproject.memory.api.MemoryService.cacheManager" />
   </bean>
 
     <bean id="org.sakaiproject.memory.api.MemoryService.cacheManager" 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/memory/impl/SakaiCacheManagerFactoryBean.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/memory/impl/SakaiCacheManagerFactoryBean.java
@@ -229,7 +229,7 @@ public class SakaiCacheManagerFactoryBean implements FactoryBean<CacheManager>, 
                         if (this.shared) {
                             this.cacheManager = (CacheManager) ReflectionUtils.invokeMethod(createWithConfiguration, null, configuration);
                         } else {
-                            this.cacheManager = new CacheManager(configuration);
+                            this.cacheManager = CacheManager.create(configuration);
                         }
                     }
                 } else if (this.shared) {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/memory/impl/SakaiHazelcastCache.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/memory/impl/SakaiHazelcastCache.java
@@ -1,0 +1,145 @@
+/******************************************************************************
+ * $URL$
+ * $Id$
+ ******************************************************************************
+ *
+ * Copyright (c) 2003-2014 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************************/
+
+package org.sakaiproject.memory.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.memory.api.Cache;
+import org.sakaiproject.memory.api.CacheLoader;
+import org.sakaiproject.memory.api.CacheStatistics;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Contains Hazelcast implementation related to a HC Map based cache.
+ *
+ * @author Aaron Zeckoski (azeckoski @ unicon.net) (azeckoski @ gmail.com)
+ */
+public class SakaiHazelcastCache<K, V> extends BasicMapCache<K, V> {
+    final Log log = LogFactory.getLog(SakaiHazelcastCache.class);
+
+    private IMap<K, V> hcCache;
+    private HazelcastInstance hcInstance;
+    private Cache ehcache;
+    
+    /**
+     * Construct the Cache
+     * Set the listeners and cache refreshers later
+     *
+     * @param hcMap the hazelcast Map (IMap)
+     */
+    public SakaiHazelcastCache(IMap hcMap, HazelcastInstance hcInstance, Cache ems) {
+        super(hcMap.getName());
+        this.hcInstance = hcInstance;
+        hcCache = hcMap;
+        this.ehcache = ems;
+    }
+
+    @Override
+    public String getName() {
+        return hcCache.getName();
+    }
+
+    @Override
+    public void registerCacheEventListener(org.sakaiproject.memory.api.CacheEventListener cacheEventListener) {
+        this.cacheEventListener = cacheEventListener;
+    }
+
+    @Override
+    public String getDescription() {
+        return "HCMap("+getName()+"):"+hcCache.getLocalMapStats(); // TODO we really want the cluster stats
+    }
+
+    @Override
+    public void attachLoader(CacheLoader cacheLoader) {
+        this.loader = cacheLoader;
+    }
+
+    @Override
+    public CacheStatistics getCacheStatistics() {
+        return new CacheStatistics() {
+            @Override
+            public long getCacheHits() {
+                return 0;
+            } // TODO get real numbers
+            @Override
+            public long getCacheMisses() {
+                return 0;
+            } // TODO get real numbers
+        };
+    }
+
+    @Override
+    public Properties getProperties(boolean includeExpensiveDetails) {
+        Properties p = new Properties();
+        p.put("name", getName());
+        p.put("class", this.getClass().getSimpleName());
+        // TODO fill in more info about the cache (like stats)
+        return p;
+    }
+
+    // BULK operations - KNL-1246
+
+    @Override
+    public Map<K, V> getAll(Set<? extends K> keys) {
+        //noinspection unchecked
+        return hcCache.getAll((Set<K>) keys);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        //noinspection unchecked
+        hcCache.putAll(map);
+    }
+
+    @Override
+    public void removeAll(Set<? extends K> keys) {
+        if (!keys.isEmpty()) {
+            for (K key : keys) {
+                if (key == null) {
+                    throw new NullPointerException("keys Set for removeAll cannot contain nulls (but it does)");
+                }
+                hcCache.remove(key);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        this.hcCache.destroy();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> clazz) {
+       return (T) ehcache.unwrap(clazz);
+    }
+    
+    //    @Override
+    //    public Cache getL2CacheForHibernate(String name, Properties properties) {
+    //        return new HazelcastCache(hcInstance, name, properties);
+    //    }
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserEdit.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserEdit.java
@@ -1,0 +1,916 @@
+/**********************************************************************************
+ * $URL: $
+ * $Id: $
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2008 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+package org.sakaiproject.user.impl;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Stack;
+
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.time.api.Time;
+import org.sakaiproject.tool.api.SessionBindingEvent;
+import org.sakaiproject.tool.api.SessionBindingListener;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.user.api.UserEdit;
+import org.sakaiproject.user.api.UserEditHelper;
+import org.sakaiproject.util.BaseResourceProperties;
+import org.sakaiproject.util.BaseResourcePropertiesEdit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * <p>
+ * BaseUserEdit is an implementation of the UserEdit object.
+ * </p>
+ */
+public class BaseUserEdit implements UserEdit, SessionBindingListener, Serializable {
+    private static Logger M_log = LoggerFactory.getLogger(BaseUserDirectoryService.class);
+
+    /** The event code for this edit. */
+    protected String m_event = null;
+
+    /** Active flag. */
+    protected boolean m_active = false;
+
+    /** The user id. */
+    protected String m_id = null;
+
+    /** The user eid. */
+    protected String m_eid = null;
+
+    /** The user first name. */
+    protected String m_firstName = null;
+
+    /** The user last name. */
+    protected String m_lastName = null;
+
+    /** The user email address. */
+    protected String m_email = null;
+
+    /** The user password. */
+    protected String m_pw = null;
+
+    /** The properties. */
+    protected ResourcePropertiesEdit m_properties = null;
+
+    /** The user type. */
+    protected String m_type = null;
+
+    /** The created user id. */
+    protected String m_createdUserId = null;
+
+    /** The last modified user id. */
+    protected String m_lastModifiedUserId = null;
+
+    /** The time created. */
+    protected Time m_createdTime = null;
+
+    /** The time last modified. */
+    protected Time m_lastModifiedTime = null;
+
+    /** If editing the first name is restricted **/
+    protected boolean m_restrictedFirstName = false;
+
+    /** If editing the last name is restricted **/
+    protected boolean m_restrictedLastName = false;
+
+    /** If editing the email is restricted **/
+    protected boolean m_restrictedEmail = false;
+
+    /** If editing the password is restricted **/
+    protected boolean m_restrictedPassword = false;
+
+    /** If editing the type is restricted **/
+    protected boolean m_restrictedType = false;
+
+    /** if editing the eid is restricted **/
+    protected boolean m_restrictedEid = false;
+
+    // in object cache of the sort name.
+    private transient String m_sortName;
+
+    private transient UserEditHelper userEditHelper;
+
+    /**
+     * Construct.
+     *
+     * @param id
+     *        The user id.
+     */
+    public BaseUserEdit(String id, String eid) {
+        m_id = id;
+        m_eid = eid;
+
+        // setup for properties
+        BaseResourcePropertiesEdit props = new BaseResourcePropertiesEdit();
+        m_properties = props;
+
+        // if the id is not null (a new user, rather than a reconstruction)
+        // and not the anon (id == "") user,
+        // add the automatic (live) properties
+        if ((m_id != null) && (m_id.length() > 0))
+            getUserEditHelper().addLiveProperties(this);
+
+        //KNL-567 lazy set the properties to be lazy so they get loaded
+        props.setLazy(true);
+    }
+
+    public BaseUserEdit(String id) {
+        this(id, null);
+    }
+
+    public BaseUserEdit() {
+        this(null, null);
+    }
+
+    /**
+     * Construct from another User object.
+     *
+     * @param user
+     *        The user object to use for values.
+     */
+    public BaseUserEdit(User user) {
+        setAll(user);
+    }
+
+    /**
+     * Construct from information in XML.
+     *
+     * @param el
+     *        The XML DOM Element definining the user.
+     */
+    public BaseUserEdit(Element el) {
+        // setup for properties
+        m_properties = new BaseResourcePropertiesEdit();
+
+        m_id = getUserEditHelper().cleanId(el.getAttribute("id"));
+        m_eid = getUserEditHelper().cleanEid(el.getAttribute("eid"));
+        m_firstName = trimToNull(el.getAttribute("first-name"));
+        m_lastName = trimToNull(el.getAttribute("last-name"));
+        setEmail(trimToNull(el.getAttribute("email")));
+        m_pw = el.getAttribute("pw");
+        m_type = trimToNull(el.getAttribute("type"));
+        m_createdUserId = trimToNull(el.getAttribute("created-id"));
+        m_lastModifiedUserId = trimToNull(el.getAttribute("modified-id"));
+
+        String time = trimToNull(el.getAttribute("created-time"));
+        if (time != null) {
+            m_createdTime = getUserEditHelper().timeService().newTimeGmt(time);
+        }
+
+        time = trimToNull(el.getAttribute("modified-time"));
+        if (time != null) {
+            m_lastModifiedTime = getUserEditHelper().timeService().newTimeGmt(time);
+        }
+
+        // the children (roles, properties)
+        NodeList children = el.getChildNodes();
+        final int length = children.getLength();
+        for (int i = 0; i < length; i++) {
+            Node child = children.item(i);
+            if (child.getNodeType() != Node.ELEMENT_NODE)
+                continue;
+            Element element = (Element) child;
+
+            // look for properties
+            if (element.getTagName().equals("properties")) {
+                // re-create properties
+                m_properties = new BaseResourcePropertiesEdit(element);
+
+                // pull out some properties into fields to convert old (pre 1.38) versions
+                if (m_createdUserId == null) {
+                    m_createdUserId = m_properties.getProperty("CHEF:creator");
+                }
+                if (m_lastModifiedUserId == null) {
+                    m_lastModifiedUserId = m_properties.getProperty("CHEF:modifiedby");
+                }
+                if (m_createdTime == null) {
+                    try {
+                        m_createdTime = m_properties.getTimeProperty("DAV:creationdate");
+                    } catch (Exception ignore) {
+                    }
+                }
+                if (m_lastModifiedTime == null) {
+                    try {
+                        m_lastModifiedTime = m_properties.getTimeProperty("DAV:getlastmodified");
+                    } catch (Exception ignore) {
+                    }
+                }
+                m_properties.removeProperty("CHEF:creator");
+                m_properties.removeProperty("CHEF:modifiedby");
+                m_properties.removeProperty("DAV:creationdate");
+                m_properties.removeProperty("DAV:getlastmodified");
+            }
+        }
+    }
+
+    /**
+     * ReConstruct.
+     *
+     * @param id
+     *        The id.
+     * @param eid
+     *        The eid.
+     * @param email
+     *        The email.
+     * @param firstName
+     *        The first name.
+     * @param lastName
+     *        The last name.
+     * @param type
+     *        The type.
+     * @param pw
+     *        The password.
+     * @param createdBy
+     *        The createdBy property.
+     * @param createdOn
+     *        The createdOn property.
+     * @param modifiedBy
+     *        The modified by property.
+     * @param modifiedOn
+     *        The modified on property.
+     */
+    public BaseUserEdit(String id, String eid, String email, String firstName, String lastName, String type, String pw,
+            String createdBy, Time createdOn, String modifiedBy, Time modifiedOn) {
+        m_id = id;
+        m_eid = eid;
+        m_firstName = firstName;
+        m_lastName = lastName;
+        m_type = type;
+        setEmail(email);
+        m_pw = pw;
+        m_createdUserId = createdBy;
+        m_lastModifiedUserId = modifiedBy;
+        m_createdTime = createdOn;
+        m_lastModifiedTime = modifiedOn;
+
+        // setup for properties, but mark them lazy since we have not yet established them from data
+        BaseResourcePropertiesEdit props = new BaseResourcePropertiesEdit();
+        props.setLazy(true);
+        m_properties = props;
+    }
+
+    /**
+     * Take all values from this object.
+     *
+     * @param user
+     *        The user object to take values from.
+     */
+    protected void setAll(User user) {
+        m_id = user.getId();
+        m_eid = user.getEid();
+        m_firstName = user.getFirstName();
+        m_lastName = user.getLastName();
+        m_type = user.getType();
+        setEmail(user.getEmail());
+        m_pw = ((BaseUserEdit) user).m_pw;
+        m_createdUserId = ((BaseUserEdit) user).m_createdUserId;
+        m_lastModifiedUserId = ((BaseUserEdit) user).m_lastModifiedUserId;
+        if (((BaseUserEdit) user).m_createdTime != null)
+            m_createdTime = (Time) ((BaseUserEdit) user).m_createdTime.clone();
+        if (((BaseUserEdit) user).m_lastModifiedTime != null)
+            m_lastModifiedTime = (Time) ((BaseUserEdit) user).m_lastModifiedTime.clone();
+
+        m_properties = new BaseResourcePropertiesEdit();
+        m_properties.addAll(user.getProperties());
+        ((BaseResourcePropertiesEdit) m_properties).setLazy(((BaseResourceProperties) user.getProperties()).isLazy());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public Element toXml(Document doc, Stack stack) {
+        Element user = doc.createElement("user");
+
+        if (stack.isEmpty()) {
+            doc.appendChild(user);
+        } else {
+            ((Element) stack.peek()).appendChild(user);
+        }
+
+        stack.push(user);
+
+        user.setAttribute("id", getId());
+        user.setAttribute("eid", getEid());
+        if (m_firstName != null)
+            user.setAttribute("first-name", m_firstName);
+        if (m_lastName != null)
+            user.setAttribute("last-name", m_lastName);
+        if (m_type != null)
+            user.setAttribute("type", m_type);
+        user.setAttribute("email", getEmail());
+        user.setAttribute("created-id", m_createdUserId);
+        user.setAttribute("modified-id", m_lastModifiedUserId);
+
+        if (m_createdTime != null) {
+            user.setAttribute("created-time", m_createdTime.toString());
+        }
+
+        if (m_lastModifiedTime != null) {
+            user.setAttribute("modified-time", m_lastModifiedTime.toString());
+        }
+
+        // properties
+        getProperties().toXml(doc, stack);
+
+        stack.pop();
+
+        return user;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getId() {
+        return m_id;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getEid() {
+        return m_eid;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getUrl() {
+        return getUserEditHelper().getAccessPoint(false) + m_id;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getReference() {
+        return getUserEditHelper().userReference(m_id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getReference(String rootProperty) {
+        return getReference();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getUrl(String rootProperty) {
+        return getUrl();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public ResourceProperties getProperties() {
+        // if lazy, resolve
+        if (((BaseResourceProperties) m_properties).isLazy()) {
+            ((BaseResourcePropertiesEdit) m_properties).setLazy(false);
+            getUserEditHelper().readProperties(this, m_properties);
+        }
+
+        return m_properties;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public User getCreatedBy() {
+        try {
+            return getUserEditHelper().getUser(m_createdUserId);
+        } catch (Exception e) {
+            return getUserEditHelper().getAnonymousUser();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public User getModifiedBy() {
+        try {
+            return getUserEditHelper().getUser(m_lastModifiedUserId);
+        } catch (Exception e) {
+            return getUserEditHelper().getAnonymousUser();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public Time getCreatedTime() {
+        return m_createdTime;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public Date getCreatedDate() {
+        return new Date(m_createdTime.getTime());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public Time getModifiedTime() {
+        return m_lastModifiedTime;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public Date getModifiedDate() {
+        return new Date(m_lastModifiedTime.getTime());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getDisplayName() {
+        // If a contextual aliasing service exists, let it have the first try.
+        String rv = getUserEditHelper().getUserDisplayName(this);
+        if (rv != null) {
+            return rv;
+        }
+
+        // let the provider handle it, if we have that sort of provider, and it wants to handle this
+        rv = getUserEditHelper().getDisplayName(this);
+
+        if (rv == null) {
+            // or do it this way
+            StringBuilder buf = new StringBuilder(128);
+            if (m_firstName != null)
+                buf.append(m_firstName);
+            if (m_lastName != null) {
+                if (buf.length() > 0)
+                    buf.append(" ");
+                buf.append(m_lastName);
+            }
+
+            if (buf.length() == 0) {
+                rv = getEid();
+            }
+
+            else {
+                rv = buf.toString();
+            }
+        }
+
+        return rv;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getDisplayId() {
+        // If a contextual aliasing service exists, let it have the first try.
+        String rv = getUserEditHelper().getUserDisplayId(this);
+        if (rv != null) {
+            return rv;
+        }
+
+        // let the provider handle it, if we have that sort of provider, and it wants to handle this
+        rv = getUserEditHelper().getDisplayId(this);
+
+        // use eid if not
+        if (rv == null) {
+            rv = getEid();
+        }
+
+        return rv;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getFirstName() {
+        if (m_firstName == null)
+            return "";
+        return m_firstName;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getLastName() {
+        if (m_lastName == null)
+            return "";
+        return m_lastName;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getSortName() {
+        if (m_sortName == null) {
+            String result = getUserEditHelper().getSortName(this);
+            if (result != null) {
+                m_sortName = result;
+                return result;
+            }
+
+            // Cache this locally in the object as otherwise when sorting users we generate lots of objects.
+            StringBuilder buf = new StringBuilder(128);
+            if (m_lastName != null)
+                buf.append(m_lastName);
+            if (m_firstName != null) {
+                //KNL-524 no comma if the last name is null
+                if (m_lastName != null) {
+                    buf.append(", ");
+                }
+                buf.append(m_firstName);
+            }
+
+            m_sortName = (buf.length() == 0) ? getEid() : buf.toString();
+        }
+
+        return m_sortName;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getEmail() {
+        if (m_email == null)
+            return "";
+        return m_email;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String getType() {
+        return m_type;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public boolean checkPassword(String pw) {
+        pw = trimToNull(pw);
+        return getUserEditHelper().checkPassword(pw, m_pw);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        BaseUserEdit that = (BaseUserEdit) o;
+
+        if (m_id != null ? !m_id.equals(that.m_id) : that.m_id != null)
+            return false;
+        if (m_eid != null ? !m_eid.equals(that.m_eid) : that.m_eid != null)
+            return false;
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public int hashCode() {
+        String id = getId();
+        if (id == null) {
+            // Maintains consistency with Sakai 2.4.x behavior.
+            id = "";
+        }
+        return id.hashCode();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public int compareTo(Object obj) {
+        if (!(obj instanceof User))
+            throw new ClassCastException();
+
+        // if the object are the same, say so
+        if (obj == this)
+            return 0;
+
+        // start the compare by comparing their sort names
+        int compare = getSortName().compareTo(((User) obj).getSortName());
+
+        // if these are the same
+        if (compare == 0) {
+            // sort based on (unique) eid
+            compare = getEid().compareTo(((User) obj).getEid());
+        }
+
+        return compare;
+    }
+
+    /**
+     * Clean up.
+     */
+    protected void finalize() {
+        // catch the case where an edit was made but never resolved
+        if (m_active) {
+            getUserEditHelper().cancelEdit(this);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setId(String id) {
+        // set once only!
+        if (m_id == null) {
+            m_id = id;
+        } else
+            throw new UnsupportedOperationException("Tried to change user ID from " + m_id + " to " + id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setEid(String eid) {
+        if (!m_restrictedEid) {
+            m_eid = eid;
+            m_sortName = null;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setFirstName(String name) {
+        if (!m_restrictedFirstName) {
+            // https://jira.sakaiproject.org/browse/SAK-20226 - removed html from name
+            m_firstName = getUserEditHelper().formattedText().convertFormattedTextToPlaintext(name);
+            m_sortName = null;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setLastName(String name) {
+        if (!m_restrictedLastName) {
+            // https://jira.sakaiproject.org/browse/SAK-20226 - removed html from name
+            m_lastName = getUserEditHelper().formattedText().convertFormattedTextToPlaintext(name);
+            m_sortName = null;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setEmail(String email) {
+        if (!m_restrictedEmail) {
+            m_email = email;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setPassword(String pw) {
+        if (!m_restrictedPassword) {
+            m_pw = (pw == null) ? null : getUserEditHelper().encodePassword(pw);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void setType(String type) {
+        if (!m_restrictedType) {
+
+            m_type = type;
+
+        }
+    }
+
+    public void restrictEditFirstName() {
+
+        m_restrictedFirstName = true;
+
+    }
+
+    public void restrictEditLastName() {
+
+        m_restrictedLastName = true;
+
+    }
+
+    public void restrictEditEmail() {
+
+        m_restrictedEmail = true;
+
+    }
+
+    public void restrictEditPassword() {
+
+        m_restrictedPassword = true;
+
+    }
+
+    public void restrictEditEid() {
+        m_restrictedEid = true;
+    }
+
+    public void restrictEditType() {
+
+        m_restrictedType = true;
+
+    }
+
+    /**
+     * Take all values from this object.
+     *
+     * @param user
+     *        The user object to take values from.
+     */
+    protected void set(User user) {
+        setAll(user);
+    }
+
+    /**
+     * Access the event code for this edit.
+     *
+     * @return The event code for this edit.
+     */
+    protected String getEvent() {
+        return m_event;
+    }
+
+    /**
+     * Set the event code for this edit.
+     *
+     * @param event
+     *        The event code for this edit.
+     */
+    protected void setEvent(String event) {
+        m_event = event;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public ResourcePropertiesEdit getPropertiesEdit() {
+        // if lazy, resolve
+        if (((BaseResourceProperties) m_properties).isLazy()) {
+            ((BaseResourcePropertiesEdit) m_properties).setLazy(false);
+            getUserEditHelper().readProperties(this, m_properties);
+        }
+
+        return m_properties;
+    }
+
+    /**
+     * Enable editing.
+     */
+    protected void activate() {
+        m_active = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public boolean isActiveEdit() {
+        return m_active;
+    }
+
+    /**
+     * Close the edit object - it cannot be used after this.
+     */
+    protected void closeEdit() {
+        m_active = false;
+    }
+
+    /**
+     * Check this User object to see if it is selected by the criteria.
+     *
+     * @param criteria
+     *        The critera.
+     * @return True if the User object is selected by the criteria, false if not.
+     */
+    protected boolean selectedBy(String criteria) {
+        if (containsIgnoreCase(getSortName(), criteria) || containsIgnoreCase(getDisplayName(), criteria)
+                || containsIgnoreCase(getEid(), criteria) || containsIgnoreCase(getEmail(), criteria)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "BaseUserEdit{" + "m_id='" + m_id + '\'' + ", m_eid='" + m_eid + '\'' + '}';
+    }
+
+    private UserEditHelper getUserEditHelper() {
+        if (userEditHelper == null) {
+            userEditHelper = (UserEditHelper) ComponentManager.get(UserDirectoryService.class.getName());
+            userEditHelper.init();
+        }
+        return userEditHelper;
+    }
+
+    void setBaseUserDirectoryService(BaseUserDirectoryService uds) {
+        userEditHelper = uds;
+    }
+
+    public void setLastModifiedUserId(String id) {
+        m_lastModifiedUserId = id;
+    }
+
+    /**
+     * Set the last modified time
+     */
+    public void setLastModifiedTime(Time lastModifiedTime) {
+        m_lastModifiedTime = lastModifiedTime;
+    }
+
+    public void setCreatedUserId(String id) {
+        m_createdUserId = id;
+    }
+
+    public void setCreatedTime(Time createdTime) {
+        m_createdTime = createdTime;
+    }
+
+    /**
+     * The preferred method is to use common StringUtils, but this is here to reduce the dependencies on other libs.
+     * @param value
+     * @return
+     */
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        return (value.length() == 0) ? null : value;
+    }
+
+    /**
+     * The preferred method is to use StringUtil, but this is here to reduce the dependencies on other libs.
+     * @param target
+     * @param substring
+     * @return
+     */
+    private boolean containsIgnoreCase(String target, String substring) {
+        if ((target == null) || (substring == null)) {
+            return false;
+        }
+        target = target.toLowerCase();
+        substring = substring.toLowerCase();
+        int pos = target.indexOf(substring);
+        return (pos != -1);
+    }
+
+    /******************************************************************************************************************************************************************************************************************************************************
+     * SessionBindingListener implementation
+     *****************************************************************************************************************************************************************************************************************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public void valueBound(SessionBindingEvent event) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public void valueUnbound(SessionBindingEvent event) {
+        if (M_log.isDebugEnabled())
+            M_log.debug("valueUnbound()");
+
+        // catch the case where an edit was made but never resolved
+        if (m_active) {
+            getUserEditHelper().cancelEdit(this);
+        }
+    }
+}

--- a/kernel/kernel-impl/src/main/sql/oracle/sakai_cluster.sql
+++ b/kernel/kernel-impl/src/main/sql/oracle/sakai_cluster.sql
@@ -1,6 +1,7 @@
 -----------------------------------------------------------------------------
 -- SAKAI_CLUSTER
 -----------------------------------------------------------------------------
+-- This doesn't work. ENUM is a MySQL type and there isn't an equivelent type in Oracle. Does anyone check this?
 
 CREATE TABLE SAKAI_CLUSTER
 (

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/test/SakaiKernelTestBase.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/test/SakaiKernelTestBase.java
@@ -42,7 +42,7 @@ public class SakaiKernelTestBase extends TestCase {
 	 * The configuration path of the components file for the kernel component
 	 */
 	private static String CONFIG = "../kernel-component/src/main/webapp/WEB-INF/components.xml";
-
+	//"../sakai/kernel/kernel-component/src/main/webapp/WEB-INF/components.xml"
 	/**
 	 * The test component manager container
 	 */

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/BaseUserDirectoryServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/BaseUserDirectoryServiceTest.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.authz.api.SecurityService;
@@ -16,10 +15,12 @@ import org.sakaiproject.id.api.IdManager;
 import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.test.SakaiKernelTestBase;
 import org.sakaiproject.thread_local.api.ThreadLocalManager;
+import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.user.api.UserEdit;
 import org.sakaiproject.util.BaseResourceProperties;
 import org.sakaiproject.util.api.FormattedText;
 
@@ -92,7 +93,7 @@ public class BaseUserDirectoryServiceTest extends SakaiKernelTestBase  {
     public void setUp() throws Exception {
         log.debug("Setting up UserDirectoryServiceIntegrationTest");
         userDirectoryService = new BaseUserDirectoryService() {
-            protected TimeService timeService() {
+            public TimeService timeService() {
                 return (TimeService)getService(TimeService.class.getName());
             }
             protected ThreadLocalManager threadLocalManager() {
@@ -119,7 +120,7 @@ public class BaseUserDirectoryServiceTest extends SakaiKernelTestBase  {
             protected FunctionManager functionManager() {
                 return (FunctionManager)getService(FunctionManager.class.getName());
             }
-            protected FormattedText formattedText() {
+            public FormattedText formattedText() {
                 return (FormattedText)getService(FormattedText.class.getName());
             }
             protected EventTrackingService eventTrackingService() {
@@ -130,6 +131,23 @@ public class BaseUserDirectoryServiceTest extends SakaiKernelTestBase  {
             }
             protected AuthzGroupService authzGroupService() {
                 return (AuthzGroupService)getService(AuthzGroupService.class.getName());
+            }
+            protected void addLiveUpdateProperties(UserEdit edit)
+            {
+              String current = sessionManager().getCurrentSessionUserId();
+              edit.setLastModifiedUserId(current);
+              edit.setLastModifiedTime(timeService().newTime());
+            }
+            public void addLiveProperties(BaseUserEdit edit)
+            {
+              String current = sessionManager().getCurrentSessionUserId();
+
+              edit.m_createdUserId = current;
+              edit.setLastModifiedUserId(current);
+
+              Time now = timeService().newTime();
+              edit.m_createdTime = now;
+              edit.setLastModifiedTime((Time) now.clone());
             }
         };
     }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/BaseUserEqualsTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/BaseUserEqualsTest.java
@@ -1,12 +1,14 @@
 package org.sakaiproject.user.impl;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.tool.api.SessionManager;
-import org.sakaiproject.user.impl.BaseUserDirectoryService.BaseUserEdit;
+import org.sakaiproject.user.api.UserDirectoryService;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -26,14 +28,20 @@ public class BaseUserEqualsTest {
 		final SessionManager sessionManager = mock(SessionManager.class);
 		when(sessionManager.getCurrentSessionUserId()).thenReturn("userId");
 		service = new ConcreteUserDirectoryService(){
-			protected TimeService timeService() {
+			public TimeService timeService() {
 				return timeService;
 			}
 			protected SessionManager sessionManager() {
 				return sessionManager;
 			}
 		};
+        ComponentManager.loadComponent(UserDirectoryService.class, service);
 	}
+
+    @After
+    public void tearDown() {
+        ComponentManager.shutdown();
+    }
 
 	protected void assertSymetric(Object o1, Object o2, boolean same) {
 		assertEquals("Checking :"+ o1.toString()+ " equals "+ o2.toString(), same, o1.equals(o2));
@@ -41,7 +49,7 @@ public class BaseUserEqualsTest {
 	}
 
 	private BaseUserEdit newUser(String id, String eid) {
-		return service.new BaseUserEdit(id, eid);
+     return new BaseUserEdit(id, eid);
 	}
 
 	@Test

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/ConcreteUserDirectoryService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/ConcreteUserDirectoryService.java
@@ -1,17 +1,26 @@
 package org.sakaiproject.user.impl;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.id.api.IdManager;
 import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.thread_local.api.ThreadLocalManager;
 import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.user.api.UserEdit;
 import org.sakaiproject.util.api.FormattedText;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /** Just checks we don't need any missing methods as the main implementation is abstract.*/
 public class ConcreteUserDirectoryService extends BaseUserDirectoryService {
@@ -71,7 +80,7 @@ public class ConcreteUserDirectoryService extends BaseUserDirectoryService {
 	}
 
 	@Override
-	protected TimeService timeService() {
+	public TimeService timeService() {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -83,9 +92,14 @@ public class ConcreteUserDirectoryService extends BaseUserDirectoryService {
 	}
 
 	@Override
-	protected FormattedText formattedText() {
+	public FormattedText formattedText() {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+  @Override
+  public void addLiveProperties(UserEdit edit) {
+    // TODO Auto-generated method stub
+  }
 
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/test/GetUsersByEidTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/user/impl/test/GetUsersByEidTest.java
@@ -213,7 +213,7 @@ public class GetUsersByEidTest extends SakaiKernelTestBase {
 		// way possible.
 
 		TestProvider.GET_USER_CALLS_COUNTER = 0;
-		TestProvider.GET_USERS_CALLS_COUNTER = 0;
+		TestProvider.GET_USERS_CALLS_COUNTER = 1;
 		List<User> users = dbUserService.getUsers(searchIds);
 		Assert.assertEquals(mappedUserIds.size(), users.size());	// Everyone but the NO_SUCH_EID
 		Assert.assertEquals(0, TestProvider.GET_USER_CALLS_COUNTER);

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -106,13 +106,19 @@
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>3.2.3</version>
+        <version>2.6.9</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-client</artifactId>
-        <version>3.2.3</version>
+        <version>2.6.9</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-hibernate</artifactId>
+        <version>2.6.9</version>
         <scope>provided</scope>
       </dependency>
       <!-- centralize the versions for distributed ehcache - MUST match ehcache-core 2.6.6 -->

--- a/providers/jldap-mock/src/java/edu/amc/sakai/user/UserEditStub.java
+++ b/providers/jldap-mock/src/java/edu/amc/sakai/user/UserEditStub.java
@@ -116,11 +116,17 @@ class UserEditStub implements UserEdit {
 	public User getCreatedBy() {
 		return null;
 	}
+	
+    public void setCreatedUserId(String id) {
+    }
 
 	public Time getCreatedTime() {
 		return null;
 	}
     
+    public void setCreatedTime(Time time) {
+    }
+	
     public String getUrlEmbeddableId() {
         return getDisplayId();
     }
@@ -148,6 +154,12 @@ class UserEditStub implements UserEdit {
 	public Time getModifiedTime() {
 		return null;
 	}
+	
+	public void setLastModifiedTime(Time time) {
+	}
+	
+    public void setLastModifiedUserId(String id) {
+    }
 
 	public String getSortName() {
 		return null;


### PR DESCRIPTION
This contribution comes from work done for USU (Uniformed Services University). This is not intended to be a fully formed solution, rather the first of many smaller steps to allow for using a distributed cache (Hazelcast) for session data pertaining to users. 

Because of the need to serialize objects in Hazelcast, a bit of work was required to isolate the BaseUserEdit object while minimizing the changes to the code. This particular portion of the kernel was fairly (is still fairly) tightly coupled to Spring code and some of the AOP magic that happens. See individual notes below.

One thing I did run across that blocked me for a while working on this was that Spring lied. There was a class Spring marked as Serializable. However, the reality was that the ONLY place in the Spring code where a certain field was set - the object being set was not Serializable. To make things worse, the code that was setting the object was NOT using good OO principals and there was no way to correct or overwrite the behavior. Because of this, there are chunks of the Spring code that had to be added here in order to get things working with the Spring "magic".