### PR TITLE
1353: reformat the grade item statistics popup

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -309,14 +309,15 @@ no-students.label = There are no students with gradebook entries
 gradebookpage.uncategorised = Uncategorized
 
 label.statistics.title = Grade Statistics for {0}
-label.statistics.average = Average
-label.statistics.graded = Graded
-label.statistics.outof = Out of
-label.statistics.gradedoutof = {0} / {1}
-label.statistics.median = Median
-label.statistics.lowest = Lowest
-label.statistics.highest = Highest
-label.statistics.variance = Variance
+label.statistics.average = Average (Mean) Score
+label.statistics.averagevalue = {0} / {1} ({2})
+label.statistics.graded = Total Graded Scores
+label.statistics.median = Median Score
+label.statistics.medianvalue = {0} / {1} ({2})
+label.statistics.lowest = Lowest Score
+label.statistics.lowestvalue = {0} / {1} ({2})
+label.statistics.highest = Highest Score
+label.statistics.highestvalue = {0} / {1} ({2})
 label.statistics.deviation = Standard Deviation
 
 coursegrade.option.override = Course Grade Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -11,19 +11,30 @@ import org.apache.commons.lang.StringUtils;
 public class FormatHelper {
 
 	/**
+	 * The value is a double (ie 12.34542) that needs to be formatted as a percentage with two decimal places precision.
+	 * And drop off any .0 if no decimal places.
+	 *
+	 * @param score as a double
+	 * @return double to decimal places
+	 */
+	public static String formatDoubleToTwoDecimalPlaces(final Double score) {
+		final NumberFormat df = NumberFormat.getInstance();
+		df.setMinimumFractionDigits(0);
+		df.setMaximumFractionDigits(2);
+		df.setRoundingMode(RoundingMode.DOWN);
+
+		return formatGrade(df.format(score));
+	}
+
+	/**
 	 * The value is a double (ie 12.34) that needs to be formatted as a percentage with two decimal places precision.
 	 * 
 	 * @param score as a double
 	 * @return percentage to decimal places with a '%' for good measure
 	 */
 	public static String formatDoubleAsPercentage(final Double score) {
-		final NumberFormat df = NumberFormat.getInstance();
-		df.setMinimumFractionDigits(0);
-		df.setMaximumFractionDigits(2);
-		df.setRoundingMode(RoundingMode.DOWN);
-
 		// TODO does the % need to be internationalised?
-		return df.format(score) + "%";
+		return formatDoubleToTwoDecimalPlaces(score) + "%";
 	}
 
 	public static String formatStringAsPercentage(final String string) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.html
@@ -7,22 +7,18 @@
 		<h3 wicket:id="title">Assignment Statistics</h3>
 
 		<dl class="dl-horizontal">
-			<dt><wicket:message key="label.statistics.graded"></wicket:message></dt>
-			<dd wicket:id="graded"></dd>
-			<dt><wicket:message key="label.statistics.outof"></wicket:message></dt>
-			<dd wicket:id="outof"></dd>
 			<dt><wicket:message key="label.statistics.average"></wicket:message></dt>
 			<dd wicket:id="average"></dd>
 			<dt><wicket:message key="label.statistics.median"></wicket:message></dt>
 			<dd wicket:id="median"></dd>
+			<dt><wicket:message key="label.statistics.deviation"></wicket:message></dt>
+			<dd wicket:id="deviation"></dd>
 			<dt><wicket:message key="label.statistics.lowest"></wicket:message></dt>
 			<dd wicket:id="lowest"></dd>
 			<dt><wicket:message key="label.statistics.highest"></wicket:message></dt>
 			<dd wicket:id="highest"></dd>
-			<dt><wicket:message key="label.statistics.variance"></wicket:message></dt>
-			<dd wicket:id="variance"></dd>
-			<dt><wicket:message key="label.statistics.deviation"></wicket:message></dt>
-			<dd wicket:id="deviation"></dd>
+			<dt><wicket:message key="label.statistics.graded"></wicket:message></dt>
+			<dd wicket:id="graded"></dd>
 		</dl>
 
 		<div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
@@ -18,6 +18,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 public class GradeStatisticsPanel extends Panel {
@@ -62,26 +63,20 @@ public class GradeStatisticsPanel extends Panel {
 			}
 		}
 
-		add(new Label("graded", new StringResourceModel("label.statistics.gradedoutof",
-				null, new Object[] {
-						String.valueOf(allGrades.size()),
-						String.valueOf(gradeInfo.size()) }).getString()));
-		add(new Label("outof", String.valueOf(assignment.getPoints())));
+		add(new Label("graded", String.valueOf(allGrades.size())));
 
 		if (allGrades.size() > 0) {
 			Collections.sort(allGrades);
-			add(new Label("average", String.valueOf(calculateAverage(allGrades))));
-			add(new Label("median", String.valueOf(calculateMedian(allGrades))));
-			add(new Label("lowest", String.valueOf(Collections.min(allGrades))));
-			add(new Label("highest", String.valueOf(Collections.max(allGrades))));
-			add(new Label("variance", String.valueOf(calculateVariance(allGrades))));
-			add(new Label("deviation", String.valueOf(calculateStandardDeviation(allGrades))));
+			add(new Label("average", constructAverageLabel(allGrades, assignment)));
+			add(new Label("median", constructMedianLabel(allGrades, assignment)));
+			add(new Label("lowest", constructLowestLabel(allGrades, assignment)));
+			add(new Label("highest", constructHighestLabel(allGrades, assignment)));
+			add(new Label("deviation", constructStandardDeviationLabel(allGrades)));
 		} else {
 			add(new Label("average", "-"));
 			add(new Label("median", "-"));
 			add(new Label("lowest", "-"));
 			add(new Label("highest", "-"));
-			add(new Label("variance", "-"));
 			add(new Label("deviation", "-"));
 		}
 
@@ -93,6 +88,56 @@ public class GradeStatisticsPanel extends Panel {
 				GradeStatisticsPanel.this.window.close(target);
 			}
 		});
+	}
+
+	private String constructAverageLabel(final List<Double> allGrades, final Assignment assignment) {
+		double average = calculateAverage(allGrades);
+		String averageFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(average));
+		Double total = assignment.getPoints();
+		String percentage = FormatHelper.formatDoubleAsPercentage(100 * (average / total.doubleValue()));
+
+		return (new StringResourceModel("label.statistics.averagevalue",
+				null,
+				new Object[] { averageFormatted, FormatHelper.formatGrade(String.valueOf(total)), percentage })).getString();
+	}
+
+	private String constructMedianLabel(final List<Double> allGrades, final Assignment assignment) {
+		double median = calculateMedian(allGrades);
+		String medianFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(median));
+		Double total = assignment.getPoints();
+		String percentage = FormatHelper.formatDoubleAsPercentage(100 * (median / total.doubleValue()));
+
+		return (new StringResourceModel("label.statistics.medianvalue",
+				null,
+				new Object[] { medianFormatted, FormatHelper.formatGrade(String.valueOf(total)), percentage })).getString();
+	}
+
+	private String constructLowestLabel(final List<Double> allGrades, final Assignment assignment) {
+		double lowest = Collections.min(allGrades);
+		String lowestFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(lowest));
+		Double total = assignment.getPoints();
+		String percentage = FormatHelper.formatDoubleAsPercentage(100 * (lowest / total.doubleValue()));
+
+		return (new StringResourceModel("label.statistics.lowestvalue",
+				null,
+				new Object[] { lowestFormatted, FormatHelper.formatGrade(String.valueOf(total)), percentage })).getString();
+	}
+
+	private String constructHighestLabel(final List<Double> allGrades, final Assignment assignment) {
+		double highest = Collections.max(allGrades);
+		String highestFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(highest));
+		Double total = assignment.getPoints();
+		String percentage = FormatHelper.formatDoubleAsPercentage(100 * (highest / total.doubleValue()));
+
+		return new StringResourceModel("label.statistics.highestvalue",
+				null,
+				new Object[] { highestFormatted, FormatHelper.formatGrade(String.valueOf(total)), percentage }).getString();
+	}
+
+	private String constructStandardDeviationLabel(final List<Double> allGrades) {
+		double deviation = calculateStandardDeviation(allGrades);
+
+		return FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(deviation));
 	}
 
 	private double calculateAverage(final List<Double> allGrades) {


### PR DESCRIPTION
Delivers #1353 - but doesn't include the graph (still awaiting confirmation of what the graph should be).  But does include the reformatting of the number statistics to round to 2 decimal places, inline the total points, include the percentage and drop the variance.