### PR TITLE
1368: add dialog for updating the course grade display

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -80,6 +80,7 @@ heading.studentpage = Grade Report for {0}
 heading.coursegrade = Course Grade Override for {0} ({1})
 heading.coursegradelog = Course Grade Override Log for {0} ({1})
 heading.zeroungradeditems = Set Zero Score for Empty Cells
+heading.updatecoursegradedisplay = Update Course Grade Display
 
 # note these are not standard wicket style properties as we format this one slightly differently
 formatter.studentname.LAST_NAME = %s, %s
@@ -333,6 +334,7 @@ label.statistics.deviation = Standard Deviation
 coursegrade.option.override = Course Grade Override
 coursegrade.option.overridelog = Course Grade Override Log
 coursegrade.option.setungraded = Set Zero Score For Empty Cells
+coursegrade.option.updatecoursegradedisplay = Update Course Grade Display
 
 label.zeroungradeditems.instructions.1 = The Gradebook automatically calculates the course grade for students as items are graded. To accurately calculate the course grades, all gradable items must be assigned a grade. Continuing will assign zero to any grade items that do not have a grade. Not zeroing may result in higher course grades than intended.
 label.zeroungradeditems.instructions.2 = <b>Note:</b> Clicking Update will assign a grade of zero to all ungraded items in this gradebook. <b>This can not be undone!</b>
@@ -353,3 +355,6 @@ column.header.coursegradeoverride.points = Points
 column.header.coursegradeoverride.calculated = Calculated Grade
 column.header.coursegradeoverride.gradeoverride = Grade Override
 
+label.updatecoursegradedisplay.instructions.1 = Select from the display options below for students' course grades. The option(s) selected here will display both to instructors and students. You may release course grades to students from the Settings.
+label.updatecoursegradedisplay.instructions.2 = Note: The "Points" display type is only available if <strong>not</strong> using Categories &amp; Weighting.
+label.updatecoursegradedisplay.success = The course grade display settings were successfully updated

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -17,6 +17,7 @@
 	<div wicket:id="gradeCommentWindow" />
 	<div wicket:id="deleteItemWindow" />
 	<div wicket:id="gradeStatisticsWindow" />
+	<div wicket:id="updateCourseGradeDisplayWindow" />
     
     <div id="gradebookGrades">
       <div id="gradebookGradesToolbar">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -79,6 +79,7 @@ public class GradebookPage extends BasePage {
 	GbModalWindow gradeCommentWindow;
 	GbModalWindow deleteItemWindow;
 	GbModalWindow gradeStatisticsWindow;
+	GbModalWindow updateCourseGradeDisplayWindow;
 
 	Form<Void> form;
 
@@ -124,6 +125,9 @@ public class GradebookPage extends BasePage {
 
 		this.gradeStatisticsWindow = new GbModalWindow("gradeStatisticsWindow");
 		this.form.add(this.gradeStatisticsWindow);
+
+		this.updateCourseGradeDisplayWindow = new GbModalWindow("updateCourseGradeDisplayWindow");
+		this.form.add(this.updateCourseGradeDisplayWindow);
 
 		final AjaxButton addGradeItem = new AjaxButton("addGradeItem") {
 			@Override
@@ -546,6 +550,10 @@ public class GradebookPage extends BasePage {
 
 	public GbModalWindow getGradeStatisticsWindow() {
 		return this.gradeStatisticsWindow;
+	}
+
+	public GbModalWindow getUpdateCourseGradeDisplayWindow() {
+		return this.updateCourseGradeDisplayWindow;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.html
@@ -19,7 +19,8 @@
 			<span class="caret"></span>
 		</a>
 		<ul class="dropdown-menu dropdown-menu-right" role="menu">
-			<li><a wicket:id="setUngraded" href="#" class="move-assignment-left" role="menuitem"><wicket:message key="coursegrade.option.setungraded" /></a></li>
+			<li><a wicket:id="setUngraded" href="#" role="menuitem"><wicket:message key="coursegrade.option.setungraded" /></a></li>
+			<li><a wicket:id="updateCourseGradeDisplay" href="#" role="menuitem"><wicket:message key="coursegrade.option.updatecoursegradedisplay" /></a></li>
 		</ul>
 	</div>
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
@@ -58,6 +58,18 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 				window.show(target);
 			}
 		});
+		menu.add(new AjaxLink<Void>("updateCourseGradeDisplay") {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void onClick(final AjaxRequestTarget target) {
+				final GbModalWindow window = gradebookPage.getUpdateCourseGradeDisplayWindow();
+				window.setComponentToReturnFocusTo(getParentCellFor(this));
+				window.setContent(new UpdateCourseGradeDisplayPanel(window.getContentId(), window));
+				window.showUnloadConfirmation(false);
+				window.show(target);
+			}
+		});
 		add(menu);
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateCourseGradeDisplayPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateCourseGradeDisplayPanel.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+
+<body>
+	<wicket:panel>
+
+		<form wicket:id="form">
+
+			<h2>
+				<wicket:message key="heading.updatecoursegradedisplay" />
+			</h2>
+	
+			<div class="form-group">
+				<div class="help-block">
+					<p><wicket:message key="label.updatecoursegradedisplay.instructions.1" /></p>
+					<p><wicket:message key="label.updatecoursegradedisplay.instructions.2" /></p>
+				</div>
+
+				<div class="checkbox">
+					<label>
+						<input wicket:id="letterGrade" type="checkbox" />
+						<wicket:message key="settingspage.displaycoursegrade.lettergrade" />
+					</label>
+				</div>
+
+				<div class="checkbox">
+					<label>
+						<input wicket:id="percentage" type="checkbox" />
+						<wicket:message key="settingspage.displaycoursegrade.percentage" />
+					</label>
+				</div>
+
+				<div class="checkbox">
+					<label>
+						<input wicket:id="points" type="checkbox" />
+						<wicket:message key="settingspage.displaycoursegrade.points" />
+					</label>
+				</div>
+
+				<div class="col-xs-offset-4 col-xs-5">
+					<button class="btn btn-primary" wicket:id="submit"><wicket:message key="button.update" /></button>
+					<button class="btn btn-default" wicket:id="cancel"><wicket:message key="button.cancel"/></button>
+				</div>
+			</div>
+
+		</form>
+
+	</wicket:panel>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateCourseGradeDisplayPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateCourseGradeDisplayPanel.java
@@ -1,0 +1,91 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.model.GbSettings;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.service.gradebook.shared.GradebookInformation;
+
+import java.util.List;
+
+/**
+ *
+ * Panel for the modal window that allows an instructor to update the Course Grade Display settings
+ *
+ */
+public class UpdateCourseGradeDisplayPanel extends Panel {
+
+	private static final long serialVersionUID = 1L;
+
+	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
+	protected GradebookNgBusinessService businessService;
+
+	private final ModalWindow window;
+
+	public UpdateCourseGradeDisplayPanel(final String id, final ModalWindow window) {
+		super(id);
+		this.window = window;
+	}
+
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+
+		// get settings data
+		final GradebookInformation settings = this.businessService.getGradebookSettings();
+
+		final GbSettings gbSettings = new GbSettings(settings);
+		final CompoundPropertyModel<GbSettings> formModel = new CompoundPropertyModel<GbSettings>(gbSettings);
+
+		// form
+		Form<GbSettings> form = new Form<GbSettings>("form", formModel);
+
+		// letter grade
+		form.add(new CheckBox("letterGrade",
+				new PropertyModel<Boolean>(formModel, "gradebookInformation.courseLetterGradeDisplayed")));
+
+		// percentage
+		form.add(new CheckBox("percentage",
+				new PropertyModel<Boolean>(formModel, "gradebookInformation.courseAverageDisplayed")));
+
+		// points
+		form.add(new CheckBox("points",
+				new PropertyModel<Boolean>(formModel, "gradebookInformation.coursePointsDisplayed")));
+
+		final AjaxButton submit = new AjaxButton("submit") {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
+				// update settings
+				UpdateCourseGradeDisplayPanel.this.businessService.updateGradebookSettings(formModel.getObject().getGradebookInformation());
+
+				getSession().info(getString("label.updatecoursegradedisplay.success"));
+				UpdateCourseGradeDisplayPanel.this.window.close(target);
+				setResponsePage(new GradebookPage());
+			}
+		};
+		form.add(submit);
+
+		final AjaxButton cancel = new AjaxButton("cancel") {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
+				UpdateCourseGradeDisplayPanel.this.window.close(target);
+			}
+		};
+		cancel.setDefaultFormProcessing(false);
+		form.add(cancel);
+
+		add(form);
+	}
+}


### PR DESCRIPTION
Delivers #1368 by adding an "Update Course Grade Display" menu option in the Course Grade column and exposing the display settings within new dialog.

I haven't implemented a preview yet.  I was thinking we should centralise all formatting of the course grade to a single component or helper as we display the course grade in several different contexts (instructor and student summary dialogs, student page, settings previews and the course grade column). Does that seem reasonable?  Maybe something along the lines of this https://github.com/payten/sakai/commit/72658e2acb54b37c168a92967b97c55d3d6b31c9 (but with some smarts added to buildGradeMatrix so the Course Grade column can use it efficiently too).