### PR TITLE
SAK-30228 Citation with a link to a file in Resources will be of type

### DIFF
--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3956,7 +3956,8 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 	            ContentResource resource = contentService.getResource(resourceId);
 	            ResourceProperties props = resource.getProperties();
 	            String displayName = props.getProperty(ResourceProperties.PROP_DISPLAY_NAME);
-	            Citation citation = citationService.addCitation("unknown");
+	            //As this citation will always have resource url so it should be of type 'electronic' not 'unknown'
+	            Citation citation = citationService.addCitation("electronic");
 	            citation.setDisplayName(displayName);
 	            citation.setCitationProperty("resourceId", resourceId);
 	            //User user = UserDirectoryService.getUser(props.getProperty(ResourceProperties.PROP_CREATOR));


### PR DESCRIPTION
'Electronic'.

when a citation is added using 'Sakai Resource Picker' it will always have a url
therefore setting it's media type as 'electronic' instead of 'unknown'.