### PR TITLE
1389: unable to focus input fields in category table

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-settings.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-settings.js
@@ -37,7 +37,7 @@ GradebookCategorySettings.prototype.setupSortableCategories = function() {
               },
       placeholder: "gb-category-sort-placeholder",
       update: $.proxy(self.updateCategoryOrders, self)
-    }).disableSelection();
+    });
 };
 
 


### PR DESCRIPTION
Category sort disableSelection call was disabling ability to focus any input field in the Settings category table in Firefox. Boo.

