### PR TITLE
SAM-2685 - Save audio uploads to content hosting

### DIFF
--- a/samigo/samigo-api/pom.xml
+++ b/samigo/samigo-api/pom.xml
@@ -39,6 +39,10 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
       </dependency>
+      <dependency>
+        <groupId>org.sakaiproject.kernel</groupId>
+        <artifactId>sakai-kernel-api</artifactId>
+      </dependency>
     </dependencies>
     
 	<build>

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/dao/grading/MediaData.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/dao/grading/MediaData.java
@@ -28,6 +28,8 @@ import java.util.Date;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.exception.ServerOverloadException;
 
 /**
  * 
@@ -55,6 +57,10 @@ public class MediaData implements Serializable {
 	private String lastModifiedBy;
 	private Date lastModifiedDate;
 	private String duration;
+	// Transient field to hold the ContentResource for media storage.
+	// When AssessmentGradingFacadeQueries.saveMedia is called, the byte array is written
+	// to a resource, rather than the blob column.
+	private ContentResource contentResource;
 
 	public MediaData() {
 	}
@@ -137,11 +143,34 @@ public class MediaData implements Serializable {
 	}
 
 	public byte[] getMedia() {
+		if (media == null && contentResource != null) {
+			try {
+				return contentResource.getContent();
+			} catch (ServerOverloadException e) {
+				return null;
+			}
+		}
 		return media;
 	}
 
 	public void setMedia(byte[] media) {
 		this.media = media;
+	}
+
+	public byte[] getDbMedia() {
+		return media;
+	}
+
+	public void setDbMedia(byte[] media) {
+		this.media = media;
+	}
+
+	public ContentResource getContentResource() {
+		return contentResource;
+	}
+
+	public void setContentResource(ContentResource contentResource) {
+		this.contentResource = contentResource;
 	}
 
 	public Long getFileSize() {

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/grading/MediaData.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/grading/MediaData.hbm.xml
@@ -13,7 +13,7 @@
     <many-to-one name="itemGradingData"
       class="org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData"
       column="ITEMGRADINGID" index="SAM_MEDIA_ITEMGRADING_I" />
-    <property name="media">
+    <property name="dbMedia">
       <column name="MEDIA" not-null="false" length="1000000000"/>
     </property>
 <!--

--- a/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
+++ b/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
@@ -200,6 +200,7 @@
         <bean class="org.sakaiproject.tool.assessment.facade.AssessmentGradingFacadeQueries">
           <property name="sessionFactory"><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/></property>
           <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
+          <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
           <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
           <property name="persistenceHelper" ref="persistenceHelper"/>
 	</bean>
@@ -280,6 +281,14 @@
 	<value>true</value>
       </property>
     </bean>
+
+	<!-- Conversion utility for moving media to Content Hosting -->
+	<!-- Doesn't really depend on SakaiBootStrap, but needs to init after it -->
+	<bean id="MediaContentConverter"
+			class="org.sakaiproject.tool.assessment.util.MediaContentConverter"
+			init-method="init" depends-on="org.sakaiproject.tool.assessment.shared.SakaiBootStrap">
+		<property name="persistenceService" ref="PersistenceService" />
+	</bean>
 
   <bean id="QTIService"
     class="org.sakaiproject.tool.assessment.services.qti.QTIService">

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -59,12 +59,19 @@ import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Expression;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.content.api.ContentCollection;
+import org.sakaiproject.content.api.ContentCollectionEdit;
 import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.content.api.ContentResourceEdit;
 import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
 import org.sakaiproject.service.gradebook.shared.GradebookService;
@@ -118,6 +125,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   
   public void setContentHostingService(ContentHostingService contentHostingService) {
 	  this.contentHostingService = contentHostingService;
+  }
+
+  private SecurityService securityService;
+
+  public void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
   }
 
   private UserDirectoryService userDirectoryService;
@@ -604,29 +617,190 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   }
   
   public Long saveMedia(byte[] media, String mimeType){
-    log.debug("****"+AgentFacade.getAgentString()+"saving media...size="+media.length+" "+(new Date()));
     MediaData mediaData = new MediaData(media, mimeType);
-    int retryCount = persistenceHelper.getRetryCount().intValue();
-    while (retryCount > 0){ 
-      try {
-        getHibernateTemplate().save(mediaData);
-        retryCount = 0;
-      }
-      catch (Exception e) {
-        log.warn("problem saving media with mimeType: "+e.getMessage());
-        retryCount = persistenceHelper.retryDeadlock(e, retryCount);
-      }
-    }
-    log.debug("****"+AgentFacade.getAgentString()+"saved media."+(new Date()));
-    return mediaData.getMediaId();
+    mediaData.setFileSize((long)media.length);
+    return saveMedia(mediaData);
   }
+
+	protected void pushAdvisor() {
+		securityService.pushAdvisor(new SecurityAdvisor() {
+			public SecurityAdvice isAllowed(String userId, String function, String reference) {
+				return SecurityAdvice.ALLOWED;
+			}
+		});
+	}
+
+	protected void popAdvisor() {
+		securityService.popAdvisor();
+	}
+
+	protected boolean checkMediaCollection(String id) {
+		pushAdvisor();
+		try {
+			contentHostingService.checkCollection(id);
+		} catch (Exception e) {
+			return false;
+		} finally {
+			popAdvisor();
+		}
+		return true;
+	}
+
+	protected boolean ensureMediaCollection(String id) {
+		pushAdvisor();
+		try {
+			ContentCollection coll = contentHostingService.getCollection(id);
+		} catch (IdUnusedException ie) {
+			log.debug("Creating collection: " + id);
+			String name = id;
+			if (name.endsWith("/")) {
+				name = id.substring(0, id.length() - 1);
+			}
+			name = name.substring(name.lastIndexOf('/') + 1);
+
+			try {
+				ContentCollectionEdit edit = contentHostingService.addCollection(id);
+				ResourcePropertiesEdit props = edit.getPropertiesEdit();
+				props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
+				contentHostingService.commitCollection(edit);
+			} catch (Exception collex) {
+				log.warn("[Samigo Media Attachments] Exception while creating collection (" + id + "): " + collex.toString());
+				return false;
+			}
+		} catch (Exception e) {
+			log.warn("[Samigo Media Attachments] General exception while ensuring collection: " + e.toString());
+		} finally {
+			popAdvisor();
+		}
+		return true;
+	}
+
+	protected boolean ensureMediaPath(String path) {
+		if (!path.startsWith("/")) {
+			throw new IllegalArgumentException("[Samigo Media Attachments] Relative media paths are not acceptable. (" + path + ")");
+		}
+
+		int lastSlash = path.lastIndexOf("/");
+
+		// Fast track already existing collections
+		if (lastSlash != 0 && checkMediaCollection(path.substring(0, lastSlash+1))) {
+			return true;
+		}
+
+		// Ensure everything exists from the root
+		int slash = 1;
+		while (slash != lastSlash) {
+			slash = path.indexOf("/", slash+1);
+			if (!ensureMediaCollection(path.substring(0, slash+1))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create or update a ContentResource for the media payload of this MediaData.
+	 * @param mediaData the complete MediaData item to save if the media byte array is not null
+	 * @return the ID in Content Hosting of the stored item; null on failure
+	 */
+	protected String saveMediaToContent(MediaData mediaData) {
+		String mediaPath = getMediaPath(mediaData);
+		if (mediaData.getMedia() != null && ensureMediaPath(mediaPath)) {
+			log.debug("=====> Saving media: " + mediaPath);
+			pushAdvisor();
+			boolean newResource = true;
+
+			try {
+				contentHostingService.checkResource(mediaPath);
+				newResource = false;
+			} catch (Exception e) {
+				// Just a check, no handling
+			}
+
+			try {
+				ContentResource chsMedia = null;
+				if (newResource) {
+					ContentResourceEdit edit = contentHostingService.addResource(mediaPath);
+					edit.setContentType(mediaData.getMimeType());
+					edit.setContent(mediaData.getMedia());
+					ResourcePropertiesEdit props = edit.getPropertiesEdit();
+					props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, mediaData.getFilename());
+					contentHostingService.commitResource(edit);
+					chsMedia = contentHostingService.getResource(mediaPath);
+				} else {
+					chsMedia = contentHostingService.updateResource(mediaPath, mediaData.getMimeType(), mediaData.getMedia());
+				}
+				// Free the byte array since it has been stored in content. Hold the new ContentResource
+				mediaData.setDbMedia(null);
+				mediaData.setContentResource(chsMedia);
+				return mediaPath;
+			} catch (Exception e) {
+				log.warn("Exception while saving media to content: " + e.toString());
+			} finally {
+				popAdvisor();
+			}
+		}
+		return null;
+	}
+
+	protected ContentResource getMediaContentResource(MediaData mediaData) {
+		if (mediaData.getContentResource() != null) {
+			return mediaData.getContentResource();
+		}
+
+		String id = getMediaPath(mediaData);
+		log.debug("=====> Reading media: " + id);
+		if (id != null) {
+			pushAdvisor();
+			try {
+				ContentResource res = contentHostingService.getResource(id);
+				return res;
+			} catch (IdUnusedException ie) {
+				log.info("Nonexistent resource when trying to load media (id: " + mediaData.getMediaId() + "): " + id);
+			} catch (Exception e) {
+				log.debug("Exception while reading media from content ("+ mediaData.getMediaId() + "):" + e.toString());
+			} finally {
+				popAdvisor();
+			}
+		}
+		return null;
+	}
+
+	protected String getMediaPath(MediaData mediaData) {
+		String mediaBase = "/private/samigo/";
+		String mediaPath = null;
+
+		ItemGradingData itemGrading = mediaData.getItemGradingData();
+
+		if (itemGrading != null) {
+			PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
+			PublishedAssessmentIfc assessment = getPublishedAssessmentByAssessmentGradingId(
+					itemGrading.getAssessmentGradingId());
+			String assessmentId = assessment.getPublishedAssessmentId().toString();
+			String siteId = publishedAssessmentService.getPublishedAssessmentSiteId(assessmentId);
+			String userId = itemGrading.getAgentId();
+			String questionId = itemGrading.getPublishedItemId().toString();
+
+			if (questionId != null && assessmentId != null) {
+				mediaPath = mediaBase + siteId + "/" + assessmentId + "/" + userId + "/" + questionId + "_"
+						+ mediaData.getFilename();
+			}
+		}
+
+		return mediaPath;
+	}
 
   public Long saveMedia(MediaData mediaData){
     log.debug("****"+mediaData.getFilename()+" saving media...size="+mediaData.getFileSize()+" "+(new Date()));
     int retryCount = persistenceHelper.getRetryCount().intValue();
+
+    String mediaPath = getMediaPath(mediaData);
+
     while (retryCount > 0){ 
       try {
-        getHibernateTemplate().save(mediaData);
+        saveMediaToContent(mediaData);
+        getHibernateTemplate().saveOrUpdate(mediaData);
         retryCount = 0;
       }
       catch (Exception e) {
@@ -727,6 +901,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   public MediaData getMedia(Long mediaId){
 
     MediaData mediaData = (MediaData) getHibernateTemplate().load(MediaData.class, mediaId);
+
+    // Only try to read from Content Hosting if this isn't a link and
+    // there is no media content in the database
+    if (mediaData.getLocation() == null && mediaData.getDbMedia() == null) {
+        mediaData.setContentResource(getMediaContentResource(mediaData));
+    }
     return mediaData;
   }
 
@@ -744,7 +924,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     List list = getHibernateTemplate().executeFind(hcb);
 
     for (int i=0;i<list.size();i++){
-      a.add((MediaData)list.get(i));
+        MediaData mediaData = (MediaData)list.get(i);
+        mediaData.setContentResource(getMediaContentResource(mediaData));
+        a.add(mediaData);
     }
     log.debug("*** no. of media ="+a.size());
     return a;
@@ -801,7 +983,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     List list = getHibernateTemplate().find(
         "from MediaData m where m.itemGradingData=?", item );
     for (int i=0;i<list.size();i++){
-      a.add((MediaData)list.get(i));
+        MediaData mediaData = (MediaData)list.get(i);
+        mediaData.setContentResource(getMediaContentResource(mediaData));
+        a.add(mediaData);
     }
     log.debug("*** no. of media ="+a.size());
     return a;
@@ -853,6 +1037,48 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     	}
   }
   
+	public List<Long> getMediaConversionBatch() {
+		final HibernateCallback<List<Long>> hcb = new HibernateCallback<List<Long>>() {
+			public List<Long> doInHibernate(Session session) throws HibernateException, SQLException {
+				Query q = session.createQuery("SELECT id FROM MediaData WHERE dbMedia IS NOT NULL AND location IS NULL");
+				q.setMaxResults(10);
+				return q.list();
+			}
+		};
+		return getHibernateTemplate().execute(hcb);
+	}
+
+	public boolean markMediaForConversion(List<Long> mediaIds) {
+		final HibernateCallback hcb = new HibernateCallback() {
+			public Integer doInHibernate(Session session) throws HibernateException, SQLException {
+				Query q = session.createQuery("UPDATE MediaData SET location = 'CONVERTING' WHERE id in (:ids)");
+				q.setParameterList("ids", mediaIds);
+				return q.executeUpdate();
+			}
+		};
+		return getHibernateTemplate().execute(hcb).equals(mediaIds.size());
+	}
+
+	public List<Long> getMediaWithDataAndLocation() {
+		final HibernateCallback<List<Long>> hcb = new HibernateCallback<List<Long>>() {
+			public List<Long> doInHibernate(Session session) throws HibernateException, SQLException {
+				Query q = session.createQuery("SELECT id FROM MediaData WHERE dbMedia IS NOT NULL AND location IS NOT NULL");
+				return q.list();
+			}
+		};
+		return getHibernateTemplate().execute(hcb);
+	}
+
+	public List<Long> getMediaInConversion() {
+		final HibernateCallback<List<Long>> hcb = new HibernateCallback<List<Long>>() {
+			public List<Long> doInHibernate(Session session) throws HibernateException, SQLException {
+				Query q = session.createQuery("SELECT id FROM MediaData WHERE location = 'CONVERTING'");
+				return q.list();
+			}
+		};
+		return getHibernateTemplate().execute(hcb);
+	}
+
   public ItemGradingData getLastItemGradingDataByAgent(
       final Long publishedItemId, final String agentId)
   {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueriesAPI.java
@@ -134,6 +134,18 @@ public interface AssessmentGradingFacadeQueriesAPI
   public HashMap getMediaItemGradingHash(Long assessmentGradingId);
   
   public List getMediaArray(Long publishedItemId, Long agentId, String which);
+
+  /** Get a batch of IDs for Media objects that have blobs in the database */
+  public List<Long> getMediaConversionBatch();
+
+  /** Sanity check query for Media objects with conflicting state of holding a blob and location */
+  public List<Long> getMediaWithDataAndLocation();
+
+  /** Sanity check for Media objects left in the converting state */
+  public List<Long> getMediaInConversion();
+
+  /** Mark a list of Media objects as being converted */
+  public boolean markMediaForConversion(List<Long> mediaIds);
   
   public ItemGradingData getLastItemGradingDataByAgent(Long publishedItemId,
       String agentId);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/MediaContentConverter.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/MediaContentConverter.java
@@ -1,0 +1,132 @@
+/**********************************************************************************
+ *
+ * Copyright (c) 2015 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.tool.assessment.util;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.tool.assessment.data.dao.grading.MediaData;
+import org.sakaiproject.tool.assessment.facade.AssessmentGradingFacadeQueriesAPI;
+import org.sakaiproject.tool.assessment.services.PersistenceService;
+
+/**
+ * A utility service to convert media blobs from database storage to using
+ * Content Hosting.
+ *
+ * This conversion is run at startup if the samigo.mediaConvert property is set
+ * to true. It uses batching and marking to be rather safe in its operation. If
+ * there are errors, they are reported in the usual log (catalina.out unless
+ * configured otherwise).
+ */
+public class MediaContentConverter {
+
+	private static final String CONVERT_MEDIA_PROP = "samigo.convertMedia";
+
+	private PersistenceService persistenceService;
+	private AssessmentGradingFacadeQueriesAPI gq;
+	private int recordsConverted = 0;
+	private int recordsNotMarked = 0;
+	private int recordsInError = 0;
+
+	Log log = LogFactory.getLog(MediaContentConverter.class);
+
+	public void init() {
+		boolean convertMedia = ServerConfigurationService.getBoolean(CONVERT_MEDIA_PROP, false);
+
+		if (convertMedia) {
+			gq = persistenceService.getAssessmentGradingFacadeQueries();
+			convert();
+		}
+	}
+
+	/**
+	 * Convert MediaData objects with blobs in the database to use Content
+	 * Hosting.
+	 */
+	public void convert() {
+		log.info("Starting Samigo Media Conversion...");
+		List<Long> ids = gq.getMediaConversionBatch();
+		if (ids.isEmpty()) {
+			String summary = outstandingSummary();
+			if ("".equals(summary)) {
+				log.info("No remaining Media to convert.");
+			} else {
+				log.info("No Media can be converted, but there are outstanding errors:\n" + outstandingSummary());
+			}
+		} else {
+			while (!ids.isEmpty()) {
+				gq.markMediaForConversion(ids);
+				for (Long mediaId : ids) {
+					convertMedia(mediaId);
+				}
+				log.info("Samigo Media Conversion in progress... " + summary());
+				ids = gq.getMediaConversionBatch();
+			}
+			log.info("Samigo Media Conversion finished... " + summary());
+			log.info(outstandingSummary());
+		}
+	}
+
+	private void convertMedia(Long mediaId) {
+		try {
+			MediaData mediaData = gq.getMedia(mediaId);
+			if ("CONVERTING".equals(mediaData.getLocation())) {
+				mediaData.setLocation(null);
+				gq.saveMedia(mediaData);
+				log.debug("MediaData converted with ID: " + mediaId);
+				recordsConverted++;
+			} else {
+				log.debug("MediaData could not be marked as in progress, ID: " + mediaId);
+				recordsNotMarked++;
+			}
+		} catch (Exception e) {
+			recordsInError++;
+			log.warn("Error converting MediaData with ID: " + mediaId, e);
+		}
+	}
+
+	private String summary() {
+		return String.format("%d records converted, %d records unsuccessfully processed", recordsConverted,
+				recordsInError + recordsNotMarked);
+	}
+
+	private String outstandingSummary() {
+		List<Long> withBoth = gq.getMediaWithDataAndLocation();
+		List<Long> inProgress = gq.getMediaInConversion();
+		if (withBoth.size() + inProgress.size() > 0) {
+			String message = "%d records remaining with data and location, %d records remaining marked as in progress\n"
+					+ "\tIDs with both fields: %s\n"
+					+ "\tIDs marked in progress: %s";
+			return String.format(message, withBoth.size(), inProgress.size(), withBoth, inProgress);
+		}
+		return "";
+	}
+
+	public PersistenceService getPersistenceService() {
+		return persistenceService;
+	}
+
+	public void setPersistenceService(PersistenceService persistenceService) {
+		this.persistenceService = persistenceService;
+	}
+
+}


### PR DESCRIPTION
 * Rename media property to dbMedia to separate database and content
   hosting handling

By changing the Hibernate mapping for the media column to the dbMedia
property, we can allow getMedia to encapsulate the behavior of using
content hosting or the database. The new dbMedia property is public, so
it can still be used directly (by the DAO). When saving, any media bytes
set are saved to CHS and the dbMedia property is set to null. This will
remove the file from the database row. Subsequent reads will find that
field is null and look for the file in CHS. The previous interface and
behavior are preserved for client code.

 * Add batch media conversion

The conversion runs on startup when triggered with
`samigo.convertMedia = true` in sakai.properties (or by another property
mechanism). This uses batching to be safe for restarts or multiple
nodes. Records are processed in batches of 10. If a batch is
interrupted, records may be left with the value of "CONVERTING" in the
location field. To reinitiate these, that field should be set to null
for those records.