### PR TITLE
SAK-30152 Fix some bouncing caused by injecting a spinner; replace with pre-allocated spinner

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -246,10 +246,10 @@
 											#end
 											</a>
 										</h4>
-										<div id="linksContainer_$validator.escapeUrl($assignmentReference)" class="itemAction spinnerBesideContainer">
+										<div class="itemAction">
 											#set($prevAction=false)
-											#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" onclick="SPNR.insertSpinnerAfter( this, null, 'linksContainer_$validator.escapeUrl($assignmentReference)' );" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
-											#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) |#else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);SPNR.insertSpinnerAfter( this, null, 'linksContainer_$validator.escapeUrl($assignmentReference)' );return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("dupli") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
+											#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)' );" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
+											#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) |#else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)' );return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")">$!tlang.getString("dupli") <span class="skip">$validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>#end
 											#if ($taggable && $allowAddAssignment)
 												#foreach ($provider in $providers)
 													#set ($helperInfo = false)
@@ -261,15 +261,16 @@
 														#else
 															#set($prevAction=true)
 														#end
-															<a name="asnActionLink" href="#toolLinkParam("$action" "doHelp_activity" "activityRef=$validator.escapeUrl($activity.reference)&providerId=$validator.escapeUrl($provider.id)")" title="$!helperInfo.description">$!helperInfo.name</a>
+															<a name="asnActionLink" href="#toolLinkParam("$action" "doHelp_activity" "activityRef=$validator.escapeUrl($activity.reference)&providerId=$validator.escapeUrl($provider.id)")" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)' );" title="$!helperInfo.description">$!helperInfo.name</a>
 													#end
 												#end
 											#end
 											#if (!$assignment.draft && $!service.allowGradeSubmission($assignment.getReference()))#if($prevAction) |#end
 											#set ($gradeScale = $assignmentContent.getTypeOfGrade())
 											## show "view submissions" link for ungraded type of assignment
-												<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerAfter( this, null, 'linksContainer_$validator.escapeUrl($assignmentReference)' ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")'; }" >#if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end <span class="skip">: $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>
+												<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)' ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)")'; }" >#if ($withGrade && $gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end <span class="skip">: $validator.escapeHtml($validator.limit($!assignment.getTitle(), 64))</span></a>
 											#end
+											<div id="linksSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)" class="allocatedSpinPlaceholder"></div>
 										</div>
 									#else
 										#if ($!allowAddAssignment)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30152

The spinner that appears when you click any of the links for an assignment ("Edit", "Duplicate", "View Submissions", "Grade") presents a spinner beside the links. This spinner is injected, and causes the content in the table to shift to the right to make room for this.

Avoid this 'bouncing' effect by using the pre-allocated spinner technique.
