### PR TITLE
SAK-29936: Add sakai.property to disable Forums Ranks feature - Phase 2 - disabling the feature in code

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -9720,10 +9720,13 @@ public class DiscussionForumTool
 	public Rank getAuthorRank(String userEid) {
 		// if both types of ranks exist for the same user, use the "Special rank assigned to selected site member(s)" type first.
 		Rank currRank = null;
-		currRank = findRankByUser(userEid);
-		if (currRank == null) {
-			int authorCount = messageManager.findAuthoredMessageCountForStudent(userEid);
-			currRank = findRankByMinPost(authorCount);
+		if (isRanksEnabled())
+		{
+			currRank = findRankByUser(userEid);
+			if (currRank == null) {
+				int authorCount = messageManager.findAuthoredMessageCountForStudent(userEid);
+				currRank = findRankByMinPost(authorCount);
+			}
 		}
 		return currRank;
 	}

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/RankManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/RankManagerImpl.java
@@ -21,6 +21,7 @@
 package org.sakaiproject.component.app.messageforums;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -33,6 +34,7 @@ import org.hibernate.Session;
 import org.sakaiproject.api.app.messageforums.Rank;
 import org.sakaiproject.api.app.messageforums.RankImage;
 import org.sakaiproject.api.app.messageforums.RankManager;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.RankImageImpl;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.RankImpl;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -72,6 +74,8 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
 
     private ContentHostingService contentHostingService;
 
+    private ServerConfigurationService serverConfigurationService;
+
     public void init() {
         LOG.info("init()");
     }
@@ -92,6 +96,15 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
         this.userDirectoryService = userDirectoryService;
     }
 
+    public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    public boolean isRanksEnabled()
+    {
+        return serverConfigurationService.getBoolean("msgcntr.forums.ranks.enable", true);
+    }
+
     private String getContextId() {
         if (TestUtil.isRunningTests()) {
             return "test-context";
@@ -102,6 +115,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
     }
 
     public void saveRank(Rank rank) {
+        if (!isRanksEnabled())
+        {
+            LOG.warn("saveRank invoked, but ranks are disabled");
+            return;
+        }
         rank.setUuid(getNextUuid());
         rank.setCreated(new Date());
         rank.setCreatedBy(getCurrentUser());
@@ -118,6 +136,10 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
         }
         if (contextId == null) {
             throw new IllegalArgumentException("Null Argument");
+        }
+        if (!isRanksEnabled())
+        {
+            return new ArrayList();
         }
         HibernateCallback hcb = new HibernateCallback() {
             public Object doInHibernate(Session session) throws HibernateException, SQLException {
@@ -138,6 +160,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
 
         if (contextId == null) {
             throw new IllegalArgumentException("Null Argument");
+        }
+
+        if (!isRanksEnabled())
+        {
+            return new ArrayList();
         }
 
         HibernateCallback hcb = new HibernateCallback() {
@@ -193,6 +220,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
 
     public void removeRank(Rank rank) {
         LOG.info("removeRank(Rank rank)");
+        if (!isRanksEnabled())
+        {
+            LOG.warn("removeRank invoked, but ranks are disabled");
+            return;
+        }
         if (rank.getRankImage() != null) {
             removeImageAttachmentObject(rank.getRankImage());
         }
@@ -201,6 +233,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
 
     public void removeImageAttachmentObject(RankImage o) {
         LOG.info("removeImageAttachmentObject(RankImage o)");
+        if (!isRanksEnabled())
+        {
+            LOG.warn("removeImageAttachmentObject invoked, but ranks are disabled");
+            return;
+        }
         getHibernateTemplate().delete(o);
     }
 
@@ -208,6 +245,12 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
         LOG.info("removeImageAttachToRank(final Rank rank, final RankImage imageAttach)");
         if (rank == null || imageAttach == null) {
             throw new IllegalArgumentException("Null Argument");
+        }
+
+        if (!isRanksEnabled())
+        {
+            LOG.warn("removeImageAttachToRank invoked, but ranks are disabled");
+            return;
         }
 
         HibernateCallback hcb = new HibernateCallback() {
@@ -249,6 +292,13 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
             throw new IllegalArgumentException("getRankById(): rankId is null");
         }
 
+        if (!isRanksEnabled())
+        {
+            // This is 'warn' because it implies some code is aware of a rank, but ranks are disabled
+            LOG.warn("getRankById invoked, but ranks are disabled");
+            return null;
+        }
+
         HibernateCallback hcb = new HibernateCallback() {
             public Object doInHibernate(Session session) throws HibernateException, SQLException {
                 Query q = session.getNamedQuery(QUERY_BY_RANK_ID);
@@ -262,6 +312,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
     }
 
     public RankImage createRankImageAttachmentObject(String attachId, String name) {
+        if (!isRanksEnabled())
+        {
+            LOG.warn("createRankImageAttachmentObject invoked, but ranks are disabled");
+            return null;
+        }
         try {
             RankImage attach = new RankImageImpl();
             attach.setCreated(new Date());
@@ -294,6 +349,12 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
 
         if (rank == null || imageAttach == null) {
             throw new IllegalArgumentException("Null Argument");
+        }
+
+        if (!isRanksEnabled())
+        {
+            LOG.warn("addImageAttachToRank invoked, but ranks are disabled");
+            return;
         }
 
         HibernateCallback hcb = new HibernateCallback() {
@@ -332,6 +393,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
             throw new IllegalArgumentException("Null Argument");
         }
 
+        if (!isRanksEnabled())
+        {
+            return new ArrayList();
+        }
+
         HibernateCallback hcb = new HibernateCallback() {
             public Object doInHibernate(Session session) throws HibernateException, SQLException {
                 Query q = session.getNamedQuery(QUERY_BY_CONTEXT_ID_USERID);
@@ -352,6 +418,11 @@ public class RankManagerImpl extends HibernateDaoSupport implements RankManager 
 
         if (contextId == null) {
             throw new IllegalArgumentException("Null Argument");
+        }
+
+        if (!isRanksEnabled())
+        {
+            return new ArrayList();
         }
 
         HibernateCallback hcb = new HibernateCallback() {

--- a/msgcntr/messageforums-components/src/webapp/WEB-INF/components.xml
+++ b/msgcntr/messageforums-components/src/webapp/WEB-INF/components.xml
@@ -680,7 +680,9 @@
 		        <property name="contentHostingService">
         		    <ref bean="org.sakaiproject.content.api.ContentHostingService"/>
 		        </property>
-		        
+				<property name="serverConfigurationService">
+					<ref bean="org.sakaiproject.component.api.ServerConfigurationService"/>
+				</property>
             </bean>           
         </property>
          <property name="transactionAttributes">


### PR DESCRIPTION
Because of the performance issues (SAK-29654) with the new Forum Ranks feature that we got in Sakai 10 (SAK-24854), we need to create a property to disable the Ranks system to avoid our database from crashing under the hundreds of thousands of queries per hour and the millions of CPU-intensive buffers each hour attribute to the Ranks feature.
However, because of the lack of time over the summer, we decided to implement this property in two phases:
Phase 1 - disable the Ranks page from the UI so that instructors and maintainers cannot add Ranks (SAK-29934)
Phase 2 - disable the Ranks feature throughout the code (this ticket)
For this ticket, create a property (or replace/reuse the property from SAK-29934) that disables all of the Ranks feature code from Forums for institutions that don't want to use the feature or those that need to avoid the performance issues.