### PR TITLE
SAK-30181 Fixed the checkbox for 'use this link as title' in citations.

### DIFF
--- a/citations/citations-tool/tool/src/webapp/vm/citation/create.vm
+++ b/citations/citations-tool/tool/src/webapp/vm/citation/create.vm
@@ -375,14 +375,12 @@
 	 */
 	function trackPreferredUrl( checkboxId )
 	{
-		// has this been clicked?
-		if( $( "#" + checkboxId ).attr( "checked" ) != null )
+		var checkBoxClicked = $( "#" + checkboxId );
+		// has this been checked?
+		if( checkBoxClicked.is(':checked') )
 		{
-			// clear all checkboxes
-			$( ".prefLink" ).attr( "checked", "" );
-			
-			// re-check this one
-			$( "#" + checkboxId ).attr( "checked", "checked" );
+			// clear all checkboxes except the clicked one
+			$(".prefLink").not(checkBoxClicked).removeAttr("checked");
 		}
 		
 		// if the checkbox has been unchecked, we do nothing

--- a/citations/citations-tool/tool/src/webapp/vm/citation/edit.vm
+++ b/citations/citations-tool/tool/src/webapp/vm/citation/edit.vm
@@ -417,14 +417,12 @@
 	 */
 	function trackPreferredUrl( checkboxId )
 	{
-		// has this been clicked?
-		if( $( "#" + checkboxId ).attr( "checked" ) != null )
+		var checkBoxClicked = $( "#" + checkboxId );
+		// has this been checked?
+		if( checkBoxClicked.is(':checked') )
 		{
-			// clear all checkboxes
-			$( ".prefLink" ).attr( "checked", "" );
-			
-			// re-check this one
-			$( "#" + checkboxId ).attr( "checked", "checked" );
+			// clear all checkboxes except the clicked one
+			$(".prefLink").not(checkBoxClicked).removeAttr("checked");
 		}
 		
 		// if the checkbox has been unchecked, we do nothing


### PR DESCRIPTION
previously we were checking if checked attribute for the checkbox
is null or not which could be either true of false, so as per
the logic checkbox was not getting unchecked.now using 'ischecked'