### PR TITLE
SAK-30148 - Allow for setting the defaults for the copy template options

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2843,6 +2843,12 @@
 # DEFAULT: false
 # site.setup.showSiteIdColumn=true
 
+### SAK-30148 Changing default checked for copy template options feature
+# DEFAULT: false for all
+# site.setup.copyUsersChecked=true
+# site.setup.copyContentChecked=true
+# site.setup.publishSiteChecked=true
+
 ### SAK-23567 Flexible way to shorten site title in tabs
 ## Max length for site title display 
 # DEFAULT: 25 characters 

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1707,6 +1707,9 @@ public class SiteAction extends PagedResourceActionII {
 			}
 			context.put("siteTypes", types);
 			context.put("templateControls", ServerConfigurationService.getString("templateControls", ""));
+			context.put("copyUsersChecked", ServerConfigurationService.getBoolean("site.setup.copyUsersChecked", false));
+			context.put("copyContentChecked", ServerConfigurationService.getBoolean("site.setup.copyContentChecked", false));
+			context.put("publishSiteChecked", ServerConfigurationService.getBoolean("site.setup.publishSiteChecked", false));
 			// put selected/default site type into context
 			String typeSelected = (String) state.getAttribute(STATE_TYPE_SELECTED);
 			context.put("typeSelected", state.getAttribute(STATE_TYPE_SELECTED) != null?state.getAttribute(STATE_TYPE_SELECTED):types.get(0));

--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -340,7 +340,6 @@ sakai.siteTypeSetup = function(){
             $('#templateList #row' + selectedTemplateId  + ' .templateSettingsPlaceholder').append($('#allTemplateSettings'));
             // hide instructions for settings
             $('#fromTemplateSettingsContainer_instruction_body').hide();
-            $('#publishSiteWrapper input').prop('checked', false);
 
             //templateControls is a json that comes from a sakai.property
             //it identifies for each site type, whether to show a control, and what attrs it has. 
@@ -354,12 +353,6 @@ sakai.siteTypeSetup = function(){
                         else {
                             $('#copyContentWrapper').hide();
                             $('#fromTemplateSettingsContainer_instruction_body_copyUsers').hide();
-                        }
-                        if (this.copyContentChecked === true) {
-                            $('#copyContentWrapper input').prop('checked', true);
-                        }
-                        else {
-                            $('#copyContentWrapper input').prop('checked', false);
                         }
                         //SAK25401
                         if (this.copyContentLocked === true) {
@@ -381,12 +374,6 @@ sakai.siteTypeSetup = function(){
                             $('#copyUsersWrapper').hide();
                             $('#fromTemplateSettingsContainer_instruction_body_copyContent').hide();
                         }
-                        if (this.copyUsersChecked === true) {
-                            $('#copyUsersWrapper input').prop('checked', true);
-                        }
-                        else {
-                            $('#copyUsersWrapper input').prop('checked', false);
-                        }
                         if (this.copyUsersLocked === true) {
                             $('#copyUsersWrapper input').prop('disabled', true);
                         }
@@ -398,8 +385,8 @@ sakai.siteTypeSetup = function(){
             }
             else {
                 //show all the controls, unchecked, unlocked, since there are no settings
-                $('#copyContentWrapper').show().find('input').prop('disabled', false).prop('checked',false);
-                $('#copyUsersWrapper').show().find('input').prop('disabled', false).prop('checked',false);
+                $('#copyContentWrapper').show().find('input').prop('disabled', false);
+                $('#copyUsersWrapper').show().find('input').prop('disabled', false);
                 $('#fromTemplateSettingsContainer_instruction_body_copyUsers').show();
                 $('#fromTemplateSettingsContainer_instruction_body_copyContent').show();
             }

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-type.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-type.vm
@@ -153,17 +153,17 @@
                     </div>
                     <div id="fromTemplateSettingsContainer">
                         <span id="copyUsersWrapper">
-                            <input type="checkbox" name="copyUsers" id="copyUsers" value="true"/>
+                            <input type="checkbox" name="copyUsers" #if ($copyUsersChecked) checked="checked" #end id="copyUsers" value="true"/>
                             <label for="copyUsers">$tlang.getString("sitetype.copyusers")</label>
                         </span>
-                        <span id="copyContentWrapper">
-                            <input type="checkbox" name="copyContent" id="copyContent" value="true"/>
+                        <span id="copyContentWrapper"> 
+                            <input type="checkbox" name="copyContent" #if ($copyContentChecked) checked="checked" #end id="copyContent" value="true"/>
                             #* SAK25401 *#
                             <input type="checkbox" name="lockedContent" id="lockedContent" checked="checked" disabled="disabled" style="display:none" />                            
                             <label for="copyContent">$tlang.getString("sitetype.copycontent")</label>
                         </span>
                         <span id="publishSiteWrapper">
-                            <input type="checkbox" name="publishSite" id="publishSite" value="true"/>
+                            <input type="checkbox" name="publishSite" #if ($publishSiteChecked) checked="checked" #end id="publishSite" value="true"/>
                             <label for="publishSite">$tlang.getString("sitetype.publishSite")</label>
                         </span>
                         <span id="fromTemplateSettingsContainer_instruction">


### PR DESCRIPTION
So I'm not 100% sure why this javascript was even turning these off but it really stumped me why this fix was so hard. It feels like this is useless javascript that came in in SAK-22450. The values of these checkboxes don't persist and seem like they should be either checked or unchecked at the time of page creation.