### PR TITLE
SAK-30450 regression: the title attribute should show the long version in site tabs

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -385,11 +385,11 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 						.equals(myWorkspaceSiteId))));
 		
 		// SAK-29138
-		m.put( "siteTitleNotTruncated", getUserSpecificSiteTitle( s, false ) );
-
-		String siteTitle = getUserSpecificSiteTitle( s );
-		m.put( "siteTitle", siteTitle );
-		m.put( "fullTitle", siteTitle );
+		String siteTitleTruncated = getUserSpecificSiteTitle( s, true );
+		String siteTitleNotTruncated = getUserSpecificSiteTitle( s, false );
+		m.put( "siteTitleNotTruncated", siteTitleNotTruncated );
+		m.put( "siteTitle", siteTitleTruncated );
+		m.put( "fullTitle", siteTitleNotTruncated );
 		
 		m.put("siteDescription", s.getHtmlDescription());
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30450

Put the non-truncated string in the tool tip for the tab.