### PR TITLE
LSNBLDR-533; fix issues with uploading files

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -1870,6 +1870,9 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 		String action = request.getParameter("sakai_action");
 		logger.debug("Received action: "+action+" for file: "+fullPath);
 		
+		// set up rundata, in case we're called from RSF
+		checkRunData(request);
+
 		if(fullPath != null)
 		{
 			Long fileSize = Long.parseLong(request.getHeader("content-length"));

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -1953,11 +1953,14 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 		{
 			if (action!=null)
 			{
+			    JetspeedRunData rundata = (JetspeedRunData) request.getAttribute(ATTR_RUNDATA);
+			    if (checkCSRFToken(request,rundata,action)) {
 				if (action.equals("doFinishUpload"))
 				{
 					notifyDragAndDropCompleted(request);
 				}
 				super.doPost(request, response);
+			    }
 			}
 			else
 			{

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -1167,28 +1167,48 @@ public class SimplePageBean {
 		    return "permission-failed";
 
 		ToolSession toolSession = sessionManager.getCurrentToolSession();
+		Long itemId = (Long)toolSession.getAttribute(LESSONBUILDER_ITEMID);
+		addBefore = (String)toolSession.getAttribute(LESSONBUILDER_ADDBEFORE);
+		toolSession.removeAttribute(LESSONBUILDER_ITEMID);
+		toolSession.removeAttribute(LESSONBUILDER_ADDBEFORE);
+
+		if (!itemOk(itemId))
+		    return "permission-failed";
+
+		// if itemId specified, better only be one resource, since we replacing an existing one
+
 		List<Reference> refs = null;
 		String returnMesssage = null;
 
 		if (toolSession.getAttribute(FilePickerHelper.FILE_PICKER_CANCEL) == null && toolSession.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS) != null) {
-
 			refs = (List) toolSession.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
 			//Changed 'refs.size != 1' to refs.isEmpty() as there can be multiple Resources
-			if (refs == null || refs.isEmpty()) {
+			// more than one is an error if replacing an existing one
+			if (refs == null || refs.isEmpty())
 				return "no-reference";
+			// if item id specified, use first item only. Can't really return an error because of the way
+			// the UI works
+			if (itemId != null && itemId != -1)
+				returnMesssage = processSingleResource(refs.get(0), type, isWebSite, isCaption, itemId);
+			else {
+			    for(Reference reference : refs){
+				returnMesssage = processSingleResource(reference, type, isWebSite, isCaption, itemId);
+			    }
 			}
-			for(Reference reference : refs){
-				returnMesssage = processSingleResource(reference, type, isWebSite, isCaption);
-			}
+			toolSession.removeAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
+			toolSession.removeAttribute(FilePickerHelper.FILE_PICKER_CANCEL);
 		} else {
+			toolSession.removeAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
+			toolSession.removeAttribute(FilePickerHelper.FILE_PICKER_CANCEL);
+
 			return "cancel";
 		}
 
 		return returnMesssage;
-	}
+        }
 
 	//This method is written to enable user to select multiple Resources from the tool
-	private String processSingleResource(Reference reference,int type, boolean isWebSite, boolean isCaption){
+	private String processSingleResource(Reference reference,int type, boolean isWebSite, boolean isCaption, Long itemId){
 
 		ToolSession toolSession = sessionManager.getCurrentToolSession();
 		String id  = reference.getId();
@@ -1255,17 +1275,6 @@ public class SimplePageBean {
 		// }finally {
 		//   if(pushed) popAdvisor();
 		//}
-
-		Long itemId = (Long)toolSession.getAttribute(LESSONBUILDER_ITEMID);
-		addBefore = (String)toolSession.getAttribute(LESSONBUILDER_ADDBEFORE);
-
-		if (!itemOk(itemId))
-		    return "permission-failed";
-
-		toolSession.removeAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
-		toolSession.removeAttribute(FilePickerHelper.FILE_PICKER_CANCEL);
-		toolSession.removeAttribute(LESSONBUILDER_ITEMID);
-		toolSession.removeAttribute(LESSONBUILDER_ADDBEFORE);
 
 		String[] split = id.split("/");
 
@@ -1384,7 +1393,7 @@ public class SimplePageBean {
 		// ideally the following should be the same, but there can be odd cases. So be safe
 		long before = 0;
 		boolean addAfter = false;
-		if (addBefore.startsWith("-")) {
+		if (addBefore != null && addBefore.startsWith("-")) {
 		    addAfter = true;
 		    addBefore = addBefore.substring(1);
 		}

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ResourcePickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ResourcePickerProducer.java
@@ -119,15 +119,21 @@ public class ResourcePickerProducer implements ViewComponentProducer, ViewParams
                 UIOutput.make(tofill, "html").decorate(new UIFreeAttributeDecorator("lang", localeGetter.get().getLanguage()))
 		    .decorate(new UIFreeAttributeDecorator("xml:lang", localeGetter.get().getLanguage()));        
 
+		Long itemId = ((FilePickerViewParameters) viewparams).getPageItemId();
+		
 		// parameters for helper
 		ToolSession toolSession = sessionManager.getCurrentToolSession();
 		toolSession.setAttribute(FilePickerHelper.FILE_PICKER_TITLE_TEXT, "Please Choose a File");
 		toolSession.setAttribute(FilePickerHelper.FILE_PICKER_INSTRUCTION_TEXT, messageLocator.getMessage("simplepage.filepicker_instructions"));
-		toolSession.setAttribute(FilePickerHelper.FILE_PICKER_MAX_ATTACHMENTS, FilePickerHelper.CARDINALITY_MULTIPLE);
+		// multiple files not valid if replacing an existing item
+		if (itemId == null || itemId == -1)
+		    toolSession.setAttribute(FilePickerHelper.FILE_PICKER_MAX_ATTACHMENTS, FilePickerHelper.CARDINALITY_MULTIPLE);
+		else
+		    toolSession.setAttribute(FilePickerHelper.FILE_PICKER_MAX_ATTACHMENTS, new Integer(1));
 		toolSession.setAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS, new ArrayList());
 		toolSession.setAttribute(FilePickerHelper.FILE_PICKER_RESOURCE_FILTER, null);
 		toolSession.setAttribute(FilePickerHelper.FILE_PICKER_ATTACH_LINKS, ServerConfigurationService.getString("lessonbuilder.attachlinks", "true"));
-		toolSession.setAttribute(SimplePageBean.LESSONBUILDER_ITEMID, ((FilePickerViewParameters) viewparams).getPageItemId());
+		toolSession.setAttribute(SimplePageBean.LESSONBUILDER_ITEMID, itemId);
 		toolSession.setAttribute(SimplePageBean.LESSONBUILDER_ADDBEFORE, ((FilePickerViewParameters) viewparams).getAddBefore());
 
 		if (simplePageBean.getCurrentPage().getOwner() != null) {

--- a/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
@@ -264,9 +264,8 @@
 		<property name="ltiService" ref="org.sakaiproject.lti.api.LTIService" />
 	</bean>
 	<!-- Over-riding the CommonsMultipartResolver to have multiple files incoming under the same form input name  -->
-	<bean id="multipartResolver" class="org.sakaiproject.lessonbuildertool.resolver.MultiCommonsMultipartResolver">
+	<bean id="commonsMultipartResolver" class="org.sakaiproject.lessonbuildertool.resolver.MultiCommonsMultipartResolver">
 	</bean>
-	
 	<bean name="gradingBean" class="org.sakaiproject.lessonbuildertool.tool.beans.GradingBean">
 		<property name="simplePageToolDao">
 			<ref bean="org.sakaiproject.lessonbuildertool.model.SimplePageToolDao" />

--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -422,6 +422,9 @@ a.edit-link:link, a.edit-link:visited, a.section-merge-link:link, a.section-merg
 .edit-col .ui-button-text, #submit-grading .ui-button-text, .portalmenu .ui-button-text {
 	font-size: 60%;
 }
+.edit-col {
+  font-size: 70%;
+}
 
 .buttonItem {
 	padding-left: 20px

--- a/velocity/tool/src/java/org/sakaiproject/cheftool/VelocityPortletPaneledAction.java
+++ b/velocity/tool/src/java/org/sakaiproject/cheftool/VelocityPortletPaneledAction.java
@@ -1178,6 +1178,19 @@ public abstract class VelocityPortletPaneledAction extends ToolServlet
 		super.doGet(req, res);
 	}
 
+	// Set up RunData if it's not already set up    
+
+        protected void checkRunData(HttpServletRequest req)
+	{
+		if (req.getAttribute(ATTR_RUNDATA) != null)
+		    return;
+
+		// set in VmServlet
+		ParameterParser params = (ParameterParser) req.getAttribute(ATTR_PARAMS);
+		JetspeedRunData rundata = new JetspeedRunData(req, getState(req), getPid(req), params);
+		req.setAttribute(ATTR_RUNDATA, rundata);
+	}
+
 	/** Tool session attribute name used to schedule a peer frame refresh. */
 	public static final String ATTR_FRAME_REFRESH = "sakai.vppa.frame.refresh";
 


### PR DESCRIPTION
Note that this isn't just in Lessons. The code in the picker didn't work when called from RSF. I've added a call to initialize RunData if it isn't already set up by Velocity.

I checked out as many combinations of uploads as I could come up with. This code fixes a number of minor issues in Lessons uploads, including a side effect of the changes to allow uploading multiple files.