### PR TITLE
SAK-30054 Get rid of the panel param for tool-reset

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -650,11 +650,6 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		String resetActionUrl = PortalStringUtil.replaceFirst(toolUrl, "/tool/", "/tool-reset/");
 		M_log.debug("includeTool resetActionUrl="+resetActionUrl);
 
-		String sakaiPanel = req.getParameter("panel");
-		if ( sakaiPanel != null && sakaiPanel.matches(".*[\"'<>].*" ) ) sakaiPanel=null;
-		if ( sakaiPanel == null ) sakaiPanel="Main";
-		resetActionUrl = URLUtils.addParameter(resetActionUrl, "panel", sakaiPanel);
-
 		// SAK-20462 - Pass through the sakai_action parameter
 		String sakaiAction = req.getParameter("sakai_action");
 		if ( sakaiAction != null && sakaiAction.matches(".*[\"'<>].*" ) ) sakaiAction=null;


### PR DESCRIPTION
Fixes bug [SAK-30054](https://jira.sakaiproject.org/browse/SAK-30054). Gets rid of the ?panel parameter for the tool-reset link.

If the tool is resetting itself, why specify a panel? Shouldn't it just reload the tool itself?