### PR TITLE
SAK-30098 Sakai build broken due to autoprefixer-rails gem.

### DIFF
--- a/reference/library/pom.xml
+++ b/reference/library/pom.xml
@@ -242,6 +242,18 @@
 								<artifactId>bootstrap-sass</artifactId>
 								<version>3.3.5.1</version>
 								<type>gem</type>
+								<exclusions>
+									<exclusion>
+										<groupId>rubygems</groupId>
+										<artifactId>autoprefixer-rails</artifactId>
+									</exclusion>
+								</exclusions>
+							</dependency>
+							<dependency>
+								<groupId>rubygems</groupId>
+								<artifactId>autoprefixer-rails</artifactId>
+								<version>6.1.1</version>
+								<type>gem</type>
 							</dependency>
 						</dependencies>
 					</plugin>


### PR DESCRIPTION
Sorry, I forgot the "SAK-30098" in the commit message.