### PR TITLE
1699: update set score error message 

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -206,7 +206,7 @@ assignment.menulabel = Open menu for {0} column
 
 
 message.edititem.success=Gradebook item ''{0}'' has been updated.
-message.edititem.error=An error occurred updating the Gradebook item. Please ensure your score is a positive number or decimal, a maximum of 10 integers in length with a maximum of 2 decimal places.
+message.edititem.error=An error occurred updating the Gradebook item.
 message.editcomment.error=An error occurred editing the comment.
 message.addcoursegradeoverride.success = The course grade was updated.
 message.addcoursegradeoverride.error = An error occurred updating the course grade.
@@ -222,12 +222,12 @@ grade.outof = /{0}
 grade.menulabel = Open menu for student {0} and assignment {1} cell
 
 grade.notifications.hascomment = Gradebook item has comments
-grade.notifications.haserror = An error occurred updating the Gradebook item.
+grade.notifications.haserror = An error occurred saving this item score.
 grade.notifications.overlimit = Score is over item's maximum point value and is providing extra credit.
 grade.notifications.concurrentedit = A concurrent edit has been detected. Please refresh the tool to view the latest scores.
 grade.notifications.concurrenteditbyuser = <span class="gb-concurrent-edit-user">{0}</span> edited this score at <span class="gb-concurrent-edit-time">{1}</span>. Please refresh the tool to view the latest scores.
 grade.notifications.isexternal = Gradebook item has been imported from an external tool and can only be edited from within that tool.
-grade.notifications.invalid = Gradebook item score must be a positive number or decimal.
+grade.notifications.invalid = Item score must be a positive number/decimal with a maximum of 10 integers and 2 decimal places.
 grade.notifications.readonly = Insufficient privileges to edit this Gradebook item score
 
 comment.option.add = Add Comment

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -217,7 +217,10 @@ public class GradeItemCellPanel extends Panel {
 								break;
 							case ERROR:
 								markError(getComponent());
-								error(getString("message.edititem.error"));
+								// show the error message
+								error(getString("grade.notifications.haserror"));
+								// and the invalid score message, just to be helpful
+								GradeItemCellPanel.this.notifications.add(GradeCellNotification.INVALID);
 								break;
 							case OVER_LIMIT:
 								markOverLimit(GradeItemCellPanel.this.gradeCell);


### PR DESCRIPTION
and invalid score message.  Also show both these messages when a service error is encountered e.g.

<img width="331" alt="screen shot 2016-03-17 at 4 13 26 pm" src="https://cloud.githubusercontent.com/assets/608337/13837055/8024c48a-ec5b-11e5-954d-612c376e391c.png">

Delivers #1699.