### PR TITLE
SAK-30085 Add direct location search to Resources for admin

### DIFF
--- a/content/content-bundles/resources/content.properties
+++ b/content/content-bundles/resources/content.properties
@@ -315,6 +315,7 @@ list.site.dropbox   = List of drop boxes
 list.toobig   = This collection is too big to expand.
 list.unselect = Uncheck All
 list.ame	  = Actions menu end
+list.jumptoresource = Jump to Resource
 
 # SAK-23367
 list.copycontent = Copy Content from My Other Sites

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -4185,6 +4185,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		boolean isSpecialSite = false;
 		if ("!admin".equals(currentSiteId) || "~admin".equals(currentSiteId)) {
 			isSpecialSite = true;
+			// SAK-30085
+			context.put("showJumpToResourceForm", true);
 		}
 		
 		

--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -52,6 +52,25 @@
 			#if($showQuota)
 			<li><span><a href="#toolLinkParam("ResourcesAction" "doShowQuota" "siteId=$validator.escapeUrl(${site.id})")" title="$clang.getString('list.quota')">$clang.getString("list.quota")</a></span></li>
 			#end
+			##SAK-30085
+			#if($showJumpToResourceForm)
+			<li class="inputItem">
+				<span class="formItem">
+					<form id="jumpToResourceForm" class="inlineForm" action="#toolForm("ResourcesAction")" method="post">
+						<input type="hidden" name="source" value="0" />	
+						<input type="hidden" name="navRoot" value="" />
+						<input type="hidden" name="criteria" value="title" />
+						<input type="hidden" name="sakai_action" value="doNavigate" />
+						<input type="hidden" name="rt_action" value="" />
+						<input type="hidden" name="selectedItemId" value="" />
+						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+						<input type="text" name="collectionId" value="" required />
+						<input type="submit" value="$clang.getString('list.jumptoresource')"/>
+					</form>
+				</span>
+			</li>
+			#end
+		</ul>
 		</ul>
 	#if ($alertMessage)
                  <br /><div class="messageValidation">$alertMessage</div><div class="clear"></div>
@@ -1049,6 +1068,29 @@
 	    }
 	}
     });
+
+	##SAK-30085
+	#if($showJumpToResourceForm)
+	$(function() {
+		var formEl = $("#jumpToResourceForm");
+		var collectionIdEl = formEl.find(":input[name=collectionId]");
+
+		formEl.on("submit", function() {
+			var collectionId = collectionIdEl.val();
+
+			if (collectionId.length == 0) {
+				return false;
+			}
+
+			if (collectionId.match(/\/$/) == null) {
+				collectionId += "/";
+				collectionIdEl.val(collectionId);
+			}
+
+			return true;
+		});
+	});
+	#end
 
 	//-->
 </script>


### PR DESCRIPTION
Introduce 'Jump to Resource' for admin user as a helper to quickly navigate to a particular collectionId.

This is a little feature that was added to the Resources tool that has been very helpful for NYU Sakai administrators.   

See https://jira.sakaiproject.org/browse/SAK-30085.