### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/assignment/runconversion.sh
+++ b/assignment/runconversion.sh
@@ -78,7 +78,7 @@ CLASSPATH="$CLASSPATH:"$m2repository"/org/sakaiproject/sakai-assignment-impl/$SA
 
 ##### COMMON KERNEL STUFF #####
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar"
-CLASSPATH="$CLASSPATH:"$m2repository"/commons-collections/commons-collections/3.2/commons-collections-3.2.jar"
+CLASSPATH="$CLASSPATH:"$m2repository"/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-codec/commons-codec/1.3/commons-codec-1.3.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-dbcp/commons-dbcp/1.2.2/commons-dbcp-1.2.2.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-pool/commons-pool/1.3/commons-pool-1.3.jar"

--- a/chat/chat-tool/tool/pom.xml
+++ b/chat/chat-tool/tool/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/content/content-runconversion.sh
+++ b/content/content-runconversion.sh
@@ -69,7 +69,7 @@ done
 shift $(($OPTIND - 1))
 
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar"
-CLASSPATH="$CLASSPATH:"$m2repository"/commons-collections/commons-collections/3.2/commons-collections-3.2.jar"
+CLASSPATH="$CLASSPATH:"$m2repository"/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-dbcp/commons-dbcp/1.2.2/commons-dbcp-1.2.2.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-pool/commons-pool/1.3/commons-pool-1.3.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/org/sakaiproject/kernel/sakai-kernel-api/$KERNELVERSION/sakai-kernel-api-$KERNELVERSION.jar"

--- a/content/content-tool/tool/pom.xml
+++ b/content/content-tool/tool/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.velocity</groupId>

--- a/edu-services/gradebook-service/impl/pom.xml
+++ b/edu-services/gradebook-service/impl/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-digester</groupId>

--- a/edu-services/sections-service/sections-impl/integration-support/pom.xml
+++ b/edu-services/sections-service/sections-impl/integration-support/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-digester</groupId>

--- a/edu-services/sections-service/sections-impl/standalone/pom.xml
+++ b/edu-services/sections-service/sections-impl/standalone/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-digester</groupId>

--- a/gradebook/app/business/pom.xml
+++ b/gradebook/app/business/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-digester</groupId>

--- a/gradebook/app/ui/pom.xml
+++ b/gradebook/app/ui/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-digester</groupId>

--- a/help/schema-export.bat
+++ b/help/schema-export.bat
@@ -14,7 +14,7 @@ set MAVEN_SRC=C:\java\projects\help\foo
 set HIBERNATE_HOME=C:\java\lib\hibernate-2.1.8
 set LIB=%HIBERNATE_HOME%\lib
 set PROPS=%HIBERNATE_HOME%\src
-set CP=%MAVEN_TARGET%;%PROPS%;%HIBERNATE_HOME%\hibernate2.jar;%LIB%\commons-logging-1.0.4.jar;%LIB%\commons-collections-2.1.1.jar;%LIB%\commons-lang-1.0.1.jar;%LIB%\cglib-full-2.0.2.jar;%LIB%\dom4j-1.4.jar;%LIB%\odmg-3.0.jar;%LIB%\xml-apis.jar;%LIB%\xerces-2.4.0.jar;%LIB%\xalan-2.4.0.jar
+set CP=%MAVEN_TARGET%;%PROPS%;%HIBERNATE_HOME%\hibernate2.jar;%LIB%\commons-logging-1.0.4.jar;%LIB%\commons-collections-3.2.2.jar;%LIB%\commons-lang-1.0.1.jar;%LIB%\cglib-full-2.0.2.jar;%LIB%\dom4j-1.4.jar;%LIB%\odmg-3.0.jar;%LIB%\xml-apis.jar;%LIB%\xerces-2.4.0.jar;%LIB%\xalan-2.4.0.jar
 set CP=%CP%;C:\java\projects\help\help-api\target\classes
 
 java -cp %CP% -Dhibernate.dialect=%HIBERNATE_DIALECT% net.sf.hibernate.tool.hbm2ddl.SchemaExport --text --format --output=%HIBERNATE_DIALECT%-ddl.sql %MAVEN_SRC%\*.hbm.xml

--- a/hierarchy/impl/pom.xml
+++ b/hierarchy/impl/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/jobscheduler/scheduler-tool/pom.xml
+++ b/jobscheduler/scheduler-tool/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>xml-apis</groupId>

--- a/jsf/jsf-tool-sun/pom.xml
+++ b/jsf/jsf-tool-sun/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/jsf/myfaces-tool/pom.xml
+++ b/jsf/myfaces-tool/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/mailarchive/mailarchive-runconversion.sh
+++ b/mailarchive/mailarchive-runconversion.sh
@@ -80,7 +80,7 @@ CLASSPATH="$CLASSPATH:"$m2repository"/org/sakaiproject/sakai-mailarchive-impl/$S
 
 ##### COMMON KERNEL STUFF #####
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar"
-CLASSPATH="$CLASSPATH:"$m2repository"/commons-collections/commons-collections/3.2/commons-collections-3.2.jar"
+CLASSPATH="$CLASSPATH:"$m2repository"/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-dbcp/commons-dbcp/1.2.2/commons-dbcp-1.2.2.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/commons-pool/commons-pool/1.3/commons-pool-1.3.jar"
 CLASSPATH="$CLASSPATH:"$m2repository"/org/sakaiproject/kernel/sakai-kernel-api/$KERNELVERSION/sakai-kernel-api-$KERNELVERSION.jar"

--- a/msgcntr/schema-export.bat
+++ b/msgcntr/schema-export.bat
@@ -14,7 +14,7 @@ set MAVEN_SRC=C:\java\projects\messageforums\foo
 set HIBERNATE_HOME=C:\java\lib\hibernate-2.1.8
 set LIB=%HIBERNATE_HOME%\lib
 set PROPS=%HIBERNATE_HOME%\src
-set CP=%MAVEN_TARGET%;%PROPS%;%HIBERNATE_HOME%\hibernate2.jar;%LIB%\commons-logging-1.0.4.jar;%LIB%\commons-collections-2.1.1.jar;%LIB%\commons-lang-1.0.1.jar;%LIB%\cglib-full-2.0.2.jar;%LIB%\dom4j-1.4.jar;%LIB%\odmg-3.0.jar;%LIB%\xml-apis.jar;%LIB%\xerces-2.4.0.jar;%LIB%\xalan-2.4.0.jar
+set CP=%MAVEN_TARGET%;%PROPS%;%HIBERNATE_HOME%\hibernate2.jar;%LIB%\commons-logging-1.0.4.jar;%LIB%\commons-collections-3.2.2.jar;%LIB%\commons-lang-1.0.1.jar;%LIB%\cglib-full-2.0.2.jar;%LIB%\dom4j-1.4.jar;%LIB%\odmg-3.0.jar;%LIB%\xml-apis.jar;%LIB%\xerces-2.4.0.jar;%LIB%\xalan-2.4.0.jar
 set CP=%CP%;C:\java\projects\messageforums\messageforums-api\target\classes
 
 java -cp %CP% -Dhibernate.dialect=%HIBERNATE_DIALECT% net.sf.hibernate.tool.hbm2ddl.SchemaExport --delimiter=; --text --format --output=%HIBERNATE_DIALECT%-ddl.sql %MAVEN_SRC%\*.hbm.xml

--- a/reset-pass/account-validator-impl/pom.xml
+++ b/reset-pass/account-validator-impl/pom.xml
@@ -141,7 +141,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>easymock</groupId>

--- a/samigo/samigo-qti/pom.xml
+++ b/samigo/samigo-qti/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/search/search-tool/tool/pom.xml
+++ b/search/search-tool/tool/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/signup/resources/build.xml
+++ b/signup/resources/build.xml
@@ -10,7 +10,7 @@
 			<file name="org.hibernate/jars/hibernate-3.1.3.jar"/>
 			<file name="dom4j/jars/dom4j-1.6.1.jar"/>
 			<file name="commons-logging/jars/commons-logging-1.1.jar"/>
-			<file name="commons-collections/jars/commons-collections-3.1.jar" />
+			<file name="commons-collections/jars/commons-collections-3.2.2.jar" />
 			<file name="mysql/jars/mysql-connector-java-3.1.14-bin.jar"/>
 			<file name="oracle/jars/ojdbc-1.4.jar"/>
 		</filelist>

--- a/syllabus/schema-export.bat
+++ b/syllabus/schema-export.bat
@@ -14,7 +14,7 @@ set MAVEN_SRC=C:\java\projects\syllabus\foo
 set HIBERNATE_HOME=C:\java\lib\hibernate-2.1.8
 set LIB=%HIBERNATE_HOME%\lib
 set PROPS=%HIBERNATE_HOME%\src
-set CP=%MAVEN_TARGET%;%PROPS%;%HIBERNATE_HOME%\hibernate2.jar;%LIB%\commons-logging-1.0.4.jar;%LIB%\commons-collections-2.1.1.jar;%LIB%\commons-lang-1.0.1.jar;%LIB%\cglib-full-2.0.2.jar;%LIB%\dom4j-1.4.jar;%LIB%\odmg-3.0.jar;%LIB%\xml-apis.jar;%LIB%\xerces-2.4.0.jar;%LIB%\xalan-2.4.0.jar
+set CP=%MAVEN_TARGET%;%PROPS%;%HIBERNATE_HOME%\hibernate2.jar;%LIB%\commons-logging-1.0.4.jar;%LIB%\commons-collections-2.2.2.jar;%LIB%\commons-lang-1.0.1.jar;%LIB%\cglib-full-2.0.2.jar;%LIB%\dom4j-1.4.jar;%LIB%\odmg-3.0.jar;%LIB%\xml-apis.jar;%LIB%\xerces-2.4.0.jar;%LIB%\xalan-2.4.0.jar
 set CP=%CP%;C:\java\projects\syllabus\syllabus-api\target\classes
 
 java -cp %CP% -Dhibernate.dialect=%HIBERNATE_DIALECT% net.sf.hibernate.tool.hbm2ddl.SchemaExport --text --format --output=%HIBERNATE_DIALECT%-ddl.sql %MAVEN_SRC%\*.hbm.xml

--- a/tool/tool-tool/su/pom.xml
+++ b/tool/tool-tool/su/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/user/user-tool-admin-prefs/admin-prefs/pom.xml
+++ b/user/user-tool-admin-prefs/admin-prefs/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/velocity/tool/pom.xml
+++ b/velocity/tool/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/