### PR TITLE
[SAK-30260] RWiki Editor Button Fix

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/commentedit.jsp
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/commentedit.jsp
@@ -47,7 +47,7 @@
 	    <!--.AJAX based edit.-->
 	    <!--<form action="?#" method="post" onsubmit="ajaxRefPopupPost(this,'?#',2,this); return false;" >-->
 	    <nobr><c:out value="${rlb.jsp_edit_comment}"/></nobr><br/>
-		<textarea cols="40" rows="10" name="content" id="content" ><c:out value="${currentRWikiObject.content}"/></textarea>
+		<textarea cols="40" rows="10" name="content" id="wiki-textarea-content" ><c:out value="${currentRWikiObject.content}"/></textarea>
 		<input type="hidden" name="action" value="commenteditsave"/>
 		<input type="hidden" name="panel" value="Main"/>
 		<input type="hidden" name="version" value="${currentRWikiObject.version.time}"/>

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/commentnew.jsp
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/commentnew.jsp
@@ -35,8 +35,8 @@
   
   <div class="rwiki_help_popup" >
 	    <form action="?#" method="post" >
-	    <nobr><label for="content"><c:out value="${rlb.jsp_new_comment}"/></label></nobr><br/>
-		<textarea cols="40" rows="10" name="content" id="content" >&#160;</textarea>
+	    <nobr><label for="wiki-textarea-content"><c:out value="${rlb.jsp_new_comment}"/></label></nobr><br/>
+		<textarea cols="40" rows="10" name="content" id="wiki-textarea-content" >&#160;</textarea>
 		<input type="hidden" name="action" value="commentnewsave"/>
 		<input type="hidden" name="panel" value="Main"/>
 		<input type="hidden" name="version" value="${currentRWikiObject.version.time}"/>

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/edit.jsp
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/edit.jsp
@@ -56,7 +56,7 @@
       <jsp:expression>request.getAttribute("sakai.html.head")</jsp:expression>
     </head>
     <jsp:element name="body">
-      <jsp:attribute name="onload">setMainFrameHeightNoScroll('<jsp:expression>request.getAttribute("sakai.tool.placement.id")</jsp:expression>');autoSaveOn('pageName','pageVersion','content','restoreContent','restoreVersion','restoreDate','autosave','tabHeadOff','<c:out value="${requestScope.rsacMap.loadAutoSave}" />');setFocus(focus_path);parent.updCourier(doubleDeep,ignoreCourier); callAllLoaders(); </jsp:attribute>
+      <jsp:attribute name="onload">setMainFrameHeightNoScroll('<jsp:expression>request.getAttribute("sakai.tool.placement.id")</jsp:expression>');autoSaveOn('pageName','pageVersion','wiki-textarea-content','restoreContent','restoreVersion','restoreDate','autosave','tabHeadOff','<c:out value="${requestScope.rsacMap.loadAutoSave}" />');setFocus(focus_path);parent.updCourier(doubleDeep,ignoreCourier); callAllLoaders(); </jsp:attribute>
       <jsp:directive.include file="header.jsp"/>
       <div id="rwiki_container">
       	<div class="portletBody">
@@ -117,7 +117,7 @@
 			   		<jsp:attribute name="class" >tabhead</jsp:attribute>
 			   		<jsp:attribute name="title" ><c:out value="${rlb.jsp_preview}"/></jsp:attribute>
 		        	<jsp:body>
-				   		<a href="#" onClick="selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOff','tabOn','editTab','tabOn','tabOff','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOff','tabHeadOn','edit','tabHeadOn','tabHeadOff'); previewContent('content','previewContent', 'pageVersion', 'realm','pageName','?' ); return false;" ><c:out value="${rlb.jsp_preview}"/></a>
+				   		<a href="#" onClick="selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOff','tabOn','editTab','tabOn','tabOff','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOff','tabHeadOn','edit','tabHeadOn','tabHeadOff'); previewContent('wiki-textarea-content','previewContent', 'pageVersion', 'realm','pageName','?' ); return false;" ><c:out value="${rlb.jsp_preview}"/></a>
 				    </jsp:body>
 				</jsp:element>
 		    </li>
@@ -196,7 +196,7 @@
 						<div id="textarea_outer_sizing_divx">
 						  <div id="textarea_inner_sizing_divx">
 						    <jsp:directive.include file="edittoolbar.jsp"/>
-						    <textarea cols="60" rows="25" name="content" id="content" onselect="storeCaret(this)" onclick="storeCaret(this)" onkeyup="storeCaret(this)" >
+						    <textarea cols="60" rows="25" name="content" id="wiki-textarea-content" onselect="storeCaret(this)" onclick="storeCaret(this)" onkeyup="storeCaret(this)" >
 						      <c:choose>
 							   <c:when test="${editBean.saveType eq 'preview' or fn:startsWith(editBean.saveType, 'attach')}">
 							    <c:out value="${editBean.previousContent}"/>
@@ -279,7 +279,7 @@
 			   				<jsp:attribute name="id" >restoreButton</jsp:attribute>
 			   				<jsp:attribute name="name" >restoreButton</jsp:attribute>
 			   				<jsp:attribute name="title" ><c:out value="${rlb.jsp_button_restore_saved_edit}"/></jsp:attribute>
-			   				<jsp:attribute name="onClick" >restoreSavedContent('pageVersion', 'content', 'restoreContent','restoreVersion','restoreDate','autosave','autoSaveOffClass' ); selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOn','tabOff','editTab','tabOff','tabOn','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOn','tabHeadOff','edit','tabHeadOff','tabHeadOn'); return false;</jsp:attribute>
+			   				<jsp:attribute name="onClick" >restoreSavedContent('pageVersion', 'wiki-textarea-content', 'restoreContent','restoreVersion','restoreDate','autosave','autoSaveOffClass' ); selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOn','tabOff','editTab','tabOff','tabOn','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOn','tabHeadOff','edit','tabHeadOff','tabHeadOn'); return false;</jsp:attribute>
 						</jsp:element>	
 		   			</p>
 		    	   	<p class="shorttext">

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/presencechat.jsp
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/presencechat.jsp
@@ -36,7 +36,7 @@
 <div class="rwiki_comments" >	
 <form action="?#" method="post" onsubmit="ajaxRefPopupPost(this,'?#',2,this); return false;" >
 	    <c:out value="${rlb.jsp_edit_comment}"/><br/>
-		<textarea cols="40" rows="5" name="content" id="content" >
+		<textarea cols="40" rows="5" name="content" id="wiki-textarea-content" >
 		</textarea>
 		<input type="hidden" name="action" value="chateditsave"/>
 		<input type="hidden" name="panel" value="Main"/>

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/edit.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/edit.vm
@@ -102,7 +102,7 @@
 		    </li>
 		    <li id="preview" class="tabHeadOff"  >
 		    	<p class="tabhead specialLink" title="${rlb.jsp_preview}">
-				   		<a href="#" onClick="selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOff','tabOn','editTab','tabOn','tabOff','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOff','tabHeadOn','edit','tabHeadOn','tabHeadOff'); previewContent('content','previewContent', 'pageVersion', 'realm','pageName','?' ); return false;" >
+				   		<a href="#" onClick="selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOff','tabOn','editTab','tabOn','tabOff','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOff','tabHeadOn','edit','tabHeadOn','tabHeadOff'); previewContent('wiki-textarea-content','previewContent', 'pageVersion', 'realm','pageName','?' ); return false;" >
 				   		${rlb.jsp_preview}
 				   		</a>
 				</p>		
@@ -168,20 +168,20 @@
 						        <div id="textarea_inner_sizing_divx">
 						           #edittoolbar()
 						           #if ( ${editBean.saveType} && ("preview" ==  ${editBean.saveType}|| ${editBean.saveType.startsWith("attach")}) )
-								   <label for="content" class="hidden">${rlb.jsp_edit_content_label}</label>
+								   <label for="wiki-textarea-content" class="hidden">${rlb.jsp_edit_content_label}</label>
 						           <textarea cols="60" 
 						                     rows="25" 
 						                     name="content" 
-						                     id="content" 
+						                     id="wiki-textarea-content" 
 						                     onselect="storeCaret(this)" 
 						                     onclick="storeCaret(this)" 
 						                     onkeyup="storeCaret(this)" >${util.escapeHtml($editBean.previousContent)}</textarea>
 						 	         #else
-								   <label for="content" class="hidden">${rlb.jsp_edit_content_label}</label>
+								   <label for="wiki-textarea-content" class="hidden">${rlb.jsp_edit_content_label}</label>
 						           <textarea cols="60" 
 						                     rows="25" 
 						                     name="content" 
-						                     id="content" 
+						                     id="wiki-textarea-content" 
 						                     onselect="storeCaret(this)" 
 						                     onclick="storeCaret(this)" 
 						                     onkeyup="storeCaret(this)" >${util.escapeHtml($currentRWikiObject.content)}</textarea>
@@ -264,9 +264,9 @@
 <script type="text/javascript" >
 #if ( ${editBean.saveType} && ("preview" ==  ${editBean.saveType}|| ${editBean.saveType.startsWith("attach")}) )
 ## If we have a preview or attach, then dont set the restore
-WikiAutoSave_autoSaveOn('realm', 'pageName','pageVersion','restoreTimestamp','content','restoreContent','restoreVersion','restoreDate','autosave','autoSaveOffClass');
+WikiAutoSave_autoSaveOn('realm', 'pageName','pageVersion','restoreTimestamp','wiki-textarea-content','restoreContent','restoreVersion','restoreDate','autosave','autoSaveOffClass');
 #else
-WikiAutoSave_autoSaveOn('realm', 'pageName','pageVersion','restoreTimestamp','content','restoreContent','restoreVersion','restoreDate','autosave','tabHeadOff');
+WikiAutoSave_autoSaveOn('realm', 'pageName','pageVersion','restoreTimestamp','wiki-textarea-content','restoreContent','restoreVersion','restoreDate','autosave','tabHeadOff');
 #end
 </script>
 

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
@@ -481,7 +481,7 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonBold" 
-   onclick="addMarkup('content','bold','__','__'); return false;" >
+   onclick="addMarkup('wiki-textarea-content','bold','__','__'); return false;" >
    <img src="/library/image/transparent.gif" 
         border="0"   
         title="${rlb.jsp_toolb_bold}" 
@@ -489,7 +489,7 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonItalic" 
-   onclick="addMarkup('content','italic','~~','~~'); return false;" >
+   onclick="addMarkup('wiki-textarea-content','italic','~~','~~'); return false;" >
    <img src="/library/image/transparent.gif" 
         border="0"  
         title="${rlb.jsp_toolb_italic}" 
@@ -497,7 +497,7 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonSuper" 
-   onclick="addMarkup('content','super','^^','^^'); return false;"  >
+   onclick="addMarkup('wiki-textarea-content','super','^^','^^'); return false;"  >
    <img src="/library/image/transparent.gif" 
         border="0" 
         title="${rlb.jsp_toolb_superscript}" 
@@ -505,14 +505,14 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonSub" 
-   onclick="addMarkup('content','sub','%%','%%'); return false;"  >
+   onclick="addMarkup('wiki-textarea-content','sub','%%','%%'); return false;"  >
    <img src="/library/image/transparent.gif" 
         border="0" 
         title="${rlb.jsp_toolb_subscript}" 
         alt="${rlb.jsp_toolb_subscript}" /></a>
 <select name="toolbarButtonHeading" 
         id="toobarButtonHeading" 
-        onChange="if ( this.value != 'none' ) { addMarkup('content','Heading 1','\n'+this.value+' ','\n'); this.value = 'none'; } return false;" >
+        onChange="if ( this.value != 'none' ) { addMarkup('wiki-textarea-content','Heading 1','\n'+this.value+' ','\n'); this.value = 'none'; } return false;" >
 	   <option value="none" >${rlb.jsp_toolb_headings}</option>
 	   <option value="h1">${rlb.jsp_toolb_heading} 1</option>
 	   <option value="h2">${rlb.jsp_toolb_heading} 2</option>
@@ -524,7 +524,7 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonTable" 
-   onclick="addMarkup('content','${rlb.jsp_table_macro_markup}','{table}\n','\n{table}'); return false;" >
+   onclick="addMarkup('wiki-textarea-content','${rlb.jsp_table_macro_markup}','{table}\n','\n{table}'); return false;" >
    <img src="/library/image/transparent.gif" 
         border="0" 
         title="${rlb.jsp_toolb_table}" 
@@ -532,7 +532,7 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonLink" 
-   onclick="addAttachment('content','editForm','editControl', 'link'); return false;"   >
+   onclick="addAttachment('wiki-textarea-content','editForm','editControl', 'link'); return false;"   >
    <img src="/library/image/transparent.gif" 
         border="0" 
         title="${rlb.jsp_toolb_link}" 
@@ -540,7 +540,7 @@ function togglePresence(target) {
 <a class="editToolBar" 
    href="#" 
    id="toolbarButtonImage" 
-   onclick="addAttachment('content','editForm', 'editControl', 'embed'); return false;"   >
+   onclick="addAttachment('wiki-textarea-content','editForm', 'editControl', 'embed'); return false;"   >
    <img src="/library/image/transparent.gif" 
         border="0" 
         title="${rlb.jsp_toolb_image}" 
@@ -567,7 +567,7 @@ function togglePresence(target) {
 <a class="autosaveToolBar" 
 			href="#" 
 			id="toolbarButtonRecover" 
-		    			    onClick="WikiAutoSave_restoreSavedContent('pageVersion', 'content', 'restoreContent','restoreVersion','restoreDate','autosave','autoSaveOffClass' ); selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOn','tabOff','editTab','tabOff','tabOn','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOn','tabHeadOff','edit','tabHeadOff','tabHeadOn'); return false;"
+		    			    onClick="WikiAutoSave_restoreSavedContent('pageVersion', 'wiki-textarea-content', 'restoreContent','restoreVersion','restoreDate','autosave','autoSaveOffClass' ); selectTabs('autosaveTab','tabOn','tabOff','previewTab','tabOn','tabOff','editTab','tabOff','tabOn','autosave','tabHeadOn','tabHeadOff','preview','tabHeadOn','tabHeadOff','edit','tabHeadOff','tabHeadOn'); return false;"
 		    			    >
 			<img src="/library/image/transparent.gif" 
 								border="0"   

--- a/rwiki/rwiki-tool/tool/src/webapp/scripts/stateswitcher.js
+++ b/rwiki/rwiki-tool/tool/src/webapp/scripts/stateswitcher.js
@@ -87,6 +87,7 @@ function onload() {
   }
 
 }
+
 function storeCaret(el) {
     if ( el.createTextRange ) 
         el.caretPos = document.selection.createRange().duplicate();

--- a/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
+++ b/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
@@ -91,13 +91,46 @@ div.tabOn {
 li.autoSaveOffClass { display: none }
 #rwiki_container { height: 100%; width: 100% }
 #guillotineFixer { clear: both }
+
+/* Stop deleting stuff and not testing it :( */
+#toolbarButtonSave {
+	background: url(/library/image/silk/page_save.png) center center no-repeat
+}
+#toolbarButtonBold {
+	background: url(/library/image/silk/text_bold.png) center center no-repeat
+}
+#toolbarButtonItalic {
+	background: url(/library/image/silk/text_italic.png) center center no-repeat
+}
+#toolbarButtonSuper {
+	background: url(/library/image/silk/text_superscript.png) center center no-repeat
+}
+#toolbarButtonSub {
+	background: url(/library/image/silk/text_subscript.png) center center no-repeat
+}
+#toolbarButtonHeading { }
+#toolbarButtonTable {
+	background: url(/library/image/silk/table.png) center center no-repeat
+}
+#toolbarButtonLink {
+	background: url(/library/image/silk/page_link.png) center center no-repeat
+}
+#toolbarButtonImage {
+	background: url(/library/image/silk/picture.png) center center no-repeat
+}
+#toolbarButtonRecover {
+	background: url(/library/image/silk/arrow_undo.png) center center no-repeat;
+	height: 1.7em;
+	vertical-align: middle
+}
+
+
 #toolbarButtonRecover {
 	height: 1.7em;
 	vertical-align: middle
 }
 .editToolBarContainer,.previewToolBarContainer,.autosaveToolBarContainer  {
 	background-color: #efefde;
-	height: 1.7em;
 	padding: 3px;
 	border: 1px solid #ccc
 }


### PR DESCRIPTION
This includes a previous CSS change for getting the buttons in the RWiki editor to appear, as well as a change in the id of the rwiki textareas to prevent conflicting ids with the rest of sakai since tools are no longer being embedded in iframes.

The main issue with the handlers attached to the buttons was that the id of the textarea was set to "content" which is used elsewhere in the morpheus portal, causing a conflict. Thus, changes were being made to the wrong element.

Essentially, this change makes the functionality of the editor buttons (i.e. bold, italic, etc) work again.