### PR TITLE
SAM-1239 - Change wording of data discrepancy message

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -451,7 +451,7 @@ assessment_has_been_submitted=This assessment has already been submitted and no 
 assessment_has_been_submitted_url=This assessment has already been submitted and no further amendments are allowed. Please contact your instructor if you have any questions.
 
 data_discrepancy_title=Data Discrepancy
-data_discrepancy_1=You are seeing this page because there might be a discrepancy between which of your answers actually got saved versus what you believe got saved. Two common causes of this discrepancy are:
+data_discrepancy_1=You are seeing this page because there was a problem saving your responses. Two common causes for this issue:
 data_discrepancy_2=When the same assessment is taken in multiple windows
 data_discrepancy_3=When a user did not save his answers before a timed assessment expired
 data_discrepancy_4=In both cases, which answers actually got saved depended on when a user last clicked <b> Next </b> or <b> Exit </b> 


### PR DESCRIPTION
We believe the original message was confusing to the users because it wasn't clear what happened. Longsight has been running with this wording change since 2.8.