### PR TITLE
SAM-1331 - Property to disable warning of modification to edited quiz

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3094,6 +3094,10 @@
 # DEFAULT: no-reply@serverName
 # samigo.fromAddress=<SAMIGO_SMTP_FROM>
 
+# SAM-1331: Warn user of modification to edited quiz
+# DEFAULT: true
+# samigo.SelectAssessmentBean.warnUserOfModification=false
+
 #########################################
 # WORKSITE SETUP/SITE INFO
 #########################################

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/select/SelectAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/select/SelectAssessmentBean.java
@@ -25,6 +25,9 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.component.cover.ComponentManager;
+
 /**
  * @author <a href="mailto:lance@indiana.edu">Lance Speelmon</a>
  * @version $Id$
@@ -49,10 +52,12 @@ implements Serializable
 	private org.sakaiproject.tool.assessment.ui.model.PagingModel takePager;
 	private boolean hasHighestMultipleSubmission = false;  // this is used to display the message on the bottom if there are any highest multiple submissions. 
 	private boolean hasAnyAssessmentBeenModified = false;  // this is used to display the message on the bottom if there is any assessment been modified after submitted.
+	private Boolean warnUserOfModification;
 	private boolean hasAnyAssessmentRetractForEdit = false;  // this is used to display the message on the bottom if there is any assessment retracted for edit.
 	private String displayAllAssessments = "2"; // display all
 	private boolean hasAverageMultipleSubmissions=false;
 	private String secureDeliveryHTMLFragments;
+	private static final ServerConfigurationService serverConfigurationService= (ServerConfigurationService) ComponentManager.get( ServerConfigurationService.class );
 	
 	/**
 	 * ArrayLists should be lists of DeliveryBean objects
@@ -292,6 +297,17 @@ implements Serializable
 	 */
 	public void setHasAverageMultipleSubmissions(boolean hasAverageMultipleSubmissions) {
 		this.hasAverageMultipleSubmissions = hasAverageMultipleSubmissions;
+	}
+
+	public Boolean getWarnUserOfModification() {
+		if(warnUserOfModification == null){
+			warnUserOfModification = serverConfigurationService.getBoolean("samigo.SelectAssessmentBean.warnUserOfModification", true);
+		}
+		return warnUserOfModification;
+	}
+
+	public void setWarnUserOfModification(Boolean warnUserOfModification) {
+		this.warnUserOfModification = warnUserOfModification;
 	}       
 	
 	public String getSecureDeliveryHTMLFragments() {

--- a/samigo/samigo-app/src/webapp/jsf/select/selectIndex.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/select/selectIndex.jsp
@@ -229,7 +229,7 @@ sorting actions for table:
       </f:facet>
 	
 	<h:outputText value="#{reviewable.assessmentTitle}" styleClass="currentSort"  rendered="#{reviewable.isRecordedAssessment}"  escape="false"/>
-	<h:outputText value="#{selectIndexMessages.asterisk}" rendered="#{reviewable.isRecordedAssessment && reviewable.feedback == 'show' && !reviewable.isAssessmentRetractForEdit && reviewable.hasAssessmentBeenModified}" styleClass="validate"/> 
+	<h:outputText value="#{selectIndexMessages.asterisk}" rendered="#{reviewable.isRecordedAssessment && reviewable.feedback == 'show' && !reviewable.isAssessmentRetractForEdit && reviewable.hasAssessmentBeenModified && select.warnUserOfModification}" styleClass="validate"/> 
 	<h:outputText value="#{selectIndexMessages.asterisk_2}" rendered="#{reviewable.isRecordedAssessment && reviewable.isAssessmentRetractForEdit}" styleClass="validate" />
 	
    </h:column>
@@ -343,7 +343,7 @@ sorting actions for table:
   <f:verbatim><br/></f:verbatim>
   
   <h:panelGrid>
-  <h:outputText value="#{selectIndexMessages.asterisk} #{selectIndexMessages.has_been_modified}" rendered="#{select.hasAnyAssessmentBeenModified}" styleClass="validate"/> 
+  <h:outputText value="#{selectIndexMessages.asterisk} #{selectIndexMessages.has_been_modified}" rendered="#{select.hasAnyAssessmentBeenModified && select.warnUserOfModification}" styleClass="validate"/> 
   <h:outputText value="#{selectIndexMessages.asterisk_2} #{selectIndexMessages.currently_being_edited}" rendered="#{select.hasAnyAssessmentRetractForEdit}" styleClass="validate"/>
   </h:panelGrid>
 


### PR DESCRIPTION
This is a quick fix to allow for a school to disable the warning because it doesn't correctly detect if only minor changes are made (See SAM-1029). I don't think that issue will be resolved anytime in the short term.