### PR TITLE
SAK-30002 joinable sets UI doesn't trim some user inputs

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -1639,6 +1639,7 @@ public class SiteManageGroupSectionRoleHandler {
 			return null;
 		}
     	int joinableSetNumOfGroupsInt;
+    	joinableSetNumOfGroups = StringUtils.trimToEmpty( joinableSetNumOfGroups );
     	if(joinableSetNumOfGroups == null || "".equals(joinableSetNumOfGroups)){
     		messages.addMessage(new TargettedMessage("numGroups.empty.alert","num-groups"));
 			return null;
@@ -1658,6 +1659,7 @@ public class SiteManageGroupSectionRoleHandler {
 			}
     	}
     	int joinableSetNumOfMembersInt;
+    	joinableSetNumOfMembers = StringUtils.trimToEmpty( joinableSetNumOfMembers );
     	if(joinableSetNumOfMembers == null || "".equals(joinableSetNumOfMembers)){
     		messages.addMessage(new TargettedMessage("maxMembers.empty.alert","num-groups"));
 			return null;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30002

Some parts of the joinable sets UIs do not trim user input. For example, you can enter " 1" for number of groups or number of users per group when generating groups for a joinable set, and you will get a validation error.

Solution is to StringUtils.trimToEmpty() all user input fields.
