### PR TITLE
SAK-30176 need to base64 encode the id because it may contain UTF8 ch…

### DIFF
--- a/cloud-content/impl/pom.xml
+++ b/cloud-content/impl/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>

--- a/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
+++ b/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
@@ -10,6 +10,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closeables;
 import com.google.inject.Module;
 
+import org.apache.commons.codec.binary.Base64;
+
 import org.jclouds.ContextBuilder;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.BlobStore;
@@ -208,10 +210,11 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
 
         Payload payload = Payloads.newInputStreamPayload(in);
         BlobStore store = getBlobStore();
+        String asciiID = Base64.encodeBase64String(id.getBytes("UTF8"));
         Blob blob = store.blobBuilder(can.name)
             .payload(payload)
             .contentLength(size)
-            .userMetadata(ImmutableMap.of("id", id, "path", filePath))
+            .userMetadata(ImmutableMap.of("id", asciiID, "path", filePath))
             .build();
         store.putBlob(can.container, blob);
 


### PR DESCRIPTION
…ars and S3 does not allow UTF8 chars in metadata sent via REST