### PR TITLE
SAK-29950 Internal Server Error when click over All site files

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -3136,7 +3136,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		}
 		
 		// id may be in format of /group/<site_id>, which leads to null value for the reference context field
-		if (siteId == null)
+		if (siteId == null && ToolManager.getCurrentPlacement() != null)
 		{
 			siteId = ToolManager.getCurrentPlacement().getContext();
 		}


### PR DESCRIPTION
The problem is caused when ToolManager.getCurrentPlacement() is null.