### PR TITLE
SAM-2724 - Fetch grading attachments eagerly

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -1532,7 +1532,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   }
 
   public List getLastSubmittedAssessmentGradingList(final Long publishedAssessmentId){
-	    final String query = "from AssessmentGradingData a where a.publishedAssessmentId=? and a.forGrade=? order by a.agentId asc, a.submittedDate desc";
+	    final String query = "select a from AssessmentGradingData a left join fetch a.assessmentGradingAttachmentSet where a.publishedAssessmentId=? and a.forGrade=? order by a.agentId asc, a.submittedDate desc";
 
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {


### PR DESCRIPTION
This is a small change to fetch any grading attachments for just the one
call used in the submission status view. This view does a
BeanUtils.copyProperties from the AssessmentGradingData, so the
uninitialized proxy fails because it is iterated outside the session.
Rather than trying to open the session in the view, this applies a
single fetch.

A more aggressive approach would be to mark the collection
as eager, however, this may cause other places that do not use the
attachments to do lots of additional loading. Here, we know that the
collection is traversed, so fetching is the best answer.

If there is need for optimization, a new DAO signature that explicitly
fetches grading attachments would be appropriate. If there are many
places that need the fetch, the added signature should be to not fetch.