### PR TITLE
SAK-30244 Change label from “Make Site Page”

### DIFF
--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -63,7 +63,7 @@ action.duplicate	 = Duplicate
 action.exception	= There was a problem with {1} - {0}
 action.info		 = Info
 action.move		 = Move
-action.makesitepage	 = Make Site Page
+action.makesitepage	 = Make Web Content Link
 action.other		 = Act on this {0}
 action.paste		 = Paste
 action.pastecopy	 = Paste copied items
@@ -380,14 +380,14 @@ props.select.help=Remember to copy the URL via Ctrl+C or Option+C. This link onl
 props.shorturl=Short URL
 
 # Keys for adding a page linking to a piece of content (Make Site Page).
-alert.page.empty = You need to enter a title for the page.
-alert.page.exists = The Site already contains a page with that name.
-alert.page.permission = You don't appear to have permission to add pages to this site.
+alert.page.empty = You need to enter a title for the Web Content Link.
+alert.page.exists = The Site already contains a Web Content Link with that name.
+alert.page.permission = You don't appear to have permission to add tools to this site.
 alert.resource.not.found = Cannot find the content.
-button.addpage = Add Page
-instr.makesitepage = This allows you to create a page within the site linking to this piece of content.
-label.page = Title of Page
-make.site.page = Make Site Page
+button.addpage = Add
+instr.makesitepage = This allows you to quickly create a Web Content Link to this piece of content.
+label.page = Title
+make.site.page = Make Web Content Link
 
 error.site.page = There was a problem displaying this page, please press the reset button to get back to the main view.
 


### PR DESCRIPTION
“Make Site Page” is confusing because it’s not a term users see in Sakai. Web Content is something see elsewhere in the interface.