### PR TITLE
SAK-29606 Allow manual archive to create ZIPs.

### DIFF
--- a/archive/archive-tool/tool/src/bundle/admin.properties
+++ b/archive/archive-tool/tool/src/bundle/admin.properties
@@ -13,6 +13,7 @@ archive.vm.archive1 		= Archive
 archive.vm.file     		= file
 archive.vm.from     		= from site
 archive.vm.import   		= Import
+archive.vm.zip      		= Zip
 archive.vm.site     		= to site
 archive.button.batch		= Batch Import/Export
 archive.button.single		= Import/Export

--- a/archive/archive-tool/tool/src/webapp/vm/archive/chef_archive.vm
+++ b/archive/archive-tool/tool/src/webapp/vm/archive/chef_archive.vm
@@ -17,6 +17,13 @@
 				$tlang.getString("archive.vm.from")
 			</label>	
 			<input type="text" size="80" name="archive-id" id="archive-id" />
+
+		</p>
+		<p class="shorttext">
+		    <label for="zip-id">
+		        $tlang.getString("archive.vm.zip")
+		    </label>
+			<input type="checkbox" name="zip-id" value="true" id="zip-id" />
 		</p>
 		<p class="act"><input type="submit" name="eventSubmit_doArchive" value="$tlang.getString("archive.vm.archive1")" class="indnt1" /></p>		
 		

--- a/common/archive-api/src/main/java/org/sakaiproject/archive/api/ArchiveService.java
+++ b/common/archive-api/src/main/java/org/sakaiproject/archive/api/ArchiveService.java
@@ -90,8 +90,8 @@ public interface ArchiveService
 	/**
 	 * Archive a site then compress it to a zip. 
 	 * @param siteId - id of site to be archived
-	 * @return true if archive and zip successful, false if not.
+	 * @return A log of messages from creating the archive
 	 * @throws IOException 
 	 */
-	public boolean archiveAndZip(String siteId) throws IOException;
+	public String archiveAndZip(String siteId) throws IOException;
 }

--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/ArchiveService2Impl.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/ArchiveService2Impl.java
@@ -170,9 +170,14 @@ public class ArchiveService2Impl implements ArchiveService
 	}
 
 	@Override
-	public boolean archiveAndZip(String siteId) throws IOException {
-		m_siteArchiver.archive(siteId, m_storagePath, FROM_SAKAI_2_8);
-		return m_siteZipper.zipArchive(siteId, m_storagePath);
+	public String archiveAndZip(String siteId) throws IOException {
+		String log = m_siteArchiver.archive(siteId, m_storagePath, FROM_SAKAI_2_8);
+		if (m_siteZipper.zipArchive(siteId, m_storagePath) ){
+			log = log + "Zipfile success.\n";
+		} else {
+			log = log + "Zipfile failed\n";
+		}
+		return log;
 	}
 	
 } // ArchiveService2Impl


### PR DESCRIPTION
When you manually create a site archive it would just create a folder. Now we give the user the option of creating a ZIP. This also means it shows up in the archives to download.
Also fixed here:
 - an unclosed input stream.
 - not returning when an error occurs downloading the file and rely on the container to not send back the actual data.
 - better path normalisation to ensure people only download files our of the archive.
 - Assume archive folder is relative to sakai.home unless an absolute path is given.