### PR TITLE
1369: fix exception due to "headers" not being set

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
@@ -162,12 +162,6 @@ public class CourseGradeOverridePanel extends Panel {
 		form.add(revertLink);
 
 		add(form);
-
-		// heading
-		add(new Label("heading",
-				new StringResourceModel("heading.coursegrade", null,
-						new Object[] { studentUser.getDisplayName(), studentUser.getDisplayId() })));
-
 	}
 
 	/**


### PR DESCRIPTION
Delivers #1369.

Headers are now set on the modal and not on the panel (accessibility thang).