### PR TITLE
1587 Add support to migrate GradebookNG between sites

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -271,8 +271,12 @@ public interface GradebookService {
 	 * to specific students or instructors (such as scores) are not.
 	 * @param gradebookUid
 	 * @return a versioned XML string
+	 * 
+	 * @deprecated This is used by the old gradebook1 entityproducer and will soon be redundant
 	 */
+	@Deprecated
 	public String getGradebookDefinitionXml(String gradebookUid);
+	
 	
 	/**
 	 * Attempt to transfer gradebook data with Category and weight and settings
@@ -280,8 +284,20 @@ public interface GradebookService {
 	 * @param fromGradebookUid
 	 * @param toGradebookUid
 	 * @param fromGradebookXml
+	 * 
+	 * @deprecated This is used by the old gradebook1 entityproducer and will soon be redundant
 	 */
+	@Deprecated
 	public void transferGradebookDefinitionXml(String fromGradebookUid, String toGradebookUid, String fromGradebookXml);
+	
+	/**
+	 * Transfer the gradebook information and assignments from one gradebook to another
+	 * 
+	 * @param gradebookInformation GradebookInformation to copy
+	 * @param assignments list of Assignments to copy
+	 * @param toGradebookUid target gradebook uid
+	 */
+	public void transferGradebook(final GradebookInformation gradebookInformation, final List<Assignment> assignments, final String toGradebookUid);
 	
 	/**
 	 * 

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/VersionedExternalizable.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/VersionedExternalizable.java
@@ -57,7 +57,10 @@ import com.thoughtworks.xstream.mapper.Mapper;
  * TODO For the functionality being checked in (site-to-site migration), this class
  * is not strictly necessary. It's here on a speculative basis for upcoming 
  * import/archive/merge development. 
+ * 
+ * @deprecated This is part of the import/export for gradebook1 which will be removed at some point
  */
+@Deprecated
 public abstract class VersionedExternalizable implements Externalizable {
 	public static String VERSION_ATTRIBUTE = "externalizableVersion";
 	

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/BaseEntityProducer.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/BaseEntityProducer.java
@@ -83,47 +83,58 @@ public class BaseEntityProducer implements EntityProducer {
 
 	// EntityProducer methods begin here.
 
+	@Override
 	public String getLabel() {
 		return label;
 	}
 
+	@Override
 	public boolean willArchiveMerge() {
 		return false;
 	}
 
+	@Override
 	public String archive(String siteId, Document doc, Stack stack, String archivePath, List attachments) {
 		return null;
 	}
 
+	@Override
 	public String merge(String siteId, Element root, String archivePath, String fromSiteId, Map attachmentNames, Map userIdTrans,
 			Set userListAllowImport) {
 		return null;
 	}
 
+	@Override
 	public boolean parseEntityReference(String reference, Reference ref) {
 		return false;
 	}
 
+	@Override
 	public String getEntityDescription(Reference ref) {
 		return null;
 	}
 
+	@Override
 	public ResourceProperties getEntityResourceProperties(Reference ref) {
 		return null;
 	}
 
+	@Override
 	public Entity getEntity(Reference ref) {
 		return null;
 	}
 
+	@Override
 	public String getEntityUrl(Reference ref) {
 		return null;
 	}
 
+	@Override
 	public Collection getEntityAuthzGroups(Reference ref, String userId) {
 		return null;
 	}
 
+	@Override
 	public HttpAccess getHttpAccess() {
 		return null;
 	}

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/BaseEntityProducer.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/BaseEntityProducer.java
@@ -40,7 +40,10 @@ import org.sakaiproject.entity.api.ResourceProperties;
  * actually need to customize. External configuration files can be used to
  * set their label, reference root, and service name. The public "init()" method can be
  * used to register as an EntityProducer.
+ *
+ * @deprecated This is part of the import/export for gradebook1 which will be removed at some point
  */
+@Deprecated
 public class BaseEntityProducer implements EntityProducer {
     //private static final Log log = LogFactory.getLog(BaseEntityProducer.class);
 

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/GradebookEntityProducer.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/GradebookEntityProducer.java
@@ -58,10 +58,12 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 		}
 	}
 
+	@Override
 	public String[] myToolIds() {
 		return toolIdArray;
 	}
 
+	@Override
 	public void contextCreated(String context, boolean toolPlacement) {
 		// Only create Gradebook storage if the Gradebook tool is actually
 		// part of the new site.
@@ -71,6 +73,7 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 		}
 	}
 
+	@Override
 	public void contextUpdated(String context, boolean toolPlacement) {
 		if (toolPlacement) {
 			if (!gradebookFrameworkService.isGradebookDefined(context)) {
@@ -87,6 +90,7 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 		}
 	}
 
+	@Override
 	public void contextDeleted(String context, boolean toolPlacement) {
 		if (gradebookFrameworkService.isGradebookDefined(context)) {
 			if (log.isDebugEnabled()) log.debug("Gradebook being deleted from context " + context);
@@ -98,6 +102,7 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 		}
 	}
 
+	@Override
 	public void transferCopyEntities(String fromContext, String toContext, List ids) {
 		String fromGradebookXml = gradebookService.getGradebookDefinitionXml(fromContext);
 		gradebookService.transferGradebookDefinitionXml(fromContext, toContext, fromGradebookXml);
@@ -121,10 +126,12 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 
 	public static final String GRADEBOOK_DEFINITION_TYPE = "sakai-gradebook";
 
+	@Override
 	public boolean canHandleType(String typeName) {
 		return (typeName.equals(GRADEBOOK_DEFINITION_TYPE));
 	}
 
+	@Override
 	public void handle(Importable importable, String siteId) {
 		if (importable.getTypeName().equals(GRADEBOOK_DEFINITION_TYPE)) {
 			gradebookService.mergeGradebookDefinitionXml(siteId, ((XmlImportable)importable).getXmlData());
@@ -137,6 +144,7 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 		return importables;
 	}
 	
+	@Override
 	public void transferCopyEntities(String fromContext, String toContext, List ids, boolean cleanup) {
 		
 			if(cleanup == true) {				

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/GradebookEntityProducer.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/GradebookEntityProducer.java
@@ -43,7 +43,10 @@ import org.sakaiproject.tool.gradebook.Gradebook;
 /**
  * Implements the Sakai EntityProducer approach to integration of tool-specific
  * storage with site management.
+ * 
+ * @deprecated This is part of the import/export for gradebook1 which will be removed at some point
  */
+@Deprecated
 public class GradebookEntityProducer extends BaseEntityProducer implements ContextObserver, EntityTransferrer, HandlesImportable {
     private static final Log log = LogFactory.getLog(GradebookEntityProducer.class);
 

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/GradebookEntityProducer.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/GradebookEntityProducer.java
@@ -107,11 +107,6 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 		String fromGradebookXml = gradebookService.getGradebookDefinitionXml(fromContext);
 		gradebookService.transferGradebookDefinitionXml(fromContext, toContext, fromGradebookXml);
 	}
-	
-	public void transferCopyEntitiesWithSettings(String fromContext, String toContext, List ids) {
-		String fromGradebookXml = gradebookService.getGradebookDefinitionXml(fromContext);
-		gradebookService.transferGradebookDefinitionXml(fromContext, toContext, fromGradebookXml);
-	}
 
 	public void setGradebookFrameworkService(GradebookFrameworkService gradebookFrameworkService) {
 		this.gradebookFrameworkService = gradebookFrameworkService;
@@ -173,13 +168,10 @@ public class GradebookEntityProducer extends BaseEntityProducer implements Conte
 						gradebookService.removeCategory(category.getId());
 					}
 				}
-				 
-				transferCopyEntitiesWithSettings(fromContext, toContext, ids);
-				
+				 				
 			}
-			else {
-				transferCopyEntities(fromContext, toContext, ids);
-			}
+			
+			transferCopyEntities(fromContext, toContext, ids);
 	
 	}
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/XmlImportable.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/XmlImportable.java
@@ -34,7 +34,10 @@ import org.sakaiproject.importer.api.Importable;
  * TODO This would subclass AbstractImportable if AbstractImportable was bumped up to
  * the importer.api package for looser coupling. Currently, the AbstractImportable JAR
  * brings in unrelated dependencies such as the QTI class.
+ * 
+ * @deprecated This is part of the import/export for gradebook1 which will be removed at some point
  */
+@Deprecated
 public class XmlImportable implements Importable {
 	private String typeName;
 	private String xmlData;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/framework/GradebookNgContextObserver.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/framework/GradebookNgContextObserver.java
@@ -1,10 +1,8 @@
 package org.sakaiproject.gradebookng.framework;
 
 import org.sakaiproject.entity.api.ContextObserver;
-import org.sakaiproject.service.gradebook.shared.GradebookFrameworkService;
 import org.sakaiproject.service.gradebook.shared.GradebookNotFoundException;
 
-import lombok.Setter;
 import lombok.extern.apachecommons.CommonsLog;
 
 /**
@@ -15,11 +13,6 @@ import lombok.extern.apachecommons.CommonsLog;
  */
 @CommonsLog
 public class GradebookNgContextObserver extends GradebookNgEntityProducer implements ContextObserver {
-
-	private static final String[] TOOL_IDS = { "sakai.gradebookng" };
-
-	@Setter
-	private GradebookFrameworkService gradebookFrameworkService;
 
 	@Override
 	public void contextCreated(final String context, final boolean toolPlacement) {
@@ -57,11 +50,6 @@ public class GradebookNgContextObserver extends GradebookNgEntityProducer implem
 				log.debug("Couldnt find gradebook. Nothing to delete.", e);
 			}
 		}
-	}
-
-	@Override
-	public String[] myToolIds() {
-		return TOOL_IDS;
 	}
 
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/framework/GradebookNgEntityProducer.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/framework/GradebookNgEntityProducer.java
@@ -9,24 +9,39 @@ import java.util.Stack;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityProducer;
+import org.sakaiproject.entity.api.EntityTransferrer;
 import org.sakaiproject.entity.api.HttpAccess;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.service.gradebook.shared.GradebookFrameworkService;
+import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import lombok.Setter;
 
 /**
- * Entity Producer for GradebookNG. This is required to participate in other entity actions. All operations are no-ops.
+ * Entity Producer for GradebookNG. This is required to participate in other entity actions but also handles the transfer of data between
+ * sites
  */
-public class GradebookNgEntityProducer implements EntityProducer {
+public class GradebookNgEntityProducer implements EntityProducer, EntityTransferrer {
+
+	protected static final String[] TOOL_IDS = { "sakai.gradebookng" };
 
 	protected final static String LABEL = "GradebookNG";
 	protected final static String referenceRoot = "/gradebookng";
 
+	/**
+	 * These are shared with the GradebookNgContextObserver
+	 */
 	@Setter
 	protected EntityManager entityManager;
+
+	@Setter
+	protected GradebookService gradebookService;
+
+	@Setter
+	protected GradebookFrameworkService gradebookFrameworkService;
 
 	/**
 	 * Register this class as an EntityProducer.
@@ -92,5 +107,29 @@ public class GradebookNgEntityProducer implements EntityProducer {
 	public HttpAccess getHttpAccess() {
 		return null;
 	}
+
+	@Override
+	public String[] myToolIds() {
+		return TOOL_IDS;
+	}
+
+	/**
+	 * Handle import via merge
+	 */
+	@Override
+	public void transferCopyEntities(final String fromContext, final String toContext, final List<String> ids) {
+		// TODO Auto-generated method stub
+
+	}
+
+	/**
+	 * Handle import via replace
+	 */
+	@Override
+	public void transferCopyEntities(final String fromContext, final String toContext, final List<String> ids, final boolean cleanup) {
+
+	}
+
+	// do we need HandlesImportable ?
 
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.entitybroker.EntityReference;
 import org.sakaiproject.entitybroker.EntityView;
-import org.sakaiproject.entitybroker.entityprovider.EntityProvider;
 import org.sakaiproject.entitybroker.entityprovider.annotations.EntityCustomAction;
 import org.sakaiproject.entitybroker.entityprovider.capabilities.ActionsExecutable;
 import org.sakaiproject.entitybroker.entityprovider.capabilities.AutoRegisterEntityProvider;
@@ -23,7 +22,6 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeCell;
-import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.SessionManager;
 
@@ -39,7 +37,7 @@ import lombok.Setter;
  *
  */
 public class GradebookNgEntityProvider extends AbstractEntityProvider implements
-		EntityProvider, AutoRegisterEntityProvider, ActionsExecutable,
+		AutoRegisterEntityProvider, ActionsExecutable,
 		Outputable, Describeable {
 
 	@Override
@@ -165,11 +163,9 @@ public class GradebookNgEntityProvider extends AbstractEntityProvider implements
 		}
 	}
 
-
 	/**
-	 * Helper to check if the user is an instructor or a TA.
-	 * Throws IllegalArgumentException if not. We don't currently need the value that this
-	 * produces so we don't return it.
+	 * Helper to check if the user is an instructor or a TA. Throws IllegalArgumentException if not. We don't currently need the value that
+	 * this produces so we don't return it.
 	 *
 	 * @param siteId
 	 * @return
@@ -183,13 +179,12 @@ public class GradebookNgEntityProvider extends AbstractEntityProvider implements
 			throw new SecurityException("You must be logged in to access GBNG data");
 		}
 
-		GbRole role = this.businessService.getUserRole(siteId);
+		final GbRole role = this.businessService.getUserRole(siteId);
 
 		if (role != GbRole.INSTRUCTOR && role != GbRole.TA) {
 			throw new SecurityException("You do not have instructor or TA-type permissions in this site.");
 		}
 	}
-
 
 	/**
 	 * Helper to get current user id

--- a/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -36,11 +36,18 @@
 	</bean>
 	
 	<bean
-		id="org.sakaiproject.gradebookng.framework.GradebookNgContextObserver"
-		class="org.sakaiproject.gradebookng.framework.GradebookNgContextObserver"
+		id="org.sakaiproject.gradebookng.framework.GradebookNgEntityProducer"
+		class="org.sakaiproject.gradebookng.framework.GradebookNgEntityProducer"
 		init-method="init">
 		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
-		<property name="gradebookFrameworkService" ref="org_sakaiproject_service_gradebook_GradebookFrameworkService" />
+		<property name="gradebookService" ref="org.sakaiproject.service.gradebook.GradebookService" />
+		<property name="gradebookFrameworkService" ref="org_sakaiproject_service_gradebook_GradebookFrameworkService" />	
 	</bean>
+	
+	<bean
+		id="org.sakaiproject.gradebookng.framework.GradebookNgContextObserver"
+		class="org.sakaiproject.gradebookng.framework.GradebookNgContextObserver"
+		parent="org.sakaiproject.gradebookng.framework.GradebookNgEntityProducer">
+	</bean>	
 
 </beans>


### PR DESCRIPTION
Delivers #1587 

See #1587 for a bunch of test cases that I worked through.

* Enhances the existing GradebookNgEntityProducer to implement EntityTransferrer so we can handle migrations.
* Reuses the same logic as the old Gradebook in terms of migrating data, however doesn't go back and forth with XML as that was just ridiculous.
* A new backend service method has been added which takes in the shared DTOs and unpacks them into the new site.
* Added error handling so we don't throw exceptions everywhere like the old Gradebook does.
* Cleaned up a bunch of the old Gradebook EntityProducer code, removed redundant stuff and deprecated a lot of the over engineered crap. Hopefully that can be deleted one day :dancer: 