### PR TITLE
LSNBLDR-579 Add date release settings to edit item dialog

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2728,6 +2728,10 @@ public class SimplePageBean {
 				SimplePage page = getPage(Long.valueOf(i.getSakaiId()));
 				if (page != null) {
 					page.setTitle(name);
+					if (hasReleaseDate)
+						page.setReleaseDate(releaseDate);
+					else
+						page.setReleaseDate(null);
 					update(page);
 				}
 			} else {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1483,6 +1483,12 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 							UIOutput.make(tableRow, "page-button", Boolean.toString("button".equals(i.getFormat())));
 							itemGroupString = simplePageBean.getItemGroupString(i, null, true);
 							UIOutput.make(tableRow, "item-groups", itemGroupString);
+							SimplePage sPage = simplePageBean.getPage(Long.parseLong(i.getSakaiId()));
+							Date rDate = sPage.getReleaseDate();
+							String rDateString = "";
+							if(rDate != null)
+								rDateString = rDate.toString();
+							UIOutput.make(tableRow, "subpagereleasedate", rDateString);
 						} else if (i.getType() == SimplePageItem.RESOURCE) {
 						        try {
 							    itemGroupString = simplePageBean.getItemGroupStringOrErr(i, null, true);
@@ -3667,6 +3673,19 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		UIInput.make(form, "assignment-points", "#{simplePageBean.points}");
 
 		UICommand.make(form, "edit-item", messageLocator.getMessage("simplepage.edit"), "#{simplePageBean.editItem}");
+
+		UIBoundBoolean.make(form, "page-releasedate2", "#{simplePageBean.hasReleaseDate}", Boolean.FALSE);
+
+		String releaseDateString = "";
+		try {
+			releaseDateString = isoDateFormat.format(new Date());
+		} catch (Exception e) {
+			System.out.println(e + "bad format releasedate " + new Date());
+		}
+
+		UIOutput releaseForm2 = UIOutput.make(form, "releaseDate2:");
+		UIOutput.make(form, "sbReleaseDate", releaseDateString);
+		UIInput.make(form, "release_date2", "#{simplePageBean.releaseDate}" );
 
 		// can't use site groups on user content, and don't want students to hack
 		// on groups for site content

--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -339,6 +339,7 @@ simplepage.youtube.needflash=You need Flash player 8+ and Javascript enabled to 
 simplepage.hide_page_label=Hide This Page:
 simplepage.hide_page_from_users=Hide this page from users (page will not appear in left margin)
 simplepage.page.releasedate=Hide page until the following date (the page will be listed with the release date)
+simplepage.page.releasedate2=Hide page until the following date (the page will be listed with the release date)
 simplepage.error=Error
 simplepage.error_colon=Error:
 simplepage.complete_required=Please complete all of the above required items before viewing this item.

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -1337,6 +1337,29 @@ $(document).ready(function() {
 			
 			if(type === 'page') {
 	                    $("#pagestuff").show();
+
+				var sbpgreleasedate = row.find(".subpagereleasedate").text();
+				if(sbpgreleasedate === '') {
+					$("#page-releasedate2").prop('checked', false);
+					localDatePicker({
+						input: '#release_date2',
+						useTime: 1,
+						parseFormat: 'YYYY-MM-DD HH:mm:ss',
+						val: sbpgreleasedate,
+						ashidden: { iso8601: 'releaseDate2ISO8601' }
+					});
+				}
+				else {
+					$("#page-releasedate2").prop('checked', true);
+					localDatePicker({
+						input: '#release_date2',
+						useTime: 1,
+						parseFormat: 'YYYY-MM-DD HH:mm:ss',
+						val: sbpgreleasedate,
+						ashidden: { iso8601: 'releaseDate2ISO8601' }
+					});
+				}
+
 			    var pagenext = row.find(".page-next").text();
 			    if(pagenext === "true") {
 				$("#item-next").prop("checked", true);
@@ -2474,6 +2497,10 @@ function checkEditItemForm() {
 		$('#edit-item-error-container').show();
 		return false;
 	}else {
+		if ($("#page-releasedate2").prop('checked'))
+			$("#release_date2").val($("#releaseDate2ISO8601").val());
+		else
+			$("#release_date2").val('');
 		$('#edit-item-error-container').hide();
 		return true;
 	}

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -397,6 +397,7 @@
                         <span rsf:id="item-name" class="link-text"></span>
                         <span rsf:id="item-format" class="item-format"></span>
                         <span rsf:id="item-path" class="item-path"></span>
+                        <span rsf:id="subpagereleasedate" class="subpagereleasedate"></span>
                       </div>
                     </div>
                     <div rsf:id="grouptext-td" aria-hidden="true" class="group-col"><div><a href="#" class="usebutton" rsf:id="grouptext-link"><span rsf:id="grouptext-icon"></span></a></div></div>
@@ -946,6 +947,15 @@
                         <label for="item-next" id="label-item-next"><span rsf:id="msg=simplepage.subpage-next"></span></label><br />
                         <input type="checkbox" name="item-button" id="item-button" rsf:id="item-button" />
                         <label for="item-button" id="label-item-button"><span rsf:id="msg=simplepage.subpage-button"></span></label><br />
+
+                        <input type="checkbox" id="page-releasedate2" rsf:id="page-releasedate2" />
+                        <label for="releaseDate2:1:date-field"><span rsf:id="msg=simplepage.page.releasedate2"></span></label><br />
+                        <div id="releaseDiv2" style="margin-left:3em">
+                            <span rsf:id="releaseDate2:" id="releaseDate2">
+                                <span style="display:none" rsf:id="sbReleaseDate" id="sbReleaseDate"></span>
+                                <input rsf:id="release_date2" type="text" id="release_date2"/>
+                            </span>
+                        </div>
                         </div>
 
                         <div id="newwindowstuff">


### PR DESCRIPTION
This adds the ability to control date release settings for a subpage in the
edit item dialog instead of in the subpage itself.