### PR TITLE
SAK-30078 Signup fails on Oracle

### DIFF
--- a/signup/api/src/java/org/sakaiproject/signup/hbm/SignupMeeting.hbm.xml
+++ b/signup/api/src/java/org/sakaiproject/signup/hbm/SignupMeeting.hbm.xml
@@ -15,7 +15,7 @@
 		<version name="version" access="field" column="version"/>
 		
 		<property name="title" column="title" type="string" length="255" not-null="true" />
-		<property name="description" column="description" type="text" not-null="false"  />
+		<property name="description" column="description" type="materialized_clob" not-null="false"  />
 		<property name="location" column="location" type="string" length="255" not-null="true" />
 		<property name="category" column="category" type="string" length="255" not-null="false" />
 		<property name="meetingType" column="meeting_type" type="string" length="50" not-null="true" />

--- a/signup/api/src/java/org/sakaiproject/signup/hbm/SignupTimeslot.hbm.xml
+++ b/signup/api/src/java/org/sakaiproject/signup/hbm/SignupTimeslot.hbm.xml
@@ -28,7 +28,7 @@
 			<list-index column="list_index" />
 			<composite-element class="org.sakaiproject.signup.model.SignupAttendee" >
 				<property name="attendeeUserId" column="attendee_user_id" length="99" type="string" not-null="true" />
-	   			<property name="comments" column="comments" type="text" not-null="false" />
+	   			<property name="comments" column="comments" type="materialized_clob" not-null="false" />
 				<property name="signupSiteId" column="signup_site_id" length="99" type="string" not-null="true" />
 				<property name="calendarEventId" column="calendar_event_id" length="2000" type="string" not-null="false" />
 				<property name="calendarId" column="calendar_id" length="99" type="string" not-null="false" />
@@ -43,7 +43,7 @@
 			<list-index column="list_index" />
 			<composite-element class="org.sakaiproject.signup.model.SignupAttendee" >
 				<property name="attendeeUserId" column="attendee_user_id" length="99" type="string" not-null="true" />
-	   			<property name="comments" column="comments" type="text" not-null="false" />
+	   			<property name="comments" column="comments" type="materialized_clob" not-null="false" />
 				<property name="signupSiteId" column="signup_site_id" length="99" type="string" not-null="true" />
 				<property name="calendarEventId" column="calendar_event_id" length="2000" type="string" not-null="false" />
 				<property name="calendarId" column="calendar_id" length="99" type="string" not-null="false" />


### PR DESCRIPTION
There is a problem related with LONG oracle data type. Meeting tables must have CLOB data type, instead.
If the tables don't exist starting up the server with this patch will create the tables correctly. But, if the tables already exist, it will be needed convert LONG's to CLOB