### PR TITLE
1628: updated the configuredGradeMappingId once the model is 'saved'

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradingSchemaPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradingSchemaPanel.java
@@ -205,6 +205,8 @@ public class SettingsGradingSchemaPanel extends Panel implements IFormModelUpdat
 		}
 
 		this.model.getObject().getGradebookInformation().setSelectedGradingScaleBottomPercents(bottomPercents);
+
+		this.configuredGradeMappingId = this.currentGradeMappingId;
 	}
 
 	/**


### PR DESCRIPTION
…so the grading schema is updates correctly when changed more than once in the session.

Delivers #1628.