### PR TITLE
SAK-30355 use bootstrap callouts from bootstrap documentation

### DIFF
--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -9,6 +9,35 @@
 	@include filter( blur(0.1em) );
 }
 
+@mixin bs-callout($color, $bgcolor) {
+  display: block;
+  margin: 20px 0;
+  padding: 15px 30px 15px 15px;
+  border: 1px solid;
+  border-left-width: 5px;
+  border-color: lighten($color, 25%);
+  border-left-color: $color;
+  background-color: $bgcolor;
+  h1, h2, h3, h4, h5, h6 {
+    margin-top: 0;
+    color: $color;
+  }
+  p:last-child {
+    margin-bottom: 0;
+  }
+  code, .highlight {
+    background-color: #fff;
+  }
+}
+
+.bs-callout-primary, .bs-callout-info, .bs-callout-success {
+  @include bs-callout($primary-color, lighten($primary-color, 45%));
+}
+
+.bs-callout-danger, .bs-callout-warning {
+  @include bs-callout($secondary-color, lighten($secondary-color, 30%));
+}
+
 @mixin icon( $width : $icon-size, $height : $icon-size ){
 	border: 0px none;
 	display: inline-block;

--- a/reference/library/src/morpheus-master/sass/modules/tool/_menu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/_menu.scss
@@ -71,11 +71,7 @@
 }
 
 .instruction{
-	font-size: 0.8em;
-	background: $warncolor;
-	border: 1px solid darken($warncolor, 15%);
-	padding: 0.7em 0.8em;
-	display: inline-block;
+	@include bs-callout($primary-color, lighten($primary-color, 45%));
 }
 
 .listNav{


### PR DESCRIPTION
I like the callouts in the bootstrap documentation:

  http://cpratt.co/twitter-bootstrap-callout-css-styles/

They seem like an improvement on our current "instruction" callouts.....

I am submitting this for comment and review. I am new to bootstrap, sass, and morpheus....

![image](https://cloud.githubusercontent.com/assets/810505/13199517/b70fa520-d7f5-11e5-950a-89feef866174.png)

CC: @SedueRey @juanjmerono 