### PR TITLE
SAK-30483 ehcache 2.6.6 no longer in maven repo

### DIFF
--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -172,7 +172,7 @@
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
-      <version>2.6.6</version>
+      <version>${sakai.ehcache.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -113,7 +113,7 @@
         <version>3.2.3</version>
         <scope>provided</scope>
       </dependency>
-      <!-- centralize the versions for distributed ehcache - MUST match ehcache-core 2.6.6 -->
+      <!-- centralize the versions for distributed ehcache -->
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-toolkit-1.6-runtime</artifactId>
@@ -123,7 +123,7 @@
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache-terracotta</artifactId>
-        <version>2.6.6</version>
+        <version>${sakai.ehcache.version}</version>
         <scope>provided</scope>
       </dependency>
       <!-- Java 8 Maven Artifact -->

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -88,7 +88,7 @@
     <sakai.commons-math.version>2.2</sakai.commons-math.version>
     <sakai.ehcache.groupId>net.sf.ehcache</sakai.ehcache.groupId>
     <sakai.ehcache.artifactId>ehcache-core</sakai.ehcache.artifactId>
-    <sakai.ehcache.version>2.6.6</sakai.ehcache.version>
+    <sakai.ehcache.version>2.6.11</sakai.ehcache.version>
     <sakai.elasticsearch.version>1.7.2</sakai.elasticsearch.version>
     <sakai.hibernate.groupId>org.hibernate</sakai.hibernate.groupId>
     <sakai.hibernate.artifactId>hibernate-core</sakai.hibernate.artifactId>
@@ -570,7 +570,7 @@
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache-core</artifactId>
-        <version>2.6.6</version>
+        <version>${sakai.ehcache.version}</version>
         <scope>provided</scope>
       </dependency>
       <!-- needed by Ehcache (and jackrabbit) -->


### PR DESCRIPTION


ehcache 2.6.6 is no longer in the maven2 repo: "Could not find artifact net.sf.ehcache:ehcache:jar:2.6.6 in central (http://repo1.maven.org/maven2)"

If you have a tool that defines this dependency using the version from master:

<dependency>
            <groupId>net.sf.ehcache</groupId>
            <artifactId>ehcache</artifactId>
            <version>${sakai.ehcache.version}</version>
        </dependency>

The build will fail. Updated version to latest in maven2 repo. Open to suggestions if this is not the appropriate fix and/or version.
