### PR TITLE
SAM-2725 - Improve "accept until" date handling

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/AuthorActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/AuthorActionListener.java
@@ -424,7 +424,9 @@ public class AuthorActionListener
 			  returnValue = false;
 		  }
 
-		  if (acceptLateSubmission && retractDate != null && retractDate.before(currentDate)) {
+		  if (acceptLateSubmission
+				  && (dueDate != null && dueDate.before(currentDate))
+				  && (retractDate == null || retractDate.before(currentDate))) {
 			  returnValue = false;
 		  }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -123,7 +123,18 @@ public class SaveAssessmentSettings
     	control.setStartDate(assessmentSettings.getStartDate());
     }
     control.setDueDate(assessmentSettings.getDueDate());
-    control.setRetractDate(assessmentSettings.getRetractDate());
+
+    if (assessmentSettings.getLateHandling() != null) {
+        control.setLateHandling(new Integer(assessmentSettings.getLateHandling()));
+    }
+
+    if (assessmentSettings.getRetractDate() == null
+            || "".equals(assessmentSettings.getRetractDateString())) {
+        control.setRetractDate(null);
+        control.setLateHandling(AssessmentAccessControl.NOT_ACCEPT_LATE_SUBMISSION);
+    } else {
+        control.setRetractDate(assessmentSettings.getRetractDate());
+    }
     control.setFeedbackDate(assessmentSettings.getFeedbackDate());
     control.setReleaseTo(assessmentSettings.getReleaseTo());
     //log.info("control RELEASETO ="+control.getReleaseTo());
@@ -179,10 +190,6 @@ public class SaveAssessmentSettings
     //log.info("**unlimited submission="+assessmentSettings.getUnlimitedSubmissions());
     //log.info("**allowed="+control.getSubmissionsAllowed());
 
-    if (assessmentSettings.getLateHandling()!=null){
-      control.setLateHandling(new Integer(assessmentSettings.
-                                                getLateHandling()));
-    }
     if (assessmentSettings.getSubmissionsSaved()!=null){
       control.setSubmissionsSaved(new Integer(assessmentSettings.getSubmissionsSaved()));
     }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -442,9 +442,20 @@ implements ActionListener
 		// set startDate, dueDate, retractDate 
 		control.setStartDate(assessmentSettings.getStartDate());
 		control.setDueDate(assessmentSettings.getDueDate());
+
+		if (assessmentSettings.getLateHandling() != null) {
+			control.setLateHandling(new Integer(assessmentSettings.getLateHandling()));
+		}
+
 		if (retractNow)
 		{
 			control.setRetractDate(new Date());
+		}
+		else if (assessmentSettings.getRetractDate() == null
+				 || "".equals(assessmentSettings.getRetractDateString()))
+		{
+			control.setLateHandling(AssessmentAccessControl.NOT_ACCEPT_LATE_SUBMISSION);
+			control.setRetractDate(null);
 		}
 		else {
 			control.setRetractDate(assessmentSettings.getRetractDate());
@@ -501,10 +512,7 @@ implements ActionListener
 			}
 		}
 
-		if (assessmentSettings.getLateHandling()!=null){
-			control.setLateHandling(new Integer(assessmentSettings.
-					getLateHandling()));
-		}
+
 		if (assessmentSettings.getSubmissionsSaved()!=null){
 			control.setSubmissionsSaved(new Integer(assessmentSettings.getSubmissionsSaved()));
 		}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
@@ -619,7 +619,9 @@ public class SelectActionListener
     	return false;
     }
     
-    if (retractDate != null && retractDate.before(currentDate) && acceptLateSubmission) {
+    if (acceptLateSubmission
+            && (dueDate != null && dueDate.before(currentDate))
+            && (retractDate == null || retractDate.before(currentDate))) {
     	return false;
     }
     


### PR DESCRIPTION
This approach addresses multiple consistency issues with "accept until"
dates for assessments. The changes are:

 * When saving an assessment with "Yes, accept until" selected, but with
   no date entered, set it to "No, not after due date"
 * Treat assessments with "Yes, accept until" with no date the same as
   asssessments with "No, not after due date" for "active" calculations
 * Reflect this slightly different active/inactive status in the
   authoring list (authorIndex)
 * Reflect the adjusted status on the assessment list for students
   (selectIndex)

This also addresses some of SAM-2738 (not considering feedback).