### PR TITLE
#1590 Fix the calculation of the category subtotals when an item is not included in course grade calcs

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2894,15 +2894,16 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				totalPossible = totalPossible.add(new BigDecimal(assignment.getPoints().toString()));
 				numOfAssignments++;
 				numScored++;
+				
+				//sanitise grade
+				if(StringUtils.isBlank(grade)) {
+					grade = "0";
+				}
+				
+				//update total points earned
+				totalEarned = totalEarned.add(new BigDecimal(grade));
 			}
 			
-			//sanitise grade
-			if(StringUtils.isBlank(grade)) {
-				grade = "0";
-			}
-			
-			//update total points earned
-			totalEarned = totalEarned.add(new BigDecimal(grade));
 		}
 		
     	if (numScored == 0 || numOfAssignments == 0 || totalPossible.doubleValue() == 0) {


### PR DESCRIPTION
Move the collection of the 'total points earned' inside the block that tests if the `total points possible` and `number of assignments` should be calculated so that we don't get incorrect `total points earned` vs `total points possible`.

Delivers #1590.