### PR TITLE
KNL-1385 wrap calls to advisors in try/catch to avoid an advisor preventing a save

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
@@ -623,7 +623,11 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 
 		// allow any advisors to make last minute changes 
 		for (AuthzGroupAdvisor authzGroupAdvisor : authzGroupAdvisors) {
-			authzGroupAdvisor.update(azGroup);
+			try {
+				authzGroupAdvisor.update(azGroup);
+			} catch (Exception e) {
+				M_log.error("Advisor error during completeSave()", e);
+			}
 		}
 		// complete the azGroup
 		m_storage.save(azGroup);
@@ -680,7 +684,11 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 
 		// allow any advisors to make last minute changes 
 		for (AuthzGroupAdvisor authzGroupAdvisor : authzGroupAdvisors) {
-			authzGroupAdvisor.groupUpdate(azGroup, userId, roleId);
+			try {
+				authzGroupAdvisor.groupUpdate(azGroup, userId, roleId);
+			} catch (Exception e) {
+				M_log.error("Advisor error during addMemberToGroup()", e);
+			}
 		}
 		
 		// add user to the azGroup
@@ -716,7 +724,11 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 
 		// allow any advisors to make last minute changes 
 		for (AuthzGroupAdvisor authzGroupAdvisor : authzGroupAdvisors) {
-			authzGroupAdvisor.groupUpdate(azGroup, userId, azGroup.getMember(userId).getRole().getId());
+			try {
+				authzGroupAdvisor.groupUpdate(azGroup, userId, azGroup.getMember(userId).getRole().getId());
+			} catch (Exception e) {
+				M_log.error("Advisor error during removeMemberFromGroup()", e);
+			}
 		}
 		// remove user from the azGroup
 		m_storage.removeUser(azGroup, userId);
@@ -860,7 +872,11 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 
 		// allow any advisors to make last minute changes 
 		for (AuthzGroupAdvisor authzGroupAdvisor : authzGroupAdvisors) {
-			authzGroupAdvisor.remove(azGroup);
+			try {
+				authzGroupAdvisor.remove(azGroup);
+			} catch (Exception e) {
+				M_log.error("Advisor error during removeAuthzGroup()", e);
+			}
 		}
         // KNL-1230 handle removal of authzgroups by processing caching changes
         try {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -961,7 +961,13 @@ public abstract class BaseSiteService implements SiteService, Observer
 
 		// Give the site advisors, if any, a chance to make last minute changes to the site
 		for(Iterator<SiteAdvisor> iter = siteAdvisors.iterator(); iter.hasNext();) {
-			iter.next().update(site);
+			try {
+				iter.next().update(site);
+			}
+			catch (Exception e)
+			{
+				M_log.error("Advisor error in doSave()", e);
+			}
 		}
 
 		site.setFullyLoaded(true);


### PR DESCRIPTION
The basic idea is that advisors do ancillary tasks: e.g., insert a privacy record into a separate table. But the advisor should never be able to throw an error (e.g., a Hibernate constraint error) that will cause the entire save to fail.