### PR TITLE
Make the travis log under the 4MB limit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # travis-ci currently has Maven 3.2 which doesn't read our .mvn folder
 # and https://github.com/travis-ci/travis-ci/issues/4613 means we can't set MAVEN_OPTS directly
-before_install: echo "MAVEN_OPTS='-Xms168m -Xmx1536m -XX:NewSize=64m -Djava.awt.headless=true'" > ~/.mavenrc
+before_install:
+  # To get some build progress you could have -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.event.ExecutionEventLogger=info
+  # but this results in more than 10,000 lines of build output
+  - echo "MAVEN_OPTS='-Xms168m -Xmx1536m -XX:NewSize=64m -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.defaultLogLevel=warn'" > ~/.mavenrc
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
When building with travis-ci you can't see the build output in the web if it's more than 4MB. To reduce the ammount of output but still get progress indicators so the build doesn't timeout we change the logging setup. Now errors are show but much less info level logging is shown.