### PR TITLE
Fix for SAK-30232. Chat messages correctly displayed now.

### DIFF
--- a/chat/chat-tool/tool/src/webapp/css/chat.css
+++ b/chat/chat-tool/tool/src/webapp/css/chat.css
@@ -25,7 +25,6 @@ LABEL.chat-date-label {
     list-style: none;
 }
 #chatList li, .chatList li{
-    text-indent: -3em;
     line-height: 1.2em;
 }
 .chat-block label {


### PR DESCRIPTION
Just got rid of some CSS here. It had the chat messages being incorrectly indented.

