### PR TITLE
SAM-1408: Auto population of Extended times bug fix

### DIFF
--- a/samigo/samigo-app/src/webapp/js/extendedTime.js
+++ b/samigo/samigo-app/src/webapp/js/extendedTime.js
@@ -185,23 +185,29 @@ function hookScripts(itemNum) {
 	var s = document.createElement("script");
 	s.type = "text/javascript";	
 	
+	var defaultStartDate = moment(document.getElementById("xt_open"+itemNum).value).format('YYYY-MM-DD HH:mm:ss');
 	var startDatePickerOptions = { input: '#xt_open' + itemNum , 
 		useTime: 1,
 		parseFormat: 'YYYY-MM-DD HH:mm:ss', 
+		val: defaultStartDate,
 		ashidden: { iso8601: 'xt_open' + itemNum + 'ISO8601' } 
 	}
 	localDatePicker(startDatePickerOptions); 
 	
+	var formattedDueDate = moment(document.getElementById("xt_due"+itemNum).value).format('YYYY-MM-DD HH:mm:ss');
 	var dueDatePickerOptions = { input: '#xt_due' + itemNum , 
 		useTime: 1,
 		parseFormat: 'YYYY-MM-DD HH:mm:ss', 
+		val: formattedDueDate,
 		ashidden: { iso8601: 'xt_due' + itemNum + 'ISO8601' } 
 	}
 	localDatePicker(dueDatePickerOptions); 
 	
+	var formattedRetractDate = moment(document.getElementById("xt_retract"+itemNum).value).format('YYYY-MM-DD HH:mm:ss');
 	var retractDatePickerOptions = { input: '#xt_retract' + itemNum , 
 		useTime: 1,
 		parseFormat: 'YYYY-MM-DD HH:mm:ss', 
+		val: formattedRetractDate,
 		ashidden: { iso8601: 'xt_retract' + itemNum + 'ISO8601' } 
 	}
 	localDatePicker(retractDatePickerOptions); 


### PR DESCRIPTION
Working solution bug fix for the scenario explained below:

"Auto population of Extended times seems to have a bug, that imho, seems like a blocker priority because of the following use case:

Instructor creates an exception with dates, and updates the due date and retract date, but not the available date. All the date times look correct (in the web page) but, when you save the quiz, the time component on fields, the ones not updated by instructor, revert to midnight. Therefore an exam will be released to one or more students (whoever is in the exception group), earlier than is intended.

This is only not a problem if the available date is in the past, then it doesn't matter (but seems like an less common scenario)."
