### PR TITLE
1492: fix external tools showing an input rather than a readonly label

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.html
@@ -3,7 +3,8 @@
 
 <body>
 <wicket:panel>
-	<input type="text" wicket:id="grade" tabindex="-1"/>
+	<span wicket:id="readonlyGrade">10</span>
+	<input type="text" wicket:id="editableGrade" tabindex="-1"/>
 
 	<span wicket:id="warningNotification" class="gb-cell-notification gb-cell-notification-warning"></span>
 	<span wicket:id="errorNotification" class="gb-cell-notification gb-cell-notification-error"></span>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -118,7 +118,13 @@ public class GradeItemCellPanel extends Panel {
 		//RENDER
 		if(isExternal || !gradeable){
 
-			add(new Label("grade", Model.of(formattedGrade)));
+			add(new Label("readonlyGrade", Model.of(formattedGrade)));
+			add(new Label("editableGrade") {
+				@Override
+				public boolean isVisible() {
+					return false;
+				}
+			});
 
 			showMenu = false;
 
@@ -130,7 +136,13 @@ public class GradeItemCellPanel extends Panel {
 			}
 
 		} else {
-			gradeCell = new TextField<String>("grade", Model.of(formattedGrade)) {
+			add(new Label("readonlyGrade") {
+				@Override
+				public boolean isVisible() {
+					return false;
+				}
+			});
+			gradeCell = new TextField<String>("editableGrade", Model.of(formattedGrade)) {
 
 				private static final long serialVersionUID = 1L;
 
@@ -160,7 +172,7 @@ public class GradeItemCellPanel extends Panel {
 				}
 			};
 
-			gradeCell.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+			gradeCell.add(new AjaxFormComponentUpdatingBehavior("scorechange.sakai") {
 				private static final long serialVersionUID = 1L;
 				private String originalGrade;
 

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -397,7 +397,7 @@
 }
 /* Toolbar */
 #gradebookGrades {
-  padding-top: 30px;
+  padding-top: 40px;
   padding-bottom: 80px;
 }
 #gradebookGradesToolbar {
@@ -410,7 +410,7 @@
   left: 0;
   width: 100%;
   white-space: nowrap; /* don't wrap so it stays on one line */
-  height: 30px;
+  height: 40px;
 }
 #gradebookGradesToolbar ul {
   list-style: none;
@@ -463,7 +463,7 @@
   border: 1px solid #bdbdbd;
   min-width: 200px;
   min-height: 100px;
-  top: 25px;
+  top: 38px;
   background-color: #FFF;
   box-shadow: 1px 1px 2px #AAA;
   z-index: 40;


### PR DESCRIPTION
While I was in there I also found a bug whereby a programmatic change of input wasn't triggering an "onchange" event. For example, when a [0-9] key is pressed we use jQuery to set the value on the input e.g. $input.val(newValue).  In IE or Chrome this does not mark the input as 'changed'.  To resolve this we now trigger a custom javascript event and bind to this in Wicket.

Delivers #1492.