### PR TITLE
SAK-30155 Only show unpublished when it is.

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/siteStatus-snippet.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/siteStatus-snippet.vm
@@ -1,10 +1,10 @@
 ## Moved from the tool nav to the top of the content so that it'll appear on the default mobile view 
 
-#if (${sitePages.softlyDeleted})
+#if (${sitePages} && ${sitePages.softlyDeleted})
 
     <span id="siteStatusSoftlyDeleted" class="Mrphs-siteStatus Mrphs-messagePanel__error--warning is-softly-deleted">${rloader.site_softly_deleted}</p>
 
-#elseif (!${sitePages.pageNavPublished})
+#elseif (${sitePages} && !${sitePages.pageNavPublished})
 
     <span id="siteStatus" class="Mrphs-siteStatus Mrphs-messagePanel__information is-unpublished">
     <h4>${rloader.sit_unpublished}</h4>


### PR DESCRIPTION
When viewing just the contents of the page (without the surrounding site and page navigation) you always get the message saying a page is unpublished when it isn’t. When in the context of a page I’m not sure that want to be seeing this message anyway so I’ve just made it that it doesn’t incorrectly show the message on page URs.

A good example of the page to test with is the features page on the gateway site.

http://localhost:8080/portal/page/!gateway-300
http://localhost:8080/portal/site/!gateway/page/!gateway-300