### PR TITLE
SAK-30518 support for SCORM module entity linking via CKEditor

### DIFF
--- a/textarea/FCKeditor/connector/src/bundle/org/sakaiproject/connector/fck/Messages.properties
+++ b/textarea/FCKeditor/connector/src/bundle/org/sakaiproject/connector/fck/Messages.properties
@@ -8,3 +8,4 @@ entitybrowser.forum=Forums
 entitybrowser.forum_topic=Forum Messages
 
 entitybrowser.ezproxy=EZ Proxy
+entitybrowser.scorm=SCORM Modules


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30518

This is simply a UI string for the SCORM heading when you click 'Browse Server' via the link tool in CKEditor.

The actual entity linking is implemented in https://jira.sakaiproject.org/browse/SCO-129
