### PR TITLE
SAK-30279 Reimplement Citations Picker to use Resources's "Picker hel…

### DIFF
--- a/citations/citations-tool/tool/src/webapp/js/new_resource.js
+++ b/citations/citations-tool/tool/src/webapp/js/new_resource.js
@@ -501,33 +501,11 @@ citations_new_resource.init = function() {
 		return false;
 	});
 	$('#PickResource').on('click', function(eventObject) {
-		var target = $(eventObject.target);
 		var successObj = {
-			linkId				: target.attr('id'),
-			baseUrl			    : target.siblings('.baseUrl').text(),
-			pickerUrl			: target.siblings('.pickerUrl').text(),
-			popupTitle			: target.siblings('.popupTitle').text(),
 			invoke				: function(jsObj) {
-				if(jsObj && jsObj.secondsBetweenSaveciteRefreshes) {
-					citations_new_resource.secondsBetweenSaveciteRefreshes = jsObj.secondsBetweenSaveciteRefreshes;
-				}
-				// If open, close it.
-				if(citations_new_resource.childWindow && citations_new_resource.childWindow[this.linkId] && citations_new_resource.childWindow[this.linkId].close) {
-					citations_new_resource.childWindow[this.linkId].close();
-				}
-				
-				// We need to add this function to the window as the FCK js calls
-				// it when a resource url is clicked.
-                window.top.SetUrl = function(url) {
-                    var baseUrl = $(eventObject.target).siblings('.baseUrl').text();
-                    window.location.href = baseUrl + "&resourceUrl=" + url;
-                };
-                
-				var picker = openWindow(this.pickerUrl,this.popupTitle,'scrollbars=yes,toolbar=yes,resizable=yes,height=' + DEFAULT_DIALOG_HEIGHT + ',width=' + DEFAULT_DIALOG_WIDTH);
-				picker.focus();
-				citations_new_resource.childWindow[this.linkId] = picker;
-				setTimeout(function() { citations_new_resource.watchForUpdates(jsObj.timestamp + 1); }
-								, citations_new_resource.secondsBetweenSaveciteRefreshes * 1000);
+				$('#sakai_action').val('doPickResource');
+				$('#ajaxRequest').val('false');
+				$('#newCitationListForm').submit();
 			}
 		};
 		citations_new_resource.processClick(successObj);

--- a/citations/citations-tool/tool/src/webapp/vm/citation/new_resource.vm
+++ b/citations/citations-tool/tool/src/webapp/vm/citation/new_resource.vm
@@ -136,12 +136,9 @@ span.searchTargetLink { margin-right:50px; }
 
           <li>
 			  <span class="searchTargetLink">
-			    <a name="PickResource" id="PickResource" title="$tlang.getString("resource.pick.resource")"  href="#">
+			    <a name="PickResource" id="PickResource" title="$tlang.getString("resource.pick.resource")"  href="#" onclick="javascript:document.getElementById('sakai_action').value='doPickResource'">
                     $tlang.getString("resource.resourcepicker")</td>
 			    </a>
-			    <span class="baseUrl" style="display:none;">#contentLink("Main")&sakai_action=doImportCitationFromResourceUrl</span>
-				<span class="pickerUrl" style="display:none;">/library/editor/FCKeditor/editor/filemanager/browser/default/browser.html?Connector=/sakai-fck-connector/web/editor/filemanager/browser/default/connectors/jsp/connector/$contentCollectionId&CurrentFolder=$contentCollectionId&langCode=en</span>
-			    <span class="popupTitle" style="display:none;">$tlang.getString("popup.title.resourcepicker")</span>
 			  </span>
           </li>
 		


### PR DESCRIPTION
…per".

1.Redirect from citations helper to filepickerhelper using startHelper
method and set mode to edit_attachment.
2.extractCitationFromRunData extracts citation from attribute
FILE_PICKER_ATTACHMENTS in session.
3.On return from FilePickerHelper, buildEditAttachmentPanel makes use of
the above method to extract citation,set in it state and pass it onto
buildEditPanel.
4.Saving the Citation's ResourceToolAction pipe in the session before it
gets overwritten by the FilePickerAction's ResourceToolAction pipe during
new file upload and then reading it back from session after
FilePickerAction's pipe gets removed.
5.Have set the resourceId and resourceUuid into the state whenever a new
citation list is created. Removed STATE_RESOURCES_ADD attribute from state
in the doReviseCitation method as citation is already created .