### PR TITLE
Bug/1418 release items to students

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -518,6 +518,11 @@ public interface GradebookService {
 	public boolean currentUserHasViewOwnGradesPerm(String gradebookUid);
 	
 	/**
+	 * Get the grade records for the given list of students and the given assignment.
+	 * This can only be called by an instructor or TA that has access, not student.
+	 * 
+	 * See {@link #getGradeDefinitionForStudentForItem} for the method call that can be made as a student.
+	 * 
 	 * @param gradebookUid
 	 * @param assignmentId
 	 * @param studentIds

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -269,9 +269,9 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				gradeDef.setGradeEntryType(gradebook.getGrade_type());
 				gradeDef.setGradeReleased(assignment.isReleased());
 				
-				// If this is the student, then the assignment needs to have
+				// If this is the student, then the global setting needs to be enabled and the assignment needs to have
 				// been released. Return null score information if not released
-				if (studentRequestingOwnScore && !assignment.isReleased()) {
+				if (studentRequestingOwnScore && (!gradebook.isAssignmentsDisplayed() || !assignment.isReleased())) {
 					gradeDef.setDateRecorded(null);
 					gradeDef.setGrade(null);
 					gradeDef.setGraderUid(null);
@@ -1647,9 +1647,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				  } else if (gradebook.getGrade_type() == GradebookService.GRADE_TYPE_PERCENTAGE) {
 					  convertPointsToPercentage(gradebook, gradeRecs);
 				  }
-				  
-				  boolean gradeReleased = gradebook.isAssignmentsDisplayed() && gbItem.isReleased();
-				  
+				  				  
 				  for (Iterator gradeIter = gradeRecs.iterator(); gradeIter.hasNext();) {
 					  AssignmentGradeRecord agr = (AssignmentGradeRecord) gradeIter.next();
 					  if (agr != null) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1658,9 +1658,13 @@ public class GradebookNgBusinessService {
     	 List<Assignment> assignments = this.getGradebookAssignments(siteId);
     	 
     	 Map<Assignment,GbGradeInfo> rval = new LinkedHashMap<>();
-    	 for(Assignment assignment: assignments) {
-    		 GradeDefinition def = this.gradebookService.getGradeDefinitionForStudentForItem(gradebook.getUid(), assignment.getId(), studentUuid);
-    		 rval.put(assignment, new GbGradeInfo(def));
+    	 
+    	 //only get grades if released for the site (the service checks it per assignment)
+    	 if (gradebook.isAssignmentsDisplayed()) {
+    		 for(Assignment assignment: assignments) {
+        		 GradeDefinition def = this.gradebookService.getGradeDefinitionForStudentForItem(gradebook.getUid(), assignment.getId(), studentUuid);
+        		 rval.put(assignment, new GbGradeInfo(def));
+        	 } 
     	 }
     	 
     	 return rval;


### PR DESCRIPTION
Delivers #1418.

* Add javadoc to getGradesForStudentsForItem to indicate it's only for instructors and TAs.
* Remove the check for gradeReleased in getGradesForStudentsForItem. This is unused and confusing.
* Fix the conditions in getGradeDefinitionForStudentForItem to add in the gradebook setting check, otherwise grades were visible even if globally hidden.
* Only fetch grades for student view if the gradebook setting is enabled.