### PR TITLE
SAK-29980 Fixed the sakai build for the config module.

### DIFF
--- a/config/configuration/bundles/pom.xml
+++ b/config/configuration/bundles/pom.xml
@@ -79,6 +79,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<delimiters>
+						<delimiter>$${*}</delimiter>
+					</delimiters>
+					<useDefaultDelimiters>false</useDefaultDelimiters>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Changed the pom.xml for config folder.
Added specific delimiter $ and removed '@' from the list and defaultdelimiter is set to false