### PR TITLE
1699: add validation for large scores and fix concurrent use error

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -24,6 +24,7 @@ package org.sakaiproject.component.gradebook;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -2383,7 +2384,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 	  	if (assignmentScore == null)
 	  		return null;
 	  	
-	  	return Double.valueOf(assignmentScore).toString();
+	  	// avoid scientific notation on large scores by using a formatter
+	  	final DecimalFormat df = new DecimalFormat();
+	  	df.setGroupingUsed(false);
+
+	  	return df.format(assignmentScore);
   	}
   
   	@Override

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -1934,15 +1934,16 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				  Double gradeAsDouble = Double.parseDouble(grade);
 				  // grade must be greater than or equal to 0
 				  if (gradeAsDouble.doubleValue() >= 0) {
+						String[] splitOnDecimal = grade.split("\\.");
 					  // check that there are no more than 2 decimal places
-					  String[] splitOnDecimal = grade.split("\\.");
-					  if (splitOnDecimal == null || splitOnDecimal.length < 2) {
+					  if (splitOnDecimal == null) {
 						  gradeIsValid = true;
-					  } else if (splitOnDecimal.length == 2) {
-						  String decimal = splitOnDecimal[1];
-						  if (decimal.length() <= 2) {
-							  gradeIsValid = true;
-						  }
+
+					  // check for a valid score matching ##########.##
+					  // where integer is maximum of 10 integers in length
+					  // and maximum of 2 decimal places
+					  } else if (grade.matches("[0-9]{0,10}(\\.[0-9]{0,2})?")) {
+						  gradeIsValid = true;
 					  }
 				  }
 			  } catch (NumberFormatException nfe) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -199,7 +199,7 @@ assignment.option.setungraded = Set Score for Empty Cells
 
 
 message.edititem.success=Gradebook item ''{0}'' has been updated.
-message.edititem.error=An error occurred updating the Gradebook item.
+message.edititem.error=An error occurred updating the Gradebook item. Please ensure your score is a positive number or decimal, a maximum of 10 integers in length with a maximum of 2 decimal places.
 message.editcomment.error=An error occurred editing the comment.
 message.addcoursegradeoverride.success = The course grade was updated.
 message.addcoursegradeoverride.error = An error occurred updating the course grade.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -214,8 +214,7 @@ public class GradeItemCellPanel extends Panel {
 								break;
 							case ERROR:
 								markError(getComponent());
-								// TODO fix this message
-								error("oh dear");
+								error(getString("message.edititem.error"));
 								break;
 							case OVER_LIMIT:
 								markOverLimit(GradeItemCellPanel.this.gradeCell);


### PR DESCRIPTION
Delivers #1699.

Changes were mostly in the service:
- avoid scientific notation in `getAssignmentScoreString` by using a DecimalFormat instead of toString.
-  introduce a regex to satisfy the new score rule to match "##########.##" where the integer is maximum of 10 integers in length and maximum of 2 decimal places

I presume these changes should go in the service?  Happy to move them to the tool if that's preferred.

Also updated the error message to contain the new rule. Left deliberately wordy so somebody might suggest something better :panda_face: 