### PR TITLE
SAK-30318 Upgrade to JRuby 1.7.24

### DIFF
--- a/reference/library/pom.xml
+++ b/reference/library/pom.xml
@@ -215,7 +215,7 @@
 								</goals>
 								<phase>process-resources</phase>
 								<configuration>
-									<jrubyVersion>1.7.20</jrubyVersion>
+									<jrubyVersion>1.7.24</jrubyVersion>
 									<execArgs>${project.build.directory}/rubygems/bin/compass
 										compile -c ${basedir}/src/${sakai.skin.source}/config.rb
 										--css-dir=../webapp/skin/${sakai.skin.target}


### PR DESCRIPTION
This fixes an edge case build error with JRuby versions < 1.7.23 (versions 1.7.20, 1.7.21, & 1.7.22 affected).

See Jira for the build error debug log.