### PR TITLE
SAK-30042 Include missing properties when creating DecoratedAttachment in entityproducer

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -285,7 +285,10 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 		for (Reference attachment : (List<Reference>) a.getHeader().getAttachments()) {
 			String url = attachment.getUrl();
 			String name = attachment.getProperties().getPropertyFormatted(attachment.getProperties().getNamePropDisplayName());
-			DecoratedAttachment decoratedAttachment = new DecoratedAttachment(name, url);
+			String attachId = attachment.getId();
+			String type = attachment.getProperties().getProperty(attachment.getProperties().getNamePropContentType());
+			String attachRef = attachment.getReference();								
+			DecoratedAttachment decoratedAttachment = new DecoratedAttachment(attachId,name,type,url,attachRef);
 			attachments.add(decoratedAttachment);
 		}
 		da.setAttachments(attachments);


### PR DESCRIPTION
When the entityproducer is creating the list of announcements, It converts the attachments to the DecoratedAttachment class calling the constructor only with 2 parameters.
The constructor can be invoked with 5 parameters to have all the information of the attachment available.