### PR TITLE
SAK-29829 - Drag&Drop notifications are not rightly cleaned up.

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -2233,6 +2233,7 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 				sendnd.notify(ne,eventTrackingService.newEvent(eventResource, ContentHostingService.REFERENCE_ROOT+item.getId(), true, notificationPriority));			
 			}
 			state.setAttribute(DRAGNDROP_FILENAME_REFERENCE_LIST, null);
+			sendnd.setFileList(null);
 		} catch (IdUnusedException e) {
 			logger.warn("Somehow we couldn't find the site.", e);
 		}


### PR DESCRIPTION
A simple patch to reset the file list after the D&D upload has finished.