### PR TITLE
SAK-30361 user membership bulk change status needs more exception handling code

### DIFF
--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
@@ -42,7 +42,6 @@ import javax.faces.application.FacesMessage;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.event.ActionEvent;
-import org.apache.commons.lang.StringUtils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -668,6 +667,14 @@ public class SiteListBean {
 					catch( AuthzPermissionException ex )
 					{
 						LOG.warn( "permission exception updating realm, id=" + realmID, ex );
+					}
+					catch( NullPointerException ex )
+					{
+						LOG.warn( "could not retieve user (" + userId + ") or user's role from site (" + site.getId() + ")", ex );
+					}
+					catch( Exception ex )
+					{
+						LOG.error( "unexpected error occurred, user=" + userId + ", site=" + site.getId(), ex );
 					}
 				}
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30361

We've had a few one-off reports of an NPE and a constraint violation exception being thrown by the bulk change status algorithm.

Although we haven't been able to reproduce this reliably, it's trivial to introduce a few extra catch() blocks to handle these specific exceptions.