### PR TITLE
1753: improve javascript and scroll performance

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -196,7 +196,7 @@ public class BasePage extends WebPage {
 
 		flagWithPopover.add(new AttributeModifier("title", message));
 		flagWithPopover.add(new AttributeModifier("data-toggle", "popover"));
-		flagWithPopover.add(new AttributeModifier("data-trigger", "focus"));
+		flagWithPopover.add(new AttributeModifier("data-trigger", "manual"));
 		flagWithPopover.add(new AttributeModifier("data-placement", "bottom"));
 		flagWithPopover.add(new AttributeModifier("data-html", "true"));
 		flagWithPopover.add(new AttributeModifier("data-container", "#gradebookGrades"));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -3,7 +3,7 @@
 <body>
 
 <wicket:extend>
-  <form wicket:id="form">
+  <form wicket:id="form" id="gradebookSpreadsheet">
     <p>
       <button wicket:id="addGradeItem" class="gb-add-gradebook-item-button" aria-haspopup="true">
       	 <wicket:message key="button.addgradeitem" />
@@ -18,30 +18,35 @@
 	<div wicket:id="deleteItemWindow" />
 	<div wicket:id="gradeStatisticsWindow" />
 	<div wicket:id="updateCourseGradeDisplayWindow" />
-    
+
+    <div id="gradebookGradesToolbar">
+      <ul class="gb-toolbar-left">
+        <li>
+          <label for="filterByGroup" style="display:none" aria-hidden="true"><wicket:message key="filter.groups" /></label>
+          <select id="filterByGroup" wicket:id="groupFilter">
+            <option value="1">Section 1</option>
+            <option value="2">Section 2</option>
+          </select>
+        </li>
+        <li><span wicket:id="studentSummary" class="gradebook-student-summary" role="status">Showing 20 of 25 Students</span></li>
+      </ul>
+      <ul class="gb-toolbar-right">
+        <li><span wicket:id="gradeItemSummary" class="gradebook-item-summary" role="status" aria-live="polite">Viewing <span class="counts"><strong class="visible">8</strong> out of <strong class="total">8</strong></span> Grade Items</span></li>
+        <li>
+          <button wicket:id="toggleGradeItemsToolbarItem" id="toggleGradeItemsToolbarItem" aria-popup="true" aria-controls="gradeItemsTogglePanel">Show/Hide Items</button>
+        </li>
+        <li>
+          <button wicket:id="toggleCategoriesToolbarItem" id="toggleCategoriesToolbarItem" aria-controls="gradebookGradesTable">Group By Category</button>
+        </li>
+      </ul>
+    </div>
     <div id="gradebookGrades">
-      <div id="gradebookGradesToolbar">
-        <ul class="gb-toolbar-left">
-          <li>
-            <label for="filterByGroup" style="display:none" aria-hidden="true"><wicket:message key="filter.groups" /></label>
-            <select id="filterByGroup" wicket:id="groupFilter">
-              <option value="1">Section 1</option>
-              <option value="2">Section 2</option>
-            </select>
-          </li>
-          <li><span wicket:id="studentSummary" class="gradebook-student-summary" role="status">Showing 20 of 25 Students</span></li>
-        </ul>
-        <ul class="gb-toolbar-right">
-          <li><span wicket:id="gradeItemSummary" class="gradebook-item-summary" role="status" aria-live="polite">Viewing <span class="counts"><strong class="visible">8</strong> out of <strong class="total">8</strong></span> Grade Items</span></li>
-          <li>
-            <button wicket:id="toggleGradeItemsToolbarItem" id="toggleGradeItemsToolbarItem" aria-popup="true" aria-controls="gradeItemsTogglePanel">Show/Hide Items</button>
-          </li>
-          <li>
-            <button wicket:id="toggleCategoriesToolbarItem" id="toggleCategoriesToolbarItem" aria-controls="gradebookGradesTable">Group By Category</button>
-          </li>
-        </ul>
-      </div>
-      <table wicket:id="table" id="gradebookGradesTable" class="table-striped table-bordered table-hover" role="grid"></table>
+      <div wicket:id="fixedHeader" id="gradebookFixedThings"></div>
+      <div id="gradebookHorizontalOverflowWrapper">
+          <div id="gradebookVerticalOverflowWrapper">
+              <table wicket:id="table" id="gradebookGradesTable" class="table-striped table-bordered table-hover" role="grid"></table>
+          </div>
+	  </div>
 	  <div wicket:id="noAssignments" class="messageInformation"><wicket:message key="no-assignments.label" /></div>
 	  <div wicket:id="noStudents" class="messageInformation"><wicket:message key="no-students.label" /></div>
     </div>
@@ -54,13 +59,6 @@
         <wicket:message key="grade.notifications.concurrenteditbyuser" />
       </li>
     </ul>
-  </div>
-  <div id="categoryTableHeader" style="display: none;">
-    <span class="gb-category-label">
-      <span wicket:id="extraCreditCategoryFlag" class="gb-category-extra-credit"></span>
-      <span class="gb-category-name"></span>
-      <span class="gb-category-weight"></span>
-    </span>
   </div>
 </wicket:extend>
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -129,10 +129,10 @@ public class GradeItemCellPanel extends Panel {
 			this.showMenu = false;
 
 			if (isExternal) {
-				getParent().add(new AttributeModifier("class", "gb-external-item-cell"));
+				getParentCellFor(this).add(new AttributeModifier("class", "gb-external-item-cell"));
 				this.notifications.add(GradeCellNotification.IS_EXTERNAL);
 			} else {
-				getParent().add(new AttributeModifier("class", "gb-grade-item-cell"));
+				getParentCellFor(this).add(new AttributeModifier("class", "gb-grade-item-cell"));
 			}
 
 		} else {
@@ -537,7 +537,7 @@ public class GradeItemCellPanel extends Panel {
 		final String popoverString = ComponentRenderer.renderComponent(popover).toString();
 
 		component.add(new AttributeModifier("data-toggle", "popover"));
-		component.add(new AttributeModifier("data-trigger", "focus"));
+		component.add(new AttributeModifier("data-trigger", "manual"));
 		component.add(new AttributeModifier("data-placement", "bottom"));
 		component.add(new AttributeModifier("data-html", "true"));
 		component.add(new AttributeModifier("data-container", "#gradebookGrades"));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradebookSpreadsheetFixedTables.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradebookSpreadsheetFixedTables.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd" >
+
+<body>
+<wicket:panel>
+
+	<table style="display: none;">
+		<thead>
+			<tr class="gb-categories-row">
+				<th colspan="3"></th>
+				<th wicket:id="categories">
+					<span class="gb-category-label">
+						<span wicket:id="extraCreditCategoryFlag" class="gb-category-extra-credit"></span>
+						<span wicket:id="name" class="gb-category-name"></span>
+						<span wicket:id="weight" class="gb-category-weight"></span>
+					</span>
+				</th>
+				<th class="gb-uncategorized" style="display: none;">
+					<span class="gb-category-label">
+						<span class="gb-category-name"><wicket:message key="gradebookpage.uncategorised"></wicket:message></span>
+					</span>
+				</th>
+			</tr>
+		</thead>
+	</table>
+</wicket:panel>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradebookSpreadsheetFixedTables.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradebookSpreadsheetFixedTables.java
@@ -1,0 +1,103 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GbCategoryType;
+import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.service.gradebook.shared.Assignment;
+import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class GradebookSpreadsheetFixedTables extends Panel {
+
+	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
+	private GradebookNgBusinessService businessService;
+
+	IModel<Map<String, Object>> model;
+
+	// TODO: Ideally this panel would not be required! 
+	// Move this to the main table as a second header row
+	// so the JavaScript does not need to insert it manually.
+	public GradebookSpreadsheetFixedTables(final String id, final IModel<Map<String, Object>> model) {
+		super(id);
+
+		this.model = model;
+	}
+
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+
+		Map<String, Object> modelData = model.getObject();
+
+		List<Assignment> assignments = (List<Assignment>) modelData.get("assignments");
+		List<CategoryDefinition> categories = (List<CategoryDefinition>) modelData.get("categories");
+
+		Collections.sort(categories, CategoryDefinition.orderComparator);
+
+		Map<Long, Integer> categoryCounts = new HashMap<Long, Integer>();
+
+		for (CategoryDefinition category : categories) {
+			categoryCounts.put(category.getId(), 0);
+		}
+
+		for (Assignment assignment : assignments) {
+			if (assignment.getCategoryId() != null) {
+				Integer increment = categoryCounts.get(assignment.getCategoryId())+1;
+				categoryCounts.put(assignment.getCategoryId(), increment);
+			}
+		}
+
+		final GradebookPage page = (GradebookPage) getPage();
+		final GradebookUiSettings settings = page.getUiSettings();
+
+		final GbCategoryType categoryType = this.businessService.getGradebookCategoryType();
+
+		categories = categories.stream().
+				filter(c -> categoryCounts.get(c.getId()) > 0).collect(Collectors.toList());
+
+		add(new ListView<CategoryDefinition>("categories", categories) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void populateItem(final ListItem<CategoryDefinition> categoryItem) {
+				CategoryDefinition category = categoryItem.getModelObject();
+				categoryItem.add(new AttributeModifier("colspan", categoryCounts.get(category.getId())));
+				categoryItem.add(new AttributeModifier("data-category-id", category.getId()));
+				String color = settings.getCategoryColor(category.getName());
+				if (color == null) {
+					color = page.generateRandomRGBColorString();
+					settings.setCategoryColor(category.getName(), color);
+					page.setUiSettings(settings);
+				}
+				categoryItem.add(new AttributeModifier("style",
+						String.format("background-color: %s;", color)));
+				categoryItem.add(new Label("name", category.getName()));
+				categoryItem.add(page.buildFlagWithPopover("extraCreditCategoryFlag",
+						getString("label.gradeitem.extracreditcategory")).
+						setVisible(category.isExtraCredit()));
+
+				if (GbCategoryType.WEIGHTED_CATEGORY.equals(categoryType) && category.getWeight() != null) {
+					String weight = String.format("%s%%", Math.round(category.getWeight() * 100));
+					categoryItem.add(new Label("weight", weight));
+				} else {
+					categoryItem.add(new WebMarkupContainer("weight").setVisible(false));
+				}
+			}
+		});
+	}
+}

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -20,9 +20,17 @@
 }
 
 /* Container */
-#gradebookGrades {
+#gradebookSpreadsheet {
   margin-top: 10px;
+}
+#gradebookGrades {
+  position: relative;
+  overflow: hidden;
   width: 100%;
+}
+#gradebookHorizontalOverflowWrapper {
+  width: 100%;
+  padding-bottom: 120px;
   overflow: auto;
   position: relative;
   -webkit-overflow-scrolling: touch;
@@ -85,10 +93,10 @@
   position: relative;
   display: block;
 }
-#gradebookGrades thead th,
-#gradebookGrades tbody th,
-#gradebookGrades thead th > span,
-#gradebookGrades tbody th > span {
+#gradebookGrades thead tr.headers th,
+#gradebookGrades tbody tr.headers th,
+#gradebookGrades thead tr.headers th > span,
+#gradebookGrades tbody tr.headers th > span {
   min-height: 100px;
   height: 100px;
 }
@@ -174,7 +182,8 @@
   bottom: 2px;
   right: 1px;
 }
-#gradebookGrades .gb-cell {
+#gradebookGrades table td,
+#gradebookGrades table .headers th {
   cursor: pointer;
 }
 #gradebookGrades tbody .btn.dropdown-toggle {
@@ -206,24 +215,30 @@
      so that the bottom-most menus display without being cropped */
   min-height: 40px;
 }
-/* Distinguish Fixed Columns */
+/* Distinguish Headers and Fixed Columns */
 #gradebookGrades.initialized table thead tr > th:nth-child(3),
 #gradebookGrades.initialized table tbody tr > td:nth-child(3) {
-  border-right: 1px solid #AAA;
+  border-right: 1px solid #BBB;
+}
+#gradebookGrades table tr.headers th {
+  border-bottom-color: #BBB;
+}
+#gradebookGrades table.table-striped tbody td {
+  border-color: #EEE;
 }
 /* Categories */
-#gradebookGrades table tr.gb-categories-row td {
-  height: 30px;
+#gradebookGrades table tr.gb-categories-row th {
+  height: 26px;
   line-height: 16px;
   font-size: 16px;
 }
-#gradebookGrades.initialized table tr.gb-categories-row > td:nth-child(1) {
+#gradebookGrades.initialized table tr.gb-categories-row > th:nth-child(1) {
   border-right: 1px solid #AAA;
 }
-#gradebookGrades.initialized table tr.gb-categories-row > td:nth-child(3) {
+#gradebookGrades.initialized table tr.gb-categories-row > th:nth-child(3) {
   border-right: 1px solid #DDD;
 }
-#gradebookGrades .gb-categories-row td {
+#gradebookGrades .gb-categories-row th {
   background: #e6e6e6;
   overflow: hidden;
 }
@@ -363,10 +378,15 @@
 #gradebookGrades .gb-fixed-header-table,
 #gradebookGrades .gb-fixed-columns-table,
 #gradebookGrades .gb-fixed-column-headers-table {
-  position: absolute;
   border-collapse: collapse;
-  box-shadow: 0 1px 1px #AAA;
   width: auto;
+}
+#gradebookGrades .gb-fixed-columns-table,
+#gradebookGrades .gb-fixed-column-headers-table {
+  position: fixed;
+}
+#gradebookGrades .gb-fixed-header-table {
+  position: absolute;
 }
 #gradebookGrades .gb-fixed-columns-table,
 #gradebookGrades .gb-fixed-column-headers-table {
@@ -431,18 +451,12 @@
   visibility: hidden;
 }
 /* Toolbar */
-#gradebookGrades {
-  padding-top: 40px;
-  padding-bottom: 80px;
-}
 #gradebookGradesToolbar {
+  position: relative;
   background: #FAFAFA;
   font-size: 0.8em;
   overflow: visible;
   padding: 0 0.4em;
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   white-space: nowrap; /* don't wrap so it stays on one line */
   height: 40px;


### PR DESCRIPTION
First pass at delivering #1753.  The aim was to improve the client-side factors contributing to page load and page scroll performance.

Here's a breakdown of the techniques to do so... for scroll render performance:
- remove animations where possible
- move all non-necessary actions from the scroll event critical path
- simplifying the fixed header HTML
- cache element widths used in fixed column/header calculations
- move toolbar from scrollable container so it doesn't need to be positioned/rerendered and change the fixed columns to the position: fixed rather than absolute
- move all render actions into a single scroll handler, wrapped with a call to window.requestAnimationFrame() to ensure that the minimum amount of redraws per scroll event are invoked

To improve page load times: 
- move the generation of the category header to the Wicket template. Ideally this would be a part of the existing DataTable, but there's not clear way to add multiple header rows (I'll leave this as a TODO). 
- use setTimeouts to move non-essential javascript from the load critical path
- move as much CSS and element attribute changes to the Wicket template where possible
- ensure the category average columns are in the correct order in the Wicket template so the javascript doesn't have to manually move them around

To improve the speed in showing a dropdown menu, I had to refactor how we handle closing the popovers.  I've also made a first pass at ensuring jQuery.find calls are more specific to improve selector performance.  More work can be done here.

