### PR TITLE
SAK-30144 When user changes their email address in Accounts tool they

### DIFF
--- a/emailtemplateservice/api/src/java/org/sakaiproject/emailtemplateservice/service/EmailTemplateService.java
+++ b/emailtemplateservice/api/src/java/org/sakaiproject/emailtemplateservice/service/EmailTemplateService.java
@@ -172,7 +172,14 @@ public interface EmailTemplateService {
     * @return
     */
    public boolean templateExists(String key, Locale locale);
-	   
-   
+   /**
+   * Utility to send message to user, also when user has changed the email address.
+   * @param userIds
+   * @param emailAddresses
+   * @param renderedTemplate
+   * @param from
+   * @param fromName
+   */
+   public void sendMessage(List<String> userIds, List<String> emailAddresses, RenderedTemplate renderedTemplate,  String from, String fromName );
    
 }

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/UserDirectoryService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/UserDirectoryService.java
@@ -178,6 +178,14 @@ public interface UserDirectoryService extends EntityProducer
 	 * @return true if the user is allowed to update their own first and last names, false if not.
 	 */
 	public boolean allowUpdateUserName(String id);
+	/**
+	 * Gets the UserEdit object from storage inorder to update the user Eid()
+	 *
+	 * @param eId  The user id.
+	 * @param newEmail the Id with which userId will be updated
+	 * @return UserEdit object
+	 */
+	public boolean updateUserId(String eId,String newEmail);
 
 	/**
 	 * check permissions for editUser()

--- a/kernel/api/src/main/java/org/sakaiproject/user/cover/UserDirectoryService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/cover/UserDirectoryService.java
@@ -154,6 +154,14 @@ public class UserDirectoryService
 		return service.allowUpdateUser(param0);
 	}
 
+	public static boolean updateUserId(java.lang.String param0,java.lang.String param1)
+	{
+		org.sakaiproject.user.api.UserDirectoryService service = getInstance();
+		if (service == null) return false;
+
+		return service.updateUserId(param0,param1);
+	}
+
 	public static org.sakaiproject.user.api.UserEdit editUser(java.lang.String param0)
 			throws org.sakaiproject.user.api.UserNotDefinedException, org.sakaiproject.user.api.UserPermissionException,
 			org.sakaiproject.user.api.UserLockedException

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -1963,6 +1963,42 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		return u;
 	}
 
+	public boolean updateUserId(String id,String newEmail)
+	{
+		try {
+			List<String> locksSucceeded = new ArrayList<String>();
+			// own or any
+			List<String> locks = new ArrayList<String>();
+			locks.add(SECURE_UPDATE_USER_ANY);
+			locks.add(SECURE_UPDATE_USER_OWN);
+			locks.add(SECURE_UPDATE_USER_OWN_EMAIL);
+			locksSucceeded = unlock(locks, userReference(id));
+
+			if(!locksSucceeded.isEmpty()) {
+				UserEdit user = m_storage.edit(id);
+				if (user == null) {
+					M_log.warn("Can't find user " + id + " when trying to update email address");
+					return false;
+				}
+				user.setEid(newEmail);
+				user.setEmail(newEmail);
+				commitEdit(user);
+				return true;
+			}
+			else {
+				M_log.warn("User with id: "+id+" failed permission checks" );
+				return false;
+			}
+		} catch (UserPermissionException e) {
+			M_log.warn("You do not have sufficient permission to edit the user with Id: "+id, e);
+			return false;
+		} catch (UserAlreadyDefinedException e) {
+			M_log.error("A users already exists with EID of: "+id +"having email :"+ newEmail, e);
+			return false;
+		}
+	}
+
+
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * UserEdit implementation
 	 *********************************************************************************************************************************************************************************************************************************************************/

--- a/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/logic/ValidationLogic.java
+++ b/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/logic/ValidationLogic.java
@@ -85,6 +85,14 @@ public interface ValidationLogic {
 	 */
 	public ValidationAccount createValidationAccount(String UserId, boolean newAccount);
 	
+
+	/**
+	 *  Create a new validation Validation account
+	 * @param userRef existing userId
+	 * @param newUserId is the new id which the user wants to have as userId
+	 * @return
+	 */
+	public ValidationAccount createValidationAccount(String userRef,String newUserId);
 	/**
 	 * Create a validation token for an account of a given status
 	 * @param UserId

--- a/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/model/ValidationAccount.hbm.xml
+++ b/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/model/ValidationAccount.hbm.xml
@@ -16,6 +16,7 @@
 	    	</generator>
 		</id>
 		<property name="userId" column="USER_ID" type="string" length="255" not-null="true" />
+		<property name="eid" column="EID" type="string" length="255"/>
 		<property name="validationToken" column="VALIDATION_TOKEN" type="string" length="255" not-null="true" />
 		<property name="validationSent" column="VALIDATION_SENT" type="timestamp" />
 		<property name="validationReceived" column="VALIDATION_RECEIVED" type="timestamp" />

--- a/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/model/ValidationAccount.java
+++ b/reset-pass/account-validator-api/src/java/org/sakaiproject/accountvalidator/model/ValidationAccount.java
@@ -58,11 +58,14 @@ public class ValidationAccount {
 	 * Status for a password reset
 	 */
 	public static final int ACCOUNT_STATUS_PASSWORD_RESET = 5;
-	
 	/**
 	 * Status for requested accounts (non-mergeable)
 	 **/
 	public static final int ACCOUNT_STATUS_REQUEST_ACCOUNT = 6;
+	/**
+	 * Status for userId updation
+	 */
+	public static final int ACCOUNT_STATUS_USERID_UPDATE = 7;
 	
 	private Long id;
 	private String userId;

--- a/reset-pass/account-validator-impl/pom.xml
+++ b/reset-pass/account-validator-impl/pom.xml
@@ -86,6 +86,10 @@
 			<artifactId>sakai-util-api</artifactId> </dependency>
 		-->
 		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.sakaiproject.entitybroker
 			</groupId>
 			<artifactId>entitybroker-api</artifactId>

--- a/reset-pass/account-validator-impl/src/bundle/validate_newUser.xml
+++ b/reset-pass/account-validator-impl/src/bundle/validate_newUser.xml
@@ -2,7 +2,7 @@
 <emailTemplates>
 	<emailTemplate>
 		<subject>Welcome To ${localSakaiName}!</subject>
-		<message>You have been invited to one or more sites in {localSakaiName}.
+		<message>You have been invited to one or more sites in ${localSakaiName}.
 
 Accept this invitation:
 

--- a/reset-pass/account-validator-impl/src/bundle/validate_userIdUpdate.xml
+++ b/reset-pass/account-validator-impl/src/bundle/validate_userIdUpdate.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<emailTemplates>
+	<emailTemplate>
+		<subject>Please Validate your ${localSakaiName} Account</subject>
+		<message>Dear ${displayName},
+
+			You have an account on ${localSakaiName} and have recently updated your Email address to ${newUserId}.
+
+			In order to make accessing  ${localSakaiName} as easy possible, your username will be updated to match this new email address. If you are happy with the change then please follow this ${url} to complete the process.
+			If you do not wish to change your username to match your email address then simply ignore this email, however, we would *strongly* recommend that you do *not* follow this course of action.
+
+			If you have any questions about this then please contact ${localSupportMail}.
+			*Please note*: Accounts that have been deactivated for longer than 90 days will be deleted.
+
+		</message>
+		<messagehtml>&lt;p&gt;Dear ${displayName}&lt;p&gt;
+
+&lt;p&gt;You have an account on ${localSakaiName} and have recently updated your Email address to ${newUserId} &lt;br/&gt;
+			
+&lt;/p&gt;
+
+&lt;p&gt;In order to make accessing  ${localSakaiName} as easy possible, your username will be updated to match this new email address. If you are happy with the change then please follow this &lt;a href=&quot;${url}&quot;&gt;link&lt;/a&gt;&lt;/p&gt; to complete the process.
+
+&lt;/p&gt;If you do not wish to change your username to match your email address then simply ignore this email, however, we would *strongly* recommend that you do *not* follow this course of action.If you have any questions about this then please contact ${localSupportMail} &lt;/p&gt;
+
+&lt;p&gt;&lt;strong&gt;Please note&lt;/strong&gt;: Accounts that have been deactivated for longer than 90 days will be deleted.&lt;/p&gt;</messagehtml>
+		<locale></locale>
+	</emailTemplate>
+
+</emailTemplates>

--- a/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages.properties
+++ b/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages.properties
@@ -80,4 +80,5 @@ submit.new.reset=Change password and log in
 activateAccount.title=Activate your account
 transferMemberships.title=Accept invitation
 passwordReset.title=Reset your password
+submit.update=Update your account
 requestAccount.title=Activate your account

--- a/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages_en_GB.properties
+++ b/reset-pass/account-validator-tool/src/bundle/org/sakaiproject/accountvalidator/bundle/messages_en_GB.properties
@@ -33,4 +33,5 @@ password2=Confirm password
 submit.login=Login
 submit.new.account=Claim your account
 submit.new.reset=Set your password
+submit.update=Update your account
 

--- a/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/AcountValidationLocator.java
+++ b/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/AcountValidationLocator.java
@@ -251,6 +251,12 @@ public class AcountValidationLocator implements BeanLocator  {
 				// A TargettedMessage will be displayed by ValidationProducer
 				return "error!";
 			}
+			if(item.getAccountStatus().equals(ValidationAccount.ACCOUNT_STATUS_USERID_UPDATE)) {
+				boolean isSuccess = userDirectoryService.updateUserId(userId,item.getEid());
+				if(!isSuccess) {
+					tml.addMessage(new TargettedMessage("msg.errUpdate.userId" , new Object[]{item.getEid()}, TargettedMessage.SEVERITY_ERROR));
+				}
+			}
 				
 	        	UserEdit u = userDirectoryService.editUser(userId);
 				if (isLegacyLinksEnabled() || ValidationAccount.ACCOUNT_STATUS_PASSWORD_RESET != accountStatus)

--- a/reset-pass/account-validator-tool/src/webapp/js/accountValidator.js
+++ b/reset-pass/account-validator-tool/src/webapp/js/accountValidator.js
@@ -113,7 +113,13 @@ VALIDATOR.validatePassword = function() {
 // Verify the passwords match
 VALIDATOR.verifyPasswordsMatch = function() {
 	var pw = VALIDATOR.get("passrow1::password1").value;
-	var pw2 = VALIDATOR.get("passrow2::password2").value;
+	if(VALIDATOR.get("passrow2::password2")) {
+		var pw2 = VALIDATOR.get("passrow2::password2").value;
+	}
+	else {
+		var pw2 = pw;
+	}
+
 	var matchMsg = VALIDATOR.get("matchMsg");
 	var noMatchMsg = VALIDATOR.get("noMatchMsg");
 	
@@ -238,6 +244,10 @@ VALIDATOR.display = function(element, show) {
 
 // Original document ready function
 $(document).ready(function() {
+    /* Hide div with yellow background if it is not null and is empty */
+    if (($('.yellowBackground').length > 0) && ($('.yellowBackground').html().trim() == '')){
+	   $('.yellowBackground').hide();
+    }
     if ($("form").length === 0) {
         $("table").remove();
         return false;

--- a/reset-pass/account-validator-tool/src/webapp/templates/newUser.html
+++ b/reset-pass/account-validator-tool/src/webapp/templates/newUser.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns:rsf="http://ponder.org.uk/rsf" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title rsf:id="msg=activateAccount.title">Activate your account</title>
+		<title rsf:id="account-title">Activate your account</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
 		<link href="../css/newUser.css" type="text/css" rel="stylesheet" media="all" />
 		<script rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
@@ -20,7 +20,7 @@
 				</ul>
 			</div>
 			<fieldset class="activateForm">
-				<legend rsf:id="msg=activateAccount.title" class="activateLegend">Activate</legend>
+				<legend rsf:id="account-title" class="activateLegend">Activate</legend>
 					<div class="centeredFeedback">
 					<div rsf:id="message-for:*"><span>Message for user here</span></div>
 				</div>

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/mocks/FakeUserDirectoryService.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/mocks/FakeUserDirectoryService.java
@@ -77,6 +77,9 @@ public class FakeUserDirectoryService implements UserDirectoryService {
 		// TODO Auto-generated method stub
 		return false;
 	}
+	public boolean updateUserId(String eId, String newEmail) {
+		return false;
+	}
 
 	public boolean allowUpdateUserPassword(String arg0) {
 		// TODO Auto-generated method stub

--- a/user/user-tool/tool/pom.xml
+++ b/user/user-tool/tool/pom.xml
@@ -30,6 +30,11 @@
       <artifactId>sakai-kernel-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sakaiproject.accountvalidator</groupId>
+      <artifactId>accountvalidator-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.sakaiproject.kernel</groupId>
       <artifactId>sakai-component-manager</artifactId>
     </dependency>

--- a/user/user-tool/tool/src/bundle/admin.properties
+++ b/user/user-tool/tool/src/bundle/admin.properties
@@ -20,6 +20,9 @@ useact.capterr   = There was a problem with the captcha.
 useact.search = Search for users
 
 
+official.user.name = Official Username
+useedi.email.exists = There is already an account with this email address.
+useedi.val.email = We recommend that you update your User ID to match your new email address. To do this please click on the link in the validation email which has been sent to {0}. If you do not wish to change your User ID then please ignore the email.
 #merged all duplicates- SAK-18304
 useconrem.alert   = Alert:
 useconrem.can     = Cancel

--- a/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/user/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -92,6 +92,7 @@ import org.sakaiproject.portal.util.PortalUtils;
 import au.com.bytecode.opencsv.CSVReader;
 import java.text.MessageFormat;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.validator.routines.EmailValidator;
 import org.sakaiproject.accountvalidator.logic.ValidationLogic;
 import org.sakaiproject.accountvalidator.model.ValidationAccount;
 import org.sakaiproject.util.PasswordCheck;
@@ -115,6 +116,7 @@ public class UsersAction extends PagedResourceActionII
 	private static final String IMPORT_EMAIL="email";
 	private static final String IMPORT_PASSWORD="password";
 	private static final String IMPORT_TYPE="type";
+	private ValidationLogic validationLogic;
 
 	// SAK-23568
 	private static final PasswordPolicyHelper pwHelper = new PasswordPolicyHelper();
@@ -139,6 +141,7 @@ public class UsersAction extends PagedResourceActionII
 	public UsersAction() {
 		super();
 		authzGroupService = ComponentManager.get(AuthzGroupService.class);
+		this.validationLogic = (ValidationLogic)ComponentManager.get(ValidationLogic.class);
 	}
 
 	/**
@@ -940,6 +943,8 @@ public class UsersAction extends PagedResourceActionII
 		
 		// commit the change
 		UserEdit edit = (UserEdit) state.getAttribute("user");
+		String valueEmail = (String)state.getAttribute("valueEmail");
+		String oldEmail = (String)state.getAttribute("oldEmail");
 		if (edit != null)
 		{
 			
@@ -953,6 +958,12 @@ public class UsersAction extends PagedResourceActionII
 			
 			try
 			{
+				//start this validation only when user has changed the email for the account else skip, also skip for admin user
+				if (!SecurityService.isSuperUser() && StringUtils.trimToNull(valueEmail) != null && StringUtils.trimToNull(oldEmail) != null && !(oldEmail.equals(valueEmail))
+						&& EmailValidator.getInstance().isValid(edit.getEid()) && !(StringUtils.equalsIgnoreCase(edit.getEid(), valueEmail))) {
+					validationLogic.createValidationAccount(edit.getId(),valueEmail);
+					addAlert(state,rb.getFormattedMessage("useedi.val.email",new String[]{valueEmail}));
+				}
 				UserDirectoryService.commitEdit(edit);
 			}
 			catch (UserAlreadyDefinedException e)
@@ -1330,6 +1341,18 @@ public class UsersAction extends PagedResourceActionII
 		
 		// get the user
 		UserEdit user = (UserEdit) state.getAttribute("user");
+		//if user has not changed the email then skip the 'email exists' verification. Also, skip it when user is admin
+		if(!SecurityService.isSuperUser() && user != null && !(StringUtils.equals(user.getEmail(), email))){
+			try {
+				UserDirectoryService.getUserByEid(email);
+				addAlert(state,rb.getString("useedi.email.exists"));
+				return false;
+			} catch (UserNotDefinedException e) {
+				//unique user ,so continue
+			}
+			//user has changed the email so save the old email in the state
+			state.setAttribute("oldEmail",user.getEmail());
+		}
 		
 		//process any additional attributes
 		//we continue processing these until we get an empty attribute KEY

--- a/user/user-tool/tool/src/webapp/vm/user/chef_users_edit.vm
+++ b/user/user-tool/tool/src/webapp/vm/user/chef_users_edit.vm
@@ -239,6 +239,7 @@ function removeOptionalAttributeBlock(elem) {
 				<input type="submit" id="eventSubmit_doCancel" name="eventSubmit_doCancel" value="$tlang.getString("useedi.can")" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );" />
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+			<input type="hidden" name="alert_message" id="alert_message" value="$alertMessage" />
                 </fieldset>
 		</form>
 </div>


### PR DESCRIPTION
should be prompted to change their username.

Adding newUserID for template when status is userId updation.When the
account status is userIdUpdation then get the user from the newly added
method in base user directory.
Overloaded the method CreateValidationAccount to have extra field for
newEmailAddress.
In Accounts tool checks if the email address already exists . If the userId
is different from email address it sends out validation link.
Check for the locks and commit user object with new emailId.
New method is added into EmailTemplateService for Accounts to use when user
changes email address.
In EmailTemplateServiceImpl have separated the common logic from
'sendRenderedMessage' into a separate method called 'sendEmailToUsers'
which can be used by the new 'sendMessage' method.