### PR TITLE
SAK-29949 joinable site setting information message is using the wrong style class

### DIFF
--- a/reference/library/src/webapp/skin/tool_base.css
+++ b/reference/library/src/webapp/skin/tool_base.css
@@ -635,22 +635,23 @@ h3 .breadCrumb{
 new message types - see http://bugs.sakaiproject.org/jira/browse/SAK-14197 
 and for usage http://www.umich.edu/~gsilver/messages/
 */
-.messageError,.messageValidation,.messageConfirmation,.messageSuccess,.messageInformation,.messageInstruction,.messageProgress{/*common to all messages types*/ margin:.5em 0;padding:3px 3px 3px 2em !important;background-position:3px 3px;background-repeat:no-repeat;height:100%;overflow:hidden;clear:both}
+.messageError,.messageValidation,.messageWarning,.messageConfirmation,.messageSuccess,.messageInformation,.messageInstruction,.messageProgress{/*common to all messages types*/ margin:.5em 0;padding:3px 3px 3px 2em !important;background-position:3px 3px;background-repeat:no-repeat;height:100%;overflow:hidden;clear:both}
 .messageError{background-image:url(images/exclamation.png);background-color:#fbb;border:1px solid #c00}
 .messageValidation{background-image:url(images/error.png);background-color:#fee;border:1px solid #f55}
+.messageWarning{background-image:url(images/error.png);background-color:#FFEF01;border:1px solid #B71;}
 .messageConfirmation{background-image:url(images/asterisk_orange.png);background-color:#ffe;border:1px solid #b71}
 .messageSuccess{background-image:url(images/accept.png);background-color:#dec;border:1px solid #9c6}
 .messageInformation{background-image:url(images/bell.png);background-color:#eee;border:1px solid #ccc;color:#000}
 .messageInstruction{background-color:#fff;color:#555;padding:3px .3em 3px 0}
 .messageProgress{background-image:url(images/progress.gif);background-color:transparent;border:1px solid #9c6}
-.messageError h4,.messageValidation h4,.messageConfirmation h4,.messageSuccess h4,.messageInformation h4,.messageInstruction h4,.messageProgress h4{display:inline}
+.messageError h4,.messageValidation h4,.messageWarning h4,.messageConfirmation h4,.messageSuccess h4,.messageInformation h4,.messageInstruction h4,.messageProgress h4{display:inline}
 h4.message,h5.message,h6.message,p.message{font-size:1em;float:left;width:90%;padding:0 .2em;margin:0}
 ul.message{list-style:none;width:90%;margin:0;padding:0;float:left;background-position:3px 3px !important;background-repeat:no-repeat}
 ul.message li{list-style:none;margin:0;padding:0 0 5px 0}
 p.closeMe{float:right;width:2em;cursor:pointer;text-align:right;margin:0;padding:0;clear:right}
 em.closeMe{font-style:normal;cursor:pointer;padding-left:1em}
 .messageContent{clear:both;margin-top:2em}
-.messageError .messageError,.messageValidation .messageValidation,.messageInformation .messageInformation,.messageConfirmation .messageConfirmation,.messageSuccess .messageSuccess,.messageInstruction .messageInstruction,.messageProgress .messageProgress{background-image:none;border:none;padding-left:0}
+.messageError .messageError,.messageValidation .messageValidation,.messageWarning .messageWarning,.messageInformation .messageInformation,.messageConfirmation .messageConfirmation,.messageSuccess .messageSuccess,.messageInstruction .messageInstruction,.messageProgress .messageProgress{background-image:none;border:none;padding-left:0}
 /*SECTION 7 DATA PANELS*/
 /*panels of normal text can have a header (ie - title) and a footer element (ie - metadata such as author, date, etc)*/
 /*see synoptic view of announcements*/

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -316,7 +316,7 @@
 				</label>
 			</p>
 			<div id="joinerrole" #if ($joinable) style="display: block;" #else  style="display: none;" #end>
-				<div class="messageValidation indnt3" style="width:60%">$tlang.getString("ediacc.yousitcan.warn")</div>
+				<div class="messageWarning indnt3" style="width:60%">$tlang.getString("ediacc.yousitcan.warn")</div>
 				<p class="checkbox indnt3">
 					<label for="joinerRole">
 							<span class="reqStar" id="joinreqStar">*</span>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29949

The message you receive when making a site joinable:

"Important: People who join your site can access the materials on your site. Sites with sensitive materials should not be made joinable."

This message is using the "messageValidation" class, which now makes it look like an error. In our institution's flavour of Sakai, we changed this to the "messageWarning" class, but this class was removed from reference's tool_base.css for whatever reason.

The linked PR reintroduces this class to tool_base.css, and changes the class on the element in chef_site-siteInfo-editAccess.vm.
