### PR TITLE
Bug/1420 keep highest etc settings not applied in category score

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -94,7 +94,8 @@ public interface GradebookService {
      * Comparator to ensure correct ordering of letter grades, catering for + and - in the grade
      */
     public static Comparator<String> lettergradeComparator = new Comparator<String>() {
-		public int compare(String o1, String o2){
+		@Override
+    	public int compare(String o1, String o2){
 			if(o1.toLowerCase().charAt(0) == o2.toLowerCase().charAt(0)) {
 				if(o1.length() == 2 && o2.length() == 2) {
 					if(o1.charAt(1) == '+') {
@@ -335,6 +336,7 @@ public interface GradebookService {
      * 
      * @deprecated 
      */
+    @Deprecated
     public List getCategories(final Long gradebookId);
     
     /**
@@ -758,6 +760,16 @@ public interface GradebookService {
      * @return percentage or null if no calculations were made
      */
     Double calculateCategoryScore(final Long categoryId, final List<Assignment> viewableAssignments, final Map<Long,String> gradeMap);
+
+    /**
+     * Calculate the category score for the given gradebook, category and student
+     * 
+     * @param gradebookUid uuid of the gradebook
+     * @param categoryId id of category
+     * @param studentUuid uuid of the student
+     * @return percentage or null if no calculations were made
+     */
+	Double calculateCategoryScore(String gradebookUid, Long categoryId, String studentUuid);
 
     /**
      * Get the course grade for a student

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -744,26 +744,27 @@ public interface GradebookService {
      * Calculate the category score for the given gradebook, student and category, looking up the grades.
      * Safe to call in context of a student.
      * 
-     * @param gradebookUid uuid of the gradebook
+     * @param gradebookId Id of the gradebook
      * @param studentUuid uuid of the student
      * @param categoryId id of category
      * @return percentage or null if no calculations were made
+     * 
      */
-	Double calculateCategoryScore(String gradebookUid, String studentUuid, Long categoryId);
+	Double calculateCategoryScore(Long gradebookId, String studentUuid, Long categoryId);
 	
 	/**
      * Calculate the category score for the given gradebook, category, viewable assignment list and grade map.
      * This doesn't do any additional grade lookups.
      * Safe to call in context of a student.
      * 
-     * @param gradebookUid uuid of the gradebook
+     * @param gradebook the gradebook. As this method is called for every student at once, this is passed in to save additional lookups by id.
      * @param studentUuid uuid of the student
      * @param categoryId id of category
      * @param assignments list of assignments the student can view
      * @param gradeMap map of assignmentId to grade, to use for the calculations
      * @return percentage or null if no calculations were made
      */
-	Double calculateCategoryScore(String gradebookUid, String studentUuid, CategoryDefinition category, final List<Assignment> viewableAssignments, Map<Long,String> gradeMap);
+	Double calculateCategoryScore(Object gradebook, String studentUuid, CategoryDefinition category, final List<Assignment> viewableAssignments, Map<Long,String> gradeMap);
 
     /**
      * Get the course grade for a student

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -24,6 +24,7 @@ package org.sakaiproject.service.gradebook.shared;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.Set;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -740,36 +741,29 @@ public interface GradebookService {
 	public List getGradingEvents(final String studentId, final long assignmentId);
     
     /**
-     * Calculate a student's score for a category given the category definition and grades for that student.
+     * Calculate the category score for the given gradebook, student and category, looking up the grades.
+     * Safe to call in context of a student.
      * 
-     * Note that this cannot be run as a student due to permission checks. 
-     * Use {@link GradebookService#calculateCategoryScore(List, String)} if in context of a student.
-     * 
-     * @param category category to perform the calculations for
-     * @param gradeMap map of assignmentId to grade, to use for the calculations
+     * @param gradebookUid uuid of the gradebook
+     * @param studentUuid uuid of the student
+     * @param categoryId id of category
      * @return percentage or null if no calculations were made
      */
-    Double calculateCategoryScore(CategoryDefinition category, Map<Long,String> gradeMap);
-    
-    /**
-     * Calculate the category score given the viewable assignments and grades for that student.
+	Double calculateCategoryScore(String gradebookUid, String studentUuid, Long categoryId);
+	
+	/**
+     * Calculate the category score for the given gradebook, category, viewable assignment list and grade map.
+     * This doesn't do any additional grade lookups.
+     * Safe to call in context of a student.
      * 
-     * @param categoryId id of category, used for validation that the assignments and grades match
+     * @param gradebookUid uuid of the gradebook
+     * @param studentUuid uuid of the student
+     * @param categoryId id of category
      * @param assignments list of assignments the student can view
      * @param gradeMap map of assignmentId to grade, to use for the calculations
      * @return percentage or null if no calculations were made
      */
-    Double calculateCategoryScore(final Long categoryId, final List<Assignment> viewableAssignments, final Map<Long,String> gradeMap);
-
-    /**
-     * Calculate the category score for the given gradebook, category and student
-     * 
-     * @param gradebookUid uuid of the gradebook
-     * @param categoryId id of category
-     * @param studentUuid uuid of the student
-     * @return percentage or null if no calculations were made
-     */
-	Double calculateCategoryScore(String gradebookUid, Long categoryId, String studentUuid);
+	Double calculateCategoryScore(String gradebookUid, String studentUuid, CategoryDefinition category, final List<Assignment> viewableAssignments, Map<Long,String> gradeMap);
 
     /**
      * Get the course grade for a student

--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/AssignmentGradeRecord.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/AssignmentGradeRecord.java
@@ -55,7 +55,8 @@ public class AssignmentGradeRecord extends AbstractGradeRecord implements Clonea
 
     static{
     	numericComparator = new Comparator<AssignmentGradeRecord>() {
-            public int compare(AssignmentGradeRecord agr1, AssignmentGradeRecord agr2) {
+            @Override
+			public int compare(AssignmentGradeRecord agr1, AssignmentGradeRecord agr2) {
                 if(agr1 == null && agr2 == null) {
                     return 0;
                 }
@@ -108,7 +109,8 @@ public class AssignmentGradeRecord extends AbstractGradeRecord implements Clonea
 
     static {
         calcComparator = new Comparator<AssignmentGradeRecord>() {
-            public int compare(AssignmentGradeRecord agr1, AssignmentGradeRecord agr2) {
+            @Override
+			public int compare(AssignmentGradeRecord agr1, AssignmentGradeRecord agr2) {
                 if(agr1 == null && agr2 == null) {
                     return 0;
                 }
@@ -138,7 +140,8 @@ public class AssignmentGradeRecord extends AbstractGradeRecord implements Clonea
     /**
      * @return Returns the pointsEarned
      */
-    public Double getPointsEarned() {
+    @Override
+	public Double getPointsEarned() {
         return pointsEarned;
     }
 
@@ -154,7 +157,8 @@ public class AssignmentGradeRecord extends AbstractGradeRecord implements Clonea
      *
      * @see org.sakaiproject.tool.gradebook.AbstractGradeRecord#getGradeAsPercentage()
      */
-    public Double getGradeAsPercentage() {
+    @Override
+	public Double getGradeAsPercentage() {
         if (pointsEarned == null) {
             return null;
         }
@@ -167,6 +171,7 @@ public class AssignmentGradeRecord extends AbstractGradeRecord implements Clonea
 	/**
 	 * @see org.sakaiproject.tool.gradebook.AbstractGradeRecord#isCourseGradeRecord()
 	 */
+	@Override
 	public boolean isCourseGradeRecord() {
 		return false;
 	}
@@ -200,7 +205,8 @@ public class AssignmentGradeRecord extends AbstractGradeRecord implements Clonea
     	this.userAbleToView = userAbleToView;
     }
 
-    public AssignmentGradeRecord clone()
+    @Override
+	public AssignmentGradeRecord clone()
     {
     	AssignmentGradeRecord agr = new AssignmentGradeRecord();
     	agr.setDateRecorded(dateRecorded);

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2944,12 +2944,12 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		List<AssignmentGradeRecord> gradeRecords = gradeRecMap.get(studentUuid);
 		this.applyDropScores(gradeRecords);
 		
-		//iterate every grade record, check its for the category we want
+		//iterate every grade record, check it's for the category we want
 		for(AssignmentGradeRecord gradeRecord: gradeRecords) {
 			
 			Assignment assignment = gradeRecord.getAssignment();
 			
-			//check match
+			//check category match
 			if(categoryId != assignment.getCategory().getId()){
 				log.error("Category id: " + categoryId + " did not match assignment categoryId: " + assignment.getCategory().getId());
 				return null;
@@ -2957,10 +2957,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 						
 			//only update the variables for the calculation if:
 			// 1. the assignment has points to be assigned
-			// 2. there is a grade for the student 
-			// 3. it's included in course grade calculations
-			// 4. it's released to the student (safety check against condition 3)
-			if(assignment.getPointsPossible() != null && gradeRecord.getPointsEarned() != null && assignment.isCounted() && assignment.isReleased()) {
+			// 2. there is a grade for the student
+			// 3. the assignment is included in course grade calculations
+			// 4. the assignment is  released to the student (safety check against condition 3)
+			// 5. the grade is not dropped from the calc
+			if(assignment.getPointsPossible() != null && gradeRecord.getPointsEarned() != null && assignment.isCounted() && assignment.isReleased() && !gradeRecord.getDroppedFromGrade()) {
 				totalPossible = totalPossible.add(new BigDecimal(assignment.getPointsPossible().toString()));
 				numOfAssignments++;
 				numScored++;

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2867,7 +2867,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		Gradebook gradebook = this.getGradebook(gradebookUid);
 		
 		//collect the data and turn it into a list of AssignmentGradeRecords
-		//this is the info that is compatible with applyDropScores
+		//this is the info that is compatible with both applyDropScores and the calculateCategoryScore method
 		List<AssignmentGradeRecord> gradeRecords = new ArrayList<>();
 		for(org.sakaiproject.service.gradebook.shared.Assignment assignment: viewableAssignments) {
 			
@@ -2883,23 +2883,22 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			
 			//recreate the assignment (required fields only)
 			Assignment a = new Assignment();
+			a.setPointsPossible(assignment.getPoints());
 			a.setUngraded(assignment.getUngraded());
 			a.setCounted(assignment.isCounted());
 			a.setExtraCredit(assignment.isExtraCredit());
+			a.setReleased(assignment.isReleased());
 			a.setRemoved(false); //shared.Assignment doesn't include removed so this will always be false
 			a.setGradebook(gradebook);
 			a.setCategory(c);
 			
 			//create the AGR
 			AssignmentGradeRecord gradeRecord = new AssignmentGradeRecord(a, studentUuid, grade);
-			gradeRecord.setPointsEarned(assignment.getPoints());
 			
 			gradeRecords.add(gradeRecord);
 		}
 		
 		return calculateCategoryScore(gradebookUid, studentUuid, category.getId(), gradeRecords);
-
-		
 	}
 	
 	@Override
@@ -2947,6 +2946,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				
 		//apply any drop/keep settings for this category
 		this.applyDropScores(gradeRecords);
+		
 		
 		//iterate every grade record, check it's for the category we want
 		for(AssignmentGradeRecord gradeRecord: gradeRecords) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -681,8 +681,7 @@ public class GradebookNgBusinessService {
 						}
 					}
 
-					// final Double categoryScore = this.gradebookService.calculateCategoryScore(category, gradeMap);
-					final Double categoryScore = this.gradebookService.calculateCategoryScore(gradebook.getUid(), student.getId(),
+					final Double categoryScore = this.gradebookService.calculateCategoryScore(gradebook, student.getId(),
 							category, assignments, gradeMap);
 
 					// add to GbStudentGradeInfo
@@ -1699,7 +1698,7 @@ public class GradebookNgBusinessService {
 
 		final Gradebook gradebook = getGradebook();
 
-		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getUid(), studentUuid, categoryId);
+		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getId(), studentUuid, categoryId);
 		log.info("Category score for category: " + categoryId + ", student: " + studentUuid + ":" + score);
 
 		return score;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -681,7 +681,9 @@ public class GradebookNgBusinessService {
 						}
 					}
 
-					final Double categoryScore = this.gradebookService.calculateCategoryScore(category, gradeMap);
+					// final Double categoryScore = this.gradebookService.calculateCategoryScore(category, gradeMap);
+					final Double categoryScore = this.gradebookService.calculateCategoryScore(gradebook.getUid(), student.getId(),
+							category, assignments, gradeMap);
 
 					// add to GbStudentGradeInfo
 					sg.addCategoryAverage(category.getId(), categoryScore);
@@ -1697,7 +1699,7 @@ public class GradebookNgBusinessService {
 
 		final Gradebook gradebook = getGradebook();
 
-		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getUid(), categoryId, studentUuid);
+		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getUid(), studentUuid, categoryId);
 		log.info("Category score for category: " + categoryId + ", student: " + studentUuid + ":" + score);
 
 		return score;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1691,33 +1691,13 @@ public class GradebookNgBusinessService {
 	 *
 	 * @param categoryId id of category
 	 * @param studentUuid uuid of student
-	 * @param grades Map of grades obtained from getGradesForStudent.
 	 * @return
 	 */
-	public Double getCategoryScoreForStudent(final Long categoryId, final String studentUuid, final Map<Assignment, GbGradeInfo> grades) {
+	public Double getCategoryScoreForStudent(final Long categoryId, final String studentUuid) {
 
-		// get assignments (filtered to just the category ones later)
-		final List<Assignment> assignments = new ArrayList<Assignment>(grades.keySet());
+		final Gradebook gradebook = getGradebook();
 
-		// build map of just the grades and assignments we want for the assignments in the given category
-		final Map<Long, String> gradeMap = new HashMap<>();
-
-		final Iterator<Assignment> iter = assignments.iterator();
-		while (iter.hasNext()) {
-			final Assignment assignment = iter.next();
-			if (categoryId == assignment.getCategoryId()) {
-				final GbGradeInfo gradeInfo = grades.get(assignment);
-				if (gradeInfo != null) {
-					gradeMap.put(assignment.getId(), gradeInfo.getGrade());
-				}
-			} else {
-				iter.remove();
-			}
-		}
-
-		// get the score
-		final Double score = this.gradebookService.calculateCategoryScore(categoryId, assignments, gradeMap);
-
+		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getUid(), categoryId, studentUuid);
 		log.info("Category score for category: " + categoryId + ", student: " + studentUuid + ":" + score);
 
 		return score;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnCellPanel.java
@@ -11,10 +11,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
-import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.gradebookng.tool.model.ScoreChangedEvent;
-import org.sakaiproject.service.gradebook.shared.Assignment;
 
 /**
  *
@@ -58,16 +56,14 @@ public class CategoryColumnCellPanel extends Panel {
 					if (studentUuid.equals(scoreChangedEvent.getStudentUuid()) &&
 							categoryId.equals(scoreChangedEvent.getCategoryId())) {
 
-						final Map<Assignment, GbGradeInfo> grades = CategoryColumnCellPanel.this.businessService
-								.getGradesForStudent(studentUuid);
 						final Double categoryAverage = CategoryColumnCellPanel.this.businessService.getCategoryScoreForStudent(categoryId,
-								studentUuid, grades);
+								studentUuid);
 
 						final String newCategoryAverage = (categoryAverage == null) ? getString("label.nocategoryscore")
 								: FormatHelper.formatDoubleAsPercentage(categoryAverage);
 						((Model<String>) getDefaultModel()).setObject(newCategoryAverage);
 
-						this.getParent().add(new AttributeAppender("class", "gb-score-dynamically-updated"));
+						getParent().add(new AttributeAppender("class", "gb-score-dynamically-updated"));
 
 						scoreChangedEvent.getTarget().add(this);
 						scoreChangedEvent.getTarget().appendJavaScript(

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -74,7 +74,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 				categoryNames.add(categoryName);
 				categoryNamesToAssignments.put(categoryName, new ArrayList<Assignment>());
 
-				final Double categoryAverage = this.businessService.getCategoryScoreForStudent(assignment.getCategoryId(), userId, grades);
+				final Double categoryAverage = this.businessService.getCategoryScoreForStudent(assignment.getCategoryId(), userId);
 				if (categoryAverage == null || categoryName.equals(GradebookPage.UNCATEGORISED)) {
 					categoryAverages.put(categoryName, getString("label.nocategoryscore"));
 				} else {


### PR DESCRIPTION
Refactor the calculateCategoryScore methods and pass the data through `applyDropScores` to ensure the category subtotal respects the settings, for both batch and incremental category score lookups.

Did some performance testing and noticed that a getGradebook lookup takes about 10ms which adds up when you have a large number of students, so ensured that we pass in the Gradebook object where possible, to avoid redundant lookups.

Delivers #1420