### PR TITLE
#1471 Updated the comment popover to remove the edit link if external…

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -207,6 +207,7 @@ grade.notifications.invalid = Gradebook item score must be a positive number or 
 
 comment.option.add = Add Comment
 comment.option.edit = Edit Comment
+comment.option.external = Editable in {0} tool
 
 delete.label = Delete Item
 delete.warning = Please be aware that deleting this gradebook item cannot be undone and scores entered will be removed from the gradebook.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -343,6 +343,7 @@ public class GradebookPage extends BasePage {
 					modelData.put("studentUuid", studentGrades.getStudentUuid());
 					modelData.put("categoryId", assignment.getCategoryId());
 					modelData.put("isExternal", assignment.isExternallyMaintained());
+					modelData.put("externalAppName", assignment.getExternalAppName());
 					modelData.put("gradeInfo", gradeInfo);
 					modelData.put("role", GradebookPage.this.role);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -12,6 +12,7 @@ import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.validator.StringValidator;
@@ -110,7 +111,8 @@ public class EditGradeCommentPanel extends Panel {
 				new Object[] { user.getDisplayName(), user.getDisplayId(), assignment.getName() })));
 
 		// textarea
-		form.add(new TextArea<String>("comment").add(StringValidator.maximumLength(500)));
+		form.add(new TextArea<String>("comment", new PropertyModel<String>(formModel, "gradeComment"))
+				.add(StringValidator.maximumLength(500)));
 
 		// instant validation
 		// AjaxFormValidatingBehavior.addToAllFormComponents(form, "onkeyup", Duration.ONE_SECOND);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -15,6 +15,7 @@
                 <p><span wicket:id="snippet"></span></p>
             </blockquote>
             <p wicket:id="editCommentContainer"><a href="javascript:void(0);" class="gb-popover-edit-comments" aria-haspopup="true"><wicket:message key="comment.option.edit" /></a></p>
+			<p wicket:id="externalComment">Editable in [Tool Name] Tool</p>  
         </li>
         <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
     </ul>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -10,6 +10,7 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.model.StringResourceModel;
 
 public class GradeItemCellPopoverPanel extends Panel {
 
@@ -32,6 +33,7 @@ public class GradeItemCellPopoverPanel extends Panel {
 		add(saveErrorNotification);
 
 		final String comment = (String) modelData.get("comment");
+
 		final WebMarkupContainer hasCommentNotification = new WebMarkupContainer("hasCommentNotification");
 		hasCommentNotification.setVisible(
 				notifications.contains(GradeItemCellPanel.GradeCellNotification.HAS_COMMENT) && StringUtils.isNotBlank(comment));
@@ -45,13 +47,24 @@ public class GradeItemCellPopoverPanel extends Panel {
 			hasCommentNotification.add(new AttributeModifier("data-assignmentid", (Long) modelData.get("assignmentId")));
 			hasCommentNotification.add(new AttributeModifier("data-studentUuid", (String) modelData.get("studentUuid")));
 
+			// for editing the comment
 			final WebMarkupContainer editCommentContainer = new WebMarkupContainer("editCommentContainer") {
 				@Override
 				public boolean isVisible() {
-					return (boolean) modelData.get("gradeable");
+					return ((boolean) modelData.get("gradeable") && !(boolean) modelData.get("isExternal"));
 				}
 			};
 			hasCommentNotification.add(editCommentContainer);
+
+			// external comments
+			final Label externalComment = new Label("externalComment",
+					new StringResourceModel("comment.option.external", null, new Object[] { modelData.get("externalAppName") })) {
+				@Override
+				public boolean isVisible() {
+					return (boolean) modelData.get("isExternal");
+				}
+			};
+			hasCommentNotification.add(externalComment);
 		}
 
 		final WebMarkupContainer isOverLimitNotification = new WebMarkupContainer("isOverLimitNotification");


### PR DESCRIPTION
…. Added the label about editing in the other tool.

Update the model to pass the external app name though. This may need to be internationalised.
Also fixed a bug introduced in the refactor with the normal edit comment panel where the form component and backing model property were mismatched. Added an explicit PropertyModel so this is easier to spot in future.