### PR TITLE
1832: fix GbGradeEntry.gradeable so TAs can VIEW and GRADE based on their permissions

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -218,6 +218,7 @@ grade.notifications.concurrentedit = A concurrent edit has been detected. Please
 grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user">{0}</span> edited this score at <span class="gb-concurrent-edit-time">{1}</span>. Please refresh the tool to view the latest scores.
 grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool.
 grade.notifications.invalid = Gradebook item score must be a positive number or decimal.
+grade.notifications.readonly = Insufficient privileges to edit this Gradebook item score
 
 comment.option.add = Add Comment
 comment.option.edit = Edit Comment

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -807,12 +807,13 @@ public class GradebookNgBusinessService {
 						// then check the group and find the user in the group
 						// if all ok, mark it as GRADEABLE
 
-						boolean categoryOk = false;
-						boolean groupOk = false;
 						boolean gradeable = false;
 
 						for (final PermissionDefinition permission : permissions) {
 							// we know they are all GRADE so no need to check here
+
+							boolean categoryOk = false;
+							boolean groupOk = false;
 
 							final Long permissionCategoryId = permission.getCategoryId();
 							final String permissionGroupReference = permission.getGroupReference();
@@ -842,7 +843,7 @@ public class GradebookNgBusinessService {
 
 							if (categoryOk && groupOk) {
 								gradeable = true;
-								continue;
+								break;
 							}
 						}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -70,7 +70,8 @@ public class GradeItemCellPanel extends Panel {
 		HAS_COMMENT("grade.notifications.hascomment"),
 		CONCURRENT_EDIT("grade.notifications.concurrentedit"),
 		ERROR("grade.notifications.haserror"),
-		INVALID("grade.notifications.invalid");
+		INVALID("grade.notifications.invalid"),
+		READONLY("grade.notifications.readonly");
 
 		private String message;
 
@@ -131,6 +132,9 @@ public class GradeItemCellPanel extends Panel {
 			if (isExternal) {
 				getParentCellFor(this).add(new AttributeModifier("class", "gb-external-item-cell"));
 				this.notifications.add(GradeCellNotification.IS_EXTERNAL);
+			} else if (!this.gradeable) {
+				getParentCellFor(this).add(new AttributeModifier("class", "gb-readonly-item-cell"));
+				this.notifications.add(GradeCellNotification.READONLY);
 			} else {
 				getParentCellFor(this).add(new AttributeModifier("class", "gb-grade-item-cell"));
 			}
@@ -516,7 +520,8 @@ public class GradeItemCellPanel extends Panel {
 				addPopover(errorNotification, this.notifications);
 			} else if (this.notifications.contains(GradeCellNotification.INVALID)
 					|| this.notifications.contains(GradeCellNotification.CONCURRENT_EDIT)
-					|| this.notifications.contains(GradeCellNotification.IS_EXTERNAL)) {
+					|| this.notifications.contains(GradeCellNotification.IS_EXTERNAL)
+					|| this.notifications.contains(GradeCellNotification.READONLY)) {
 				warningNotification.setVisible(true);
 				addPopover(warningNotification, this.notifications);
 			} else if (this.notifications.contains(GradeCellNotification.OVER_LIMIT)) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -18,6 +18,7 @@
 			<p wicket:id="externalComment">Editable in [Tool Name] Tool</p>  
         </li>
         <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
+        <li wicket:id="isReadOnlyNotification" class="gb-popover-notification-is-readonly text-info"><span wicket:id="message"></span></li>
     </ul>
 
 </wicket:panel>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.java
@@ -85,6 +85,12 @@ public class GradeItemCellPopoverPanel extends Panel {
 				.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.IS_EXTERNAL.getMessage())));
 		add(isExternalNotification);
 
+		final WebMarkupContainer isReadOnlyNotification = new WebMarkupContainer("isReadOnlyNotification");
+		isReadOnlyNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.READONLY));
+		isReadOnlyNotification
+				.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.READONLY.getMessage())));
+		add(isReadOnlyNotification);
+
 		final WebMarkupContainer isInvalidNotification = new WebMarkupContainer("isInvalidNotification");
 		isInvalidNotification.setVisible(notifications.contains(GradeItemCellPanel.GradeCellNotification.INVALID));
 		isInvalidNotification.add(new Label("message", new ResourceModel(GradeItemCellPanel.GradeCellNotification.INVALID.getMessage())));

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -275,10 +275,12 @@
 /* Table Cells */
 #gradebookGrades .gb-grade-item-cell,
 #gradebookGrades .gb-external-item-cell,
+#gradebookGrades .gb-readonly-item-cell,
 #gradebookGrades td.gb-category-item-column-cell {
   text-align: center;
   white-space: nowrap;
 }
+#gradebookGrades .gb-readonly-item-cell,
 #gradebookGrades .gb-external-item-cell {
   color: #777;
   font-style: italic;
@@ -822,14 +824,18 @@ ul.feedbackPanel li span {
   content: "\f071";
   color: rgb(200,144,0);
 }
+.gb-readonly-item-cell .gb-cell-notification-warning,
 .gb-external-item-cell .gb-cell-notification-warning {
   opacity: 0.2;
   font-style: normal;
 }
+.gb-readonly-item-cell .gb-cell-notification-warning:before,
 .gb-external-item-cell .gb-cell-notification-warning:before {
   color: #CCC;
   content: '\f023';
 }
+.gb-readonly-item-cell:focus .gb-cell-notification-warning,
+.gb-readonly-item-cell .gb-cell-notification-warning:focus,
 .gb-external-item-cell:focus .gb-cell-notification-warning,
 .gb-external-item-cell .gb-cell-notification-warning:focus {
   display:block;


### PR DESCRIPTION
Hi @steveswinsburg,

Okidokes.. take 2.

I had a go at fixing #1832 by slightly tweaking the inner loop that sets GbGradeEntry.gradeable. Now we reset categoryOk and groupOk for each permission rather than for each grade entry.

So basically, for a TA with these permissions:

<img width="502" alt="screen shot 2016-03-01 at 2 29 23 pm" src="https://cloud.githubusercontent.com/assets/608337/13416869/081906f2-dfba-11e5-9c25-e07cb263c38e.png">

The see a mixture of editable and readonly cells:

<img width="441" alt="screen shot 2016-03-01 at 2 19 15 pm" src="https://cloud.githubusercontent.com/assets/608337/13416860/f74fbf3c-dfb9-11e5-84f4-1520dbcefd36.png">

Hoping that looks ok!