### PR TITLE
SAK-29958 'About Sakai' help page uses question mark icon in a confusing manner; other styling issues

### DIFF
--- a/help/help-tool/src/webapp/css/help.css
+++ b/help/help-tool/src/webapp/css/help.css
@@ -1,0 +1,414 @@
+/* BEGIN CSS Reset */
+
+body {
+  line-height: 1.5;
+  color: #333333;
+  font-size: 87.5%; }
+
+body h1 {
+  font-weight: normal;
+  color: #222222;
+  font-size: 2.5em;
+  line-height: 1;
+  margin-bottom: 0.5em; }
+  body h1 body h1 img {
+    margin: 0; }
+
+body h2 {
+  font-weight: normal;
+  color: #222222;
+  font-size: 1.5em;
+  margin-bottom: 0.75em; }
+
+body h3 {
+  font-weight: normal;
+  color: #222222;
+  font-size: 1.3em;
+  line-height: 1;
+  margin-bottom: 1em; }
+
+body p {
+  margin: 0 0 1.5em; }
+  body p body p img.left {
+    display: inline;
+    float: left;
+    margin: 1.5em 1.5em 1.5em 0;
+    padding: 0; }
+  body p body p img.right {
+    display: inline;
+    float: right;
+    margin: 1.5em 0 1.5em 1.5em;
+    padding: 0; }
+
+body a {
+  text-decoration: underline;
+  color: #000099; }
+  body a body a:visited {
+    color: #000066; }
+  body a body a:focus {
+    color: black; }
+  body a body a:hover {
+    color: black; }
+  body a body a:active {
+    color: #cc0099; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-family: inherit;
+  vertical-align: baseline; }
+
+div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
+a, abbr, acronym, address, del, dfn, em, img,
+dl, dt, dd, ol, ul, li, fieldset, form, label, legend, caption, tbody, tfoot, thead, tr {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline; }
+
+blockquote, q {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  quotes: "" ""; }
+  blockquote blockquote:before, blockquote q:before, q blockquote:before, q q:before,
+  blockquote blockquote:after, blockquote q:after, q blockquote:after, q q:after {
+    content: ""; }
+
+th, td, caption {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  text-align: left;
+  font-weight: normal;
+  vertical-align: middle; }
+
+table {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border-collapse: separate;
+  border-spacing: 0;
+  vertical-align: middle; }
+
+a img {
+  border: none; }
+
+p {
+  margin: 0 0 1.5em; }
+
+a {
+  text-decoration: underline;
+  color: #000099; }
+  a a:visited {
+    color: #000066; }
+  a a:focus {
+    color: black; }
+  a a:hover {
+    color: black; }
+  a a:active {
+    color: #cc0099; }
+
+blockquote {
+  margin: 1.5em;
+  color: #666;
+  font-style: italic; }
+
+strong {
+  font-weight: bold; }
+
+em {
+  font-style: italic; }
+
+tt {
+  font: 1em 'andale mono', 'lucida console', monospace;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: pre-wrap;
+  background-color: whiteSmoke;
+  padding: 8.5px;
+  margin: 0 0 18px;
+  border: 1px solid #CCC;
+  border-radius: 3px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  word-wrap: break-word;
+}
+
+code {
+  padding: 2px 4px;
+  color: #d14;
+  white-space: nowrap;
+  background-color: #f7f7f9;
+  border: 1px solid #e1e1e8;
+}
+pre {
+  background-color: #f5f5f5;
+  display: block;
+  padding: 9.5px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 20px;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre;
+  white-space: pre-wrap;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+}
+pre.prettyprint {
+  margin-bottom: 20px;
+}
+pre code {
+  padding: 0;
+  color: inherit;
+  white-space: pre;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border: 0;
+}
+.pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll;
+}
+
+li ul, li ol {
+  margin: 0 1.5em; }
+
+ul {
+  margin: 0 1.5em 1.5em 1.5em;
+  list-style-type: disc; }
+
+ol {
+  margin: 0 1.5em 1.5em 1.5em;
+  list-style-type: decimal; }
+
+table {
+  margin-bottom: 1.4em;
+  width: 100%; }
+
+th {
+  font-weight: bold; }
+
+thead th {
+  background: #c3d9ff; }
+
+th, td, caption {
+  padding: 4px 10px 4px 5px; }
+
+tr.even td {
+  background: #e5ecf9; }
+
+.clearfix {
+  overflow: hidden;
+  display: inline-block; }
+  .clearfix .clearfix {
+    display: block; }
+.clear {
+    clear: both; }
+   
+p.indent1 { text-indent: 2em; }
+p.indent2 { text-indent: 4em; }
+p.indent3 { text-indent: 6em; }
+p.indent4 { text-indent: 8em; }
+p.indent5 { text-indent: 10em; }
+p.indent6 { text-indent: 12em; }
+p.indent7 { text-indent: 14em; }
+p.indent8 { text-indent: 16em; }
+p.indent9 { text-indent: 18em; }
+p.indent10 { text-indent: 20em; }
+
+/* END CSS Reset */
+
+/* BEGIN ScreenSteps Template Default */
+body div#wrapper {
+  margin-top: 2em; }
+body div#article-content {
+  padding-bottom: 1em; }
+  body div#article-content div.step-container {
+    clear: left;
+  }
+  body div#article-content div.step-instructions {
+    text-align: left; }
+  body div#article-content div.step-container div.step-instructions {
+    clear: left; }
+  body div#article-content div.step-container div.step-image-container {
+    margin-bottom: 1em;
+    float: left;
+    position: relative;
+    border: 1px solid #ccc;
+    padding: 5px; }
+    body div#article-content div.step-container div.step-image-container div.step-image-caption { padding: 5px; }
+      body div#article-content div.step-container div.step-image-fullsize { padding-bottom: 25px;}
+      body div#article-content div.step-container div.step-image-container div.step-image-caption {
+        text-align: right;
+        font-size: 0.75em;
+        padding: 0;
+        position: absolute;
+        bottom: 5px;
+        right: 10px;}
+      body div#article-content div.step-container div.step-image-container div.step-image-caption a {
+        text-decoration: none;
+        color: #777;
+        background: url("../images/icon-zoom.png") no-repeat;
+        padding-left: 19px;
+        line-height: 16px !important;
+        display: block;
+        float: right;}
+        div#article-content div.step-container div.step-image-container:after {
+          content: ".";
+          display: block;
+          height: 0;
+          clear: both;
+          visibility: hidden;}
+        html>body div#article-content div.step-container div.step-image-container div.step-image-caption a {
+          background: url("../images/icon-zoom.png") no-repeat;
+          padding-left: 19px; }
+  body div#article-content div.right {
+    overflow: hidden;
+    display: inline-block; }
+    body div#article-content div.right {
+      display: block; }
+    body div#article-content div.right div.step-image-container {
+      float: right;
+      margin-left: 1em; }
+      body div#article-content div.right div.step-image-container div.step-image-caption a {
+        display: block;
+        text-align: right; }
+div#article-navigation {
+  border-top: 1px solid #cfcfcf;
+  padding: 1em 0 1.25em 0;
+  margin-top: 2.5em;
+  font-family: Georgia, serif;
+  font-size: 1.1em;
+  color: #222;}
+div#article-navigation ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;}
+div#article-navigation a {
+  color: #222;
+  text-decoration: none;
+  display: block; }
+div#article-navigation a:hover {text-decoration: underline;}
+div#article-navigation li#article-page-count {
+  float: left;
+  width: 135px;
+  text-align: center; }
+div#article-navigation li#next-article {
+  margin: 0;
+  padding: 0;
+  float: right;
+  width: 320px;
+  text-align: right; }
+div#article-navigation li#next-article a {
+  padding: 0 29px 0 0;
+  background: url("../images/ui/icon-next.png") no-repeat top right;
+  line-height: 21px;
+  display: block; }
+div#article-navigation li#previous-article {
+  margin: 0;
+  line-height: 21px;
+  float: left;
+  width: 320px;
+  text-align: left; }
+div#article-navigation li#previous-article a {
+  padding: 0 0 0 29px;
+  background: url("../images/ui/icon-previous.png") no-repeat top left;
+  line-height: 21px;
+  display: block; }
+ 
+body div#TOC {
+  padding: 1em 2em; }
+  body div#TOC div.section h2 {
+    font-size: 1.4em;
+    margin-bottom: 0.5em; }
+  body div#TOC div.section div.description {
+    font-size: 85%; }
+body div#lessonNavigation {
+  border-top: 1px solid #ccc;
+  padding-top: 1em;
+  padding-bottom: 1px;}
+  body div#lessonNavigation table td {
+    width: 33%;
+    padding: 0 2em; }
+    body div#lessonNavigation table td.TOC {
+      text-align: center;
+      padding: 0; }
+body.lucida {
+  font-family: "Lucida Grande", Lucida, Verdana, sans-serif; }
+
+body.helvetica {
+  font-family: "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif; }
+
+body.courier {
+  font-family: "Courier New", Courier, mono; }
+
+body.georgia {
+  font-family: Georgia, "Times New Roman", Times, serif; }
+
+body.trebuchet {
+  font-family: "Trebuchet MS","Helvetica Neue", Arial, Helvetica, Geneva, sans-serif; }
+ 
+body.lucida h2, body.helvetica h2, body.trebuchet h2 {
+  font-family: Georgia, "Times New Roman", Times, serif; }
+
+body.georgia h2 {
+  font-family: "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif; }
+
+/* END ScreenSteps Template Default */
+
+/* BEGIN ScreenSteps Template Custom */
+body div#wrapper {
+  width: 640px;
+  margin: 2em auto; }
+body div.step-container .step-title {
+  border-bottom: 3px solid #ccc; }
+
+/* END ScreenSteps Template Custom */
+
+body div#wrapper img {
+  width: auto;
+  height: auto;
+  max-width: 640px;
+}
+div#article-navigation li#previous-article,
+div#article-navigation li#next-article
+{
+  width: 240px;
+}
+
+span.helpIcon {
+    background-image: url("/library/image/help/en/About-Sakai-Help/Tool-Help.png");
+    background-repeat: no-repeat;
+    background-position: center;
+    display: inline-block;
+    height: 16px;
+    width: 16px;
+    vertical-align: text-top;
+}

--- a/help/help-tool/src/webapp/html/help.html
+++ b/help/help-tool/src/webapp/html/help.html
@@ -6,8 +6,8 @@
 <meta content="sakai.help" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="../css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){
@@ -32,10 +32,8 @@
 <p>Also note that while all users have the ability to search and view all available help, your user account must have the necessary permissions in order to perform administrative or site management tasks. Help articles may describe features or settings that are not available to you, depending on your role within a site. See What are permissions and roles? for more information.</p>
       </div>      <div id="steps-container">          <div id="step-2393" class="step-container">            <h2 class="step-title">Navigating Help</h2>            <div class="step-instructions"><p>You can navigate to any Help article by clicking on the title of a collection name in the contents pane on the left to expand the collection, and then clicking on the article title.</p></div>          </div>
           <div class="clear"></div>          <div id="step-2394" class="step-container">            <h2 class="step-title">Searching Help</h2>            <div class="step-instructions"><p>You can search Help content by entering a search term or phrase in the search pane on the left, and clicking on the Search button. Search results are ranked by relevance.</p></div>          </div>
-          <div class="clear"></div>          <div id="step-2395" class="step-container">            <h2 class="step-title">Tool Help</h2>                      <div class="step-image-container">
-            <img src="/library/image/help/en/About-Sakai-Help/Tool-Help.png" width="20" height="24" class="step-image" alt="Tool Help">
-</div>
-            <div class="step-instructions"><p>While using a tool, you can go directly to the Help for that tool by clicking on the Help icon in the tool title bar.</p></div>          </div>
+          <div class="clear"></div>          <div id="step-2395" class="step-container">            <h2 class="step-title">Tool Help</h2>
+          <div class="step-instructions"><p>While using a tool, you can go directly to the Help for that tool by clicking on the Help icon (<span class="helpIcon"></span>) in the tool title bar.</p></div>          </div>
           <div class="clear"></div>          <div id="step-2396" class="step-container">            <h2 class="step-title">Additional Help Resources</h2>            <div class="step-instructions"><p>If the information you're looking for is not available here, try looking in the online <a href="https://confluence.sakaiproject.org" target="_blank">Sakai Community Wiki</a>.</p></div>          </div>
           <div class="clear"></div>      </div>      
     </div>

--- a/help/help/src/sakai_screensteps_aboutHelpInstructorGuide/About-Sakai-Help.html
+++ b/help/help/src/sakai_screensteps_aboutHelpInstructorGuide/About-Sakai-Help.html
@@ -6,8 +6,8 @@
 <meta content="sakai.help" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){
@@ -32,10 +32,8 @@
 <p>Also note that while all users have the ability to search and view all available help, your user account must have the necessary permissions in order to perform administrative or site management tasks. Help articles may describe features or settings that are not available to you, depending on your role within a site. See <a href="content.hlp?docId=whatarePermissionsandRoles">What are permissions and roles?</a> for more information.</p>
       </div>      <div id="steps-container">          <div id="step-6109" class="step-container">            <h2 class="step-title">Navigating Help</h2>            <div class="step-instructions"><p>You can navigate to any Help article by clicking on the title of a collection name in the contents pane on the left to expand the collection, and then clicking on the article title.</p></div>          </div>
           <div class="clear"></div>          <div id="step-6110" class="step-container">            <h2 class="step-title">Searching Help</h2>            <div class="step-instructions"><p>You can search Help content by entering a search term or phrase in the search pane on the left, and clicking on the Search button. Search results are ranked by relevance.</p></div>          </div>
-          <div class="clear"></div>          <div id="step-6111" class="step-container">            <h2 class="step-title">Tool Help</h2>                      <div class="step-image-container">
-            <img src="/library/image/help/en/About-Sakai-Help/Tool-Help.png" width="20" height="24" class="step-image" alt="Tool Help">
-</div>
-            <div class="step-instructions"><p>While using a tool, you can go directly to the Help for that tool by clicking on the Help icon in the tool title bar.</p></div>          </div>
+          <div class="clear"></div>          <div id="step-2395" class="step-container">            <h2 class="step-title">Tool Help</h2>
+          <div class="step-instructions"><p>While using a tool, you can go directly to the Help for that tool by clicking on the Help icon (<span class="helpIcon"></span>) in the tool title bar.</p></div>          </div>
           <div class="clear"></div>          <div id="step-6112" class="step-container">            <h2 class="step-title">Additional Help Resources</h2>            <div class="step-instructions"><p>If the information you're looking for is not available here, try looking in the online <a href="https://confluence.sakaiproject.org" target="_blank">Sakai Community Wiki</a>.</p></div>          </div>
           <div class="clear"></div>      </div>      
     </div>

--- a/help/help/src/sakai_screensteps_accessibilityInstructorGuide/Accessibility-Information.html
+++ b/help/help/src/sakai_screensteps_accessibilityInstructorGuide/Accessibility-Information.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="ADA, 508, accessibility compliance, screen readers, JAWS" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_accessibilityInstructorGuide/Rich-Text-Editor-Accessibility-Guidelines.html
+++ b/help/help/src/sakai_screensteps_accessibilityInstructorGuide/Rich-Text-Editor-Accessibility-Guidelines.html
@@ -6,8 +6,8 @@
 <meta content="accessibility" name="description">
 <meta content="accessibility, CKeditor, rich text editor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_aliasesAdministratorGuide/How-do-I-add-an-alias-.html
+++ b/help/help/src/sakai_screensteps_aliasesAdministratorGuide/How-do-I-add-an-alias-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.aliases" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_aliasesAdministratorGuide/How-do-I-delete-an-alias-.html
+++ b/help/help/src/sakai_screensteps_aliasesAdministratorGuide/How-do-I-delete-an-alias-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.aliases" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_aliasesAdministratorGuide/What-are-Aliases-.html
+++ b/help/help/src/sakai_screensteps_aliasesAdministratorGuide/What-are-Aliases-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.aliases, main" name="description">
 <meta content="site id, email archive address" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-add-an-announcement-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-add-an-announcement-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="announcement, reminder, notify participants, event reminder" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-change-Announcements-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-change-Announcements-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="roles, permissions, modify permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-delete-an-announcement-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-delete-an-announcement-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="sakai.announcements, remove announcement" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-edit-an-announcement-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-edit-an-announcement-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="sakai.announcements" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-merge-announcements-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-merge-announcements-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-reorder-announcements-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/How-do-I-reorder-announcements-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="reorder, sort" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsInstructorGuide/What-is-the-Announcements-tool-.html
+++ b/help/help/src/sakai_screensteps_announcementsInstructorGuide/What-is-the-Announcements-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_announcementsStudentGuide/How-do-I-view-announcements-.html
+++ b/help/help/src/sakai_screensteps_announcementsStudentGuide/How-do-I-view-announcements-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-add-an-assignment-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-add-an-assignment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="peer review, release assignment, honor pledge, peer assessment, release grade, assignment availablity, group access, model answer, submission format, submission notification, group submission, group assignment, peer evaluation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-change-the-Assignments-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-change-the-Assignments-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="permissions, roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-delete-an-assignment-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-delete-an-assignment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="delete assignment, remove assignment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-download-assignments-for-grading-offline-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-download-assignments-for-grading-offline-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="offline grading, download submissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-edit-an-existing-assignment-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-edit-an-existing-assignment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="modify assignment, change assignment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-grade-an-assignment-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-grade-an-assignment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="grading, resubmissions, return grades" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-release-assignment-grades-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-release-assignment-grades-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="view grades, view feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-submit-an-assignment-for-a-student-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-submit-an-assignment-for-a-student-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-upload-graded-assignment-submissions-and-feedback-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/How-do-I-upload-graded-assignment-submissions-and-feedback-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="upload grades, bulk upload, upload assignments" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsInstructorGuide/What-is-the-Assignments-tool-.html
+++ b/help/help/src/sakai_screensteps_assignmentsInstructorGuide/What-is-the-Assignments-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsStudentGuide/How-do-I-complete-a-peer-assessment-assignment-.html
+++ b/help/help/src/sakai_screensteps_assignmentsStudentGuide/How-do-I-complete-a-peer-assessment-assignment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="peer review, reviewer, peer evaluation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsStudentGuide/How-do-I-submit-an-assignment-.html
+++ b/help/help/src/sakai_screensteps_assignmentsStudentGuide/How-do-I-submit-an-assignment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="turn in assignment, hand in assignment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_assignmentsStudentGuide/How-do-I-view-my-assignment-feedback-.html
+++ b/help/help/src/sakai_screensteps_assignmentsStudentGuide/How-do-I-view-my-assignment-feedback-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.assignment" name="description">
 <meta content="instructor comments, instructor feedback, assignment grades, peer review comments" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_becomeUserAdministratorGuide/How-do-I-log-in-as-another-user-.html
+++ b/help/help/src/sakai_screensteps_becomeUserAdministratorGuide/How-do-I-log-in-as-another-user-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.su" name="description">
 <meta content="impoersonate user, login as user" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_becomeUserAdministratorGuide/How-do-I-view-user-info-.html
+++ b/help/help/src/sakai_screensteps_becomeUserAdministratorGuide/How-do-I-view-user-info-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.su" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_becomeUserAdministratorGuide/What-is-Become-User-.html
+++ b/help/help/src/sakai_screensteps_becomeUserAdministratorGuide/What-is-Become-User-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.su, main" name="description">
 <meta content="impersonate user, login as user" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-add-a-chat-room-.html
+++ b/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-add-a-chat-room-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.chat" name="description">
 <meta content="new room, group chat" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-change-the-Chat-Room-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-change-the-Chat-Room-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.chat" name="description">
 <meta content="permissions, roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-clear-the-chat-history-.html
+++ b/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-clear-the-chat-history-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.chat" name="description">
 <meta content="remove history, clear chat messages" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-delete-a-chat-room-.html
+++ b/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-delete-a-chat-room-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.chat" name="description">
 <meta content="remove room" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-read--post--or-delete-Chat-Room-messages-.html
+++ b/help/help/src/sakai_screensteps_chatInstructorGuide/How-do-I-read--post--or-delete-Chat-Room-messages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.chat" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_chatInstructorGuide/What-is-the-Chat-Room-tool-.html
+++ b/help/help/src/sakai_screensteps_chatInstructorGuide/What-is-the-Chat-Room-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.chat, main" name="description">
 <meta content="text chat, synchronous" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/How-do-I-create-a-new-course-or-project-site-.html
+++ b/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/How-do-I-create-a-new-course-or-project-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitesetup" name="description">
 <meta content="add course, add project" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/How-do-I-navigate-in-a-site-.html
+++ b/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/How-do-I-navigate-in-a-site-.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="navigation, tool menu, help, reset" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-are-course-sites-.html
+++ b/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-are-course-sites-.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="course, role, site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-are-project-sites-.html
+++ b/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-are-project-sites-.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="roles, non-credit sites" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-does-Unpublished-Site-mean-.html
+++ b/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-does-Unpublished-Site-mean-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="publish course, unpublish, unavailable, manage access" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-is-the-Reset-button-.html
+++ b/help/help/src/sakai_screensteps_courseandProjectSitesInstructorGuide/What-is-the-Reset-button-.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="refresh" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-access-a-site-via-delegated-access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-access-a-site-via-delegated-access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-delegate-site-access-to-a-user-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-delegate-site-access-to-a-user-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-edit-user-permissions-in-Delegated-Access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-edit-user-permissions-in-Delegated-Access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-let-a-non-admin-manage-delegated-access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-let-a-non-admin-manage-delegated-access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-let-a-non-admin-manage-shopping-period-access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-let-a-non-admin-manage-shopping-period-access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-remove-user-permissions-in-Delegated-Access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-remove-user-permissions-in-Delegated-Access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-search-users-in-Delegated-Access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-search-users-in-Delegated-Access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-set-a-shopping-period-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/How-do-I-set-a-shopping-period-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/What-is-Delegated-Access-.html
+++ b/help/help/src/sakai_screensteps_delegatedAccessAdministratorGuide/What-is-Delegated-Access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.delegatedaccess, main" name="description">
 <meta content="junior admin, jr admin, role swap" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_dropBoxInstructorGuide/How-do-I-upload-files-to-multiple-dropbox-folders-.html
+++ b/help/help/src/sakai_screensteps_dropBoxInstructorGuide/How-do-I-upload-files-to-multiple-dropbox-folders-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.dropbox" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_dropBoxInstructorGuide/What-is-the-Drop-Box-tool-.html
+++ b/help/help/src/sakai_screensteps_dropBoxInstructorGuide/What-is-the-Drop-Box-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.dropbox, main" name="description">
 <meta content="student folders" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_dropBoxStudentGuide/How-do-I-add-items-to-the-Drop-Box-.html
+++ b/help/help/src/sakai_screensteps_dropBoxStudentGuide/How-do-I-add-items-to-the-Drop-Box-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.dropbox" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-change-the-Email-Archive-permissions-.html
+++ b/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-change-the-Email-Archive-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailbox" name="description">
 <meta content="permissions, roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-modify-the-Email-Archive-options-.html
+++ b/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-modify-the-Email-Archive-options-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailbox" name="description">
 <meta content="course listserv, change email address, site email address, listerv" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-send-messages-to-the-Email-Archive-.html
+++ b/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-send-messages-to-the-Email-Archive-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailbox" name="description">
 <meta content="listserv, site listserv" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-view-Email-Archive-messages-.html
+++ b/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/How-do-I-view-Email-Archive-messages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailbox" name="description">
 <meta content="listserv, site listserv" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/What-is-the-Email-Archive-tool-.html
+++ b/help/help/src/sakai_screensteps_emailArchiveInstructorGuide/What-is-the-Email-Archive-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailbox, main" name="description">
 <meta content="listserv, site listserv" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailArchiveStudentGuide/How-do-I-view-archived-messages-.html
+++ b/help/help/src/sakai_screensteps_emailArchiveStudentGuide/How-do-I-view-archived-messages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailbox" name="description">
 <meta content="email archive, course listserv, class listserv" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailInstructorGuide/How-do-I-change-the-Email-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_emailInstructorGuide/How-do-I-change-the-Email-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailsender" name="description">
 <meta content="permissions, roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailInstructorGuide/How-do-I-send-an-Email-message-.html
+++ b/help/help/src/sakai_screensteps_emailInstructorGuide/How-do-I-send-an-Email-message-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailsender" name="description">
 <meta content="external email, external recipients" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailInstructorGuide/How-to-I-set-the-Email-tool-options-for-my-site-.html
+++ b/help/help/src/sakai_screensteps_emailInstructorGuide/How-to-I-set-the-Email-tool-options-for-my-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailsender" name="description">
 <meta content="default email settings" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailInstructorGuide/What-is-the-Email-tool-.html
+++ b/help/help/src/sakai_screensteps_emailInstructorGuide/What-is-the-Email-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.mailsender, main" name="description">
 <meta content="external email, email archive" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailTemplatesAdministratorGuide/How-do-I-add-a-new-email-template-.html
+++ b/help/help/src/sakai_screensteps_emailTemplatesAdministratorGuide/How-do-I-add-a-new-email-template-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.emailtemplateservice" name="description">
 <meta content="language, internationalization, custom template" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailTemplatesAdministratorGuide/How-do-I-edit-an-email-template-.html
+++ b/help/help/src/sakai_screensteps_emailTemplatesAdministratorGuide/How-do-I-edit-an-email-template-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.emailtemplateservice" name="description">
 <meta content="custom email template" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_emailTemplatesAdministratorGuide/What-is-the-Email-Templates-tool-.html
+++ b/help/help/src/sakai_screensteps_emailTemplatesAdministratorGuide/What-is-the-Email-Templates-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.emailtemplateservice, main" name="description">
 <meta content="custom name, local sakai name" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_externalToolLTIInstructorGuide/How-do-I-configure-the-External-Tool--LTI--settings-.html
+++ b/help/help/src/sakai_screensteps_externalToolLTIInstructorGuide/How-do-I-configure-the-External-Tool--LTI--settings-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.basiclti" name="description">
 <meta content="basic lti" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_externalToolLTIInstructorGuide/What-is-the-External-Tool--LTI--.html
+++ b/help/help/src/sakai_screensteps_externalToolLTIInstructorGuide/What-is-the-External-Tool--LTI--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.basiclti, main" name="description">
 <meta content="basic lti" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_externalToolsAdministratorGuide/How-do-I-make-an-LTI-1.1-tool-available-to-site-owners-.html
+++ b/help/help/src/sakai_screensteps_externalToolsAdministratorGuide/How-do-I-make-an-LTI-1.1-tool-available-to-site-owners-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.basiclti.admin" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_externalToolsAdministratorGuide/What-are-External-Tools-.html
+++ b/help/help/src/sakai_screensteps_externalToolsAdministratorGuide/What-are-External-Tools-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.basiclti.admin" name="description">
 <meta content="LTI, LTI 1, LTI 2, basic LTI, IMS" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-add-a-new-topic-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-add-a-new-topic-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="Forum, Message, Topic, Permission Level," name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-create-forums-and-topics-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-create-forums-and-topics-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="Forum, Topic, Grade, permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-delete-a-forum-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-delete-a-forum-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="remove forum, erase forum" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-delete-a-forum-post--i.e.-conversation--.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-delete-a-forum-post--i.e.-conversation--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="Delete, Forum, Post, Topic, Conversation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-delete-a-topic-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-delete-a-topic-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="remove topic" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-email-a-forum-post-author-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-email-a-forum-post-author-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="forum, communication, email, message, conversation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-grade-discussion-forums-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-grade-discussion-forums-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="grading forums, grading discussions, grading topics" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-moderate-a-topic-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-moderate-a-topic-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="moderate, Topic, forum," name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-modify-forum-template-settings-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-modify-forum-template-settings-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="forum, template, settings, permission level, role, default settings" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-move-a-thread-to-a-different-topic-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-move-a-thread-to-a-different-topic-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="thread, topic, move conversation, sakai.forums" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-organize-forums-and-topics-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-organize-forums-and-topics-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="organize, forums, topics, reorder, rearrange" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-post-to-a-forum-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-post-to-a-forum-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="Forum, Topic, Conversation, post message" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-reply-to-a-forum-post--i.e.-conversation--.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-reply-to-a-forum-post--i.e.-conversation--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="Forum, Topic, Conversation, post message, reply" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-watch-or-subscribe-to-forums-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/How-do-I-watch-or-subscribe-to-forums-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums" name="description">
 <meta content="watch, subscribe, notifications" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_forumsInstructorGuide/What-is-the-Forums-tool-.html
+++ b/help/help/src/sakai_screensteps_forumsInstructorGuide/What-is-the-Forums-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.forums, main" name="description">
 <meta content="Forum, category  topics, conversations, discussions, threads" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-are-grades-calculated-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-are-grades-calculated-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="grades, calculating grades, course grades" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-add-items-to-the-Gradebook-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-add-items-to-the-Gradebook-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-enter-and-or-edit-grades-in-the-Gradebook-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-enter-and-or-edit-grades-in-the-Gradebook-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="Grade entry, Grading, Manual Grading" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-export-grades-from-the-Gradebook-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-export-grades-from-the-Gradebook-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="pdf, csv, excel, print grades, offline grading" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-import-grades-into-the-Gradebook-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-import-grades-into-the-Gradebook-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="csv, excel, offline grades" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-override-a-course-grade-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-override-a-course-grade-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="manual grade change" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-set-all-ungraded-items-to-zero-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-set-all-ungraded-items-to-zero-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="calculate course grades" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-set-up-my-Gradebook-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-do-I-set-up-my-Gradebook-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="grade categories, weighting, extra credit, points, percentages, dropping grades, dropping scores" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-does-extra-credit-work-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/How-does-extra-credit-work-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="bonus points, optional credit" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookInstructorGuide/What-is-the-Gradebook-.html
+++ b/help/help/src/sakai_screensteps_gradebookInstructorGuide/What-is-the-Gradebook-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool, main" name="description">
 <meta content="grades, scores, course grade, drop grades, extra credit, weighted" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_gradebookStudentGuide/How-do-I-view-my-Gradebook-grades-.html
+++ b/help/help/src/sakai_screensteps_gradebookStudentGuide/How-do-I-view-my-Gradebook-grades-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.gradebook.tool" name="description">
 <meta content="view scores, view grades, view marks" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-delete-a-job-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-delete-a-job-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="Quartz, remove job" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-filter-events-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-filter-events-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-purge-softly-deleted-sites-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-purge-softly-deleted-sites-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="remove soft deletes, permanently delete site data" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-schedule-a-new-job-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-schedule-a-new-job-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="Quartz, trigger, run job manually" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-view-jobs-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-view-jobs-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="Quartz" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-view-running-jobs-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-view-running-jobs-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="Quartz" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-view-the-event-log-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/How-do-I-view-the-event-log-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler" name="description">
 <meta content="events, Quartz" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/What-is-the-Job-Scheduler-.html
+++ b/help/help/src/sakai_screensteps_jobSchedulerAdministratorGuide/What-is-the-Job-Scheduler-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.scheduler, main" name="description">
 <meta content="Quartz" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-a-file-from-Resources-to-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-a-file-from-Resources-to-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="content links, file links, resource files" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-a-question-to-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-a-question-to-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="question poll, in-line poll" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-a-website-link-to-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-a-website-link-to-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="URL, add URL, web address, internet address" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-activities-to-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-activities-to-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="assignments links, forum links, topic links, test links, quiz links" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-additional-top-level-Lessons-pages-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-additional-top-level-Lessons-pages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="index of pages, heirarchy" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-subpages-to-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-subpages-to-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="nested pages" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-text-to-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-add-text-to-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="Lessons text, add content, content block, right text editor, page authoring" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-allow-comments-to-be-posted-on-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-allow-comments-to-be-posted-on-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="student comments, page comments" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-allow-students-to-add-content-to-Lessons-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-allow-students-to-add-content-to-Lessons-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="interaction, student pages, student web pages" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-create-a-new-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-create-a-new-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="lessons " edit tools add new page lesson top level retitle name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-delete-a-Lessons-subpage-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-delete-a-Lessons-subpage-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="remove page, delete subpage" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-delete-a-top-level-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-delete-a-top-level-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="remove page" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-delete-items-on-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-delete-items-on-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="remove item, remove page item" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-a-YouTube-video-on-a-Lessons-Page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-a-YouTube-video-on-a-Lessons-Page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-a-video-from-my-computer-on-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-a-video-from-my-computer-on-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="upload video file" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-an-audio-file-on-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-an-audio-file-on-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="audio files, mp3" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-an-image-on-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-embed-an-image-on-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="insert image, insert photo, add picture, page image, insert picture" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-export-Lessons-content-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-export-Lessons-content-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="IMS CC, common cartriddge, course content export, export file, course archive, content archive" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-import-Lessons-content-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-import-Lessons-content-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="IMS CC, common cartridge, import content, import course archive" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-limit-access-to-Lessons-page-items-to-groups-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-limit-access-to-Lessons-page-items-to-groups-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="conditional release, restricted content, limited access, groups" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-rename-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-rename-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="re-title, change lesson title, modify page title" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-reorder-items-on-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-reorder-items-on-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="lessons, reorder, re-order, rearrange items, sort items" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-require-completion-of-a-Lessons-item-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-require-completion-of-a-Lessons-item-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="prerequisite, conditional release, requirements, selective release" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-require-completion-of-a-Lessons-page-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-require-completion-of-a-Lessons-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="selective release, sequenced content, conditional release" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-view-the-Index-of-Pages-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/How-do-I-view-the-Index-of-Pages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="nested pages, lessons hierarchy, index of pages" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsInstructorGuide/What-is-the-Lessons-tool-.html
+++ b/help/help/src/sakai_screensteps_lessonsInstructorGuide/What-is-the-Lessons-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool, main" name="description">
 <meta content="content, module builder, lesson builder" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_lessonsStudentGuide/How-do-I-add-Student-Content-in-Lessons-.html
+++ b/help/help/src/sakai_screensteps_lessonsStudentGuide/How-do-I-add-Student-Content-in-Lessons-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.lessonbuildertool" name="description">
 <meta content="student pages" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-add-an-MOTD-announcement-.html
+++ b/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-add-an-MOTD-announcement-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="MOTD, admin announcement, system reminder, server-wide notice" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-delete-an-MOTD-announcement-.html
+++ b/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-delete-an-MOTD-announcement-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="remove MOTD announcement" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-edit-an-MOTD-announcement-.html
+++ b/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-edit-an-MOTD-announcement-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="update MOTD, modify MOTD" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-merge-MOTD-announcements-.html
+++ b/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-merge-MOTD-announcements-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-reorder-MOTD-announcements-.html
+++ b/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/How-do-I-reorder-MOTD-announcements-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.announcements" name="description">
 <meta content="reorder, sort" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/What-is-the-admin-Announcements-tool-or-Message-of-the-Day--MOTD--.html
+++ b/help/help/src/sakai_screensteps_mOTDAnnouncementsAdministratorGuide/What-is-the-admin-Announcements-tool-or-Message-of-the-Day--MOTD--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.motd, main" name="description">
 <meta content="announcements, system announcements, admin announcements" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-evict-expired-members-.html
+++ b/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-evict-expired-members-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.memory" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-locate-maxed-out-caches-.html
+++ b/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-locate-maxed-out-caches-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.memory" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-reset-all-caches-.html
+++ b/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-reset-all-caches-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.memory" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-view-Memory-Status-.html
+++ b/help/help/src/sakai_screensteps_memoryAdministratorGuide/How-do-I-view-Memory-Status-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.memory" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_memoryAdministratorGuide/What-is-the-admin-Memory-tool-.html
+++ b/help/help/src/sakai_screensteps_memoryAdministratorGuide/What-is-the-admin-Memory-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.memory" name="description">
 <meta content="cache" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-create-a-Messages-folder-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-create-a-Messages-folder-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages" name="description">
 <meta content="course mail, email" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-delete-a-message-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-delete-a-message-.html
@@ -6,8 +6,8 @@
 <meta content="samigo.messages" name="description">
 <meta content="course mail, email" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-determine-who-site-participants-can-send-a-message-to-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-determine-who-site-participants-can-send-a-message-to-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages" name="description">
 <meta content="messages, limit message, permission," name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-move-a-message-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-move-a-message-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages" name="description">
 <meta content="move to folder" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-reply-to-a-message-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-reply-to-a-message-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages" name="description">
 <meta content="reply all" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-send-a-message-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-send-a-message-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages" name="description">
 <meta content="course mail, email" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-view-my-messages-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/How-do-I-view-my-messages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages" name="description">
 <meta content="course mail, email" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_messagesInstructorGuide/What-is-the-Messages-tool-.html
+++ b/help/help/src/sakai_screensteps_messagesInstructorGuide/What-is-the-Messages-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.messages, main" name="description">
 <meta content="email, course mail" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/How-do-I-view-and-edit-my-account-details-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/How-do-I-view-and-edit-my-account-details-.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="email, password, userame, sakai.singleuser" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-are-the-My-Workspace-Message-Center-Notifications-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-are-the-My-Workspace-Message-Center-Notifications-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.synoptic.messagecenter" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-are-the-My-Workspace-Recent-Announcements-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-are-the-My-Workspace-Recent-Announcements-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.myworkspace.announcements" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-are-the-Resources-in-My-Workspace-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-are-the-Resources-in-My-Workspace-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="Resources, MyWorkspace" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-Membership-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-Membership-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.membership" name="description">
 <meta content="enrolled sites, site list, joining sites, joinable, unjoin" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-My-Workspace-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-My-Workspace-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.iframe.myworkspace" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-Site-Navigation-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-Site-Navigation-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.myworkspace.sitenavigation" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-Worksite-Setup-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-Worksite-Setup-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitesetup, main" name="description">
 <meta content="edit site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-My-Workspace-Calendar-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-My-Workspace-Calendar-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.summary.calendar" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-My-Workspace-Message-of-the-Day-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-My-Workspace-Message-of-the-Day-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.myworkspace.motd" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-My-Workspace-Tool-Menu-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-My-Workspace-Tool-Menu-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.myworkspace.toolmenu" name="description">
 <meta content="My Workspace, landing page, navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-Preferences-tool-.html
+++ b/help/help/src/sakai_screensteps_myWorkspaceInstructorGuide/What-is-the-Preferences-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.preferences" name="description">
 <meta content="time zone, language, email digest, email notifications, tab order, rearrange tabs, hide sites, site drawer" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_newsInstructorGuide/How-do-I-add-a-News-tool-.html
+++ b/help/help/src/sakai_screensteps_newsInstructorGuide/How-do-I-add-a-News-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.news" name="description">
 <meta content="RSS, configure RSS, add news feed, site info" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_newsInstructorGuide/How-do-I-delete-a-News-tool-.html
+++ b/help/help/src/sakai_screensteps_newsInstructorGuide/How-do-I-delete-a-News-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.news" name="description">
 <meta content="RSS, delete news feed, site info, remove news" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_newsInstructorGuide/How-do-I-edit-the-News-tool-.html
+++ b/help/help/src/sakai_screensteps_newsInstructorGuide/How-do-I-edit-the-News-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.news" name="description">
 <meta content="RSS, configure RSS, edit news feed" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_newsInstructorGuide/What-is-the-News-tool-.html
+++ b/help/help/src/sakai_screensteps_newsInstructorGuide/What-is-the-News-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.news, main" name="description">
 <meta content="RSS, news feed, RSS feed" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-refresh-location--session--and-server-data-.html
+++ b/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-refresh-location--session--and-server-data-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.online" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-view-active-servers-.html
+++ b/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-view-active-servers-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.online" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-view-active-sessions-.html
+++ b/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-view-active-sessions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.online" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-view-user-locations-.html
+++ b/help/help/src/sakai_screensteps_onlineAdministratorGuide/How-do-I-view-user-locations-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.online" name="description">
 <meta content="user IP address" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_onlineAdministratorGuide/What-is-the-Online-tool-.html
+++ b/help/help/src/sakai_screensteps_onlineAdministratorGuide/What-is-the-Online-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.online, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_permissionsandRolesInstructorGuide/How-do-I-change-participant-roles-within-a-site-.html
+++ b/help/help/src/sakai_screensteps_permissionsandRolesInstructorGuide/How-do-I-change-participant-roles-within-a-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="permissions, roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_permissionsandRolesInstructorGuide/What-are-Permissions-and-Roles-.html
+++ b/help/help/src/sakai_screensteps_permissionsandRolesInstructorGuide/What-are-Permissions-and-Roles-.html
@@ -6,8 +6,8 @@
 <meta content="" name="description">
 <meta content="default roles, default participant roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-add-a-podcast-.html
+++ b/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-add-a-podcast-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.podcasts" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-allow-students-to-upload-podcast-files-.html
+++ b/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-allow-students-to-upload-podcast-files-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.podcasts" name="description">
 <meta content="roles, permissions, change podcast permissions, modify podcast permissions, edit podcast permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-subscribe-to-a-podcast-.html
+++ b/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-subscribe-to-a-podcast-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.podcasts" name="description">
 <meta content="subscribe to RSS, iTunes" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-view-or-download-an-individual-podcast-.html
+++ b/help/help/src/sakai_screensteps_podcastsInstructorGuide/How-do-I-view-or-download-an-individual-podcast-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.podcasts" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_podcastsInstructorGuide/What-is-the-Podcasts-tool-.html
+++ b/help/help/src/sakai_screensteps_podcastsInstructorGuide/What-is-the-Podcasts-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.podcasts, main" name="description">
 <meta content="RSS feed" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-add-a-new-poll-.html
+++ b/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-add-a-new-poll-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.polls" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-modify-Polls-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-modify-Polls-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.polls" name="description">
 <meta content="roles, permissions, change poll permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-take-a-poll-.html
+++ b/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-take-a-poll-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.polls" name="description">
 <meta content="vote" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-view-poll-results-.html
+++ b/help/help/src/sakai_screensteps_pollsInstructorGuide/How-do-I-view-poll-results-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.polls" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_pollsInstructorGuide/What-is-the-Polls-tool-.html
+++ b/help/help/src/sakai_screensteps_pollsInstructorGuide/What-is-the-Polls-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.polls" name="description">
 <meta content="vote" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_postEmInstructorGuide/How-do-I-add-PostEm-feedback-.html
+++ b/help/help/src/sakai_screensteps_postEmInstructorGuide/How-do-I-add-PostEm-feedback-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.postem" name="description">
 <meta content="feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_postEmInstructorGuide/What-is-the-PostEm-tool-.html
+++ b/help/help/src/sakai_screensteps_postEmInstructorGuide/What-is-the-PostEm-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.postem, main" name="description">
 <meta content="feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_postEmStudentGuide/How-do-I-view-my-feedback-in-PostEm-.html
+++ b/help/help/src/sakai_screensteps_postEmStudentGuide/How-do-I-view-my-feedback-in-PostEm-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.postem" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-add-pictures-to-my-profile-picture-gallery-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-add-pictures-to-my-profile-picture-gallery-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="image gallery, profile photos" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-change-my-privacy-settings-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-change-my-privacy-settings-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="photo, personal info, status, kudos, wall posts, connections" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-post-to-my-wall-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-post-to-my-wall-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="status, profile, comment on wall" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-search-for-and-add-connections-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-search-for-and-add-connections-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="friend" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-send-a-message-to-a-connection-in-Profile-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-send-a-message-to-a-connection-in-Profile-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-set-my-notification-and-other-profile-preferences-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-set-my-notification-and-other-profile-preferences-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="Twitter, tweet, status posts, gravatar, notifications, email, widget, kudos, pictures, online status" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-set-up-my-profile-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/How-do-I-set-up-my-profile-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2" name="description">
 <meta content="social media, twitter, linkedin, facebook, connections, profile photo, profile image" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_profileInstructorGuide/What-is-the-Profile-tool-.html
+++ b/help/help/src/sakai_screensteps_profileInstructorGuide/What-is-the-Profile-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.profile2, main" name="description">
 <meta content="Profile, picture, status, Twitter, social media, privacy" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_realmsAdministratorGuide/How-do-I-create-a-new--or-custom-role-within-a-Realm-.html
+++ b/help/help/src/sakai_screensteps_realmsAdministratorGuide/How-do-I-create-a-new--or-custom-role-within-a-Realm-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.realms" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_realmsAdministratorGuide/How-do-I-modify-an-existing-role-within-a-Realm-.html
+++ b/help/help/src/sakai_screensteps_realmsAdministratorGuide/How-do-I-modify-an-existing-role-within-a-Realm-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.realms" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_realmsAdministratorGuide/How-do-I-search-Realms-.html
+++ b/help/help/src/sakai_screensteps_realmsAdministratorGuide/How-do-I-search-Realms-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.realms" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_realmsAdministratorGuide/What-are-Realms-.html
+++ b/help/help/src/sakai_screensteps_realmsAdministratorGuide/What-are-Realms-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.realms" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesAdministratorGuide/What-Resources-are-specific-to-admin-users-.html
+++ b/help/help/src/sakai_screensteps_resourcesAdministratorGuide/What-Resources-are-specific-to-admin-users-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-add-a-web-link-or-URL-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-add-a-web-link-or-URL-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-add-and-display-contextual-information-about-a-file-or-folder-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-add-and-display-contextual-information-about-a-file-or-folder-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-allow-all-students-to-upload-content-to-a-selected-folder-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-allow-all-students-to-upload-content-to-a-selected-folder-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-allow-group-members-to-upload-content-to-a-group-Resources-folder-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-allow-group-members-to-upload-content-to-a-group-Resources-folder-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-copy-a-Resources-file-or-folder-from-one-site-to-another-site-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-copy-a-Resources-file-or-folder-from-one-site-to-another-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-copy-a-file-or-folder-within-Resources-in-the-same-site-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-copy-a-file-or-folder-within-Resources-in-the-same-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-citation-list-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-citation-list-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-group-folder-in-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-group-folder-in-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-text-document-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-text-document-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-zip-archive-file-in-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-a-zip-archive-file-in-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-an-HTML-page-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-an-HTML-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-folders-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-create-folders-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-drag-and-drop-files-from-my-computer-to-a-Resources-folder-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-drag-and-drop-files-from-my-computer-to-a-Resources-folder-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="upload files, drag-n-drop, drag and drop" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-hide-files-and-folders-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-hide-files-and-folders-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-make-a-file-or-folder-publicly-viewable-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-make-a-file-or-folder-publicly-viewable-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-make-a-link-to-a-Resources-folder-appear-in-the-Tool-Menu-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-make-a-link-to-a-Resources-folder-appear-in-the-Tool-Menu-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-move-a-file-or-folder-within-Resources-in-the-same-site-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-move-a-file-or-folder-within-Resources-in-the-same-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-navigate-the-Resources-tool-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-navigate-the-Resources-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="reset, breadcrumbs, directory structure" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-notify-site-participants-that-content-has-been-added-to-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-notify-site-participants-that-content-has-been-added-to-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-obtain-the-URL-for-a-file-or-folder-in-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-obtain-the-URL-for-a-file-or-folder-in-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-remove-a-file-or-folder-in-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-remove-a-file-or-folder-in-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="delete files, delete folders" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-reorder-files-or-folders-within-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-reorder-files-or-folders-within-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-restore-a-removed-file-or-folder-in-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-restore-a-removed-file-or-folder-in-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="undelete" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-set-the-display-of-a-Resources-item-to-a-specific-time-period-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-set-the-display-of-a-Resources-item-to-a-specific-time-period-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-unhide-files-or-folders-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-unhide-files-or-folders-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-a-new-version-of-a-file-in-Resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-a-new-version-of-a-file-in-Resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-and-unpack-a-zip-file-to-a-Resources-folder-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-and-unpack-a-zip-file-to-a-Resources-folder-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="unzip" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-files-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-files-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-or-download-multiple-resources-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/How-do-I-upload-or-download-multiple-resources-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="WebDAV" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/What-is-the-Resources-quota-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/What-is-the-Resources-quota-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_resourcesInstructorGuide/What-is-the-Resources-tool-.html
+++ b/help/help/src/sakai_screensteps_resourcesInstructorGuide/What-is-the-Resources-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.resources, main" name="description">
 <meta content="manage files, upload files, drag and drop files, folders" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-add-a-content-template-to-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-add-a-content-template-to-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="content template, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-add-edit-a-table-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-add-edit-a-table-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="table, add, edit, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-add-special-characters-to-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-add-special-characters-to-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="special characters, diacritical marks, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-create-a-link-to-a-Resources-item-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-create-a-link-to-a-Resources-item-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="link, website, text hyperlink, resources folder, file, document, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-create-a-link-to-a-web-site-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-create-a-link-to-a-web-site-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="link website text hyperlink" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-create-a-link-to-an-activity-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-create-a-link-to-an-activity-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="link, website, text hyperlink, forums, test, quiz assignments, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-a-YouTube-video-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-a-YouTube-video-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="embed YouTube video, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-a-linked-web-image-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-a-linked-web-image-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="embed image, picture, photo, text box link, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-an-image-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-an-image-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="embed image, picture, photo, text box, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-an-mp3-audio-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-an-mp3-audio-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="audio embed mp3, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-an-mp4-video-in-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-embed-an-mp4-video-in-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="mp4 video embed, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-paste-text-from-a-Microsoft-Word-document-to-a-text-box-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/How-do-I-paste-text-from-a-Microsoft-Word-document-to-a-text-box-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="Word, paste, Microsoft, CKeditor" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/What-actions-can-I-perform-using-the-Rich-Text-Editor-icons-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/What-actions-can-I-perform-using-the-Rich-Text-Editor-icons-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor" name="description">
 <meta content="html editor, WYSIWYG, icons, editor toolbar" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/What-is-the-Rich-Text-Editor-.html
+++ b/help/help/src/sakai_screensteps_richTextEditorInstructorGuide/What-is-the-Rich-Text-Editor-.html
@@ -6,8 +6,8 @@
 <meta content="CKeditor, main" name="description">
 <meta content="html editor, WYSIWYG" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-edit-Roster-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-edit-Roster-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.site.roster2" name="description">
 <meta content="roles, permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-view-group-membership-in-the-roster-.html
+++ b/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-view-group-membership-in-the-roster-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.site.roster2" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-view-roster-photos-and-or-profiles-.html
+++ b/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-view-roster-photos-and-or-profiles-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.site.roster2" name="description">
 <meta content="photo, profile, view pictures, student pictures, roster pictures" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-view-search-the-roster-.html
+++ b/help/help/src/sakai_screensteps_rosterInstructorGuide/How-do-I-view-search-the-roster-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.site.roster2" name="description">
 <meta content="view roster, view photos, student photos, student pictures, profile" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_rosterInstructorGuide/What-is-the-Roster-tool-.html
+++ b/help/help/src/sakai_screensteps_rosterInstructorGuide/What-is-the-Roster-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.site.roster2, main" name="description">
 <meta content="class roster, student photos, student profiles, class photos, class pictures, roster photos" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-add-items-to-the-Schedule-Calendar-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-add-items-to-the-Schedule-Calendar-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="calendar entry, recurring event, schedule event, calendar post" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-change-the-calendar-view-in-the-Schedule-tool-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-change-the-calendar-view-in-the-Schedule-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="schedule, view settings, default view, day, month, week, year, list, monthly view, week at a glance" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-customize-my-Schedule-Calendar-display-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-customize-my-Schedule-Calendar-display-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.summary.calendar" name="description">
 <meta content="calendar item priority, view calendar by week, view calendar by month" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-delete-a-calendar-item-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-delete-a-calendar-item-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="schedule, delete schedule, delete event, remove calendar item, remove" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-edit-a-calendar-item-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-edit-a-calendar-item-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="schedule, edit schedule, edit event" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-import-Schedule-Calendar-entries-from-a-file-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-import-Schedule-Calendar-entries-from-a-file-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="bulk import, calendar import" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-merge-the-Schedule-Calendar-with-another-site-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-merge-the-Schedule-Calendar-with-another-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="calendar, merge, combine" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-modify-Schedule-Calendar-permissions-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-modify-Schedule-Calendar-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="roles, permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-print-the-Schedule-Calendar-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-print-the-Schedule-Calendar-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="PDF, printer-friendly" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-view-calendar-item-details-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/How-do-I-view-calendar-item-details-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule" name="description">
 <meta content="schedule, view details" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_scheduleInstructorGuide/What-is-the-Schedule-Calendar-tool-.html
+++ b/help/help/src/sakai_screensteps_scheduleInstructorGuide/What-is-the-Schedule-Calendar-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.schedule, main" name="description">
 <meta content="calendar, course calendar, calendar post" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_searchInstructorGuide/How-do-I-perform-a-basic-search-.html
+++ b/help/help/src/sakai_screensteps_searchInstructorGuide/How-do-I-perform-a-basic-search-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.search" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_searchInstructorGuide/How-do-I-perform-an-advanced-search-.html
+++ b/help/help/src/sakai_screensteps_searchInstructorGuide/How-do-I-perform-an-advanced-search-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.search" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_searchInstructorGuide/What-is-the-Search-tool-.html
+++ b/help/help/src/sakai_screensteps_searchInstructorGuide/What-is-the-Search-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.search, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-are-sections-different-than-groups-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-are-sections-different-than-groups-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections" name="description">
 <meta content="groups, teaching assistants, TAs" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-add-site-members-to-a-section-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-add-site-members-to-a-section-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections" name="description">
 <meta content="add students to section" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-add-teaching-assistants-to-a-section-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-add-teaching-assistants-to-a-section-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections" name="description">
 <meta content="TA, TAs" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-create-a-section-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-create-a-section-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections" name="description">
 <meta content="add section" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-delete-a-section-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-delete-a-section-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections" name="description">
 <meta content="remove sections" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-edit-a-section-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/How-do-I-edit-a-section-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections" name="description">
 <meta content="modify section" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/What-is-the-Section-Info-tool-.html
+++ b/help/help/src/sakai_screensteps_sectionInfoInstructorGuide/What-is-the-Section-Info-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sections, main" name="description">
 <meta content="TAs, teaching assistants" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-can-I-use-the-Sign-Up-tool-in-my-site-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-can-I-use-the-Sign-Up-tool-in-my-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-add-meetings-to-the-site-Schedule-or-Calendar-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-add-meetings-to-the-site-Schedule-or-Calendar-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-create-a-meeting-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-create-a-meeting-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-edit-a-meeting-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-edit-a-meeting-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-export-meeting-data-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-export-meeting-data-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-manually-add-users-to-meetings-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-manually-add-users-to-meetings-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-modify-Sign-Up-tool-permissions-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-modify-Sign-Up-tool-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="permissions, roles" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-view-meetings-in-Sign-Up-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-I-view-meetings-in-Sign-Up-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-students-or-participants-sign-up-for-meetings-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/How-do-students-or-participants-sign-up-for-meetings-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/What-are-Sign-Up-meeting-types-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/What-are-Sign-Up-meeting-types-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_signUpInstructorGuide/What-is-the-Sign-Up-tool-.html
+++ b/help/help/src/sakai_screensteps_signUpInstructorGuide/What-is-the-Sign-Up-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.signup, main" name="description">
 <meta content="sign-up sheets, appointments" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteArchiveAdministratorGuide/How-do-I-export-archive-an-individual-site-.html
+++ b/help/help/src/sakai_screensteps_siteArchiveAdministratorGuide/How-do-I-export-archive-an-individual-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.archive" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteArchiveAdministratorGuide/How-do-I-import-an-individual-site-archive-.html
+++ b/help/help/src/sakai_screensteps_siteArchiveAdministratorGuide/How-do-I-import-an-individual-site-archive-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitearchive" name="description">
 <meta content="import archive, import site, restore site archive" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteArchiveAdministratorGuide/What-is-the-Site-Archive-tool-.html
+++ b/help/help/src/sakai_screensteps_siteArchiveAdministratorGuide/What-is-the-Site-Archive-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.archive" name="description">
 <meta content="backup courses, site backup, archiving courses, archiving sites" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-add-a-class-roster-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-add-a-class-roster-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="add section, add class, add roster" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-add-users-to-my-course-or-project-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-add-users-to-my-course-or-project-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="Add users, Add to site, Add Participants, Add students" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-choose-which-tools-will-be-available-in-my-course-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-choose-which-tools-will-be-available-in-my-course-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="add tool, active tool, inactive tool" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-control-site-access-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-control-site-access-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="publish, global access, manage site access, unpublished" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-copy-my-content-from-one-site-to-another-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-copy-my-content-from-one-site-to-another-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="copy course, import content, import site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-create-groups-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-create-groups-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="Groups, Teams, Random Group Generation, joinable groups, joinable set" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-delete-a-class-roster-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-delete-a-class-roster-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="remove section, remove class, remove roster" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-duplicate-a-site-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-duplicate-a-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="copy site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-edit-the-site-information-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-edit-the-site-information-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="language, site contact, skin, theme, site description" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-import-content-from-an-archive-file-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-import-content-from-an-archive-file-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="import testbank, import course archive, import CC, common cartridge, Blackboard import, Bb import, IMS CC" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-link-to-a-parent-site-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-link-to-a-parent-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="child site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-rearrange-or-rename-the-items-in-the-Tool-Menu-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-rearrange-or-rename-the-items-in-the-Tool-Menu-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="custom tool name, custom tool title, rename tool link, reorder menu, page order, hide tool, disable tool" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-remove-users-from-my-course-or-project-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/How-do-I-remove-users-from-my-course-or-project-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="delete user, unenroll user" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/What-is-the-Site-Info-tool-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/What-is-the-Site-Info-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo, main" name="description">
 <meta content="control panel, site management" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_siteInfoInstructorGuide/What-is-the-User-Audit-Log-.html
+++ b/help/help/src/sakai_screensteps_siteInfoInstructorGuide/What-is-the-User-Audit-Log-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.siteinfo" name="description">
 <meta content="enrollment, remove user, add user, update user" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-Soft-Delete-a-site-from-the-Sites-tool-.html
+++ b/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-Soft-Delete-a-site-from-the-Sites-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites" name="description">
 <meta content="delete course, remove course, remove site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-add-a-site-using-the-Sites-tool-.html
+++ b/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-add-a-site-using-the-Sites-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites" name="description">
 <meta content="create site, new site, new course, create course" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-add-a-stealthed-tool-to-a-site-.html
+++ b/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-add-a-stealthed-tool-to-a-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-edit-a-site-using-the-Sites-tool-.html
+++ b/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-edit-a-site-using-the-Sites-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-search-for-a-site-using-the-Sites-tool-.html
+++ b/help/help/src/sakai_screensteps_sitesAdministratorGuide/How-do-I-search-for-a-site-using-the-Sites-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites" name="description">
 <meta content="locate site, find site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitesAdministratorGuide/What-is-the-Sites-tool-.html
+++ b/help/help/src/sakai_screensteps_sitesAdministratorGuide/What-is-the-Sites-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/How-do-I-create-predefined-reports-available-throughout-the-system-.html
+++ b/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/How-do-I-create-predefined-reports-available-throughout-the-system-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats.admin" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/How-do-I-view-reports-for-a-specific-site-.html
+++ b/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/How-do-I-view-reports-for-a-specific-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats.admin" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/How-do-I-view-server-wide-reports-.html
+++ b/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/How-do-I-view-server-wide-reports-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats.admin" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/What-is-Sitestats-Admin-.html
+++ b/help/help/src/sakai_screensteps_sitestatsAdminAdministratorGuide/What-is-Sitestats-Admin-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats.admin, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-create-and-run-a-report-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-create-and-run-a-report-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="add report, custom report, save report, generate report, view report" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-delete-a-report-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-delete-a-report-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="remove report" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-duplicate-a-report-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-duplicate-a-report-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="copy report" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-edit-a-report-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-edit-a-report-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="change report, modify report" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-export-a-report-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-export-a-report-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="export to excel, export to pdf, export to csv, download report" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-modify-preferences-in-the-Statistics-tool-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-modify-preferences-in-the-Statistics-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-print-a-report-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-print-a-report-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="print user activity, print custom report" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-view-summary-reports-in-the-Statistics-tool-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/How-do-I-view-summary-reports-in-the-Statistics-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats" name="description">
 <meta content="overview reports, site visits, user activity" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_statisticsInstructorGuide/What-is-the-Statistics-tool-.html
+++ b/help/help/src/sakai_screensteps_statisticsInstructorGuide/What-is-the-Statistics-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitestats, main" name="description">
 <meta content="reporting, user activity, events, site stats" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-add-my-syllabus-as-a-file-attachment-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-add-my-syllabus-as-a-file-attachment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus" name="description">
 <meta content="syllabus file, file attachment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-create-a-multi-part-syllabus-based-on-number-of-items-needed-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-create-a-multi-part-syllabus-based-on-number-of-items-needed-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus" name="description">
 <meta content="syllabus, sakai.syllabus, bulk add syllabus items" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-create-a-multi-part-syllabus-by-dates-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-create-a-multi-part-syllabus-by-dates-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus" name="description">
 <meta content="bulk add" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-create-a-syllabus-using-cut-and-paste-from-a-document-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-create-a-syllabus-using-cut-and-paste-from-a-document-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus" name="description">
 <meta content="cut and paste syllabus" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-point-my-syllabus-to-a-webpage-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-point-my-syllabus-to-a-webpage-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus" name="description">
 <meta content="external webpage, external url, redirect to url, syllabus url" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-print-the-syllabus-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/How-do-I-print-the-syllabus-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus" name="description">
 <meta content="printer-friendly" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_syllabusInstructorGuide/What-is-the-Syllabus-tool-.html
+++ b/help/help/src/sakai_screensteps_syllabusInstructorGuide/What-is-the-Syllabus-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.syllabus, main" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add--copy--move--or-remove-a-question-pool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add--copy--move--or-remove-a-question-pool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="random draw, question set, test bank" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-calculated-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-calculated-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="tests, quizzes, calculated, formula, variables, answer points value, feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-file-upload-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-file-upload-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="file upload, tests, quizzes, answer point value, feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-fill-in-the-blank-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-fill-in-the-blank-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="tests, quizzes, fill in the blank, answer point value, feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-new-question--with-the-assessment-builder--.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-new-question--with-the-assessment-builder--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="assessment, question" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-numeric-response-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-numeric-response-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="tests, quizzes, numeric response, answer points value, feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-question-to-a-question-pool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-question-to-a-question-pool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test bank, random draw, question set" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-true-false-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-a-true-false-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="true/false question, test &amp; quizzes, assessment, rich-text editor, T/F, question type" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-an-audio-recording-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-an-audio-recording-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="tests, quizzes, answer point value, audio recording, feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-an-extended-matching-items-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-add-an-extended-matching-items-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-copy-questions-from-the-question-pool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-copy-questions-from-the-question-pool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="copy questions, question pool, assign, tests and quizzes" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-matching-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-matching-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test, quiz, question, match" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-multiple-choice-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-multiple-choice-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="quiz, assessment, test" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-new-assessment-using-markup-text-or-cut-and-paste-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-new-assessment-using-markup-text-or-cut-and-paste-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="copy and paste, paste from Word" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-short-answer-essay-question-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-short-answer-essay-question-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="tests, quizzes, short answer, essay, answer point value, feedback" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-survey-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-a-survey-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="survey, matrix of choices" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-an-assessment-in-Tests---Quizzes-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-create-an-assessment-in-Tests---Quizzes-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test, quiz, exam, survey" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-grade-Tests---Quizzes-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-grade-Tests---Quizzes-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="grade by question, grade by student, grade quiz, grade assessment, assessment, test, exam, quiz" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-import-a-question-pool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-import-a-question-pool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="import questions, export questions, QTI, IMS" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-import-and-export-assessments-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-import-and-export-assessments-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="QTI, Respondus, IMS" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-inspect-and-adjust-the-settings-of-an-assessment-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-inspect-and-adjust-the-settings-of-an-assessment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test, exam, quiz, survey, assessment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-publish-an-assessment--i.e.-test-or-quiz--.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-publish-an-assessment--i.e.-test-or-quiz--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test, quiz, exam, survey, assessment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-set-up-a-random-question-set-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-set-up-a-random-question-set-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="random draw, random question pool, randomize" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-share-a-question-pool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-share-a-question-pool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-use-assessment-parts-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-do-I-use-assessment-parts-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="exam parts, random draw, question set, rearrange parts" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-to-I-add-multiple-parts-to-an-assessment-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/How-to-I-add-multiple-parts-to-an-assessment-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test, quiz, part, random, assessment" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/What-is-a-question-pool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/What-is-a-question-pool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="question bank, random draw, random question set, test bank" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/What-is-the-Tests---Quizzes-Event-Log-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/What-is-the-Tests---Quizzes-Event-Log-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="event log, tests and quizzes, assessment events" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/What-is-the-Tests---Quizzes-tool-.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesInstructorGuide/What-is-the-Tests---Quizzes-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo, main" name="description">
 <meta content="exam, assessment, survey" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesStudentGuide/How-do-I-submit-an-assessment--i.e.-test-or-quiz--.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesStudentGuide/How-do-I-submit-an-assessment--i.e.-test-or-quiz--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="take a test, take a quiz, take a survey, test, quiz, exam, survey" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_testsQuizzesStudentGuide/How-do-I-view-the-feedback-on-my-assessment--i.e.-test-or-quiz--.html
+++ b/help/help/src/sakai_screensteps_testsQuizzesStudentGuide/How-do-I-view-the-feedback-on-my-assessment--i.e.-test-or-quiz--.html
@@ -6,8 +6,8 @@
 <meta content="sakai.samigo" name="description">
 <meta content="test results, quiz scores, assessment results, assessment scores" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/How-do-I-export-search-results-from-User-Membership-.html
+++ b/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/How-do-I-export-search-results-from-User-Membership-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.usermembership" name="description">
 <meta content="download membership information, download search results" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/How-do-I-filter-search-results-in-User-Membership-.html
+++ b/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/How-do-I-filter-search-results-in-User-Membership-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.usermembership" name="description">
 <meta content="internal accounts, external accounts, user type" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/How-do-I-search-for-an-account-in-User-Membership-.html
+++ b/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/How-do-I-search-for-an-account-in-User-Membership-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.usermembership" name="description">
 <meta content="find enrolled sites, find user's groups" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/What-is-User-Membership-.html
+++ b/help/help/src/sakai_screensteps_userMembershipAdministratorGuide/What-is-User-Membership-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.usermembership, main" name="description">
 <meta content="users' enrolled sites, group membership" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-add-a-new-account-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-add-a-new-account-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users" name="description">
 <meta content="manually add account, manually add user" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-create-multiple-new-user-accounts-by-importing-a-file-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-create-multiple-new-user-accounts-by-importing-a-file-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users" name="description">
 <meta content="importing accounts, csv import, bulk account creation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-disable-a-user-account-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-disable-a-user-account-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users" name="description">
 <meta content="lock account" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-edit-a-user-account-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-edit-a-user-account-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users" name="description">
 <meta content="update account details, reset password, update email, change email, change user id, update user id" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-remove-a-user-account-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-remove-a-user-account-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users" name="description">
 <meta content="delete account, delete user" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-search-for-a-user-account-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/How-do-I-search-for-a-user-account-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users" name="description">
 <meta content="find user, locate user account, user account details" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_usersAdministratorGuide/What-is-the-Users-tool-.html
+++ b/help/help/src/sakai_screensteps_usersAdministratorGuide/What-is-the-Users-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.users, main" name="description">
 <meta content="create user, search for user, update user information" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-create-a-Web-Content-link-to-a-folder-in-Resources.html
+++ b/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-create-a-Web-Content-link-to-a-folder-in-Resources.html
@@ -6,8 +6,8 @@
 <meta content="sakai.iframe" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-create-a-Web-Content-link-to-a-web-site-.html
+++ b/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-create-a-Web-Content-link-to-a-web-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.iframe" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-delete-a-Web-Content-link-.html
+++ b/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-delete-a-Web-Content-link-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.iframe" name="description">
 <meta content="remove web link" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-edit-a-Web-Content-link-.html
+++ b/help/help/src/sakai_screensteps_webContentInstructorGuide/How-do-I-edit-a-Web-Content-link-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.iframe" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_webContentInstructorGuide/What-is-the-Web-Content-tool-.html
+++ b/help/help/src/sakai_screensteps_webContentInstructorGuide/What-is-the-Web-Content-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.iframe" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-add-attachments-to-a-wiki-page-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-add-attachments-to-a-wiki-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="file attachments" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-add-images-to-a-wiki-page-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-add-images-to-a-wiki-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-create-a-new-wiki-page-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-create-a-new-wiki-page-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="add page, page links, new pages" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-edit-wiki-pages-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-edit-wiki-pages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="notifications, wiki markup" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-search-wiki-pages-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-search-wiki-pages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-set-wiki-permissions-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-set-wiki-permissions-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="roles, permissions" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-view-wiki-page-history-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-view-wiki-page-history-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="revert to earlier version, version history" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-view-wiki-page-info-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-view-wiki-page-info-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="RSS, PDF, wiki permissions, external linking, last edited, page links" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-view-wiki-pages-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-view-wiki-pages-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="navigate wiki pages, wiki navigation" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-watch-or-subscribe-to-a-wiki-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/How-do-I-watch-or-subscribe-to-a-wiki-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki" name="description">
 <meta content="notifications" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_wikiInstructorGuide/What-is-the-Wiki-tool-.html
+++ b/help/help/src/sakai_screensteps_wikiInstructorGuide/What-is-the-Wiki-tool-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.rwiki, main" name="description">
 <meta content="collaborative, web authoring, RSS, subscribe" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-are-sites-deleted-.html
+++ b/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-are-sites-deleted-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sites" name="description">
 <meta content="remove site, purge course data, purge site, delete site, delete course, remove course" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-do-I-Hard-Delete-a-site-.html
+++ b/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-do-I-Hard-Delete-a-site-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitesetup, sakai.sites" name="description">
 <meta content="remove site, remove course, purge course, purge site data, delete course" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-do-I-Soft-Delete-a-site-from-Worksite-Setup-.html
+++ b/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-do-I-Soft-Delete-a-site-from-Worksite-Setup-.html
@@ -6,8 +6,8 @@
 <meta content="saka.sitesetup" name="description">
 <meta content="delete course, remove course, remove site" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-do-I-define-the-default-set-of-tools-added-to-site-on-site-creation-.html
+++ b/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-do-I-define-the-default-set-of-tools-added-to-site-on-site-creation-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitesetup" name="description">
 <meta content="standard toolset" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){

--- a/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-does-Worksite-Setup-differ-for-admin-users-.html
+++ b/help/help/src/sakai_screensteps_worksiteSetupAdministratorGuide/How-does-Worksite-Setup-differ-for-admin-users-.html
@@ -6,8 +6,8 @@
 <meta content="sakai.sitesetup" name="description">
 <meta content="" name="search">
 <link href="/library/skin/tool_base.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
-<link href="/library/skin/neo-default/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/library/skin/morpheus-default/tool.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
+<link href="/sakai-help-tool/css/help.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <link href="/library/js/jquery/featherlight/0.4.0/featherlight.min.css" media="screen" rel="stylesheet" type="text/css" charset="utf-8">
 <script src="/library/js/jquery/jquery-1.11.3.min.js" type="text/javascript" charset="utf-8"></script><script src="/library/js/jquery/featherlight/0.4.0/featherlight.min.js" type="text/javascript" charset="utf-8"></script><script type="text/javascript" charset="utf-8">
     $(document).ready(function(){


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29958

The section "Tool Help" starts with the question mark icon on a new line, all by itself. This can give the user the impression that there is a missing image or element here, rather than the reality which is it's showing you the help icon.

The linked PR refactors the markup to inline the image:

"... the Help icon ( [?] ) in the tool title bar."

The PR also removes references to /library/skin/neo-default/*, as this directory no longer exists, and re-introduces help.css as a local file in the help project to improve the look and feel of the help content.