### PR TITLE
SAM-2717 - Handle copy of null grading attachments

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/dao/grading/AssessmentGradingData.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/dao/grading/AssessmentGradingData.java
@@ -452,7 +452,14 @@ public class AssessmentGradingData implements java.io.Serializable
 
 	public void setAssessmentGradingAttachmentList(
 			List<AssessmentGradingAttachment> assessmentGradingAttachmentList) {
-		Set<AssessmentGradingAttachment> assessmentGradingAttachmentSet = new HashSet<AssessmentGradingAttachment>(assessmentGradingAttachmentList);
+		Set<AssessmentGradingAttachment> assessmentGradingAttachmentSet = null;
+
+		if (assessmentGradingAttachmentList != null) {
+			assessmentGradingAttachmentSet = new HashSet<AssessmentGradingAttachment>(assessmentGradingAttachmentList);
+		} else {
+			assessmentGradingAttachmentSet = new HashSet<AssessmentGradingAttachment>();
+		}
+
 		this.assessmentGradingAttachmentSet = assessmentGradingAttachmentSet;
 	}
 


### PR DESCRIPTION
There is a setter for the grading attachment list on
AssessmentGradingData, which wraps an underlying HashSet. When copying,
for example, from AgentResults, where there are no attachments, the
HashSet constructor on the null value throws an
InvocationTargetException, which obscured the problem. This change
creates a new, empty set if null is passed to this setter.