### PR TITLE
1353: Add a basic grade statistics popup

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -306,3 +306,14 @@ no-assignments.label = There are no gradebook items
 no-students.label = There are no students with gradebook entries
 
 gradebookpage.uncategorised = Uncategorized
+
+label.statistics.title = Grade Statistics for {0}
+label.statistics.average = Average
+label.statistics.graded = Graded
+label.statistics.outof = Out of
+label.statistics.gradedoutof = {0} / {1}
+label.statistics.median = Median
+label.statistics.lowest = Lowest
+label.statistics.highest = Highest
+label.statistics.variance = Variance
+label.statistics.deviation = Standard Deviation

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -16,6 +16,7 @@
 	<div wicket:id="gradeLogWindow" />
 	<div wicket:id="gradeCommentWindow" />
 	<div wicket:id="deleteItemWindow" />
+	<div wicket:id="gradeStatisticsWindow" />
     
     <div id="gradebookGrades">
       <div id="gradebookGradesToolbar">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -79,6 +79,7 @@ public class GradebookPage extends BasePage {
 	GbModalWindow gradeLogWindow;
 	GbModalWindow gradeCommentWindow;
 	GbModalWindow deleteItemWindow;
+	GbModalWindow gradeStatisticsWindow;
 
 	Form<Void> form;
 
@@ -121,6 +122,9 @@ public class GradebookPage extends BasePage {
 
 		this.deleteItemWindow = new GbModalWindow("deleteItemWindow");
 		this.form.add(this.deleteItemWindow);
+
+		this.gradeStatisticsWindow = new GbModalWindow("gradeStatisticsWindow");
+		this.form.add(this.gradeStatisticsWindow);
 
 		final AjaxButton addGradeItem = new AjaxButton("addGradeItem") {
 			@Override
@@ -544,6 +548,10 @@ public class GradebookPage extends BasePage {
 
 	public GbModalWindow getDeleteItemWindow() {
 		return this.deleteItemWindow;
+	}
+
+	public GbModalWindow getGradeStatisticsWindow() {
+		return this.gradeStatisticsWindow;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -172,12 +172,16 @@ public class AssignmentColumnHeaderPanel extends Panel {
 
 		});
 
-		menu.add(new Link<Long>("viewAssignmentGradeStatistics", Model.of(assignment.getId())) {
+		menu.add(new AjaxLink<Long>("viewAssignmentGradeStatistics", Model.of(assignment.getId())) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void onClick() {
-				setResponsePage(new GradebookPage());
+			public void onClick(final AjaxRequestTarget target) {
+				final GradebookPage gradebookPage = (GradebookPage) getPage();
+				final GbModalWindow window = gradebookPage.getGradeStatisticsWindow();
+				window.setComponentToReturnFocusTo(getParentCellFor(this));
+				window.setContent(new GradeStatisticsPanel(window.getContentId(), getModel(), window));
+				window.show(target);
 			}
 		});
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+
+<body>
+	<wicket:panel>
+
+		<h3 wicket:id="title">Assignment Statistics</h3>
+
+		<dl class="dl-horizontal">
+			<dt><wicket:message key="label.statistics.graded"></wicket:message></dt>
+			<dd wicket:id="graded"></dd>
+			<dt><wicket:message key="label.statistics.outof"></wicket:message></dt>
+			<dd wicket:id="outof"></dd>
+			<dt><wicket:message key="label.statistics.average"></wicket:message></dt>
+			<dd wicket:id="average"></dd>
+			<dt><wicket:message key="label.statistics.median"></wicket:message></dt>
+			<dd wicket:id="median"></dd>
+			<dt><wicket:message key="label.statistics.lowest"></wicket:message></dt>
+			<dd wicket:id="lowest"></dd>
+			<dt><wicket:message key="label.statistics.highest"></wicket:message></dt>
+			<dd wicket:id="highest"></dd>
+			<dt><wicket:message key="label.statistics.variance"></wicket:message></dt>
+			<dd wicket:id="variance"></dd>
+			<dt><wicket:message key="label.statistics.deviation"></wicket:message></dt>
+			<dd wicket:id="deviation"></dd>
+		</dl>
+
+		<div>
+			<input type="button" wicket:id="done" wicket:message="value:button.done" />
+		</div>
+	</wicket:panel>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
@@ -1,0 +1,135 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Collections;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
+import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
+import org.sakaiproject.service.gradebook.shared.Assignment;
+
+public class GradeStatisticsPanel extends Panel {
+
+	private static final long serialVersionUID = 1L;
+
+	private final ModalWindow window;
+
+	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
+	protected GradebookNgBusinessService businessService;
+
+	public GradeStatisticsPanel(final String id, final IModel<Long> model, final ModalWindow window) {
+		super(id, model);
+		this.window = window;
+	}
+
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+
+		final Long assignmentId = ((Model<Long>) getDefaultModel()).getObject();
+
+		Assignment assignment = businessService.getAssignment(assignmentId.longValue());
+
+		add(new Label("title", new StringResourceModel("label.statistics.title",
+				null, new Object[] { assignment.getName() }).getString()));
+
+		List<GbStudentGradeInfo> gradeInfo = businessService.buildGradeMatrix(Arrays.asList(assignment));
+
+		List<Double> allGrades = new ArrayList<>();
+
+		for (int i=0; i < gradeInfo.size(); i++) {
+			final GbStudentGradeInfo studentGradeInfo = gradeInfo.get(i);
+
+			Map<Long, GbGradeInfo> studentGrades = studentGradeInfo.getGrades();
+			GbGradeInfo grade = studentGrades.get(assignmentId);
+
+			if (grade == null || grade.getGrade() == null) {
+				// this is not the grade you are looking for 
+			} else {
+				allGrades.add(Double.valueOf(grade.getGrade()));
+			}
+		}
+
+		add(new Label("graded", new StringResourceModel("label.statistics.gradedoutof",
+				null, new String[]{
+				String.valueOf(allGrades.size()),
+				String.valueOf(gradeInfo.size())}).getString()));
+		add(new Label("outof", String.valueOf(assignment.getPoints())));
+
+		if (allGrades.size() > 0) {
+			Collections.sort(allGrades);
+			add(new Label("average", String.valueOf(calculateAverage(allGrades))));
+			add(new Label("median", String.valueOf(calculateMedian(allGrades))));
+			add(new Label("lowest", String.valueOf(Collections.min(allGrades))));
+			add(new Label("highest", String.valueOf(Collections.max(allGrades))));
+			add(new Label("variance", String.valueOf(calculateVariance(allGrades))));
+			add(new Label("deviation", String.valueOf(calculateStandardDeviation(allGrades))));
+		} else {
+			add(new Label("average", "-"));
+			add(new Label("median", "-"));
+			add(new Label("lowest", "-"));
+			add(new Label("highest", "-"));
+			add(new Label("variance", "-"));
+			add(new Label("deviation", "-"));
+		}
+
+		add(new AjaxLink<Void>("done") {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void onClick(final AjaxRequestTarget target) {
+				GradeStatisticsPanel.this.window.close(target);
+			}
+		});
+	}
+
+
+	private double calculateAverage(List<Double> allGrades) {
+		double sum = 0;
+		for (int i = 0; i < allGrades.size(); i++) {
+			sum += allGrades.get(i);
+		}
+		return sum / allGrades.size();
+	}
+
+
+	private double calculateMedian(List<Double> allGrades) {
+		int middle = allGrades.size()/2;
+		if (allGrades.size()%2 == 1) {
+			return allGrades.get(middle);
+		} else {
+			return (allGrades.get(middle-1) + allGrades.get(middle)) / 2.0;
+		}
+	}
+
+
+	private double calculateVariance(List<Double> allGrades) {
+		double mean = calculateAverage(allGrades);
+		double sum = 0;
+
+		for (int i = 0; i < allGrades.size(); i++) {
+			double grade = allGrades.get(i);
+			sum += (mean - grade) * (mean - grade);
+		}
+
+		return sum / allGrades.size();
+	}
+
+
+	private double calculateStandardDeviation(List<Double> allGrades) {
+		return Math.sqrt(calculateVariance(allGrades));
+	}
+}


### PR DESCRIPTION
Delivers #1353 with a basic statistics summary, like this:

<img width="1074" alt="screen shot 2016-01-29 at 4 50 53 pm" src="https://cloud.githubusercontent.com/assets/608337/12668242/9aed8910-c6a8-11e5-8ac7-cf574ab48ca8.png">

I understand the issue describes some sort of graph representation... perhaps we can add that as a nice to have outside of this requirement, which may be to just show the hard data?
