### PR TITLE
SAK-30074 site info -> edit class roster(s) -> 'update' button issues

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -536,6 +536,7 @@ sitedicla.alert  = Alert:
 sitedicla.can    = Cancel
 sitedicla.class  = Roster
 sitedicla.rem    = Remove
+sitedicla.remsel = Remove Selected
 sitedicla.tabhol = Table holds the information of site classes.
 sitedicla.theis  = There is no class assigned to the site
 sitedicla.upd    = Update

--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -1050,3 +1050,42 @@ var toggleArchiveTermList = function() {
 
 }
 
+function checkEnableRemove()
+{
+    var selected = false;
+    var checkboxes = document.getElementsByName( "providerClassDeletes" );
+    if( checkboxes !== null )
+    {
+        selected = findSelectedInCheckboxes( checkboxes );
+    }
+
+    checkboxes = document.getElementsByName( "cmRequestedClassDeletes" );
+    if( checkboxes !== null && !selected )
+    {
+        selected = findSelectedInCheckboxes( checkboxes );
+    }
+
+    checkboxes = document.getElementsByName( "manualClassDeletes" );
+    if( checkboxes !== null && !selected )
+    {
+        selected = findSelectedInCheckboxes( checkboxes );
+    }
+
+    var btnRemove = document.getElementById( "btnRemove" );
+    btnRemove.disabled = !selected;
+    btnRemove.className = (selected ? "active" : "");
+}
+
+function findSelectedInCheckboxes( checkboxes )
+{
+    if( checkboxes !== null )
+    {
+        for( var i = 0; i < checkboxes.length; i++ )
+        {
+            if( checkboxes[i].checked )
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -6,7 +6,6 @@
 	<script type="text/javascript" src="/sakai-site-manage-tool/js/jquery.asmselect.js"></script>
 	<link type="text/css" href="/sakai-site-manage-tool/css/jquery.asmselect.css" rel="stylesheet" media="screen" />
 #end
-<script type="text/javascript" src="/sakai-site-manage-tool/js/site-manage.js"></script>
 <script type="text/javascript">
 <!-- hide from non-JS browsers
 	function checkPublish(checked)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -30,7 +30,7 @@
 							</label></h4>
 						</td>
 						<td headers="remove" class="screenOnly">
-							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="providerClassDeletes" value="$id" id="pcl$providerCourseListNum" />
+							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="providerClassDeletes" value="$id" id="pcl$providerCourseListNum" onclick="checkEnableRemove();" />
 						</td>
 					</tr>
 				#end
@@ -46,7 +46,7 @@
 							</h4>
 						</td>
 						<td headers="remove" class="screenOnly">
-							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="cmRequestedClassDeletes" value="$id.eid" id="cmrcl$cmRequestedCourseListNum" />
+							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="cmRequestedClassDeletes" value="$id.eid" id="cmrcl$cmRequestedCourseListNum" onclick="checkEnableRemove();" />
 						</td>
 					</tr>
 				#end
@@ -62,7 +62,7 @@
 							</h4>
 						</td>
 						<td headers="remove" class="screenOnly">
-							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="manualClassDeletes" value="$id" id="mcl$manualCourseListNum" />
+							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="manualClassDeletes" value="$id" id="mcl$manualCourseListNum" onclick="checkEnableRemove();" />
 						</td>
 					</tr>
 				#end
@@ -71,7 +71,7 @@
 				<input type="hidden" name="continue" value="$!templateIndex" />
 				<input type="hidden" name="back" value="12" />
 				<input type="hidden" name="templateIndex" value="$!templateIndex" />
-				<input type="submit" accesskey="s"  class="active" name="eventSubmit_doContinue" value="$tlang.getString("sitedicla.upd")" />
+				<input type="submit" accesskey="s" class="active" name="eventSubmit_doContinue" id="btnRemove" disabled="disabled" value="$tlang.getString("sitedicla.remsel")" />
 				<input type="submit" accesskey="x"  name="eventSubmit_doBack" value="$tlang.getString("sitedicla.can")" />
 			</p>
 		


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30074

In the Edit Rosters main screen, the 'Update' button should be renamed to 'Remove Selected', as all you can do with the button is remove selected rosters from the site.

Also, the button should be disabled by default, and should only be enabled when at least one roster has been selected from the list.
