### PR TITLE
SAK-30321 Cleanup Maven build warnings.

### DIFF
--- a/basiclti/basiclti-blis/pom.xml
+++ b/basiclti/basiclti-blis/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>org.tsugi</groupId>
             <artifactId>tsugi-util</artifactId>
-            <version>${parent.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/basiclti-common/pom.xml
+++ b/basiclti/basiclti-common/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.tsugi</groupId>
             <artifactId>tsugi-util</artifactId>
-            <version>${parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/basiclti/basiclti-impl/pom.xml
+++ b/basiclti/basiclti-impl/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.tsugi</groupId>
             <artifactId>tsugi-util</artifactId>
-	    <version>${parent.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/basiclti-pack/pom.xml
+++ b/basiclti/basiclti-pack/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.tsugi</groupId>
             <artifactId>tsugi-util</artifactId>
-            <version>${parent.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/basiclti-portlet/pom.xml
+++ b/basiclti/basiclti-portlet/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.tsugi</groupId>
             <artifactId>tsugi-util</artifactId>
-            <version>${parent.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/pom.xml
+++ b/basiclti/pom.xml
@@ -158,7 +158,7 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>${project.groupId}</groupId>
+                <groupId>org.tsugi</groupId>
                 <artifactId>tsugi-util</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
There was basically a bad entry in the dependency management section that meant that versions had been introduced for all the tsugi-util dependencies. Fixing this meant we could drop the versions that were causing the maven build warnings.