### PR TITLE
SAK-30370 present the ckeditor basic toolbar config to a user on a small device

### DIFF
--- a/reference/library/src/webapp/editor/ckeditor.launch.js
+++ b/reference/library/src/webapp/editor/ckeditor.launch.js
@@ -97,7 +97,6 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         defaultLanguage: 'en',
         allowedContent: true, // http://docs.ckeditor.com/#!/guide/dev_advanced_content_filter-section-3
         language: language + (country ? '-' + country.toLowerCase() : ''),
-        height: 310,
         // This is used for uploading by the autorecorder and fmath_formula plugins.
         // TODO Get this to work with elfinder.
         fileConnectorUrl : '/sakai-fck-connector/web/editor/filemanager/browser/default/connectors/jsp/connector' + collectionId + '?' + folder,
@@ -119,7 +118,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
 
         toolbar_Basic:
         [
-            ['Source', '-', 'Bold', 'Italic', 'Link', 'Unlink']
+            ['Source', '-', 'Bold', 'Italic', 'Underline', '-', 'Link', 'Unlink', '-', 'NumberedList','BulletedList', 'Blockquote']
         ],
         toolbar_Full:
         [
@@ -155,87 +154,46 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         templates: 'customtemplates'
     };
 
-    //NOTE: The height and width properties are handled discretely here.
-    //      The ultimate intent is that the caller-supplied config will simply
-    //      overlay the default config. The outstanding question is whether
-    //      some properties should disallow override (because of specific setup
-    //      here that we would not want duplicated throughout calling code) or
-    //      if their override would just be discouraged. We also probably want
-    //      some symbolic things like editorSize: 'small', where the supplied
-    //      values are interpreted and translated into dimensions, toolbar set,
-    //      and anything else relevant. This will allow editor indifference
-    //      on the part of tool code, requesting whatever editor be launched
-    //      with appropriate settings applied, rather than detecting the editor
-    //      and supplying specific values for the desired effect. This set of
-    //      "logical" configuration options is yet to be determined.
-    if (config) {
-        if (config.width) {
-            ckconfig.width = config.width;
-        } else if (w) {
-            ckconfig.width = w;
+    //To add extra plugins outside the plugins directory, add them here! (And in the variable)
+    (function() {
+        // SAK-30370 present a nice and simple editor without plugins to the user on a tiny screen.
+        if ($(window).width() < 800) {
+            ckconfig.toolbar = 'Basic';
         }
+        else {
+            CKEDITOR.plugins.addExternal('lineutils',basePath+'lineutils/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('widget',basePath+'widget/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('iframedialog',basePath+'iframedialog/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('movieplayer',basePath+'movieplayer/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('wordcount',basePath+'wordcount/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('fmath_formula',basePath+'fmath_formula/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('audiorecorder',basePath+'audiorecorder/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('image2',basePath+'image2/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('autosave',basePath+'autosave/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('fontawesome',basePath+'fontawesome/', 'plugin.js');
+            /*
+               To enable after the deadline uncomment these two lines and add atd-ckeditor to toolbar
+               and to extraPlugins. This also needs extra stylesheets.
+               See readme for more info http://www.polishmywriting.com/atd-ckeditor/readme.html
+               You have to actually setup a server or get an API key
+               Hopefully this will get easier to configure soon.
+             */
+            CKEDITOR.plugins.addExternal('atd-ckeditor',basePath+'atd-ckeditor/', 'plugin.js'); 
+            /*
+               Replace this with your own server if you download it from http://openatd.wordpress.com/
+               Or you can proxy to the public one, see the page for more information.
+             */
+            //ckconfig.atd_rpc='//localhost/proxy/spellcheck';
+            //ckconfig.extraPlugins+="atd-ckeditor,";
+            //ckconfig.contentsCss = basePath+'/atd-ckeditor/atd.css';
 
-        if (config.height) {
-            ckconfig.height = config.height;
-        } else if (h) {
-            ckconfig.height = h;
+            ckconfig.extraPlugins+="image2,audiorecorder,movieplayer,wordcount,fmath_formula,autosave,fontawesome";
+
+            //SAK-29648
+            ckconfig.contentsCss = basePath+'/fontawesome/font-awesome/css/font-awesome.min.css';
+            CKEDITOR.dtd.$removeEmpty.span = false;
+            CKEDITOR.dtd.$removeEmpty['i'] = false;
         }
-
-        if (config && config.toolbarSet && ckconfig['toolbar_' + config.toolbarSet]) {
-            ckconfig.toolbar = config.toolbarSet;
-		}
-
-		if (config.fullPage) {
-			ckconfig.fullPage = true;
-		}
-
-		if (config.audiorecorder) {
-			ckconfig.audiorecorder = config.audiorecorder;
-		}
-
-		if (config.disableBrowseServer)
-		{
-			ckconfig.filebrowserBrowseUrl = null;
-			ckconfig.filebrowserImageBrowseUrl = null;
-			ckconfig.filebrowserFlashBrowseUrl = null;
-			ckconfig.filebrowserLinkBrowseUrl = null;
-		}
-	}
-
-		//To add extra plugins outside the plugins directory, add them here! (And in the variable)
-		(function() { 
-		   CKEDITOR.plugins.addExternal('lineutils',basePath+'lineutils/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('widget',basePath+'widget/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('iframedialog',basePath+'iframedialog/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('movieplayer',basePath+'movieplayer/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('wordcount',basePath+'wordcount/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('fmath_formula',basePath+'fmath_formula/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('audiorecorder',basePath+'audiorecorder/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('image2',basePath+'image2/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('autosave',basePath+'autosave/', 'plugin.js'); 
-		   CKEDITOR.plugins.addExternal('fontawesome',basePath+'fontawesome/', 'plugin.js'); 
-			 /*
-			  To enable after the deadline uncomment these two lines and add atd-ckeditor to toolbar
-			  and to extraPlugins. This also needs extra stylesheets.
-			  See readme for more info http://www.polishmywriting.com/atd-ckeditor/readme.html
-			  You have to actually setup a server or get an API key
-			  Hopefully this will get easier to configure soon.
-			 */
-			 CKEDITOR.plugins.addExternal('atd-ckeditor',basePath+'atd-ckeditor/', 'plugin.js'); 
-			 /*
-			 Replace this with your own server if you download it from http://openatd.wordpress.com/
-			 Or you can proxy to the public one, see the page for more information.
-			 */
-			 //ckconfig.atd_rpc='//localhost/proxy/spellcheck';
-			 //ckconfig.extraPlugins+="atd-ckeditor,";
-			 //ckconfig.contentsCss = basePath+'/atd-ckeditor/atd.css';
-			 
-			 ckconfig.extraPlugins+="image2,audiorecorder,movieplayer,wordcount,fmath_formula,autosave,fontawesome";
-			 
-			 //SAK-29648
-			 ckconfig.contentsCss = basePath+'/fontawesome/font-awesome/css/font-awesome.min.css';
-			 CKEDITOR.dtd.$removeEmpty.span = false;
-			 CKEDITOR.dtd.$removeEmpty['i'] = false;
     })();
 
 	  CKEDITOR.replace(targetId, ckconfig);


### PR DESCRIPTION
I made one opinionated change here: I remove the ability for the tool "config" variable to override height and width. I think it's bad (legacy) behavior to allow the tool to define hard-coded values. The tool should define a container and the ckeditor will fill that container. Hard-coded values present serious usability issues for small-screen devices.

Nice and tiny editor for your tiny-screen device:

![image](https://cloud.githubusercontent.com/assets/810505/13295734/341a1974-daf8-11e5-8799-4c30f275b4b1.png)

CC: @botimer and @jonespm 
