### PR TITLE
1832: Rework how a cell decides whether to be readonly or editable

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -218,6 +218,7 @@ grade.notifications.concurrentedit = A concurrent edit has been detected. Please
 grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user">{0}</span> edited this score at <span class="gb-concurrent-edit-time">{1}</span>. Please refresh the tool to view the latest scores.
 grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool.
 grade.notifications.invalid = Gradebook item score must be a positive number or decimal.
+grade.notifications.readonly = Insufficient privileges to edit this Gradebook item score
 
 comment.option.add = Add Comment
 comment.option.edit = Edit Comment

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -805,14 +805,12 @@ public class GradebookNgBusinessService {
 						// iterate the permissions
 						// if category, compare the category,
 						// then check the group and find the user in the group
-						// if all ok, mark it as GRADEABLE
-
-						boolean categoryOk = false;
-						boolean groupOk = false;
-						boolean gradeable = false;
-
+						// add all available permission functions to the GbGradeInfo
 						for (final PermissionDefinition permission : permissions) {
 							// we know they are all GRADE so no need to check here
+
+							boolean permissionPassesCategory = false;
+							boolean permissionPassesGroup = false;
 
 							final Long permissionCategoryId = permission.getCategoryId();
 							final String permissionGroupReference = permission.getGroupReference();
@@ -822,33 +820,28 @@ public class GradebookNgBusinessService {
 
 							// if permissions category is null (can grade all categories) or they match (can grade this category)
 							if (permissionCategoryId == null || permissionCategoryId.equals(gradeCategoryId)) {
-								categoryOk = true;
+								permissionPassesCategory = true;
 								log.debug("Category check passed");
 							}
 
 							// if group reference is null (can grade all groups) or group membership contains student (can grade this group)
 							if (StringUtils.isBlank(permissionGroupReference)) {
-								groupOk = true;
+								permissionPassesGroup = true;
 								log.debug("Group check passed #1");
 							} else {
 								final List<String> groupMembers = groupMembershipsMap.get(permissionGroupReference);
 								log.debug("groupMembers: " + groupMembers);
 
 								if (groupMembers != null && groupMembers.contains(student.getId())) {
-									groupOk = true;
+									permissionPassesGroup = true;
 									log.debug("Group check passed #2");
 								}
 							}
 
-							if (categoryOk && groupOk) {
-								gradeable = true;
-								continue;
+							if (permissionPassesGroup && permissionPassesCategory) {
+								entry.getValue().getFunctions().add(permission.getFunction());
 							}
 						}
-
-						// set the gradeable flag on this grade instance
-						final GbGradeInfo gradeInfo = entry.getValue();
-						gradeInfo.setGradeable(gradeable);
 					}
 				}
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbGradeInfo.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbGradeInfo.java
@@ -1,6 +1,8 @@
 package org.sakaiproject.gradebookng.business.model;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -8,6 +10,7 @@ import org.sakaiproject.service.gradebook.shared.GradeDefinition;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.sakaiproject.service.gradebook.shared.GraderPermission;
 
 /**
  * Similar to GradeDefinition but serialisable and grader permission aware
@@ -25,12 +28,13 @@ public class GbGradeInfo implements Serializable, Comparable<GbGradeInfo> {
 	@Getter
 	private final String gradeComment;
 
+
 	/**
-	 * Whether or not a user is able to grade this instance of the grade
+	 * Functions available to the user on this grade
 	 */
 	@Getter
 	@Setter
-	private boolean gradeable;
+	private List<String> functions;
 
 	/**
 	 * Constructor. Takes a GradeDefinition or null. If null, a stub is created.
@@ -43,12 +47,16 @@ public class GbGradeInfo implements Serializable, Comparable<GbGradeInfo> {
 		if (gd == null) {
 			this.grade = null;
 			this.gradeComment = null;
-			this.gradeable = false;
 		} else {
 			this.grade = gd.getGrade();
 			this.gradeComment = gd.getGradeComment();
-			this.gradeable = false;
 		}
+
+		this.functions = new ArrayList<>(); 
+	}
+
+	public boolean canEdit() {
+		return getFunctions().contains(GraderPermission.GRADE.toString());
 	}
 
 	@Override
@@ -66,5 +74,4 @@ public class GbGradeInfo implements Serializable, Comparable<GbGradeInfo> {
 				.toComparison();
 
 	}
-
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -70,7 +70,8 @@ public class GradeItemCellPanel extends Panel {
 		HAS_COMMENT("grade.notifications.hascomment"),
 		CONCURRENT_EDIT("grade.notifications.concurrentedit"),
 		ERROR("grade.notifications.haserror"),
-		INVALID("grade.notifications.invalid");
+		INVALID("grade.notifications.invalid"),
+		READONLY("grade.notifications.readonly");
 
 		private String message;
 
@@ -106,7 +107,7 @@ public class GradeItemCellPanel extends Panel {
 		// Note: gradeInfo may be null
 		this.rawGrade = (gradeInfo != null) ? gradeInfo.getGrade() : "";
 		this.comment = (gradeInfo != null) ? gradeInfo.getGradeComment() : "";
-		this.gradeable = (gradeInfo != null) ? gradeInfo.isGradeable() : false; // ensure this is ALWAYS false if gradeInfo is null.
+		this.gradeable = (gradeInfo != null) ? gradeInfo.canEdit() : false; // ensure this is ALWAYS false if gradeInfo is null.
 
 		if (role == GbRole.INSTRUCTOR) {
 			this.gradeable = true;
@@ -131,6 +132,9 @@ public class GradeItemCellPanel extends Panel {
 			if (isExternal) {
 				getParentCellFor(this).add(new AttributeModifier("class", "gb-external-item-cell"));
 				this.notifications.add(GradeCellNotification.IS_EXTERNAL);
+			} else if (!this.gradeable) {
+				getParentCellFor(this).add(new AttributeModifier("class", "gb-readonly-item-cell"));
+				this.notifications.add(GradeCellNotification.READONLY);
 			} else {
 				getParentCellFor(this).add(new AttributeModifier("class", "gb-grade-item-cell"));
 			}
@@ -516,7 +520,8 @@ public class GradeItemCellPanel extends Panel {
 				addPopover(errorNotification, this.notifications);
 			} else if (this.notifications.contains(GradeCellNotification.INVALID)
 					|| this.notifications.contains(GradeCellNotification.CONCURRENT_EDIT)
-					|| this.notifications.contains(GradeCellNotification.IS_EXTERNAL)) {
+					|| this.notifications.contains(GradeCellNotification.IS_EXTERNAL)
+					|| this.notifications.contains(GradeCellNotification.READONLY)) {
 				warningNotification.setVisible(true);
 				addPopover(warningNotification, this.notifications);
 			} else if (this.notifications.contains(GradeCellNotification.OVER_LIMIT)) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -18,6 +18,7 @@
 			<p wicket:id="externalComment">Editable in [Tool Name] Tool</p>  
         </li>
         <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
+        <li wicket:id="isReadOnlyNotification" class="gb-popover-notification-is-readonly text-info"><span wicket:id="message"></span></li>
     </ul>
 
 </wicket:panel>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -85,6 +85,12 @@ public class GradeItemCellPopoverPanel extends Panel {
 				.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.IS_EXTERNAL.getMessage())));
 		add(isExternalNotification);
 
+		final WebMarkupContainer isReadOnlyNotification = new WebMarkupContainer("isReadOnlyNotification");
+		isReadOnlyNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.READONLY));
+		isReadOnlyNotification
+				.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.READONLY.getMessage())));
+		add(isReadOnlyNotification);
+
 		final WebMarkupContainer isInvalidNotification = new WebMarkupContainer("isInvalidNotification");
 		isInvalidNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.INVALID));
 		isInvalidNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.INVALID.getMessage())));

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -275,10 +275,12 @@
 /* Table Cells */
 #gradebookGrades .gb-grade-item-cell,
 #gradebookGrades .gb-external-item-cell,
+#gradebookGrades .gb-readonly-item-cell,
 #gradebookGrades td.gb-category-item-column-cell {
   text-align: center;
   white-space: nowrap;
 }
+#gradebookGrades .gb-readonly-item-cell,
 #gradebookGrades .gb-external-item-cell {
   color: #777;
   font-style: italic;
@@ -822,14 +824,18 @@ ul.feedbackPanel li span {
   content: "\f071";
   color: rgb(200,144,0);
 }
+.gb-readonly-item-cell .gb-cell-notification-warning,
 .gb-external-item-cell .gb-cell-notification-warning {
   opacity: 0.2;
   font-style: normal;
 }
+.gb-readonly-item-cell .gb-cell-notification-warning:before,
 .gb-external-item-cell .gb-cell-notification-warning:before {
   color: #CCC;
   content: '\f023';
 }
+.gb-readonly-item-cell:focus .gb-cell-notification-warning,
+.gb-readonly-item-cell .gb-cell-notification-warning:focus,
 .gb-external-item-cell:focus .gb-cell-notification-warning,
 .gb-external-item-cell .gb-cell-notification-warning:focus {
   display:block;


### PR DESCRIPTION
.. by adding all functions available for a user on a particular GbGradeEntry onto that grade entry so we can assertain if the user can VIEW and or GRADE that item when rendering the cells.

Hi @steveswinsburg,

I had a go at doing #1832 by refactoring GbGradeEntry.gradeable and instead using a list of the functions available to the user.  Does it seem ok?

So basically, for a TA with these permissions:

<img width="502" alt="screen shot 2016-03-01 at 2 29 23 pm" src="https://cloud.githubusercontent.com/assets/608337/13416869/081906f2-dfba-11e5-9c25-e07cb263c38e.png">

The see a mixture of editable and readonly cells:

<img width="441" alt="screen shot 2016-03-01 at 2 19 15 pm" src="https://cloud.githubusercontent.com/assets/608337/13416860/f74fbf3c-dfb9-11e5-84f4-1520dbcefd36.png">

Thanks