### PR TITLE
SAK-30080 Activate create button when using mouse.

### DIFF
--- a/user/user-tool/tool/src/webapp/js/userCreateValidation.js
+++ b/user/user-tool/tool/src/webapp/js/userCreateValidation.js
@@ -155,5 +155,9 @@ jQuery(document).ready(function () {
         USER.passwordValid = true;
         USER.passwordsMatch = true;
     }
+    if (!USER.get("email") || !USER.get("email").required )
+    {
+        USER.emailValid = true;
+    }
     USER.validateForm();
 });


### PR DESCRIPTION
If you tab through the fields on a new account page on the !gateway site then the create user button correctly appears, but if you click with the mouse it always thinks the email address is invalid because it’s validator never gets called. Here we pre-check if we need to validate the email.