### PR TITLE
SAK-30576 update and cancel buttons are too close to the text of the item above

### DIFF
--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -182,6 +182,10 @@ a.noPointers, input.noPointers {
 	pointer-events: none;
 }
 
+.act {
+	padding: 1em 0;
+}
+
 /*** Begin button spinner overlay ***/
 @-moz-keyframes rotate {
 	from {-moz-transform: rotate(0deg);}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30576

https://docs.google.com/document/d/18XDuDF4xNsEF0F-5D7s7eWc9qEXSxPbJj0vpI9mlb3M/edit?pref=2&pli=1

Preferences-1: update and cancel buttons are too close to the text of the item above

This is caused by the removal of the 'act' class from tool_base.css, which provided "padding: 1em 0". This class is used heavily across the code base (mostly on p and div tags), especially in velocity tools.