### PR TITLE
SAK-27971 Fix links to stats with user’s name has “‘“

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
@@ -120,10 +120,6 @@ public class MessageForumStatisticsBean {
 		public void setSiteUser(String newValue){
 			this.siteUser = newValue;
 		}
-		
-		public String getEscapedSiteUser(){
-			return this.siteUser.replaceAll("'", "\\\\'");
-		}
 
 		public String getSiteUserId(){
 			return this.siteUserId;
@@ -349,7 +345,6 @@ public class MessageForumStatisticsBean {
 	private static final String PERCENT_READ_SORT = "sort_by_percent_read";
 	private static final String GRADE_SORT = "sort_by_grade";
 	private static final String SITE_USER_ID = "siteUserId";
-	private static final String SITE_USER = "siteUser";
 	private static final String FORUM_TITLE_SORT = "sort_by_forum_title";
 	private static final String TOPIC_TITLE_SORT = "sort_by_topic_title";
 	private static final String FORUM_DATE_SORT = "sort_by_forum_date";

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
@@ -418,7 +418,6 @@
                     <h:outputText value=" #{msgs.cdfm_me}" rendered="#{message.currentUserAndAnonymous}" />
                     <h:commandLink action="#{mfStatisticsBean.processActionStatisticsUser}" immediate="true" title=" #{message.anonAwareAuthor}" rendered="#{ForumTool.instructor && !message.useAnonymousId}" styleClass="#{message.useAnonymousId ? 'anonymousAuthor' : ''}">
                         <f:param value="#{message.authorEid}" name="siteUserId"/>
-                        <f:param value="#{message.message.author}" name="siteUser"/>
                         <h:outputText value="#{message.anonAwareAuthor}" />
                     </h:commandLink>
 				</h:panelGroup>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewMessage.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewMessage.jsp
@@ -236,7 +236,6 @@
 						<h:outputText value=" #{msgs.cdfm_me}" styleClass="textPanelFooter" rendered="#{ForumTool.selectedMessage.currentUserAndAnonymous}" />
 						<h:commandLink action="#{mfStatisticsBean.processActionStatisticsUser}" immediate="true" title=" #{ForumTool.selectedMessage.anonAwareAuthor }" styleClass="textPanelFooter #{ForumTool.selectedMessage.useAnonymousId ? 'anonymousAuthor' : ''}" rendered="#{ForumTool.instructor && !ForumTool.selectedMessage.useAnonymousId}">
                         	<f:param value="#{ForumTool.selectedMessage.authorEid}" name="siteUserId"/>
-                        	<f:param value="#{ForumTool.selectedMessage.message.author}" name="siteUser"/>
                         	<h:outputText value="#{ForumTool.selectedMessage.anonAwareAuthor}"/>
                         </h:commandLink>
 						<h:outputText value=" #{msgs.cdfm_openb} "  styleClass="textPanelFooter" />

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThreadBodyInclude.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThreadBodyInclude.jsp
@@ -63,7 +63,6 @@
                 <f:verbatim><span class="md"></f:verbatim>
                 <h:commandLink action="#{mfStatisticsBean.processActionStatisticsUser}" immediate="true" title=" #{message.anonAwareAuthor }" rendered="#{ForumTool.instructor && !message.useAnonymousId}" styleClass="textPanelFooter md #{message.read ? '' : 'unreadMsg'} #{message.useAnonymousId ? 'anonymousAuthor' : ''}">
                     <f:param value="#{message.authorEid}" name="siteUserId"/>
-                    <f:param value="#{message.message.author}" name="siteUser"/>
                     <h:outputText value="  #{message.anonAwareAuthor}"/>
                 </h:commandLink>
 

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsList.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsList.jsp
@@ -43,7 +43,6 @@
   				</f:facet>
   				<h:commandLink action="#{mfStatisticsBean.processActionStatisticsUser}" immediate="true">
   				    <f:param value="#{stat.siteUserId}" name="siteUserId"/>
-  				    <f:param value="#{stat.escapedSiteUser}" name="siteUser"/>
   				    <h:outputText rendered="#{!stat.useAnonId}" value="#{stat.siteUser}" />
   				    <h:outputText rendered="#{stat.useAnonId}" value="#{stat.siteAnonId}" styleClass="anonymousAuthor"/>
 	          	</h:commandLink>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsListByTopic.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsListByTopic.jsp
@@ -244,7 +244,6 @@
   				<h:outputLink value="/tool/#{ForumTool.currentToolId}/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser" target="dialogFrame"
 					onclick="dialogLinkClick(this);">
 					<f:param value="#{stat.siteUserId}" name="siteUserId"/>
-  				    <f:param value="#{stat.escapedSiteUser}" name="siteUser"/>
   				    <f:param value="dialogDiv" name="dialogDivId"/>
 					<f:param value="dialogFrame" name="frameId"/>
 					<h:outputText rendered="#{!stat.useAnonId}" value="#{stat.siteUser}" />
@@ -257,7 +256,6 @@
   				</f:facet>
   				<h:commandLink action="#{mfStatisticsBean.processActionStatisticsUser}" immediate="true" styleClass="font-size: small">
   				    <f:param value="#{stat.siteUserId}" name="siteUserId"/>
-  				    <f:param value="#{stat.escapedSiteUser}" name="siteUser"/>
 				   	<h:outputText value="#{msgs.stat_forum_details}" />
 	          	</h:commandLink>
   			</h:column>


### PR DESCRIPTION
If the user’s name had a ‘ in it then it would break the JavaScript that was used to activate the link and cause the tool to stop working. The users name doesn’t actually need to passed, just the ID and so we can just drop all the code that passes the users name.