### PR TITLE
SAK-30112 Don’t needlessly leak connections.

### DIFF
--- a/providers/jldap/src/java/edu/amc/sakai/user/LDAPJSSESecureSocketFactory.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/LDAPJSSESecureSocketFactory.java
@@ -112,6 +112,6 @@ public class LDAPJSSESecureSocketFactory
     {
         Socket socket = factory.createSocket();
         socket.connect(new InetSocketAddress(host, port), connectTimeout);
-        return factory.createSocket(host, port);
+        return socket;
     }
 }


### PR DESCRIPTION
This was making 2 connections to the LDAP server and throwing one of them away without closing it.