### PR TITLE
SAM-2674 When shuffling items, cope with blank instructions

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -24,6 +24,7 @@
 package org.sakaiproject.tool.assessment.ui.listener.delivery;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -1433,12 +1434,14 @@ public class DeliveryActionListener
     	  }
       }
 
-      // Never randomize Fill-in-the-blank or Numeric Response, always randomize matching
-      if (randomize && !(item.getTypeId().equals(TypeIfc.FILL_IN_BLANK)||
-    		  item.getTypeId().equals(TypeIfc.FILL_IN_NUMERIC) || 
-    		  item.getTypeId().equals(TypeIfc.MATRIX_CHOICES_SURVEY) ||
-    		  item.getTypeId().equals(TypeIfc.CALCULATED_QUESTION)) || // CALCULATED_QUESTION
-    		  item.getTypeId().equals(TypeIfc.MATCHING))
+      List<Long> alwaysRandomizeTypes = Arrays.asList(TypeIfc.MATCHING);
+      List<Long> neverRandomizeTypes = Arrays.asList(TypeIfc.FILL_IN_BLANK,
+              TypeIfc.FILL_IN_NUMERIC,
+              TypeIfc.MATRIX_CHOICES_SURVEY,
+              TypeIfc.CALCULATED_QUESTION);
+
+      if (alwaysRandomizeTypes.contains(item.getTypeId()) ||
+              (randomize && !neverRandomizeTypes.contains(item.getTypeId())))
       {
             ArrayList shuffled = new ArrayList();
             Iterator i1 = text.getAnswerArraySorted().iterator();
@@ -1460,8 +1463,9 @@ public class DeliveryActionListener
 			agentString = getAgentString();
 		}
 
+        String itemText = (item.getText() == null) ? "" : item.getText();
         Collections.shuffle(shuffled, 
-        		new Random( (long) item.getText().hashCode() + (getAgentString() + "_" + item.getItemId().toString()).hashCode()));
+        		new Random( (long) itemText.hashCode() + (getAgentString() + "_" + item.getItemId().toString()).hashCode()));
         /*
         if (item.getTypeId().equals(TypeIfc.MATCHING))
         {


### PR DESCRIPTION
Previously this would throw an NPE when a randomized item had no
instruction text.

Also clarifies the logic around which item types can and can't be
randomized, as SAM-1816 corrected a bug with calculated questions that
stemmed from a complicated boolean, and NYU hit a similar case locally
with the "hotspot" question type in the same piece of code.