### PR TITLE
SAK-29458 Fix for Icon URL is ignored / not displayed. Added code to display icon back.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -62,6 +62,9 @@
 # DEFAULT: false
 # portal.cookie.policy.warning.enabled = true
 #
+# Allow a specific icon for sites. Should we allow sites to supply a specific icon for their site.
+# portal.siteicon.allow=true
+
 # Cookie policy URL
 # portal.cookie.policy.warning.url = /library/content/cookie_policy.html
 

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageNav.vm
@@ -11,6 +11,10 @@
     #end ## END of IF ($sitePages.siteHTMLInclude)
 
     <h1 class="skip" tabindex="-1" id="totoolmenu">${rloader.sit_toolshead}</h1>
+    <!--Added this check in to make sure that we just don't have an empty img element in the page. -->
+	#if(${sitePages.pageNavIconUrl} != "")
+        <img src="${sitePages.pageNavIconUrl}" alt="">
+	#end
 
     <nav id="toolMenu" role="navigation" aria-label="${rloader.sit_toolshead}" class="Mrphs-toolsNav__menu">
         <ul>

--- a/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -52,6 +52,11 @@ body.#{$namespace}toolMenu-collapsed{
 	}
 }
 
+#toolMenuWrap img{
+  max-width: 100%;
+  height: auto;
+}
+
 #toolMenuWrap{
 	background: $toolMenuBGColor;
 	display: block;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -4231,6 +4231,9 @@ public class SiteAction extends PagedResourceActionII {
 		// 1. the skin list
 		// For course site, display skin list based on "disable.course.site.skin.selection" value set with sakai.properties file. The setting defaults to be false.
 		boolean disableCourseSkinChoice = ServerConfigurationService.getString("disable.course.site.skin.selection", "false").equals("true");
+		//Do we allow them to use a specific icon for the site. Related to SAK-29458 for Sakai 11
+		//Default to true for now. Requires the portal.siteicon.allow value in the sakai.properties file.
+		context.put("allowSiteIcon",ServerConfigurationService.getBoolean("portal.siteicon.allow",true));
 		// For non-course site, display skin list based on "disable.noncourse.site.skin.selection" value set with sakai.properties file. The setting defaults to be true.
 		boolean disableNonCourseSkinChoice = ServerConfigurationService.getString("disable.noncourse.site.skin.selection", "true").equals("true");
 		if ((isCourseSite && !disableCourseSkinChoice) || (!isCourseSite && !disableNonCourseSkinChoice))

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -277,10 +277,12 @@ function submitRemoveSection(index){
 				</span>
 			</div>
 		#else
-			<div class="shorttext">
-				<label for="iconUrl">$tlang.getString("sitediinf.ico")</label>
-				<input type="text" name="iconUrl" id="iconUrl" size="40" maxlength="255" value="$!validator.escapeHtml($!iconUrl)" />
-			</div>
+			#if($allowSiteIcon)
+				<div class="shorttext">
+					<label for="iconUrl">$tlang.getString("sitediinf.ico")</label>
+					<input type="text" name="iconUrl" id="iconUrl" size="40" maxlength="255" value="$!validator.escapeHtml($!iconUrl)" />
+				</div>
+			#end
 		#end
 		<p class="shorttext required">
 			<label for="siteContactName">


### PR DESCRIPTION
Also requires a property change in sakai.properties. Defaults to true for now. I added back in logic to:

* Display a site-icon
* Allow the system to specify if it wants to allow them in the first place using a property.

portal.siteicon.allow=***