### PR TITLE
SAK-30151 A few bugs with the new spinner used in the Manage Groups interfaces

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
@@ -159,7 +159,7 @@
 	                	</fieldset>
                 </div>
                 <p class="act">
-                    <input accesskey ="s" rsf:id="save" class="active" value="Save" type="submit" id="save" onclick="SPNR.disableControlsAndSpin( this, null );" />
+                    <input accesskey ="s" rsf:id="save" class="active" value="Save" type="submit" id="save" />
                     <input accesskey ="x" rsf:id="cancel" value="Cancel" type="submit" id="cancel" onclick="SPNR.disableControlsAndSpin( this, null );" />
                 </p>
             </form>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
@@ -107,7 +107,7 @@
 		<input rsf:id="groupId" id="groupId" type="hidden"/>
 		<p class="act">
 
-			<input accesskey ="s" id="save" rsf:id="save" class="active" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, escapeList );" />
+			<input accesskey ="s" id="save" rsf:id="save" class="active" value="Save" type="submit" />
 			<input accesskey ="x" id="cancel" rsf:id="cancel" value="Cancel" type="submit" onclick="SPNR.disableControlsAndSpin( this, escapeList );" />
 		</p>			
 	</form>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30151



* JavaScript error for group name in use doesn't post back to the server; leaves spinner and all controls disabled
* On adding regular group or auto group, controls are duplicated

These places make the spinner call in the jQuery validation methods, so the call in the onclick is not necessary.
