### PR TITLE
1560: disabled checkbox label styles

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.html
@@ -25,7 +25,7 @@
 					<div class="checkbox">
 						<label>
 							<input wicket:id="extraCredit" type="checkbox" />
-							<wicket:message key="label.addgradeitem.extracredit" />
+							<span><wicket:message key="label.addgradeitem.extracredit" /></span>
 						</label>
 					</div>
 				</div>
@@ -90,7 +90,7 @@
 					<div class="checkbox">
 						<label>
 							<input wicket:id="released" type="checkbox" />
-							<wicket:message key="label.addgradeitem.release" />
+							<span><wicket:message key="label.addgradeitem.release" /></span>
 						</label>
 					</div>
 				</div>
@@ -100,7 +100,7 @@
 					<div class="checkbox">
 						<label>
 							<input wicket:id="counted" type="checkbox" />
-							<wicket:message key="label.addgradeitem.include" />
+							<span><wicket:message key="label.addgradeitem.include" /></span>
 						</label>
 					</div>
 				</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
@@ -143,6 +143,7 @@ public class AddOrEditGradeItemPanelContent extends Panel {
 			}
 		};
 		extraCredit.setOutputMarkupId(true);
+		extraCredit.setEnabled(!assignment.isCategoryExtraCredit());
 		add(extraCredit);
 
 		// released

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -1012,6 +1012,12 @@ ul.feedbackPanel li span {
 .radio input[type="radio"][disabled]{
   background-color: #eee;
 }
+.checkbox input[type="checkbox"][disabled]+span,
+.radio input[type="radio"][disabled]+span,
+.checkbox input[type="checkbox"][disabled]+label,
+.radio input[type="radio"][disabled]+label{
+  color: #999;
+}
 
 /* Mobile bits and pieces */
 /* Disable fixed columns and headers for small devices */


### PR DESCRIPTION
Delivers #1560 and fixes a bug whereby the extra credit checkbox wasn't disabled when it should be.