### PR TITLE
SAK-30202 allow limited updates of external assignments through the GradebookService API

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -365,14 +365,14 @@ public interface GradebookService {
 	public Long addAssignment(String gradebookUid, Assignment assignmentDefinition);
 	
 	/**
-	 * Modify the definition of an existing Gradebook-managed assignment.
+	 * Modify the definition of an existing Gradebook item.
 	 * 
 	 * Clients should be aware that it's allowed to change the points value of an
 	 * assignment even if students have already been scored on it. Any existing
 	 * scores will not be adjusted.
 	 * 
-	 * This method cannot be used to modify the definitions of externally-managed
-	 * assessments or to make Gradebook-managed assignments externally managed. 
+	 * This method can be used to manage both internal and external gradebook items,
+	 * however the title, due date and total points will not be edited for external gradebook items.
 	 * 
 	 * @param assignmentId the id of the assignment that needs to be changed
 	 * @param assignmentDefinition the new properties of the assignment


### PR DESCRIPTION
The `updateAssignment` method has a hard restriction on not allowing edits on external assignments. This is because some fields (title, due date, total points) cannot be changed in the `GradebookService` as they would then be out of sync with the external application that manages that assignment.

External tools currently use the `GradebookExternalAssessmentService` methods however there doesn't appear to be a reason why the external assessment can't just be managed through the normal service method and those fields filtered out from the edit.

It also simplifies dependencies and means the service can handle the logic of what to update rather than each application having to manage this.

See also:
* GradebookNG PR #1529
* https://jira.sakaiproject.org/browse/SAK-30202
