### PR TITLE
SAK-30510 Provide quartz job to report on LTI Tools

### DIFF
--- a/basiclti/basiclti-api/src/bundle/org/sakaiproject/lti/impl/LTIReportingJob.properties
+++ b/basiclti/basiclti-api/src/bundle/org/sakaiproject/lti/impl/LTIReportingJob.properties
@@ -1,0 +1,9 @@
+# Has to be in shared so that it can be loaded
+to=To Address
+to.description=The recipient of the report
+from=From Address
+from.description=The sender of the report
+period=Reporting Period(ms)
+period.description=The period over which we will look for LTI tools being installed.
+toolId=LTI Tool ID
+toolId.description=The LTI Tool that the report is generated for.

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -470,6 +470,17 @@ public interface LTIService {
 	 */
 	public List<Map<String, Object>> getContents(String search, String order, int first, int last);
 
+
+	/**
+	 * This finds a set of LTI Contents objects.
+	 * @param search The SQL search string to limit the results
+	 * @param order The SQL order by string.
+	 * @param first The first item that should be returned.
+	 * @param last The last item that should be returned.
+	 * @param siteId The site ID or null to search as admin.
+	 * @return A List of LTI Contents objects.
+	 */
+	public List<Map<String, Object>> getContentsDao(String search, String order, int first, int last, String siteId);
 	/**
 	 * 
 	 * @param search

--- a/basiclti/basiclti-impl/pom.xml
+++ b/basiclti/basiclti-impl/pom.xml
@@ -96,6 +96,10 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
@@ -1,0 +1,127 @@
+package org.sakaiproject.lti.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.sakaiproject.email.api.EmailService;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.util.ResourceLoader;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This Reports on new instances of an LTI tool in a site.
+ */
+public class LTIReportingJob implements Job {
+
+    private final Log log = LogFactory.getLog(LTIReportingJob.class);
+
+    protected final ResourceLoader rb = new ResourceLoader("email");
+
+    private LTIService ltiService;
+    private SiteService siteService;
+    private EmailService emailService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+
+        // The ID of the LTI tool to report on.
+        long toolId = context.getMergedJobDataMap().getLongFromString("toolId");
+        // The number of milliseconds in the past to look for tools added in.
+        int period = context.getMergedJobDataMap().getIntFromString("period");
+        // The emails address to send the reports to
+        String to = context.getMergedJobDataMap().getString("to");
+        // The from address
+        String from = context.getMergedJobDataMap().getString("from");
+
+
+        Map<String, Object> tool = ltiService.getToolDao(toolId, null);
+        if (tool == null) {
+            log.warn("Failed to find LTI tool for "+ toolId);
+            return;
+        }
+
+        String toolTitle = (String) tool.get("title");
+
+        // SELECT * FROM lti_content where tool_id = ? created_at > date_sub(now(),  interval ???? second) ;
+        String search = String.format("tool_id = %d AND created_at > date_sub(now(), interval %d second)",
+            toolId, period / 1000);
+        List<Map<String, Object>> contents = ltiService.getContentsDao(search, null, 0, 0, null);
+        DateFormat df = DateFormat.getDateTimeInstance( DateFormat.SHORT, DateFormat.SHORT, rb.getLocale());
+
+        boolean sendEmail = false;
+        StringBuilder email = new StringBuilder();
+        email.append(rb.getFormattedMessage("new.tools.body.header", new String[]{toolTitle, formatDuration(period)}));
+        for(Map<String, Object> content : contents) {
+            String siteId = (String)content.get("SITE_ID");
+            try {
+                Site site = siteService.getSite(siteId);
+                // TODO Check the LTI tool is still in the site.
+                String title = site.getTitle();
+                User user = site.getModifiedBy();
+                Date date = site.getModifiedDate();
+                String url = site.getUrl();
+                email.append(rb.getFormattedMessage("new.tools.body.entry",
+                    new Object[]{title, url, user.getDisplayName(), df.format(date)}));
+                sendEmail = true;
+
+            } catch (IdUnusedException e) {
+                // Most likely the newly added LTI's site has been deleted
+                log.debug("Failed to find site with ID of: "+ siteId);
+            }
+        }
+        email.append(rb.getString("new.tools.body.footer"));
+
+        if (!sendEmail) {
+            // We check here because it may be the case that the site we were going to notify about
+            // doesn't exist any longer.
+            log.debug("No contents found, no email will be sent.");
+            return;
+        }
+        String subject = rb.getFormattedMessage("new.tools.subject", new String[]{toolTitle, formatDuration(period)});
+        String body = email.toString();
+
+        emailService.send(from,to,subject, body, null, null, null);
+        log.debug("Sent mail from "+ from+ " to "+ to+ " with details of "+ contents.size()+ " changes");
+    }
+
+    /**
+     * Formats a duration sensibly.
+     * @param remaining Time remaining in milliseconds.
+     * @return a String roughly representing the duration.
+     */
+    protected String formatDuration(long remaining) {
+        if (remaining < 1000) {
+            return "< 1 second";
+        } else if (remaining < 60000) {
+            return remaining / 1000 + " second(s)";
+        } else if (remaining < 3600000) {
+            return remaining / 60000 + " minute(s)";
+        } else if (remaining < 86400000) {
+            return remaining / 3600000 + " hour(s)";
+        } else {
+            return remaining / 86400000 + " day(s)";
+        }
+    }
+
+    public void setLtiService(LTIService ltiService) {
+        this.ltiService = ltiService;
+    }
+
+    public void setSiteService(SiteService siteService) {
+        this.siteService = siteService;
+    }
+
+    public void setEmailService(EmailService emailService) {
+        this.emailService = emailService;
+    }
+}

--- a/basiclti/basiclti-pack/src/webapp/WEB-INF/components.xml
+++ b/basiclti/basiclti-pack/src/webapp/WEB-INF/components.xml
@@ -75,4 +75,52 @@
             <property name="jobName"><value>Synchronise LTI Site Memberships</value></property>
             <property name="schedulerManager"><ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" /></property>
         </bean>
+
+        <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.LTIReportingJob"
+              class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobBeanWrapper"
+              init-method="init">
+            <property name="beanId">
+                <value>org.sakaiproject.lti.impl.LTIReportingJob</value>
+            </property>
+            <property name="jobName">
+                <value>LTI Addition Reporting</value>
+            </property>
+            <property name="resourceBundleBase" value="org.sakaiproject.lti.impl.LTIReportingJob"/>
+            <property name="configurableJobProperties">
+                <set>
+                    <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                        <property name="required" value="true"/>
+                        <property name="labelResourceKey" value="to"/>
+                        <property name="descriptionResourceKey" value="to.description"/>
+                        <property name="defaultValue" value="user@example.com"/>
+                    </bean>
+                    <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                        <property name="required" value="true"/>
+                        <property name="labelResourceKey" value="from"/>
+                        <property name="descriptionResourceKey" value="from.description"/>
+                        <property name="defaultValue" value="sender@example.com"/>
+                    </bean>
+                    <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                        <property name="required" value="true"/>
+                        <property name="labelResourceKey" value="period"/>
+                        <property name="descriptionResourceKey" value="period.description"/>
+                        <property name="defaultValue" value="86400000"/>
+                    </bean>
+                    <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                        <property name="required" value="true"/>
+                        <property name="labelResourceKey" value="toolId"/>
+                        <property name="descriptionResourceKey" value="toolId.description"/>
+                        <property name="defaultValue" value=""/>
+                    </bean>
+                </set>
+            </property>
+            <property name="schedulerManager">
+                <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
+            </property>
+        </bean>
+        <bean id="org.sakaiproject.lti.impl.LTIReportingJob" class="org.sakaiproject.lti.impl.LTIReportingJob">
+            <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+            <property name="ltiService" ref="org.sakaiproject.lti.api.LTIService"/>
+            <property name="emailService" ref="org.sakaiproject.email.api.EmailService"/>
+        </bean>
 </beans>


### PR DESCRIPTION
This allows simple reporting on instances of an LTI tool being added to sites.
If you have a centrally provisioned tool this allows a support person to get a regular email when a new instance of the tool is added.