### PR TITLE
SAM-2605 Show crossmark in EMI questions

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverExtendedMatchingItems.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverExtendedMatchingItems.jsp
@@ -100,9 +100,8 @@ should be included in file importing DeliveryMessages
             alt="#{deliveryMessages.alt_correct}" url="/images/checkmark.gif" >
           </h:graphicImage>
           <h:graphicImage id="image2"
-            rendered="#{responseAndCorrectStatus.isCorrect ne 'true'}"
-            width="16" height="16"
-            alt="#{deliveryMessages.alt_incorrect}" url="/images/delivery/spacer.gif">
+            rendered="#{responseAndCorrectStatus.isCorrect eq 'false'}"
+            alt="#{deliveryMessages.alt_incorrect}" url="/images/crossmark.gif">
           </h:graphicImage>
         </h:column>
         <h:column>


### PR DESCRIPTION
A minor change to show the crossmark instead of a blank space.
From now on, the behaviour will be:
 * If the response is correct shows the checkmark
 * If the response is incorrect shows the crossmark
 * If there is no respones shows nothing