### PR TITLE
SAK-29727 Get directory from POST body.

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/components/FileSelectorPanel.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/components/FileSelectorPanel.java
@@ -214,7 +214,7 @@ public class FileSelectorPanel extends Panel {
 			// get dir
 	    	Request req = RequestCycle.get().getRequest();
 			try{
-				currentDir = req.getQueryParameters().getParameterValue("dir").toString();
+				currentDir = req.getRequestParameters().getParameterValue("dir").toString();
 				String enc = "UTF-8";
 				RequestCycle.get().scheduleRequestHandlerAfterCurrent(new EmptyRequestHandler());
 				WebResponse response = (WebResponse) getResponse();


### PR DESCRIPTION
In the upgrade to Wicket the code was changed to only look in the URL parameters, the jQuery File Tree plugin sends the directory in the POST body and so it was being ignored. Switching to look in both URL parameters and the POST body is how it used to work, and fixes the issue where you can’t browse resources when generating a report.