### PR TITLE
SAK-30329: Improper use of a constant in Calendar creation code

### DIFF
--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -4274,7 +4274,7 @@ extends VelocityPortletStateAction
 					if ((m_calObj.getDay_Of_Week(true))== 7) // if end of week, exit the loop
 					{
 						row  = 7;
-						col = SECOND_PAGE_START_HOUR;
+						col = 8;
 					}
 					else // if it is not the end of week, complete with days from next month
 					{


### PR DESCRIPTION
While working in CalendarAction.java, I noticed that a constant (SECOND_PAGE_START_HOUR) was being used improperly for an unrelated value.

If a developer were to modify the constant for its intended purpose, it could result in early termination of the loops that create the calendar views.

My patch simply replaces the use of the constant with the literal value in this case of the loop to avoid the above situation.
