### PR TITLE
SAK-30001; assignment create/update doesn't show Turnitin errors in UI

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -897,7 +897,7 @@ content_review.error.SUBMISSION_ERROR_RETRY_EXCEEDED_CODE = All attempts to subm
 content_review.pending.info = This attachment has been submitted and is pending review.
 
 content_review.error = An unknown error occurred. The originality review for this attachment is not available.
-content_review.error.createAssignment=An error with {0} has occurred while creating this assignment. {1} has saved the assignment in draft mode. Please try posting this assignment again later.
+content_review.error.createAssignment=An error with {0} has occurred while creating this assignment. {1} has saved the assignment in draft mode. Please try posting this assignment again later. {2}
 content_review.note=<div><br /><em>NOTE:</em><ul><li>When submitting attachments, students should only use these file types: {0}.</li> <li>Students should always save files with the appropriate extension.</li> </ul></div>
 content_review.accepted.types.delimiter=,
 content_review.accepted.types.lparen=(

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -9510,7 +9510,7 @@ public class AssignmentAction extends PagedResourceActionII
         } catch (Exception e) {
             M_log.error(e);
 			String uiService = ServerConfigurationService.getString("ui.service", "Sakai");
-			String[] args = new String[]{contentReviewService.getServiceName(), uiService};
+			String[] args = new String[]{contentReviewService.getServiceName(), uiService, e.toString()};
             state.setAttribute("alertMessage", rb.getFormattedMessage("content_review.error.createAssignment", args));
         }
 		return false;


### PR DESCRIPTION
While this looks like it's low risk, I haven't been able to test it. I've tested the change in 10, but the way this message is generated changed between 10 and 11. I spent a couple of hours trying to get Turnitin running on 11 and failed. But we'll have to do it for production.