### PR TITLE
KNL-1384; fix clickjack protection for separate content domain

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
@@ -1300,7 +1300,7 @@ public class RequestFilter implements Filter
 			res.setHeader("X-UA-Compatible",m_UACompatible);
 		}
 
-		if (!isLTIProviderAllowed) {
+		if (!isLTIProviderAllowed && (!useContentHostingDomain || !req.getServerName().equals(chsDomain))) {
 			res.setHeader("X-Frame-Options", "SAMEORIGIN");
 		}
 


### PR DESCRIPTION
Note that the issue has been shown and the patch tested in Sakai 10, as we don' have a sakai 11 system with separate content hosting domain.