### PR TITLE
SAK-30570: Remove white(ish) colour from text that was making it invisible

### DIFF
--- a/signup/tool/src/webapp/css/signupStyle.css
+++ b/signup/tool/src/webapp/css/signupStyle.css
@@ -274,7 +274,6 @@ table.organizer td {
 	vertical-align: top;
 	margin-left: 30px;
 	background: #e7eef5;
-	color: #e7eef5;
 	width: 350px;
 }
 


### PR DESCRIPTION
With the colour removed the text is black.

This 'si' style is used in 2 other places - when you copy a meeting and when you modify a meeting.  In both cases, the text was invisible because of this style so removing it helped these cases as well. 