### PR TITLE
KNL-1396 The finalize() call would break tests.

### DIFF
--- a/kernel/component-manager/src/test/java/org/sakaiproject/util/ComponentBuilder.java
+++ b/kernel/component-manager/src/test/java/org/sakaiproject/util/ComponentBuilder.java
@@ -101,11 +101,5 @@ public class ComponentBuilder {
 			dir.delete();
 		}
 	}
-	
-	@Override
-	protected void finalize() {
-		tearDown();
-	}
-	
 
 }


### PR DESCRIPTION
The test would finish and then the directory would get deleted, then the next test would start up and it would use the same directory location (recreating it). Then the finalize() method on the first test would be called and this would remove the directory which was now being used by the second test.

The other option would have been to have had all the tests use a different directory, but removing the finalize() is a sensible thing todo as it could cause confusion in the future. In my tests even when a test failed I was still seeing the directory get cleaned up, it's only if the caller doesn't call tearDown() that the directory would remain.