### PR TITLE
SAM-2556 - Update tool_sam.css

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -498,7 +498,7 @@ a.hideDivision {
 
 .mcAnswerText {
 	display:inline-table;
-	width: 80%;
+	/*width: 80%;*/
 	float:unset;
 }
 /* Someone put a paragraph in a multiple choice answer */


### PR DESCRIPTION
Update so that the clickable area for a multiple choice question answer does not include white space which causes inadvertent changes by students when using touch screens or clicking in the whitespace for whatever reason.

With touchscreen laptops this is becoming a serious problem.