### PR TITLE
SAM-2630 Question progress improvements.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3040,6 +3040,13 @@
 # Default: false 
 # samigo.wysiwyg.delivery.disable=true
 
+# SAM-2630 subtask SAM-2657
+# Use the following paths for the images used in the question progress panel.
+# These images should be 15px x 15px. Note that the context is /samigo-app/
+# samigo.questionprogress.unansweredpath = /images/whiteBubble15.png
+# samigo.questionprogress.answeredpath = /images/blackBubble15.png
+# samigo.questionprogress.markdpath = /images/questionMarkBubble15.png
+
 #########################################
 # WORKSITE SETUP/SITE INFO
 #########################################

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -299,6 +299,10 @@ public class DeliveryBean
   private static ResourceBundle eventLogMessages = ResourceBundle.getBundle("org.sakaiproject.tool.assessment.bundle.EventLogMessages");
 
   private static String EXTENDED_TIME_KEY = "extendedTime";
+
+  private static String questionProgressUnansweredPath = ServerConfigurationService.getString("samigo.questionprogress.unansweredpath", "/images/whiteBubble15.png");
+  private static String questionProgressAnsweredPath = ServerConfigurationService.getString("samigo.questionprogress.answeredpath", "/images/blackBubble15.png");
+  private static String questionProgressMardPath = ServerConfigurationService.getString("samigo.questionprogress.mardpath", "/images/questionMarkBubble15.png");
   
   /**
    * Creates a new DeliveryBean object.
@@ -4120,6 +4124,17 @@ public class DeliveryBean
 		  headMJ.append("<script src=\"").append(MATHJAX_SRC_PATH).append("\"  language=\"JavaScript\" type=\"text/javascript\"></script>\n");
 		  return headMJ.toString();
 	  }
-	  
+
+    public String getQuestionProgressUnansweredPath () {
+      return questionProgressUnansweredPath;
+    }
+
+    public String getQuestionProgressAnsweredPath () {
+      return questionProgressAnsweredPath;
+    }
+
+    public String getQuestionProgressMardPath () {
+      return questionProgressMardPath;
+    }
 }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/LinearAccessDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/LinearAccessDeliveryActionListener.java
@@ -254,6 +254,9 @@ public class LinearAccessDeliveryActionListener extends DeliveryActionListener
 
       HashMap publishedAnswerHash = pubService.preparePublishedAnswerHash(publishedAssessment);
 
+      if(itemGradingHash != null) {
+          delivery.setTableOfContents(getContents(publishedAssessment, itemGradingHash,delivery, publishedAnswerHash));
+      }
       // get current page contents
       delivery.setPageContents(getPageContents(publishedAssessment, delivery, itemGradingHash, publishedAnswerHash));
   }

--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -1079,6 +1079,11 @@ td.feedbackColumn2 {
 	border: 2px solid #004B8D;
 	padding-bottom: 1em;
 }
+
+div#questionProgressPanel div.tier1 {
+	margin-left: 12px;
+}
+
 #questionProgressClick {
 	height: 200px;
 	width: 40px;
@@ -1103,7 +1108,7 @@ td.feedbackColumn2 {
 .questionProgressTable {
 
 }
-.questionProgressTable td {
+.questionProgressTable td, .questionProgressTable_linear td {
 	border: 1px solid #ddd;
 	text-align: right;
 	background-color: #ddd;
@@ -1153,4 +1158,76 @@ p.progressItem img {
 	/* Internet Explorer */
 	filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
 
+}
+
+button.partLink {
+	margin: 0 !important;
+	border: none !important;
+	padding: 0 !important;
+	color: #069;
+	cursor: pointer;
+	background-color: transparent;
+	display: inline;
+	outline: none;
+	outline-offset: 0;
+
+	/* Below added to handle long part titles */
+	line-height: 1;
+	overflow: hidden;
+	text-align: left;
+	width: 160px;
+}
+
+button.partLink:hover {
+	color: #30a7fc;
+}
+
+button.partLink::-moz-focus-inner {
+	border: none;
+	padding: 0;
+}
+
+div[id^='partTable'] {
+	display: none;
+	padding-bottom: 5px;
+}
+
+.numberOfQuestionsInPart {
+	position: absolute;
+	right: 5px;
+}
+.partTitle {
+	border-bottom: solid grey 1px;
+	display: inline-block;
+	width: 295px;
+	margin-bottom: 3px;
+	padding-bottom: 5px;
+	line-height: 1;
+}
+
+input[type='reset'].linearButton {
+	background: none transparent;
+	margin: 2px !important;
+	border: none !important;
+	padding: 0 !important;
+	outline: none;
+	outline-offset: 0;
+	box-shadow: none !important;
+	height: 100% !important;
+}
+
+.linearPastQuestion {
+	opacity: 0.4;
+	filter: alpha(opacity=40); /* msie */
+	background-color: inherit;
+}
+
+.arrow {
+	vertical-align: middle;
+	position: absolute;
+	right: 280px;
+}
+
+.hiddenArrow {
+	display: none;
 }

--- a/samigo/samigo-app/src/webapp/jsf/delivery/questionProgress.jspf
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/questionProgress.jspf
@@ -32,43 +32,59 @@
 
 
 <f:verbatim><p class="progressItem"></f:verbatim>
-  <h:graphicImage alt="unanswered icon" url="/images/whiteBubble15.png" /><h:outputText value=" #{deliveryMessages.unans_q}" /><br/>
-  <h:graphicImage alt="answered icon" url="/images/blackBubble15.png" /><h:outputText value=" answered question" escape="false" /><br/>
-  <h:graphicImage alt="marked for review icon" url="/images/questionMarkBubble15.png" rendered="#{delivery.displayMardForReview}" /><h:outputText value=" #{deliveryMessages.q_marked}" rendered="#{delivery.displayMardForReview}"/>
+        <h:graphicImage alt="unanswered icon" url="#{delivery.questionProgressUnansweredPath}" /><h:outputText value=" #{deliveryMessages.unans_q}" /><br/>
+        <h:graphicImage alt="answered icon" url="#{delivery.questionProgressAnsweredPath}" /><h:outputText value=" answered question" escape="false" /><br/>
+        <h:graphicImage alt="marked for review icon" url="#{delivery.questionProgressMardPath}" rendered="#{delivery.displayMardForReview}" /><h:outputText value=" #{deliveryMessages.q_marked}" rendered="#{delivery.displayMardForReview}"/>
 <f:verbatim></p></f:verbatim>
 
 
 </div>
 <br />
 <div class="tier1">
-    <h:dataTable value="#{delivery.tableOfContents.partsContents}" var="part" rendered="#{delivery.navigation ne '1'}">
+    <h:dataTable value="#{delivery.tableOfContents.partsContents}" var="part" >
       <h:column>
       <h:panelGroup>
-        <h:outputText value="#{deliveryMessages.p} #{part.number}:  #{part.nonDefaultText}" /> 
-        <h:dataTable value="#{part.itemContents}" var="question" id="tocquestions" styleClass="questionProgressTable">
+        <h:outputText value="<div class=\"partTitle\">" escape="false" />
+        <h:outputText value="<button type=\"button\" id=\"partLink-#{part.number}\" class=\"partLink\">" escape="false"/>
+        <h:graphicImage alt="a right arrow" id="rightArrow" value="/images/right_arrow.gif" styleClass="arrow #{(part.number eq delivery.partIndex+1) ? 'hiddenArrow' : ''}" />
+        <h:graphicImage alt="a down arrow" id="downArrow" value="/images/down_arrow.gif" styleClass="arrow #{(part.number eq delivery.partIndex+1) ? '' : 'hiddenArrow'}" />
+        <h:outputText value=" #{deliveryMessages.p} #{part.number}: #{part.nonDefaultText}</button>" escape="false" />
+        <h:outputText value="<span class=\"numberOfQuestionsInPart\">#{part.questions} question(s)</span></div>" escape="false" />
+        <h:outputText value="<div id=\"partTable-#{part.number}\" >" escape="false"/>
+        <h:dataTable value="#{part.itemContents}" var="question" id="tocquestions" styleClass="#{(delivery.navigation eq '2') ? 'questionProgressTable' : 'questionProgressTable_linear'}">
           <h:column>
             <h:panelGroup>
 
 		<f:verbatim><p class="progressItem"></f:verbatim>
+              <h:panelGroup styleClass="#{((question.number eq delivery.questionIndex+1) and (part.number eq delivery.partIndex+1)) ? 'currentQuestion' : ''} #{((delivery.navigation eq '1') and ((part.number le delivery.partIndex+1 and question.number lt delivery.questionIndex+1) or (part.number lt delivery.partIndex+1))) ? 'linearPastQuestion' : ''}">
 		<h:graphicImage alt="Loading question..." url="/images/loading.gif" style="display:none;padding-left:1em;"/>
-		<h:commandLink title="#{question.strippedText} (#{question.pointsDisplayString}#{question.roundedMaxPoints} #{deliveryMessages.pt})" action="#{delivery.goto_question}" styleClass="#{((question.number eq delivery.questionIndex+1) and (part.number eq delivery.partIndex+1)) ? 'currentQuestion' : ''}" onmouseup="questionProgress.disableLink(this);">
+		<h:commandLink title="#{question.strippedText} (#{question.pointsDisplayString}#{question.roundedMaxPoints} #{deliveryMessages.pt})" action="#{delivery.goto_question}" rendered="#{delivery.navigation eq '2'}" onmouseup="questionProgress.disableLink(this);">
                 <h:outputText escape="false" value="#{question.sequence} " >
 			<f:convertNumber maxFractionDigits="2"/>
         	</h:outputText>
 
-        <h:graphicImage alt="unanswered icon" url="/images/whiteBubble15.png" rendered="#{question.unanswered && !question.review}" />
-		<h:graphicImage alt="marked for review icon" url="/images/questionMarkBubble15.png" rendered="#{question.review}" />
-		<h:graphicImage alt="answered icon" url="/images/blackBubble15.png" rendered="#{!question.unanswered && !question.review}" />
+                <h:graphicImage alt="unanswered icon" url="#{delivery.questionProgressUnansweredPath}" rendered="#{question.unanswered && !question.review}" />
+                <h:graphicImage alt="answered icon" url="#{delivery.questionProgressAnsweredPath}" rendered="#{!question.unanswered && !question.review}" />
+                <h:graphicImage alt="marked for review icon" url="#{delivery.questionProgressMardPath}" rendered="#{question.review}"/>
+
 
                 <f:param name="partnumber" value="#{part.number}" />
                 <f:param name="questionnumber" value="#{question.number}" />
               </h:commandLink>
+                  <h:commandButton styleClass="linearButton" type="reset" rendered="#{delivery.navigation eq '1'}">
+                      <h:outputText escape="false" value="#{question.sequence} " >
+                          <f:convertNumber maxFractionDigits="2"/>
+                      </h:outputText>
 
-		<f:verbatim></p></f:verbatim>
-		
+                      <h:graphicImage alt="unanswered icon" url="#{delivery.questionProgressUnansweredPath}" rendered="#{question.unanswered}" />
+                      <h:graphicImage alt="answered icon" url="#{delivery.questionProgressAnsweredPath}" rendered="#{!question.unanswered}" />
+                  </h:commandButton>
+                  </h:panelGroup>
+		        <f:verbatim></p></f:verbatim>
             </h:panelGroup>
           </h:column>
         </h:dataTable>
+          <f:verbatim></div></f:verbatim>
       </h:panelGroup>
       </h:column>
     </h:dataTable>


### PR DESCRIPTION
Three main features were requested for the question progress panel
within Samigo. These features were:
    1. Collapsible Parts
    2. Supporting Linear Assessments
    3. Configurable icons

1. Collapsible parts
  In Samigo, the question progress (qp) side panel's parts are now
  collapsible. By default, the current part's questions are shown.
  Clicking on the part title in the question progress panel will show
  or hide that part's questions via a sliding animation. As some parts
  are now hidden, the total number of questions within a part is shown
  in the part title. There is an arrow indicator which points to the
  right when the part is collapsed and points down when expanded.

2. Supporting Linear Assessments
  The question progress panel is now displayed for linear assessments.
  The navigation ability and question text on hover has been removed.
  Past questions are dimmed to show that they are no longer available.

3. Configurable icons
  Created three sakai.property's:
    * samigo.questionprogress.unasweredpath
    * samigo.questionprogress.answeredpath
    * samigo.questionprogress.mardpath
  which are used to determine the file location for the question
  progress panel's icons. The defaults are for the included icons.