### PR TITLE
KNL-1422: revert KNL-1402, can't download PDF or use plugins

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
@@ -364,8 +364,8 @@ public class RequestFilter implements Filter
 			//    as well so folks can log in on this node.
 			// 2) any GET URL's from contentPaths (POST's any other methods not
 			//    allowed.
-			String requestURI = req.getRequestURI();
 			if (useContentHostingDomain) {
+				String requestURI = req.getRequestURI();
 				if(req.getQueryString() != null) requestURI += "?" + req.getQueryString();
 				if (startsWithAny(requestURI, contentPaths) && "GET".equalsIgnoreCase(req.getMethod())) {
 					if  (!req.getServerName().equals(chsDomain) && !(startsWithAny(requestURI, contentExceptions))) {
@@ -381,10 +381,6 @@ public class RequestFilter implements Filter
 						return;
 					}
 				}
-			} else if (startsWithAny(requestURI, contentPaths) && "GET".equalsIgnoreCase(req.getMethod()) && !(startsWithAny(requestURI, contentExceptions))) {
-			    // everything except same origin
-			    resp.addHeader("Content-Security-Policy", "sandbox allow-forms allow-scripts allow-top-navigation allow-popups allow-pointer-lock");
-			    resp.addHeader("X-Content-Security-Policy", "sandbox allow-forms allow-scripts allow-top-navigation allow-popups allow-pointer-lock");
 			}
 
 			// check on file uploads and character encoding BEFORE checking if


### PR DESCRIPTION
This was intended as a way to get most of the benefits of a separate content hostname via Content-Security-Policy. It’s a nice idea, but it doesn’t work. The problem is that it causes PDF files not to be displayed. And it also causes plugins not to work in HTML files, if HTML is set to be displayed.

The problem it was trying to fix is really only present in Lessons by default, since /access/content downloads HTML by default rather than displaying it.

We need a more complex fix, that can’t be done in RequestFilter, because it depends upon content type, which isn’t known in RequestFilter until it’s too late.

This patch reverts the RequestFilter patch. Once it’s been accepted, I’ll consider a fix in Lessons for /access/lessonbuilder, which is where the actual issue is. 