### PR TITLE
1422: Set Zero Score for Empty Cells

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -74,6 +74,7 @@ heading.updateungradeditems = Set Score for Empty Cells
 heading.gradelog = Grade Log for {0} ({1})
 heading.editcomment = Comment for {0} ({1}) - {2}
 heading.studentpage = Grade Report for {0}
+heading.zeroungradeditems = Set Zero Score for Empty Cells
 
 # note these are not standard wicket style properties as we format this one slightly differently
 formatter.studentname.LAST_NAME = %s, %s
@@ -321,4 +322,8 @@ label.statistics.deviation = Standard Deviation
 
 coursegrade.option.override = Course Grade Override
 coursegrade.option.overridelog = Course Grade Override Log
-coursegrade.option.setungraded = Set Score For Empty Cells
+coursegrade.option.setungraded = Set Zero Score For Empty Cells
+
+label.zeroungradeditems.instructions.1 = The Gradebook automatically calculates the course grade for students as items are graded. To accurately calculate the course grades, all gradable items must be assigned a grade. Continuing will assign zero to any grade items that do not have a grade. Not zeroing may result in higher course grades than intended.
+label.zeroungradeditems.instructions.2 = <b>Note:</b> Clicking Update will assign a grade of zero to all ungraded items in this gradebook. <b>This can not be undone!</b>
+

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
@@ -51,7 +51,7 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 			public void onClick(final AjaxRequestTarget target) {
 				final GbModalWindow window = gradebookPage.getAddOrEditGradeItemWindow();
 				window.setComponentToReturnFocusTo(getParentCellFor(this));
-				window.setContent(new EmptyPanel(window.getContentId()));
+				window.setContent(new ZeroUngradedItemsPanel(window.getContentId(), window));
 				window.showUnloadConfirmation(false);
 				window.show(target);
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+
+<body>
+	<wicket:panel>
+
+		<h2>
+			<wicket:message key="heading.zeroungradeditems" />
+		</h2>
+
+		<div class="form-group">
+			<div class="help-block">
+				<p><wicket:message key="label.zeroungradeditems.instructions.1" /></p>
+				<p><wicket:message key="label.zeroungradeditems.instructions.2" /></p>
+			</div>
+
+			<div class="col-xs-offset-4 col-xs-5">
+				<button class="btn btn-primary" wicket:id="submit"><wicket:message key="button.update" /></button>
+				<button class="btn btn-default" wicket:id="cancel"><wicket:message key="button.cancel"/></button>
+			</div>
+		</div>
+
+	</wicket:panel>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.java
@@ -1,0 +1,75 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import java.util.List;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.service.gradebook.shared.Assignment;
+
+/**
+ *
+ * Panel for the modal window that allows an instructor to zero the ungraded scores for all gradebook items 
+ *
+ */
+public class ZeroUngradedItemsPanel extends Panel {
+
+	private static final long serialVersionUID = 1L;
+
+	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
+	protected GradebookNgBusinessService businessService;
+
+	private final ModalWindow window;
+
+	private static final double ZERO_GRADE = 0;
+
+	public ZeroUngradedItemsPanel(final String id, final ModalWindow window) {
+		super(id);
+		this.window = window;
+	}
+
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+
+		final AjaxButton submit = new AjaxButton("submit") {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
+
+				// fetch all assignments
+				List<Assignment> assignments = businessService.getGradebookAssignments();
+
+				for (Assignment assignment : assignments) {
+					final long assignmentId = assignment.getId().longValue();
+					ZeroUngradedItemsPanel.this.businessService.updateUngradedItems(assignmentId, ZERO_GRADE);
+				}
+
+				ZeroUngradedItemsPanel.this.window.close(target);
+				setResponsePage(new GradebookPage());
+			}
+		};
+		add(submit);
+
+		final AjaxButton cancel = new AjaxButton("cancel") {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
+				ZeroUngradedItemsPanel.this.window.close(target);
+			}
+		};
+		cancel.setDefaultFormProcessing(false);
+		add(cancel);
+	}
+}

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -544,7 +544,7 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
     event.preventDefault();
     $(document).scrollTop(self.$table.offset().top - 10);
     self.$spreadsheet.scrollLeft(0);
-    var $targetCell = $(self.$table.find("thead tr > *").get($(this).index()));
+    var $targetCell = $(self.$table.find("thead tr:last > *").get($(this).index()));
 
     self.$spreadsheet.data("activeCell", $targetCell);
 
@@ -592,23 +592,23 @@ GradebookSpreadsheet.prototype.proxyEventToElementsInOriginalCell = function(eve
       return true;
     }
   // or a dropdown?
-  } else if ($(event.target).is("a.btn.dropdown-toggle")) {
+  } else if ($target.is("a.btn.dropdown-toggle")) {
     setTimeout(function() {
       $originalCell.find("a.btn.dropdown-toggle").focus().trigger("click");
     });
     return true;
   // or the row selector?
-  } else if ($(event.target).is(".gb-row-selector")) {
+  } else if ($target.is(".gb-row-selector")) {
     $originalCell.next().focus();
     return true;
   // or a flag?
-  } else if ($(event.target).closest(".gb-grade-item-flags").length == 1) {
+  } else if ($target.closest(".gb-grade-item-flags").length == 1) {
     setTimeout(function() {
-      $originalCell.find($(event.target).attr("class").split(' ').map(function(cssClass) {return "." + cssClass}).join(" ")).focus();
+      $originalCell.find($target.attr("class").split(' ').map(function(cssClass) {return "." + cssClass}).join(" ")).focus();
     });
     return true;
   // external item flag?
-  } else if ($(event.target).closest(".gb-external-app-flag").length == 1) {
+  } else if ($target.closest(".gb-external-app-flag").length == 1) {
     setTimeout(function() {
       $originalCell.find(".gb-external-app-flag").focus();
     });

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -177,14 +177,14 @@
 #gradebookGrades .gb-cell {
   cursor: pointer;
 }
-#gradebookGradesTable tbody .btn.dropdown-toggle {
+#gradebookGrades tbody .btn.dropdown-toggle {
   opacity: 0.3;
   border-color: #EEE;
 }
-#gradebookGradesTable tbody .btn.dropdown-toggle:focus,
-#gradebookGradesTable tbody .btn.dropdown-toggle:active,
-#gradebookGradesTable tbody .btn.dropdown-toggle:hover,
-#gradebookGradesTable tbody .open .btn.dropdown-toggle {
+#gradebookGrades tbody .btn.dropdown-toggle:focus,
+#gradebookGrades tbody .btn.dropdown-toggle:active,
+#gradebookGrades tbody .btn.dropdown-toggle:hover,
+#gradebookGrades tbody .open .btn.dropdown-toggle {
     opacity: 1;
     border-color: #DDD;
 }

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -613,6 +613,13 @@
 #gradebookGrades .gb-student-filter {
   position: relative;
 }
+#gradebookGrades .gb-student-filter input {
+  height: 2em;
+}
+#gradebookGrades .gb-student-filter-clear,
+#gradebookGrades .gb-student-filter-clear:hover {
+  text-decoration: none;
+}
 #gradebookGrades .gb-student-filter-clear:before {
   position: absolute;
   top: 2px;
@@ -623,9 +630,7 @@
   font-size: 1em;
   width: 1.2em;
   text-align: right;
-}
-#gradebookGrades .gb-student-filter-clear:hover {
-  text-decoration: none;
+  height: 2em;
 }
 /* Popover Notifications */
 .gb-grade-item-flags .popover {


### PR DESCRIPTION
Delivers #1422.

Hi @steveswinsburg.  I implemented "Set Zero Score..." as per the original Gradebook rather than a "Set *arbitrary* Score..." as it didn't really make sense when different grade items have different point totals.  

Unless the it was meant to be a "Set Percentage for Empty Cells" whereby the user could define a percentage and we turn that into a corresponding point value for each item?  But then we'd need to worry about the extra credit values.  The other setungraded displays a popup when an EC value is detected and that would tricky to nigh too hard.

I've also brought across the verbiage from the old Gradebook... it's wordy but tells an accurate story.

Also included a few CSS tweaks for the dropdowns and a sneaky IE11 patch for the student filter.