### PR TITLE
SAK-30571: font colour for dropdown menus in forms is too light

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ sakai-demo.zip
 .sass-cache
 .metadata
 .DS_Store
+*nb-configuration.xml

--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -94,7 +94,7 @@
 	background-position: right 50%;
 	background-repeat: no-repeat;
 	border: 1px solid $button-border-color;
-	color: #777;
+	color: $text-color;
 	font-family: $font-family;
 	font-size: #{$default-font-size - 1};
 	padding: 0.3em 2.2em 0.3em 0.5em;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30571

The default style for the dropdown menus (select) in forms is using a light gray colour (#777777), which is not appropriate and makes the options seem disabled. This PR changes the colour to $text-color. 