### PR TITLE
SAK-30325 send user direct link instead of proxying data from s3/swift

### DIFF
--- a/cloud-content/impl/pom.xml
+++ b/cloud-content/impl/pom.xml
@@ -24,6 +24,10 @@
       <artifactId>sakai-kernel-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sakaiproject.kernel</groupId>
+      <artifactId>sakai-component-manager</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
+++ b/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
@@ -2,8 +2,14 @@ package coza.opencollab.sakai.cloudcontent;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.util.Date;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -11,7 +17,7 @@ import com.google.common.io.Closeables;
 import com.google.inject.Module;
 
 import org.apache.commons.codec.binary.Base64;
-
+import org.apache.commons.codec.digest.DigestUtils;
 import org.jclouds.ContextBuilder;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.BlobStore;
@@ -19,15 +25,14 @@ import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.http.HttpRequest;
 import org.jclouds.io.Payload;
 import org.jclouds.io.Payloads;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
-
 import org.jclouds.aws.s3.AWSS3ProviderMetadata;
 import org.jclouds.openstack.swift.v1.SwiftApiMetadata;
 import org.jclouds.osgi.ApiRegistry;
 import org.jclouds.osgi.ProviderRegistry;
-
 import org.sakaiproject.content.api.FileSystemHandler;
 import org.springframework.util.FileCopyUtils;
 
@@ -84,6 +89,11 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
      * set here, meaning that the buffer should be bounded on it instead.
      */
     private static final int MAX_UPLOAD_BYTES = 1024 * 1024 * 1024;
+    
+    /**
+     * This is how long we want the signed URL to be valid for.
+     */
+    private static final int SIGNED_URL_VALIDITY_SECONDS = 10 * 60;
 
     /**
      * Default constructor.
@@ -181,6 +191,20 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
     /**
      * {@inheritDoc}
      */
+	@Override
+	public URI getAssetDirectLink(String id, String root, String filePath) throws IOException {
+        ContainerAndName can = getContainerAndName(id, root, filePath);
+        HttpRequest hr = context.getSigner().signGetBlob(can.container, can.name, SIGNED_URL_VALIDITY_SECONDS);
+        if (hr == null){
+            throw new IOException("No object found to creat signed url " + id);
+        }
+        
+        return hr.getEndpoint();
+	}
+    
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public InputStream getInputStream(String id, String root, String filePath) throws IOException {
         ContainerAndName can = getContainerAndName(id, root, filePath);
@@ -188,9 +212,52 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
         if (blob == null){
             throw new IOException("No object found for " + id);
         }
-        //we copy this to a byte array first since Sakai does some funny stuff 
-        //and with the stream and then swift and sakai don't play nice.
-        return new ByteArrayInputStream(FileCopyUtils.copyToByteArray(blob.getPayload().openStream()));
+
+        // There are some oddities with streaming larger files to the user,
+        // so download to a temp file first. For now, call 100MB the threshold.
+        long maxStreamSize = 1024 * 1024 * 100;
+
+        StorageMetadata metadata = blob.getMetadata();
+        Long size = metadata.getSize();
+
+        if (size != null && size.longValue() > maxStreamSize) {
+            return streamFromTempFile(blob);
+        } else {
+            return blob.getPayload().openStream();
+        }
+    }
+
+    // Hacky implementation of downloading Blobs to temp files...
+    // This should probably happen in a specified location and use
+    // hashing to be sure of contents before reusing.
+    private InputStream streamFromTempFile(Blob blob) {
+        StorageMetadata metadata = blob.getMetadata();
+        String name = metadata.getName();
+        Date modified = metadata.getLastModified();
+        String filename = name + "-" + modified.getTime();
+        filename = DigestUtils.md5Hex(filename);
+
+        File check = new File(filename + ".tmp");
+        FileInputStream stream = null;
+
+        if (check.exists()) {
+            try {
+                stream = new FileInputStream(check);
+            } catch (FileNotFoundException e) {
+                stream = null;
+            }
+        } else {
+            try {
+                File tmp = File.createTempFile(filename, ".tmp");
+                FileOutputStream fos = new FileOutputStream(tmp);
+                FileCopyUtils.copy(blob.getPayload().openStream(), fos);
+                stream = new FileInputStream(tmp);
+            } catch (IOException e) {
+                stream = null;
+            }
+        }
+
+        return stream;
     }
 
     /**

--- a/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
+++ b/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/BlobStoreFileSystemHandler.java
@@ -33,6 +33,7 @@ import org.jclouds.aws.s3.AWSS3ProviderMetadata;
 import org.jclouds.openstack.swift.v1.SwiftApiMetadata;
 import org.jclouds.osgi.ApiRegistry;
 import org.jclouds.osgi.ProviderRegistry;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.FileSystemHandler;
 import org.springframework.util.FileCopyUtils;
 
@@ -50,6 +51,12 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
      * The BlobStore context (connection).
      */
     private BlobStoreContext context;
+
+    /**
+     * ServerConfigurationService injected via components.xml
+     */
+    private ServerConfigurationService serverConfigurationService;
+
     /**
      * The jclouds provider name to use.
      */
@@ -89,16 +96,30 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
      * set here, meaning that the buffer should be bounded on it instead.
      */
     private static final int MAX_UPLOAD_BYTES = 1024 * 1024 * 1024;
-    
+
     /**
      * This is how long we want the signed URL to be valid for.
      */
     private static final int SIGNED_URL_VALIDITY_SECONDS = 10 * 60;
 
     /**
+     * The largest a blob can be before we write it to temp file to avoid OOMing Tomcat
+     */
+    private static long maxBlobStreamSize = 1024 * 1024 * 100;
+    
+    /** 
+     * A preferred directory to write temporary blobs. Maybe a large, temporary partition?
+     */
+    private static String temporaryBlobDirectory;
+
+    /**
      * Default constructor.
      */
     public BlobStoreFileSystemHandler() {
+    }
+
+    public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+        this.serverConfigurationService = serverConfigurationService;
     }
 
     /**
@@ -179,6 +200,27 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
                 .credentials(identity, credential)
                 .modules(modules)
                 .buildView(BlobStoreContext.class);
+
+        // There are some oddities with streaming larger files to the user,
+        // so download to a temp file first. For now, call 100MB the threshold.
+        maxBlobStreamSize = (long) serverConfigurationService.getInt("cloud.content.maxblobstream.size", 1024 * 1024 * 100);
+        temporaryBlobDirectory = serverConfigurationService.getString("cloud.content.temporary.directory", null);
+        
+        if (temporaryBlobDirectory != null) {
+            File baseDir = new File(temporaryBlobDirectory);
+            if (!baseDir.exists()) {
+                try {
+                    // Can't write into the preferred temp dir
+                    if (!baseDir.mkdirs()) {
+                        temporaryBlobDirectory = null;
+                    }
+                }
+                catch (SecurityException se) {
+                    // JVM security hasn't whitelisted this dir
+                    temporaryBlobDirectory = null;
+                }
+            }
+        }
     }
     
     /**
@@ -191,17 +233,17 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
     /**
      * {@inheritDoc}
      */
-	@Override
-	public URI getAssetDirectLink(String id, String root, String filePath) throws IOException {
+    @Override
+    public URI getAssetDirectLink(String id, String root, String filePath) throws IOException {
         ContainerAndName can = getContainerAndName(id, root, filePath);
         HttpRequest hr = context.getSigner().signGetBlob(can.container, can.name, SIGNED_URL_VALIDITY_SECONDS);
-        if (hr == null){
+        if (hr == null) {
             throw new IOException("No object found to creat signed url " + id);
         }
-        
+
         return hr.getEndpoint();
-	}
-    
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -213,32 +255,36 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
             throw new IOException("No object found for " + id);
         }
 
-        // There are some oddities with streaming larger files to the user,
-        // so download to a temp file first. For now, call 100MB the threshold.
-        long maxStreamSize = 1024 * 1024 * 100;
-
         StorageMetadata metadata = blob.getMetadata();
         Long size = metadata.getSize();
 
-        if (size != null && size.longValue() > maxStreamSize) {
-            return streamFromTempFile(blob);
+        if (size != null && size.longValue() > maxBlobStreamSize) {
+            return streamFromTempFile(blob, size);
         } else {
-            return blob.getPayload().openStream();
+            // SAK-30325: why can't we just send the stream straight back: blob.getPayload().openStream() ?
+            // Good question, but it doesn't work properly unless the stream is fully copied and re-streamed....
+            return new ByteArrayInputStream(FileCopyUtils.copyToByteArray(blob.getPayload().openStream()));
         }
     }
 
     // Hacky implementation of downloading Blobs to temp files...
     // This should probably happen in a specified location and use
     // hashing to be sure of contents before reusing.
-    private InputStream streamFromTempFile(Blob blob) {
+    private InputStream streamFromTempFile(Blob blob, Long filesize) {
         StorageMetadata metadata = blob.getMetadata();
         String name = metadata.getName();
-        Date modified = metadata.getLastModified();
-        String filename = name + "-" + modified.getTime();
+        String filename = name + "-" + filesize;
         filename = DigestUtils.md5Hex(filename);
-
-        File check = new File(filename + ".tmp");
         FileInputStream stream = null;
+
+        // See if the temp file already exists
+        File check;
+        if (temporaryBlobDirectory != null) {
+            check = new File(temporaryBlobDirectory, filename);
+        }
+        else {
+            check = new File(System.getProperty("java.io.tmpdir"), filename);
+        }
 
         if (check.exists()) {
             try {
@@ -248,10 +294,9 @@ public class BlobStoreFileSystemHandler implements FileSystemHandler {
             }
         } else {
             try {
-                File tmp = File.createTempFile(filename, ".tmp");
-                FileOutputStream fos = new FileOutputStream(tmp);
+                FileOutputStream fos = new FileOutputStream(check);
                 FileCopyUtils.copy(blob.getPayload().openStream(), fos);
-                stream = new FileInputStream(tmp);
+                stream = new FileInputStream(check);
             } catch (IOException e) {
                 stream = null;
             }

--- a/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/SwiftFileSystemHandler.java
+++ b/cloud-content/impl/src/main/java/coza/opencollab/sakai/cloudcontent/SwiftFileSystemHandler.java
@@ -274,8 +274,8 @@ public class SwiftFileSystemHandler implements FileSystemHandler {
     /**
      * {@inheritDoc}
      */
-	@Override
-	public URI getAssetDirectLink(String id, String root, String filePath) throws IOException {
+    @Override
+    public URI getAssetDirectLink(String id, String root, String filePath) throws IOException {
         ContainerAndName can = getContainerAndName(id, root, filePath);
         ObjectApi objectApi = swiftApi.getObjectApi(region, can.container);
         SwiftObject so = objectApi.get(can.name, GetOptions.NONE);
@@ -284,7 +284,7 @@ public class SwiftFileSystemHandler implements FileSystemHandler {
         }
         
         return so.getUri();
-	}
+    }
 
     /**
      * {@inheritDoc}

--- a/cloud-content/pack/src/webapp/WEB-INF/components.xml
+++ b/cloud-content/pack/src/webapp/WEB-INF/components.xml
@@ -6,10 +6,12 @@
   <!-- These beans are lazy inited as they won't startup unless correctly configured -->
   <bean id="org.sakaiproject.content.api.FileSystemHandler.swift" class="coza.opencollab.sakai.cloudcontent.SwiftFileSystemHandler"
         init-method="init" destroy-method="destroy" lazy-init="true">
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
   </bean>
 
   <bean id="org.sakaiproject.content.api.FileSystemHandler.blobstore" class="coza.opencollab.sakai.cloudcontent.BlobStoreFileSystemHandler"
         init-method="init" destroy-method="destroy" lazy-init="true">
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
   </bean>
 
 </beans>

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -552,6 +552,30 @@
 # DEFAULT: <!DOCTYPE html>
 #content.html.doctype=<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 
+# #######################################################################
+# CLOUD-CONTENT
+# #######################################################################
+
+# SAK-30325 Largest blob size in bytes that will be processed in the JVM memory
+# Any blob larger than this size will be written to a temp file.
+# Hopefully, your blobs are being delivered directly to the user via a direct link
+# but Sakai sometimes still needs the blob directly (e.g., Assignments ZIP download)
+# DEFAULT: 104857600
+# cloud.content.maxblobstream.size=52429600
+
+# SAK-30325 Where should the temp blob files be written
+# DEFAULT will use java temp dir
+# cloud.content.temporary.directory=/big/partition/with/space
+
+# SAK-30325 Should we send headers X-Accel-Redirect and X-Sendfile so the load balancer can proxy the file
+# This accomplishes the goal of making your loadbalancer handle large file proxying instead of the JVM.
+# DEFAULT false
+# cloud.content.sendfile=true
+
+# SAK-30325 Should we redirect the user directly to the file asset instead of proxying the asset in Sakai's JVM?
+# DEFAULT true if using a valid FileSystemHandler that supports direct url links (ignored for default file system handler)
+# cloud.content.directurl=false
+
 # ########################################################################
 # DIGEST
 # ########################################################################

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/FileSystemHandler.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/FileSystemHandler.java
@@ -2,12 +2,24 @@ package org.sakaiproject.content.api;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * This is the api for reading and writing files to some file system.
  *
  */
 public interface FileSystemHandler {
+
+    /**
+     * Retrieve a direct link to the asset.
+     * 
+     * @param id The id of the resource. Will not be null or empty.
+     * @param root The root of the storage. Could be null or empty.
+     * @param filePath The path to the file. Will not be null or empty.
+     * @return A URI to retrieve the asset.
+     * @throws IOException If the asset cannot be found.
+     */
+    public URI getAssetDirectLink(String id, String root, String filePath) throws IOException;
 
     /**
      * Retrieves an input stream from the file.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/AbstractContentResource.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/AbstractContentResource.java
@@ -44,7 +44,8 @@ import org.w3c.dom.Element;
  */
 public class AbstractContentResource implements ContentResource{
 	
-	private ContentResource wrapped;
+	// Use package visibility to allow things in impl to get the raw resource
+	ContentResource wrapped;
 	
 	public AbstractContentResource(ContentResource wrapped) {
 		this.wrapped = wrapped;

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -7025,7 +7025,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					res.setContentType(contentType);
 					res.addHeader("Content-Disposition", disposition);
 					// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4187336
-					if (len <= Integer.MAX_VALUE){
+					if (len <= Integer.MAX_VALUE) {
 						res.setContentLength((int)len);
 					} else {
 						res.addHeader("Content-Length", Long.toString(len));
@@ -7033,8 +7033,22 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 
 					// Bypass loading the asset and just send the user a link to it.
 					if (directLinkUri != null) {
-						res.sendRedirect(directLinkUri.toString());
-						return;
+						if (m_serverConfigurationService.getBoolean("cloud.content.sendfile", false)) {
+							int hostLength = new String(directLinkUri.getScheme() + "://" + directLinkUri.getHost()).length();
+							String linkPath = "/sendfile" + directLinkUri.toString().substring(hostLength);
+							if (M_log.isDebugEnabled()) {
+								M_log.debug("X-Sendfile: " + linkPath);
+							}
+
+							// Nginx uses X-Accel-Redirect and Apache and others use X-Sendfile
+							res.addHeader("X-Accel-Redirect", linkPath);
+							res.addHeader("X-Sendfile", linkPath);
+							return;
+						}
+						else if (m_serverConfigurationService.getBoolean("cloud.content.directurl", true)) {
+							res.sendRedirect(directLinkUri.toString());
+							return;
+						}
 					}
 
 					// stream the content using a small buffer to keep memory managed

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -7006,7 +7006,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				{
 					contentType = contentType + "; charset=" + encoding;
 				}
-				
+
 				// KNL-1316 let's see if the user already has a cached copy. Code copied and modified from Tomcat DefaultServlet.java
 				long headerValue = req.getDateHeader("If-Modified-Since");
 				if (headerValue != -1 && (lastModTime < headerValue + 1000)) {
@@ -7015,11 +7015,28 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					return; 
 				}
 
-				ArrayList<Range> ranges = parseRange(req, res, len);
-				res.addHeader("Accept-Ranges", "bytes");
+				// If there is a direct link to the asset, no sense streaming it.
+				// Send the asset directly to the load-balancer or to the client
+				URI directLinkUri = m_storage.getDirectLink(resource);
 
-		        if (req.getHeader("Range") == null || (ranges == null) || (ranges.isEmpty())) {
-		        	
+				ArrayList<Range> ranges = parseRange(req, res, len);
+				if (directLinkUri != null || req.getHeader("Range") == null || (ranges == null) || (ranges.isEmpty())) {
+					res.addHeader("Accept-Ranges", "none");
+					res.setContentType(contentType);
+					res.addHeader("Content-Disposition", disposition);
+					// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4187336
+					if (len <= Integer.MAX_VALUE){
+						res.setContentLength((int)len);
+					} else {
+						res.addHeader("Content-Length", Long.toString(len));
+					}
+
+					// Bypass loading the asset and just send the user a link to it.
+					if (directLinkUri != null) {
+						res.sendRedirect(directLinkUri.toString());
+						return;
+					}
+
 					// stream the content using a small buffer to keep memory managed
 					InputStream content = null;
 					OutputStream out = null;
@@ -7031,15 +7048,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 						{
 							throw new IdUnusedException(ref.getReference());
 						}
-	
-						res.setContentType(contentType);
-						res.addHeader("Content-Disposition", disposition);
-						// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4187336
- 						if (len <= Integer.MAX_VALUE){
- 							res.setContentLength((int)len);
- 						} else {
- 							res.addHeader("Content-Length", Long.toString(len));
- 						}
+
 
 						// set the buffer of the response to match what we are reading from the request
 						if (len < STREAM_BUFFER_SIZE)
@@ -7088,9 +7097,9 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		        } 
 		        else 
 		        {
-		        	// Output partial content. Adapted from Apache Tomcat 5.5.27 DefaultServlet.java
-		        	
-		        	res.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
+		            // Output partial content. Adapted from Apache Tomcat 5.5.27 DefaultServlet.java
+		            res.addHeader("Accept-Ranges", "bytes");
+		            res.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 
 		            if (ranges.size() == 1) {
 
@@ -13429,6 +13438,13 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		 * Open and be ready to read / write.
 		 */
 		public void open();
+
+		/**
+		 * Get a direct link to the asset so it doesn't have to be streamed.
+		 * @param resource
+		 * @return URI or null if no direct link is available
+		 */
+		public URI getDirectLink(ContentResource resource);
 
 		/**
 		 * Get a count of all members of a collection, where 'member' means the collection

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.sql.Blob;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -2306,6 +2307,25 @@ public class DbContentService extends BaseContentService
             {
                 out();
             }
+        }
+        
+        /**
+         * Return a URI containing a direct link to the asset.
+         * 
+         * @param rootFolder
+         * @param resource
+         * @return URI representing a direct link to the asset or null
+         */
+        public URI getDirectLink(ContentResource resource)
+        {
+        	try {
+        		return fileSystemHandler.getAssetDirectLink(((BaseResourceEdit) resource).m_id, m_bodyPath, ((BaseResourceEdit) resource).m_filePath);
+        	}
+        	catch (IOException e) {
+        		M_log.debug("No direct link available for resource: " + resource.getId());
+        	}
+        	
+        	return null;
         }
 
         /**

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -2319,7 +2319,18 @@ public class DbContentService extends BaseContentService
         public URI getDirectLink(ContentResource resource)
         {
         	try {
-        		return fileSystemHandler.getAssetDirectLink(((BaseResourceEdit) resource).m_id, m_bodyPath, ((BaseResourceEdit) resource).m_filePath);
+        		// SAK-30325 - HTML items not being BaseResourceEdits causes a
+        		// ClassCastException here, which gets swallowed and turned into a 404.
+        		// This is an ugly hack because of the necessary casting here (to get m_filePath).
+        		// This is another case where the nested classes and fuzzy boundaries causes
+        		// rather sloppy object orientation. A more complete treatment would reevaluate
+        		// the interfaces, remove the Edits, and extract these classes and casts.
+        		ContentResource rawResource = (resource instanceof WrappedContentResource) ?
+        				((WrappedContentResource) resource).wrapped : resource;
+        		if (!(rawResource instanceof BaseResourceEdit)) {
+        			return null;
+        		}
+        		return fileSystemHandler.getAssetDirectLink(((BaseResourceEdit) rawResource).m_id, m_bodyPath, ((BaseResourceEdit) rawResource).m_filePath);
         	}
         	catch (IOException e) {
         		M_log.debug("No direct link available for resource: " + resource.getId());

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DefaultFileSystemHandler.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DefaultFileSystemHandler.java
@@ -1,11 +1,14 @@
 package org.sakaiproject.content.impl;
 
 import org.sakaiproject.content.api.FileSystemHandler;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+
 import org.springframework.util.FileCopyUtils;
 
 /**
@@ -88,4 +91,9 @@ public class DefaultFileSystemHandler implements FileSystemHandler {
         }
         return false;
     }
+
+	@Override
+	public URI getAssetDirectLink(String id, String root, String filePath) throws IOException {
+		return null;
+	}
 }


### PR DESCRIPTION
Don't proxy large files into JVM memory to deliver them to user.... two main things here:

a) Write to a temp file if the blob asset is too large.

b) Send the user a direct link to the asset (usually a pre-signed, temporary link) instead of forcing the asset to be proxied by the Sakai JVM