### PR TITLE
SAK-30067 clean-up assignments javascript, velocity macros, remove old spinners and code in favour of new centralized approach

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -524,7 +524,6 @@ viewsubmissions	= View Submissions
 allowResubmit	= Allow Resubmission
 allowGradeOverride = Assign Grade Overrides
 allowVisibleDate    = Use Visible Date
-gen.proces = Processing......
 gen.first = First
 gen.previous = Previous
 gen.next = Next
@@ -815,7 +814,6 @@ allowResubmission.select.student = Allow resubmission from
 ## single file upload
 singleatt = Single Uploaded File only
 att.upl = Choose File: 
-processmessage.file = Uploading file(s)
 size.exceeded = The upload size limit of {0} MB has been exceeded. 
 notpermis4 = You do not have proper permissions to add resources.
 alert.toolong = The name ''{0}'' is too long.

--- a/assignment/assignment-tool/tool/src/webapp/chef_header.vm
+++ b/assignment/assignment-tool/tool/src/webapp/chef_header.vm
@@ -1,8 +1,9 @@
 ## $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/chef_header.vm,v 1.1 2005/04/13 19:20:45 ggolden.umich.edu Exp $
 ## This is here so that we can add extra bits to the <head> of the page.
 
-#header_prepend('<link href="/sakai-assignment-tool/css/assignment.css" type="text/css" rel="stylesheet" media="all" />')
+#header_append('<link href="/sakai-assignment-tool/css/assignment.css" type="text/css" rel="stylesheet" media="all" />')
 #header_append('<script type="text/javascript">includeLatestJQuery("assignment_chef_header");</script>')
 #header_append('<script type="text/javascript" src="/sakai-assignment-tool/js/assignments.js"></script>')
+#header_append('<script type="text/javascript" src="/library/js/spinner.js"></script>')
 
 #chef_start()

--- a/assignment/assignment-tool/tool/src/webapp/css/assignment.css
+++ b/assignment/assignment-tool/tool/src/webapp/css/assignment.css
@@ -179,10 +179,6 @@ label.disabled {
     color: #aaa;
 }
 
-a.noPointers, input.noPointers {
-    pointer-events: none;
-}
-
 /* start SAK-29314 */
 .navigator {
     width: 100%;
@@ -228,25 +224,8 @@ a.noPointers, input.noPointers {
     margin-top: 0.5em;
 }
 
-.centreColumn .messageProgress {
-    display: none;
-    text-align: left;
-    margin: 0 auto;
-}
-
 .leftColumn .instruction.textPanelFooter, .rightColumn .instruction.textPanelFooter {
     margin-top: 0.5em;
-}
-
-.spinner {
-    display: inline;
-    vertical-align: middle;
-    visibility: hidden;
-}
-
-.spinnerFrame {
-    margin: 0 2px;
-    position:absolute;
 }
 
 td.specialLink a:link, td.specialLink a:visited {
@@ -262,4 +241,68 @@ td.specialLink a:link, td.specialLink a:visited {
 
 select.selectSet {
     display: none;
+}
+
+.extraNode {
+    border:1px solid #69d;
+    padding: 0  1.5em 1em 1.5em;
+    width:50%;
+    min-width:500px;
+}
+
+.extraNodeLink {
+    cursor:pointer;
+}
+
+.extraNode legend {
+    padding:0 .5em;
+    color:#555
+}
+
+.userList {
+    margin-left:36px !important
+}
+
+.userList .selectedItem {
+    background:#def;
+    color:#000;
+    font-weight:bold
+}
+
+.userList li label:hover {
+    cursor:pointer;
+    background:#ffe
+}
+
+fieldset .alertMessageInline,fieldset .alertMessage {
+    border:none
+}
+
+.smallMatches {
+    background-color: lightyellow;
+    border-style: solid;
+    border-width: 1px;
+    border-color: lightgray;
+    padding: 1em 1em 1em 2em;
+}
+
+.itemAction.spinnerBesideContainer a {
+    margin: 0 4px;
+}
+
+div#pagingHeader {
+    height: 20px;
+    display: flex;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
+    justify-content: center;
+}
+
+.itemAction a:link {
+    border: 1px solid transparent;
 }

--- a/assignment/assignment-tool/tool/src/webapp/js/assignments.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/assignments.js
@@ -1,26 +1,26 @@
 // 'Namespace'
-var ASN = {};
+var ASN = ASN || {};
 
-function getSelect(selectBox) {
+ASN.getSelect = function(selectBox) {
     if (selectBox && selectBox instanceof HTMLSelectElement) { 
         return selectBox.options[selectBox.selectedIndex].value;
     }
-}
+};
 
-function setSelect(selectBox,index) {
+ASN.setSelect = function(selectBox,index) {
     if (selectBox && selectBox instanceof HTMLSelectElement) { 
         selectBox.value = index;
     }
-}
+};
 
 // Parses select fields on a form and returns the date object for a specific prefix
-function getSelectDate (prefix) {
-  var sMonth = parseInt(getSelect(document.getElementById(prefix+"month")));
-  var sDay = parseInt(getSelect(document.getElementById(prefix+"day")));
-  var sYear = parseInt(getSelect(document.getElementById(prefix+"year")));
-  var sHour = parseInt(getSelect(document.getElementById(prefix+"hour")));
-  var sMinute = parseInt(getSelect(document.getElementById(prefix+"min")));
-  var sAmpm = getSelect(document.getElementById(prefix+"ampm"));
+ASN.getSelectDate = function(prefix) {
+  var sMonth = parseInt(ASN.getSelect(document.getElementById(prefix+"month")));
+  var sDay = parseInt(ASN.getSelect(document.getElementById(prefix+"day")));
+  var sYear = parseInt(ASN.getSelect(document.getElementById(prefix+"year")));
+  var sHour = parseInt(ASN.getSelect(document.getElementById(prefix+"hour")));
+  var sMinute = parseInt(ASN.getSelect(document.getElementById(prefix+"min")));
+  var sAmpm = ASN.getSelect(document.getElementById(prefix+"ampm"));
   if (sAmpm === "PM") {
       sHour += 12;
   }
@@ -28,40 +28,27 @@ function getSelectDate (prefix) {
       sHour = 0;
   }
   return new Date(sYear,sMonth-1,sDay,sHour,sMinute,0,0);
-}
+};
 
 // Sets a various fields of a select date with a prefix to the date field
-function setSelectDate (prefix,dateval) {
+ASN.setSelectDate = function(prefix,dateval) {
     if (dateval && dateval instanceof Date) {
-        setSelect(document.getElementById(prefix+"year"),dateval.getFullYear());
-        setSelect(document.getElementById(prefix+"month"),dateval.getMonth()+1);
-        setSelect(document.getElementById(prefix+"day"),dateval.getDate());
+        ASN.setSelect(document.getElementById(prefix+"year"),dateval.getFullYear());
+        ASN.setSelect(document.getElementById(prefix+"month"),dateval.getMonth()+1);
+        ASN.setSelect(document.getElementById(prefix+"day"),dateval.getDate());
         var sHour = dateval.getHours();
         var sAmpm = sHour >= 12 ? 'PM' : 'AM';
         sHour = sHour % 12;
         if (sHour === 0) {
            sHour = 12; 
         }
-        setSelect(document.getElementById(prefix+"hour"),sHour);
-        setSelect(document.getElementById(prefix+"ampm"),sAmpm);
-        setSelect(document.getElementById(prefix+"min"),dateval.getMinutes());
+        ASN.setSelect(document.getElementById(prefix+"hour"),sHour);
+        ASN.setSelect(document.getElementById(prefix+"ampm"),sAmpm);
+        ASN.setSelect(document.getElementById(prefix+"min"),dateval.getMinutes());
     }
-}
+};
 
-function dueDateChange(field) {
-  var dueprefix = "new_assignment_due";
-  var acceptprefix = "new_assignment_close";
-
-  var dueDate = getSelectDate(dueprefix);
-  var acceptDate = getSelectDate(acceptprefix);
-
-  if (dueDate.getTime() > acceptDate.getTime()) {
-    //Due date > accept date, update acceptDate field to match
-    setSelectDate(acceptprefix,dueDate); 
-  }
-
-}
-function setupAssignNew(){
+ASN.setupAssignNew = function(){
     // show the previously opened field
     $('.extraNode').hide();
     showNode = $('#attachments_for').val();
@@ -72,7 +59,7 @@ function setupAssignNew(){
         $('#noAllPurpose').hide('');
         $('#hasAllPurpose').show('');
     }
-    resizeFrame('grow');
+    ASN.resizeFrame('grow');
     
     $(".toggleRoleLink").click(function(){
         var actionType;
@@ -84,13 +71,13 @@ function setupAssignNew(){
             $('#roleDiv_' + roleType).show('');
             $('#collapse_' + roleType).show('');
             $('#expand_' + roleType).hide('');
-            resizeFrame('grow');
+            ASN.resizeFrame('grow');
         }
         else {
             $('#roleDiv_' + roleType).hide('');
             $('#expand_' + roleType).show('');
             $('#collapse_' + roleType).hide('');
-            resizeFrame('grow');
+            ASN.resizeFrame('grow');
         }
     });
     
@@ -120,13 +107,13 @@ function setupAssignNew(){
             $('#' + 'has' + nodeType).hide('');
             $('.extraNode').hide();
             $('#extraNodeLinkList').show();
-            resizeFrame('grow');
+            ASN.resizeFrame('grow');
         }
         if (linkType === "add" || linkType === "edit") {
             $('.extraNode').hide();
             $('#' + this.id.substring(0, this.id.indexOf('_')) + '-node').fadeIn('slow');
             $('#extraNodeLinkList').hide();
-            resizeFrame('grow');
+            ASN.resizeFrame('grow');
         }
         location.href = '#extraNodesTop';
     });
@@ -240,7 +227,7 @@ function setupAssignNew(){
                 $('#extraNodeLinkList').show();			
             }
             else {
-                resizeFrame('grow');
+                ASN.resizeFrame('grow');
                 location.href = '#extraNodesBoxTop';
             }
         }
@@ -281,9 +268,9 @@ function setupAssignNew(){
         }
     });
     
-}
+};
 
-function resizeFrame(updown) 
+ASN.resizeFrame = function(updown)
 {
     if (top.location !== self.location)
     {
@@ -303,17 +290,16 @@ function resizeFrame(updown)
     } 
     else 
     {
-//			throw( "resizeFrame did not get the frame (using name=" + window.name + ")" );
+        //throw( "resizeFrame did not get the frame (using name=" + window.name + ")" );
     }
-}
+};
 
 // toggle a fade
 jQuery.fn.fadeToggle = function(speed, easing, callback) {
     return this.animate({opacity: 'toggle'}, speed, easing, callback);
-}; 
+};
 
-
-function setupToggleAreas(toggler, togglee, openInit, speed){
+ASN.setupToggleAreas = function(toggler, togglee, openInit, speed){
     // toggler=class of click target
     // togglee=class of container to expand
     // openInit=true - all togglee open on enter
@@ -324,28 +310,13 @@ function setupToggleAreas(toggler, togglee, openInit, speed){
     else {
         $('.' + togglee).hide();
         $('.collapse').hide();
-        resizeFrame();
+        ASN.resizeFrame();
     }
     $('.' + toggler).click(function(){
         $(this).next('.' + togglee).fadeToggle(speed);
         $(this).find('.expand').toggle();
         $(this).find('.collapse').toggle();
-        resizeFrame();
-    });
-}
-
-// SAK-29314 - onclick on any of the nav panel buttons...
-ASN.setupItemNavigator = function()
-{
-    $( ".navigator input:button" ).click( function()
-    {
-        // Disable all buttons
-        $( ".navigator input:button" ).attr( "disabled", "disabled" ).addClass( "disabled" );
-
-        // Show the progress indicator and hide the return to list button
-        $( ".messageProgress" ).css( "display", "inline" );
-        $( ".cancelgradesubmission" ).css( "display", "none" );
-        
+        ASN.resizeFrame();
     });
 };
 
@@ -445,7 +416,7 @@ ASN.toggleGroups = function(clickedElement) {
     }
 };
 
-function highlightSelectedAttachment()
+ASN.highlightSelectedAttachment = function()
 {
     endsWith = function(str, suffix)
     {
@@ -475,32 +446,39 @@ function highlightSelectedAttachment()
             }
         }
     }
-}
+};
 
-ASN.enableLinks = function()
-{
-    var downloadAll = document.getElementById( "downloadAll" );
-    var uploadAll = document.getElementById( "uploadAll" );
-    var releaseGrades = document.getElementById( "releaseGrades" );
-    var helpItems = document.getElementById( "helpItems" );
-    var links = [downloadAll, uploadAll, releaseGrades, helpItems];
-    for( i = 0; i < links.length; i++ )
-    {
-        if( links[i] !== null )
-        {
-            links[i].className = "";
+ASN.saveChanges = function(formName, textAreaId) {
+    var _textArea = document.getElementById(textAreaId);
+    if (_textArea !== null) {
+        if (typeof FCKeditorAPI !== "undefined") {
+            var editor = FCKeditorAPI.GetInstance(textAreaId);
+            document[formName].savedText.value = editor.GetXHTML(false);
         }
     }
 };
 
-// SAK-29314
-ASN.navPanelAction = function( submissionID, action )
+ASN.allowClick = function(object)
 {
-    document.gradeForm.action += "&submissionId=" + submissionID;
-    document.gradeForm.onsubmit();
-    document.getElementById( "option" ).value = action;
-    document.gradeForm.submit();
-    return false;
+    object.onclick='';
+    object.style.color='#000';
+    var rv = linkFlag;
+    // set the flag to be false
+    linkFlag = false;
+    //return the current flag status
+    return rv;
+};
+
+ASN.params_unserialize = function(p){
+    var ret = [],
+    seg = p.replace(/^\?/,'').split('&'),
+    len = seg.length, i = 0, s;
+    for (;i<len;i++) {
+        if (!seg[i]) { continue; }
+        s = seg[i].split('=');
+        ret.push({'name':s[0],'value':s[1]});
+    }
+    return ret;
 };
 
 // SAK-29314
@@ -549,268 +527,30 @@ ASN.toggleSubNavButtons = function( checkBoxClicked )
 // SAK-29314
 ASN.toggleElements = function( elements, disabled )
 {
-    for( i = 0; i < elements.length; i ++ )
+    for( i = 0; i < elements.length; i++ )
     {
         elements[i].disabled = disabled;
     }
 };
 
-// SAK-29314
-ASN.disableControls = function( escape, linkName )
+ASN.enableLinks = function()
 {
-    // Clone and disable all drop downs (disable the clone, hide the original)
-    var dropDowns = ASN.nodeListToArray( document.getElementsByTagName( "select" ) );
-    for( i = 0; i < dropDowns.length; i++ )
-    {
-        // Hide the original drop down
-        var select = dropDowns[i];
-        select.style.display = "none";
+    var links = [
+        document.getElementById( "downloadAll" ),
+        document.getElementById( "uploadAll" ),
+        document.getElementById( "releaseGrades" ),
+        document.getElementById( "helpItems" )
+    ];
 
-        // Create the cloned element and disable it
-        var newSelect = document.createElement( "select" );
-        newSelect.setAttribute( "id", select.getAttribute( "id" ) + "Disabled" );
-        newSelect.setAttribute( "name", select.getAttribute( "name" ) + "Disabled" );
-        newSelect.setAttribute( "disabled", "true" );
-        newSelect.className = select.className;
-        newSelect.innerHTML = select.innerHTML;
-
-        // Add the clone to the DOM where the original was
-        var parent = select.parentNode;
-        parent.insertBefore( newSelect, select );
-    }
-
-    // Get all the input elements, separate into lists by type
-    var allInputs = ASN.nodeListToArray( document.getElementsByTagName( "input" ) );
-    var elementsToCloneAndDisable = [];
-    var elementsToDisable = [];
-    for( i = 0; i < allInputs.length; i++ )
-    {
-         if( (allInputs[i].type === "submit" || allInputs[i].type === "button" || allInputs[i].type === "checkbox") 
-                && allInputs[i].id !== escape )
-        {
-            elementsToCloneAndDisable.push( allInputs[i] );
-        }
-        else if( allInputs[i].type === "text" && allInputs[i].id !== escape )
-        {
-            elementsToDisable.push( allInputs[i] );
-        }
-    }
-
-    // Disable all element
-    ASN.toggleElements( elementsToDisable, true );
-    for( i = 0; i < elementsToCloneAndDisable.length; i++ )
-    {
-        ASN.cloneAndHideElement( "", elementsToCloneAndDisable[i] );
-    }
-
-    // Get the download/upload links
-    var downAll = document.getElementById( "downloadAll" );
-    var upAll = document.getElementById( "uploadAll" );
-    var release = document.getElementById( "releaseGrades" );
-    var helpItems = document.getElementById( "helpItems" );
-    var links = [downAll, upAll, release, helpItems];
     for( i = 0; i < links.length; i++ )
     {
         if( links[i] !== null )
         {
-            ASN.disableLink( links[i] );
-        }
-    }
-
-    if( linkName !== null )
-    {
-        var links = ASN.nodeListToArray( document.getElementsByName( linkName ) );
-        for( i = 0; i < links.length; i++ )
-        {
-            if( links[i] !== null )
-            {
-                ASN.disableLink( links[i] );
-            }
+            links[i].className = "";
         }
     }
 };
 
-// SAK-29314
-ASN.nodeListToArray = function( nodeList )
-{
-    var array = [];
-    for( var i = nodeList.length >>> 0; i--; )
-    {
-        array[i] = nodeList[i];
-    }
-
-    return array;
-};
-
-// SAK-29314
-ASN.changePageSize = function()
-{
-    ASN.disableControls();
-    ASN.showSpinner( "navSpinner" );
-    document.pagesizeForm.submit();
-};
-
-// SAK-29314
-ASN.changeView = function()
-{
-    document.getElementById( "option" ).value = "changeView";
-    ASN.disableControls();
-    ASN.showSpinner( "viewSpinner" );
-    document.viewForm.submit();
-    return false;
-};
-
-// SAK-29314
-ASN.applySearchFilter = function( searchOption )
-{
-    document.getElementById( "option" ).value = searchOption;
-
-    // Disable everything but the search field
-    ASN.disableControls( "search" );
-
-    // Clone and disable the search field (disable the clone, hide the original)
-    var original = document.getElementById( "search" );
-    var clone = document.createElement( "input" );
-    var parent = original.parentNode;
-    clone.setAttribute( "type", "text" );
-    clone.setAttribute( "id", "searchDisabled" );
-    clone.setAttribute( "name", "searchDisabled" );
-    clone.setAttribute( "className", original.getAttribute( "className" ) );
-    clone.value = original.value;
-    clone.setAttribute( "disabled", "true" );
-    original.style.display = "none";
-    parent.insertBefore( clone, original );
-
-    ASN.showSpinner( "userFilterSpinner" );
-    document.viewForm.submit();
-    return false;
-};
-
-// SAK-29314
-ASN.doLinkAction = function( action )
-{
-    document.getElementById( "option" ).value = action;
-    ASN.disableControls();
-    ASN.showSpinner( "navSpinner" );
-};
-
-// SAK-29314
-ASN.applyDefaultGrade = function()
-{
-    // If the default grade field is a text field, we need to do the clone & hide approach
-    var defaultGradeTextField = document.getElementById( "defaultGrade_2" );
-    if( defaultGradeTextField !== null )
-    {
-        // Disable everything but the text field
-        ASN.disableControls( "defaultGrade_2" );
-
-        // Clone and disable the text field (disable the clone, hide the original)
-        var clone = document.createElement( "input" );
-        var parent = defaultGradeTextField.parentNode;
-        clone.setAttribute( "type", "text" );
-        clone.setAttribute( "id", "defaultGrade_2Disabled" );
-        clone.setAttribute( "name", "defaultGrade_2Disabled" );
-        clone.setAttribute( "size", defaultGradeTextField.getAttribute( "size" ) );
-        clone.setAttribute( "className", defaultGradeTextField.getAttribute( "className" ) );
-        clone.value = defaultGradeTextField.value;
-        clone.setAttribute( "disabled", "true" );
-        defaultGradeTextField.style.display = "none";
-        parent.insertBefore( clone, defaultGradeTextField );
-    }
-
-    // Otherwise, it's a drop down, so we can just take the normal approach
-    else
-    {
-        ASN.disableControls();
-    }
-
-    ASN.showSpinner( "applyGradeSpinner" );
-    document.defaultGradeForm.submit();
-};
-
-// SAK-29314
-ASN.showSpinner = function( spinnerID )
-{
-    document.getElementById( spinnerID ).style.visibility = "visible";
-};
-
-// SAK-29314
-ASN.cloneAndHideElement = function( divId, element )
-{
-    // First, set the element to be invisible
-    element.style.display = "none";
-
-    // Now create a new disabled element with the same attributes as the existing element
-    var newElement = document.createElement( "input" );
-
-    newElement.setAttribute( "type", element.type );
-    newElement.setAttribute( "id", element.getAttribute( "id" ) + "Disabled" );
-    newElement.setAttribute( "name", element.getAttribute( "name" ) + "Disabled" );
-    newElement.setAttribute( "value", element.getAttribute( "value" ) );
-    newElement.className = element.className + " noPointers";
-    newElement.setAttribute( "disabled", "true" );
-    if( element.type === "checkbox" )
-    {
-        newElement.checked = element.checked;
-    }
-
-    if( "" !== divId )
-    {
-        var div = document.getElementById( divId );
-        div.insertBefore( newElement, element );
-    }
-    else
-    {
-        var parent = element.parentNode;
-        parent.insertBefore( newElement, element );
-    }
-};
-
-// SAK-29314
-ASN.doGradingFormAction = function( reference, option )
-{
-    // Apply the reference to the form's action handler if necessary
-    if( reference !== null )
-    {
-        document.gradeForm.action = document.gradeForm.action + "&submissionId=" + reference;
-    }
-
-    // Call the form's onSubmit function; change the hidden option value
-    document.gradeForm.onsubmit();
-    document.getElementById( "option" ).value = option;
-
-    // 'Disable' all form controls to prevent click happy users, except the grade text field; show the spinner
-    ASN.disableControls( "grade" );
-    ASN.showSpinner( "gradeFormSpinner" );
-
-    // Submit the form
-    document.gradeForm.submit();
-    return false;
-};
-
-// SAK-29314
-ASN.doGradingPreviewAction = function()
-{
-    var buttons = ASN.nodeListToArray( document.getElementsByTagName( "input" ) );
-    for( i = 0; i < buttons.length; i++ )
-    {
-        if( buttons[i].type === "submit" || buttons[i].type === "button" )
-        {
-            ASN.cloneAndHideElement( "", buttons[i] );
-        }
-    }
-
-    ASN.showSpinner( "gradeFormPreviewSpinner" );
-};
-
-// SAK-29314
-ASN.disableLink = function( link )
-{
-    link.className = "noPointers";
-    link.disabled = true;
-};
-
-// SAK-29708
 ASN.checkEnableRemove = function()
 {
     var selected = false;
@@ -828,31 +568,312 @@ ASN.checkEnableRemove = function()
     document.getElementById( "btnRemove" ).className = (selected ? "active" : "" );
 };
 
-ASN.doReorderAction = function( action )
+ASN.toggleResubmitTimePanel = function()
 {
-    document.reorderForm.onsubmit();
-    document.getElementById( "option" ).value = action;
-
-    // Disable links
-    var undoLast = document.getElementById( "undo-last" );
-    var undoAll = document.getElementById( "undo-all" );
-    var sortByTitle = document.getElementById( "sortByTitle" );
-    var sortByOpenDate = document.getElementById( "sortByOpenDate" );
-    var sortByDueDate = document.getElementById( "sortByDueDate" );
-    var links = [undoLast, undoAll, sortByTitle, sortByOpenDate, sortByDueDate];
-    for( var i = 0; i < links.length; i++ )
+    if( document.getElementById( "allowResubmitNumber" ).value !== 0 && document.getElementById( "allowResubmitTime" ) !== null )
     {
-        if( links[i] !== null )
+        document.getElementById( "allowResubmitTime" ).style.display = "block";
+    }
+    else
+    {
+        document.getElementById( "allowResubmitTime" ).style.display = "none";
+    }
+};
+
+ASN.togglePeerAssessmentOptions = function(checked){
+    var section = document.getElementById("peerAssessmentOptions");
+    if(checked){
+        section.style.display="block";
+        ASN.resizeFrame('grow');
+    }else{
+        section.style.display="none";
+        ASN.resizeFrame('shrink');
+    }
+};
+
+ASN.toggleReviewServiceOptions = function(checked){
+    var section = document.getElementById("reviewServiceOptions");
+    if(checked){
+        section.style.display="block";
+        ASN.resizeFrame('grow');
+    }else{
+        section.style.display="none";
+        ASN.resizeFrame('shrink');
+    }
+};
+
+ASN.toggleSmallMatchesOptions = function(checked){
+    var section = document.getElementById("smallMatchesOptions");
+    if(checked){
+        section.style.display="inline-block";
+        ASN.resizeFrame('grow');
+    }else{
+        section.style.display="none";
+        ASN.resizeFrame('shrink');
+    }
+};
+
+ASN.toggleSmallMatchesDisabled = function(){
+    var radioOption1 = document.getElementById("wordCount");
+    var radioOption2 = document.getElementById("percentage");
+    var excludeWords = document.getElementById("tiiExcludeValueWords");
+    var excludePercentages = document.getElementById("tiiExcludeValuePercentages");
+
+    excludeWords.disabled = true;
+    excludeWords.value = "";
+    excludePercentages.disabled = true;
+    excludePercentages.value = "";
+    if(radioOption1.checked){
+        excludeWords.disabled = false;
+    }else if(radioOption2.checked){
+        excludePercentages.disabled = false;
+    }
+};
+
+ASN.toggleSelectAll = function(caller, elementName)
+{
+    var newValue = caller.checked;
+    var elements = document.getElementsByName(elementName);
+    if(elements)
+    {
+        //SAK-19147 don't toggle last "Save all submissions in one folder"
+        for(var i = 0; i < elements.length; i++)
         {
-            ASN.disableLink( links[i] );
+            if( elements[i].id !== "withoutFolders" )
+            {
+                elements[i].checked = newValue;
+            }
+        }
+    }
+};
+
+ASN.deselectSelectAll = function( caller )
+{
+    var checked = caller.checked;
+    if( !checked )
+    {
+        document.getElementById( "selectall" ).checked = checked;
+    }
+};
+
+ASN.handleEnterKeyPress = function(ev)
+{
+    if (!ev)
+    {
+        ev = window.event;
+    }
+
+    if (ev && ev.keyCode === 13)
+    {
+         return false; 
+    }
+};
+
+ASN.invokeDownloadUrl = function(accessPointUrl, actionString, alertMessage, param0, param1, param2, param3, clickedElement)
+{
+     var extraInfoArray = [];
+    if (document.getElementById('studentSubmissionText') && document.getElementById('studentSubmissionText').checked)
+    {
+        extraInfoArray[extraInfoArray.length]="studentSubmissionText=true";
+    }
+
+     if (document.getElementById('studentSubmissionAttachment') && document.getElementById('studentSubmissionAttachment').checked)
+    {
+        extraInfoArray[extraInfoArray.length]="studentSubmissionAttachment=true";
+    }
+    if (document.getElementById('gradeFile') && document.getElementById('gradeFile').checked)
+    {
+        if (document.getElementById('gradeFileFormat_excel').checked)
+        {
+            extraInfoArray[extraInfoArray.length]="gradeFile=true&gradeFileFormat="+document.getElementById('gradeFileFormat_excel').value;
+        } else {
+            extraInfoArray[extraInfoArray.length]="gradeFile=true&gradeFileFormat="+document.getElementById('gradeFileFormat_csv').value;
+        }
+    }
+    if (document.getElementById('feedbackTexts') && document.getElementById('feedbackTexts').checked)
+    {
+        extraInfoArray[extraInfoArray.length]="feedbackTexts=true";
+    }
+    if (document.getElementById('feedbackComments') && document.getElementById('feedbackComments').checked)
+    {
+        extraInfoArray[extraInfoArray.length]="feedbackComments=true";
+    }
+    if (document.getElementById('feedbackAttachments') && document.getElementById('feedbackAttachments').checked)
+    {
+        extraInfoArray[extraInfoArray.length]="feedbackAttachments=true";
+    }
+    if (extraInfoArray.length === 0)
+    {
+        alert(alertMessage);
+    }
+    else
+    {
+        SPNR.disableControlsAndSpin( clickedElement, null );
+
+        if (document.getElementById('withoutFolders') && document.getElementById('withoutFolders').checked)
+        {
+            extraInfoArray[extraInfoArray.length]="withoutFolders=true";
+        }
+
+        accessPointUrl = accessPointUrl + "?";
+        for(i=0; i<extraInfoArray.length; i++) 
+        { 
+            accessPointUrl = accessPointUrl + extraInfoArray[i] + "&"; 
+        }
+        // cut the & in the end
+        accessPointUrl = accessPointUrl.substring(0, accessPointUrl.length-1);
+        // attach the assignment reference
+        accessPointUrl = accessPointUrl + "&contextString=" + param0 + "&viewString=" + param1 + "&searchString=" + param2 + "&searchFilterOnly=" + param3;
+        window.location.href=accessPointUrl;
+        document.getElementById('downloadUrl').value=accessPointUrl; 
+        document.getElementById('uploadAllForm').action=actionString; 
+        setTimeout("ASN.submitForm( 'uploadAllForm', null, null, null, false )", 1500);
+    }
+};
+
+/* Enables the submit/resubmit button. If checkForFile is true, then it disables the submit/resubmit button if the clonableUpload button has no value*/
+ASN.enableSubmitUnlessNoFile = function(checkForFile)
+{
+    var btnPost = document.getElementById('post');
+    var doEnable = true;
+    if (checkForFile)
+    {
+        var btnClonableUpload = document.getElementById('clonableUpload');
+        if (btnClonableUpload && btnClonableUpload.value === "")
+        {
+             doEnable = false;
         }
     }
 
-    // Disable controls and activate spinner
-    ASN.disableControls();
-    ASN.showSpinner( "reorderSpinner" );
+    if (doEnable)
+    {
+        btnPost.removeAttribute('disabled');
+    }
+    else
+    {
+        btnPost.setAttribute('disabled', 'disabled');
+    }
+};
 
-    // Submit the form
-    document.reorderForm.submit();
-    return false;
+ASN.submitForm = function( formID, option, submissionID, view, returnFalse )
+{
+    // Get the form
+    var form = document.getElementById( formID );
+    if( form !== null )
+    {
+        // Apply the submission ID to the form's action if one is supplied
+        if( submissionID !== null )
+        {
+            form.action += "&submissionId=" + submissionID;
+        }
+
+        // Do the onsubmit() if the form has one
+        if( form && form.onsubmit )
+        {
+            form.onsubmit();
+        }
+
+        // If an option was given, apply it to the element
+        if( option !== null )
+        {
+            var optionElement = document.getElementById( "option" );
+            if( optionElement !== null )
+            {
+                optionElement.value = option;
+            }
+        }
+
+        // If a view was given, apply it to the element
+        if( view !== null )
+        {
+            var viewElement = document.getElementById( "view" );
+            if( viewElement !== null )
+            {
+                viewElement.value = view;
+            }
+        }
+
+        // Do the submit() if the form has one
+        if( form && form.submit )
+        {
+            form.submit();
+        }
+
+        // Return false if requested
+        if( returnFalse )
+        {
+            return false;
+        }
+    }
+};
+
+ASN.doStudentViewSubmissionAction = function( formID, option, attachmentID )
+{
+    document.getElementById( formID ).currentAttachment.value = attachmentID;
+    ASN.submitForm( formID, option, null, null, true );
+};
+
+ASN.doTagsListAction = function( formID, value, providerID )
+{
+    var form = document.getElementById( formID );
+    form.sakai_action.value = value;
+    form.providerId.value = providerID;
+};
+
+ASN.showAllowResubmission = function()
+{
+    document.getElementById('allowResubmission_shown').style.display="inline";
+    document.getElementById('allowResubmission_hidden').style.display="none";
+    $('#allowResubmission_shownInner').addClass('highLightBlock').fadeIn(2000,function(){
+        $(this).removeClass('highLightBlock');
+    });
+    document.getElementById('allowResToggle').value="checked";
+    ASN.resizeFrame('grow');
+};
+
+ASN.hideAllowResubmission = function()
+{
+    $('#allowResubmission_shownInner').fadeOut('fast', function() {
+        document.getElementById('allowResubmission_shown').style.display="none";
+        document.getElementById('allowResubmission_hidden').style.display="inline";
+        document.getElementById('allowResToggle').value="";
+    });
+};
+
+ASN.showSendFeedback = function()
+{
+    document.getElementById('sendFeedback_shown').style.display="inline";
+    document.getElementById('sendFeedback_hidden').style.display="none";
+    $('#sendFeedback_shownInner').addClass('highLightBlock').fadeIn(2000,function(){
+        $(this).removeClass('highLightBlock');
+    });
+   ASN.resizeFrame('grow');
+};
+
+ASN.hideSendFeedback = function()
+{
+    $('#sendFeedback_shownInner').fadeOut('fast', function() {
+        document.getElementById('sendFeedback_shown').style.display="none";
+        document.getElementById('sendFeedback_hidden').style.display="inline";
+    });
+};
+
+ASN.toggleIsGroupSubmission = function(checked){
+    if (checked) {
+        $("#site").prop("disabled", true);
+        $("#groups").prop("checked", true).trigger("click");
+    } else {
+        $("#site").prop("disabled", false);
+    }
+};
+
+ASN.toggleAutoAnnounceOptions = function(checked){
+    var section = document.getElementById("selectAutoAnnounceOptions");
+    if(checked){
+        section.style.display="block";
+        resizeFrame('grow');
+    }else{
+        section.style.display="none";
+        resizeFrame('shrink');
+    }
 };

--- a/assignment/assignment-tool/tool/src/webapp/js/scoringAgent.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/scoringAgent.js
@@ -1,18 +1,21 @@
-function openScoringAgent(url) {
+// Namespace
+var ASN_SCRAGNT = ASN_SCRAGNT || {};
+
+ASN_SCRAGNT.openScoringAgent = function(url) {
 	window.open(url,'_blank',
-     'width=800,height=600,top=20,left=100,menubar=yes,status=yes,location=no,toolbar=yes,scrollbars=yes,resizable=yes');
-}
+		'width=800,height=600,top=20,left=100,menubar=yes,status=yes,location=no,toolbar=yes,scrollbars=yes,resizable=yes');
+};
 
 /*
  * Retrieve a student's grade from the external scoring service and update
  * the score input with the returned grade
  */
-function refreshScore(refreshUrl) {
-	jQuery.getJSON(encodeUrl(refreshUrl),function(data){
+ASN_SCRAGNT.refreshScore = function(refreshUrl) {
+	jQuery.getJSON(ASN_SCRAGNT.encodeUrl(refreshUrl),function(data){
 		if (data['score']) {
 			var newScore = data['score'];
 			var inp = document.getElementById("grade");
-			if(newScore != '' && newScore > 0) {
+			if(newScore !== '' && newScore > 0) {
 				newScore = Math.round(newScore*10)/10;
 			}
 			
@@ -20,13 +23,13 @@ function refreshScore(refreshUrl) {
 			$('#scoringAgent-refresh-reminder').hide();
 		}
 	});
-}
+};
 
-function displayRefreshReminder() {
+ASN_SCRAGNT.displayRefreshReminder = function() {
 	$('#scoringAgent-refresh-reminder').show();
-}
+};
 
-function encodeUrl(url) {
+ASN_SCRAGNT.encodeUrl = function(url) {
 
 	if (url.indexOf("?") > 0) {
 		encodedParams = "?";
@@ -47,4 +50,4 @@ function encodeUrl(url) {
 		url = parts[0] + encodedParams;
 	}
 	return url;
-}
+};

--- a/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
@@ -1,4 +1,4 @@
-var ASN_SVS = {};
+var ASN_SVS = ASN_SVS || {};
 
 /* For the cancel button - if the user made progress, we need them to confirm that they want to discard their progress */
 ASN_SVS.confirmDiscardOrSubmit = function(attachmentsModified)
@@ -19,16 +19,9 @@ ASN_SVS.confirmDiscardOrSubmit = function(attachmentsModified)
 	}
 	else
 	{
-		ASN_SVS.cancelProceed();
+		ASN.submitForm( 'addSubmissionForm', 'cancel', null, null, false );
 	}
-}
-
-ASN_SVS.cancelProceed = function()
-{
-	document.addSubmissionForm.onsubmit();
-	document.addSubmissionForm.option.value='cancel'; 
-	document.addSubmissionForm.submit(); 
-}
+};
 
 ASN_SVS.undoCancel = function()
 {
@@ -36,5 +29,4 @@ ASN_SVS.undoCancel = function()
 	var confirmationDialogue = document.getElementById("confirmationDialogue");
 	submitPanel.removeAttribute('style');
 	confirmationDialogue.setAttribute('style', 'display:none;');
-}
-
+};

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -1,13 +1,25 @@
 <!-- $Id$ -->
 <!-- start:  assignment_macros.vm -->
 #macro( propertyDetails $props )
-	<span class="textPanelFooter">(
-	#if (!$props.getBooleanProperty($props.NamePropIsCollection))
-		$props.getPropertyFormatted($props.NamePropContentLength);
-	#end
-	$props.getPropertyFormatted($props.NamePropCreationDate)
-	)</span>
+    <span class="textPanelFooter">(
+    #if (!$props.getBooleanProperty($props.NamePropIsCollection))
+        $props.getPropertyFormatted($props.NamePropContentLength);
+    #end
+    $props.getPropertyFormatted($props.NamePropCreationDate)
+    )</span>
 #end
+
+##defines a macro to display attachment details
+#macro( attachmentDetails )
+    #if ($props.getBooleanProperty($props.NamePropIsCollection))
+        <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")"/>
+    #else
+        <img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
+    #end
+    <a href="$attachment.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
+    #propertyDetails($props)
+#end
+
 #macro( assignmentTitleIcon $assignment )
     #if ($!assignment.isGroup() )
         <span class="group_icon" title="$tlang.getString('gen.groupassignment')" alt="$tlang.getString('gen.groupassignment')"></span>
@@ -15,9 +27,256 @@
         <span class="user_icon" title="$tlang.getString('gen.userassignment')" alt="$tlang.getString('gen.userassignment')"></span>
     #end
 #end
+
 #macro( sectionIcon $group )
     #if ($!group.getProperties().get("sections_category"))
         <span class="section_icon" title="$tlang.getString('gen.section.info')" alt="$tlang.getString('gen.section.info')"></span> 
     #end
+#end
+
+## Defining macro to repeat buttons at the top and bottom of the page
+#macro( buttonBar $submitnotif )
+    <div class="act">
+        <input accesskey="s" type="button" class="active" name="post" value="$tlang.getString("gen.pos")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'newAssignmentForm', 'post', null, null, true );" />
+        <input accesskey="v" type="button" name="preview" value="$tlang.getString("gen.pre")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'newAssignmentForm', 'preview', null, null, true );" />
+        #if (!($!assignment && !$assignment.draft))
+            <input accesskey="d" type="button" name="save" value="$tlang.getString("gen.savdra")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'newAssignmentForm', 'save', null, null, true );" />
+        #end
+        <input accesskey="x" type="button" name="cancel" value="$tlang.getString("gen.can")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'newAssignmentForm', 'canceledit', null, null, true );" />
+    </div>
+#end
+
+## Macro for the paginator
+#macro( paginator $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
+    <div class="listNav">
+        <div class="instruction" id="pagingHeader">
+            $tlang.getString( "gen.viewing" ) $topMsgPos - $btmMsgPos $tlang.getString( "gen.of" ) $allMsgNumber $tlang.getString( "gen.items" )
+        </div>
+        #if( $pagesize != 0 )
+            <form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
+                <fieldset>
+                    <legend>$tlang.getString( "gen.first" )</legend>
+                    <input type="submit" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")"
+                        onclick="SPNR.disableControlsAndSpin( this, null ); ASN.resizeFrame();"
+                        #if( $goFPButton != "true" ) disabled="disabled" #end />
+                </fieldset>
+                <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+            </form>
+            <form name="prevpageForm" class="inlineForm" method="post" action="#toolForm( "$action" )">
+                <fieldset>
+                    <legend>$tlang.getString( "gen.previous" ) $pagesize</legend>
+                    <input type="submit" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getString( "gen.previous" ) $pagesize" accesskey="p"
+                        onclick="SPNR.disableControlsAndSpin( this, null ); ASN.resizeFrame();"
+                        #if( $goPPButton != "true" ) disabled="disabled" #end />
+                </fieldset>
+                <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+            </form>
+        #end
+        <form id="pagesizeForm" name="pagesizeForm" class="inlineForm" method="post" action="#toolForm("$action")">
+            <input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
+            <label for="selectPageSize" class="skip">$tlang.getString("newassig.selectmessage")</label>
+            <select id="selectPageSize" name="selectPageSize" onchange="SPNR.insertSpinnerAfter( this, null, 'pagingHeader' ); ASN.submitForm( 'pagesizeForm', null, null, null, false );">
+                #foreach( $i in $!pagesizes )
+                    <option value="$i" #if( $pagesize == $i ) selected="selected" #end>$tlang.getString( "list.show" ) $i $tlang.getString( "list.itemsper" )</option>
+                #end
+            </select>
+            <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+        </form>
+        #if( $pagesize != 0 )
+            <form name="nextpageForm" class="inlineForm" method="post" action="#toolForm( "$action" )">
+                <fieldset>
+                    <legend>$tlang.getString( "gen.next" ) $pagesize</legend>
+                    <input type="submit" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getString( "gen.next" ) $pagesize" accesskey="n"
+                        onclick="SPNR.disableControlsAndSpin( this, null ); ASN.resizeFrame();"
+                        #if( $goNPButton != "true" ) disabled="disabled" #end />
+                </fieldset>
+                <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+            </form>
+            <form name="lastpageForm" class="inlineForm" method="post" action="#toolForm( "$action" )">
+                <fieldset>
+                    <legend>$tlang.getString( "gen.last" )</legend>
+                    <input type="submit" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString( "gen.last" )"
+                        onclick="SPNR.disableControlsAndSpin( this, null ); ASN.resizeFrame();"
+                        #if( $goLPButton != "true" ) disabled="disabled" #end />
+                </fieldset>
+                <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+            </form>
+        #end
+    </div>
+#end
+
+## Macro for the top nav bar HREF and #toolLink/#toolLinkParam
+#macro( navBarHREF $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view $current )
+    <ul class="navIntraTool actionToolBar">
+        #set( $prevAction = false )
+        #if( $allowAddAssignment )
+            #set( $prevAction = true )
+            <li class="firstToolBarItem">
+                <span>
+                    <a href="#toolLink( "$action" "doNew_assignment" )" title="$!tlang.getString( "new" )">$!tlang.getString( "new" )</a>
+                </span>
+            </li>
+        #end
+        <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+            #if( !$!view.equals( "lisofass1" ) )
+                <span>
+                    <a href="#toolLinkParam( "$action" "doView" "view=lisofass1" )" title="$!tlang.getString( "lisofass1" )">$!tlang.getString( "lisofass1" )</a>
+                </span>
+            #else
+                <span class="current">$!tlang.getString( "lisofass1" )</span>
+            #end
+        </li>
+
+        #if( $withGrade && $!allowGradeSubmission )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                #if( !$!view.equals( "all" ) )
+                    <span>
+                        <a href="#toolLinkParam( "$action" "doView" "view=grarep" )" title="$!tlang.getString( "gen.grarep" )">$!tlang.getString( "gen.grarep" )</a>
+                    </span>
+                #else
+                    <span class="current">$!tlang.getString( "gen.grarep" )</span>
+                #end
+            </li>
+        #end
+
+        #if( $allowAddAssignment )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                #if( !$!view.equals( "stuvie" ) )
+                    <span>
+                        <a href="#toolLinkParam( "$action" "doView" "view=stuvie" )" title="$!tlang.getString( "gen.stuvie" )">$!tlang.getString( "gen.stuvie" )</a>
+                    </span>
+                #else
+                    <span class="current">$!tlang.getString( "gen.stuvie" )</span>
+                #end
+            </li>
+        #end
+        #if( ($allowAllGroups) && ($assignmentscheck) )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                #if( !$!current.equals( "reorder" ) )
+                    <span>
+                        <a href="#toolLink( "$action" "doReorder" )" title="$tlang.getString( "gen.reorder" )">$tlang.getString( "gen.reorder" )</a>
+                    </span>
+                #else
+                    <span class="current">$!tlang.getString( "gen.reorder" )</span>
+                #end
+            </li>
+        #end
+        #if( $allowUpdateSite )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                <span>
+                    <a href="#toolLink( "$action" "doPermissions" )" title="$tlang.getString( "permis" )">$tlang.getString( "permis" )</a>
+                </span>
+            </li>
+            #if( $enableViewOption )
+                <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                    #if( !$!current.equals( "options" ) )
+                        <span>
+                            <a href="#toolLink( "$action" "doOptions" )" title="$tlang.getString( "options" )">$tlang.getString( "options" )</a>
+                        </span>
+                    #else
+                        <span class="current">$!tlang.getString( "options" )</span>
+                    #end
+                </li>
+            #end
+        #end
+    </ul>
+#end
+
+## Macro for the top nav bar using onclick JavaScript
+#macro( navBarOnClick $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view $formID $current )
+    <ul class="navIntraTool actionToolBar">
+        #set( $prevAction = false )
+        #if( $allowAddAssignment )
+            #set( $prevAction = true )
+            <li class="firstToolBarItem">
+                #if( $current == "new" )
+                    <span class="current">$!tlang.getString( "new" )</span>
+                #else
+                    <span>
+                        <a href="javascript:void(0)" title="$!tlang.getString( "new" )" onclick="ASN.submitForm( '$formID', 'new', null, 'new', true );">
+                            $!tlang.getString( "new" )
+                        </a>
+                    </span
+                #end
+            </li>
+        #end
+        #if( !$!view.equals( "lisofass1" ) )
+            #set( $prevAction = true )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                <span>
+                    <a href="javascript:void(0)" title="$!tlang.getString( "lisofass1" )" onclick="ASN.submitForm( '$formID', 'view', null, 'lisofass1', true );">
+                        $!tlang.getString( "lisofass1" )
+                    </a>
+                </span>
+            </li>
+        #elseif( $current == "list" )
+            <li>
+                <span class="current">$!tlang.getString( "lisofass1" )</span>
+            </li>
+        #else
+            <li>
+                <span class="disabled">$!tlang.getString( "lisofass1" )</span>
+            </li>
+        #end
+        #if( $withGrade && $!allowGradeSubmission )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                #if( $current == "gradeReport" )
+                    <span class="current">$!tlang.getString( "gen.grarep" )</span>
+                #else
+                    <span>
+                        <a href="javascript:void(0)" title="$!tlang.getString( "gen.grarep" )" onclick="ASN.submitForm( '$formID', 'view', null, 'grarep', true );">
+                            $!tlang.getString( "gen.grarep" )
+                        </a>
+                    </span>
+                #end
+            </li>
+        #end
+        #if( $allowAddAssignment )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                #if( !$!view.equals( "stuvie" ) )
+                    <span>
+                        <a href="javascript:void(0)" title="$!tlang.getString( "gen.stuvie" )" onclick="ASN.submitForm( '$formID', 'view', null, 'stuvie', true );">
+                            $!tlang.getString( "gen.stuvie" )
+                        </a>
+                    </span>
+                #elseif( $current == "studentView" )
+                    <span class="current">$!tlang.getString( "gen.stuvie" )</span>
+                #else
+                    <span class="disabled">$!tlang.getString( "gen.stuvie" )</span>
+                #end
+            </li>
+        #end
+        #if( ($allowAllGroups) && ($assignmentscheck) )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                #if( $current == "reorder" )
+                    <span class="current">$tlang.getString( "gen.reorder" )</span>
+                #else
+                    <span>
+                        <a href="javascript:void(0)" title="$tlang.getString( "gen.reorder" )" onclick="ASN.submitForm( '$formID', 'reorderNavigation', null, null, true );">
+                            $tlang.getString( "gen.reorder" )
+                        </a>
+                    </span>
+                #end
+            </li>
+        #end
+        #if( $allowUpdateSite )
+            <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                <span>
+                    <a href="javascript:void(0)" title="$tlang.getString( "permis" )" onclick="ASN.submitForm( '$formID', 'permissions', null, null, true );">
+                        $tlang.getString( "permis" )
+                    </a>
+                </span>
+            </li>
+            #if( $enableViewOption )
+                <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
+                    <span>
+                        <a href="javascript:void(0)" title="$tlang.getString( "options" )" onclick="ASN.submitForm( '$formID', 'options', null, null, true );">
+                            $tlang.getString( "options" )
+                        </a>
+                    </span>
+                </li>
+            #end
+        #end
+    </ul>
 #end
 <!-- end:  assignment_macros.vm -->

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_delete_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_delete_assignment.vm
@@ -52,9 +52,8 @@
 				#end
 			</table>
 			<p class="act">
-				<input type="submit" accesskey="s" id="delete" onclick="ASN.disableControls(); ASN.showSpinner( 'deleteSpinner' );" class="active" name="eventSubmit_doDelete_assignment" value="$tlang.getString("delet")" />
-				<input type="submit" accesskey="x" id="cancel" onclick="ASN.disableControls(); ASN.showSpinner( 'deleteSpinner' );" name="eventSubmit_doCancel_delete_assignment" value="$tlang.getString("gen.can")" />
-				<img id="deleteSpinner" class="spinner" src="/library/image/indicator.gif" />
+				<input type="submit" accesskey="s" id="delete" onclick="SPNR.disableControlsAndSpin( this, null );" class="active" name="eventSubmit_doDelete_assignment" value="$tlang.getString("delet")" />
+				<input type="submit" accesskey="x" id="cancel" onclick="SPNR.disableControlsAndSpin( this, null );" name="eventSubmit_doCancel_delete_assignment" value="$tlang.getString("gen.can")" />
 			</p>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -6,20 +6,9 @@
 <script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>
 
 <script type="text/javascript">
-focus_path = [ '$fField' ];
-function handleEnterKeyPress(ev)
-	{
-		if (!ev) ev = window.event;
-			if (ev && ev.keyCode == 13)
-			{
-				 return false; 
-			 }
-		 }
-</script>
-<script type="text/javascript">
+	focus_path = [ '$fField' ];
 	$(document).ready(function(){
-		setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
-		ASN.setupItemNavigator();
+		ASN.setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
 		//click anywhere to close the peer assessment information box
 		$(document).click(function(ev){
 			var $pan = $('#peerReviewInfo')
@@ -28,25 +17,25 @@ function handleEnterKeyPress(ev)
 		disableBackButton();
 	});
 
-var reportsExpanded = false;
-function handleReportsTriangleDisclosure(btn)
-{
-	var reportsDiv = document.getElementById("reportsDiv");
-	if (reportsExpanded)
+	var reportsExpanded = false;
+	function handleReportsTriangleDisclosure(btn)
 	{
-		btn.src = "#imageLink("sakai/expand.gif")";
-		btn.alt = "$tlang.getString('review.report.expand')";
-		reportsDiv.style.display="none";
+		var reportsDiv = document.getElementById("reportsDiv");
+		if (reportsExpanded)
+		{
+			btn.src = "#imageLink("sakai/expand.gif")";
+			btn.alt = "$tlang.getString('review.report.expand')";
+			reportsDiv.style.display="none";
+		}
+		else
+		{
+			btn.src = "#imageLink("sakai/collapse.gif")";
+			btn.alt = "$tlang.getString('review.report.collapse')";
+			reportsDiv.removeAttribute("style");
+			ASN.resizeFrame();
+		}
+		reportsExpanded = !reportsExpanded;
 	}
-	else
-	{
-		btn.src = "#imageLink("sakai/collapse.gif")";
-		btn.alt = "$tlang.getString('review.report.collapse')";
-		reportsDiv.removeAttribute("style");
-		resizeFrame();
-	}
-	reportsExpanded = !reportsExpanded;
-}
 </script>
 <div class="portletBody">
 
@@ -54,43 +43,7 @@ function handleReportsTriangleDisclosure(btn)
 #set( $assignmentContent = $assignment.getContent() )
 #set( $gradeType = $assignmentContent.TypeOfGrade )
 
-<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-			#set($prevAction=true)
-			<li class="firstToolBarItem">
-				<span><a href="#" title = "$!tlang.getString('new')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='new';document.getElementById('view').value='new';document.gradeForm.submit();return false;">$!tlang.getString("new")</a></span>
-			</li>
-		#end
-		<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-			<span><a href="#" title = "$!tlang.getString('lisofass1')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='lisofass1';document.gradeForm.submit();return false;">$!tlang.getString("lisofass1")</a></span>
-		</li>	
-		#if ($withGrade && $!allowGradeSubmission)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$!tlang.getString('gen.grarep')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='grarep';document.gradeForm.submit();return false;">$!tlang.getString("gen.grarep")</a></span>
-			</li>				
-		#end
-		#if ($allowAddAssignment)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$!tlang.getString('gen.stuvie')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='stuvie';document.gradeForm.submit();return false;">$!tlang.getString("gen.stuvie")</a></span>
-			</li>	
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$tlang.getString('gen.reorder')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='reorderNavigation';document.gradeForm.submit();return false;">$tlang.getString('gen.reorder')</a></span>
-			</li>	
-		#end
-		#if ($allowUpdateSite)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$tlang.getString('permis')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='permissions';document.gradeForm.submit();return false;">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)	
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#" title="$tlang.getString('options')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='options';document.gradeForm.submit();return false;">$tlang.getString('options')</a></span>
-				</li>
-			#end	
-		#end
-	</ul>
+	#navBarOnClick( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "gradeForm" "" )
 	## confirmation
 	#if ($!gradingDone)
 		<div class="success">
@@ -135,20 +88,19 @@ function handleReportsTriangleDisclosure(btn)
 					<div class="leftColumn">
 						<input type="button" name="prevsubmission1" class="prevsubmission" value="$tlang.getString( "nav.prev" )"
 							#if( !$!goPTButton ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'prevsubmission' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevsubmission', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 
 						#if ($gradeType != 1)
 						<input type="button" name="prevungraded1" class="prevUngraded" value="$tlang.getString( "nav.prev.ungraded" )"
 							#if( !$!goPrevUngradedEnabled ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'prevUngraded' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevUngraded' '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						#end
 
 						<div class="instruction textPanelFooter">$tlang.getString( "nav.message" )</div>
 					</div>
 					<div class="centreColumn">
 						<input type="button" name="cancelgradesubmission1" class="cancelgradesubmission" value="$tlang.getString( "nav.list" )"
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'cancelgradesubmission' );" />
-						<div class="messageProgress">$tlang.getString( "gen.proces" )</div>
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgradesubmission', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						<div id="subsOnlyContainer">
 							<input type="checkbox" id="chkSubsOnly1" name="chkSubsOnly1" #if( $subsOnlySelected ) checked="checked" #end
 								onclick="ASN.toggleSubNavButtons( this );" />
@@ -160,12 +112,12 @@ function handleReportsTriangleDisclosure(btn)
 						#if ($gradeType != 1)
 						<input type="button" name="nextungraded1" class="nextUngraded" value="$tlang.getString( "nav.next.ungraded" )"
 							#if( !$!goNextUngradedEnabled ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'nextUngraded' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'nextUngraded', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						#end
 
 						<input type="button" name="nextsubmission1" class="nextsubmission" value="$tlang.getString( "nav.next" )"
 							#if( !$!goNTButton ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'nextsubmission' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'nextsubmission', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						<div class="instruction textPanelFooter">$tlang.getString( "nav.message" )</div>
 					</div>
 				</fieldset>
@@ -319,13 +271,13 @@ function handleReportsTriangleDisclosure(btn)
 		## show or hide assignment instruction and attachment
 			#if ($assignment_expand_flag)
 				<p class="discTria">
-					<a href="#" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='hide_instruction';document.gradeForm.submit();return false;">
+					<a href="javascript:void(0)" onclick="ASN.submitForm( 'gradeForm', 'hide_instruction', null, null, true );">
 					<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("gradingsub.opecliass")" border="0" width="13" height="13" align="top" /></a>
 					$tlang.getString("gen.assinf")
 				</p>	
 			#else
 				<p class="discTria">
-					<a href="#" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='show_instruction';document.gradeForm.submit();return false;">
+					<a href="javascript:void(0)" onclick="ASN.submitForm( 'gradeForm', 'show_instruction', null, null, true );">
 					<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("gen.clocli")" border="0" width="13" height="13" align="top" /></a>
 					$tlang.getString("gen.assinf")
 				</p>	
@@ -578,7 +530,7 @@ function handleReportsTriangleDisclosure(btn)
 											&nbsp<img id="infoImg" title="$tlang.getString('peerassessment.peerGradeInfo')" src="/library/image/silk/information.png" onclick="$('#peerReviewInfo').show();"/>
 										#end
 										</label>
-										<input type="text" name="$name_grade" size="5" maxlength="11" value="$!value_grade" id="grade" onkeypress="return handleEnterKeyPress(event);" /> <span class="instruction">($tlang.getString("grade.max") $assignmentContent.getMaxGradePointDisplay())</span>
+										<input type="text" name="$name_grade" size="5" maxlength="11" value="$!value_grade" id="grade" onkeypress="return ASN.handleEnterKeyPress(event);" /> <span class="instruction">($tlang.getString("grade.max") $assignmentContent.getMaxGradePointDisplay())</span>
 										
 										<!--for grading via an external scoring service, if enabled for the associated gradebook item -->
 										#if($scoringComponentEnabled)
@@ -605,7 +557,7 @@ function handleReportsTriangleDisclosure(btn)
 
                                                                 #if ($assignment.isGroup())
                                                                     <p class="checkbox" id="tempGradeOverride" >
-                                                                        <input type="checkbox" id="allowGradeOverrideToggle" #if($value_grades && $value_grades.size()>0)checked="checked"#end name ="allowGradeOverrideToggle" onclick="if(checked){document.getElementById('gradeOverridePanel').style.display='block';resizeFrame();}else{document.getElementById('gradeOverridePanel').style.display = 'none';}" />
+                                                                        <input type="checkbox" id="allowGradeOverrideToggle" #if($value_grades && $value_grades.size()>0)checked="checked"#end name ="allowGradeOverrideToggle" onclick="if(checked){document.getElementById('gradeOverridePanel').style.display='block';ASN.resizeFrame();}else{document.getElementById('gradeOverridePanel').style.display = 'none';}" />
                                                                         <label for="allowGradeOverrideToggle">$tlang.getString("allowGradeOverride")</label>
                                                                     </p>
                                                                     <div id="gradeOverridePanel" style="margin-left: 50px;width:80%;#if(!$value_grades || $value_grades.size()<1)display:none;#end">
@@ -634,7 +586,7 @@ function handleReportsTriangleDisclosure(btn)
                                                                         #elseif ($gradeType == 3)
                                                                             $!submitterName
                                                                             <div class="shorttext">
-                                                                                <span class="instruction">$tlang.getString("gen.grade.override")</span> <input type="text" name="$group_name_grade" size="5" maxlength="11" value="$!group_value_grade" id="grade" onkeypress="return handleEnterKeyPress(event);" /> <span class="instruction">($tlang.getString("grade.max") $assignmentContent.getMaxGradePointDisplay())</span>
+                                                                                <span class="instruction">$tlang.getString("gen.grade.override")</span> <input type="text" name="$group_name_grade" size="5" maxlength="11" value="$!group_value_grade" id="grade" onkeypress="return ASN.handleEnterKeyPress(event);" /> <span class="instruction">($tlang.getString("grade.max") $assignmentContent.getMaxGradePointDisplay())</span>
                                                                             </div>    
                                                                         #elseif ($gradeType == 4)
                                                                             $!submitterName
@@ -740,9 +692,9 @@ function handleReportsTriangleDisclosure(btn)
 						#end		
 						<p class="act">
 							#if ($!props)
-								<input type="button" name="attach" value="$tlang.getString('gen.adddroatt')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='attach';document.gradeForm.submit();return false;" accesskey="a"/>
+								<input type="button" name="attach" value="$tlang.getString('gen.adddroatt')" onclick="ASN.submitForm( 'gradeForm', 'attach', null, null, true );" accesskey="a"/>
 							#else
-								<input type="button" name="attach" value="$tlang.getString('gen.addatt')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='attach';document.gradeForm.submit();return false;" accesskey="a"/>
+								<input type="button" name="attach" value="$tlang.getString('gen.addatt')" onclick="ASN.submitForm( 'gradeForm', 'attach', null, null, true );" accesskey="a"/>
 							#end
 						</p>
 						#if ($!prevFeedbackAttachments)
@@ -792,7 +744,7 @@ function handleReportsTriangleDisclosure(btn)
 							#set($resubmitStyle="display:none")
 						#end
 						<p class="checkbox" id="tempAllowRes" #if ($submissionType == 4) style = "display:none"#end>
-							<input type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber && $submissionType != 4) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitContainer').style.display = 'block';resizeFrame();}else{document.getElementById('allowResubmitContainer').style.display = 'none';}" /> 
+							<input type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber && $submissionType != 4) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitContainer').style.display = 'block';ASN.resizeFrame();}else{document.getElementById('allowResubmitContainer').style.display = 'none';}" />
 							<label for="allowResToggle">$tlang.getString("allowResubmit")</label>
 	    				</p>
 						<div id="allowResubmitContainer" style="$!resubmitStyle">
@@ -838,11 +790,10 @@ function handleReportsTriangleDisclosure(btn)
 			<div class="viewNav highlight" style="width:70%;line-height:1.4em;padding-top:.75em;">
 				<span class="act">
 					## SAK-29314
-					<input type="button" accesskey="d" class="active"  name="save" value="$tlang.getString('gen.savdragra')" onclick="ASN.doGradingFormAction( '$validator.escapeUrl( $submission.Reference )', 'savegrade' );" title="$tlang.getString("gen.savdratit")" />
-					<input type="button" accesskey="s" name="return" value="$tlang.getString('gen.retustud')" onclick="ASN.doGradingFormAction( '$validator.escapeUrl( $submission.Reference )', 'returngrade' );" title="$tlang.getString("gen.retustudtit")" />
-					<input type="button" accesskey="v" name="preview" value="$tlang.getString('gen.pre')" onclick="ASN.doGradingFormAction( '$validator.escapeUrl( $submission.Reference )', 'previewgrade' );" />
-					<input type="button" accesskey="x" name="cancel" value="$tlang.getString('cancel_changes')" onclick="ASN.doGradingFormAction( null, 'cancelgrade' );" />
-					<img id="gradeFormSpinner" class="spinner" src="/library/image/indicator.gif" />
+					<input type="button" accesskey="d" class="active"  name="save" value="$tlang.getString('gen.savdragra')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'savegrade', '$validator.escapeUrl( $submission.Reference )', null, true );" title="$tlang.getString("gen.savdratit")" />
+					<input type="button" accesskey="s" name="return" value="$tlang.getString('gen.retustud')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'returngrade', '$validator.escapeUrl( $submission.Reference )', null, true );" title="$tlang.getString("gen.retustudtit")" />
+					<input type="button" accesskey="v" name="preview" value="$tlang.getString('gen.pre')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'previewgrade', '$validator.escapeUrl( $submission.Reference )', null, true );" />
+					<input type="button" accesskey="x" name="cancel" value="$tlang.getString('cancel_changes')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgrade', null, null, true );" />
 					#if ($!prevSubmissionId)
 						<input type="hidden" name="prevSubmissionId" id="prevSubmissionId" value = "$!prevSubmissionId" />
 					#end
@@ -879,20 +830,19 @@ function handleReportsTriangleDisclosure(btn)
 					<div class="leftColumn">
 						<input type="button" name="prevsubmission2" class="prevsubmission" value="$tlang.getString( "nav.prev" )"
 							#if( !$!goPTButton ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'prevsubmission' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevsubmission', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 
 						#if ($gradeType != 1)
 						<input type="button" name="prevungraded2" class="prevUngraded" value="$tlang.getString( "nav.prev.ungraded" )"
 							#if( !$!goPrevUngradedEnabled ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'prevUngraded' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevUngraded', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						#end
 
 						<div class="instruction textPanelFooter">$tlang.getString( "nav.message" )</div>
 					</div>
 					<div class="centreColumn">
 						<input type="button" name="cancelgradesubmission2" class="cancelgradesubmission" value="$tlang.getString( "nav.list" )"
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'cancelgradesubmission' );" />
-						<div class="messageProgress">$tlang.getString( "gen.proces" )</div>
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgradesubmission', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						<div id="subsOnlyContainer">
 							<input type="checkbox" id="chkSubsOnly2" name="chkSubsOnly2" #if( $subsOnlySelected ) checked="checked" #end
 								onclick="ASN.toggleSubNavButtons( this );" />
@@ -904,12 +854,12 @@ function handleReportsTriangleDisclosure(btn)
 						#if ($gradeType != 1)
 						<input type="button" name="nextungraded2" class="nextUngraded" value="$tlang.getString( "nav.next.ungraded" )"
 							#if( !$!goNextUngradedEnabled ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'nextUngraded' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'nextUngraded', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						#end
 
 						<input type="button" name="nextsubmission2" class="nextsubmission" value="$tlang.getString( "nav.next" )"
 							#if( !$!goNTButton ) disabled="disabled" #end 
-							onclick="ASN.navPanelAction( '$validator.escapeUrl( $submission.Reference )', 'nextsubmission' );" />
+							onclick="SPNR.disableControlsAndSpin( this, null ); submitForm( 'gradeForm', 'nextsubmission', '$validator.escapeUrl( $submission.Reference )', null, true );" />
 						<div class="instruction textPanelFooter">$tlang.getString( "nav.message" )</div>
 					</div>
 				</fieldset>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -7,74 +7,21 @@
 
 <script type="text/javascript">
 	$(document).ready(function(){
-		setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
+		ASN.setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
 
 		$('#submissionList input:checkbox').click(function(){
 			if ( $("#submissionList input:checked").length ===0){
-				hideAllowResubmission()
-				hideSendFeedback()
-				}
+				ASN.hideAllowResubmission()
+				ASN.hideSendFeedback()
+			}
 			else{
-				showAllowResubmission()
-				showSendFeedback()
+				ASN.showAllowResubmission()
+				ASN.showSendFeedback()
 			}
 		});
 
 		ASN.enableLinks();
 	});
-
-	function showAllowResubmission()
-	{
-		document.getElementById('allowResubmission_shown').style.display="inline";
-		document.getElementById('allowResubmission_hidden').style.display="none";
-		$('#allowResubmission_shownInner').addClass('highLightBlock').fadeIn(2000,function(){
-			$(this).removeClass('highLightBlock')
-		});
-		document.getElementById('allowResToggle').value="checked";
-		resizeFrame('grow');
-	}
-	
-	function hideAllowResubmission()
-	{
-		$('#allowResubmission_shownInner').fadeOut('fast', function() {
-			document.getElementById('allowResubmission_shown').style.display="none";
-			document.getElementById('allowResubmission_hidden').style.display="inline";
-			document.getElementById('allowResToggle').value="";
-		});
-
-	}
- 	
-	function showSendFeedback()
-	{
-	    document.getElementById('sendFeedback_shown').style.display="inline";
-	    document.getElementById('sendFeedback_hidden').style.display="none";
-		$('#sendFeedback_shownInner').addClass('highLightBlock').fadeIn(2000,function(){
-			$(this).removeClass('highLightBlock')
-		});
-	   resizeFrame('grow');
-	}
-
-	function  hideSendFeedback()
-	{
-		$('#sendFeedback_shownInner').fadeOut('fast', function() {
-		    document.getElementById('sendFeedback_shown').style.display="none";
-		    document.getElementById('sendFeedback_hidden').style.display="inline";
-		});
-	}
-
-	function toggleSelectAll(caller, elementName)
-	{
-					var newValue = caller.checked;
-					var elements = document.getElementsByName(elementName);
-			
-					if(elements)
-					{
-						for(var i = 0; i < elements.length; i++)
-						{
-							elements[i].checked = newValue;
-						}
-					}
-	}
 
 	function handleReportsTriangleDisclosure(header, content)
 	{
@@ -93,52 +40,14 @@
 			content.style.display = "none";
 		}
 	}
+
+	var escapeList = [ 'toggleModel' ];
 </script>
 
 #set ($submissionType = $assignmentContent.getTypeOfSubmission())
 
 <div class="portletBody">
-	<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-			#set($prevAction=true)
-			<li  class="firstToolBarItem">
-				<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
-			</li>	
-		#end
-		<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-			<span><a href="#toolLinkParam("$action" "doView" "view=lisofass1")" title="$!tlang.getString('lisofass1')">$!tlang.getString('lisofass1')</a></span>
-		</li>			
-		#if ($withGrade && $!allowGradeSubmission)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLinkParam("$action" "doView" "view=grarep")" title="$!tlang.getString("gen.grarep")">$!tlang.getString("gen.grarep")</a></span>
-			</li>	
-		#end
-			#if (!$!view.equals('stuvie'))
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString("gen.stuvie")">$!tlang.getString("gen.stuvie")</a></span>
-				</li>	
-			#else
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>			
-					<span class="current">$!tlang.getString("gen.stuvie")</span>
-				</li>	
-			#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLink("$action" "doReorder")" title="$tlang.getString('gen.reorder')">$tlang.getString('gen.reorder')</a></span>
-			</li>	
-		#end
-		#if ($allowUpdateSite)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)	
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-				</li>
-			#end	
-		#end
-	</ul>
+    #navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
 	<h3>
 		$validator.escapeHtml($assignment.getTitle()) 
 		#if ($!assignment.isGroup() )
@@ -165,12 +74,12 @@
 			#if (!$assignment.isGroup())
 				#if (!$value_CheckAnonymousGrading.equals("true") && $!groups.hasNext())
 					<div class="navPanel">
-						<div class="viewNav">
+						<div class="viewNav spinnerBesideContainer">
 							<label for="view">
 								$tlang.getString("gen.view2")
 							</label>
 							<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-							<select id="view" name="view" size="1" tabindex="3" onchange="ASN.changeView();">
+							<select id="view" name="view" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, escapeList, null ); ASN.submitForm( 'viewForm', 'changeView', null, null, true );">
 								#if (!$showSubmissionByFilterSearchOnly)
 									<option value="all" #if($!view.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
 								#else
@@ -180,7 +89,6 @@
 									<option value="$!aGroup.Reference" #if($!view.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
 								#end
 							</select>
-							<img id="viewSpinner" class="spinner" src="/library/image/indicator.gif" />
 						</div>
 					</div>
 				#end
@@ -191,11 +99,10 @@
 					<label for="$form_search" class="skip">$tlang.getString("search_students")</label>
 					<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
 						name="search" id="search" type="text" class="searchField" size="20" />
-					<input type="button" value="$tlang.getString('search')" onclick="ASN.applySearchFilter('search');" />
+					<input type="button" value="$tlang.getString('search')" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'viewForm', 'search', null, null, true );" />
 						#if (($!searchString) && (!$searchString.equals("")))
-							<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="ASN.applySearchFilter('clearSearch');" />
+							<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'viewForm', 'clearSearch', null, null, true );" />
 						#end
-					<img id="userFilterSpinner" class="spinner" src="/library/image/indicator.gif" />
 				</p>
 			#end
 			#end
@@ -213,11 +120,11 @@
 			#else
 				<div class="listNav">
 						## download all
-							<a href="" class="noPointers" id="downloadAll" onclick="ASN.doLinkAction( 'download' );document.getElementById( 'viewForm' ).submit();return false;" title="$!tlang.getString('downall')">$!tlang.getString('downall')</a>
+							<a href="" class="noPointers" id="downloadAll" onclick="SPNR.insertSpinnerAfter( this, escapeList, 'pagingHeader' ); ASN.submitForm( 'viewForm', 'download', null, null, true );" title="$!tlang.getString('downall')">$!tlang.getString('downall')</a>
 						#if(!$disableGrade)
 							## upload all
-								|  <a href="" class="noPointers" id="uploadAll" onclick="ASN.doLinkAction( 'upload' );document.getElementById( 'viewForm' ).submit();return false;" title="$!tlang.getString('uploadall.title')">$!tlang.getString('uploadall.title')</a>
-							|  <a href="" class="noPointers" id="releaseGrades" onclick="ASN.doLinkAction( 'releaseGrades' );document.getElementById( 'viewForm' ).submit();return false;"
+								|  <a href="" class="noPointers" id="uploadAll" onclick="SPNR.insertSpinnerAfter( this, escapeList, 'pagingHeader' ); ASN.submitForm( 'viewForm', 'upload', null, null, true );" title="$!tlang.getString('uploadall.title')">$!tlang.getString('uploadall.title')</a>
+							|  <a href="" class="noPointers" id="releaseGrades" onclick="SPNR.insertSpinnerAfter( this, escapeList, 'pagingHeader' ); ASN.submitForm( 'viewForm', 'releaseGrades', null, null, true );"
 							#if ($withGrade)
 								title="$!tlang.getString('relgrad')">$!tlang.getString('relgrad')</a>
 							#else
@@ -229,7 +136,7 @@
 								#set ($helperInfo = false)
 								#set ($helperInfo = $provider.provider.getItemsHelperInfo($activity.Reference))
 								#if ($helperInfo)
-									|  <a id="helpItems" class="noPointers" onclick="ASN.disableControls();" href="#toolLinkParam("$action" "doHelp_items" "activityRef=$validator.escapeUrl($activity.Reference)&providerId=$validator.escapeUrl($provider.provider.id)")" title="$!helperInfo.description">$!helperInfo.name</a>
+									|  <a id="helpItems" class="noPointers" onclick="SPNR.insertSpinnerAfter( this, escapeList, 'pagingHeader' );" href="#toolLinkParam("$action" "doHelp_items" "activityRef=$validator.escapeUrl($activity.Reference)&providerId=$validator.escapeUrl($provider.provider.id)")" title="$!helperInfo.description">$!helperInfo.name</a>
 								#end
 							#end
 						#end
@@ -247,7 +154,7 @@
 			<div class="viewNav">
 			#set ($gradeType = $typeOfGrade)
 			#if(!$disableGrade)
-				<form name="defaultGradeForm" class="inlineForm" method="post" action="#toolForm($action)">
+				<form id="defaultGradeForm" name="defaultGradeForm" class="inlineForm" method="post" action="#toolForm($action)">
 					<input type="hidden" name="$!form_action" value="setScore" />
 					<label for="defaultGrade_1" style="display:block" class="textPanelFooter">$!form_label</label>
 					##for non-point-based grading, choose the default grade from drop-down
@@ -272,76 +179,12 @@
 						## instructor needs to type in default points in point-based-grading
 						<input type="text" id="defaultGrade_2" name="defaultGrade" value="$!defaultGrade" size="5" />
 					#end
-					<input type="button" accesskey="a" class="active"  name="apply" value="$tlang.getString('gen.applygrade')" onclick="ASN.applyDefaultGrade();" title="$tlang.getString("gen.applygrade")" />
-					<img id="applyGradeSpinner" class="spinner" src="/library/image/indicator.gif" />
+					<input type="button" accesskey="a" class="active" name="apply" value="$tlang.getString('gen.applygrade')" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'defaultGradeForm', null, null, null, false );" title="$tlang.getString("gen.applygrade")" />
 					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 				</form>
 			#end
 			</div>
-			<div class="listNav">
-				<div class="instruction">
-					$tlang.getString("gen.viewing") $topMsgPos - $btmMsgPos $tlang.getString("gen.of") $allMsgNumber $tlang.getString("gen.items")
-					<img id="navSpinner" class="spinner" src="/library/image/indicator.gif" />
-				</div>
-				#if ($pagesize != 0)
-					#if ($goFPButton == "true")
-						<form name="firstpageForm" class="inlineForm"  method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-					#if ($goPPButton == "true")
-						<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getString('gen.previous') $pagesize" accesskey="p" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-				#end	
-				<form name="pagesizeForm" class="inlineForm" method="post" action="#toolForm("$action")">
-					<input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
-					<label for="selectPageSize" class="skip">$tlang.getString("newassig.selectmessage")</label>
-					<select id="selectPageSize" name="selectPageSize" onchange="ASN.changePageSize();">
-						#foreach ($i in $!pagesizes)
-							<option value="$i" #if($pagesize == $i) selected="selected" #end>$tlang.getString("list.show") $i $tlang.getString("list.itemsper")</option>
-						#end
-					</select>
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-				#if ($pagesize != 0)
-					#if ($goNPButton == "true")
-						<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getString('gen.next') $pagesize" accesskey="n" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-					#if ($goLPButton == "true")
-						<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString('gen.last')" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls(); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-				#end
-			</div>
+			#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
 		</div>
 		<form name= "listSubmissionsForm" action="#toolForm("AssignmentAction")" method="post">
 			<input type="hidden" name="assignmentId" value="$assignment.Reference" />
@@ -441,7 +284,7 @@
 			#end
 			<div id="sendFeedback_hidden" #if (!$!showSendFeedback && $!value_SubmissionType != 4) style="display:block" #else style="display:none" #end>
 				<p class="discTria">
-					<a href="#" onclick="javascript:showSendFeedback();">
+					<a href="javascript:void(0)" onclick="ASN.showSendFeedback();">
 						<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("sendFeedback.show")" border="0" width="13" height="13" align="top" />
 						$tlang.getString("sendFeedback.show")
 					</a>
@@ -449,7 +292,7 @@
 			</div>
 			<div id="sendFeedback_shown" #if ($!showSendFeedback && $!value_SubmissionType != 4) style="display:block" #else style="display:none"#end>
 				<p class="discTria">
-					<a href="#" onclick="javascript:hideSendFeedback();">
+					<a href="javascript:void(0)" onclick="ASN.hideSendFeedback();">
 						<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("sendFeedback.hide")" border="0" width="13" height="13" align="top" />
 						$tlang.getString("sendFeedback.hide")
 					</a>
@@ -488,7 +331,7 @@
 			<div id="allowResubmission_hidden" #if (!$!showAllowResubmission && $!value_SubmissionType != 4)style="display:block"#else style="display:none"#end>
 				<input type="hidden" name = "allowResToggle" id = "allowResToggle" value="checked" />
 				<p class="discTria">
-					<a href="#" onclick="javascript:showAllowResubmission();">
+					<a href="javascript:void(0)" onclick="ASN.showAllowResubmission();">
 					<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("allowResubmission.show")" border="0" width="13" height="13" align="top" />
 						#if ($assignment.isGroup())
 							$tlang.getString("allowResubmission.groups.label")
@@ -500,7 +343,7 @@
 			</div>
 			<div id="allowResubmission_shown" #if ($!showAllowResubmission && $!value_SubmissionType != 4)style="display:block"#else style="display:none"#end>
 				<p class="discTria">
-					<a href="#" onclick="javascript:hideAllowResubmission();">
+					<a href="javascript:void(0)" onclick="ASN.hideAllowResubmission();">
 						<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("allowResubmission.hide")" border="0" width="13" height="13" align="top" />
 						#if ($assignment.isGroup())
 							$tlang.getString("allowResubmission.groups.label")
@@ -522,7 +365,7 @@
 								<label for="allowResubmitNumber">
 									$tlang.getString("allow.resubmit.number")
 								</label>
-								<select name="$name_allowResubmitNumber" id="allowResubmitNumber" onchange="if (document.getElementById('allowResubmitNumber').value!=0 && document.getElementById('allowResubmitTime') !=null){document.getElementById('allowResubmitTime').style.display = 'block';}else {document.getElementById('allowResubmitTime').style.display = 'none';}">
+								<select name="$name_allowResubmitNumber" id="allowResubmitNumber" onchange="ASN.toggleResubmitTimePanel();">
 									#foreach ($i in [1..10])
 										<option value="$i" #if($i==$!value_allowResubmitNumber)selected="selected"#end>
 											$i
@@ -557,8 +400,7 @@
 
 								## for save the resubmission choice
 								<div class="act">
-									<input type="submit" class="active" onclick="ASN.disableControls(); ASN.showSpinner( 'applyResubmissionSpinner' );" name="eventSubmit_doSave_resubmission_option" value="$tlang.getString("update")" accesskey="s" />
-									<img id="applyResubmissionSpinner" class="spinner" src="/library/image/indicator.gif" />
+									<input type="submit" class="active" onclick="SPNR.disableControlsAndSpin( this, escapeList );" name="eventSubmit_doSave_resubmission_option" value="$tlang.getString("update")" accesskey="s" />
 								</div>
 							</p>
 						</div>	
@@ -570,14 +412,14 @@
 			<table class="listHier lines nolines" id ="submissionList" cellpadding="0" cellspacing="0" summary="$tlang.getString("gen.viewassliststudentsummary")">
 				<tr>
 					<th id="selectResubmit" class="smallCol">
-						<input type="checkbox" name="toggleAllSelectAllowResubmit" value="" id="toggleAllSelectAllowResubmit" onclick="javascript:toggleSelectAll(this, 'selectedAllowResubmit')" />
+						<input type="checkbox" name="toggleAllSelectAllowResubmit" value="" id="toggleAllSelectAllowResubmit" onclick="ASN.toggleSelectAll(this, 'selectedAllowResubmit')" />
 						<label for="toggleAllSelectAllowResubmit" class="skip">$tlang.getString("allowResubmission.toggleall")</label>
 					</th> 
 					<th id="attachment" class="attach">
 						<img src="#imageLink("sakai/attachments.gif")" border="0" alt="$tlang.getString("gen.att")" width="15" height="15" />
 					</th>
 					<th id="studentname">
-						<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_lastName")'; return false;"   title="$tlang.getString("gen.sorbylas")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_lastName")'; return false;"   title="$tlang.getString("gen.sorbylas")">
 							#if ($assignment.isGroup())
 								$tlang.getString("gen.group")
 							#else
@@ -593,7 +435,7 @@
 						</a>
 					</th>
 					<th id="submitted">
-						<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitTime")'; return false;"  title="$tlang.getString("listsub.sorbysub")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitTime")'; return false;"  title="$tlang.getString("listsub.sorbysub")">
 							$tlang.getString("gen.subm4")
 							#if ($sortedBy.equals($!sort_submitTime)) 
 								#if ($sortedAsc.equals("true")) 
@@ -605,7 +447,7 @@
 						</a>
 					</th>
 					<th id="status">
-						<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitStatus")'; return false;"  title="$tlang.getString("list.sorbysta")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitStatus")'; return false;"  title="$tlang.getString("list.sorbysta")">
 							$tlang.getString("gen.status")
 							#if ($sortedBy.equals($!sort_submitStatus)) 
 								#if ($sortedAsc.equals("true")) 
@@ -626,7 +468,7 @@
 					#end
 					#if ($withGrade)
 						<th id="grade">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitGrade")'; return false;"  title="$tlang.getString("gen.sorbygra")">
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitGrade")'; return false;"  title="$tlang.getString("gen.sorbygra")">
 								$tlang.getString("gen.gra")
 								#if ($sortedBy.equals($!sort_submitGrade)) 
 									#if ($sortedAsc.equals("true")) 
@@ -640,7 +482,7 @@
 					#end	
 					#if ($allowReviewService && $assignmentContent.AllowReviewService)
 						<th id="reviewService">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitReview")'; return false;" onkeypress="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitReview")'; return false;" title="$tlang.getString("gen.sorbyreview")">
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitReview")'; return false;" onkeypress="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitReview")'; return false;" title="$tlang.getString("gen.sorbyreview")">
 								$reviewServiceName
 								#if ($sortedBy.equals($!sort_submitReview)) 
 									#if ($sortedAsc.equals("true")) 
@@ -653,7 +495,7 @@
 						</td>
 					#end
 					<th id="gradereleased">
-						<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitReleased")'; return false;"  title="$tlang.getString("listsub.sorbyrel")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_grade_submission" "criteria=$!sort_submitReleased")'; return false;"  title="$tlang.getString("listsub.sorbyrel")">
 							$tlang.getString("gen.relea")
 							#if ($sortedBy.equals($!sort_submitReleased)) 
 								#if ($sortedAsc.equals("true")) 

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -1,93 +1,35 @@
 <!-- $Id$ -->
 <!-- start: chef_assignments_instructor_new_edit_assignment.vm  -->
-##Defining macro to repeat buttons at the top and bottom of the page
-#macro(buttonBar $submitnotif)
-	<div class="act">
-		<input accesskey="s" type="button" class="active" name="post" value="$tlang.getString("gen.pos")"
-				onclick="javascript:document.newAssignmentForm.onsubmit();showNotif('$submitnotif','post','newAssignmentForm');document.getElementById('option').value='post';document.newAssignmentForm.submit();return false;" />
-		<input accesskey="v" type="button" name="preview" value="$tlang.getString("gen.pre")"
-				onclick="javascript:document.newAssignmentForm.onsubmit();showNotif('$submitnotif','preview','newAssignmentForm');document.getElementById('option').value='preview';document.newAssignmentForm.submit();return false;" />
-		#if (!($!assignment && !$assignment.draft))
-			<input accesskey="d" type="button" name="save" value="$tlang.getString("gen.savdra")"
-				onclick="javascript:document.newAssignmentForm.onsubmit();showNotif('$submitnotif','save','newAssignmentForm');document.getElementById('option').value='save';document.newAssignmentForm.submit();return false;" />
-		#end
-		<input accesskey="x" type="button" name="cancel" value="$tlang.getString("gen.can")"
-				onclick="javascript:document.newAssignmentForm.onsubmit();document.getElementById('option').value='canceledit';document.newAssignmentForm.submit();return false;" />
-		<span id="$submitnotif" style="visibility:hidden">$tlang.getString("gen.proces")</span>
-	</div>
-#end
 ##<!-- $Header: Exp $ -->
 ## Assignments - Instructor new Assignment view
 #set( $H = '-' )
 <!-- jQuery already loaded in assignment_chef_header -->
 <link href="/library/js/jquery/ui/1.11.3/themes/ui-lightness/jquery-ui.min.css" rel="stylesheet" type="text/css" />
-<link href="/sakai-assignment-tool/css/assignment.css" type="text/css" rel="stylesheet" />
 
 <script type="text/javascript">
-$(document).ready(function() {
- 	setupAssignNew();
- 	#if($turnitin_forceSingleAttachment)
-	 	$("#new_assignment_use_review_service").click(function (){
-	 		var checked = this.checked;
-	 		if(checked){
-	 			$("#subType").val(5);
-	 		}
-	 		$("#subType > option").each(function(){
-	 			if(checked){
-	 				if($(this).val() != 5){
-	 					$(this).prop('disabled', 'disabled');
-	 				}
-	 			}else{
-	 				$(this).removeProp('disabled');
-	 			
-	 			}
-	 		});
-	 	});
- 	#end
-	SetMaxPoint(document.getElementById('$name_GradeType'), document.getElementById('$name_GradePoints'));
-});
-</script>
+	$(document).ready(function() {
+		ASN.setupAssignNew();
+		#if($turnitin_forceSingleAttachment)
+		 	$("#new_assignment_use_review_service").click(function (){
+		 		var checked = this.checked;
+		 		if(checked){
+		 			$("#subType").val(5);
+		 		}
+		 		$("#subType > option").each(function(){
+		 			if(checked){
+		 				if($(this).val() != 5){
+		 					$(this).prop('disabled', 'disabled');
+		 				}
+		 			}else{
+		 				$(this).removeProp('disabled');
+		 			
+		 			}
+		 		});
+		 	});
+		#end
+		SetMaxPoint(document.getElementById('$name_GradeType'), document.getElementById('$name_GradePoints'));
+	});
 
-<style type="text/css">
-	.extraNode {
-		border:1px solid #69d;
-		padding: 0  1.5em 1em 1.5em;
-		width:50%;
-		min-width:500px;
-	}
-	.extraNodeLink{
-		cursor:pointer;
-	}
-	.extraNode legend{
-		padding:0 .5em;
-		color:#555
-	}
-	.userList {
-		margin-left:36px !important
-	}
-	.userList .selectedItem{
-		background:#def;
-		color:#000;
-		font-weight:bold
-	}
-	.userList li label:hover{
-		cursor:pointer;
-		background:#ffe
-	}		
-
-	fieldset .alertMessageInline,fieldset .alertMessage {
-		border:none
-	}
-
-	.smallMatches{
-		background-color: lightyellow;
-		border-style: solid;
-		border-width: 1px;
-		border-color: lightgray;
-		padding: 1em 1em 1em 2em;
-	}
-</style>
-<script type="text/javascript">
     function SetMaxPoint(obj_option, obj_textfield)
     {
 		if (obj_option === null || obj_textfield === null)
@@ -109,79 +51,6 @@ $(document).ready(function() {
 			obj_textfield.style.backgroundColor = '#eee';
 			document.getElementById('req-$name_GradePoints').style.display="none";
 			document.getElementById('new_assignment_grade_points').value="";
-		}
-	}
-
-	#*
-	## This function is deprecated
-		function SetCloseDate(obj_checkbox, obj_1, obj_2, obj_3, obj_4, obj_5, obj_6)
-		{
-			if (obj_checkbox.checked)
-			{
-				obj_1.disabled = false;
-				obj_2.disabled = false;
-				obj_3.disabled = false;
-				obj_4.disabled = false;
-				obj_5.disabled = false;
-				obj_6.disabled = false;
-			}
-			else
-			{
-				obj_1.disabled = true;
-				obj_2.disabled = true;
-				obj_3.disabled = true;
-				obj_4.disabled = true;
-				obj_5.disabled = true;
-				obj_6.disabled = true;
-			}
-		}
-	*#
-	
-	function togglePeerAssessmentOptions(checked){
-		var section = document.getElementById("peerAssessmentOptions");
-		if(checked){
-			section.style.display="block";
-			resizeFrame('grow');
-		}else{
-			section.style.display="none";
-			resizeFrame('shrink');
-		}
-	}
-	
-	function toggleReviewServiceOptions(checked){
-		var section = document.getElementById("reviewServiceOptions");
-		if(checked){
-			section.style.display="block";
-			resizeFrame('grow');
-		}else{
-			section.style.display="none";
-			resizeFrame('shrink');
-		}
-	}
-	
-	function toggleSmallMatchesOptions(checked){
-		var section = document.getElementById("smallMatchesOptions");
-		if(checked){
-			section.style.display="inline-block";
-		}else{
-			section.style.display="none";
-		}
-	}
-	
-	function toggleSmallMatchesDisabled(){
-		var radioOption1 = document.getElementById("wordCount");
-		var radioOption2 = document.getElementById("percentage")
-		var excludeWords = document.getElementById("tiiExcludeValueWords");
-		var excludePercentages = document.getElementById("tiiExcludeValuePercentages");
-		
-		excludeWords.disabled = true;
-		excludeWords.value = "";
-		excludePercentages.disabled = true;
-		excludePercentages.value = "";
-		if(radioOption1.checked){
-			excludeWords.disabled = false;
-		}else if(radioOption2.checked){
-			excludePercentages.disabled = false;
 		}
 	}
 
@@ -207,7 +76,7 @@ $(document).ready(function() {
 				document.getElementById('allowResubmitNumber').style.display = 'block';
 				document.getElementById('allowResubmitTime').style.display = 'block';
 				document.getElementById('resubmitNotification').style.display = 'block';
-				resizeFrame();
+				ASN.resizeFrame();
 			}
 		}
 		else
@@ -216,7 +85,7 @@ $(document).ready(function() {
 				if (useReview.checked)
 				{
 					reviewSwitchNe2.style.removeProperty('display');
-					toggleReviewServiceOptions(this.checked);
+					ASN.toggleReviewServiceOptions(this.checked);
 				}
 				useReview.checked=false;
 				useReview.disabled=true;
@@ -231,58 +100,10 @@ $(document).ready(function() {
 		}
 	}
 
-	function toggleIsGroupSubmission(checked){
-		if (checked) {
-			$("#site").prop("disabled", true);
-			$("#groups").prop("checked", true).trigger("click");
-		} else {
-			$("#site").prop("disabled", false);
-		}
-	}
-	
-	function toggleAutoAnnounceOptions(checked){
-		var section = document.getElementById("selectAutoAnnounceOptions");
-		if(checked){
-			section.style.display="block";
-			resizeFrame('grow');
-		}else{
-			section.style.display="none";
-			resizeFrame('shrink');
-		}
-	}
-</script>
-<script type="text/javascript">
 	focus_path = [ '$fField' ];
 </script>
 <div class="portletBody">
-	<ul class="navIntraTool actionToolBar">
-		#if ($allowAddAssignment)
-			<li class="firstToolBarItem">
-				<span class="current">$!tlang.getString("new")</span>
-			</li>
-			<li>
-				<span><a href="#" title = "$!tlang.getString('lisofass1')" onclick="javascript:document.newAssignmentForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='lisofass1';document.newAssignmentForm.submit();return false;">$!tlang.getString("lisofass1")</a></span>
-			</li>	
-			#if ($withGrade && $!allowGradeSubmission)
-				<li>
-					<span><a href="#" title="$!tlang.getString('gen.grarep')" onclick="javascript:document.newAssignmentForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='grarep';document.newAssignmentForm.submit();return false;">$!tlang.getString("gen.grarep")</a></span>
-				</li>
-			#end
-				<li>
-					<span><a href="#" title="$!tlang.getString('gen.stuvie')" onclick="javascript:document.newAssignmentForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='stuvie';document.newAssignmentForm.submit();return false;">$!tlang.getString("gen.stuvie")</a></span>
-				</li>				
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li>		
-				<span><a href="#" title="$tlang.getString('gen.reorder')" onclick="javascript:document.newAssignmentForm.onsubmit();document.getElementById('option').value='reorderNavigation';document.newAssignmentForm.submit();return false;">$tlang.getString('gen.reorder')</a></span>
-			</li>
-		#end
-		#if ($allowUpdateSite)
-			<li>
-				<span><a href="#" title="$tlang.getString('permis')" onclick="javascript:document.newAssignmentForm.onsubmit();document.getElementById('option').value='permissions';document.newAssignmentForm.submit();return false;">$tlang.getString('permis')</a></span>
-			</li>	
-		#end
-	</ul>
+	#navBarOnClick( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "newAssignmentForm" "new" )
 	<h3>
 		#if($validator.escapeHtml($!value_title) && $validator.escapeHtml($!value_title) !='')
 			$validator.escapeHtml($!value_title) <span class="highlight">	$tlang.getString("edit")</span>
@@ -305,7 +126,7 @@ $(document).ready(function() {
 	#set($submitnotif="submitnotifTop")
 	#buttonBar($submitnotif)
 
-	<form name = "newAssignmentForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
+	<form name="newAssignmentForm" id="newAssignmentForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
 		<input type="hidden" name="assignmentId" value="$!assignment.Reference" />
 		<input type="hidden" name="assignmentContentId" value="$!assignment.ContentReference" />
 		<input type="hidden" name="eventSubmit_doAssignment_form" value="" />
@@ -343,7 +164,7 @@ $(document).ready(function() {
                 #if ($visible_date_enabled) 
                <p class="shorttext">
                 <p class="checkbox" id="tempVisibleDate" >
-                    <input type="checkbox" id="allowVisibleDateToggle" name="allowVisibleDateToggle" #if($!new_assignment_visibletoggle)checked="checked"#end onclick="if(checked){jQuery('.visibleDatePanel').show();resizeFrame();}else{jQuery('.visibleDatePanel').hide();}" />
+                    <input type="checkbox" id="allowVisibleDateToggle" name="allowVisibleDateToggle" #if($!new_assignment_visibletoggle)checked="checked"#end onclick="if(checked){jQuery('.visibleDatePanel').show();ASN.resizeFrame();}else{jQuery('.visibleDatePanel').hide();}" />
                     <label for="allowVisibleDateToggle">$tlang.getString("allowVisibleDate")</label>
                 </p>
                <p class="shorttext visibleDatePanel" #if(!$!new_assignment_visibletoggle)style="display:none;"#end>
@@ -535,7 +356,7 @@ $(document).ready(function() {
 			#set($resubmitStyle="display:none")
 		#end
 		<p class="checkbox" id="tempAllowRes" #if ($value_SubmissionType == 4) style = "display:none"#end>
-			<input type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitNumber').style.display = 'block';document.getElementById('allowResubmitTime').style.display = 'block';document.getElementById('resubmitNotification').style.display = 'block';resizeFrame();}else{document.getElementById('allowResubmitNumber').style.display = 'none';document.getElementById('allowResubmitTime').style.display = 'none';document.getElementById('resubmitNotification').style.display = 'none';}" /> 
+			<input type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitNumber').style.display = 'block';document.getElementById('allowResubmitTime').style.display = 'block';document.getElementById('resubmitNotification').style.display = 'block';ASN.resizeFrame();}else{document.getElementById('allowResubmitNumber').style.display = 'none';document.getElementById('allowResubmitTime').style.display = 'none';document.getElementById('resubmitNotification').style.display = 'none';}" /> 
 			<label for="allowResToggle">$tlang.getString("allowResubmit")</label>
 	    </p>
 		<p class="shorttext" id="allowResubmitNumber" style="$!resubmitStyle">
@@ -650,9 +471,9 @@ $(document).ready(function() {
 		#if ($!name_CheckAutoAnnounce)
 			<p class="checkbox  indnt2">
 				#if ($value_CheckAutoAnnounce.equals("true"))
-					<input id="$name_CheckAutoAnnounce" name="$name_CheckAutoAnnounce" type="checkbox" value="true" checked="checked" onclick="toggleAutoAnnounceOptions(this.checked)" />
+					<input id="$name_CheckAutoAnnounce" name="$name_CheckAutoAnnounce" type="checkbox" value="true" checked="checked" onclick="ASN.toggleAutoAnnounceOptions(this.checked)" />
 				#else
-					<input id="$name_CheckAutoAnnounce" name="$name_CheckAutoAnnounce" type="checkbox" value="true" onclick="toggleAutoAnnounceOptions(this.checked)" />
+					<input id="$name_CheckAutoAnnounce" name="$name_CheckAutoAnnounce" type="checkbox" value="true" onclick="ASN.toggleAutoAnnounceOptions(this.checked)" />
 				#end
 				<label for="$name_CheckAutoAnnounce">
 					$tlang.getString("gen.anntheope") 
@@ -690,7 +511,7 @@ $(document).ready(function() {
 				#if (4 == $value_SubmissionType)
 					<div id="review.switch.ne.1" class="information">$reviewSwitchNe1</div>
 					<div class="checkbox  indnt2">
-						<input id="$name_UseReviewService" name="$name_UseReviewService" type="checkbox" value="true"  onclick="toggleReviewServiceOptions(this.checked)" disabled="disabled"/>
+						<input id="$name_UseReviewService" name="$name_UseReviewService" type="checkbox" value="true" onclick="ASN.toggleReviewServiceOptions(this.checked)" disabled="disabled"/>
 
 						<label id="lblReviewService" for="$name_UseReviewService" class="instruction">
 							$reviewServiceUse
@@ -700,9 +521,9 @@ $(document).ready(function() {
 					<div id="review.switch.ne.1" class="information" style="display:none;">$reviewSwitchNe1</div>
 					<div class="checkbox indnt2">
 						#if($!value_UseReviewService.equals("true"))
-							<input id="$name_UseReviewService" name="$name_UseReviewService" type="checkbox" value="true" checked="checked" onclick="toggleReviewServiceOptions(this.checked)"/>
+							<input id="$name_UseReviewService" name="$name_UseReviewService" type="checkbox" value="true" checked="checked" onclick="ASN.toggleReviewServiceOptions(this.checked)"/>
 						#else
-							<input id="$name_UseReviewService" name="$name_UseReviewService" type="checkbox" value="true" onclick="toggleReviewServiceOptions(this.checked)"/>
+							<input id="$name_UseReviewService" name="$name_UseReviewService" type="checkbox" value="true" onclick="ASN.toggleReviewServiceOptions(this.checked)"/>
 						#end
 
 						<label id="lblReviewService" for="$name_UseReviewService">
@@ -793,9 +614,9 @@ $(document).ready(function() {
 					#if($show_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_SMALL_MATCHES)
 						<div class="checkbox indnt1">
 							#if ($value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE == 1 || $value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE == 2)
-								<input type="checkbox" value="true" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_SMALL_MATCHES" checked="checked"  onclick="toggleSmallMatchesOptions(this.checked)"/>
+								<input type="checkbox" value="true" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_SMALL_MATCHES" checked="checked" onclick="ASN.toggleSmallMatchesOptions(this.checked)"/>
 							#else
-								<input type="checkbox" value="true" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_SMALL_MATCHES" onclick="toggleSmallMatchesOptions(this.checked)"/>
+								<input type="checkbox" value="true" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_SMALL_MATCHES" onclick="ASN.toggleSmallMatchesOptions(this.checked)"/>
 							#end
 							<label for="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE">
 								$tlang.getString("review.exclude.smallMatches") 
@@ -808,14 +629,14 @@ $(document).ready(function() {
 								#end
 								$tlang.getString("review.exclude.matches.by")<span class="reqStar">*</span>
 								<br/>
-								<input onchange="toggleSmallMatchesDisabled()" type="radio" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE" id="wordCount" value="1" #if ($value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE ==  1) checked="checked" #end/>
+								<input onchange="ASN.toggleSmallMatchesDisabled()" type="radio" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE" id="wordCount" value="1" #if ($value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE ==  1) checked="checked" #end/>
 								<label for="wordCount">
 									$tlang.getString("review.exclude.matches.wordmax") 
 								</label>
 								<input type="text" size="3" maxlength="3" id="tiiExcludeValueWords" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_VALUE" #if ($value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE ==  1) value="$value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_VALUE" #else disabled="disabled" #end/>
 								<br/>
 								
-								<input onchange="toggleSmallMatchesDisabled()" type="radio" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE" id="percentage" value="2" #if ($value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE == 2) checked="checked" #end/>
+								<input onchange="ASN.toggleSmallMatchesDisabled()" type="radio" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE" id="percentage" value="2" #if ($value_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_TYPE == 2) checked="checked" #end/>
 								<label for="percentage">
 									$tlang.getString("review.exclude.matches.percentage") 
 								</label>
@@ -1049,9 +870,9 @@ $(document).ready(function() {
 				</h4>
 				<div class="checkbox  indnt2">
 					#if ($!value_UsePeerAssessment.equals("true"))
-						<input id="$name_UsePeerAssessment" name="$name_UsePeerAssessment" type="checkbox" value="true" checked="checked" onclick="togglePeerAssessmentOptions(this.checked)"/>
+						<input id="$name_UsePeerAssessment" name="$name_UsePeerAssessment" type="checkbox" value="true" checked="checked" onclick="ASN.togglePeerAssessmentOptions(this.checked)"/>
 					#else
-						<input id="$name_UsePeerAssessment" name="$name_UsePeerAssessment" type="checkbox" value="true"  onclick="togglePeerAssessmentOptions(this.checked)"/>
+						<input id="$name_UsePeerAssessment" name="$name_UsePeerAssessment" type="checkbox" value="true"  onclick="ASN.togglePeerAssessmentOptions(this.checked)"/>
 					#end
 					<label for="$name_UsePeerAssessment">
 						$peerAssessmentUse
@@ -1156,7 +977,7 @@ $(document).ready(function() {
 
                                  #if ($group_submissions_enabled)
                                     <p class="checkbox  indnt2">
-                            <input id="$name_CheckIsGroupSubmission" name="$name_CheckIsGroupSubmission" type="checkbox" value="1" onclick="toggleIsGroupSubmission(this.checked);"
+                            <input id="$name_CheckIsGroupSubmission" name="$name_CheckIsGroupSubmission" type="checkbox" value="1" onclick="ASN.toggleIsGroupSubmission(this.checked);"
                             #if ($!value_CheckIsGroupSubmission.equals("1") && $!groupsList)
                                 checked="checked"
                                         #end
@@ -1183,13 +1004,13 @@ $(document).ready(function() {
 
 				<p class="checkbox  indnt2">
                     #if( !$!allowGroupAssignmentsInGradebook )
-                        <input type="radio" name="range" id="site" value="site" onclick="if (document.getElementById('addToGradebook') !=null){$('#addToGradebook').fadeOut('slow'); ASN.showOrHideAccessMessages( false ); resizeFrame()};$('#groupTable').fadeOut('slow'); ASN.showOrHideAccessMessages( false ); resizeFrame();" 
+                        <input type="radio" name="range" id="site" value="site" onclick="if (document.getElementById('addToGradebook') !=null){$('#addToGradebook').fadeOut('slow'); ASN.showOrHideAccessMessages( false ); ASN.resizeFrame()};$('#groupTable').fadeOut('slow'); ASN.showOrHideAccessMessages( false ); ASN.resizeFrame();" 
                         #if( $!range == "site" || $selectedGroupsNotFound )
                             checked="checked"
                         #end
                         />
 					#else
-                        <input type="radio" name="range" id="site" value="site" onclick="$('#groupTable').fadeOut('slow'); ASN.showOrHideAccessMessages( false ); resizeFrame();" 
+                        <input type="radio" name="range" id="site" value="site" onclick="$('#groupTable').fadeOut('slow'); ASN.showOrHideAccessMessages( false ); ASN.resizeFrame();" 
                         #if( $!range == "site" || $selectedGroupsNotFound )
                             checked="checked"
                         #elseif ($!value_CheckIsGroupSubmission.equals("1") && $!groupsList)
@@ -1210,7 +1031,7 @@ $(document).ready(function() {
 			## added group awareness
 			<p class="checkbox indnt2">
                 #if( !$!allowGroupAssignmentsInGradebook )
-                    <input type="radio" name="range" id="groups" value="groups" onclick="if (document.getElementById('addToGradebook') != null){document.getElementById('addToGradebook').style.display = 'none';document.getElementById('$!name_Addtogradebook').checked=false};$('#groupTable').fadeIn('slow'); ASN.showOrHideAccessMessages( true ); resizeFrame();" 
+                    <input type="radio" name="range" id="groups" value="groups" onclick="if (document.getElementById('addToGradebook') != null){document.getElementById('addToGradebook').style.display = 'none';document.getElementById('$!name_Addtogradebook').checked=false};$('#groupTable').fadeIn('slow'); ASN.showOrHideAccessMessages( true ); ASN.resizeFrame();" 
                     #if( $!range == "groups" && !$selectedGroupsNotFound )
                         checked="checked"
                     #elseif( !$!groupsList )
@@ -1218,7 +1039,7 @@ $(document).ready(function() {
                     #end
                     />
 				#else
-                    <input type="radio" name="range" id="groups" value="groups" onclick="$('#groupTable').fadeIn('slow'); ASN.showOrHideAccessMessages( true ); resizeFrame();" 
+                    <input type="radio" name="range" id="groups" value="groups" onclick="$('#groupTable').fadeIn('slow'); ASN.showOrHideAccessMessages( true ); ASN.resizeFrame();"
                     #if( $!range == "groups" && !$selectedGroupsNotFound )
                         checked="checked"
                     #elseif( !$!groupsList )
@@ -1242,7 +1063,7 @@ $(document).ready(function() {
 			<table id="groupTable" style="width:80%;display:$listDisplay" class="listHier lines indnt3" border="0" cellpadding="0" cellspacing="0" summary="$tlang.getString('group.list.summary')">
 					<tr>
 						<th id ="selectAllGroups" style="width:2em;padding-left:.4em">
-                            <input type="checkbox" name="selectall" id="selectall" title="$tlang.getString('gen.toggle')" onclick="toggleSelectAll(this, 'selectedGroups'); ASN.showOrHideSelectGroupsMessage();"  />
+                            <input type="checkbox" name="selectall" id="selectall" title="$tlang.getString('gen.toggle')" onclick="ASN.toggleSelectAll(this, 'selectedGroups'); ASN.showOrHideSelectGroupsMessage();"  />
 						</th>
 						<th id ="groupname">
 								$tlang.getString('gen.title')
@@ -1371,10 +1192,10 @@ $(document).ready(function() {
 				</td>
 				<td class="itemAction" style="white-space:nowrap">
 					<div id="nomodelanswer"  #if(!$!modelanswer) style="display:block"#else style="display:none" #end>
-						<a id="modelanswer_add" class="extraNodeLink" href="#">$tlang.getString("new")<span class="skip"> $tlang.getString("modelAnswer")</span></a>
+						<a id="modelanswer_add" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("new")<span class="skip"> $tlang.getString("modelAnswer")</span></a>
 					</div>
 					<div id="hasmodelanswer"  #if($!modelanswer) style="display:block"#else style="display:none" #end>
-						<a id="modelanswer_edit" class="extraNodeLink" href="#">$tlang.getString("gen.revi")<span class="skip"> $tlang.getString("modelAnswer")</span></a> | <a id="modelanswer_delete" class="extraNodeLink" href="#">$tlang.getString("delet")<span class="skip"> $tlang.getString("modelAnswer")</span></a>
+						<a id="modelanswer_edit" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("gen.revi")<span class="skip"> $tlang.getString("modelAnswer")</span></a> | <a id="modelanswer_delete" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("delet")<span class="skip"> $tlang.getString("modelAnswer")</span></a>
 						<input id = "modelanswer_to_delete" name = "modelanswer_to_delete" type= "hidden" value = "false" />
 					</div>
 				</td>
@@ -1387,14 +1208,14 @@ $(document).ready(function() {
 					</td>
 					<td class="itemAction" style="white-space:nowrap">
 						<div id="nonote"  #if(!$!note) style="display:block"#else style="display:none" #end> 
-							<a id="note_add" class="extraNodeLink" href="#">$tlang.getString("new")<span class="skip"> $tlang.getString("note")</span></a>
+							<a id="note_add" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("new")<span class="skip"> $tlang.getString("note")</span></a>
 						</div>
 						<div id="hasnote"  #if($!note) style="display:block"#else style="display:none" #end>
 							#if ($!allowEditAssignmentNoteItem)
-								<a id="note_edit" class="extraNodeLink" href="#">$tlang.getString("gen.revi")<span class="skip"> $tlang.getString("note")</span></a> | <a id="note_delete" class="extraNodeLink" href="#">$tlang.getString("delet")<span class="skip"> $tlang.getString("note")</span></a>
+								<a id="note_edit" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("gen.revi")<span class="skip"> $tlang.getString("note")</span></a> | <a id="note_delete" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("delet")<span class="skip"> $tlang.getString("note")</span></a>
 							#else
 								#if ($!allowReadAssignmentNoteItem)
-									<a id="note_edit" class="extraNodeLink" href="#">$tlang.getString("gen.view2")</a>
+									<a id="note_edit" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("gen.view2")</a>
 								#end
 							#end
 						</div>
@@ -1408,19 +1229,19 @@ $(document).ready(function() {
 				</td>
 				<td class="itemAction" style="white-space:nowrap">
 					<div id="noallPurpose" #if(!$!allPurpose) style="display:block"#else style="display:none" #end>
-						<a id="allPurpose_add" class="extraNodeLink" href="#">$tlang.getString("new")<span class="skip"> $tlang.getString("allPurpose")</span></a>
+						<a id="allPurpose_add" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("new")<span class="skip"> $tlang.getString("allPurpose")</span></a>
 					</div>
 					<div id="hasallPurpose" #if($!allPurpose) style="display:block"#else style="display:none" #end>
-						<a id="allPurpose_edit" class="extraNodeLink" href="#">$tlang.getString("gen.revi")<span class="skip"> $tlang.getString("allPurpose")</span></a> | <a id="allPurpose_delete" class="extraNodeLink" href="#">$tlang.getString("delet")<span class="skip"> $tlang.getString("allPurpose")</span></a>
+						<a id="allPurpose_edit" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("gen.revi")<span class="skip"> $tlang.getString("allPurpose")</span></a> | <a id="allPurpose_delete" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("delet")<span class="skip"> $tlang.getString("allPurpose")</span></a>
 					</div>
 					<input type="hidden" name="value_allPurpose" #if($!allPurpose) value="true" #else value="false" #end />
 					<input id = "allPurpose_to_delete" name = "allPurpose_to_delete" type= "hidden" value = "false" />
 					#*
 						<div id="noAllPurpose" #if(!$!allPurpose) style="display:block"#else style="display:none" #end>
-							<a id="allPurpose_add" class="extraNodeLink" href="#">$tlang.getString("new")</a>
+							<a id="allPurpose_add" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("new")</a>
 						</div>
 						<div id="hasAllPurpose" #if($!allPurpose) style="display:block"#else style="display:none" #end>
-							<a id="allPurpose_edit" class="extraNodeLink" href="#">$tlang.getString("gen.revi")</a> | <a id="allPurpose_delete" class="extraNodeLink" href="#">$tlang.getString("delet")</a>
+							<a id="allPurpose_edit" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("gen.revi")</a> | <a id="allPurpose_delete" class="extraNodeLink" href="javascript:void(0)">$tlang.getString("delet")</a>
 						</div>
 					*#
 				</td>
@@ -1843,10 +1664,10 @@ $(document).ready(function() {
 	            		#set($showInputString = $showInputString.concat($role))
 						<tr>
 							<td class="groupCell">					
-								<a href="#" id="collapse_$roleCount" class="toggleRoleLink" style="display:none;" title="$collapseString">
+								<a href="javascript:void(0)" id="collapse_$roleCount" class="toggleRoleLink" style="display:none;" title="$collapseString">
 									<img src="/library/image/sakai/collapse.gif" alt="$collapseString" /><img src="/library/image/silk/group.png"/>
 								</a>
-								<a href="#" id="expand_$roleCount" class="toggleRoleLink" style="display:inline" title="$expandString">
+								<a href="javascript:void(0)" id="expand_$roleCount" class="toggleRoleLink" style="display:inline" title="$expandString">
 									<img src="/library/image/sakai/expand.gif"  alt="$expandString"/><img src="/library/image/silk/group.png"/>
 								</a>
 								<input id="$showInputString" name="showInputString_$roleCount" #if ($!value_allPurposeAccessList.contains($role)) checked="checked" #end type="checkbox" name="allPurpose_$role" class="selectAllMembers"/>
@@ -1882,22 +1703,5 @@ $(document).ready(function() {
 		#buttonBar($submitnotif)
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>
-	<script type="text/JavaScript">
-		<!--
-			function toggleSelectAll(caller, elementName)
-			{
-				var newValue = caller.checked;
-				var elements = document.getElementsByName(elementName);
-				
-				if(elements)
-				{
-					for(var i = 0; i < elements.length; i++)
-					{
-						elements[i].checked = newValue;
-					}
-				}
-			}
-		-->
-	</script>
-</div>	
+</div>
 <!-- end: chef_assignments_instructor_new_edit_assignment.vm  -->

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_assignment.vm
@@ -2,42 +2,14 @@
 <!-- start: chef_assignments_instructor_preview_assignment.vm  -->
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/assignment/chef_assignments_instructor_preview_assignment.vm,v 1.9 2005/06/14 14:47:34 zqian.umich.edu Exp $ -->
 <div class="portletBody">
-	<ul class="navIntraTool actionToolBar">
-		#if ($allowAddAssignment)
-			<li  class="firstToolBarItem">
-				<span class="current">$!tlang.getString("new")</span>
-			</li>
-			<li>
-				<span><a href="#toolLinkParam("$action" "doView" "view=lisofass1")" title = "$!tlang.getString('lisofass1')">$!tlang.getString("lisofass1")</a></span>
-			</li>				
-			#if ($withGrade && $!allowGradeSubmission)
-				<li>
-					<span><a href="#toolLinkParam("$action" "doView" "view=grarep")" title="$!tlang.getString("gen.grarep")">$!tlang.getString("gen.grarep")</a></span>
-				</li>
-			#end
-			<li>
-				<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString("gen.stuvie")">$!tlang.getString("gen.stuvie")</a></span>
-			</li>	
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li><span><a href="#toolLink("$action" "doReorder")" title="$tlang.getString('gen.reorder')">$tlang.getString('gen.reorder')</a></span></li>
-		#end
-		#if ($allowUpdateSite)
-			<li><span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span></li>
-			#if ($enableViewOption)	
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-				</li>
-			#end
-		#end
-	</ul>
+	#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
 	<h3>
 		$tlang.getString("prevassig.preass")
 	</h3>
 	
 		#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div>#end
 		<div class="clear"></div>
-		<form name="previewAssignmentsForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;"> 
+		<form id="previewAssignmentsForm" name="previewAssignmentsForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
 			<input type="hidden" name="assignmentId" value="$!value_assignment_id" />
 			<input type="hidden" name="assignmentContentId" value="$!value_assignmentcontent_id" />
 			<input type="hidden" name="$name_order" id="$name_order" value="$!value_position_order" />
@@ -359,18 +331,13 @@
 				</p>				
 			#end
 			<div class="act">
-				<input accesskey ="s" type="button" class="active" name="post" value="$tlang.getString('gen.pos')" 
-						onclick="javascript:document.previewAssignmentsForm.onsubmit();showNotif('submitnotif','post','previewAssignmentsForm');document.getElementById('option').value='post';document.previewAssignmentsForm.submit();return false;" />
+				<input accesskey="s" type="button" class="active" name="post" value="$tlang.getString('gen.pos')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'previewAssignmentsForm', 'post', null, null, true );" />
 				#if ($isDraft)
-					<input accesskey ="d" type="button" class="active" name="save" value="$tlang.getString('gen.savdra')" 
-							onclick="javascript:document.previewAssignmentsForm.onsubmit();showNotif('submitnotif','save','previewAssignmentsForm');document.getElementById('option').value='save';document.previewAssignmentsForm.submit();return false;" />
+					<input accesskey ="d" type="button" class="active" name="save" value="$tlang.getString('gen.savdra')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'previewAssignmentsForm', 'save', null, null, true );" />
 				#end
 				## back to edit assignment page
-				<input accesskey ="r" type="button" class="active" name="revise" value="$tlang.getString('gen.revi')" 
-					onclick="javascript:document.previewAssignmentsForm.onsubmit();showNotif('submitnotif','revise','previewAssignmentsForm');document.getElementById('option').value='revise';document.previewAssignmentsForm.submit();return false;" />
-				<input accesskey ="r" type="button" class="active" name="done" value="$tlang.getString('gen.don')" 
-					onclick="javascript:document.previewAssignmentsForm.onsubmit();showNotif('submitnotif','done','previewAssignmentsForm');document.getElementById('option').value='done';document.previewAssignmentsForm.submit();return false;" />
-				<span id="submitnotif" style="visibility:hidden">$tlang.getString("gen.proces")</span>
+				<input accesskey="r" type="button" class="active" name="revise" value="$tlang.getString('gen.revi')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'previewAssignmentsForm', 'revise', null, null, true );" />
+				<input accesskey="r" type="button" class="active" name="done" value="$tlang.getString('gen.don')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'previewAssignmentsForm', 'done', null, null, true );" />
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
@@ -2,44 +2,10 @@
 <!-- start:  chef_assignments_instructor_preview_grading_submission.vm -->
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm,v 1.5 2005/05/16 02:26:05 zqian.umich.edu Exp $ -->
 <div class="portletBody">
-	<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-				#set($prevAction=true)
-				<li  class="firstToolBarItem">
-					<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
-				</li>
-				<li>
-					<span><a href="#toolLinkParam("$action" "doView" "view=lisofass1")" title = "$!tlang.getString('lisofass1')">$!tlang.getString("lisofass1")</a></span>
-				</li>	
-				#if ($withGrade && $!allowGradeSubmission)
-					<li>
-						<span><a href="#toolLinkParam("$action" "doView" "view=grarep")" title="$!tlang.getString("gen.grarep")">$!tlang.getString("gen.grarep")</a></span>
-					</li>	
-				#end
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString("gen.stuvie")">$!tlang.getString("gen.stuvie")</a></span>
-			</li>
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLink("$action" "doReorder")" title="$tlang.getString('gen.reorder')">$tlang.getString('gen.reorder')</a></span>
-			</li>	
-		#end
-		#if ($allowUpdateSite)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>			
-				<span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)		
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-				</li>	
-			#end
-		#end
-	</ul>
+	#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
 		<h3>$tlang.getString("gen.pre") $tlang.getString("gen.instrcomment") 	$tlang.getString("gen.to") 				$tlang.getString("gen.openquote")$validator.escapeHtml($assignment.title)$tlang.getString("gen.closequote")</h3>
 		#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div><div class="clear"></div>#end		
-		<form action="#toolForm("AssignmentAction")" method="post" >   
+		<form id="previewGradeSubmissionForm" action="#toolForm("AssignmentAction")" method="post" >
 			<table class="itemSummary">
 				<tr>
 					<th>
@@ -256,11 +222,10 @@
 			#end
 			<p class="act">
 				## SAK-29314
-				<input accesskey="d" onclick="ASN.doGradingPreviewAction();" name="eventSubmit_doSave_preview_grade_submission" type="submit" value="$tlang.getString("gen.savdragra")" title="$tlang.getString("gen.savdratit")" class="active" />
-				<input accesskey="s" onclick="ASN.doGradingPreviewAction();" name="eventSubmit_doReturn_preview_grade_submission" type="submit" value="$tlang.getString("gen.retustud")" title="$tlang.getString("gen.retustudtit")" />
-				<input accesskey="r" onclick="ASN.doGradingPreviewAction();" name="eventSubmit_doCancel_preview_grade_submission" type="submit" value="$tlang.getString("gen.revi")" />
-				<input accesskey="x" onclick="ASN.doGradingPreviewAction();" name="eventSubmit_doCancel_preview_to_list_submission" type="submit" value="$tlang.getString("gen.can")" />
-				<img id="gradeFormPreviewSpinner" class="spinner" src="/library/image/indicator.gif" />
+				<input accesskey="d" onclick="SPNR.disableControlsAndSpin( this, null );" name="eventSubmit_doSave_preview_grade_submission" type="submit" value="$tlang.getString("gen.savdragra")" title="$tlang.getString("gen.savdratit")" class="active" />
+				<input accesskey="s" onclick="SPNR.disableControlsAndSpin( this, null );" name="eventSubmit_doReturn_preview_grade_submission" type="submit" value="$tlang.getString("gen.retustud")" title="$tlang.getString("gen.retustudtit")" />
+				<input accesskey="r" onclick="SPNR.disableControlsAndSpin( this, null );" name="eventSubmit_doCancel_preview_grade_submission" type="submit" value="$tlang.getString("gen.revi")" />
+				<input accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );" name="eventSubmit_doCancel_preview_to_list_submission" type="submit" value="$tlang.getString("gen.can")" />
 			</p>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
@@ -9,57 +9,8 @@
 
 <div class="portletBody">
 	#if ($allowAddAssignment || ($withGrade && $!allowGradeSubmission))
-	## for user who cannot create assignment nor grade submission, no need to show "Assignment List" link at all since there is really no other toolbar choices
-	<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-			#set($prevAction=true)
-			<li  class="firstToolBarItem">			
-				<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
-			</li>	
-		#end
-		#if (!$!view.equals('lisofass1'))
-			#set($prevAction=true)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>			
-				<span><a href="#toolLinkParam("$action" "doView" "view=lisofass1")" title="$!tlang.getString('lisofass1')">$!tlang.getString('lisofass1')</a></span>
-			</li>	
-		#else
-			<li>
-				<span class="disabled">$!tlang.getString("lisofass1")</span>
-			</li>	
-		#end
-		#if ($withGrade && $!allowGradeSubmission)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLinkParam("$action" "doView" "view=grarep")" title="$!tlang.getString("gen.grarep")">$!tlang.getString("gen.grarep")</a></span>
-			</li>	
-		#end
-		#if ($allowAddAssignment)
-			#if (!$!view.equals('stuvie'))
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString("gen.stuvie")">$!tlang.getString("gen.stuvie")</a></span>
-				</li>	
-			#else
-				<li  #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span class="disabled">$!tlang.getString("gen.stuvie")</span>
-				</li>	
-			#end
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li  #if($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span class="current">$tlang.getString('gen.reorder')</span>
-			</li>	
-		#end
-		#if ($allowUpdateSite)
-			<li  #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true) #end>
-				<span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)		
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-				</li>
-			#end	
-		#end
-	</ul>
+		## for user who cannot create assignment nor grade submission, no need to show "Assignment List" link at all since there is really no other toolbar choices
+		#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "reorder" )
 	#end
 	#if ($alertMessage)<div class="alertMessage" style="width:80%  !important">$tlang.getString("gen.alert") $alertMessage</div><div style="display:block;clear:both"></div>#end
 	
@@ -79,11 +30,11 @@
 		<ul class="itemAction noPrint">
 			<li style="display:inline">
 				<span id="undo-last-inact" style="padding:0 .3em 0 0;border:none">$tlang.getString("reorder.undo.last.label")</span>
-				<a href="#" id="undo-last"  style="display:none">$tlang.getString("reorder.undo.last.label")</a>
+				<a href="javascript:void(0)" id="undo-last"  style="display:none">$tlang.getString("reorder.undo.last.label")</a>
 			</li>
 			<li style="display:inline;border-left:1px solid #ccc;padding-left:1em">
 				<span id="undo-all-inact"  style="padding:0 .3em 0 0;border:none">$tlang.getString("reorder.undo.all.label")</span>
-					<a id="undo-all" href="#"  style="display:none">$tlang.getString("reorder.undo.all.label")</a>
+					<a id="undo-all" href="javascript:void(0)"  style="display:none">$tlang.getString("reorder.undo.all.label")</a>
 			</li>
 			<li style="display:inline;color:#000">
 				<span id="failedValidMessage" style="display:none">$tlang.getString('reorder.fail.valid.message')</span>
@@ -95,7 +46,7 @@
 		<span id="lastItemMoved"  style="display:none"></span>
 
 		<div id="reorder-list-sortingToolBar" class="itemAction">
-			<a class="title" id="sortByTitle" href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
+			<a class="title" id="sortByTitle" href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
 					$tlang.getString("listassig.sorbytit") 
 					#if ($sortedBy.equals("title")) 
 						#if ($sortedAsc.equals("true")) 
@@ -106,7 +57,7 @@
 					#end 
 				</a>
 				|
-				<a href="#" id="sortByOpenDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=opendate")'; return false;"  title="$tlang.getString("listassig.sorbyope")">
+				<a href="javascript:void(0)" id="sortByOpenDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=opendate")'; return false;"  title="$tlang.getString("listassig.sorbyope")">
 					$tlang.getString("listassig.sorbyope")
 					#if ($sortedBy.equals("opendate")) 
 						#if ($sortedAsc.equals("true")) 
@@ -117,7 +68,7 @@
 					#end 
 				</a>
 				|
-				<a href="#" id="sortByDueDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=duedate")'; return false;"  title="$tlang.getString("gen.sorbydue")">
+				<a href="javascript:void(0)" id="sortByDueDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=duedate")'; return false;"  title="$tlang.getString("gen.sorbydue")">
 					$tlang.getString("gen.sorbydue") ##$tlang.getString("gen.due1")
 					#if ($sortedBy.equals("duedate")) 
 						#if ($sortedAsc.equals("true")) 
@@ -150,11 +101,11 @@
 				</span>
 				<span class="close">
 					$!assignment.dueTime.toStringLocalFull()
-				  <select name="position_$validator.escapeUrl("$assignment.id")" onchange="moveRow(this,this.value);" class="selectSet">
-					#foreach($i in [1..$assignmentsize])
-					<option value="$i"#if("$i" == "$count") selected="selected"#end>$i</option>
-					#end
-				  </select>
+					<select name="position_$validator.escapeUrl("$assignment.id")" class="selectSet">
+						#foreach($i in [1..$assignmentsize])
+						<option value="$i"#if("$i" == "$count") selected="selected"#end>$i</option>
+						#end
+					</select>
 				</span>
 			</li>
 			#set($count = $count + 1)
@@ -162,9 +113,8 @@
 		</ul>
 
 		<p class="act" style="margin:0;padding:.3em 0;">
-			<input type="button" name="save" value="$tlang.getString("gen.sav")" onclick="ASN.doReorderAction( 'reorder' );" class="active" accesskey="s" />
-			<input type="button" name="cancel" value="$tlang.getString("gen.can")" onclick="ASN.doReorderAction( 'cancelreorder' );" accesskey="x" />
-			<img id="reorderSpinner" class="spinner" src="/library/image/indicator.gif" />
+			<input type="button" name="save" value="$tlang.getString("gen.sav")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'reorderForm', 'reorder', null, null, true );" class="active" accesskey="s" />
+			<input type="button" name="cancel" value="$tlang.getString("gen.can")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'reorderForm', 'cancelreorder', null, null, true );" accesskey="x" />
 		</p>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>						

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -2,43 +2,8 @@
 <!-- start: chef_assignments_instructory_report_submissions.vm  -->
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm,v 1.6 2005/06/03 15:38:27 gsilver.umich.edu Exp $ -->
 <div class="portletBody">
-	<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-			#set($prevAction=true)
-			<li  class="firstToolBarItem">
-				<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
-			</li>
-		#end
-		<li #if ($prevAction==false) class="firstToolBarItem" #end>
-			<span><a href="#toolLinkParam("$action" "doView" "view=lisofass1")" title="$!tlang.getString('lisofass1')">$!tlang.getString('lisofass1')</a></span>
-		</li>
-		<li>
-			<span class="current">$!tlang.getString('gen.grarep')</span>
-		</li> 
-	
-		#if ($allowAddAssignment)
-			<li>
-				<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString('gen.stuvie')">$!tlang.getString('gen.stuvie')</a></span>
-			</li>				
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li>
-				<span><a href="#toolLink("$action" "doReorder")" title="$tlang.getString('gen.reorder')">$tlang.getString('gen.reorder')</a></span>
-			</li>	
-		#end
-		#if ($allowUpdateSite)
-			<li>
-				<span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)		
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-				</li>
-			#end	
-		#end
-	</ul>
-		<h3>
+	#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
+	<h3>
 		#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div><div class="clear"></div>#end
 		$!tlang.getString('gen.grarep')
 	</h3>
@@ -47,7 +12,7 @@
 			<div class="viewNav">
 			<br />
 			#if (!$hasAtLeastOneAnonAssignment)
-			<form name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
+			<form id="viewForm" name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
 			<input type="hidden" name="option" id="option" value="x" />
 			<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
 			<span class="skip">$tlang.getString("newassig.selectmessage")</span>
@@ -57,7 +22,8 @@
 				</div>
 				<span class="skip">$tlang.getString("newassig.selectmessage")</span>
 
-				<select id="view" name="viewgroup" size="1" tabindex="3" onchange="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
+				<div class="spinnerBesideContainer">
+					<select id="view" name="viewgroup" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null, true );">nchange="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
 
 					#if (!$showSubmissionByFilterSearchOnly)
 						<option value="all" #if($!view.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
@@ -67,19 +33,18 @@
 					#foreach($aGroup in $groups)
 						<option value="$!aGroup.Reference" #if($!view.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
 					#end
-				</select>
-				<img id="groupSpinner" class="spinner" src="/library/image/indicator.gif" />
+					</select>
+				</div>
 				<p />
 				#end
 
 				<label for="$form_search" class="skip">$tlang.getString("search")</label>
 				<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
 					name="search" id="search" type="text" class="searchField" size="20" />
-				<input type="button" value="$tlang.getString('search')" onclick="ASN.applySearchFilter('search');" />
+				<input type="button" value="$tlang.getString('search')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'search', null, null, true );" />
 				#if (($!searchString) && (!$searchString.equals("")))
-					<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="ASN.applySearchFilter('clearSearch');" />
+					<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'clearSearch', null, null, true );" />
 				#end
-				<img id="userFilterSpinner" class="spinner" src="/library/image/indicator.gif" />
 				<p />
 
 				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
@@ -96,70 +61,7 @@
 				
 				
 			</div>
-			<div class="listNav">
-				<div class="instruction">
-					$tlang.getString("gen.viewing") $topMsgPos - $btmMsgPos $tlang.getString("gen.of") $allMsgNumber $tlang.getString("gen.items")
-					<img id="navSpinner" class="spinner" src="/library/image/indicator.gif" />
-				</div>
-				#if ($pagesize != 0)
-					#if ($goFPButton == "true")
-						<form name="firstpageForm" class="inlineForm"  method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" name="eventSubmit_doList_first" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="|&lt;" title="$tlang.getString("gen.first")" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" name="eventSubmit_doList_first" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="|&lt;" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-					#if ($goPPButton == "true")
-						<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" name="eventSubmit_doList_prev" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="&lt;" title="$tlang.getString('gen.previous') $pagesize" accesskey="p" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" name="eventSubmit_doList_prev" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="&lt;" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-				#end	
-				<form name="pagesizeForm" class="inlineForm" method="post" action="#toolForm("$action")">
-					<input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
-					<label for="selectPageSize" class="skip">$tlang.getString("newassig.selectmessage")</label>
-					<select id="selectPageSize" name="selectPageSize" onchange="ASN.disableLink( 'downloadAll' ); ASN.changePageSize();">
-						#foreach ($i in $!pagesizes)
-							<option value="$i" #if($pagesize == $i) selected="selected" #end>$tlang.getString("list.show") $i $tlang.getString("list.itemsper")</option>
-						#end
-					</select>
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-				#if ($pagesize != 0)
-					#if ($goNPButton == "true")
-						<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" name="eventSubmit_doList_next" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="&gt;" title="$tlang.getString('gen.next') $pagesize" accesskey="n" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" name="eventSubmit_doList_next" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="&gt;" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-					#if ($goLPButton == "true")
-						<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" name="eventSubmit_doList_last" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="&gt;|" title="$tlang.getString('gen.last')" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#else
-						<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-							<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" name="eventSubmit_doList_last" onclick="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'navSpinner' );" value="&gt;|" disabled="disabled" /></fieldset>
-							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						</form>
-					#end
-				#end
-			</div>
+			#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
 		</div>	
 		#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div><div class="clear"></div>#end
 		<form name="reportForm" action="#toolForm("AssignmentAction")" method="post">
@@ -171,7 +73,7 @@
 				<table class="listHier lines nolines" border="0" cellspacing="0" summary="$tlang.getString("gen.viewasslistreportsummary")">
 					<tr>
 						<th id="studentname">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_lastName")'; return false;"
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_lastName")'; return false;"
 								 title=" $tlang.getString("gen.sorbylas")">
 								 $tlang.getString("gen.stunam")
 								#if ($sortedBy.equals($!sortedBy_lastName)) 
@@ -184,7 +86,7 @@
 							</a>
 						</th>
 						<th id="assignment">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_assignment")'; return false;" 
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_assignment")'; return false;" 
 							  title="$tlang.getString("listassig.sorbytit")">
 								$tlang.getString("gen.assig")
 								#if ($sortedBy.equals($!sortedBy_assignment)) 
@@ -197,7 +99,7 @@
 							</a>
 						</th>
 						<th id="grade">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_grade")'; return false;" 
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_grade")'; return false;" 
 							  title=" $tlang.getString("gen.sorbygra")">
 								$tlang.getString("gen.gra")
 								#if ($sortedBy.equals($!sortedBy_grade)) 
@@ -210,7 +112,7 @@
 							</a>
 						</th>
 						<th id="scale">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_maxGrade")'; return false;"
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_maxGrade")'; return false;"
 								 title="$tlang.getString("repsubmi.sorbysca")">
 								 $tlang.getString("gen.sca")
 								#if ($sortedBy.equals($!sortedBy_maxGrade)) 
@@ -223,7 +125,7 @@
 							</a>
 						</th>
 						<th id="submitted">
-							<a href="#" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_submitTime")'; return false;" 
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("AssignmentAction" "doSort_submission" "criteria=$!sortedBy_submitTime")'; return false;" 
 								 title="$tlang.getString("repsubmi.sorbytur")">
 								 $tlang.getString("gen.subm4")
 								#if ($sortedBy.equals($!sortedBy_submitTime)) 

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -2,43 +2,7 @@
 <!-- start: chef_assignments_instructor_student_list_submissions.vm  -->
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm,v 1.8 2005/05/28 03:04:35 ggolden.umich.edu Exp $ -->
 <div class="portletBody">
-		<ul class="navIntraTool actionToolBar">
-			#set($prevAction=false)
-			#if ($allowAddAssignment)
-				#set($prevAction=true)
-				<li  class="firstToolBarItem">
-					<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
-				</li>
-				<li>	
-					<span class="current">$!tlang.getString("lisofass1")</span>
-				</li>	
-			#end
-			#if ($withGrade && $!allowGradeSubmission)
-				<li #if ($prevAction==false) class="firstToolBarItem"  #set($prevAction=true) #end>
-					<span><a href="#toolLinkParam("$action" "doView" "view=grarep")" title="$!tlang.getString("gen.grarep")">$!tlang.getString("gen.grarep")</a></span>
-				</li>			
-			#end
-			#if ($allowAddAssignment)
-				<li #if ($prevAction==false) class="firstToolBarItem"  #set($prevAction=true) #end>
-					<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString("gen.stuvie")">$!tlang.getString("gen.stuvie")</a></span>
-				</li>	
-			#end
-			#if (($allowAllGroups) && ($assignmentscheck))
-				<li #if ($prevAction==false) class="firstToolBarItem"  #set($prevAction=true) #end>				
-					<span><a href="#toolLink("$action" "doReorder")" title="$tlang.getString('gen.reorder')">$tlang.getString('gen.reorder')</a></span>
-				</li>	
-			#end
-			#if ($allowUpdateSite)
-				<li #if ($prevAction==false) class="firstToolBarItem"  #set($prevAction=true) #end>				
-					<span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span>
-				</li>
-				#if ($enableViewOption)		
-					<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-						<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-					</li>
-				#end	
-			#end
-	</ul>
+	#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
 	<h3>
 		$!tlang.getString('lisofass2')
 	</h3>
@@ -53,19 +17,20 @@
 			</p>
 		<div class="navPanel">
 			<div class="viewNav">
-				<form name="viewFormList" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
+				<form id="viewFormList" name="viewFormList" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
 					<input type="hidden" name="eventSubmit_doView" value="view" />
-					<label for="view">$tlang.getString("gen.view2")</label>
-					<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-					<select name="view" id="view" size="1" tabindex="3" onchange="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'viewSpinner' );document.viewFormList.submit();">
-						<option value="lisofass1" >$!tlang.getString('lisofass1')</option>
-						<option value="lisofass2" selected="selected" >$!tlang.getString('lisofass2')</option>
-					</select>
-					<img id="viewSpinner" class="spinner" src="/library/image/indicator.gif" />
+					<div class="spinnerBesideContainer">
+						<label for="view">$tlang.getString("gen.view2")</label>
+						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
+						<select name="view" id="view" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewFormList', null, null, null, false );">
+							<option value="lisofass1" >$!tlang.getString('lisofass1')</option>
+							<option value="lisofass2" selected="selected" >$!tlang.getString('lisofass2')</option>
+						</select>
+					</div>
 					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 				</form>
 					#if ($!groups.hasNext() || !$hasAtLeastOneAnonAssignment)
-					<form name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
+					<form id="viewForm" name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
 						<input type="hidden" name="option" id="option" value="x" />
 						<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
 						#if( $!groups.hasNext() )
@@ -74,7 +39,8 @@
 						</div>
  						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
 
- 						<select id="viewgroup" name="viewgroup" size="1" tabindex="3" onchange="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
+ 						<div class="spinnerBesideContainer">
+							<select id="viewgroup" name="viewgroup" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null, true );">ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
 
 							#if (!$showSubmissionByFilterSearchOnly)
 								<option value="all" #if($!viewGroup.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
@@ -84,8 +50,8 @@
  							#foreach($aGroup in $groups)
  								<option value="$!aGroup.Reference" #if($!viewGroup.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
  							#end
- 						</select>
-						<img id="groupSpinner" class="spinner" src="/library/image/indicator.gif" />
+ 							</select>
+						</div>
 						#end
  						<p />
 
@@ -93,11 +59,10 @@
 					<label for="$form_search" class="skip">$tlang.getString("search")</label>
 					<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" 
 						name="search" id="search" type="text" class="searchField" size="20" />
-					<input type="button" value="$tlang.getString('search')" onclick="ASN.applySearchFilter( 'search', true );" />
+					<input type="button" value="$tlang.getString('search')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'search', null, null, true );" />
 					#if (($!searchString) && (!$searchString.equals("")))
-						<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="ASN.applySearchFilter( 'clearSearch', true );" />
+						<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'clearSearch', null, null, true );" />
 					#end
-					<img id="userFilterSpinner" class="spinner" src="/library/image/indicator.gif" />
 					#end
 
 					#end
@@ -141,20 +106,23 @@
 							#set($submitterName=$submitterName.concat(" (").concat($submitterId).concat(")"))
 							#end
 						<tr>
-							<td headers="studentname" class="specialLink">	
+							<td headers="studentname" class="specialLink">
 								<h4>
+									<div class="spinnerBesideContainer">
+								#set( $userSpinnerID = "userSpinner_" + $member.Id )
 								#if (!$studentListShowSet.contains($member.Id))
-									<a href="#" onclick="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'userSpinner_$member.Id' );location='#toolLinkParam("AssignmentAction" "doShow_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
+										<a href="javascript:void(0)" onclick="SPNR.insertSpinnerInPreallocated( this, null, '$userSpinnerID' ); location='#toolLinkParam("AssignmentAction" "doShow_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;"
 											title="$tlang.getString("stulistsunbm.shostuass")" name="studentLink" >
 										<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("stulistsunbm.shostuass")" width="13" height="13" border="0" />
 								#else 
-									<a href="#" onclick="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'userSpinner_$member.Id' );location='#toolLinkParam("AssignmentAction" "doHide_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
+										<a href="javascript:void(0)" onclick="SPNR.insertSpinnerInPreallocated( this, null, '$userSpinnerID' ); location='#toolLinkParam("AssignmentAction" "doHide_student_submission" "studentId=$validator.escapeUrl($member.Id)")'; return false;" 
 											title="$tlang.getString("stulistsunbm.hidstuass")" name="studentLink" >
 										<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("stulistsunbm.hidstuass")" width="13" height="13" border="0" />
 								#end
 										$submitterName
-									</a>
-									<img id="userSpinner_$member.Id" class="spinner" src="/library/image/indicator.gif" />
+										</a>
+										<div id="$userSpinnerID" class="allocatedSpinPlaceholder"></div>
+									</div>
 								</h4>
 							</td>
 							<td colspan="4">
@@ -181,12 +149,12 @@
 											<h5>
 												<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$validator.escapeUrl($assignment.Reference)&submissionId=$validator.escapeUrl($submission.Reference)&option=lisofass2")" title="$validator.limit($validator.escapeHtml($assignment.Title), 40)">$validator.limit($validator.escapeHtml($assignment.Title), 40)</a>
 												#if ($allowAddAssignment && $allowSubmitByInstructor)
-												#set( $spinnerID = "submitFor_" + $member.Id + "_" + $validator.escapeUrl($assignment.Reference) )
-												<div class="itemAction">
-													<a onclick="ASN.disableControls( null, 'studentLink' );ASN.showSpinner( '$spinnerID' );" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)&submitterId=$validator.escapeUrl($member.id)")">
+												#set( $submitSpinnerID = "submitFor_" + $member.Id + "_" + $validator.escapeUrl($assignment.Reference) )
+												<div class="itemAction spinnerBesideContainer">
+													<a onclick="SPNR.insertSpinnerInPreallocated( this, null, '$submitSpinnerID' );" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignment.Reference)&submitterId=$validator.escapeUrl($member.id)")">
 														$tlang.getString("submitforstudent")
 													</a>
-													<img id="$spinnerID" class="spinner" src="/library/image/indicator.gif" />
+													<div id="$submitSpinnerID" class="allocatedSpinPlaceholder"></div>
 												</div>
 												#end
 											#else

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_uploadAll.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_uploadAll.vm
@@ -1,88 +1,6 @@
 <!-- $Id$ -->
 <!-- start: chef_assignments_instructor_uploadALL.vm  -->
 ## showing the page for preparing upload zip file
-<script type="text/JavaScript">
-	<!--
-		function submitform(id)
-		{
-			var theForm = document.getElementById(id);
-			if(theForm && theForm.onsubmit)
-			{
-				theForm.onsubmit();
-			}
-			if(theForm && theForm.submit)
-			{
-				theForm.submit();
-			}
-		}
-		
-		function invokeDownloadUrl(accessPointUrl, actionString, alertMessage, param0, param1, param2, param3)
-	{
-			var extraInfoArray = [];
-			if (document.getElementById('studentSubmissionText') && document.getElementById('studentSubmissionText').checked)
-			{
-					extraInfoArray[extraInfoArray.length]="studentSubmissionText=true";
-			}
-			if (document.getElementById('studentSubmissionAttachment') && document.getElementById('studentSubmissionAttachment').checked)
-			{
-					extraInfoArray[extraInfoArray.length]="studentSubmissionAttachment=true";
-			}	
-			if (document.getElementById('gradeFile') && document.getElementById('gradeFile').checked)
-			{
-				if (document.getElementById('gradeFileFormat_excel').checked)
-				{
-					extraInfoArray[extraInfoArray.length]="gradeFile=true&gradeFileFormat="+document.getElementById('gradeFileFormat_excel').value;
-				} else {
-					extraInfoArray[extraInfoArray.length]="gradeFile=true&gradeFileFormat="+document.getElementById('gradeFileFormat_csv').value;
-				}
-			}
-			if (document.getElementById('feedbackTexts') && document.getElementById('feedbackTexts').checked)
-			{
-					extraInfoArray[extraInfoArray.length]="feedbackTexts=true";
-			}
-			if (document.getElementById('feedbackComments') && document.getElementById('feedbackComments').checked)
-			{
-					extraInfoArray[extraInfoArray.length]="feedbackComments=true";
-			}
-			if (document.getElementById('feedbackAttachments') && document.getElementById('feedbackAttachments').checked)
-			{
-					extraInfoArray[extraInfoArray.length]="feedbackAttachments=true";
-			}
-			if (document.getElementById('includeNotSubmitted') && document.getElementById('includeNotSubmitted').checked)
-			{
-					extraInfoArray[extraInfoArray.length]="includeNotSubmitted=true";
-			}
-			if (extraInfoArray.length == 0)
-			{
-				alert(alertMessage);
-			}
-			else
-			{
-				// SAK-29314
-				ASN.disableControls();
-				ASN.showSpinner('downloadUploadSpinner');
-
-				if (document.getElementById('withoutFolders') && document.getElementById('withoutFolders').checked)
-				{
-						extraInfoArray[extraInfoArray.length]="withoutFolders=true";
-				}
-				accessPointUrl = accessPointUrl + "?";
-				for(i=0; i<extraInfoArray.length; i++) 
-				{ 
-   			accessPointUrl = accessPointUrl + extraInfoArray[i] + "&"; 
-				}
-				// cut the & in the end
-				accessPointUrl = accessPointUrl.substring(0, accessPointUrl.length-1);
-				// attach the assignment reference
-				accessPointUrl = accessPointUrl + "&contextString=" + param0 + "&viewString=" + param1 + "&searchString=" + param2 + "&searchFilterOnly=" + param3;
-   	window.location.href=accessPointUrl;
-   	document.getElementById('downloadUrl').value=accessPointUrl; 
-   	document.getElementById('uploadAllForm').action=actionString; 
-   	setTimeout("submitform('uploadAllForm')", 1500);
-   }
-	}
-	//-->
-</script>
 <div class="portletBody">
 	<h3>
 	#if ($!download)
@@ -120,51 +38,51 @@
 				#if (!$!download)
 					<div class="shorttext">
 						<h4><span class="reqStar">*</span><label for="file">$tlang.getString("uploadall.choose.file")</label></h4>
-						<input type="file" name="file" id="file" class="upload" onchange="javascript:document.getElementById('filechosenconfirm').style.display='block';" />
+						<input type="file" name="file" id="file" class="upload" onchange="document.getElementById('filechosenconfirm').style.display='block';" />
 						<p id="filechosenconfirm" class="information" style="display:none;clear:both">$tlang.getString("uploadall.choose.file.confirm")</p>
 						<h4><span class="reqStar">*</span>$tlang.getString("uploadall.choose.file2")</h4>
 					</div>
 			#end
 			<p class="checkbox indnt2">
 			 ## select-all box
-			 <input type="checkbox" name="selectall" id="selectall" title="$tlang.getString('gen.toggle')" onclick="javascript:toggleSelectAll(this)"  />
+			 <input type="checkbox" name="selectall" id="selectall" title="$tlang.getString('gen.toggle')" onclick="ASN.toggleSelectAll(this, 'choices')" />
 			 <label for="selectall">$tlang.getString("all")</label><br/>
 			 #if ($!includeSubmissionText)
 					## student submission text
-					<input id="studentSubmissionText" type="checkbox" value="studentSubmissionText" name="choices" class="toggleSelectedAll" #if($!hasSubmissionText)checked="checked"#end onclick="deselectSelectAll( this );" />
+					<input id="studentSubmissionText" type="checkbox" value="studentSubmissionText" name="choices" class="toggleSelectedAll" #if($!hasSubmissionText)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 					<label for="studentSubmissionText">$tlang.getString("uploadall.choose.file.studentSubmissionText")</label><br/>
 				#end
 				#if ($!includeSubmissionAttachment)
 					## student submission attachment
-					<input id="studentSubmissionAttachment" type="checkbox" value="studentSubmissionAttachment" name="choices" class="toggleSelectedAll" #if($!hasSubmissionAttachment)checked="checked"#end onclick="deselectSelectAll( this );" />
+					<input id="studentSubmissionAttachment" type="checkbox" value="studentSubmissionAttachment" name="choices" class="toggleSelectedAll" #if($!hasSubmissionAttachment)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 					<label for="studentSubmissionAttachment">$tlang.getString("uploadall.choose.file.studentSubmissionAttachment")</label><br/>
 				#end
 				## grade files
-				<input id="gradeFile" type="checkbox" value="gradeFile" name="choices" class="toggleSelectedAll" #if($!hasGradeFile)checked="checked"#end onclick="deselectSelectAll( this );" />
+				<input id="gradeFile" type="checkbox" value="gradeFile" name="choices" class="toggleSelectedAll" #if($!hasGradeFile)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 				<label for="gradeFile">$tlang.getString("uploadall.choose.file.gradeFile")</label><br/>
 			</p>
 				<p class="checkbox indnt3">
-					<input id="gradeFileFormat_csv" type="radio" value="csv" name="gradeFileFormat" #if($gradeFileFormat=="csv")checked="checked"#end onclick="deselectSelectAll( this );" />
+					<input id="gradeFileFormat_csv" type="radio" value="csv" name="gradeFileFormat" #if($gradeFileFormat=="csv")checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 					<label for="gradeFileFormat_csv">$tlang.getString("uploadall.choose.file.gradeFile.csv")</label><br/>
-					<input id="gradeFileFormat_excel" type="radio" value="excel" name="gradeFileFormat" #if($gradeFileFormat=="excel")checked="checked"#end onclick="deselectSelectAll( this );" />
+					<input id="gradeFileFormat_excel" type="radio" value="excel" name="gradeFileFormat" #if($gradeFileFormat=="excel")checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 					<label for="gradeFileFormat_excel">$tlang.getString("uploadall.choose.file.gradeFile.excel")</label><br/>
 				</p>
 			<p class="checkbox indnt2">
 				#if ($!includeSubmissionText)
 					## feedback text
-					<input id="feedbackTexts" type="checkbox" value="feedbackTexts" name="choices" class="toggleSelectedAll" #if($!hasFeedbackText)checked="checked"#end onclick="deselectSelectAll( this );" />
+					<input id="feedbackTexts" type="checkbox" value="feedbackTexts" name="choices" class="toggleSelectedAll" #if($!hasFeedbackText)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 					<label for="feedbackTexts">$tlang.getString("uploadall.choose.file.feedbackTexts")</label><br/>	
 				#end
 			 ## feedback comments
-				<input id="feedbackComments" type="checkbox" value="feedbackComments" name="choices" class="toggleSelectedAll" #if($!hasComments)checked="checked"#end onclick="deselectSelectAll( this );" />
+				<input id="feedbackComments" type="checkbox" value="feedbackComments" name="choices" class="toggleSelectedAll" #if($!hasComments)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 				<label for="feedbackComments">$tlang.getString("uploadall.choose.file.feedbackComments")</label><br/>	
 			 ## feedback attachments
-				<input id="feedbackAttachments" type="checkbox" value="feedbackAttachments" name="choices" class="toggleSelectedAll" #if($!hasFeedbackAttachment)checked="checked"#end onclick="deselectSelectAll( this );" />
+				<input id="feedbackAttachments" type="checkbox" value="feedbackAttachments" name="choices" class="toggleSelectedAll" #if($!hasFeedbackAttachment)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 				<label for="feedbackAttachments">$tlang.getString("download.feedback.attachment")</label><br/>
 			<br/>
 			## SAK-19147 output without folders
 			#if ($!download && $enableFlatDownload)
-				<input id="withoutFolders" type="checkbox" value="withoutFolders" name="choices" class="toggleNotSelectedAll" #if($!withoutFolders)checked="checked"#end onclick="deselectSelectAll( this );" />
+				<input id="withoutFolders" type="checkbox" value="withoutFolders" name="choices" class="toggleNotSelectedAll" #if($!withoutFolders)checked="checked"#end onclick="ASN.deselectSelectAll( this );" />
 				<label for="withoutFolders">$tlang.getString("uploadall.folders.no")</label><br/>
 			#end
 			## include empty submissions, old behavior
@@ -194,38 +112,16 @@
 				#set($alertMessage = $tlang.getString('downloadall.alert.choose.element'))
 				#set($actionString="#toolLinkParam($action 'doDownload_all')")
 				<input type="button" name="downloadButton" id="downloadButton"  accesskey="d" class="active"
-						onclick="invokeDownloadUrl('$accessPointUrl', '$actionString', '$alertMessage', '$contextString', '$viewString', '$searchString', '$showSubmissionByFilterSearchOnly');" value="$tlang.getString('downloadall.button.download')" />
+						onclick="ASN.invokeDownloadUrl('$accessPointUrl', '$actionString', '$alertMessage', '$contextString', '$viewString', '$searchString', '$showSubmissionByFilterSearchOnly', this);" value="$tlang.getString('downloadall.button.download')" />
 			#else
 				<input type="button" name="uploadButton" id="uploadButton"  accesskey="s" class="active"
-						onclick="ASN.disableControls();ASN.showSpinner('downloadUploadSpinner');document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doUpload_all')'; submitform('uploadAllForm');" value="$tlang.getString('uploadall.button.upload')" />
+						onclick="SPNR.disableControlsAndSpin( this, null ); document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doUpload_all')'; ASN.submitForm( 'uploadAllForm', null, null, null, false );" value="$tlang.getString('uploadall.button.upload')" />
 			#end	
 					<input type="button" name="cancelButton" id="cancelButton"  accesskey="x"
-						onclick="ASN.disableControls();ASN.showSpinner('downloadUploadSpinner');document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doCancel_download_upload_all')'; submitform('uploadAllForm');" value="$tlang.getString('gen.can')" />
-					<img id="downloadUploadSpinner" class="spinner" src="/library/image/indicator.gif" />
+						onclick="SPNR.disableControlsAndSpin( this, null ); document.getElementById('uploadAllForm').action='#toolLinkParam($action 'doCancel_download_upload_all')'; ASN.submitForm( 'uploadAllForm', null, null, null, false );" value="$tlang.getString('gen.can')" />
 		</p>
 		</div>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>
-	<script type="text/JavaScript">
-		<!--
-			function toggleSelectAll(caller)
-			{
-				var newValue = caller.checked;
-				$('.toggleSelectedAll').each(function(){
-					$(this).prop('checked', newValue);
-				});
-			}
-
-			// SAK-29240
-			function deselectSelectAll( caller )
-			{
-				var checked = caller.checked;
-				if( !checked )
-				{
-					$( "#selectall" ).prop( "checked", checked );
-				}
-			}
-		-->
-	</script>
 </div>
 <!-- end: chef_assignments_instructor_uploadALL.vm  -->

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_assignment.vm
@@ -27,7 +27,7 @@
 		#if ($allowAddAssignment && !$hideAssignmentFlag)
 		## show assignment content
 		<p class="discTria">
-			<a href="#" onclick="location='#toolLink("AssignmentAction" "doHide_view_assignment")'; return false;" title="$tlang.getString("gen.hidassinf")">
+			<a href="javascript:void(0)" onclick="location='#toolLink("AssignmentAction" "doHide_view_assignment")'; return false;" title="$tlang.getString("gen.hidassinf")">
 				<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("gen.hidassinf")" border="0" width="13" height="13" />
     			$tlang.getString("gen.settfor") "$validator.escapeHtml($assignment.title)"
 			 </a>
@@ -256,7 +256,7 @@
 		#elseif ($allowAddAssignment && $hideAssignmentFlag)
 			## hide the assignment content
 			<p class="discTria">
-				<a href="#" onclick="location='#toolLink("AssignmentAction" "doShow_view_assignment")'; return false;" title="$tlang.getString("viewassig.shoassinf")">	
+				<a href="javascript:void(0)" onclick="location='#toolLink("AssignmentAction" "doShow_view_assignment")'; return false;" title="$tlang.getString("viewassig.shoassinf")">	
 				<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("viewassig.shoassinf")" border="0" width="13" height="13" align="top"  />
 				$tlang.getString("gen.settfor") "$validator.escapeHtml($assignment.title)"
 				</a>
@@ -268,7 +268,7 @@
 		<input type="hidden" name="assignmentContentId" value="$assignment.ContentReference" />
 		#if (!$hideStudentViewFlag)
 			<p class="discTria">
-				<a href="#" onclick="location='#toolLink("AssignmentAction" "doHide_view_student_view")'; return false;">
+				<a href="javascript:void(0)" onclick="location='#toolLink("AssignmentAction" "doHide_view_student_view")'; return false;">
 				<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("gen.open")" border="0" width="13" height="13" align="top" />
 				$tlang.getString("gen.stuvieof") "$validator.escapeHtml($assignment.title)"
 				</a>
@@ -447,7 +447,7 @@
 				</div>	
 		#else
 			<p class="discTria">
-				<a href="#" onclick="location='#toolLink("AssignmentAction" "doShow_view_student_view")'; return false;">
+				<a href="javascript:void(0)" onclick="location='#toolLink("AssignmentAction" "doShow_view_student_view")'; return false;">
 				<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("gen.open")" border="0" width="13" height="13" align="top" />
 				$tlang.getString("gen.stuvieof") "$validator.escapeHtml($assignment.title)"
 				</a>
@@ -456,10 +456,10 @@
 		#end
 		<p class="act">
 			#if ($assignment.Draft)
-				<input type="submit" accesskey="s" name="eventSubmit_doPost_assignment" value="$tlang.getString("gen.pos")" class="active" />
-				 <input type="submit"accesskey="x" name="eventSubmit_doDone_view_assignment" value="$tlang.getString("gen.can")" />
+				<input type="submit" accesskey="s" name="eventSubmit_doPost_assignment" value="$tlang.getString("gen.pos")" class="active" onclick="SPNR.disableControlsAndSpin( this, null );" />
+				<input type="submit"accesskey="x" name="eventSubmit_doDone_view_assignment" value="$tlang.getString("gen.can")" onclick="SPNR.disableControlsAndSpin( this, null );" />
 			#else
-				<input type="submit" accesskey="x" name="eventSubmit_doDone_view_assignment" value="$tlang.getString("gen.backtolist")" class="active"  />
+				<input type="submit" accesskey="x" name="eventSubmit_doDone_view_assignment" value="$tlang.getString("gen.backtolist")" class="active" onclick="SPNR.disableControlsAndSpin( this, null );" />
 		#end
 		</p>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -2,110 +2,34 @@
 <!-- start: chef_assignments_list_assignments.vm  -->
 ##<!-- $Header: Exp $ -->
 ## Assignments - list view
-#parse("/vm/assignment/assignment_macros.vm")
 <!-- JQuery already loaded in assignment_chef_header -->
-<link href="/sakai-assignment-tool/css/assignment.css" type="text/css" rel="stylesheet" media="all" />
-<script type="text/javascript" src="/sakai-assignment-tool/js/assignments.js"></script>
 
 <script type="text/javascript">
-  focus_path = ["search"];
-</script>
-<script type='text/javascript'>
-var linkFlag = true;
+	focus_path = ["search"];
+	var linkFlag = true;
 
-function allowClick(object)
-{
-		object.onclick='';
-	 object.style.color='#000';
-	 var rv = linkFlag;
-	 ## set the flag to be false
-	 linkFlag = false;
-	 ##return the current flag status
-	 return rv;
-}
-
-function params_unserialize(p){
-	var ret = [],
-    seg = p.replace(/^\?/,'').split('&'),
-    len = seg.length, i = 0, s;
-	for (;i<len;i++) {
-    	if (!seg[i]) { continue; }
-    	s = seg[i].split('=');
-		ret.push({'name':s[0],'value':s[1]});
+	function duplicateLink(lnk) {
+		var params = ASN.params_unserialize(lnk.search.substring(1));
+		params.push({'name':'sakai_csrf_token','value':'$sakai_csrf_token'});
+		var myForm = document.createElement("form");
+		myForm.action = lnk.pathname;
+		myForm.method = "post";
+		for (var i=0; i<params.length; i++) {
+			var myInput = document.createElement("input");
+			myInput.type = "hidden";
+			myInput.name = params[i].name;
+			myInput.value = params[i].value;
+			myForm.appendChild(myInput);
+		}
+		document.body.appendChild(myForm);
+		myForm.submit();
+		return false;
 	}
-	return ret;
-}
-
-function duplicateLink(lnk) {
-	var params = params_unserialize(lnk.search.substring(1));
-	params.push({'name':'sakai_csrf_token','value':'$sakai_csrf_token'});
-	var myForm = document.createElement("form");
-	myForm.action = lnk.pathname;
-	myForm.method = "post";
-	for (var i=0; i<params.length; i++) {
-		var myInput = document.createElement("input");
-		myInput.type = "hidden";
-		myInput.name = params[i].name;
-		myInput.value = params[i].value;
-		myForm.appendChild(myInput);
-	}
-	document.body.appendChild(myForm);
-	myForm.submit();
-	return false;
-}
 </script>
 <div class="portletBody">
 	#if ($allowAddAssignment || ($withGrade && $!allowGradeSubmission))
-	## for user who cannot create assignment nor grade submission, no need to show "Assignment List" link at all since there is really no other toolbar choices
-	<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-			#set($prevAction=true)
-			<li  class="firstToolBarItem"><span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span></li>
-		#end
-		<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end 
-			#if (!$!view.equals('lisofass1'))
-				>
-				<span><a href="#toolLinkParam("$action" "doView" "view=lisofass1")" title="$!tlang.getString('lisofass1')">$!tlang.getString('lisofass1')</a></span>
-			#else
-				 >
-				<span class="current">$!tlang.getString("lisofass1")</span>
-			#end
-		</li>	
-		
-		#if ($withGrade && $!allowGradeSubmission)
-			<li#if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLinkParam("$action" "doView" "view=grarep")" title="$!tlang.getString("gen.grarep")">$!tlang.getString("gen.grarep")</a></span>
-			</li>
-		#end
-	
-		#if ($allowAddAssignment)
-			<li  #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end 
-				#if (!$!view.equals('stuvie'))
-					>
-					<span><a href="#toolLinkParam("$action" "doView" "view=stuvie")" title="$!tlang.getString("gen.stuvie")">$!tlang.getString("gen.stuvie")</a></span>
-				#else
-					>
-					<span class="current">$!tlang.getString("gen.stuvie")</span>
-				#end
-			</li>	
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLink("$action" "doReorder")" title="$tlang.getString('gen.reorder')">$tlang.getString('gen.reorder')</a></span>
-			</li>
-		#end
-		#if ($allowUpdateSite)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#toolLink("$action" "doPermissions")" title="$tlang.getString('permis')">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)		
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#toolLink("$action" "doOptions")" title="$tlang.getString('options')">$tlang.getString('options')</a></span>
-				</li>
-			#end	
-		#end
-	</ul>
+		## for user who cannot create assignment nor grade submission, no need to show "Assignment List" link at all since there is really no other toolbar choices
+		#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
 	#end
 	#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div><div class="clear"></div>#end
 	<h3>
@@ -120,17 +44,18 @@ function duplicateLink(lnk) {
 		#if ($allowAddAssignment)
 			#if (!$!view.equals('stuvie'))
 			<div class="viewNav">
-				<form name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
+				<form id="viewForm" name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
 					<input type="hidden" name="eventSubmit_doView" value="view" />
-					<label for="view">
-						$tlang.getString("gen.view2")
-					</label>
-					<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-					<select id="view" name="view" size="1" tabindex="3" onchange="ASN.disableControls( null, 'asnActionLink' );ASN.showSpinner( 'viewSpinner' );document.viewForm.submit();">
-						<option value="lisofass1" #if($!view.equals('lisofass1'))selected="selected"#end >$!tlang.getString('lisofass1')</option>
-						<option value="lisofass2" #if($!view.equals('lisofass2'))selected="selected"#end >$!tlang.getString('lisofass2')</option>
-					</select>
-					<img id="viewSpinner" class="spinner" src="/library/image/indicator.gif" />
+					<div class="spinnerBesideContainer">
+						<label for="view">
+							$tlang.getString("gen.view2")
+						</label>
+						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
+						<select id="view" name="view" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null, true );">
+							<option value="lisofass1" #if($!view.equals('lisofass1'))selected="selected"#end >$!tlang.getString('lisofass1')</option>
+							<option value="lisofass2" #if($!view.equals('lisofass2'))selected="selected"#end >$!tlang.getString('lisofass2')</option>
+						</select>
+					</div>
 					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 				</form>
 			</div>
@@ -144,70 +69,7 @@ function duplicateLink(lnk) {
 				<div class="instruction">$tlang.getString("stulistassig.selanass")</div>
 			</div>
 		#end
-		<div class="listNav">
-			<div  class="instruction">
-				$tlang.getString("gen.viewing") $topMsgPos - $btmMsgPos $tlang.getString("gen.of") $allMsgNumber $tlang.getString("gen.items")
-				<img id="navSpinner" class="spinner" src="/library/image/indicator.gif" />
-			</div>
-			#if ($pagesize != 0)
-				#if ($goFPButton == "true")
-					<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#else
-					<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_first" value="|&lt;" disabled="disabled" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#end
-				#if ($goPPButton == "true")
-					<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getString('gen.previous') $pagesize" accesskey="p" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#else
-					<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_prev" value="&lt;" disabled="disabled" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#end
-			#end	
-			<form name="pagesizeForm" class="inlineForm" method="post" action="#toolForm("$action")">
-				<input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
-				<label for="selectPageSize" class="skip">$tlang.getString("newassig.selectmessage")</label>
-				<select id="selectPageSize" name="selectPageSize" onchange="ASN.changePageSize();">
-					#foreach ($i in $!pagesizes)
-						<option value="$i" #if($pagesize == $i) selected="selected" #end>$tlang.getString("list.show") $i $tlang.getString("list.itemsper")</option>
-					#end
-				</select>
-				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-			</form>
-			#if ($pagesize != 0)
-				#if ($goNPButton == "true")
-					<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getString('gen.next') $pagesize" accesskey="n" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#else
-					<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_next" value="&gt;" disabled="disabled" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#end
-				#if ($goLPButton == "true")
-					<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString('gen.last')" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#else
-					<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.last')</legend><input type="submit" onclick="ASN.disableControls( null, 'asnActionLink' ); ASN.showSpinner( 'navSpinner' );" name="eventSubmit_doList_last" value="&gt;|" disabled="disabled" /></fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#end
-			#end
-		</div>
+		#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
 	</div>
 		<form name="listAssignmentsForm" action="#toolForm("$action")" method="post">
 			<input type="hidden" name="source" value="0" />			
@@ -217,7 +79,7 @@ function duplicateLink(lnk) {
 						&nbsp;
 					</th>
 					<th id="title">
-						<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
 							$tlang.getString("gen.asstit")
 							#if ($sortedBy.equals("title")) 
 								#if ($sortedAsc.equals("true")) 
@@ -231,18 +93,18 @@ function duplicateLink(lnk) {
 					#if ($!allowGradeSubmission)
 						<th id="$tlang.getString('gen.visible')">
 							#if (!$sortedBy.equalsIgnoreCase("$tlang.getString('gen.visible')"))
-								<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=for")'; return false;"   title="$tlang.getString('gen.sortbyfor')">$tlang.getString("gen.visible")</a>
+								<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=for")'; return false;"   title="$tlang.getString('gen.sortbyfor')">$tlang.getString("gen.visible")</a>
 							#else
 								#if ($sortedAsc.equals("true"))
-									<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=for")'; return false;"    title="$tlang.getString('gen.sortbyforasc')">$tlang.getString("gen.visible") <img src = "#imageLink('sakai/sortascending.gif')" border="0" alt="$tlang.getString('gen.sortbyforasc')" /></a>
+									<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=for")'; return false;"    title="$tlang.getString('gen.sortbyforasc')">$tlang.getString("gen.visible") <img src = "#imageLink('sakai/sortascending.gif')" border="0" alt="$tlang.getString('gen.sortbyforasc')" /></a>
 								#else
-									<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=for")'; return false;"    title="$tlang.getString('gen.sortbyfordesc')">$tlang.getString("gen.visible") <img src = "#imageLink('sakai/sortdescending.gif')" border="0" alt ="$tlang.getString('gen.sortbyfordesc')" /></a>
+									<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=for")'; return false;"    title="$tlang.getString('gen.sortbyfordesc')">$tlang.getString("gen.visible") <img src = "#imageLink('sakai/sortdescending.gif')" border="0" alt ="$tlang.getString('gen.sortbyfordesc')" /></a>
 								#end
 							#end
 						</th>
 					#end
 					<th id="status">
-						<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=assignment_status")'; return false;"   title="$tlang.getString("list.sorbysta")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=assignment_status")'; return false;"   title="$tlang.getString("list.sorbysta")">
 							$tlang.getString("gen.status")
 							#if ($sortedBy.equals("assignment_status")) 
 								#if ($sortedAsc.equals("true")) 
@@ -254,7 +116,7 @@ function duplicateLink(lnk) {
 						</a>
 					</th>
 					<th id="openDate">
-						<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=opendate")'; return false;"  title="$tlang.getString("listassig.sorbyope")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=opendate")'; return false;"  title="$tlang.getString("listassig.sorbyope")">
 							$tlang.getString("gen.open")
 							#if ($sortedBy.equals("opendate")) 
 								#if ($sortedAsc.equals("true")) 
@@ -266,7 +128,7 @@ function duplicateLink(lnk) {
 						</a>
 					</th>
 					<th id="dueDate">
-						<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=duedate")'; return false;"  title="$tlang.getString("gen.sorbydue")">
+						<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=duedate")'; return false;"  title="$tlang.getString("gen.sorbydue")">
 							$tlang.getString("gen.due")
 							#if ($sortedBy.equals("duedate")) 
 								#if ($sortedAsc.equals("true")) 
@@ -281,9 +143,9 @@ function duplicateLink(lnk) {
 						#if ($!view.equals('lisofass1'))
 						#if ($!showNumSubmissionColumn)
 						<th id="num_submissions">
-							<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_submissions")'; return false;"   title="$tlang.getString("listassig.sorbynum1")">$tlang.getString("gen.in")</a>
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_submissions")'; return false;"   title="$tlang.getString("listassig.sorbynum1")">$tlang.getString("gen.in")</a>
 								#if ($sortedBy.equals("num_submissions")) 
-									<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_submissions")'; return false;"   title="$tlang.getString("listassig.sorbynum1")">
+									<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_submissions")'; return false;"   title="$tlang.getString("listassig.sorbynum1")">
 										#if ($sortedAsc.equals("true")) 
 											<img id="sortascendingtotalsubmissions" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
 										#else 
@@ -292,9 +154,9 @@ function duplicateLink(lnk) {
 									</a>
 								#end
 								/
-							<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_ungraded")'; return false;"  title="$tlang.getString("listassig.sorbynum2")">$tlang.getString("gen.new")</a>
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_ungraded")'; return false;"  title="$tlang.getString("listassig.sorbynum2")">$tlang.getString("gen.new")</a>
 								#if ($sortedBy.equals("num_ungraded")) 
-									<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_ungraded")'; return false;"   title="$tlang.getString("listassig.sorbynum2")">
+									<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=num_ungraded")'; return false;"   title="$tlang.getString("listassig.sorbynum2")">
 										#if ($sortedAsc.equals("true")) 
 											<img id="sortascendingungradedsubmissions" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
 										#else 
@@ -308,7 +170,7 @@ function duplicateLink(lnk) {
 					#end
 					#if ($withGrade && $!allowGradeSubmission)
 						<th id="maxgrade">
-							<a href="#" onclick="location='#toolLinkParam("$action" "doSort" "criteria=max_grade")'; return false;"   title="$tlang.getString("gen.sorbymax")">
+							<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=max_grade")'; return false;"   title="$tlang.getString("gen.sorbymax")">
 								$tlang.getString("gen.sca")
 								#if ($sortedBy.equals("max_grade")) 
 									#if ($sortedAsc.equals("true")) 
@@ -384,10 +246,10 @@ function duplicateLink(lnk) {
 											#end
 											</a>
 										</h4>
-										<div class="itemAction">
+										<div id="linksContainer_$validator.escapeUrl($assignmentReference)" class="itemAction spinnerBesideContainer">
 											#set($prevAction=false)
-											#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
-											#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) | #else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("dupli") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
+											#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" onclick="SPNR.insertSpinnerAfter( this, null, 'linksContainer_$validator.escapeUrl($assignmentReference)' );" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
+											#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) |#else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);SPNR.insertSpinnerAfter( this, null, 'linksContainer_$validator.escapeUrl($assignmentReference)' );return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("dupli") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
 											#if ($taggable && $allowAddAssignment)
 												#foreach ($provider in $providers)
 													#set ($helperInfo = false)
@@ -395,7 +257,7 @@ function duplicateLink(lnk) {
 													#set ($helperInfo = $provider.getActivityHelperInfo($activity.reference))
 													#if ($helperInfo)
 														#if($prevAction)
-															| 
+															|
 														#else
 															#set($prevAction=true)
 														#end
@@ -403,11 +265,10 @@ function duplicateLink(lnk) {
 													#end
 												#end
 											#end
-											#if (!$assignment.draft && $!service.allowGradeSubmission($assignment.getReference()))#if($prevAction) | #end
+											#if (!$assignment.draft && $!service.allowGradeSubmission($assignment.getReference()))#if($prevAction) |#end
 											#set ($gradeScale = $assignmentContent.getTypeOfGrade())
 											## show "view submissions" link for ungraded type of assignment
-												<a name="asnActionLink" href="#" onclick="if(allowClick(this)){ASN.disableControls( null, 'asnActionLink' );ASN.showSpinner( 'viewSubmissionsSpinner_$assignmentReference' );window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")';}" >#if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end <span class="skip">: $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>
-												<img id="viewSubmissionsSpinner_$assignmentReference" class="spinner" src="/library/image/indicator.gif" />
+												<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerAfter( this, null, 'linksContainer_$validator.escapeUrl($assignmentReference)' ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")'; }" >#if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end <span class="skip">: $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>
 											#end
 										</div>
 									#else
@@ -543,7 +404,7 @@ function duplicateLink(lnk) {
 									$tlang.getString("gen.viewallgroupssections")
 								#elseif( $groupTitleList.size() > 0 )
 									<div class="groupsContainer">
-										<h4 class="collapse" onclick="ASN.toggleGroups( this ); resizeFrame();">
+										<h4 class="collapse" onclick="ASN.toggleGroups( this ); ASN.resizeFrame();">
 											$groupTitleList.size()
 											#if( $groupTitleList.size() == 1 )
 												$tlang.getString( "selected.group" )
@@ -613,9 +474,11 @@ function duplicateLink(lnk) {
 											#set($totalNumber = $ungradedNumber)
 										#end
 									#end
-									<a name="asnActionLink" href="#" onclick="if(allowClick(this)){ASN.disableControls( null, 'asnActionLink' );ASN.showSpinner( 'viewSubmissionsSpinner2_$assignmentReference' );window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")';}" >
-									<span class="skip"> #if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end : $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64)). </span> <span class="skip">$!tlang.getString("gen.subm2"): </span>$!totalNumber/<span class="skip">$!tlang.getString("ungra"): </span>$!ungradedNumber</a>
-									<img id="viewSubmissionsSpinner2_$assignmentReference" class="spinner" src="/library/image/indicator.gif" />
+									<div class="spinnerBesideContainer">
+										<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerAfter( this, null, null ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")'; }" >
+											<span class="skip"> #if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end : $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64)). </span> <span class="skip">$!tlang.getString("gen.subm2"): </span>$!totalNumber/<span class="skip">$!tlang.getString("ungra"): </span>$!ungradedNumber
+										</a>
+									</div>
 								#end
 								</td>
 								#end
@@ -817,7 +680,8 @@ function duplicateLink(lnk) {
 			</table>
 			#if ($!allowRemoveAssignment && $!view.equals('lisofass1'))
 				<p class="act">
-					<input type="submit" id="btnRemove" name="eventSubmit_doDelete_confirm_assignment" value="$tlang.getString("removeSelected")" accesskey="s" disabled="disabled" />
+					<input type="submit" id="btnRemove" name="eventSubmit_doDelete_confirm_assignment" value="$tlang.getString("removeSelected")" accesskey="s" disabled="disabled"
+						onclick="SPNR.disableControlsAndSpin( this, null );" />
 				</p>
 			#end
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_options.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_options.vm
@@ -4,6 +4,7 @@
 	focus_path = [ "$form-notify" ];
 </script>
 <div class="portletBody">
+	#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "options" )
 	<h3>
 		$tlang.getString("options")
 	</h3>
@@ -21,9 +22,8 @@
             </p>
 		</fieldset>
 		<p class="act">
-			<input type="submit" class="active" name="eventSubmit_doUpdate_options" id = "eventSubmit_doUpdate_option_default" value="$tlang.getString("update")" accesskey="s" onclick="ASN.disableControls(); ASN.showSpinner( 'optionsSpinner' );" />
-			<input type="submit" name="eventSubmit_doCancel_options" value="$tlang.getString("gen.can")" accesskey="x" onclick="ASN.disableControls(); ASN.showSpinner( 'optionsSpinner' );"/>
-			<img id="optionsSpinner" class="spinner" src="/library/image/indicator.gif" />
+			<input type="submit" class="active" name="eventSubmit_doUpdate_options" id = "eventSubmit_doUpdate_option_default" value="$tlang.getString("update")" accesskey="s" onclick="SPNR.disableControlsAndSpin( this, null );" />
+			<input type="submit" name="eventSubmit_doCancel_options" value="$tlang.getString("gen.can")" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );"/>
 		</p>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_scoring_agent.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_scoring_agent.vm
@@ -1,20 +1,19 @@
 <script type="text/javascript"  src="/sakai-assignment-tool/js/scoringAgent.js"></script>
 
 <span style="margin-left:10px;" id="scoringAgent-area">
-   	<a href="#" id="scoringAgent-link" onclick="openScoringAgent('$scoreUrl');displayRefreshReminder();">
-   	    <img src="$scoringAgentImage" title="$scoreText" alt="$scoreText" />
-   	</a>
-   
-   	<!--if grading then show link to refresh grade -->
-   	#if($refreshScoreUrl)
-   		<a href="#" id="scoringAgent-refresh" onclick="refreshScore('$refreshScoreUrl');">
-   		   <img src="/../library/image/silk/arrow_refresh-blue.png" 
-   		       alt="$tlang.getFormattedMessage("scoringAgent.refresh", $scoringAgentName)" 
-   		       title="$tlang.getFormattedMessage("scoringAgent.refresh", $scoringAgentName)" 
-   		       style="margin-left: 10px;"/>
-   		       
-   		   <span style="display:none" id="scoringAgent-refresh-reminder">$tlang.getString('scoringAgent.refreshReminder')</span>
-   		</a>
-   		
-   	#end
+    <a href="javascript:void(0)" id="scoringAgent-link" onclick="ASN_SCRAGNT.openScoringAgent('$scoreUrl'); ASN_SCRAGNT.displayRefreshReminder();">
+        <img src="$scoringAgentImage" title="$scoreText" alt="$scoreText" />
+    </a>
+
+    <!--if grading then show link to refresh grade -->
+    #if($refreshScoreUrl)
+        <a href="javascript:void(0)" id="scoringAgent-refresh" onclick="ASN_SCRAGNT.refreshScore('$refreshScoreUrl');">
+           <img src="/../library/image/silk/arrow_refresh-blue.png" 
+               alt="$tlang.getFormattedMessage("scoringAgent.refresh", $scoringAgentName)" 
+               title="$tlang.getFormattedMessage("scoringAgent.refresh", $scoringAgentName)" 
+               style="margin-left: 10px;"/>
+
+           <span style="display:none" id="scoringAgent-refresh-reminder">$tlang.getString('scoringAgent.refreshReminder')</span>
+        </a>
+    #end
 </span>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_preview_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_preview_submission.vm
@@ -162,10 +162,10 @@
 		#end
 		##	$tlang.getString("gen.title")
 	 #end
-	<form name="addSubmissionForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
+	<form id="addSubmissionForm" name="addSubmissionForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
 		<input type="hidden" name="assignmentId" value="$assignment.Id" />
 		<input type="hidden" name="eventSubmit_doRead_add_submission_form" value="x" />
-		<input type="hidden" name="option" value="cancel" />
+		<input type="hidden" name="option" id="option" value="cancel" />
 		## submission information
 		#set($timeSubmitted=false)
 		#set($timeSubmitted=$submission.TimeSubmitted)
@@ -177,50 +177,15 @@
 					<input name="eventSubmit_doPost_submission" type="submit" value="$tlang.getString("gen.subm3")" disabled="disabled" />
 					<input name="eventSubmit_doCancel_show_submission" type="submit" value="$tlang.getString("gen.revi")" disabled="disabled" />
 			#else
-				<input
-					type="button"
-					class="active"
 					#if ($submitted && $!timeSubmitted)
 						#set($name=$tlang.getString("resubmit"))
 					#else
 						#set($name=$tlang.getString("gen.subm3"))
 					#end
-					name="post"
-					accesskey="s"
-					id="post" 
-					value="$!name"
-					onclick="showNotif('submitnotif','post','addSubmissionForm'); document.addSubmissionForm.option.value='post'; document.addSubmissionForm.submit(); return false;"
-				/>
-				<input
-					class="disableme" 
-					type="button" 
-					accesskey="d"
-					name="save" 
-					id="save" 
-					value="$tlang.getString("gen.savdra")"
-					onclick="showNotif('submitnotif','save','addSubmissionForm');document.addSubmissionForm.option.value='save'; document.addSubmissionForm.submit(); return false;"
-				/>
-				<input
-					class="disableme" 
-					type="button" 
-					name="revise" 
-					accesskey="r"
-					id="revise" 
-					value="$tlang.getString("gen.revi")"
-					onclick="document.addSubmissionForm.option.value='revise';document.addSubmissionForm.submit(); return false;"
-				/>
+				<input type="button" class="active" name="post" accesskey="s" id="post" value="$!name" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'post', null, null, true );" />
+				<input class="disableme" type="button" accesskey="d" name="save" id="save" value="$tlang.getString("gen.savdra")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'save', null, null, true );" />
+				<input class="disableme" type="button" name="revise" accesskey="r" id="revise" value="$tlang.getString("gen.revi")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'revise', null, null, true );" />
 			#end
-## gsilver - what used for? confusion.
-##		<input
-##				class="disableme" 
-##			type="button" 
-##		name="revise" 
-##				accesskey="x"
-##				id="done" 
-##				value="$tlang.getString("gen.don")"
-##				onclick="document.addSubmissionForm.option.value='revise'; document.addSubmissionForm.submit(); return false;"
-##			/>
-			<span id="submitnotif" style="visibility:hidden">$tlang.getString("gen.proces")</span>
 		</div>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
@@ -2,60 +2,13 @@
 <!-- start: check_assignments_instructor_grading_submission.vm  -->
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm,v 1.10 2005/06/03 15:32:15 zqian.umich.edu Exp $ -->
 <script type="text/javascript">
-focus_path = [ '$fField' ];
-function handleEnterKeyPress(ev)
-	{
-		if (!ev) ev = window.event;
-			if (ev && ev.keyCode == 13)
-			{
-				 return false; 
-			 }
-		 }
-</script>
-<script type="text/javascript">
+	focus_path = [ '$fField' ];
 	$(document).ready(function(){
-		setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
-		ASN.setupItemNavigator();
+		ASN.setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
 	});
 </script>
 <div class="portletBody">
-<ul class="navIntraTool actionToolBar">
-		#set($prevAction=false)
-		#if ($allowAddAssignment)
-			#set($prevAction=true)
-			<li class="firstToolBarItem">
-				<span><a href="#toolLink("$action" "doNew_assignment")" title="$!tlang.getString("new")">$!tlang.getString("new")</a></span>
-			</li>
-		#end
-		<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-			<span><a href="#" title = "$!tlang.getString('lisofass1')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='lisofass1';document.gradeForm.submit();return false;">$!tlang.getString("lisofass1")</a></span>
-		</li>	
-		#if ($withGrade && $!allowGradeSubmission)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$!tlang.getString('gen.grarep')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='grarep';document.gradeForm.submit();return false;">$!tlang.getString("gen.grarep")</a></span>
-			</li>				
-		#end
-		#if ($allowAddAssignment)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$!tlang.getString('gen.stuvie')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='view';document.getElementById('view').value='stuvie';document.gradeForm.submit();return false;">$!tlang.getString("gen.stuvie")</a></span>
-			</li>	
-		#end
-		#if (($allowAllGroups) && ($assignmentscheck))
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$tlang.getString('gen.reorder')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='reorderNavigation';document.gradeForm.submit();return false;">$tlang.getString('gen.reorder')</a></span>
-			</li>	
-		#end
-		#if ($allowUpdateSite)
-			<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-				<span><a href="#" title="$tlang.getString('permis')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='permissions';document.gradeForm.submit();return false;">$tlang.getString('permis')</a></span>
-			</li>
-			#if ($enableViewOption)	
-				<li #if ($prevAction==false) class="firstToolBarItem" #set($prevAction=true)  #end>
-					<span><a href="#" title="$tlang.getString('options')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='options';document.gradeForm.submit();return false;">$tlang.getString('options')</a></span>
-				</li>
-			#end	
-		#end
-	</ul>
+	#navBarOnClick( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "gradeForm" "" )
 	## confirmation
 	#if ($!gradingDone)
 		<div class="success">
@@ -132,15 +85,14 @@ function handleEnterKeyPress(ev)
 				#end
 		   </div>
 			<div class="itemNav highlightPanel" style="float:right;text-align:right;clear:right">
-				## prev button				
-				<input type="button" name="prevsubmission1" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='prevsubmission_review';document.gradeForm.submit();return false;"/>
+				## prev button
+				<input type="button" name="prevsubmission1" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="ASN.submitForm( 'gradeForm', 'prevsubmission_review', '$validator.escapeUrl($submission.Reference)', null, true );"/>
 				## back to list button
-				<input type="button" name="cancelgradesubmission1" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='cancelgradesubmission_review';document.gradeForm.submit();return false;"/>
+				<input type="button" name="cancelgradesubmission1" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="ASN.submitForm( 'gradeForm', 'cancelgradesubmission_review', '$validator.escapeUrl($submission.Reference)', null, true );"/>
 				## next button
-				<input type="button" name="nextsubmission1" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='nextsubmission_review';document.gradeForm.submit();return false;"/>
+				<input type="button" name="nextsubmission1" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="ASN.submitForm( 'gradeForm', 'nextsubmission_review', '$validator.escapeUrl($submission.Reference)', null, true );"/>
 				#if(!$view_only)
 					<div class="instruction textPanelFooter" style="text-align:center">$tlang.getString("nav.message")</div>
-					<div class="messageProgress" style="visibility:hidden;text-align:left;">$tlang.getString("gen.proces")</div>
 				#end
 			</div>
 		</div>
@@ -149,13 +101,13 @@ function handleEnterKeyPress(ev)
 		## show or hide assignment instruction and attachment
 			#if ($assignment_expand_flag)
 				<p class="discTria">
-					<a href="#" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='hide_instruction_review';document.gradeForm.submit();return false;">
+					<a href="javascript:void(0)" onclick="ASN.submitForm( 'gradeForm', 'hide_instruction_review', null, null, true );">
 					<img src="#imageLink("sakai/collapse.gif")" alt="$tlang.getString("gradingsub.opecliass")" border="0" width="13" height="13" align="top" /></a>
 					$tlang.getString("gen.assinf")
 				</p>	
 			#else
 				<p class="discTria">
-					<a href="#" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='show_instruction_review';document.gradeForm.submit();return false;">
+					<a href="javascript:void(0)" onclick="ASN.submitForm( 'gradeForm', 'show_instruction_review', null, null true );">
 					<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("gen.clocli")" border="0" width="13" height="13" align="top" /></a>
 					$tlang.getString("gen.assinf")
 				</p>	
@@ -350,7 +302,7 @@ function handleEnterKeyPress(ev)
 											<spn class="instruction">$tlang.getString("peerassessment.noscore")</span>
 										#end
 									#else
-										<input type="text" name="$name_grade" size="5" maxlength="11" value="$!value_grade" id="grade" onkeypress="return handleEnterKeyPress(event);" /> 
+										<input type="text" name="$name_grade" size="5" maxlength="11" value="$!value_grade" id="grade" onkeypress="return ASN.handleEnterKeyPress(event);" />
 									#end
 									<span class="instruction">($tlang.getString("grade.max") $assignment.getContent().getMaxGradePointDisplay())</span>
 								</p>	
@@ -391,14 +343,14 @@ function handleEnterKeyPress(ev)
 				<span class="act">
 					#if($view_only)
 						#if($item_removed)
-							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.restorereview')" onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='toggleremove_review';document.gradeForm.submit();return false;" title="$tlang.getString("peerassessment.restorereview")" />
+							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.restorereview')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'toggleremove_review', '$validator.escapeUrl($submission.Reference)', null, true );" title="$tlang.getString("peerassessment.restorereview")" />
 						#else
-							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.removereview')" onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='toggleremove_review';document.gradeForm.submit();return false;" title="$tlang.getString("peerassessment.removereview")" />
+							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.removereview')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'toggleremove_review', '$validator.escapeUrl($submission.Reference)', null, true );" title="$tlang.getString("peerassessment.removereview")" />
 						#end
 					#else
-						<input type="button" accesskey="s" name="return" value="$tlang.getString('gen.sav')" onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='savegrade_review';document.gradeForm.submit();return false;" title="$tlang.getString("gen.sav")" />	
-						<input type="button" accesskey="x" name="cancel" value="$tlang.getString('cancel_changes')" onclick="javascript:document.gradeForm.onsubmit();document.getElementById('option').value='cancelgrade_review';document.gradeForm.submit();return false;" />
-						<input type="button" name="returnSubmit" value="$tlang.getString('gen.subm3')" onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='submitgrade_review';document.gradeForm.submit();return false;" title="$tlang.getString("gen.subm3")" />
+						<input type="button" accesskey="s" name="return" value="$tlang.getString('gen.sav')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'savegrade_review', '$validator.escapeUrl($submission.Reference)', null, true );" title="$tlang.getString("gen.sav")" />
+						<input type="button" accesskey="x" name="cancel" value="$tlang.getString('cancel_changes')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgrade_review', null, null, true );" />
+						<input type="button" name="returnSubmit" value="$tlang.getString('gen.subm3')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'submitgrade_review', '$validator.escapeUrl($submission.Reference)', null, true );" title="$tlang.getString("gen.subm3")" />
 					#end
 					#if ($!prevSubmissionId)
 						<input type="hidden" name="prevSubmissionId" value = "$!prevSubmissionId" />
@@ -412,14 +364,13 @@ function handleEnterKeyPress(ev)
 			</div>				
 			<div class="itemNav highlightPanel" style="float:right;text-align:right;clear:right;margin-top:0">
 				## prev button				
-				<input type="button" name="prevsubmission2" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='prevsubmission_review';document.gradeForm.submit();return false;"/>
+				<input type="button" name="prevsubmission2" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevsubmission_review', '$validator.escapeUrl($submission.Reference)', null, true );"/>
 				## back to list button
-				<input type="button" name="cancelgradesubmission2" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='cancelgradesubmission_review';document.gradeForm.submit();return false;"/>
+				<input type="button" name="cancelgradesubmission2" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm' 'cancelgradesubmission_review', '$validator.escapeUrl($submission.Reference)', null, true );"/>
 				## next button
-				<input type="button" name="nextsubmission2" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="javascript:document.gradeForm.action=document.gradeForm.action+'&submissionId=$validator.escapeUrl($submission.Reference)';document.gradeForm.onsubmit();document.getElementById('option').value='nextsubmission_review';document.gradeForm.submit();return false;"/>
+				<input type="button" name="nextsubmission2" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'nextsubmission_review', '$validator.escapeUrl($submission.Reference)', null, true );"/>
 				#if(!$view_only)
-					<div class="instruction textPanelFooter" style="text-align:center">$tlang.getString("nav.message")</div>				
-					<div class="messageProgress" style="visibility:hidden;text-align:left">$tlang.getString("gen.proces")</div>
+					<div class="instruction textPanelFooter" style="text-align:center">$tlang.getString("nav.message")</div>
 				#end
 			</div>
 		</div>	

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment.vm
@@ -3,7 +3,7 @@
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm,v 1.2 2005/05/19 19:39:49 gsilver.umich.edu Exp $ -->
 <script type="text/javascript">
     $(document).ready(function(){
-        setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
+        ASN.setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
     });
 </script>
 
@@ -272,7 +272,7 @@
 		#end
 		#else
 			<p class="discTria">
-				<a href="#" onclick="location='#toolLink("AssignmentAction" "doShow_view_assignment")'; return false;" title="$tlang.getString("viewassig.shoassinf")">	
+				<a href="javascript:void(0)" onclick="location='#toolLink("AssignmentAction" "doShow_view_assignment")'; return false;" title="$tlang.getString("viewassig.shoassinf")">	
 				<img src="#imageLink("sakai/expand.gif")" alt="$tlang.getString("gen.open")" border="0" width="13" height="13" align="top" alt="$tlang.getString("viewassig.shoassinf")" /></a>
 				$tlang.getString("gen.settfor") "$validator.escapeHtml($assignment.title)"
 			</p>	
@@ -281,7 +281,7 @@
 		<input type="hidden" name="assignmentId" value="$assignment.Reference" />
 		<input type="hidden" name="assignmentContentId" value="$assignment.ContentReference" />
 			<div class="act">
-				<input type="submit" name="eventSubmit_doCancel_student_view_assignment" value="$tlang.getString("gen.don")" />
+				<input type="submit" name="eventSubmit_doCancel_student_view_assignment" value="$tlang.getString("gen.don")" onclick="SPNR.disableControlsAndSpin( this, null );" />
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -5,16 +5,16 @@
 <link href="/library/js/jquery/ui/1.11.3/themes/ui-lightness/jquery-ui.min.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript">
     $(document).ready(function(){
-        setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
+        ASN.setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
         $( "#accordion" ).accordion({
 	        	heightStyle: 'content',
 	        	active: 0,
 	        	collapsible: true,
 	        	change: function(event, ui){
-	                    resizeFrame();
+	                    ASN.resizeFrame();
 	            },
 	            activate: function(event, ui){
-	                    resizeFrame();
+	                    ASN.resizeFrame();
 	            }
             }
         );
@@ -35,7 +35,7 @@ function handleReportsTriangleDisclosure(btn)
 		btn.src="/library/image/sakai/collapse.gif";
 		btn.alt="$tlang.getString('review.report.collapse')";
 		reportsDiv.style.display="block";
-		resizeFrame();
+		ASN.resizeFrame();
 	}
 	reportsExpanded = !reportsExpanded;
 }
@@ -511,25 +511,10 @@ function handleReportsTriangleDisclosure(btn)
 			#end
 		<form action="#toolForm("AssignmentAction")" method="post" >
 			<div class="act">
-				<input type="submit" accesskey="x" name="eventSubmit_doCancel_view_grade" value="$tlang.getString("gen.backtolist")" accesskey="x" class="active TB_hideControl"/>
+				<input type="submit" accesskey="x" name="eventSubmit_doCancel_view_grade" value="$tlang.getString("gen.backtolist")" accesskey="x" class="active TB_hideControl"
+					onclick="SPNR.disableControlsAndSpin( this, null );" />
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>
 	</div>
-	
-
-							
-				
-					
-	<script type="text/javascript">
-		<!--
-			function display_item(id) {
-				var item = document.getElementById(id);
-				if(item.style.display == 'none')
-				item.style.display = 'block';
-				else
-				item.style.display = 'none';
-			}
-		//-->
-	</script>
 <!-- end: chef_assignments_student_view_grade.vm  -->

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_group_error.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_group_error.vm
@@ -80,7 +80,8 @@
 
 		<form action="#toolForm("AssignmentAction")" method="post" >
 			<div class="act">
-				<input type="submit" accesskey="x" name="eventSubmit_doCancel_view_grade" value="$tlang.getString("gen.backtolist")" accesskey="x" class="active TB_hideControl"/>
+				<input type="submit" accesskey="x" name="eventSubmit_doCancel_view_grade" value="$tlang.getString("gen.backtolist")" accesskey="x" class="active TB_hideControl"
+					onclick="SPNR.disableControlsAndSpin( this, null );" />
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -2,7 +2,7 @@
 <!-- start: chef_assignments_student_view_submission.vm  -->
 <script type="text/javascript">
 $(document).ready(function(){
-    setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
+    ASN.setupToggleAreas('toggleAnchor', 'toggledContent', false, 'fast');
     $('#submissionFileCount').val(1);
     $('#addMoreAttachmentControls').click(function(e){
         e.preventDefault();
@@ -19,30 +19,10 @@ $(document).ready(function(){
             }
         }
         $('.cloned a').show();
-        resizeFrame('grow');
+        ASN.resizeFrame('grow');
     });
     
 });
-var notifyDeleteControl = function(){
-    $('#submissionFileCount').val(parseInt($('#submissionFileCount').val(), 10) - 1);
-    if ($('#submissionFileCount').val() < 5) {
-        $('#addMoreAttachmentControls').show();
-        $('#addMoreAttachmentControlsInactive').hide();
-    }
-};
-
-function submitform(id)
-{
-	var theForm = document.getElementById(id);
-	if(theForm && theForm.onsubmit)
-	{
-		theForm.onsubmit();
-	}
-	if(theForm && theForm.submit)
-	{
-		theForm.submit();
-	}
-}
 	
 var reportsExpanded = false;
 function handleReportsTriangleDisclosure(btn)
@@ -62,30 +42,6 @@ function handleReportsTriangleDisclosure(btn)
 		resizeFrame();
 	}
 	reportsExpanded = !reportsExpanded;
-}	
-
-/* Enables the submit/resubmit button. If checkForFile is true, then it disables the submit/resubmit button if the clonableUpload button has no value*/
-function enableSubmitUnlessNoFile(checkForFile)
-{
-	var btnPost = document.getElementById('post');
-	var doEnable = true;
-	if (checkForFile)
-	{
-		var btnClonableUpload = document.getElementById('clonableUpload');
-		if (btnClonableUpload && btnClonableUpload.value == "")
-		{
-			doEnable = false;
-		}
-	}
-
-	if (doEnable)
-	{
-		btnPost.removeAttribute('disabled');
-	}
-	else
-	{
-		btnPost.setAttribute('disabled', 'disabled');
-	}
 }
 </script>
 ## Include other javascript specific to this page
@@ -606,7 +562,7 @@ function enableSubmitUnlessNoFile(checkForFile)
 			#end
 			##just show a simple done button for non-electronic submission type
 			<form name="dummyForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
-				<input type="submit" accesskey="x" name="eventSubmit_doCancel_show_submission" value="$tlang.getString('gen.don')" />
+				<input type="submit" accesskey="x" name="eventSubmit_doCancel_show_submission" value="$tlang.getString('gen.don')" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 			</form>
 		#else
@@ -834,9 +790,11 @@ function enableSubmitUnlessNoFile(checkForFile)
 											#propertyDetails($props)
 										</td>
 										<td class="itemAction">
-											<a href="#" onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='removeAttachment'; document.addSubmissionForm.currentAttachment.value='$attachment.id'; document.addSubmissionForm.submit(); return false;">
-												$tlang.getString("stuviewsubm.removeatt")<span class="skip"> $validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</span>
-											</a>
+											<div class="spinnerBesideContainer">
+												<a href="javascript:void(0)" onclick="SPNR.insertSpinnerAfter( this, null, null ); ASN.doStudentViewSubmissionAction( 'addSubmissionForm', 'removeAttachment', '$attachment.id' );">
+													$tlang.getString("stuviewsubm.removeatt")<span class="skip"> $validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</span>
+												</a>
+											</div>
 										</td>
 									</tr>
 								#end
@@ -864,23 +822,15 @@ function enableSubmitUnlessNoFile(checkForFile)
 												<span><label for="clonableUpload">$howManySubAtts</label></span>
 											</td>
 											<td>
-												<div id="clonableUploadW"> 
-													<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUpload" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';submitform('addSubmissionForm');"/> 
-													<span id="submitnotifxxx" class="messageProgress" style="visibility:hidden">$tlang.getString("processmessage.file")</span>
+												<div id="clonableUploadW spinnerBesideContainer"> 
+													<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="SPNR.insertSpinnerAfter( this, null, null ); document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUpload" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';ASN.submitForm( 'addSubmissionForm', null, null, null, false );"/> 
 												</div>
 											</td>
 											<td>
 												<span class="navIntraToolLink">
-													<input
-														class="disableme enabled" 
-														type="button" 
-														value="$howManySubAttsLinks"
-														name="attach" 
-														id="attach"
-														accesskey="a" #if(!$allowSubmit) disabled="disabled"#end
-														onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='attach'; document.addSubmissionForm.submit(); return false;"
-													/>
-												</span>	
+													<input class="disableme enabled" type="button" value="$howManySubAttsLinks" name="attach" id="attach" accesskey="a" #if(!$allowSubmit) disabled="disabled"#end
+														onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'attach', null, null, true );" />
+												</span>
 											</td>
 										</tr>	
 										<tr>
@@ -905,22 +855,16 @@ function enableSubmitUnlessNoFile(checkForFile)
 											<label for="upload">$tlang.getString("att.upl")</label>
 										</td>
 										<td>
-											<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';submitform('addSubmissionForm');"/> 
-											<span id="submitnotifxxx" class="messageProgress" style="visibility:hidden">$tlang.getString("processmessage.file")</span>
+											<div class="spinnerBesideContainer">
+												<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="SPNR.insertSpinnerAfter( this, null, null ); document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';ASN.submitForm( 'addSubmissionForm', null, null, null, false );"/>
+											</div>
 											<input type="hidden" name="submissionFileCount" id="submissionFileCount" value="1"/>
 										</td>
 										<td>
 											## add browse resources button here
 											#set($howManySubAttsLinks=$tlang.getString("stuviewsubm.attfromserverlabel.singular"))
-											<input
-												class="disableme enabled"
-												type="button"
-												value="$howManySubAttsLinks"
-												name="attach"
-												id="attach"
-												accesskey="a" #if(!$allowSubmit) disabled="disabled"#end
-												onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='attach'; document.addSubmissionForm.submit(); return false;"
-											/>
+											<input class="disableme enabled" type="button" value="$howManySubAttsLinks" name="attach" id="attach" accesskey="a" #if(!$allowSubmit) disabled="disabled"#end
+												onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'attach', null, null, true );" />
 										</td>
 									</tr>
 								</tbody>
@@ -930,16 +874,6 @@ function enableSubmitUnlessNoFile(checkForFile)
 				#elseif ($submissionType == 5)
 					## attachments > 1, but the assignment type is single uploaded file only
 
-					##defines a macro to display attachment details
-					#macro (attachmentDetails)
-						#if ($props.getBooleanProperty($props.NamePropIsCollection))
-							<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")"/>
-						#else
-							<img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
-						#end
-						<a href="$attachment.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
-						#propertyDetails($props)
-					#end
 					<div class="assignmentAttachBox">
 					<h3>
 						#if ($submissionType == 5)
@@ -954,15 +888,15 @@ function enableSubmitUnlessNoFile(checkForFile)
 						#set ($props = $attachment.Properties)
 						#if ($!props)
 							<div class="assignmentAttachRadio">
-								<input type="radio" name="attachmentSelection" value="$attachments.indexOf($attachment)" onclick="highlightSelectedAttachment(); enableSubmitUnlessNoFile(false);">
+								<input type="radio" name="attachmentSelection" value="$attachments.indexOf($attachment)" onclick="ASN.highlightSelectedAttachment(); ASN.enableSubmitUnlessNoFile(false);">
 								#attachmentDetails()
 								<br>
 							</div>
 						#end
 					#end
 
-					<div class="assignmentAttachRadio assignmentAttachmentHighlight">
-						<input type="radio" name="attachmentSelection" value="newAttachment" onclick="highlightSelectedAttachment(); enableSubmitUnlessNoFile(true);" checked />
+					<div class="assignmentAttachRadio assignmentAttachmentHighlight spinnerBesideContainer">
+						<input type="radio" name="attachmentSelection" value="newAttachment" onclick="ASN.highlightSelectedAttachment(); ASN.enableSubmitUnlessNoFile(true);" checked />
 						<span>
 							#set($attachment = $newSingleUploadedFile)
 							#if (!$attachment)
@@ -974,24 +908,16 @@ function enableSubmitUnlessNoFile(checkForFile)
 							#set($props = $attachment.Properties)
 							#if ($props)
 								#attachmentDetails()
-								<a href="#" onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='removeNewSingleUploadedFile'; document.addSubmissionForm.submit(); return false;">
+								<a href="javascript:void(0)" onclick="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'addSubmissionForm', 'removeNewSingleUploadedFile', null, null, true );">
 									$tlang.getString("stuviewsubm.removeatt")<span class="skip"> $validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</span>
 								</a>
 								<br>
 							#else
 								$tlang.getString("stuviewsubm.uploadnew")
-								<input type="file" name="upload" class="upload" id="clonableUpload" #if ($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="javascript:showNotif('submitnotifxxx','post','addSubmissionForm');document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "")';submitform('addSubmissionForm');"/>
-								<span id="submitnotifxxx" class="messageProgress" style="visibility:hidden">$tlang.getString("processmessage.file")</span>
+								<input type="file" name="upload" class="upload" id="clonableUpload" #if($content_review_acceptedMimeTypes) accept="$content_review_acceptedMimeTypes" #end onchange="SPNR.insertSpinnerAfter( this, null, null ); document.getElementById('addSubmissionForm').action='#toolLinkParam("AssignmentAction" "doAttachUploadSingle" "sakai_csrf_token=$validator.escapeUrl($sakai_csrf_token)")';ASN.submitForm( 'addSubmissionForm', null, null, null, false );"/>
 								<span class="navIntraToolLink">
-									<input
-										class="disableme enabled"
-										type="button"
-										value="$tlang.getString("stuviewsubm.attfromserverlabel")"
-										name="attach"
-										id="attach"
-										accesskey="a" #if(!$allowSubmit) disabled="disabled"#end
-										onclick="document.addSubmissionForm.onsubmit();document.addSubmissionForm.option.value='attach'; document.addSubmissionForm.submit(); return false;"
-									/>
+									<input class="disableme enabled" type="button" value="$tlang.getString("stuviewsubm.attfromserverlabel")" name="attach" id="attach" accesskey="a" #if(!$allowSubmit) disabled="disabled"#end
+										onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'attach', null, null, true );" />
 								</span>
 							#end
 						</span>
@@ -1172,69 +1098,32 @@ function enableSubmitUnlessNoFile(checkForFile)
 				<div id="submitPanel"
 					#if ($!deleted.equalsIgnoreCase("true") || !$!canSubmit)
 					 class="act">
-						<input 
-							type="button" 
-							name="cancel"
-							accesskey="x"
-							id="cancel" 
-							value="$tlang.getString("gen.don")"
-							onclick="ASN_SVS.confirmDiscardOrSubmit($!new_attachments); return false;"
-						/>
+						<input type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.don")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.confirmDiscardOrSubmit(); return false;" />
 					#else
 					 class="act messageInformation">
-							<input
-								type="button"
-								class="active"
 								#if ($submitted && $!timeSubmitted)
 									#set($name=$tlang.getString("resubmit"))
 								#else
 									#set($name=$tlang.getString("gen.subm3"))
 								#end
-								name="post"
-								accesskey="s"
-								id="post" 
-								value="$!name"
-								onclick="document.addSubmissionForm.onsubmit();showNotif('submitnotif','post','addSubmissionForm'); document.addSubmissionForm.option.value='post'; document.addSubmissionForm.submit(); return false;"
+								<input type="button" class="active" name="post" accesskey="s" id="post" value="$!name"
+									onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'post', null, null, true );" 
 								#if ($submitted && ($submissionType == 2 || $submissionType == 5) && !$!new_attachments && !$!newSingleUploadedFile && (!$!newSingleAttachmentList || $!newSingleAttachmentList.isEmpty()))
-									disabled
+									disabled="disabled"
 								#end
 							/>
 					## for single file upload case, no need for preview or save draft
 					#if ($submissionType!=5)
-							<input
-								class="disableme" 
-								type="button" 
-								name="preview" 
-								accesskey="v"
-								id="preview" 
-								value="$tlang.getString("gen.pre")"
-								onclick="document.addSubmissionForm.onsubmit();showNotif('submitnotif','preview','addSubmissionForm');document.addSubmissionForm.option.value='preview'; document.addSubmissionForm.submit(); return false;"
-							/>
-							<input
-								class="disableme" 
-								type="button" 
-								name="save" 
-								accesskey="d"
-								id="save" 
-								value="$tlang.getString("gen.savdra")"
-								onclick="document.addSubmissionForm.onsubmit();showNotif('submitnotif','save','addSubmissionForm');document.addSubmissionForm.option.value='save'; document.addSubmissionForm.submit(); return false;"
-							/>
+							<input class="disableme" type="button" name="preview" accesskey="v" id="preview" value="$tlang.getString("gen.pre")"
+								onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'preview', null, null, true );" />
+							<input class="disableme" type="button" name="save" accesskey="d" id="save" value="$tlang.getString("gen.savdra")"
+								onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'save', null, null, true );" />
 							#end
 							#if ($!linkInvoked)
-
-								<input class="disableme" type="submit" accesskey="x" onClick="window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" />
-		
-							#else						
-							
-							<input 
-								class="disableme"
-								type="button" 
-								name="cancel"
-								accesskey="x"
-								id="cancel" 
-								value="$tlang.getString("gen.can")"
-								onclick="ASN_SVS.confirmDiscardOrSubmit($!new_attachments); return false"
-							/>
+								<input class="disableme" type="submit" accesskey="x" onClick="SPNR.disableControlsAndSpin( this, null ); window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" />
+							#else
+								<input class="disableme" type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.can")"
+									onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.confirmDiscardOrSubmit(); return false;" />
 							#end
 
                             #if ($submitted && ($submissionType == 2 || $submissionType == 5) && !$!new_attachments)
@@ -1245,12 +1134,11 @@ function enableSubmitUnlessNoFile(checkForFile)
                                 <span class="messageInformation">$tlang.getString("stuviewsubm.submitreminder")</span>
                             #end
 					#end
-				<span id="submitnotif" style="visibility:hidden">$tlang.getString("gen.proces")</span>
 			</div>
 			<div id="confirmationDialogue" class="act messageInformation" style="display:none;">
 				$tlang.getString("gen.can.discard")
-				<input class="disableme" type="button" name="yes" accesskey="y" id="yes" value="$tlang.getString("gen.yes")" onclick="ASN_SVS.cancelProceed()" />
-				<input class="active" type="button" name="no" accesskey="n" id="no" value="$tlang.getString("gen.no")" onclick="ASN_SVS.undoCancel()" />
+				<input class="disableme" type="button" name="yes" accesskey="y" id="yes" value="$tlang.getString("gen.yes")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'cancel', null, null, false );" />
+				<input class="active" type="button" name="no" accesskey="n" id="no" value="$tlang.getString("gen.no")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.undoCancel();" />
 			</div>
 		#else
 				#if ($submission.getGradeReleased() && $!submission.FeedbackText && ($submission.FeedbackText.length()>0))
@@ -1377,21 +1265,11 @@ function enableSubmitUnlessNoFile(checkForFile)
 					#end
 					
 		#if ($!linkInvoked)
-
-			<input type="submit" accesskey="x" onClick="window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" class="disableme"/>
-	
-		#else						
-					
-					
+			<input type="submit" accesskey="x" onClick="SPNR.disableControlsAndSpin( this, null ); window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" class="disableme"/>
+		#else
 			<p class="act">
-				<input 
-					type="button" 
-					name="cancel"
-					accesskey="x"
-					id="cancel" 
-					value="$tlang.getString("gen.don")"
-					onclick="ASN_SVS.confirmDiscardOrSubmit($!new_attachments); return false;"
-				/>
+				<input type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.don")"
+					onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.confirmDiscardOrSubmit(); return false;" />
 			</p>
 		#end
 		#end

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -1,7 +1,6 @@
 <!-- $Id$ -->
 <!-- start:  chef_assignments_student_view_submission_confirmation.vm  -->
 ## showing the submission confirmation page
-<link href="/sakai-assignment-tool/css/assignment.css" type="text/css" rel="stylesheet" media="all" />
 <div class="portletBody">
 	<h3>
                 #if ($!assignment.isGroup())
@@ -193,11 +192,11 @@
 		#end	
 		#if ($!linkInvoked)
 		<p class="act">
-			<input type="submit" accesskey="x" onClick="window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")"  class="active" />
-		</p>		
-		#else	
+			<input type="submit" accesskey="x" onClick="SPNR.disableControlsAndSpin( this, null ); window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" class="active" />
+		</p>
+		#else
 		<p class="act">
-			<input type="submit" accesskey="x" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString('gen.backtolist')"  class="active" />
+			<input type="submit" accesskey="x" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString('gen.backtolist')" class="active" onclick="SPNR.disableControlsAndSpin( this, null );" />
 		</p>
 		#end
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_tags_list.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_tags_list.vm
@@ -1,21 +1,9 @@
 <!-- $Id$ -->
 <!-- start: chef_assignments_tags_list.vm  -->
 <script type="text/javascript">
-
-function saveChanges(formName, textAreaId) {
-	var _textArea = document.getElementById(textAreaId);
-	if (_textArea != null) {
-		if (typeof FCKeditorAPI != "undefined") {
-			var editor = FCKeditorAPI.GetInstance(textAreaId);
-			document[formName].savedText.value = editor.GetXHTML(false);
-		}
-	}
-}
-
-iframeId = '$iframeId';
-
+	iframeId = '$iframeId';
 </script>
-<form name="form" action="#toolForm("AssignmentAction")" method="post">
+<form id="form" name="form" action="#toolForm("AssignmentAction")" method="post">
 	<input type="hidden" name="sakai_action" value=""/>
 	<input type="hidden" name="providerId" value=""/>
 	<input type="hidden" name="criteria" value=""/>
@@ -36,68 +24,7 @@ iframeId = '$iframeId';
 			#if (!$tagList.isEmpty())
 				#set ($pager = $provider.getPager())
 				#if ($pager.getTotalItems() > 5)
-				<div class="listNav">
-					
-					<div  class="instruction">
-						$tlang.getString("gen.viewing") $pager.getFirstItemNumber() - $pager.getLastItemNumber() $tlang.getString("gen.of") $pager.getTotalItems() $tlang.getString("gen.items")
-					</div>
-					<div class="inlineForm">
-						#if ($pager.canFirst())
-							<fieldset><legend>$tlang.getString("gen.first")</legend>
-								<input type="submit"
-								       onclick="saveChanges('form', '$name_submission_text'); form.sakai_action.value='doPage_tags'; form.providerId.value='$provider.provider.id';"
-								       name="page" value="|&lt;"
-								       title="$tlang.getString("gen.first")" />
-							</fieldset>
-						#else
-							<fieldset><legend>$tlang.getString("gen.first")</legend>
-								<input type="submit" value="|&lt;" disabled="disabled" />
-							</fieldset>	
-						#end
-						#if ($pager.canPrevious())
-							<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend>
-								<input type="submit"
-								       onclick="saveChanges('form', '$name_submission_text'); form.sakai_action.value='doPage_tags'; form.providerId.value='$provider.provider.id';"
-								       name="page" value="&lt;"
-								       title="$tlang.getString('gen.previous') $pagesize" />
-							</fieldset>
-						#else
-							<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend>
-								<input type="submit" value="&lt;" disabled="disabled" />
-							</fieldset>	
-						#end
-							<label for="pageSize" class="skip">$tlang.getString("newassig.selectmessage")</label>
-							<select name="pageSize" onchange="saveChanges('form', '$name_submission_text'); form.sakai_action.value='doPage_tags'; form.providerId.value='$provider.provider.id'; form.submit();">
-								#foreach ($i in $!pager.getPageSizes())
-									<option value="$i" #if($pager.getPageSize() == $i) selected="selected" #end>$tlang.getString("list.show") $i $tlang.getString("list.itemsper")</option>
-								#end
-							</select>
-						#if ($pager.canNext())
-							<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend>						
-								<input type="submit"
-		                               onclick="saveChanges('form', '$name_submission_text'); form.sakai_action.value='doPage_tags'; form.providerId.value='$provider.provider.id';"
-		                               name="page"
-								       value="&gt;"
-								       title="$tlang.getString('gen.next') $pagesize" />
-							</fieldset>	
-						#else
-							<input type="submit" value="&gt;" disabled="disabled" />
-						#end
-						#if ($pager.canLast())
-							<fieldset><legend>$tlang.getString('gen.last')</legend>						
-								<input type="submit"
-		                               onclick="saveChanges('form', '$name_submission_text'); form.sakai_action.value='doPage_tags'; form.providerId.value='$provider.provider.id';"
-								       name="page"
-								       value="&gt;|"
-								       title="$tlang.getString('gen.last')" />
-							</fieldset>	
-						#else
-							<fieldset><legend>$tlang.getString('gen.last')</legend>						
-								<input type="submit" value="&gt;|" disabled="disabled" />
-							</fieldset>	
-						#end
-					</div>
-				</div>
+				#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
 				</div>
 				#end
 				<table class="listHier lines nolines" border="0" cellspacing="0" summary="$tlang.getString('tag.list.summary')">
@@ -105,10 +32,10 @@ iframeId = '$iframeId';
 					<tr>
 						#foreach ($column in $columns)
 							#if ($column.isSortable())
-								<th><a href="#"
-									   onclick="saveChanges('form', '$name_submission_text'); form.sakai_action.value='doSort_tags'; form.providerId.value='$provider.provider.id'; form.criteria.value='$column.name'; form.submit(); return false;"
-								   	   title="$!column.getDescription()">
-									$!column.getDisplayName()
+								<th>
+									<div class="spinnerBesideContainer">
+										<a href="javascript:void(0)" title="$!column.getDescription()" onclick="SPNR.insertSpinnerAfter( this, null, 'pagingHeader' ); ASN.saveChanges('form', '$name_submission_text'); ASN.doTagsListAction( form, 'doSort_tags', '$provider.provider.id' ); form.criteria.value='$column.name'; form.submit(); return false;">
+											$!column.getDisplayName()
 									#if ($provider.getSort().getSort().equals($!column.getName()))
 										#if ($provider.getSort().isAscending())
 											<img id="sortascendinglastname" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
@@ -116,7 +43,9 @@ iframeId = '$iframeId';
 											<img id="sortdescendinglastname" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
 										#end
 									#end
-								</a></th>
+										</a>
+									</div>
+								</th>
 							#else
 								<th>$column.getDisplayName()</th>
 							#end

--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -58,7 +58,7 @@
 	}
 }
 
-.button_color{
+.button_color, button {
 	color: $button-color-text-color;
 	cursor: pointer;
 	border-top: 1px solid $button-color-border-color;
@@ -189,7 +189,7 @@ a.noPointers, input.noPointers {
 	height: 100%;
 }
 
-.spinPlaceholder {
+.spinPlaceholder, .allocatedSpinPlaceholder {
 	position: relative;
 	display: inline-block;
 	width: 16px;
@@ -201,7 +201,10 @@ a.noPointers, input.noPointers {
 	@include display-flex;
 	@include align-items( center );
 	label {
-		margin-top: 0px;
+		margin: 0 4px 0 0;
+	}
+	select {
+		margin-bottom: 0px;
 	}
 }
 /*** End button spinner overlay ***/

--- a/reference/library/src/webapp/js/spinner.js
+++ b/reference/library/src/webapp/js/spinner.js
@@ -21,7 +21,7 @@
  */
 
 // Spinner namespace
-var SPNR = {};
+var SPNR = SPNR || {};
 
 /********** MAIN FUNCTIONS TO BE CALLED FROM OUTSIDE LIBRARY ******************/
 
@@ -68,6 +68,43 @@ SPNR.insertSpinnerAfter = function( clickedElement, escapeList, overrideSpinnerL
 };
 
 /**
+ * This function is to be used in special cases where injecting an element into the DOM
+ * causes 'bouncing' effects, where content is shifted dynamically.
+ * 
+ * In these special cases, you can add an empty div with a unique ID and the class
+ * "allocatedSpinPlaceholder", so that the area is pre-allocated. This function will use
+ * the pre-allocated div rather than injecting a div dynamically to avoid 'bouncing'.
+ * 
+ * If the div with the ID provided cannot be found, this will fallback to the
+ * insertSpinnerAfter() algorithm.
+ * 
+ * If no escapes are needed, pass in null for the escapeList parameter.
+ * 
+ * @param {type} clickedElement - the element being interacted with
+ * @param {type} escapeList - array of IDs you do not wish to be disabled
+ * @param {type} allocatedID - the ID of the div manually added to the page to contain the spinner
+ */
+SPNR.insertSpinnerInPreallocated = function( clickedElement, escapeList, allocatedID )
+{
+    // Get the pre-allocated div for the spinner
+    var div = document.getElementById( allocatedID );
+    if( div !== null )
+    {
+        // Clone and disable all controls, passing the escape list
+        SPNR.disableControlsAndSpin( clickedElement, escapeList );
+
+        // Apply the class to get the spinner
+        div.className = "spinPlaceholder";
+    }
+
+    // If the div couldn't be found, fallback to the insertSpinerAfter() algorithm
+    else
+    {
+        SPNR.insertSpinnerAfter( clickedElement, escapeList, null );
+    }
+};
+
+/**
  * This function is to be used with typical elements that have enough area to overlay
  * a spinner graphic on top. It will (clone and) disable all elements on the page,
  * and render a spinner graphic over top of the clicked element.
@@ -109,7 +146,7 @@ SPNR.disableLinkPointers = function( escapeList )
         if( escapeList.indexOf( links[i].id ) === -1 )
         {
             links[i].style.pointerEvents = "none";
-            links[i].className = "noPointers";
+            links[i].className += " noPointers";
             links[i].disabled = true;
         }
     }
@@ -131,7 +168,7 @@ SPNR.disableInputs = function( clickedElement, escapeList )
     var allInputs = SPNR.nodeListToArray( document.getElementsByTagName( "input" ) );
     for( i = 0; i < allInputs.length; i++ )
     {
-        if( (allInputs[i].type === "submit" || allInputs[i].type === "button" || allInputs[i].type === "checkbox") 
+        if( (allInputs[i].type === "submit" || allInputs[i].type === "button" || allInputs[i].type === "checkbox" || allInputs[i].type === "radio") 
                 && escapeList.indexOf( allInputs[i].id ) === -1 )
         {
             // If this is the clicked button, activate the spinner on it; otherwise just disable the button

--- a/reset-pass/account-validator-tool/src/webapp/js/accountValidator.js
+++ b/reset-pass/account-validator-tool/src/webapp/js/accountValidator.js
@@ -1,7 +1,7 @@
 // bbailla2, plukasew, bjones86 - SAK-24427
 
 // 'Namespace'
-var VALIDATOR = {};
+var VALIDATOR = VALIDATOR || {};
 
 // Variables
 VALIDATOR.passwordValid = false;

--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -3,7 +3,7 @@ var utils = utils || {};
 var selTools = new Array();
 var ltiPrefix = "lti_";
 // SAK-22384
-var MATHJAX = {};
+var MATHJAX = MATHJAX || {};
 MATHJAX.isInstalled = false;
 MATHJAX.checkBoxIdPrefix = "jax-";
  


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30067

PR introduces significant code refactoring in Assignments to address the following issues:

* moving most JavaScript functions out of .vm files and into the appropriate .js file(s) (with the exception of some that are making use of inline Velocity variables, which I didn't have time to refactor appropriately)
* namespacing all JavaScript functions (in the .js files) to avoid collisions (best practise)
* introduction of a new submitForm() JavaScript function to handle common form submission routines
* removing most inline, long chains of JavaScript functionality in onclicks in favour of calling a common method in a JavaScript file; mostly the newly introduced submitForm function mentioned above (best practise and for readability)
* moving macros defined in individual .vm files into the assignment_macros.vm file
* creation of two new macros to handle the navBar and buttons, to eliminate code duplication in several files
* creation of a new macro to handle the paginator controls which are common between several interfaces
* removing all old spinners and JavaScript code in favour of the new centralized approach introduced in SAK-30059
* replace occurances of href="#" with href="javascript:void(0)" to avoid page bouncing in certain browsers
