### PR TITLE
SAK-30308 - Change the groupid and artifact id back

### DIFF
--- a/basiclti/basiclti-blis/pom.xml
+++ b/basiclti/basiclti-blis/pom.xml
@@ -20,8 +20,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.tsugi</groupId>
-            <artifactId>tsugi-util</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>basiclti-util</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/basiclti-common/pom.xml
+++ b/basiclti/basiclti-common/pom.xml
@@ -24,8 +24,8 @@
             <artifactId>basiclti-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.tsugi</groupId>
-            <artifactId>tsugi-util</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>basiclti-util</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/basiclti/basiclti-impl/pom.xml
+++ b/basiclti/basiclti-impl/pom.xml
@@ -28,8 +28,8 @@
             <artifactId>basiclti-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.tsugi</groupId>
-            <artifactId>tsugi-util</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>basiclti-util</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/basiclti-pack/pom.xml
+++ b/basiclti/basiclti-pack/pom.xml
@@ -24,8 +24,8 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.tsugi</groupId>
-            <artifactId>tsugi-util</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>basiclti-util</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/basiclti-portlet/pom.xml
+++ b/basiclti/basiclti-portlet/pom.xml
@@ -24,8 +24,8 @@
             <artifactId>basiclti-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.tsugi</groupId>
-            <artifactId>tsugi-util</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>basiclti-util</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/basiclti/pom.xml
+++ b/basiclti/pom.xml
@@ -153,8 +153,8 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.tsugi</groupId>
-                <artifactId>tsugi-util</artifactId>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>basiclti-util</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/basiclti/tsugi-util/pom.xml
+++ b/basiclti/tsugi-util/pom.xml
@@ -9,8 +9,8 @@
     </parent>
 
     <name>Tsugi LTI Utilities (tsugi-util)</name>
-    <groupId>org.tsugi</groupId>
-    <artifactId>tsugi-util</artifactId>
+    <groupId>org.sakaiproject.basiclti</groupId>
+    <artifactId>basiclti-util</artifactId>
     <organization>
         <name>Tsugi Project</name>
         <url>www.tsugi.org/</url>

--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -28,8 +28,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.tsugi</groupId>
-            <artifactId>tsugi-util</artifactId>
+            <groupId>org.sakaiproject.basiclti</groupId>
+            <artifactId>basiclti-util</artifactId>
             <version>${sakai.version}</version>
         </dependency>
 


### PR DESCRIPTION
This leaves the packagename org.tsugi but changes the pom.xml to revert the group is to org.sakaiproject.basiclti and the artifactid to basiclti-util