### PR TITLE
1607: Improve usability for sorting and cell focus (firefox)

### DIFF
--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -308,6 +308,12 @@
 #gradebookGrades .gb-due-date {
   margin-bottom: 1.2em;
 }
+#gradebookGradesTable td:focus,
+#gradebookGradesTable th:focus {
+  outline: 2px solid #3698DB;
+  outline-color: rgba(54, 152, 219, 0.8);
+  outline-offset: -1px;
+}
 /* Row selector/highlights */
 #gradebookGrades .gb-row-selector {
   width: 14px;
@@ -335,7 +341,9 @@
   border-color: #3698DB;
 }
 #gradebookGrades tbody .gb-highlighted-row {
-    outline: 1px solid #3698DB;
+  outline: 1px solid #3698DB;
+  outline-color: rgba(54, 152, 219, 0.8);
+  outline-offset: 0px;
 }
 /* Fixed header/column */
 #gradebookGrades .gb-fixed-header-table,

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -112,13 +112,21 @@
 #gradebookGrades th .gb-title a:hover {
   text-decoration: none;
 }
-#gradebookGrades th .gb-title .gb-sort-ascending:before {
+#gradebookGrades th .gb-title a:after {
   font-family: 'gradebook-icons';
-  content: '\f0d8';
+  content: '\f0dc';
+	position: absolute;
+	right: 0;
+	top: 0;
+	font-style: normal;
 }
-#gradebookGrades th .gb-title .gb-sort-descending:before {
+#gradebookGrades th .gb-title a.gb-sort-descending:after {
   font-family: 'gradebook-icons';
   content: '\f0d7';
+}
+#gradebookGrades th .gb-title a.gb-sort-ascending:after {
+  font-family: 'gradebook-icons';
+  content: '\f0d8';
 }
 #gradebookGrades th .gb-title a:before {
   margin-right: 4px;


### PR DESCRIPTION
Delivers #1607.

Introduces sort icons for sortable header links and also makes the cell focus outline consistent between Chrome, Safari and Firefox (Firefox previously showed a dotted line rather than a coloured border).