### PR TITLE
SAK-30474 Made changes to some of the tool icons for Morpheus

### DIFF
--- a/reference/library/src/morpheus-master/sass/base/_icons.scss
+++ b/reference/library/src/morpheus-master/sass/base/_icons.scss
@@ -16,21 +16,21 @@
 
 	.icon-sakai-iframe-site{ 				@extend .fa-university;}
 	.icon-sakai-motd{ 					@extend .fa-university;}
-	.icon-sakai-syllabus{					@extend .fa-file-text-o;}
+	.icon-sakai-syllabus{					@extend .fa-map-o;}
 	.icon-sakai-schedule{					@extend .fa-calendar;}
-	.icon-sakai-signup{					@extend .fa-calendar;}
-	.icon-sakai-resources{					@extend .fa-folder;}
-	.icon-sakai-dropbox{					@extend .fa-dropbox;}
-	.icon-sakai-assignment-grades{				@extend .fa-tasks;}
-	.icon-sakai-samigo{					@extend .fa-puzzle-piece;}
-	.icon-sakai-gradebook-tool{				@extend .fa-check-square-o;}
-	.icon-sakai-gradebookng{				@extend .fa-check-square-o;}
+	.icon-sakai-signup{					@extend .fa-calendar-check-o ;}
+	.icon-sakai-resources{					@extend .fa-folder-open;}
+	.icon-sakai-dropbox{					@extend .fa-exchange;}
+	.icon-sakai-assignment-grades{				@extend .fa-file-text;}
+	.icon-sakai-samigo{					@extend .fa-list-ol;}
+	.icon-sakai-gradebook-tool{				@extend .fa-book;}
+	.icon-sakai-gradebookng{				@extend .fa-book;}
 	.icon-sakai-announcements{				@extend .fa-bullhorn;}
 	.icon-sakai-chat{					@extend .fa-comments-o;}
 	.icon-sakai-rwiki{ 					@extend .fa-edit;}
 	.icon-sakai-mailbox{					@extend .fa-envelope-o;}
 	.icon-sakai-emailtemplateservice{			@extend .fa-envelope;}
-	.icon-sakai-news{					@extend .fa-newspaper-o;}
+	.icon-sakai-news{					@extend .fa-rss;}
 	.icon-sakai-simple-rss{					@extend .fa-newspaper-o;}
 	.icon-sakai-basiclti{					@extend .fa-globe;}
 	.icon-sakai-messages{					@extend .fa-inbox;}
@@ -38,8 +38,8 @@
 	.icon-sakai-site-roster2{				@extend .fa-users;}
 	.icon-sakai-sections{					@extend .fa-user;}
 	.icon-sakai-resetpass{					@extend .fa-user;}
-	.icon-sakai-createuser{					@extend .fa-user;}
-	.icon-sakai-realms{					@extend .fa-user;}
+	.icon-sakai-createuser{					@extend .fa-user-plus;}
+	.icon-sakai-realms{					@extend .fa-sitemap;}
 	.icon-sakai-profile2{					@extend .fa-user;}
 	.icon-sakai-membership{					@extend .fa-users;}
 	.icon-sakai-singleuser{					@extend .fa-user;}
@@ -50,28 +50,28 @@
 	.icon-sakai-iframe{					@extend .fa-globe;}
 	.icon-sakai-sitebrowser{				@extend .fa-globe;}
 	.icon-sakai-search{					@extend .fa-search;}
-	.icon-sakai-poll{					@extend .fa-check-square;}
+	.icon-sakai-poll{					@extend .fa-bar-chart;}
 	.icon-sakai-mailtool{					@extend .fa-envelope-o;}
 	.icon-sakai-lessonbuildertool{				@extend .fa-leanpub;}
 	.icon-sakai-lessonbuildertool{				@extend .fa-leanpub;}
 	.icon-sakai-sitestats{					@extend .fa-pie-chart;}
 	.icon-sakai-sitestats-admin{				@extend .fa-pie-chart;}
 	.icon-sakai-forums{					@extend .fa-comments;}
-	.icon-sakai-podcasts{					@extend .fa-file-audio-o;}
-	.icon-sakai-postem{					@extend .fa-pencil-square-o;}
+	.icon-sakai-podcasts{					@extend .fa-microphone;}
+	.icon-sakai-postem{					@extend .fa-sticky-note-o;}
 	.icon-sakai-users{					@extend .fa-users;}
-	.icon-sakai-su{						@extend .fa-user;}
+	.icon-sakai-su{						@extend .fa-user-secret;}
 	.icon-sakai-usermembership{				@extend .fa-user;}
-	.icon-sakai-aliases{					@extend .fa-gear;}
+	.icon-sakai-aliases{					@extend .fa-tags;}
 	.icon-sakai-sites{					@extend .fa-list;}
 	.icon-sakai-archive{					@extend .fa-archive;}
-	.icon-sakai-online{					@extend .fa-gear;}
+	.icon-sakai-online{					@extend .fa-server;}
 	.icon-sakai-memory{					@extend .fa-hdd-o;}
 	.icon-sakai-scheduler{					@extend .fa-clock-o;}
 	.icon-sakai-basiclti-admin{				@extend .fa-globe;}
-	.icon-sakai-adminsiteperms{				@extend .fa-gear;}
+	.icon-sakai-adminsiteperms{				@extend .fa-sliders;}
 	.icon-sakai-message-bundle-manager{			@extend .fa-gear;}
-	.icon-sakai-delegatedaccess{				@extend .fa-gear;}
+	.icon-sakai-delegatedaccess{				@extend .fa-hand-o-right;}
 	.icon-sakai-web-168{					@extend .fa-globe;}
 	.icon-sakai-pasystem{					@extend .fa-bell;}
 	.icon-sakai-feedback{					@extend .fa-paper-plane-o;}


### PR DESCRIPTION
I've made some changes and updates to the tool icons in Morpheus to make them more unique and applicable to the tool. Some of the tool icons were used for other tools too (e.g. fa-user and fa-gear were used a lot); some implied the wrong association (e.g. Drop Box with [Dropbox](https://www.dropbox.com/)).

I've updated tool icons for the following core tools:
- Aliases
- Assignments
- Become User
- Create User
- Drop Box
- Gradebook
- GradebookNG
- News
- Online
- Podcast
- Polls
- PostEm
- Resources
- Realms
- Sign-up
- Syllabus
- Tests & Quizzes

Please see the following screenshots from common sites comparing the former icons (on the left) and my changes (on the right).

**In a course or project site (changes on the right):**
![01-site](https://cloud.githubusercontent.com/assets/12685096/13621064/90984a3a-e562-11e5-925b-fe303ae2819f.png)
![02-site](https://cloud.githubusercontent.com/assets/12685096/13621091/da0c1d2c-e562-11e5-8c62-30b47ef7d048.png)

**In Administration Workspace (changes on the right):**
![03-admin](https://cloud.githubusercontent.com/assets/12685096/13621076/a7fd7556-e562-11e5-9e49-a64ddac073e2.png)

**On the Gateway (changes on the right):**
![04-gateway](https://cloud.githubusercontent.com/assets/12685096/13621095/e73110f2-e562-11e5-9ed9-63f152d8d58c.png)

