### PR TITLE
Suppress category info in student view when categories disabled

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GbCategoryType.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GbCategoryType.java
@@ -1,0 +1,46 @@
+package org.sakaiproject.gradebookng.business;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents the category types allowed in the gradebook. Must be kept in sync with GradebookService if that ever changes.
+ *
+ * @author Steve Swinsburg (steve.swinsburg@gmail.com)
+ *
+ */
+public enum GbCategoryType {
+
+	NO_CATEGORY(1),
+	ONLY_CATEGORY(2),
+	WEIGHTED_CATEGORY(3);
+
+	private int value;
+
+	GbCategoryType(final int value) {
+		this.value = value;
+	}
+
+	/**
+	 * Get the value for the type
+	 *
+	 * @return
+	 */
+	public int getValue() {
+		return this.value;
+	}
+
+	// also need to maintain a map of the types so we can lookup the enum based on type
+	private static Map<Integer, GbCategoryType> map = new HashMap<Integer, GbCategoryType>();
+
+	static {
+		for (final GbCategoryType type : GbCategoryType.values()) {
+			map.put(type.value, type);
+		}
+	}
+
+	public static GbCategoryType valueOf(final int value) {
+		return map.get(value);
+	}
+
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1690,7 +1690,7 @@ public class GradebookNgBusinessService {
 	}
 
 	/**
-	 * Get the settings for this gradebook
+	 * Get the settings for this gradebook. Note that this CANNOT be called by a student.
 	 *
 	 * @return
 	 */
@@ -1898,8 +1898,22 @@ public class GradebookNgBusinessService {
 		final String siteId = getCurrentSiteId();
 		final Gradebook gradebook = getGradebook(siteId);
 
-		return GradebookService.CATEGORY_TYPE_WEIGHTED_CATEGORY == gradebook.getCategory_type() ||
-				GradebookService.CATEGORY_TYPE_ONLY_CATEGORY == gradebook.getCategory_type();
+		return GbCategoryType.ONLY_CATEGORY.getValue() == gradebook.getCategory_type() ||
+				GbCategoryType.WEIGHTED_CATEGORY.getValue() == gradebook.getCategory_type();
+	}
+
+	/**
+	 * Get the currently configured gradebook category type
+	 *
+	 * @return GbCategoryType wrapper around the int value
+	 */
+	public GbCategoryType getGradebookCategoryType() {
+		final String siteId = getCurrentSiteId();
+		final Gradebook gradebook = getGradebook(siteId);
+
+		final int configuredType = gradebook.getCategory_type();
+
+		return GbCategoryType.valueOf(configuredType);
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
@@ -19,6 +19,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
@@ -26,7 +27,6 @@ import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
-import org.sakaiproject.service.gradebook.shared.GradebookInformation;
 import org.sakaiproject.tool.gradebook.Gradebook;
 
 public class InstructorGradeSummaryGradesPanel extends Panel {
@@ -39,7 +39,7 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 	private GbStudentGradeInfo gradeInfo;
 	private List<CategoryDefinition> categories;
 
-	int configuredCategoryType = 0;
+	GbCategoryType configuredCategoryType;
 
 	public InstructorGradeSummaryGradesPanel(final String id, final IModel<Map<String, Object>> model) {
 		super(id, model);
@@ -61,9 +61,8 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 		this.gradeInfo = this.businessService.buildGradeMatrix(assignments, Collections.singletonList(userId)).get(0);
 		this.categories = this.businessService.getGradebookCategories();
 
-		// get settings
-		final GradebookInformation gbInfo = this.businessService.getGradebookSettings();
-		this.configuredCategoryType = gbInfo.getCategoryType();
+		// get configured category type
+		this.configuredCategoryType = this.businessService.getGradebookCategoryType();
 
 		// setup
 		final List<String> categoryNames = new ArrayList<String>();
@@ -224,7 +223,7 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private String getCategoryName(final Assignment assignment) {
-		if (this.configuredCategoryType == 1) {
+		if (this.configuredCategoryType == GbCategoryType.NO_CATEGORY) {
 			return getString(GradebookPage.UNCATEGORISED);
 		}
 		return StringUtils.isBlank(assignment.getCategoryName()) ? getString(GradebookPage.UNCATEGORISED) : assignment.getCategoryName();
@@ -236,6 +235,6 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private boolean isCategoryWeightEnabled() {
-		return (this.configuredCategoryType == 3) ? true : false;
+		return (this.configuredCategoryType == GbCategoryType.WEIGHTED_CATEGORY) ? true : false;
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -19,6 +19,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
@@ -26,7 +27,6 @@ import org.sakaiproject.gradebookng.tool.pages.BasePage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
-import org.sakaiproject.service.gradebook.shared.GradebookInformation;
 import org.sakaiproject.tool.gradebook.Gradebook;
 
 public class StudentGradeSummaryGradesPanel extends Panel {
@@ -36,7 +36,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
 	protected GradebookNgBusinessService businessService;
 
-	int configuredCategoryType = 0;
+	GbCategoryType configuredCategoryType;
 
 	public StudentGradeSummaryGradesPanel(final String id, final IModel<Map<String, Object>> model) {
 		super(id, model);
@@ -54,9 +54,8 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		final Map<Assignment, GbGradeInfo> grades = this.businessService.getGradesForStudent(userId);
 		final List<Assignment> assignments = new ArrayList(grades.keySet());
 
-		// get settings
-		final GradebookInformation gbInfo = this.businessService.getGradebookSettings();
-		this.configuredCategoryType = gbInfo.getCategoryType();
+		// get configured category type
+		this.configuredCategoryType = this.businessService.getGradebookCategoryType();
 
 		// setup
 		final List<String> categoryNames = new ArrayList<String>();
@@ -199,7 +198,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private String getCategoryName(final Assignment assignment) {
-		if (this.configuredCategoryType == 1) {
+		if (this.configuredCategoryType == GbCategoryType.NO_CATEGORY) {
 			return getString("gradebookpage.uncategorised");
 		}
 		return StringUtils.isBlank(assignment.getCategoryName()) ? getString(GradebookPage.UNCATEGORISED) : assignment.getCategoryName();
@@ -211,6 +210,6 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private boolean isCategoryWeightEnabled() {
-		return (this.configuredCategoryType == 3) ? true : false;
+		return (this.configuredCategoryType == GbCategoryType.WEIGHTED_CATEGORY) ? true : false;
 	}
 }


### PR DESCRIPTION
Delivers the student view fix for #1487.

Add a new enum to wrap up the category types so we don't have to use the explicit ints.
Add a method to get the currently configured category type. This is because a student cannot access gradebook settings so the earlier fix actually broke for a logged in student.
Change the student grade summary panels to use this new approach