### PR TITLE
SAM-2690 IllegalArgumentException when clicking 'preview' or 'print' while editing a published assessment

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AuthorBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AuthorBean.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
+import org.apache.commons.lang.StringUtils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -58,6 +59,7 @@ public class AuthorBean implements Serializable
   private String assessmentTypeId;
   private String assessmentDescription;
   private String assessmentID;
+  private String editPublishedAssessmentID;
   private AssessmentFacade assessment;
   private ArrayList assessmentTemplateList;
   private ArrayList assessments;
@@ -123,6 +125,14 @@ public class AuthorBean implements Serializable
   public String getAssessmentID()
   {
     return assessmentID;
+  }
+
+  /**
+   * @return the id for the published assessment being edited.
+   */
+  public String getEditPublishedAssessmentID()
+  {
+    return StringUtils.trimToEmpty( editPublishedAssessmentID );
   }
 
   public AssessmentFacade getAssessment()
@@ -298,6 +308,14 @@ public class AuthorBean implements Serializable
   public void setAssessTitle(String string)
   {
     assessTitle = string;
+  }
+
+  /**
+   * @param string the id
+   */
+  public void setEditPublishedAssessmentID( String string )
+  {
+    editPublishedAssessmentID = string;
   }
 
   /**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ActionSelectListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ActionSelectListener.java
@@ -57,6 +57,7 @@ public class ActionSelectListener implements ValueChangeListener {
 		DeliveryBean delivery = (DeliveryBean) ContextUtil.lookupBean("delivery");
 		PersonBean person = (PersonBean) ContextUtil.lookupBean("person");
 		String newValue = ae.getNewValue().toString();
+		String publishedID = ContextUtil.lookupParam( "publishedId" );
 		log.debug("**** ae.getNewValue : " + newValue);
 
 		
@@ -142,11 +143,12 @@ public class ActionSelectListener implements ValueChangeListener {
 			totalScoreListener.processAction(null);
 			author.setJustPublishedAnAssessment(true);
 		}
-		if ("edit_published".equals(newValue)) {
+		else if ("edit_published".equals(newValue)) {
 			ConfirmEditPublishedAssessmentListener confirmEditPublishedAssessmentListener = new ConfirmEditPublishedAssessmentListener();
 			confirmEditPublishedAssessmentListener.processAction(null);
 			author.setOutcome("confirmEditPublishedAssessment");
 			author.setFromPage("author");
+			author.setEditPublishedAssessmentID( publishedID );
 			author.setJustPublishedAnAssessment(true);
 		}
 		else if ("preview_published".equals(newValue)) {

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex.jsp
@@ -311,6 +311,7 @@ $(document).ready(function() {
 		<f:selectItem itemLabel="#{commonMessages.edit_action}" itemValue="edit_published" itemDisabled="#{!author.canEditPublishedAssessment(publishedAssessment)}"/>
 		<f:selectItems value="#{author.publishedSelectActionList}" />
 		<f:selectItem itemLabel="#{commonMessages.remove_action}" itemValue="remove_published" itemDisabled="#{!author.canRemovePublishedAssessment(publishedAssessment)}"/>
+		<f:param name="publishedId" value="#{publishedAssessment.publishedAssessmentId}"/>
 		<f:valueChangeListener	type="org.sakaiproject.tool.assessment.ui.listener.author.ActionSelectListener" />
 	  </h:selectOneMenu>
 	  <h:selectOneMenu id="publishedSelectAction2" value="select" onchange="clickPublishedSelectActionLink(this);" rendered="#{(author.isGradeable && publishedAssessment.submittedCount > 0) && (author.isEditable && !(!author.editPubAssessmentRestricted || !publishedAssessment.hasAssessmentGradingData))}">
@@ -325,6 +326,7 @@ $(document).ready(function() {
 		<f:selectItem itemLabel="#{commonMessages.edit_action}" itemValue="edit_published" itemDisabled="#{!author.canEditPublishedAssessment(publishedAssessment)}"/>
 		<f:selectItems value="#{author.publishedSelectActionList}" />
 		<f:selectItem itemLabel="#{commonMessages.remove_action}" itemValue="remove_published" itemDisabled="#{!author.canRemovePublishedAssessment(publishedAssessment)}"/>
+		<f:param name="publishedId" value="#{publishedAssessment.publishedAssessmentId}"/>
 		<f:valueChangeListener	type="org.sakaiproject.tool.assessment.ui.listener.author.ActionSelectListener" />
 	  </h:selectOneMenu>
 	  <h:selectOneMenu id="publishedSelectAction4" value="select" onchange="clickPublishedSelectActionLink(this);" rendered="#{!(author.isGradeable && publishedAssessment.submittedCount > 0) && (author.isEditable && !(!author.editPubAssessmentRestricted || !publishedAssessment.hasAssessmentGradingData))}">

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex_noHeader.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex_noHeader.jsp
@@ -307,6 +307,7 @@ $(document).ready(function() {
 		<f:selectItem itemLabel="#{commonMessages.edit_action}" itemValue="edit_published" itemDisabled="#{!author.canEditPublishedAssessment(publishedAssessment)}"/>
 		<f:selectItems value="#{author.publishedSelectActionList}" />
 		<f:selectItem itemLabel="#{commonMessages.remove_action}" itemValue="remove_published" itemDisabled="#{!author.canRemovePublishedAssessment(publishedAssessment)}"/>
+		<f:param name="publishedId" value="#{publishedAssessment.publishedAssessmentId}"/>
 		<f:valueChangeListener	type="org.sakaiproject.tool.assessment.ui.listener.author.ActionSelectListener" />
 	  </h:selectOneMenu>
 	  <h:selectOneMenu id="publishedSelectAction2" value="select" onchange="clickPublishedSelectActionLink(this);" rendered="#{(author.isGradeable && publishedAssessment.submittedCount > 0) && !(author.isEditable && (!author.editPubAssessmentRestricted || !publishedAssessment.hasAssessmentGradingData))}">
@@ -321,6 +322,7 @@ $(document).ready(function() {
 		<f:selectItem itemLabel="#{commonMessages.edit_action}" itemValue="edit_published" itemDisabled="#{!author.canEditPublishedAssessment(publishedAssessment)}"/>
 		<f:selectItems value="#{author.publishedSelectActionList}" />
 		<f:selectItem itemLabel="#{commonMessages.remove_action}" itemValue="remove_published" itemDisabled="#{!author.canRemovePublishedAssessment(publishedAssessment)}"/>
+		<f:param name="publishedId" value="#{publishedAssessment.publishedAssessmentId}"/>
 		<f:valueChangeListener	type="org.sakaiproject.tool.assessment.ui.listener.author.ActionSelectListener" />
 	  </h:selectOneMenu>
 	  <h:selectOneMenu id="publishedSelectAction4" value="select" onchange="clickPublishedSelectActionLink(this);" rendered="#{!(author.isGradeable && publishedAssessment.submittedCount > 0) && (author.isEditable && !(!author.editPubAssessmentRestricted || !publishedAssessment.hasAssessmentGradingData))}">

--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -154,6 +154,7 @@ document.links[newindex].onclick();
       <h:commandLink  title="#{commonMessages.action_preview}" action="beginAssessment" rendered="#{assessmentBean.assessmentId > 0}">
         <h:outputText value="#{commonMessages.action_preview}"/>
         <f:param name="assessmentId" value="#{assessmentBean.assessmentId}"/>
+        <f:param name="publishedId" value="#{author.editPublishedAssessmentID}"/>
         <f:param name="actionString" value="previewAssessment" />
         <f:param name="fromEdit" value="true" />
         <f:param name="isFromPrint" value="false" />
@@ -167,6 +168,7 @@ document.links[newindex].onclick();
 	</h:commandLink>
 	<h:commandLink action="#{pdfAssessment.prepPDF}" rendered="#{assessmentBean.showPrintLink eq 'true' && assessmentBean.showPrintAssessment eq 'true'}">
 		<f:param name="assessmentId" value="#{assessmentBean.assessmentId}"/>
+		<f:param name="publishedId" value="#{author.editPublishedAssessmentID}"/>
 		<f:param name="actionString" value="editAssessment"/>
 		<f:param name="isFromPrint" value="true" />
 		<h:outputText value="#{printMessages.print}" escape="false" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2690

When editing a published quiz, selecting 'Preview' or 'Print' will generate a stack trace (see the JIRA). This bug is caused by the code introduced in SAM-2533, coupled with the introduction of the ability to edit published assessments.

More info in the JIRA.