### PR TITLE
SAK-29988 Usability improvements for Syllabus

### DIFF
--- a/syllabus/syllabus-app/src/bundle/org/sakaiproject/tool/syllabus/bundle/Messages.properties
+++ b/syllabus/syllabus-app/src/bundle/org/sakaiproject/tool/syllabus/bundle/Messages.properties
@@ -32,9 +32,9 @@ bar_ok=ok
 bar_rearrange=Rearrange Items
 bar_save=save
 bar_new=Add
+bar_publish=Add and Publish
 bar_edit=edit
 bar_back=back
-bar_post=Post
 bar_preview=Preview
 bar_save_draft=Save Draft
 bar_redirect=Redirect
@@ -118,7 +118,7 @@ mainEditNotice=Syllabus Items
 mainEditHeaderItem=Syllabus Item
 mainEditLinkUpTitle=Move item up
 mainEditLinkDownTitle=Move item down
-mainEditHeaderStatus=Post
+mainEditHeaderStatus=Publish
 mainEditHeaderRemove=Remove
 mainCaption=This table presents in one column all the syllabus items. Each group of three rows presents the title of the item, the body, and any attachments to the item.  
 mainEditListSummary=List of syllabus items. Each row represents an item. Column 1: item title. Column 2: link to move item up in list. Column 3: link to move item down in list. Column 4: item status. Column 5: checkbox to select item for deletion.
@@ -152,7 +152,7 @@ last_modified=Last modified
 openLinkNewWindow=Open this link in a new window
 goToItem=Go to item
 selectThisCheckBox=Select to Remove
-selectThisCheckBoxPost=Select to Post
+selectThisCheckBoxPost=Select to Publish
 selectThisCheckBoxCal=Select to Link to Calendar
 attachmentTitle=Title
 publicPrivate=Select public or to site only
@@ -162,13 +162,13 @@ save=Save
 back=Back
 revise=Edit
 permission_error_permission=You have no permission for this action!
-posted=Posted
+posted=Published
 draft=Draft
 
 button_save=Save this item
 button_cancel=Cancel - go back
 button_preview=Preview this item
-button_post=Post this item
+button_publish=Publish this item
 
 print_friendly = View a printable version of the current page
 send_to_printer=Send To Printer
@@ -265,3 +265,5 @@ clickToExpandAndCollapse=Click to expand/collapse, change attachments or edit bo
 
 iframeSecurity=For increased security, URL's that begin with 'http' rather than 'https' will open in a new window or tab.  If the page did not automatically open, click <a href='{0}' target="_blank">here</a>
 syllabus_PopupBlocked=If pop-up is blocked, <a target="syllabus" href="{0}">click here</a> or allow pop-ups.
+
+draftTitlePrefix=DRAFT -

--- a/syllabus/syllabus-app/src/java/org/sakaiproject/tool/syllabus/entityproviders/SyllabusEntityProvider.java
+++ b/syllabus/syllabus-app/src/java/org/sakaiproject/tool/syllabus/entityproviders/SyllabusEntityProvider.java
@@ -1,9 +1,8 @@
 package org.sakaiproject.tool.syllabus.entityproviders;
 
-import java.io.Serializable;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -40,7 +39,9 @@ import org.sakaiproject.entitybroker.entityprovider.search.Search;
 import org.sakaiproject.entitybroker.exception.EntityNotFoundException;
 import org.sakaiproject.entitybroker.util.AbstractEntityProvider;
 import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.InUseException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
@@ -63,6 +64,8 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 
 	/**
 	 * site/siteId
+	 * @param view
+	 * @return 
 	 */
 	@EntityCustomAction(action = "site", viewKey = EntityView.VIEW_LIST)
 	public Syllabus getSyllabusForSite(EntityView view) {
@@ -117,7 +120,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 		//Get the data
 		Set syllabusData = syllabusManager.getSyllabiForSyllabusItem(siteSyllabus);
 		
-		List<Item> items = new ArrayList<Item>();
+		List<Item> items = new ArrayList<>();
 		Iterator iter = syllabusData.iterator();
 		while(iter.hasNext()) {
 			SyllabusData sd = (SyllabusData)iter.next();
@@ -154,7 +157,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 			item.setEndDate(endDate);
 			
 			//get the attachments
-			List<Attachment> attachments = new ArrayList<Attachment>();
+			List<Attachment> attachments = new ArrayList<>();
 			Set syllabusAttachments = syllabusManager.getSyllabusAttachmentsForSyllabusData(sd);
 			Iterator iter2 = syllabusAttachments.iterator();
 			while(iter2.hasNext()) {
@@ -285,8 +288,18 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 					title = title.trim();
 					if(!"".equals(title)){
 						SyllabusItem item = syllabusManager.getSyllabusItemByContextId(siteId);
-						int initPosition = syllabusManager.findLargestSyllabusPosition(item).intValue() + 1;
-						String published = ServerConfigurationService.getBoolean("syllabus.new.published.default", false) ? SyllabusData.ITEM_POSTED : SyllabusData.ITEM_DRAFT; 
+						int initPosition = syllabusManager.findLargestSyllabusPosition(item) + 1;
+
+						String published;
+						if( params.containsKey( "published" ) )
+						{
+							published = Boolean.parseBoolean( params.get( "published" ).toString() ) ? SyllabusData.ITEM_POSTED : SyllabusData.ITEM_DRAFT;
+						}
+						else
+						{
+							published = ServerConfigurationService.getBoolean("syllabus.new.published.default", false) ? SyllabusData.ITEM_POSTED : SyllabusData.ITEM_DRAFT; 
+						}
+
 						SyllabusData data = syllabusManager.createSyllabusDataObject(title, new Integer(initPosition), null, null, published, "none", null, null, Boolean.FALSE, null, null);
 						data.setView("no");
 						try {
@@ -328,7 +341,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 						if(data != null){
 							boolean foundItem = false;
 							int arrayCount = 0;
-							List<SyllabusData> movedData = new ArrayList<SyllabusData>();
+							List<SyllabusData> movedData = new ArrayList<>();
 							String error = "";
 							Set syllabusData = syllabusManager.getSyllabiForSyllabusItem(item);
 							if(syllabusData != null){
@@ -362,8 +375,8 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 											//but can be a random pattern like 1,4,5,6,9...  This means we can only swap positions
 											Integer p1 = data.getPosition();
 											Integer p2 = d.getPosition();
-											data.setPosition(new Integer(p2));
-											d.setPosition(new Integer(p1));
+											data.setPosition(p2);
+											d.setPosition(p1);
 										}else{
 											//this isn't being moved
 											iterator.remove();
@@ -393,7 +406,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 					}else if("body".equals(params.get("name"))){
 						String body = (String) params.get("value");
 						StringBuilder alertMsg = new StringBuilder();
-			        	String cleanedText = null;
+			        	String cleanedText;
 			    		try
 			    		{
 			    			cleanedText  =  FormattedText.processFormattedText(body, alertMsg);
@@ -419,7 +432,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 								}else{
 									throw new IllegalArgumentException("End Date must be after start date");
 								}
-							}catch(Exception e){
+							}catch(ParseException | IllegalArgumentException e){
 								log.error(e.getMessage(), e);
 								throw new IllegalArgumentException("Date isn't in the correct format: " + startDate + ", should be: yyyy-MM-dd HH:mm");
 							}
@@ -437,7 +450,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 								}else{
 									throw new IllegalArgumentException("End Date must be after start date");
 								}
-							} catch (Exception e) {
+							} catch (ParseException | IllegalArgumentException e) {
 								log.error(e.getMessage(), e);
 								throw new IllegalArgumentException("Date isn't in the correct format: " + endDate + ", should be: yyyy-MM-dd HH:mm");
 							}
@@ -487,7 +500,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 						if(id.toLowerCase().startsWith("/attachment"))
 							try{
 								contentHostingService.removeResource(id);
-							}catch(Exception e){
+							}catch(PermissionException | IdUnusedException | TypeException | InUseException e){
 								log.error(e.getMessage(), e);
 							}
 					}
@@ -512,7 +525,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 						if(attachmentIdStr.toLowerCase().startsWith("/attachment")){
 							try{
 								contentHostingService.removeResource(attachmentIdStr);
-							}catch(Exception e){
+							}catch(PermissionException | IdUnusedException | TypeException | InUseException e){
 								log.error(e.getMessage(), e);
 							}
 						}

--- a/syllabus/syllabus-app/src/webapp/js/syllabus.js
+++ b/syllabus/syllabus-app/src/webapp/js/syllabus.js
@@ -45,14 +45,14 @@ function setupAccordion(iframId, isInstructor, msgs, openDataId){
 			//find how much this item was dragged:
 			var dragEndIndex = ui.item.index();
 			var moved = dragStartIndex - dragEndIndex;
-			if(moved != 0){
+			if(moved !== 0){
 				//update the position:
 				postAjax($(ui.item).children(":first").attr("syllabusItem"), {"move": moved}, msgs);
 			}
 		}
 		});
 	}
-	if(activeVar === false && openDataId && openDataId != ''){
+	if(activeVar === false && openDataId && openDataId !== ''){
 		//instructor is working on this data item, keep it open and focused on when refreshing
 		$( "#accordion div[syllabusItem=" + openDataId + "].group .ui-accordion-header").click().focus();
 		
@@ -75,7 +75,7 @@ function mySetMainFrameHeight(id, minHeight)
 {
 	// run the script only if this window's name matches the id parameter
 	// this tells us that the iframe in parent by the name of 'id' is the one who spawned us
-	if (typeof window.name != "undefined" && id != window.name) return;
+	if (typeof window.name !== "undefined" && id !== window.name) return;
 
 	var frame = parent.document.getElementById(id);
 	if (frame)
@@ -90,16 +90,16 @@ function mySetMainFrameHeight(id, minHeight)
 		var clientH = document.body.clientHeight;
 		var innerDocScrollH = null;
 
-		if (typeof(frame.contentDocument) != 'undefined' || typeof(frame.contentWindow) != 'undefined')
+		if (typeof(frame.contentDocument) !== 'undefined' || typeof(frame.contentWindow) !== 'undefined')
 		{
 			// very special way to get the height from IE on Windows!
 			// note that the above special way of testing for undefined variables is necessary for older browsers
 			// (IE 5.5 Mac) to not choke on the undefined variables.
  			var innerDoc = (frame.contentDocument) ? frame.contentDocument : frame.contentWindow.document;
-			innerDocScrollH = (innerDoc != null) ? innerDoc.body.scrollHeight : null;
+			innerDocScrollH = (innerDoc !== null) ? innerDoc.body.scrollHeight : null;
 		}
 
-		if (document.all && innerDocScrollH != null)
+		if (document.all && innerDocScrollH !== null)
 		{
 			// IE on Windows only
 			height = innerDocScrollH;
@@ -163,7 +163,7 @@ function setupEditable(msgs, iframId){
 			postAjax($(this).parents('div.group').attr("syllabusItem"), params, msgs);
 		},
 		validate: function(value) {
-		    if($.trim(value) == '') {
+		    if($.trim(value) === '') {
 		        return msgs.required;
 		    }
 		}
@@ -325,14 +325,14 @@ function showMessage(message, success){
 	//set topPos to top of the scroll bar for this iFrame
 	try{
 		topPos = $(window.parent.$("html,body")).scrollTop();
-		if(topPos == 0){
+		if(topPos === 0){
 			//try a different method to be sure
 			topPos = $(window.parent.$("body")).scrollTop();
 		}
 	}catch(e){}
 	//if this is an iframe, adjust top by the offset of the iframe
 	try{
-		if(topPos != 0){
+		if(topPos !== 0){
 			topPos = topPos - $(window.parent.$("iframe")).offset().top; 
 		}
 	}catch(e){}
@@ -347,7 +347,7 @@ function showMessage(message, success){
 }
 
 function postAjax(id, params, msgs){
-	var d = $.Deferred
+	var d = $.Deferred;
 	$.ajax({
 		type: 'POST',
 		url: "/direct/syllabus/" + id + ".json",
@@ -371,7 +371,7 @@ function postAjax(id, params, msgs){
 
 function getDateTime(dateTimeStr){
 	var split = dateTimeStr.split(" ");
-	if(split.length == 3){
+	if(split.length === 3){
 		var dateStr = split[0];
 		var timeStr = split[1] + " " + split[2];
 		var date = new Date(Date.parse(dateStr));
@@ -389,14 +389,14 @@ function setupToggleImages(action, imgClass, classOn, classOff, msgs){
 	$("." + imgClass).click(function(event){
 		var status;
 		//custom action for calendar:
-		if(action == "linkCalendar"){
+		if(action === "linkCalendar"){
 			//make sure at least one date is set
 			if(!$(this).hasClass(classOn)){
 				//only warn user is they are turning on the calendar sync
 				var startTime = $(this).parents('div.group').find(".startTimeInput").text();
 				var endTime = $(this).parents('div.group').find(".endTimeInput").text();
-				if((startTime == null || "" == $.trim(startTime) || $.trim(startTime) == $.trim(msgs.clickToAddStartDate))
-						&& (endTime == null || "" == $.trim(endTime) || $.trim(endTime) == $.trim(msgs.clickToAddEndDate))){
+				if((startTime === null || "" === $.trim(startTime) || $.trim(startTime) === $.trim(msgs.clickToAddStartDate))
+						&& (endTime === null || "" === $.trim(endTime) || $.trim(endTime) === $.trim(msgs.clickToAddEndDate))){
 					showMessage(msgs.calendarDatesNeeded, false);
 					event.stopPropagation();
 					return;
@@ -416,12 +416,15 @@ function setupToggleImages(action, imgClass, classOn, classOff, msgs){
 			$(this).parents('div.group').find("." + classOn).fadeIn();
 		}
 		//custom action for publish and unpublish:
-		if(action == "publish"){
+		if(action === "publish"){
 			//toggle the draft class
 			if(status){
 				$(this).parent().find(".editItemTitle").parent().removeClass("draft");
+				$(this).parent().find( ".draftTitlePrefix " ).remove();
 			}else{
 				$(this).parent().find(".editItemTitle").parent().addClass("draft");
+				var span = "<span class='draftTitlePrefix'>" + msgs.draftTitlePrefix + "</span>";
+				$(this).parent().find(".editItemTitle").parent().prepend( span );
 			}
 		}
 		
@@ -504,9 +507,37 @@ function showConfirmDelete(deleteButton, msgs, event){
 	event.stopPropagation();
 }
 
+function doAddItemButtonClick( msgs, published )
+{
+	var title = $( "#newTitle" ).val();
+	if( !title || "" === title.trim() )
+	{
+		$( "#requiredTitle" ).show();
+		setTimeout( function() { $( "#requiredTitle" ).fadeOut(); }, 5000 );
+	}
+	else
+	{
+		// ID doesn't exist since we're adding a new one
+		var id = "0";
+		params = 
+		{
+			"add" : true,
+			"title": title,
+			"siteId": $("#siteId").val(),
+			"published": published
+		
+		};
+
+		postAjax( id, params, msgs );
+		if( $( "#successInfo" ).is( ":visible" ) )
+		{
+			location.reload();
+		}
+	}
+}
+
 function showConfirmAdd(msgs, mainframeId){
 	$('#container', this.top.document).append("<div></div>");
-	var emptyDiv = $('<div></div>', this.top.document);
 	$('<div></div>').appendTo('body')
 		.html("<div><h6>" + msgs.syllabus_title + "</h6><input type='text' id='newTitle'/></div><div style='display:none' id='requiredTitle' class='warning'>" + msgs.required + "</div>" +
 				"<h6>" + msgs.syllabus_content + "</h6><div class='bodyInput' id='newContentDiv'><textarea cols='120' id='newContentTextAreaWysiwyg'/></div>")
@@ -525,34 +556,12 @@ function showConfirmAdd(msgs, mainframeId){
 			resizable: true,
 			buttons: [
 				{
+					text: msgs.bar_publish,
+					click: function() { doAddItemButtonClick( msgs, true ); $( this ).dialog( "close" ); }
+				},
+				{
 					text: msgs.bar_new,
-					click: function () {
-						var title = $("#newTitle").val();
-						if(!title || "" == title.trim()){
-							$("#requiredTitle").show();
-							setTimeout(
-								function(){
-									$("#requiredTitle").fadeOut();
-								},
-								5000
-							);
-						}else{
-							$("#newContentTextAreaWysiwyg").val($('#newContentDiv').find('iframe').contents().find('body').html()).change();
-							// id doesn't exist since we are adding a new one
-							var id = "0";
-							params = {
-								"add" : true,
-								"title": title,
-								"siteId": $("#siteId").val(),
-								"content": $("#newContentTextAreaWysiwyg").val()
-							};
-							postAjax(id, params, msgs);
-							if($("#successInfo").is(":visible")){
-								location.reload();
-							}
-							$(this).dialog("close");
-						}
-					}
+					click: function() { doAddItemButtonClick( msgs, false ); $( this ).dialog( "close" ); }
 				},
 				{
 					text: msgs.bar_cancel,
@@ -578,5 +587,5 @@ function showConfirmAdd(msgs, mainframeId){
 if(typeof String.prototype.trim !== 'function') {
 	String.prototype.trim = function() {
 		return this.replace(/^\s+|\s+$/g, ''); 
-	}
+	};
 }

--- a/syllabus/syllabus-app/src/webapp/syllabus/css/syllabus.css
+++ b/syllabus/syllabus-app/src/webapp/syllabus/css/syllabus.css
@@ -445,7 +445,7 @@ a.draft{
 .actionIcon{
 	padding-right: .5em;
 }
-.editItemTitle{
+.editItemTitle, .draftTitlePrefix {
 	padding-left: .5em;
 }
 

--- a/syllabus/syllabus-app/src/webapp/syllabus/edit.jsp
+++ b/syllabus/syllabus-app/src/webapp/syllabus/edit.jsp
@@ -201,9 +201,9 @@
 					<h:commandButton
 						action="#{SyllabusTool.processEditPost}"
 						styleClass="active"
-						value="#{msgs.bar_post}" 
+						value="#{msgs.bar_publish}"
 						accesskey="s"
-						title="#{msgs.button_post}" />
+						title="#{msgs.button_publish}" />
 					<h:commandButton
 						action="#{SyllabusTool.processEditPreview}"
 						value="#{msgs.bar_preview}"

--- a/syllabus/syllabus-app/src/webapp/syllabus/edit_bulk.jsp
+++ b/syllabus/syllabus-app/src/webapp/syllabus/edit_bulk.jsp
@@ -270,13 +270,13 @@
 					<h:commandButton
 						action="#{SyllabusTool.processEditBulkPost}"
 						styleClass="active"
-						value="#{msgs.bar_post}" 
+						value="#{msgs.bar_publish}" 
 						accesskey="s"
-						title="#{msgs.button_post}" />
+						title="#{msgs.button_publish}" />
 					<h:commandButton
 						action="#{SyllabusTool.processEditBulkDraft}"
 						styleClass="active"
-						value="#{msgs.bar_save_draft}" 
+						value="#{msgs.bar_new}" 
 						accesskey="s"
 						title="#{msgs.button_save}" />
 					<h:commandButton

--- a/syllabus/syllabus-app/src/webapp/syllabus/main.jsp
+++ b/syllabus/syllabus-app/src/webapp/syllabus/main.jsp
@@ -65,7 +65,9 @@
 				deleteItemTitle: $("#messages #deleteItemTitle").html(),
 				deleteAttachmentTitle: $("#messages #deleteAttachmentTitle").html(),
 				bar_new: $("#messages #bar_new").html(),
-				addItemTitle: $("#messages #addItemTitle").html()
+				bar_publish: $("#messages #bar_publish").html(),
+				addItemTitle: $("#messages #addItemTitle").html(),
+				draftTitlePrefix: $("#messages #draftTitlePrefix").html()
 			};
 		setupAccordion('<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>',<h:outputText value="#{SyllabusTool.editAble == 'true' ? true : false}"/>, msgs, 
 							'<h:outputText value="#{SyllabusTool.openDataId}"/>');
@@ -248,6 +250,7 @@
 								<f:verbatim>class="draft"</f:verbatim>
 							</f:subview>
 							<f:verbatim>></f:verbatim>
+							<h:outputText styleClass="draftTitlePrefix" rendered="#{eachEntry.status == eachEntry.draftStatus}" value="#{msgs.draftTitlePrefix}" />
 							<h:outputText styleClass="editItem editItemTitle" value="#{eachEntry.entry.title}" />
 							<f:subview id="dateStudent" rendered="#{!SyllabusTool.editAble && (eachEntry.entry.startDate != null || eachEntry.entry.endDate != null)}">
 								<f:verbatim><span style="font-weight: normal; color: grey; float: right"></f:verbatim>
@@ -379,7 +382,9 @@
 				<span id="deleteItemTitle"></f:verbatim><h:outputText value="#{msgs.deleteItemTitle}"/><f:verbatim></span>
 				<span id="deleteAttachmentTitle"></f:verbatim><h:outputText value="#{msgs.addItemTitle}"/><f:verbatim></span>
 				<span id="bar_new"></f:verbatim><h:outputText value="#{msgs.bar_new}"/><f:verbatim></span>
+				<span id="bar_publish"></f:verbatim><h:outputText value="#{msgs.bar_publish}" /><f:verbatim></span>
 				<span id="addItemTitle"></f:verbatim><h:outputText value="#{msgs.addItemTitle}"/><f:verbatim></span>
+				<span id="draftTitlePrefix"></f:verbatim><h:outputText value="#{msgs.draftTitlePrefix}"/><f:verbatim></span>
 			</span>
 		</f:verbatim>
 	</sakai:view_content>

--- a/syllabus/syllabus-app/src/webapp/syllabus/main_edit.jsp
+++ b/syllabus/syllabus-app/src/webapp/syllabus/main_edit.jsp
@@ -325,7 +325,7 @@
 									</f:verbatim>
 								</h:panelGroup>
 							</f:facet>
-							<h:selectBooleanCheckbox styleClass="postBox" value="#{eachEntry.posted}" title="#{msgs.selectThisCheckBoxPost}" onchange="toggleCalendarCheckbox(this);"/>
+							<h:selectBooleanCheckbox styleClass="postBox" value="#{eachEntry.posted}" title="#{msgs.selectThisCheckBoxPublish}" onchange="toggleCalendarCheckbox(this);" />
 						</h:column>
 						<h:column rendered="#{! SyllabusTool.displayNoEntryMsg}">
 							<f:facet name="header">

--- a/syllabus/syllabus-app/src/webapp/syllabus/read.jsp
+++ b/syllabus/syllabus-app/src/webapp/syllabus/read.jsp
@@ -212,7 +212,7 @@
 					<h:commandButton
 						action="#{SyllabusTool.processReadPost}"
 						styleClass="active"
-						value="#{msgs.bar_post}"
+						value="#{msgs.bar_publish}"
 						accesskey="s" />
 					<h:commandButton
 						action="#{SyllabusTool.processReadPreview}"


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29988

This PR introduces the following usability improvements:
* add/change buttons on Add Item and Bulk Add Item to be explicit regarding published status (Instead of one button obeying the sakai.property, there are now three buttons for each UI; Add and Publish, Add, and Cancel)
    * will still fall back to sakai.property if the 'published' parameter is not included in the REST call
* change occurances of the word 'Post' to 'Publish' for consistency across interfaces
* add the prefix 'DRAFT - ' to the non-editable portion of a draft item's title, to visually reinforce the idea that the item is not published (this is how other tools handle this as well, such as Assignments, Announcements and Forums)

While I was in the project/files, I fixed up some minor JavaScript issues and switched some syntax to Java 7 style.