### PR TITLE
SAK-25880 Remove the flash button in the default configuration of CKE…

### DIFF
--- a/reference/library/src/webapp/editor/ckeditor.launch.js
+++ b/reference/library/src/webapp/editor/ckeditor.launch.js
@@ -138,8 +138,8 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             ['BidiLtr', 'BidiRtl' ],
             ['Link','Unlink','Anchor'],
             (sakai.editor.enableResourceSearch
-                ? ['AudioRecorder','ResourceSearch', 'Image','Movie','Flash','Table','HorizontalRule','Smiley','SpecialChar','fmath_formula','FontAwesome']
-                : ['AudioRecorder','Image','Movie','Flash','Table','HorizontalRule','Smiley','SpecialChar','fmath_formula','FontAwesome']),
+                ? ['AudioRecorder','ResourceSearch', 'Image','Movie','Table','HorizontalRule','Smiley','SpecialChar','fmath_formula','FontAwesome']
+                : ['AudioRecorder','Image','Movie','Table','HorizontalRule','Smiley','SpecialChar','fmath_formula','FontAwesome']),
             '/',
             ['Styles','Format','Font','FontSize'],
             ['TextColor','BGColor'],


### PR DESCRIPTION
SAK-25880 Remove the flash button in the default configuration of CKEditor. Only remove the button in configuration. No code is removed in case any institutions wants to return to the previous configuration.