### PR TITLE
1603: Set focus inside a wicket modal open show and then return focus logically

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbModalWindow.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbModalWindow.java
@@ -1,0 +1,93 @@
+package org.sakaiproject.gradebookng.tool.model;
+
+import java.util.List;
+import java.util.ArrayList;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+
+/**
+ * A custom ModalWindow that adds behaviours specific to our tool
+ */
+public class GbModalWindow extends ModalWindow {
+
+	private Component componentToReturnFocusTo;
+	private List<WindowClosedCallback> closeCallbacks;
+
+	public GbModalWindow(String id) {
+		super(id);
+
+		closeCallbacks = new ArrayList<>();
+	}
+
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+
+		setMaskType(MaskType.TRANSPARENT);
+		setResizable(false);
+		setUseInitialHeight(false);
+
+		setDefaultWindowClosedCallback();
+
+		setWindowClosedCallback(new WindowClosedCallback() {
+			@Override
+			public void onClose(AjaxRequestTarget target) {
+				closeCallbacks.forEach((callback) -> {
+					callback.onClose(target);
+				});
+			}
+		});
+	}
+
+	@Override
+	protected CharSequence getShowJavaScript() {
+		// focus the first input field in the content pane
+		String focusJavascript = String.format("setTimeout(function() {$('#%s :input:first:visible').focus();});", this.getContent().getMarkupId());
+
+		return super.getShowJavaScript().toString() + focusJavascript;
+	}
+
+	@Override
+	public ModalWindow setContent(Component component) {
+		component.setOutputMarkupId(true);
+
+		return super.setContent(component);
+	}
+
+
+	/**
+	 * Set the component to return focus to upon closing the window
+	 * @param component
+	 */
+	public void setComponentToReturnFocusTo(Component component) {
+		componentToReturnFocusTo = component;
+	}
+
+	public void addWindowClosedCallback(WindowClosedCallback callback) {
+		closeCallbacks.add(callback);
+	}
+
+	public void clearWindowClosedCallbacks() {
+		closeCallbacks = new ArrayList<>();
+		setDefaultWindowClosedCallback();
+	}
+
+	private void setDefaultWindowClosedCallback() {
+		addWindowClosedCallback(new WindowClosedCallback() {
+			@Override
+			public void onClose(final AjaxRequestTarget target) {
+				// Ensure the date picker is hidden
+				target.appendJavaScript("$('#ui-datepicker-div').hide();");
+
+				// Ensure any mask is hidden
+				target.appendJavaScript("GradebookGradeSummaryUtils.clearBlur();");
+
+				// Return focus to defined component 
+				if (componentToReturnFocusTo != null) {
+					target.appendJavaScript(String.format("setTimeout(function() {$('#%s').focus();});", componentToReturnFocusTo.getMarkupId()));
+				}
+			}
+		});
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -14,8 +14,6 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.event.IEvent;
-import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
-import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow.MaskType;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.DataTable;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.HeadersToolbar;
@@ -44,6 +42,7 @@ import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
 import org.sakaiproject.gradebookng.business.util.Temp;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.model.ScoreChangedEvent;
+import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.panels.AddOrEditGradeItemPanel;
 import org.sakaiproject.gradebookng.tool.panels.AssignmentColumnHeaderPanel;
 import org.sakaiproject.gradebookng.tool.panels.CategoryColumnCellPanel;
@@ -73,12 +72,12 @@ public class GradebookPage extends BasePage {
 	// doubles as a translation key
 	public static final String UNCATEGORISED = "gradebookpage.uncategorised";
 
-	ModalWindow addOrEditGradeItemWindow;
-	ModalWindow studentGradeSummaryWindow;
-	ModalWindow updateUngradedItemsWindow;
-	ModalWindow gradeLogWindow;
-	ModalWindow gradeCommentWindow;
-	ModalWindow deleteItemWindow;
+	GbModalWindow addOrEditGradeItemWindow;
+	GbModalWindow studentGradeSummaryWindow;
+	GbModalWindow updateUngradedItemsWindow;
+	GbModalWindow gradeLogWindow;
+	GbModalWindow gradeCommentWindow;
+	GbModalWindow deleteItemWindow;
 
 	Form<Void> form;
 
@@ -101,64 +100,32 @@ public class GradebookPage extends BasePage {
 		/**
 		 * Note that SEMI_TRANSPARENT has a 100% black background and TRANSPARENT is overridden to 10% opacity
 		 */
-		this.addOrEditGradeItemWindow = new ModalWindow("addOrEditGradeItemWindow");
-		this.addOrEditGradeItemWindow.setMaskType(MaskType.TRANSPARENT);
-		this.addOrEditGradeItemWindow.setResizable(false);
-		this.addOrEditGradeItemWindow.setUseInitialHeight(false);
+		this.addOrEditGradeItemWindow = new GbModalWindow("addOrEditGradeItemWindow");
 		this.addOrEditGradeItemWindow.showUnloadConfirmation(false);
-		this.addOrEditGradeItemWindow.setCloseButtonCallback(new ModalWindow.CloseButtonCallback() {
-			@Override
-			public boolean onCloseButtonClicked(final AjaxRequestTarget target) {
-				// Ensure the date picker is hidden
-				target.appendJavaScript("$('#ui-datepicker-div').hide();");
-				return true;
-			}
-		});
 		this.form.add(this.addOrEditGradeItemWindow);
 
-		this.studentGradeSummaryWindow = new ModalWindow("studentGradeSummaryWindow");
-		this.studentGradeSummaryWindow.setMaskType(MaskType.TRANSPARENT);
-		this.studentGradeSummaryWindow.setResizable(false);
-		this.studentGradeSummaryWindow.setUseInitialHeight(false);
+		this.studentGradeSummaryWindow = new GbModalWindow("studentGradeSummaryWindow");
 		this.studentGradeSummaryWindow.setWidthUnit("%");
 		this.studentGradeSummaryWindow.setInitialWidth(70);
-		this.studentGradeSummaryWindow.setCloseButtonCallback(new ModalWindow.CloseButtonCallback() {
-			@Override
-			public boolean onCloseButtonClicked(final AjaxRequestTarget target) {
-				target.appendJavaScript("GradebookGradeSummaryUtils.clearBlur();");
-				return true;
-			}
-		});
 		this.form.add(this.studentGradeSummaryWindow);
 
-		this.updateUngradedItemsWindow = new ModalWindow("updateUngradedItemsWindow");
-		this.updateUngradedItemsWindow.setMaskType(MaskType.TRANSPARENT);
-		this.updateUngradedItemsWindow.setResizable(false);
-		this.updateUngradedItemsWindow.setUseInitialHeight(true);
+		this.updateUngradedItemsWindow = new GbModalWindow("updateUngradedItemsWindow");
 		this.form.add(this.updateUngradedItemsWindow);
 
-		this.gradeLogWindow = new ModalWindow("gradeLogWindow");
-		this.gradeLogWindow.setMaskType(MaskType.TRANSPARENT);
-		this.gradeLogWindow.setResizable(false);
-		this.gradeLogWindow.setUseInitialHeight(false);
+		this.gradeLogWindow = new GbModalWindow("gradeLogWindow");
 		this.form.add(this.gradeLogWindow);
 
-		this.gradeCommentWindow = new ModalWindow("gradeCommentWindow");
-		this.gradeCommentWindow.setMaskType(MaskType.TRANSPARENT);
-		this.gradeCommentWindow.setResizable(false);
-		this.gradeCommentWindow.setUseInitialHeight(false);
+		this.gradeCommentWindow = new GbModalWindow("gradeCommentWindow");
 		this.form.add(this.gradeCommentWindow);
 
-		this.deleteItemWindow = new ModalWindow("deleteItemWindow");
-		this.deleteItemWindow.setMaskType(MaskType.TRANSPARENT);
-		this.deleteItemWindow.setResizable(false);
-		this.deleteItemWindow.setUseInitialHeight(false);
+		this.deleteItemWindow = new GbModalWindow("deleteItemWindow");
 		this.form.add(this.deleteItemWindow);
 
 		final AjaxButton addGradeItem = new AjaxButton("addGradeItem") {
 			@Override
 			public void onSubmit(final AjaxRequestTarget target, final Form form) {
-				final ModalWindow window = getAddOrEditGradeItemWindow();
+				final GbModalWindow window = getAddOrEditGradeItemWindow();
+				window.setComponentToReturnFocusTo(this);
 				window.setContent(new AddOrEditGradeItemPanel(window.getContentId(), window, null));
 				window.show(target);
 			}
@@ -173,6 +140,7 @@ public class GradebookPage extends BasePage {
 
 		};
 		addGradeItem.setDefaultFormProcessing(false);
+		addGradeItem.setOutputMarkupId(true);
 		this.form.add(addGradeItem);
 
 		// first get any settings data from the session
@@ -551,27 +519,27 @@ public class GradebookPage extends BasePage {
 	 *
 	 * @return
 	 */
-	public ModalWindow getAddOrEditGradeItemWindow() {
+	public GbModalWindow getAddOrEditGradeItemWindow() {
 		return this.addOrEditGradeItemWindow;
 	}
 
-	public ModalWindow getStudentGradeSummaryWindow() {
+	public GbModalWindow getStudentGradeSummaryWindow() {
 		return this.studentGradeSummaryWindow;
 	}
 
-	public ModalWindow getUpdateUngradedItemsWindow() {
+	public GbModalWindow getUpdateUngradedItemsWindow() {
 		return this.updateUngradedItemsWindow;
 	}
 
-	public ModalWindow getGradeLogWindow() {
+	public GbModalWindow getGradeLogWindow() {
 		return this.gradeLogWindow;
 	}
 
-	public ModalWindow getGradeCommentWindow() {
+	public GbModalWindow getGradeCommentWindow() {
 		return this.gradeCommentWindow;
 	}
 
-	public ModalWindow getDeleteItemWindow() {
+	public GbModalWindow getDeleteItemWindow() {
 		return this.deleteItemWindow;
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -1,9 +1,10 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
-import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
@@ -18,6 +19,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.SortDirection;
 import org.sakaiproject.gradebookng.business.model.GbAssignmentGradeSortOrder;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
@@ -46,6 +48,8 @@ public class AssignmentColumnHeaderPanel extends Panel {
 	@Override
 	public void onInitialize() {
 		super.onInitialize();
+
+		getParentCellFor(this).setOutputMarkupId(true);
 
 		final Assignment assignment = this.modelData.getObject();
 
@@ -159,7 +163,8 @@ public class AssignmentColumnHeaderPanel extends Panel {
 			@Override
 			public void onClick(final AjaxRequestTarget target) {
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
-				final ModalWindow window = gradebookPage.getAddOrEditGradeItemWindow();
+				final GbModalWindow window = gradebookPage.getAddOrEditGradeItemWindow();
+				window.setComponentToReturnFocusTo(getParentCellFor(this));
 				window.setContent(new AddOrEditGradeItemPanel(window.getContentId(), window, getModel()));
 				window.showUnloadConfirmation(false);
 				window.show(target);
@@ -263,8 +268,9 @@ public class AssignmentColumnHeaderPanel extends Panel {
 			public void onClick(final AjaxRequestTarget target) {
 
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
-				final ModalWindow window = gradebookPage.getUpdateUngradedItemsWindow();
+				final GbModalWindow window = gradebookPage.getUpdateUngradedItemsWindow();
 				final UpdateUngradedItemsPanel panel = new UpdateUngradedItemsPanel(window.getContentId(), getModel(), window);
+				window.setComponentToReturnFocusTo(getParentCellFor(this));
 				window.setContent(panel);
 				window.showUnloadConfirmation(false);
 				window.show(target);
@@ -291,9 +297,10 @@ public class AssignmentColumnHeaderPanel extends Panel {
 			public void onClick(final AjaxRequestTarget target) {
 
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
-				final ModalWindow window = gradebookPage.getDeleteItemWindow();
+				final GbModalWindow window = gradebookPage.getDeleteItemWindow();
 				final DeleteItemPanel panel = new DeleteItemPanel(window.getContentId(), getModel(), window);
 
+				window.setComponentToReturnFocusTo(getParentCellFor(this));
 				window.setContent(panel);
 				window.showUnloadConfirmation(false);
 				window.show(target);
@@ -310,5 +317,14 @@ public class AssignmentColumnHeaderPanel extends Panel {
 
 		add(menu);
 
+	}
+
+
+	private Component getParentCellFor(final Component component) {
+		if (StringUtils.equals(component.getMarkupAttributes().getString("wicket:id"), "header")) {
+			return component;
+		} else {
+			return getParentCellFor(component.getParent());
+		}
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -32,6 +32,7 @@ import org.sakaiproject.gradebookng.business.GradeSaveResponse;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.ScoreChangedEvent;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 
@@ -325,8 +326,9 @@ public class GradeItemCellPanel extends Panel {
 			public void onClick(final AjaxRequestTarget target) {
 
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
-				final ModalWindow window = gradebookPage.getGradeLogWindow();
+				final GbModalWindow window = gradebookPage.getGradeLogWindow();
 
+				window.setComponentToReturnFocusTo(getParentCellFor(this));
 				window.setContent(new GradeLogPanel(window.getContentId(), getModel(), window));
 				window.show(target);
 
@@ -341,12 +343,14 @@ public class GradeItemCellPanel extends Panel {
 			public void onClick(final AjaxRequestTarget target) {
 
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
-				final ModalWindow window = gradebookPage.getGradeCommentWindow();
+				final GbModalWindow window = gradebookPage.getGradeCommentWindow();
 
 				final EditGradeCommentPanel panel = new EditGradeCommentPanel(window.getContentId(), getModel(), window);
 				window.setContent(panel);
 				window.showUnloadConfirmation(false);
-				window.setWindowClosedCallback(new ModalWindow.WindowClosedCallback() {
+				window.clearWindowClosedCallbacks();
+				window.setComponentToReturnFocusTo(getParentCellFor(GradeItemCellPanel.this.gradeCell));
+				window.addWindowClosedCallback(new ModalWindow.WindowClosedCallback() {
 					private static final long serialVersionUID = 1L;
 
 					@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -16,6 +16,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 
 /**
  *
@@ -33,7 +34,7 @@ public class StudentGradeSummaryPanel extends Panel {
 	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
 	protected GradebookNgBusinessService businessService;
 
-	public StudentGradeSummaryPanel(final String id, final IModel<Map<String, Object>> model, final ModalWindow window) {
+	public StudentGradeSummaryPanel(final String id, final IModel<Map<String, Object>> model, final GbModalWindow window) {
 		super(id, model);
 
 		this.window = window;
@@ -55,7 +56,6 @@ public class StudentGradeSummaryPanel extends Panel {
 			@Override
 			public void onClick(final AjaxRequestTarget target) {
 				StudentGradeSummaryPanel.this.window.close(target);
-				target.appendJavaScript("GradebookGradeSummaryUtils.clearBlur();");
 			}
 		});
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.java
@@ -6,11 +6,11 @@ import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
-import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.sakaiproject.gradebookng.business.model.GbStudentNameSortOrder;
+import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 
 /**
@@ -50,7 +50,7 @@ public class StudentNameCellPanel extends Panel {
 			public void onClick(final AjaxRequestTarget target) {
 
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
-				final ModalWindow window = gradebookPage.getStudentGradeSummaryWindow();
+				final GbModalWindow window = gradebookPage.getStudentGradeSummaryWindow();
 
 				final Component content = new StudentGradeSummaryPanel(window.getContentId(), StudentNameCellPanel.this.model, window);
 
@@ -60,14 +60,15 @@ public class StudentNameCellPanel extends Panel {
 					target.add(content);
 				} else {
 					window.setContent(content);
+					window.setComponentToReturnFocusTo(this);
 					window.show(target);
 				}
 
 				content.setOutputMarkupId(true);
 				target.appendJavaScript("new GradebookGradeSummary($(\"#" + content.getMarkupId() + "\"));");
 			}
-
 		};
+		link.setOutputMarkupId(true);
 
 		// name label
 		link.add(new Label("name", getFormattedStudentName(firstName, lastName, nameSortOrder)));

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -760,7 +760,7 @@ GradebookSpreadsheet.prototype._cloneCell = function($cell) {
   var $clone = $cell.clone();
 
   // remove any ids
-  $clone.find("[id]").each(function() {
+  $clone.find("[id]").andSelf().each(function() {
     $(this).data("id", $(this).attr("id")).removeAttr("id");
   });
 


### PR DESCRIPTION
Hi @steveswinsburg.  I've introduced GbModalWindow, an extension of ModalWindow, which adds the ability to set a `componentToReturnFocusTo` and allow multiple `WindowClosedCallback` to be set on the window (by default only allows the one and sometimes we have multiple).  

It also includes generic Javascript hooks to ensure date pickers and any modal masks are hidden upon closing any of the windows and other properties previously defined for all instances i.e.

```
		setMaskType(MaskType.TRANSPARENT);
		setResizable(false);
		setUseInitialHeight(false);
```