### PR TITLE
#1367 update settings so that course grade points cannot be selected …

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -267,6 +267,7 @@ settingspage.displaycoursegrade.preview-points-first = 176/200
 settingspage.displaycoursegrade.preview-points-second = [176/200]
 settingspage.displaycoursegrade.instructions = Choose the options for formatting the course grade. You must choose at least one option.
 settingspage.displaycoursegrade.notenough = Display course grade is selected but you didn't select any formatting options.
+settingspage.displaycoursegrade.incompatible = Points can not be displayed as a course grade when weighted categories are enabled. Please select different course grade display options.
 
 settingspage.categories.none = No categories
 settingspage.categories.categoriesonly = Categories only

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -99,6 +99,14 @@ public class SettingsPage extends BasePage {
 					}
 				}
 
+				// if categories and weighting selected AND if course grade display points was selected,
+				// give error message
+				if (model.getGradebookInformation().getCategoryType() == GbCategoryType.WEIGHTED_CATEGORY.getValue()
+						&& model.getGradebookInformation().isCourseGradeDisplayed()
+						&& model.getGradebookInformation().isCoursePointsDisplayed()) {
+					error(getString("settingspage.displaycoursegrade.incompatible"));
+				}
+
 				// validate the course grade display settings
 				if (model.getGradebookInformation().isCourseGradeDisplayed()) {
 					int displayOptions = 0;


### PR DESCRIPTION
…if weighted categories enabled

Finalises #1367.

I didn't implement the changes to the data because it was incompatible with the error message (choose different options and re-release). If the options were reset they woudn't have anything to change and could save the form again without re-releasing. The error now blocks the save unless they fix the settings.