### PR TITLE
SAK-30159 Adding elFinder support to Assignments.

### DIFF
--- a/textarea/elfinder-sakai/pom.xml
+++ b/textarea/elfinder-sakai/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>messageforums-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.sakaiproject.assignment</groupId>
+            <artifactId>sakai-assignment-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/assignment/AssignmentFsItem.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/assignment/AssignmentFsItem.java
@@ -1,0 +1,50 @@
+package org.sakaiproject.elfinder.sakai.assignment;
+
+import cn.bluejoe.elfinder.service.FsItem;
+import cn.bluejoe.elfinder.service.FsVolume;
+
+/**
+ * Created by neelam on 11-Jan-16.
+ */
+public class AssignmentFsItem implements FsItem {
+    private final FsVolume fsVolume;
+    private final String id;
+    private final String title;
+    
+    public AssignmentFsItem(FsVolume fsVolume, String id, String title){
+        this.id = id;
+        this.fsVolume = fsVolume;
+        this.title = title;
+    }
+    @Override
+    public FsVolume getVolume() {
+        return fsVolume;
+    }
+    public String getId() {
+        return id;
+    }
+    
+    public String getTitle(){
+        return title;
+    }
+    
+    @Override
+    public boolean equals(Object object){
+        if(this == object){
+            return true;
+        }
+        if(object == null || getClass() != object.getClass()){
+            return false;
+        }
+        AssignmentFsItem second = (AssignmentFsItem)object;
+        if(id != null ? !id.equals(second.getId()) : second.getId()!= null) return false;
+        return !(fsVolume != null ? !fsVolume.equals(second.fsVolume) : second.fsVolume!= null);
+    }
+    
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (fsVolume != null ? fsVolume.hashCode() : 0);
+        return result;
+    }
+}

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/assignment/AssignmentSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/assignment/AssignmentSiteVolumeFactory.java
@@ -1,0 +1,232 @@
+package org.sakaiproject.elfinder.sakai.assignment;
+
+import cn.bluejoe.elfinder.service.FsItem;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.assignment.api.Assignment;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.elfinder.sakai.ReadOnlyFsVolume;
+import org.sakaiproject.elfinder.sakai.SakaiFsService;
+import org.sakaiproject.elfinder.sakai.SiteVolume;
+import org.sakaiproject.elfinder.sakai.SiteVolumeFactory;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.time.api.Time;
+import org.sakaiproject.user.api.UserDirectoryService;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+
+/**
+ * Created by neelam on 11-Jan-16.
+ */
+public class AssignmentSiteVolumeFactory implements SiteVolumeFactory {
+
+    private static final Log LOG = LogFactory.getLog(AssignmentSiteVolumeFactory.class);
+    private AssignmentService assignmentService;
+    private UserDirectoryService userDirectoryService;
+
+    public void setAssignmentService(AssignmentService assignmentService) {
+        this.assignmentService = assignmentService;
+    }
+
+    public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+        this.userDirectoryService = userDirectoryService;
+    }
+
+    @Override
+    public String getPrefix() {
+        return "assignment";
+    }
+
+    @Override
+    public SiteVolume getVolume(SakaiFsService sakaiFsService, String siteId) {
+        return new AssignmentSiteVolume(sakaiFsService,siteId);
+    }
+
+    @Override
+    public String getToolId() {
+        return "sakai.assignment.grades";
+    }
+    
+    public class AssignmentSiteVolume extends ReadOnlyFsVolume implements SiteVolume{
+        private SakaiFsService service;
+        private String siteId;
+
+        public AssignmentSiteVolume(SakaiFsService service, String siteId) {
+            this.service = service;
+            this.siteId = siteId;
+        }
+
+        @Override
+        public String getSiteId() {
+            return this.siteId;
+        }
+
+        @Override
+        public SiteVolumeFactory getSiteVolumeFactory() {
+            return AssignmentSiteVolumeFactory.this;
+        }
+
+        @Override
+        public boolean isWriteable(FsItem item) {
+            return false;
+        }
+
+        @Override
+        public boolean exists(FsItem fsItem) {
+            return false;
+        }
+
+        @Override
+        public FsItem fromPath(String path){
+            if(path != null && !path.isEmpty()){
+                String[] parts = path.split("/");
+                if(parts.length > 2 && (getPrefix().equals(parts[1]))){
+                    try {
+                        Assignment assignment = assignmentService.getAssignment(parts[2]);
+                        return new AssignmentFsItem(this, assignment.getId(), assignment.getTitle());
+                    } catch (IdUnusedException e) {
+                        LOG.warn("Unexpected IdUnusedException for assignment in " + e.getClass().getName() + ": " + e.getMessage());
+                    } catch (PermissionException e) {
+                        LOG.warn("Unexpected Permission Exception for assignment in  " + e.getClass().getName() + ": " + e.getMessage());
+                    }
+
+                }
+            }
+            return this.getRoot();
+        }
+
+        @Override
+        public String getDimensions(FsItem fsItem) {
+            return null;
+        }
+
+        @Override
+        public long getLastModified(FsItem fsItem) {
+            return 0L;
+        }
+
+        @Override
+        public String getMimeType(FsItem fsItem) {
+            return this.isFolder(fsItem)?"directory":"sakai/assignments";
+        }
+
+        @Override
+        public String getName() {
+            return "Assignments";
+        }
+
+        @Override
+        public String getName(FsItem fsItem) {
+            if(this.getRoot().equals(fsItem)) {
+                return getName();
+            }
+            else if(fsItem instanceof AssignmentFsItem){
+                return ((AssignmentFsItem)fsItem).getTitle();
+            }
+            else{
+                throw new IllegalArgumentException("Could not get title for: " + fsItem.toString());
+            }
+        }
+
+        @Override
+        public FsItem getParent(FsItem fsItem) {
+            if(this.getRoot().equals(fsItem)){
+                return service.getSiteVolume(siteId).getRoot();
+            }
+            else if(fsItem instanceof AssignmentFsItem){
+                return this.getRoot();
+            }
+            return null;
+        }
+
+        @Override
+        public String getPath(FsItem fsItem) throws IOException {
+            if(this.getRoot().equals(fsItem)) {
+                return "";
+            }
+            else if(fsItem instanceof AssignmentFsItem){
+                AssignmentFsItem assignmentFsItem = (AssignmentFsItem)fsItem;
+                return "/"+ getPrefix() +"/" + assignmentFsItem.getId();
+            }
+            else{
+                throw new IllegalArgumentException("Wrong Type: " + fsItem.toString());
+            }
+        }
+
+        @Override
+        public FsItem getRoot() {
+            return new AssignmentFsItem(this, "", "");
+        }
+
+        @Override
+        public long getSize(FsItem fsItem) throws IOException {
+            return 0;
+        }
+
+        @Override
+        public String getThumbnailFileName(FsItem fsItem) {
+            return null;
+        }
+
+        @Override
+        public boolean hasChildFolder(FsItem fsItem) {
+            return fsItem instanceof AssignmentFsItem;
+        }
+
+        @Override
+        public boolean isFolder(FsItem fsItem) {
+            if(fsItem instanceof AssignmentFsItem && ((AssignmentFsItem)fsItem).getTitle().equals(""))
+                return true;
+            return false;
+        }
+
+        @Override
+        public boolean isRoot(FsItem fsItem) {
+            return false;
+        }
+
+        @Override
+        public FsItem[] listChildren(FsItem fsItem) {
+            List<FsItem> items = new ArrayList<>();
+            if(this.getRoot().equals(fsItem)){
+                Iterator assignmentIterator = assignmentService.getAssignmentsForContext(this.siteId, userDirectoryService.getCurrentUser().getId());
+                long nowMs = System.currentTimeMillis();
+                while(assignmentIterator.hasNext()){
+                    Assignment thisAssignment = (Assignment) assignmentIterator.next();
+                    Time thisAssignmentCloseTime = thisAssignment.getCloseTime();
+                    boolean assignmentClosed = false;
+                    if(thisAssignmentCloseTime!=null){
+                        if(thisAssignmentCloseTime.getTime() < nowMs){
+                            assignmentClosed=true;
+                        }
+                    }
+                    //Not displaying closed assignment or assignment in draft state
+                    if(thisAssignment.getDraft() || assignmentClosed ) continue;
+                    items.add(new AssignmentFsItem(this, thisAssignment.getId(), thisAssignment.getTitle()));
+                }
+                
+            }
+            else if(fsItem instanceof AssignmentFsItem){
+                items.add(fsItem);
+            }
+            
+            return items.toArray(new FsItem[0]);
+        }
+
+        @Override
+        public InputStream openInputStream(FsItem fsItem) throws IOException {
+            return null;
+        }
+
+        @Override
+        public String getURL(FsItem fsItem) {
+            return null;
+        }
+    }
+}

--- a/textarea/elfinder-sakai/src/webapp/WEB-INF/applicationContext.xml
+++ b/textarea/elfinder-sakai/src/webapp/WEB-INF/applicationContext.xml
@@ -27,13 +27,14 @@
                             <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
                             <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
 						</bean>
-						<!--
-						  This is disabled because it isn't doing permission checks but it's been useful in development
-						  to have multiple tools working.-->
 						<bean class="org.sakaiproject.elfinder.sakai.msgcntr.MsgCntrSiteVolumeFactory">
 							<property name="discussionForumManager" ref="org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager"/>
 							<property name="messageForumsForumManager" ref="org.sakaiproject.api.app.messageforums.MessageForumsForumManager"/>
 							<property name="uiPermissionsManager" ref="org.sakaiproject.api.app.messageforums.ui.UIPermissionsManager"/>
+							<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
+						</bean>
+						<bean class="org.sakaiproject.elfinder.sakai.assignment.AssignmentSiteVolumeFactory">
+							<property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService"/>
 							<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
 						</bean>
 					</set>


### PR DESCRIPTION
Added Assignments in the elfinder.Displaying assignments for the current
user in a particular site thus logged in user can see assignments which they
have permissions for. Closed and indraft assignments are not shown.