### PR TITLE
SAK-30352 use fetch strategy of select instead of join 

### DIFF
--- a/signup/api/src/java/org/sakaiproject/signup/hbm/SignupMeeting.hbm.xml
+++ b/signup/api/src/java/org/sakaiproject/signup/hbm/SignupMeeting.hbm.xml
@@ -59,21 +59,21 @@
 		
 		<property name="uuid" column="vevent_uuid" length="36" type="string" not-null="false" />
 		
-		<list name="signupTimeSlots" cascade="save-update,delete" fetch="join">
+		<list name="signupTimeSlots" cascade="save-update,delete" fetch="select" batch-size="50">
 			<key column="meeting_id" not-null="true"/>
 			<list-index column="list_index" />
 			<one-to-many 
 				class="org.sakaiproject.signup.model.SignupTimeslot" />
 		</list>
 		
-		<list name="signupSites" cascade="save-update,delete" fetch="join">
+		<list name="signupSites" cascade="save-update,delete" fetch="select" batch-size="50">
 			<key column="meeting_id" not-null="true"/>
 			<list-index column="list_index" />
 			<one-to-many
 				class="org.sakaiproject.signup.model.SignupSite" />
 		</list>
 		
-		<list name="signupAttachments" cascade="save-update,delete" table="signup_attachments" fetch="join">
+		<list name="signupAttachments" cascade="save-update,delete" table="signup_attachments" fetch="select" batch-size="50">
 			<key column="meeting_id" not-null="true"/>
 			<list-index column="list_index" />
 			<composite-element class="org.sakaiproject.signup.model.SignupAttachment" >

--- a/signup/api/src/java/org/sakaiproject/signup/hbm/SignupSite.hbm.xml
+++ b/signup/api/src/java/org/sakaiproject/signup/hbm/SignupSite.hbm.xml
@@ -19,7 +19,7 @@
 		<property name="calendarEventId" column="calendar_event_id" type="string" length="2000" not-null="false"/>
 		<property name="calendarId" column="calendar_id" length="99" type="string"  not-null="false"/>
 		
-		<list name="signupGroups" cascade="save-update,delete" table="signup_site_groups" fetch="join">
+		<list name="signupGroups" cascade="save-update,delete" table="signup_site_groups" fetch="select" batch-size="50">
 			<key column="signup_site_id" not-null="true"/>
 			<list-index column="list_index" />
 			<composite-element class="org.sakaiproject.signup.model.SignupGroup">

--- a/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/SignupMeetingsBean.java
+++ b/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/SignupMeetingsBean.java
@@ -591,8 +591,14 @@ public class SignupMeetingsBean implements SignupBeanConstants {
 	 *         current user.
 	 */
 	public boolean isAllowedToDelete() {
-		if (getSignupMeetings() == null)
+		if (sakaiFacade.isAllowedSite(sakaiFacade.getCurrentUserId(), SakaiFacade.SIGNUP_DELETE_SITE, sakaiFacade.getCurrentLocationId())) {
+			return true;
+		}
+
+		if (getSignupMeetings() == null) {
 			return false;
+		}
+
 		for (SignupMeetingWrapper meetingW : signupMeetings) {
 			if (meetingW.getMeeting().getPermission().isDelete())
 				return true;
@@ -605,15 +611,24 @@ public class SignupMeetingsBean implements SignupBeanConstants {
 	/**
 	 * This is a getter method for UI.
 	 * 
-	 * @return true if atleast one of the meeting has update permission for the
+	 * @return true if at least one of the meetings has update permission for the
 	 *         current user.
 	 */
 	public boolean isAllowedToUpdate() {
-		if (getSignupMeetings() == null)
+		// Do we really need to loop through 1000 meetings if the user has elevated site permissions?!
+		if (sakaiFacade.isAllowedSite(sakaiFacade.getCurrentUserId(), SakaiFacade.SIGNUP_UPDATE_SITE, sakaiFacade.getCurrentLocationId())) {
+			return true;
+		}
+
+		// This call to getSignupMeetings() is going to make Hibernate load lots and lots of data
+		if (getSignupMeetings() == null) {
 			return false;
+		}
+
 		for (SignupMeetingWrapper meetingW : signupMeetings) {
-			if (meetingW.getMeeting().getPermission().isUpdate())
+			if (meetingW.getMeeting().getPermission().isUpdate()) {
 				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
because join is a multiplier:

for example (meetings x sites x groups x waiting list) = lots of rows returned by one query. 

Also see if we can avoid looping through every meeting to answer simple question of whether user has permission to update or delete.