### PR TITLE
SAK-30112 Good timeouts when connecting to LDAP.

### DIFF
--- a/providers/jldap/src/java/edu/amc/sakai/user/JLDAPDirectoryProvider.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/JLDAPDirectoryProvider.java
@@ -144,6 +144,15 @@ public class JLDAPDirectoryProvider implements UserDirectoryProvider, LdapConnec
 	private LDAPSocketFactory secureSocketFactory = 
 		new LDAPJSSESecureSocketFactory();
 
+	/**
+	 * Sockect factory for unsecure connections. Only relevant if
+	 * {@link #secureConnection} is <code>false</code>. Defaults to a new instance
+	 * of {@link LDAPSimpleSocketFactory}
+	 */
+	private LDAPSocketFactory socketFactory =
+		new LDAPSimpleSocketFactory();
+
+
 	/** LDAP referral following behavior. Defaults to {@link #DEFAULT_IS_FOLLOW_REFERRALS} */
 	private boolean followReferrals = DEFAULT_IS_FOLLOW_REFERRALS;
 
@@ -1252,6 +1261,23 @@ public class JLDAPDirectoryProvider implements UserDirectoryProvider, LdapConnec
 	public void setSecureSocketFactory(LDAPSocketFactory secureSocketFactory) 
 	{
 		this.secureSocketFactory = secureSocketFactory;
+	}
+
+	/**
+	 * {@inheritDoc}
+     */
+	public LDAPSocketFactory getSocketFactory()
+	{
+		return socketFactory;
+	}
+
+
+	/**
+	 * {@inheritDoc}
+     */
+	public void setSocketFactory(LDAPSocketFactory socketFactory)
+	{
+		this.socketFactory = socketFactory;
 	}
 
 	public String getBasePath()

--- a/providers/jldap/src/java/edu/amc/sakai/user/LDAPJSSESecureSocketFactory.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/LDAPJSSESecureSocketFactory.java
@@ -1,0 +1,117 @@
+/* **************************************************************************
+ * $OpenLDAP$
+ *
+ * Copyright (C) 1999, 2000, 2001 Novell, Inc. All Rights Reserved.
+ *
+ * THIS WORK IS SUBJECT TO U.S. AND INTERNATIONAL COPYRIGHT LAWS AND
+ * TREATIES. USE, MODIFICATION, AND REDISTRIBUTION OF THIS WORK IS SUBJECT
+ * TO VERSION 2.0.1 OF THE OPENLDAP PUBLIC LICENSE, A COPY OF WHICH IS
+ * AVAILABLE AT HTTP://WWW.OPENLDAP.ORG/LICENSE.HTML OR IN THE FILE "LICENSE"
+ * IN THE TOP-LEVEL DIRECTORY OF THE DISTRIBUTION. ANY USE OR EXPLOITATION
+ * OF THIS WORK OTHER THAN AS AUTHORIZED IN VERSION 2.0.1 OF THE OPENLDAP
+ * PUBLIC LICENSE, OR OTHER PRIOR WRITTEN CONSENT FROM NOVELL, COULD SUBJECT
+ * THE PERPETRATOR TO CRIMINAL AND CIVIL LIABILITY.
+ ******************************************************************************/
+
+package edu.amc.sakai.user;
+
+import com.novell.ldap.LDAPSocketFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+
+/**
+ * Represents a socket factory that creates secure socket connections to
+ * LDAP servers using JSSE technology. Unlike the one in the JLDAP library this
+ * actually has a connection connectTimeout that is sensible in production.
+ * This modifies the standard one in the JLDAP library to specify a connect
+ * timeout so that we don't wait forever to connect to a server.
+ *
+ * @see LDAPConnection#LDAPConnection(LDAPSocketFactory)
+ * @see LDAPConnection#setSocketFactory
+ */
+public class LDAPJSSESecureSocketFactory
+        implements LDAPSocketFactory, org.ietf.ldap.LDAPSocketFactory
+{
+    private SocketFactory factory;
+    // The connectTimeout to make connections in.
+    private int connectTimeout = 5000;
+
+    /**
+     * Constructs an LDAPSecureSocketFactory object using the default provider
+     * for a JSSE SSLSocketFactory.
+     *
+     * <p>Setting the keystore for the default provider is specific to
+     * the provider implementation.  For Sun's JSSE provider, the property
+     * javax.net.ssl.truststore should be set to the path of a keystore that
+     * holds the trusted root certificate of the directory server.</P>
+     *
+     * For information on creating keystores see the keytool documentation on
+     * <a href="http://java.sun.com/j2se/1.4/docs/tooldocs/tools.html#security">
+     * Java 2, security tools</a>.
+     */
+    public LDAPJSSESecureSocketFactory()
+    {
+        factory = SSLSocketFactory.getDefault();
+        return;
+    }
+
+    /**
+     * Constructs an LDAPSocketFactory object using the
+     * SSLSocketFactory specified.
+     *
+     * For information on using the the SSLSocketFactory, see also
+     * <a href="http://java.sun.com/j2se/1.4/docs/api/javax/net/ssl/SSLSocketFactory.html">
+     * javax.net.ssl.SSLSocketFactory</a>
+     */
+    public LDAPJSSESecureSocketFactory(SSLSocketFactory factory)
+    {
+        this.factory = factory;
+        return;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    /**
+     * Returns the socket connected to the LDAP server with the specified
+     * host name and port number.
+     *
+     * <p>The secure connection is established to the server when this
+     * call returns.  This method is called by the constructor of LDAPConnection
+     * </p>
+     *
+     * @param host The host name or a dotted string representing the IP address
+     *             of the LDAP server to which you want to establish
+     *             a connection.
+     *<br><br>
+     * @param port The port number on the specified LDAP server that you want to
+     *             use for this connection. The default LDAP port for SSL
+     *             connections is 636.
+     *
+     * @return A socket to the LDAP server using the specific host name and
+     *         port number.
+     *
+     * @exception IOException A socket to the specified host and port
+     *                          could not be created.
+     *
+     * @exception UnknownHostException The specified host could not be found.
+     */
+    public java.net.Socket createSocket(String host, int port)
+            throws IOException, UnknownHostException
+    {
+        Socket socket = factory.createSocket();
+        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        return factory.createSocket(host, port);
+    }
+}

--- a/providers/jldap/src/java/edu/amc/sakai/user/LDAPSimpleSocketFactory.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/LDAPSimpleSocketFactory.java
@@ -1,0 +1,34 @@
+package edu.amc.sakai.user;
+
+import com.novell.ldap.LDAPSocketFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+/**
+ * This simple socket factory sets a connect timeout on any sockets it creates.
+ * Otherwise attempting to connect to a down host can effectively hang until the
+ * pool creation timeout is hit.
+ */
+public class LDAPSimpleSocketFactory implements LDAPSocketFactory {
+
+    // The number of ms to wait for a socket connect to complete.
+    private int connectTimeout = 5000;
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        Socket socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        return socket;
+    }
+}

--- a/providers/jldap/src/java/edu/amc/sakai/user/LdapConnectionManagerConfig.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/LdapConnectionManagerConfig.java
@@ -83,6 +83,20 @@ public interface LdapConnectionManagerConfig {
 	 * @param the current secureSocketFactory. Should not return <code>null</code>.
 	 */
 	public void setSecureSocketFactory(LDAPSocketFactory secureSocketFactory);
+
+	/**
+	 * The socket factory to be used when creating insecure connections.
+	 * This factory will only be used if {@link #isSecureConnection()} returns
+	 * <code>false</code>. Can return <code>null</code> if no socket factory
+	 * needs to be used.
+     */
+	public LDAPSocketFactory getSocketFactory();
+
+	/**
+	 * @param socketFactory the socketFactory to use.
+     */
+	public void setSocketFactory(LDAPSocketFactory socketFactory);
+
 	
 	/**
 	 * @return the directory operation timeout

--- a/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapConnectionManager.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapConnectionManager.java
@@ -2,13 +2,9 @@ package edu.amc.sakai.user;
 
 import java.io.UnsupportedEncodingException;
 
+import com.novell.ldap.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import com.novell.ldap.LDAPConnection;
-import com.novell.ldap.LDAPConstraints;
-import com.novell.ldap.LDAPException;
-import com.novell.ldap.LDAPTLSSocketFactory;
 
 /**
  * Allocates connected, constrained, and optionally
@@ -42,13 +38,11 @@ public class SimpleLdapConnectionManager implements LdapConnectionManager {
 		
 		if ( config.isSecureConnection() ) {
 			if ( M_log.isDebugEnabled() ) {
-				M_log.debug("init(): initializing secure socket factory");
+				M_log.debug("init(): initializing keystore");
 			}
 			initKeystoreLocation();
 			initKeystorePassword();
-			LDAPConnection.setSocketFactory(config.getSecureSocketFactory());
 		}
-			
 	}
 	
 	/**
@@ -59,10 +53,7 @@ public class SimpleLdapConnectionManager implements LdapConnectionManager {
 		if ( M_log.isDebugEnabled() ) {
 			M_log.debug("getConnection()");
 		}
-		
-		LDAPConnection conn = new LDAPConnection();
-		applyConstraints(conn);
-		connect(conn);
+		LDAPConnection conn = newConnection();
 
 		if ( config.isAutoBind() ) {
 			if ( M_log.isDebugEnabled() ) {
@@ -80,6 +71,7 @@ public class SimpleLdapConnectionManager implements LdapConnectionManager {
 
 		return conn;
 	}
+
 	
 	/**
 	 * {@inheritDoc}
@@ -98,7 +90,28 @@ public class SimpleLdapConnectionManager implements LdapConnectionManager {
 		return conn;
 	}
 
-	private void bind(LDAPConnection conn, String dn, String pw) 
+	protected LDAPConnection newConnection() throws LDAPException {
+
+		if (M_log.isDebugEnabled() ) {
+			M_log.debug("newConnection()");
+		}
+		LDAPConnection connection;
+		if (config.isSecureConnection()) {
+			connection = new LDAPConnection(config.getSecureSocketFactory());
+		} else {
+			LDAPSocketFactory factory = config.getSocketFactory();
+			if (factory != null) {
+				connection = new LDAPConnection(factory);
+			} else {
+				connection = new LDAPConnection();
+			}
+		}
+		applyConstraints(connection);
+		connect(connection);
+		return connection;
+	}
+
+	private void bind(LDAPConnection conn, String dn, String pw)
 	throws LDAPException {
 		
 		if ( M_log.isDebugEnabled() ) {


### PR DESCRIPTION
This makes sure that you have sensible timeouts when connecting to LDAP. This is especially useful when you have multiple LDAP servers as if one goes down you want to retry again, rather than waiting 60 seconds for the pool object creation timer to fire.