### PR TITLE
SAK-30299 fix bug where the replace feature was not migrating content

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -11815,6 +11815,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 					site = addToolToSiteIfMissing(site, missingToolId);
 					commitSite(site);
 				}
+				
+				//now update toolIds to match importTools so that the content is imported
+				toolIds.clear();
+				toolIds.addAll(importTools.keySet());
 			}
 			
 			Map transversalMap = new HashMap();


### PR DESCRIPTION
There is a bug in the import from site code when using the 'replace' option in conjunction with '`site.setup.import.addmissingtools=true`

The feature is intended to both add missing tools and import the content at the same time, which is what happens if the Import from Site option "Merge" is chosen.

However, if the "Replace" content option is chosen in the Import from Site tool, then the Instructor only gets the missing tool added and must invoke the Import from Site tool a second time to import actual content.

This fix resolves the problem and ensures the tool lists are in sync.
