### PR TITLE
SAK-30310; gradebook 2 won't show inline

### DIFF
--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ByteArrayServletResponse.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ByteArrayServletResponse.java
@@ -50,7 +50,7 @@ public class ByteArrayServletResponse extends HttpServletResponseWrapper
 
 	private boolean isCommitted = false;
 
-	private int contentLength = -1;
+	private long contentLength = -1L;
 
 	private String redirect = null;
 
@@ -126,6 +126,11 @@ public class ByteArrayServletResponse extends HttpServletResponseWrapper
 	@Override
 	public void setContentLength(int i)
 	{
+		contentLength = (long)i;
+	}
+
+	public void setContentLengthLong(long i)
+	{
 		contentLength = i;
 	}
 
@@ -152,7 +157,7 @@ public class ByteArrayServletResponse extends HttpServletResponseWrapper
 	{
 		// System.out.println("Forwarding request CT="+contentType+" CL="+contentLength);
 		if ( contentType != null ) super.setContentType(contentType);
-		if ( contentLength > 0 ) super.setContentLength(contentLength);
+		if ( contentLength > 0L ) super.setContentLength((int)contentLength);
 		ServletOutputStream output = super.getOutputStream();
 		if ( redirect != null ) super.sendRedirect(redirect);
 		outStream.getContent().writeTo(output);


### PR DESCRIPTION
See jira for details. This adds support (sort of) to a wrapper for setContentLengthLong. That is used by Gradebook 2, probably as of Tomcat 8. Because the Java interface doesn't contain this method, I actually truncate to 32 bits and use the old interface to implement it. I don't believe the code involved will ever be used to download huge files, so I think this is OK. To do it for real would be complex. I'm willing to do the complexity, but so far I haven't found a way to generate a case that uses the code, so I couldn't test it.

With this patch Gradebook 2 seems to work inline.