### PR TITLE
Fix category subtotal so that it now dynamically updates

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1640,13 +1640,23 @@ public class GradebookNgBusinessService {
 
 		final Map<Assignment, GbGradeInfo> rval = new LinkedHashMap<>();
 
-		// only get grades if released for the site (the service checks it per assignment)
-		if (gradebook.isAssignmentsDisplayed()) {
-			for (final Assignment assignment : assignments) {
-				final GradeDefinition def = this.gradebookService.getGradeDefinitionForStudentForItem(gradebook.getUid(),
-						assignment.getId(), studentUuid);
-				rval.put(assignment, new GbGradeInfo(def));
+		// iterate all assignments and get the grades
+		// if student, only proceed if grades are released for the site
+		// if instructor or TA, skip this check
+		// permission checks are still applied at the assignment level in the GradebookService
+		final GbRole role = this.getUserRole(siteId);
+
+		if (role == GbRole.STUDENT) {
+			final boolean released = gradebook.isAssignmentsDisplayed();
+			if (!released) {
+				return rval;
 			}
+		}
+
+		for (final Assignment assignment : assignments) {
+			final GradeDefinition def = this.gradebookService.getGradeDefinitionForStudentForItem(gradebook.getUid(),
+					assignment.getId(), studentUuid);
+			rval.put(assignment, new GbGradeInfo(def));
 		}
 
 		return rval;


### PR DESCRIPTION
Delivers #1473.

Only have the guard around the iteration of the assignments to get the grades if user is a student, otherwise get it regardless. This forms part of the workflow for dynamic updates of category scores and was preventing them from being updated, even if instructor.