### PR TITLE
SAK-30569 membership -> my current sites: search box and buttons should be right aligned on the page

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/_menu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/_menu.scss
@@ -95,6 +95,18 @@
 		}
 	}
 }
+
 .viewNav{
 
+}
+
+.navPanel {
+	.floatLeft {
+		float: left;
+		padding: 1em;
+	}
+
+	.floatRight {
+		float: right;
+	}
 }

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership.vm
@@ -18,13 +18,13 @@
 
 	#if ($unjoinableSites.size() > 0 || $search.length() > 0)
 	<div class="navPanel">
-		<div class="viewNav">
+		<div class="floatLeft">
 			<h3 style="margin:0;padding:0">
 				$tlang.getString("mb.cursit") 
-			</h3>                                                                                           
+			</h3>
 		</div>
 
-		<div class="searchNav">
+		<div class="floatRight">
 			<form name="searchform" method="post" class="inlineForm" action="#toolForm("$action")">
 			<label for="search" class="skip">$tlang.getString("mb.list.search")</label>
 			<input type="text" size="15" id="search" name="search" value="$validator.escapeHtml($search)" /> 
@@ -40,13 +40,13 @@
 		
 		<div class="navPanel">
 			#if ($alertMessage)
-				<p class="information messageInformation viewNav" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
+				<p class="information messageInformation" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
 					$validator.escapeHtml($alertMessage)
 				</p>
 			#end
 	
 
-		<div class="listNav">
+			<div class="listNav">
 				<div class="instruction">
 					$tlang.getString("mb.list.viewing") $topMsgPos - $btmMsgPos $tlang.getString("mb.list.of") $allMsgNumber $tlang.getString("mb.list.sites")
 					<div id="pagerSpinner" class="allocatedSpinPlaceholder"></div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership_joinable.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership_joinable.vm
@@ -15,12 +15,12 @@
 	</ul>
 			
 	<div class="navPanel">
-		<div class="viewNav">
+		<div class="floatLeft">
 			<h3 style="margin:0;padding:0">
 				$tlang.getString("mb.joinable")
 			</h3>
 		</div>
-		<div class="searchNav">
+		<div class="floatRight">
 	#if ($openSites.size() > 0 || $search.length() > 0)
 			<form name="searchform" method="post" class="inlineForm" action="#toolForm("$action")">
 			<label for="search" class="skip">$tlang.getString("mb.list.search")</label>
@@ -36,20 +36,17 @@
 
 	#if ($openSites.size() > 0)
 		<div class="navPanel">
-			<div class="viewNav">
-				<div class="instruction">
-					<br />
-				#if ($search.length() > 0)
-					$tlang.getString("mb.listsearchjoin")${search}$tlang.getString("mb.listsearchjoin2")
-				#else
-					$tlang.getString("mb.listjoin")
-				#end
-				</div>
+			<div class="instruction">
+			#if ($search.length() > 0)
+				$tlang.getString("mb.listsearchjoin")${search}$tlang.getString("mb.listsearchjoin2")
+			#else
+				$tlang.getString("mb.listjoin")
+			#end
 			</div>
 			
 			## join/unjoin action info normally is the only value of "alertMessage"
 			#if ($alertMessage)
-				<p class="information messageInformation viewNav" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
+				<p class="information messageInformation" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
 					$validator.escapeHtml($alertMessage)
 				</p>
 			#end
@@ -167,7 +164,7 @@
 		<br>
 		## join/unjoin action info normally is the only value of "alertMessage"
 		#if ($alertMessage)
-			<p class="information messageInformation viewNav" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
+			<p class="information messageInformation" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
 				$validator.escapeHtml($alertMessage)
 			</p>
 		#end
@@ -177,7 +174,7 @@
 		<br>
 		## join/unjoin action info normally is the only value of "alertMessage"
 		#if ($alertMessage)
-			<p class="information messageInformation viewNav" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
+			<p class="information messageInformation" id="messageHolder" style="width:50%;padding:0 0 0 2em;margin:0">
 				$validator.escapeHtml($alertMessage)
 			</p>
 		#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30569

Classes 'viewNav' and 'searchNav' were at some point removed from tool_base.css, which defined how these elements are displayed. 