### PR TITLE
KNL-1419 Only send notifications to site members.

### DIFF
--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/SiteEmailNotification.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/SiteEmailNotification.java
@@ -131,11 +131,11 @@ public class SiteEmailNotification extends EmailNotification
 				users.retainAll(users2);
 			}
 
-			//only use direct site members for the base list of users
-			refineToSiteMembers(users, site);
-
 			// add any other users
 			addSpecialRecipients(users, ref);
+
+			//only use direct site members for the base list of users
+			refineToSiteMembers(users, site);
 
 			return users;
 		}


### PR DESCRIPTION
If a user is a member of the global review realm and has the content.all.groups permission then they get all notification message even if they aren't actially a member of the site. This prevents non-site members from ever getting a notification.