### PR TITLE
SAM-2634 release to groups messaging issues in Samigo

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -1018,17 +1018,24 @@ label.inactive
     padding: 0;
 }
 
-div.expand, div.collapse {
+div.expanded, div.collapsed {
     cursor: pointer !important;
     padding-left: 1em !important;
 }
 
-div.expand {
+div.expanded {
     background: url('/library/image/sakai/collapse.gif') no-repeat left !important;
 }
 
-div.collapse {
+div.collapsed {
     background: url('/library/image/sakai/expand.gif') no-repeat left !important;
+}
+
+ul.groupList {
+    display: block;
+    list-style-type: disc;
+    margin: 1em 0 1em 0;
+    padding-left: 40px;
 }
 
 div.multiple_editor {

--- a/samigo/samigo-app/src/webapp/js/info.js
+++ b/samigo/samigo-app/src/webapp/js/info.js
@@ -17,10 +17,10 @@ function toggleGroups(clickedElement) {
             }
             
             // Change the triangle disclosure icon as appropriate
-            if (clickedElement.className === "collapse") {
-                clickedElement.className = "expand";
+            if (clickedElement.className === "collapsed") {
+                clickedElement.className = "expanded";
             } else {
-                clickedElement.className = "collapse";
+                clickedElement.className = "collapsed";
             }
         }
     }

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex.jsp
@@ -409,14 +409,14 @@ $(document).ready(function() {
       <h:outputText value="#{authorFrontDoorMessages.entire_site}" rendered="#{publishedAssessment.releaseTo ne 'Anonymous Users' && publishedAssessment.releaseTo ne 'Selected Groups'}" />
       
         <t:div rendered="#{publishedAssessment.releaseTo eq 'Selected Groups'}">
-            <t:div id="groupsHeader" onclick="#{publishedAssessment.groupCount gt 0 ? 'toggleGroups( this );' : ''}" styleClass="#{publishedAssessment.groupCount ge 1 ? 'collapse' : 'alertMessage'}">
+            <t:div id="groupsHeader" onclick="#{publishedAssessment.groupCount gt 0 ? 'toggleGroups( this );' : ''}" styleClass="#{publishedAssessment.groupCount ge 1 ? 'collapsed' : 'messageError'}">
                 <h:outputText value="#{publishedAssessment.groupCount} " rendered ="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount gt 0}" />
                 <h:outputText value="#{authorFrontDoorMessages.selected_groups} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount gt 1}"/>
                 <h:outputText value="#{authorFrontDoorMessages.selected_group} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount eq 1}"/>
                 <h:outputText value="#{authorFrontDoorMessages.no_selected_groups_error}" rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount eq 0}"/>
             </t:div>
             <t:div id="groupsPanel" style="display: none;">
-                <t:dataList layout="unorderedList" value="#{publishedAssessment.releaseToGroupsList}" var="group">
+                <t:dataList layout="unorderedList" value="#{publishedAssessment.releaseToGroupsList}" var="group" styleClass="groupList">
                     <h:outputText value="#{group}" />
                 </t:dataList>
             </t:div>

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex_noHeader.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex_noHeader.jsp
@@ -401,14 +401,14 @@ $(document).ready(function() {
       <h:outputText value="#{authorFrontDoorMessages.entire_site}" rendered="#{publishedAssessment.releaseTo ne 'Anonymous Users' && publishedAssessment.releaseTo ne 'Selected Groups'}" />
       
         <t:div rendered="#{publishedAssessment.releaseTo eq 'Selected Groups'}">
-            <t:div id="groupsHeader" onclick="#{publishedAssessment.groupCount gt 0 ? 'toggleGroups( this );' : ''}" styleClass="#{publishedAssessment.groupCount ge 1 ? 'collapse' : 'alertMessage'}">
+            <t:div id="groupsHeader" onclick="#{publishedAssessment.groupCount gt 0 ? 'toggleGroups( this );' : ''}" styleClass="#{publishedAssessment.groupCount ge 1 ? 'collapsed' : 'messageError'}">
                 <h:outputText value="#{publishedAssessment.groupCount} " rendered ="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount gt 0}" />
                 <h:outputText value="#{authorFrontDoorMessages.selected_groups} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount gt 1}"/>
                 <h:outputText value="#{authorFrontDoorMessages.selected_group} " rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount eq 1}"/>
                 <h:outputText value="#{authorFrontDoorMessages.no_selected_groups_error}" rendered="#{publishedAssessment.releaseTo eq 'Selected Groups' and publishedAssessment.groupCount eq 0}"/>
             </t:div>
             <t:div id="groupsPanel" style="display: none;">
-                <t:dataList layout="unorderedList" value="#{publishedAssessment.releaseToGroupsList}" var="group">
+                <t:dataList layout="unorderedList" value="#{publishedAssessment.releaseToGroupsList}" var="group" styleClass="groupList">
                     <h:outputText value="#{group}" />
                 </t:dataList>
             </t:div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2634

Currently in trunk, if you release a test/quiz to any number of groups, the 'Release To' column appears blank. The markup to show/hide the groups the quiz is released to is there, but because of the introduction of the '.collapse' class in morpheus-default/tool.css, it is hidden (display=none). Changing class names in sam_tool.css will rectify this regression.

Another regression introduced by morpheus is setting the default list style for ol's and ul's to none:

ol, ul {list-style: outside none none;}

We have to override this in sam_tool.css so that we can have bullet-ed lists again.

The second issue is the style class being used when the group(s) have been deleted, to inform the maintainer that the quiz is effectively useless. Currently it uses the 'alertMessage' class, which is not as strongly styled for an error as the 'messageError' class.