### PR TITLE
SAM-1408: retractDate setting update for extended time

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
@@ -454,6 +454,8 @@ public class BeginDeliveryActionListener implements ActionListener
     		}
     	}
     	else {
+    		if (extTimeService.hasExtendedTime() && extTimeService.getTimeLimit() > 0)
+    			control.setTimeLimit(extTimeService.getTimeLimit());
     		String timeLimitInSetting = control.getTimeLimit() == null ? "0" : control.getTimeLimit().toString();
     		Date attemptDate = unSubmittedAssessmentGrading.getAttemptDate();
     		delivery.setBeginTime(attemptDate);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/ExtendedTimeService.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/ExtendedTimeService.java
@@ -53,9 +53,9 @@ public class ExtendedTimeService {
 		this.hasExtendedTime = (metaString != null);
 		if (this.hasExtendedTime) {
 			this.timeLimit = extractExtendedTime();
-			this.startDate = determineDate(1, publishedAssessment.getStartDate(), publishedAssessment);
-			this.dueDate = determineDate(2, publishedAssessment.getDueDate(), publishedAssessment);
-			this.retractDate = determineDate(3, publishedAssessment.getRetractDate(), publishedAssessment);
+			this.startDate = determineDate(1, publishedAssessment.getStartDate());
+			this.dueDate = determineDate(2, publishedAssessment.getDueDate());
+			this.retractDate = determineDate(3, this.dueDate);
 		} else {
 			this.timeLimit = 0;
 			this.startDate = publishedAssessment.getStartDate();
@@ -128,7 +128,7 @@ public class ExtendedTimeService {
 	 * @param defaultDate
 	 * @return
 	 */
-	private Date determineDate(int dateType, Date defaultDate, PublishedAssessmentFacade publishedAssessment) {
+	private Date determineDate(int dateType, Date defaultDate) {
 		Date xtDate = defaultDate;
 
 		String[] extendedTimeItems = metaString.split("[|]");


### PR DESCRIPTION
This is a bug fix for extended time retractDate setting. The original patch contribution used the entire site's retractDate value (if it had a value). otherwise the entire Site's dueDate value was used. The fix makes use of the extendedTime sections's retractDate value, if it does not have a value, the extendedTime's dueDate will be used (NOT the entire Site's retractDate/dueDate value)