### PR TITLE
Bug/1419 course grade students not working

### DIFF
--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/Gradebook.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/Gradebook.java
@@ -211,15 +211,15 @@ public class Gradebook implements Serializable {
 	public void setVersion(int version) {
 		this.version = version;
 	}
-    /**
-     * @return Returns the courseGradeDisplayed.
-     */
+	
+	/**
+	 * Is the course grade to be shown at all?
+	 * @return boolean
+	 */
     public boolean isCourseGradeDisplayed() {
         return courseGradeDisplayed;
     }
-    /**
-     * @param courseGradeDisplayed The courseGradeDisplayed to set.
-     */
+   
     public void setCourseGradeDisplayed(boolean courseGradeDisplayed) {
         this.courseGradeDisplayed = courseGradeDisplayed;
     }
@@ -232,6 +232,10 @@ public class Gradebook implements Serializable {
       this.totalPointsDisplayed = totalPointsDisplayed;
     }
 
+    /**
+	 * If the course grade is displayed, should the total points be displayed?
+	 * @return true/false if total points should be displayed
+	 */
     public boolean isCoursePointsDisplayed() {
 		return coursePointsDisplayed;
 	}
@@ -240,6 +244,10 @@ public class Gradebook implements Serializable {
 		this.coursePointsDisplayed = coursePointsDisplayed;
 	}
 
+	/**
+	 * If the course grade is displayed, should the percentage be displayed?
+	 * @return true/false if percentage should be displayed
+	 */
 	public boolean isCourseAverageDisplayed() {
       return courseAverageDisplayed;
     }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1827,6 +1827,7 @@ public class GradebookNgBusinessService {
     		 return true;
     	 }
     	 
+    	 //if TA, permission checks
     	 if(role == GbRole.TA) {
     	 
 	    	 //if no defs, implicitly allowed
@@ -1844,7 +1845,17 @@ public class GradebookNgBusinessService {
 	    	 return false;
     	 }
     	 
-    	 //students not currently supported. Could leverage the settings later.
+    	 //if student, check the settings
+    	 //this could actually get the settings but it would be more processing
+    	 if(role == GbRole.STUDENT) {
+    		 Gradebook gradebook = this.getGradebook(siteId);
+    		 
+    		 if(gradebook.isCourseGradeDisplayed()) {
+    			 return true;
+    		 }
+    	 }
+    	 
+    	 //other roles not yet catered for, catch all.
     	 return false;
      }
      


### PR DESCRIPTION
Delivers #1419.

* Added javadoc to Gradebook course grade setting to explain what they actually do.\
* Updated GBNG business service to flesh out the course grade check for students and use the settings.