### PR TITLE
SAK-30334 Improvements to mobile user experience plus changes from additional feedback

### DIFF
--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -76,6 +76,7 @@ moresite_administration = ADMINISTRATION
 moresite_other = OTHER
 moresite_unknown_term = (unknown academic term)
 moresite_organize_favorites = Organize Favorites
+moresite_favorites = Favorites
 
 timeout_dialog_title = Timeout Alert
 timeout_dialog_warning_message = Your session will timeout in <span>{0}</span> minutes.

--- a/portal/portal-impl/impl/src/bundle/sitenav_en_GB.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav_en_GB.properties
@@ -69,6 +69,7 @@ moresite_administration = ADMINISTRATION
 moresite_other = OTHER
 moresite_unknown_term = (unknown academic term)
 moresite_organize_favorites = Organise Favourites
+moresite_favorites = Favourites
 
 timeout_dialog_title = Timeout Alert
 timeout_dialog_warning_message = Your session will timeout in <span>{0}</span> minutes.

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1884,6 +1884,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				
 				logoutWarningMessage = rloader.getString("sit_logout_warn");
 			}
+			rcontext.put("userIsLoggedIn", session.getUserId() != null);
 			rcontext.put("loginTopLogin", Boolean.valueOf(topLogin));
 			rcontext.put("logoutWarningMessage", logoutWarningMessage);
 

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeLoginNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeLoginNav.vm
@@ -4,11 +4,13 @@
 
     #if (!${loginTopLogin})
 
-        <div class="Mrphs-sitesNav__menuitem view-all-sites-btn">
-            <a href="javascript:void(0);" title="${rloader.sit_allsites}" role="menuitem" aria-haspopup="true">
-                <i class="fa fa-th all-sites-icon"></i> <span class="all-sites-label">${rloader.sit_worksites}</span>
-            </a>
-        </div>
+        #if (${userIsLoggedIn})
+            <div class="Mrphs-sitesNav__menuitem view-all-sites-btn">
+                <a href="javascript:void(0);" title="${rloader.sit_allsites}" role="menuitem" aria-haspopup="true">
+                    <i class="fa fa-th all-sites-icon"></i> <span class="all-sites-label">${rloader.sit_worksites}</span>
+                </a>
+            </div>
+        #end
 
         <ul id="loginLinks" class="Mrphs-userNav">
 
@@ -118,7 +120,6 @@
         </ul> <!-- end of nav#loginLinks-->
 
         ## parse("/vm/morpheus/snippets/loginImage-snippet.vm")
-
     #else ## ELSE of IF (!${loginTopLogin})
 
         #parse("/vm/morpheus/snippets/loginForm-snippet.vm")

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeLoginNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeLoginNav.vm
@@ -46,7 +46,9 @@
                                     <div class="Mrphs-userNav__submenuitem--profile-and-image">
                                         #if (${tabsSites.mrphs_profileToolUrl})
                                             <div class="has-avatar">
-                                                <div class="Mrphs-userNav__submenuitem--profilepicture" style="background-image:url(/direct/profile/${loginUserDispId}/image/thumb)" tabindex="-1"></div>
+                                                <a class="Mrphs-userNav__submenuitem--profilelink" href="${tabsSites.mrphs_profileToolUrl}">
+                                                    <span class="Mrphs-userNav__submenuitem--profilepicture" style="background-image:url(/direct/profile/${loginUserDispId}/image/thumb)" tabindex="-1"></span>
+                                                </a>
                                             </div>
                                             <div class="Mrphs-userNav__submenuitem--profile">
                                                 <a role="menuitem" href="${tabsSites.mrphs_profileToolUrl}" class="Mrphs-userNav__submenuitem--dashboard">

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeSitesNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeSitesNav.vm
@@ -15,7 +15,8 @@
                 </li>           
             #end ## END of IF (${site.isMyWorkspace})
 
-            #if (!${site.isMyWorkspace} && (${site.favorite} == "true" || ${site.isCurrentSite}))
+            ## Only show other sites if they're the current site, a favorite of the current user, or if there *is* no current user and we're showing Gateway sites.
+            #if (!${site.isMyWorkspace} && (${site.favorite} == "true" || ${site.isCurrentSite} || !${userIsLoggedIn}))
                 <li class="Mrphs-sitesNav__menuitem #if (${site.isCurrentSite}) is-selected #end">
                     <a href="${site.siteUrl}" title="${site.fullTitle}" role="menuitem" aria-haspopup="true">
                         <span>#if ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )${site.shortDescription}#else${site.siteTitle}#end</span>

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/moresites.vm
@@ -5,8 +5,18 @@
 <div id="selectSite" class="outscreen" tabindex="-1">
     <div id="selectSite-navbar" class="Mrphs-toolTitleNav">
         <!-- View all sites, add new site, preferences -->
-        <ul id="otherSitesMenu">
 
+        <!-- Close button -->
+        <div id="otherSiteCloseW">
+            <a href="#" onclick="closeDrawer()" class="toggler" title="${rloader.sit_othersitesclose}">
+                <i class="fa fa-close"></i>
+                <span class="skip">
+                    ${rloader.sit_othersitesclose}
+                </span>
+            </a>
+        </div>
+
+        <ul id="otherSitesMenu">
             #if (${tabsSites.worksiteToolUrl})
 
                 <li><a id="allSites" href="${tabsSites.mrphs_worksiteToolUrl}"><span>${rloader.sit_allsites}</span></a></li>
@@ -24,25 +34,14 @@
                 <li><a href="${tabsSites.prefsToolUrl}"><span>${rloader.sit_preferences}</span></a></li>
 
             #end ## END of IF (${tabsSites.prefsToolUrl})
-
-            <!-- Close button -->
-            <li id="otherSiteCloseW">
-                <a href="#" onclick="closeDrawer()" class="toggler" title="${rloader.sit_othersitesclose}">
-                    <span class="hamburger">
-                        <i class="fa fa-close"></i>
-                    </span>
-                    <span class="skip">
-                        ${rloader.sit_othersitesclose}
-                    </span>
-                </a>
-            </li>
         </ul>
 
     </div>
 
     <ul class="tab-bar">
         <li class="tab-btn active" data-tab-target="otherSitesCategorWrap">${rloader.sit_worksites}</li>
-        <li class="organizeFavorites tab-btn" data-tab-target="organizeFavorites">${rloader.moresite_organize_favorites} <span class="favoriteCount"></span></li>
+        <li class="organizeFavorites tab-btn" data-tab-target="organizeFavorites">
+            <span class="favorites-desktop">${rloader.moresite_organize_favorites}</span><span class="favorites-mobile">${rloader.moresite_favorites}</span> <span class="favoriteCount"></span></li>
     </ul>
 
     <div class="tab-box" id="otherSitesCategorWrap">
@@ -73,8 +72,8 @@
 
         <div class="moresites-left-col">
             #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
-                <div class="fav-sites-term">
-                    #if ($tabsSites.tabsMoreTermsLeftPane.get($termKey).size() > 0)
+                #if ($tabsSites.tabsMoreTermsLeftPane.get($termKey).size() > 0)
+                    <div class="fav-sites-term">
                         #if ( !$termKey || $termKey == "" )
                             <h4>${rloader.sit_notermkey}</h4>
                         #else
@@ -86,15 +85,15 @@
                                 #displaySite($site)
                             #end
                         </ul>
-                    #end
-                </div>
+                    </div>
+                #end
             #end
         </div>
 
         <div class="moresites-right-col">
             #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
-                <div class="fav-sites-term">
-                    #if ($tabsSites.tabsMoreTermsRightPane.get($termKey).size() > 0)
+                #if ($tabsSites.tabsMoreTermsRightPane.get($termKey).size() > 0)
+                    <div class="fav-sites-term">
                         #if ( $termKey && $termKey != "" )
                             <h4>$termKey</h4>
 
@@ -113,15 +112,16 @@
                                 #end
                             </ul>
                         #end
-                    #end
-                </div>
+                    </div>
+                #end
             #end
         </div>
 
     </div><!--  end of #otherSitesCategorWrap -->
 
     <div style="display: none" class="tab-box" id="organizeFavorites">
-        <h2>Organize your favorites</h2>
+        <h2 class="heading">${rloader.moresite_organize_favorites}</h2>
+
         <ul id="organizeFavoritesList" class="organizeFavoritesList favoriteSiteList">
         </ul>
 

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/moresites.vm
@@ -2,131 +2,125 @@
 <div id="maxToolsInt" style="display: none">${maxToolsInt}</div>
 <div id="refreshNotificationText" style="display: none">${rloader.sit_refresh_favorites}</div>
 
-<div id="selectSite" class="outscreen" tabindex="-1">
-    <div id="selectSite-navbar" class="Mrphs-toolTitleNav">
-        <!-- View all sites, add new site, preferences -->
+<div id="selectSiteModal" class="outscreen">
+    <div id="selectSite">
+        <div id="selectSite-navbar" class="Mrphs-toolTitleNav">
+            <!-- View all sites, add new site, preferences -->
 
-        <!-- Close button -->
-        <div id="otherSiteCloseW">
-            <a href="#" onclick="closeDrawer()" class="toggler" title="${rloader.sit_othersitesclose}">
-                <i class="fa fa-close"></i>
-                <span class="skip">
-                    ${rloader.sit_othersitesclose}
-                </span>
-            </a>
+            <ul id="otherSitesMenu">
+                #if (${tabsSites.worksiteToolUrl})
+
+                    <li><a id="allSites" href="${tabsSites.mrphs_worksiteToolUrl}"><span>${rloader.sit_allsites}</span></a></li>
+
+                    #if ($allowAddSite)
+
+                        <li><a id="newSite" href="${tabsSites.mrphs_worksiteToolUrl}?panel=Shortcut&amp;sakai_action=doNew_site&amp"><span>${rloader.sit_newsite}</span></a></li>
+
+                    #end ## END of IF ($allowAddSite)
+
+                #end ## END of IF (${tabsSites.worksiteToolUrl})
+
+                #if (${tabsSites.prefsToolUrl})
+
+                    <li><a href="${tabsSites.prefsToolUrl}"><span>${rloader.sit_preferences}</span></a></li>
+
+                #end ## END of IF (${tabsSites.prefsToolUrl})
+            </ul>
+
         </div>
 
-        <ul id="otherSitesMenu">
-            #if (${tabsSites.worksiteToolUrl})
-
-                <li><a id="allSites" href="${tabsSites.mrphs_worksiteToolUrl}"><span>${rloader.sit_allsites}</span></a></li>
-
-                #if ($allowAddSite)
-
-                    <li><a id="newSite" href="${tabsSites.mrphs_worksiteToolUrl}?panel=Shortcut&amp;sakai_action=doNew_site&amp"><span>${rloader.sit_newsite}</span></a></li>
-
-                #end ## END of IF ($allowAddSite)
-
-            #end ## END of IF (${tabsSites.worksiteToolUrl})
-
-            #if (${tabsSites.prefsToolUrl})
-
-                <li><a href="${tabsSites.prefsToolUrl}"><span>${rloader.sit_preferences}</span></a></li>
-
-            #end ## END of IF (${tabsSites.prefsToolUrl})
+        <ul class="tab-bar">
+            <li class="tab-btn active" data-tab-target="otherSitesCategorWrap">${rloader.sit_worksites}</li>
+            <li class="organizeFavorites tab-btn" data-tab-target="organizeFavorites">
+                <span class="favorites-desktop">${rloader.moresite_organize_favorites}</span><span class="favorites-mobile">${rloader.moresite_favorites}</span> <span class="favoriteCount"></span></li>
         </ul>
 
-    </div>
+        <div class="tab-pane">
+            <div class="tab-box" id="otherSitesCategorWrap">
 
-    <ul class="tab-bar">
-        <li class="tab-btn active" data-tab-target="otherSitesCategorWrap">${rloader.sit_worksites}</li>
-        <li class="organizeFavorites tab-btn" data-tab-target="organizeFavorites">
-            <span class="favorites-desktop">${rloader.moresite_organize_favorites}</span><span class="favorites-mobile">${rloader.moresite_favorites}</span> <span class="favoriteCount"></span></li>
-    </ul>
-
-    <div class="tab-box" id="otherSitesCategorWrap">
-
-        <div id="otherSiteSearch">
-            <input type="text" id="txtSearch" name="txtSearch" maxlength="50" placeholder=" ${rloader.sit_search}">
-            <a id="otherSiteSearchClear" class="other-site-search-clear" href="javascript:void(0);"></a>
-        </div>
-        <div id="noSearchResults" class="is-hidden">${rloader.sit_search_none}</div>
-
-
-        #macro( displaySite $site )
-            <li class="fav-sites-entry #if (${site.isCurrentSite})is-selected #end #if (${site.isMyWorkspace})my-workspace #end">
-                <a class="site-favorite-btn" data-site-id="${site.siteId}" href="javascript:void(0);"></a>
-
-                <div class="fav-title">
-                    <a href="${site.siteUrl}" title="${site.siteTitleNotTruncated}">
-                        #if ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )
-                            <span class="fullTitle">${site.shortDescription}</span>
-                        #else
-                            <span class="fullTitle">${site.siteTitle}</span>
-                        #end
-                    </a>
+                <div id="otherSiteSearch">
+                    <input type="text" id="txtSearch" name="txtSearch" maxlength="50" placeholder=" ${rloader.sit_search}">
+                    <a id="otherSiteSearchClear" class="other-site-search-clear" href="javascript:void(0);"></a>
                 </div>
-                <a href="#" id="${site.siteId}" class="toolMenus"><i class="fa fa-chevron-down"></i></a>
-            </li>
-        #end
+                <div id="noSearchResults" class="is-hidden">${rloader.sit_search_none}</div>
 
-        <div class="moresites-left-col">
-            #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
-                #if ($tabsSites.tabsMoreTermsLeftPane.get($termKey).size() > 0)
-                    <div class="fav-sites-term">
-                        #if ( !$termKey || $termKey == "" )
-                            <h4>${rloader.sit_notermkey}</h4>
-                        #else
-                            <h4>$termKey</h4>
-                        #end
 
-                        <ul class="otherSitesCategorList favoriteSiteList">
-                            #foreach( $site in $tabsSites.tabsMoreTermsLeftPane.get($termKey))
-                                #displaySite($site)
-                            #end
-                        </ul>
-                    </div>
+                #macro( displaySite $site )
+                    <li class="fav-sites-entry #if (${site.isCurrentSite})is-selected #end #if (${site.isMyWorkspace})my-workspace #end">
+                        <a class="site-favorite-btn" data-site-id="${site.siteId}" href="javascript:void(0);"></a>
+
+                        <div class="fav-title">
+                            <a href="${site.siteUrl}" title="${site.siteTitleNotTruncated}">
+                                #if ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )
+                                    <span class="fullTitle">${site.shortDescription}</span>
+                                #else
+                                    <span class="fullTitle">${site.siteTitle}</span>
+                                #end
+                            </a>
+                        </div>
+                        <a href="#" id="${site.siteId}" class="toolMenus"><i class="fa fa-chevron-down"></i></a>
+                    </li>
                 #end
-            #end
-        </div>
 
-        <div class="moresites-right-col">
-            #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
-                #if ($tabsSites.tabsMoreTermsRightPane.get($termKey).size() > 0)
-                    <div class="fav-sites-term">
-                        #if ( $termKey && $termKey != "" )
-                            <h4>$termKey</h4>
-
-                            <ul class="otherSitesCategorList favoriteSiteList">
-                                <!-- anchor "my workspace" to the top of the list -->
-                                #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
-                                    #if (${site.isMyWorkspace})
-                                        #displaySite($site)
-                                    #end
+                <div class="moresites-left-col">
+                    #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
+                        #if ($tabsSites.tabsMoreTermsLeftPane.get($termKey).size() > 0)
+                            <div class="fav-sites-term">
+                                #if ( !$termKey || $termKey == "" )
+                                    <h4>${rloader.sit_notermkey}</h4>
+                                #else
+                                    <h4>$termKey</h4>
                                 #end
 
-                                #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
-                                    #if (${site.siteType} != #"course" && !${site.isMyWorkspace})
+                                <ul class="otherSitesCategorList favoriteSiteList">
+                                    #foreach( $site in $tabsSites.tabsMoreTermsLeftPane.get($termKey))
                                         #displaySite($site)
                                     #end
-                                #end
-                            </ul>
+                                </ul>
+                            </div>
                         #end
-                    </div>
-                #end
-            #end
+                    #end
+                </div>
+
+                <div class="moresites-right-col">
+                    #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
+                        #if ($tabsSites.tabsMoreTermsRightPane.get($termKey).size() > 0)
+                            <div class="fav-sites-term">
+                                #if ( $termKey && $termKey != "" )
+                                    <h4>$termKey</h4>
+
+                                    <ul class="otherSitesCategorList favoriteSiteList">
+                                        <!-- anchor "my workspace" to the top of the list -->
+                                        #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
+                                            #if (${site.isMyWorkspace})
+                                                #displaySite($site)
+                                            #end
+                                        #end
+
+                                        #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
+                                            #if (${site.siteType} != #"course" && !${site.isMyWorkspace})
+                                                #displaySite($site)
+                                            #end
+                                        #end
+                                    </ul>
+                                #end
+                            </div>
+                        #end
+                    #end
+                </div>
+
+            </div><!--  end of #otherSitesCategorWrap -->
+
+            <div style="display: none" class="tab-box" id="organizeFavorites">
+                <h2 class="heading">${rloader.moresite_organize_favorites}</h2>
+
+                <ul id="organizeFavoritesList" class="organizeFavoritesList favoriteSiteList">
+                </ul>
+
+                <!-- Items are put here when unfavorited from the "organize" screen -->
+                <ul id="organizeFavoritesPurgatoryList" class="favoriteSiteList">
+                </ul>
+            </div>
         </div>
-
-    </div><!--  end of #otherSitesCategorWrap -->
-
-    <div style="display: none" class="tab-box" id="organizeFavorites">
-        <h2 class="heading">${rloader.moresite_organize_favorites}</h2>
-
-        <ul id="organizeFavoritesList" class="organizeFavoritesList favoriteSiteList">
-        </ul>
-
-        <!-- Items are put here when unfavorited from the "organize" screen -->
-        <ul id="organizeFavoritesPurgatoryList" class="favoriteSiteList">
-        </ul>
     </div>
 </div>

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
@@ -18,7 +18,7 @@
         </li>
         <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--worksite">
             <a href="#sitetabs" id="more-sites-menu" class="Mrphs-skipNav__link js-toggle-sites-nav" title="${rloader.sit_jumpworksite}" accesskey="w">
-		      ${rloader.sit_more}
+                <i class="fa fa-th all-sites-icon"></i> ${rloader.sit_worksites}
             </a>
         </li>
     </ul>

--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -5,20 +5,40 @@
 var dhtml_view_sites = function(){
 
   // first time through set up the DOM
-  $PBJQ('#selectSite').addClass('dhtml_more_tabs'); // move the selectSite in the DOM
+  $PBJQ('#selectSiteModal').addClass('dhtml_more_tabs'); // move the selectSite in the DOM
   $PBJQ('.more-tab').position();
 
   // then recast the function to the post initialized state which will run from then on
   dhtml_view_sites = function(){
 
-    if ($PBJQ('#selectSite').hasClass('outscreen') ) {
+    if ($PBJQ('#selectSiteModal').hasClass('outscreen') ) {
 
       $PBJQ('body').toggleClass('active-more-sites');
-      $PBJQ('#selectSite').toggleClass('outscreen');
+
+      // In mobile mode, hide the tools nav prior to showing sites
+      if ($PBJQ('body').hasClass('toolsNav--displayed')) {
+        toggleToolsNav();
+      }
+
+      // Align with the bottom of the main header in desktop mode
+      var allSitesButton = $('.view-all-sites-btn:visible');
+
+      if (allSitesButton.length > 0) {
+        // Raise the button to keep it visible over the modal overlay
+        allSitesButton.css('z-index', 1005);
+
+        var topPadding = 10;
+        var topPosition = allSitesButton.offset().top + allSitesButton.outerHeight() + topPadding;
+        var rightPosition = $PBJQ('body').outerWidth() - (allSitesButton.offset().left + allSitesButton.outerWidth());
+        $PBJQ('#selectSiteModal').css('top', topPosition).css('right', rightPosition);
+      }
+
+      $PBJQ('.tab-pane').css('max-height', $PBJQ('body').height());
+
+      $PBJQ('#selectSiteModal').toggleClass('outscreen');
 
       $PBJQ('#txtSearch').focus();
       createDHTMLMask(dhtml_view_sites);
-      $PBJQ('#selectSite').attr('tabindex', '0');
 
       $PBJQ('.selectedTab').bind('click', function(e){
         dhtml_view_sites();
@@ -101,7 +121,11 @@ var dhtml_view_sites = function(){
 
       // hide the dropdown
       $PBJQ('body').toggleClass('active-more-sites');
-      $PBJQ('#selectSite').toggleClass('outscreen'); //hide the box
+      $PBJQ('#selectSiteModal').toggleClass('outscreen'); //hide the box
+
+      // Restore the button's zIndex so it doesn't hover over other overlays
+      var allSitesButton = $('.view-all-sites-btn');
+      allSitesButton.css('z-index', 'auto');
 
       $PBJQ('#selectSite').attr('tabindex', '-1');
       removeDHTMLMask()
@@ -116,7 +140,7 @@ var dhtml_view_sites = function(){
 
 function closeDrawer() {
 
-  $PBJQ('#selectSite').toggleClass('outscreen');  //hide the box
+  $PBJQ('#selectSiteModal').toggleClass('outscreen');  //hide the box
   removeDHTMLMask();
   $PBJQ('#selectSite').attr('tabindex', '-1');
   $PBJQ('#otherSiteTools').remove();
@@ -250,9 +274,9 @@ $PBJQ(document).ready(function(){
 
   });
 
-  // Open all Sites with mobile view 	
+  // Open all Sites with mobile view
    $PBJQ(".js-toggle-sites-nav", "#skipNav").on("click", dhtml_view_sites);
-  
+
   // Open all Sites with Desktop view
   $PBJQ("#show-all-sites, .view-all-sites-btn").on("click", dhtml_view_sites);
 

--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
@@ -3,27 +3,12 @@
  */
 
 function toggleToolsNav(event){
-
-  event.preventDefault();
+  if (event) {
+    event.preventDefault();
+  }
   $PBJQ('body').toggleClass('toolsNav--displayed');
 
 }
-
-function toggleSitesNav(event){
-
-  event.preventDefault();
-  $PBJQ('body').toggleClass('sitesNav--displayed');
-  // remove class if siteNav submenus are activated
-  $PBJQ('#linkNav .Mrphs-sitesNav__dropdown').removeClass('is-clicked');
-  $PBJQ('#linkNav .Mrphs-sitesNav__submenu').removeClass('is-visible');
-
-}
-
-$PBJQ(document).ready(function(){
-	if( $PBJQ('#linkNav').length == 0 ){
-		$PBJQ('.js-toggle-sites-nav').hide();
-	}
-});
 
 $PBJQ(document).ready(function(){
   $PBJQ('i.clickable', '#roleSwitch').click( function(){
@@ -31,6 +16,4 @@ $PBJQ(document).ready(function(){
   });
 });
 
-// Remove toogle sites nav on Skip nav to More sites view @TODO need to clean this toggleSitesNav code since it is not used anymore
-//$PBJQ(".js-toggle-sites-nav", "#skipNav").on("click", toggleSitesNav);
 $PBJQ(".js-toggle-tools-nav", "#skipNav").on("click", toggleToolsNav);

--- a/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -24,6 +24,7 @@
 			top: 2.7em;
 			overflow: visible;
 			position: absolute;
+			padding: 0;
 			@include box-shadow( 0px 0 0px 0px rgba(0,0,0,0) );
 			@include transition( left 0.26s linear );
 			&:after {
@@ -46,6 +47,9 @@
 	&.outscreen{
 		left: 110%;
 		max-width: 100%;
+		@media #{$phone}{
+			display: none;
+		}
 	}
 	h4{
 		font-size: 1.8em;
@@ -99,12 +103,20 @@
 
 ul#otherSitesMenu{
 	margin: 0;
-	float: right;
+	@media #{$desktop}{
+		float: right;
+	}
+	@media #{$phone}{
+		margin-left: 5px;
+	}
 	display: inline-block;
 	li{
 		display: inline-block;
 		a{
 			@extend .button;
+			@media #{$phone}{
+				padding: 0.3em;
+			}
 		}
 	}
 }
@@ -119,20 +131,24 @@ ul#otherSitesMenu{
 		width: 49%;
 		float: left;
 		margin-right: 1%;
-		margin-top: -2em;
 		@media #{$more-sites-single-column}{
 			width: 100%;
 			float: none;
+		}
+		.fav-sites-term:first-child h4{
+			margin-top: 0;
 		}
 	}
 	.moresites-right-col{
 		display: inline-block;
 		width: 49%;
 		float: left;
-		margin-top: -2em;
 		@media #{$more-sites-single-column}{
 			width: 100%;
 			float: none;
+		}
+		.fav-sites-term:first-child h4{
+			margin-top: 0;
 		}
 	}
 }
@@ -162,7 +178,16 @@ ul.otherSitesCategorList{
 
 #otherSiteSearch{
 	display: block;
-	text-align: right;
+
+	@media #{$more-sites-single-column}{
+		text-align: left;
+		margin-bottom: 1em;
+	}
+
+	@media #{$desktop}{
+		text-align: right;
+	}
+
 	label{
 		color: $text-color;
 	}
@@ -193,14 +218,13 @@ ul.otherSitesCategorList{
 }
 
 #otherSiteCloseW{
+	display: inline-block;
+	float: right;
 	background: none;
 	padding: 0 0 0 0;
 	margin: 0 0 0 0;
 	border: 0px none;
 	font-size: 2em;
-	@media #{$phone}{
-		left: 90%;
-	}
 	.toggler{
 		text-decoration: none;
 		color: darken($errorcolor, 50%);
@@ -263,6 +287,30 @@ ul.favoriteSiteList > li{
 
 #organizeFavorites{
 	padding-left: 1em;
+	@media #{$phone}{
+		.heading{
+			display: none;
+		}
+	}
+}
+
+.tab-btn.organizeFavorites{
+	@media #{$desktop}{
+		.favorites-desktop{
+			display: inline;
+		}
+		.favorites-mobile{
+			display: none;
+		}
+	}
+	@media #{$phone}{
+		.favorites-desktop{
+			display: none;
+		}
+		.favorites-mobile{
+			display: inline;
+		}
+	}
 }
 
 .organizeFavoritesList{
@@ -275,6 +323,10 @@ ul.favoriteSiteList > li{
 		cursor: grab;
 		cursor: -moz-grab;
 		cursor: -webkit-grab;
+
+		@media #{$phone}{
+			display: none;
+		}
 	}
 	.fav-drag-handle:active{
 		cursor: grabbing;

--- a/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -2,26 +2,25 @@
 	background: rgba(0,0,0,0.45);
 	position: fixed;
 }
-#selectSite{
+
+#selectSiteModal{
 	position: fixed;
+        z-index: 1005;
+	overflow:visible;
 	@include transition( left 0.4s linear );
 	&.dhtml_more_tabs{
 		background: $toolMenuBGColor;
 		display: block;
 		position: fixed;
-		top: 0;
-		left: 40%;
 		width: 60% ;
 		max-height: 100%;
 		padding: 0 1em 1em 1em;
-		overflow-y: auto;
-		overflow-x: hidden;
-		z-index: 1005;
 		@include box-shadow( 5px 0 50px 0px rgba(0,0,0,0.5) );
 		@media #{$phone}{
 			width: 100%;
-			left: 0;
+			height: 100%;
 			top: 2.7em;
+			left: 0;
 			overflow: visible;
 			position: absolute;
 			padding: 0;
@@ -51,9 +50,31 @@
 			display: none;
 		}
 	}
+	&:after{
+	        bottom: 100%;
+		left: 97%;
+		border: solid transparent;
+		content: " ";
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+		border-color: rgba(255, 255, 255, 0);
+		border-bottom-color: $toolTabBGColor;
+		border-width: 7px;
+		margin-left: -7px;
+		outline: 0;
+	}
+}
+
+#selectSite{
 	h4{
 		font-size: 1.8em;
   		margin: 1.5em 0 0.6em 0;
+	}
+	.tab-pane{
+		overflow-y: auto;
+		overflow-x: hidden;
 	}
 	.tab-box{
 		border: 1px solid $toolBorderColor;
@@ -217,20 +238,6 @@ ul.otherSitesCategorList{
 	}
 }
 
-#otherSiteCloseW{
-	display: inline-block;
-	float: right;
-	background: none;
-	padding: 0 0 0 0;
-	margin: 0 0 0 0;
-	border: 0px none;
-	font-size: 2em;
-	.toggler{
-		text-decoration: none;
-		color: darken($errorcolor, 50%);
-	}
-}
-
 .otherSiteToolIcon{
 	padding-right: 0.5em;
 }
@@ -295,14 +302,13 @@ ul.favoriteSiteList > li{
 }
 
 .tab-btn.organizeFavorites{
-	@media #{$desktop}{
-		.favorites-desktop{
-			display: inline;
-		}
-		.favorites-mobile{
-			display: none;
-		}
+	.favorites-desktop{
+		display: inline;
 	}
+	.favorites-mobile{
+		display: none;
+	}
+
 	@media #{$phone}{
 		.favorites-desktop{
 			display: none;

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -455,23 +455,28 @@ body.is-logged-out{
 	}
 }
 
-.view-all-sites-btn {
+.view-all-sites-btn{
 	display: inline-block;
 	padding-right: 1em;
 	border-right: 1px solid $toolBorderColor;
+
+	@media #{$phone}{
+		display: none;
+	}
 }
 
-.view-all-sites-btn a {
+.view-all-sites-btn a{
 	text-decoration: none;
 }
 
-.all-sites-icon, .all-sites-label {
+.all-sites-icon, .all-sites-label{
 	display: inline-block;
 	vertical-align: middle;
 }
 
-.all-sites-icon {
+.all-sites-icon{
 	font-size: 16pt;
+	padding-right: 2px;
 }
 
 #linkNav{

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -324,10 +324,6 @@ body.is-logged-out{
 	}
 
 	.#{$namespace}userNav__dropdown, .#{$namespace}userNav__drop{
-		@extend .fa-angle-down;
-		@extend .fa;
-		@extend .fa-lg;
-		@extend .sitesNav__drop;
 		float: right;
 		position: relative;
 		margin-top: -2.5em;
@@ -456,6 +452,7 @@ body.is-logged-out{
 }
 
 .view-all-sites-btn{
+	position: relative;
 	display: inline-block;
 	padding-right: 1em;
 	border-right: 1px solid $toolBorderColor;

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -302,6 +302,9 @@ body.is-logged-out{
 	}
 
 	.has-avatar{
+		.#{$namespace}userNav__submenuitem--profilelink{
+			padding: 0 !important;
+		}
 		.#{$namespace}userNav__submenuitem--profilepicture{
 			width:32px;
 			height:32px;


### PR DESCRIPTION
Incorporates several changes to make the new "Favorites" drawer look
better on mobile devices:

  * Show the "Organize Favorites" tab as just a "Favorites"
    display (without the drag/drop that was there before).  The
    standard drag/drop library doesn't seem to support touch events, and
    mobile users never see the list they were organizing anyway.

  * Move the close button to the top right

  * Resize the other buttons to fit in a single row

  * Fix an issue where the search box wouldn't take focus because it was
    underneath another div.

Also includes a second commit based on feedback from @jeffpasch and @kyleblythe.  Happy to squash these two into a single commit for ease of merging (I only left them separate to make review a bit easier)