### PR TITLE
Upgrade to the newer Sakai maven plugin.

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1612,7 +1612,7 @@
         <plugin>
           <groupId>org.sakaiproject.maven.plugins</groupId>
           <artifactId>sakai</artifactId>
-          <version>1.4.2</version>
+          <version>1.4.3</version>
         </plugin>
         <!-- OTHER maven plugins -->
         <plugin>


### PR DESCRIPTION
1.4.3 Fixes SMP-26 which means new deploy directories aren’t created automatically.