### PR TITLE
LSNBLDR-584 Add date release info to show page

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -3211,15 +3211,19 @@ public class SimplePageBean {
 	    return ret;
 	}
 
-         public String getReleaseString(SimplePageItem i) {
+         public String getReleaseString(SimplePageItem i, Locale locale) {
 	     if (i.getType() == SimplePageItem.PAGE) {
 		 SimplePage page = getPage(Long.valueOf(i.getSakaiId()));
 		 if (page == null)
 		     return null;
 		 if (page.isHidden())
 		     return messageLocator.getMessage("simplepage.hiddenpage");
-		 if (page.getReleaseDate() != null && page.getReleaseDate().after(new Date()))
-		     return messageLocator.getMessage("simplepage.pagenotreleased");
+		 if (page.getReleaseDate() != null && page.getReleaseDate().after(new Date())) {
+			 Date releaseDate = page.getReleaseDate();
+			 DateFormat fullDate = DateFormat.getDateInstance(DateFormat.MEDIUM, (locale == null) ? Locale.getDefault(Locale.Category.FORMAT) : locale);
+			 DateFormat shortTime = DateFormat.getTimeInstance(DateFormat.SHORT, (locale == null) ? Locale.getDefault(Locale.Category.FORMAT) : locale);
+			 return messageLocator.getMessage("simplepage.pagenotreleased.until").replace("{0}", fullDate.format(releaseDate)).replace("{1}", shortTime.format(releaseDate));
+		 }
 	     }
 	     return null;
 	 }

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1559,7 +1559,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 						    }
 						}
 
-						String releaseString = simplePageBean.getReleaseString(i);
+						String releaseString = simplePageBean.getReleaseString(i, M_locale);
 						if (itemGroupString != null || releaseString != null || entityDeleted || notPublished) {
 							if (itemGroupString != null)
 							    itemGroupString = simplePageBean.getItemGroupTitles(itemGroupString, i);

--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -46,6 +46,7 @@ simplepage.not_yet_available_releasedate=This page will not be available until {
 simplepage.not_available_hidden=This page is hidden.
 simplepage.hiddenpage=[Hidden]
 simplepage.pagenotreleased=[Not released]
+simplepage.pagenotreleased.until=[Not released until {0} at {1}]
 
 simplepage.create_assignment=Create new assignment using Assignments
 simplepage.create_assignment2=Create new assignment using Assignment 2


### PR DESCRIPTION
This adds the date release information to be included in the not released
message in Lessons next to a subpage item.