### PR TITLE
SAK-30200 Announcement email notification during site import duplicate.

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/event/cover/NotificationService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/cover/NotificationService.java
@@ -65,6 +65,8 @@ public class NotificationService
 
 	public static java.lang.String SECURE_REMOVE_NOTIFICATION = org.sakaiproject.event.api.NotificationService.SECURE_REMOVE_NOTIFICATION;
 
+	public static final int NOTI_IGNORE = org.sakaiproject.event.api.NotificationService.NOTI_IGNORE;
+
 	public static int NOTI_NONE = org.sakaiproject.event.api.NotificationService.NOTI_NONE;
 
 	public static int NOTI_REQUIRED = org.sakaiproject.event.api.NotificationService.NOTI_REQUIRED;

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/EmailNotification.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/EmailNotification.java
@@ -208,7 +208,10 @@ public class EmailNotification implements NotificationAction
 	public void reNotify(String notificationId, String resourceFilter, int eventPriority, Event event)
 	{
 		// ignore events marked for no notification
-		if (eventPriority == NotificationService.NOTI_NONE) return;
+		if (eventPriority == NotificationService.NOTI_NONE
+				|| eventPriority == NotificationService.NOTI_IGNORE) {
+			return;
+		}
 
 		// get the list of potential recipients
 		List recipients = getRecipients(event);


### PR DESCRIPTION
Note Announcements are normally marked as drafts except when using the
property import.importAsDraft=false