### PR TITLE
SAK-30585 fix HTML structure of navBar for all JSF tools

### DIFF
--- a/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ToolBarItemRenderer.java
+++ b/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ToolBarItemRenderer.java
@@ -31,101 +31,130 @@ import javax.faces.context.ResponseWriter;
 import org.sakaiproject.jsf.util.JSFDepends;
 import org.sakaiproject.jsf.util.RendererUtil;
 
-
 public class ToolBarItemRenderer extends JSFDepends.CommandLinkRenderer
 {
-  public boolean supportsComponentType(UIComponent component)
-  {
-    return (component instanceof org.sakaiproject.jsf.component.ToolBarItemComponent);
-  }
-
-  public void encodeBegin(FacesContext context, UIComponent component) throws IOException
-  {
-      if (!component.isRendered()) return;
-
-    if (!isDisabled(context, component))
+    public boolean supportsComponentType(UIComponent component)
     {
-        // use default link rendering, after closing open span tag
-	  ResponseWriter writer = context.getResponseWriter();
-	  	writer.write(""); // normaly just close the span
-      super.encodeBegin(context, component);
-    }
-    else
-    {
-        // setup to render the disabled link ourselves - close open span tag after adding inactive attributes
-      ResponseWriter writer = context.getResponseWriter();
-      writer.write(""); //normally, add aria and class attributes and close the span
+        return (component instanceof org.sakaiproject.jsf.component.ToolBarItemComponent);
     }
 
-  }
-
-  public void encodeChildren(FacesContext context, UIComponent component) throws IOException
-  {
-      if (!component.isRendered()) return;
-
-      if (!isDisabled(context, component))
-      {
-          // use default rendering
-          super.encodeChildren(context, component);
-      }
-      else
-      {
-          // render the text of the disabled link ourselves
-      String label = "";
-      Object value = ((UICommand) component).getValue();
-      if (value != null)
-      {
-      label = value.toString();
-      }
-
-      ResponseWriter writer = context.getResponseWriter();
-      writer.write(label);
-      }
-  }
-
-  public void encodeEnd(FacesContext context, UIComponent component) throws IOException
-  {
-      if (!component.isRendered()) return;
-
-    if (!isDisabled(context, component))
+    public void encodeBegin(FacesContext context, UIComponent component) throws IOException
     {
-        // use default link rendering
-      super.encodeEnd(context, component);
-    }
-    else
-    {
-        // rendering of end of disabled link taken care of already
-    }
-  }
-
-  /**
-   * Check if the component is disabled.
-   * @param component
-   * @return true if the component has a boolean "disabled" attribute set, false if not
-   */
-  protected boolean isDisabled(FacesContext context, UIComponent component)
-  {
-    boolean disabled = false;
-    Object value = RendererUtil.getAttribute(context, component, "disabled");
-    if (value != null)
-    {
-      if (value instanceof Boolean)
-      {
-        disabled = ((Boolean) value).booleanValue();
-      }
-      else
-      {
-        if (!(value instanceof String))
+        if (!component.isRendered())
         {
-          value = value.toString();
+            return;
         }
-        disabled = (new Boolean((String) value)).booleanValue();
-      }
+
+        if (!isDisabled(context, component) && !isCurrent( context, component ))
+        {
+            // use default link rendering, after closing open span tag
+            ResponseWriter writer = context.getResponseWriter();
+            writer.write(""); // normaly just close the span
+            super.encodeBegin(context, component);
+        }
+        else
+        {
+            // setup to render the disabled/current link ourselves - close open span tag after adding inactive attributes
+            ResponseWriter writer = context.getResponseWriter();
+            writer.write(""); //normally, add aria and class attributes and close the span
+        }
     }
 
-    return disabled;
-  }
+    public void encodeChildren(FacesContext context, UIComponent component) throws IOException
+    {
+        if (!component.isRendered())
+        {
+            return;
+        }
+
+        if (!isDisabled(context, component) && !isCurrent( context, component ))
+        {
+            // use default rendering
+            super.encodeChildren(context, component);
+        }
+        else
+        {
+            // render the text of the disabled/current link ourselves
+            String label = "";
+            Object value = ((UICommand) component).getValue();
+            if (value != null)
+            {
+                label = value.toString();
+            }
+
+            ResponseWriter writer = context.getResponseWriter();
+            writer.write(label);
+        }
+    }
+
+    public void encodeEnd(FacesContext context, UIComponent component) throws IOException
+    {
+        if (!component.isRendered())
+        {
+            return;
+        }
+
+        if (!isDisabled(context, component) && !isCurrent( context, component ))
+        {
+            // use default link rendering
+            super.encodeEnd(context, component);
+        }
+        else
+        {
+            // rendering of end of disabled/current link taken care of already
+        }
+    }
+
+    /**
+     * Check if the component is the currently active tool bar item
+     * @param context
+     * @param component
+     * @return true if the component is the active tool bar item, false if not
+     */
+    protected boolean isCurrent( FacesContext context, UIComponent component )
+    {
+        return getBooleanAttribute( context, component, "current" );
+    }
+
+    /**
+     * Check if the component is disabled.
+     * @param context
+     * @param component
+     * @return true if the component has a boolean "disabled" attribute set, false if not
+     */
+    protected boolean isDisabled(FacesContext context, UIComponent component)
+    {
+        return getBooleanAttribute( context, component, "disabled" );
+    }
+
+    /**
+     * Utility method to retrieve an arbitrary Boolean attribute from the component's attribute map
+     * @param context
+     * @param component
+     * @param attributeName
+     * @return The value of the boolean attribute requested
+     */
+    private boolean getBooleanAttribute( FacesContext context, UIComponent component, String attributeName )
+    {
+        boolean retVal = false;
+        Object value = RendererUtil.getAttribute( context, component, attributeName );
+        if( value != null )
+        {
+            if( value instanceof Boolean )
+            {
+                retVal = (Boolean) value;
+            }
+            else
+            {
+                if( !(value instanceof String) )
+                {
+                    value = value.toString();
+                }
+
+                retVal = Boolean.valueOf( (String) value );
+            }
+        }
+
+        return retVal;
+    }
 }
-
-
-

--- a/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ToolBarRenderer.java
+++ b/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ToolBarRenderer.java
@@ -20,11 +20,9 @@
 *
 **********************************************************************************/
 
-
 package org.sakaiproject.jsf.renderer;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.faces.component.UIComponent;
@@ -41,122 +39,116 @@ import org.sakaiproject.jsf.util.RendererUtil;
  */
 public class ToolBarRenderer extends Renderer
 {
-  /**
-   * This component renders its children
-   * @return true
-   */
-  public boolean getRendersChildren()
-  {
-	  return true;
-  }
-  
-  public boolean supportsComponentType(UIComponent component)
-  {
-    return (component instanceof org.sakaiproject.jsf.component.ToolBarComponent);
-  }
-
-  public void encodeBegin(FacesContext context, UIComponent component) throws IOException
-  {
-	if(!component.isRendered()){
-		//tool_bar tag is not to be rendered, return now
-		return;
-	}
-    ResponseWriter writer = context.getResponseWriter();
-    writer.write("<ul class=\"navIntraTool actionToolbar jsfToolbar\">");
-
-    return;
-  }
-  
-  /**
-   * We put all our processing in the encodeChildren method
-   * @param context
-   * @param component
-   * @throws IOException
-   */
-  public void encodeChildren(FacesContext context, UIComponent component)
-    throws IOException
-  {
-    if (!component.isRendered())
+    /**
+     * This component renders its children
+     * @return true
+     */
+    public boolean getRendersChildren()
     {
-      return;
+        return true;
     }
 
-    String clientId = null;
-
-    if (component.getId() != null &&
-      !component.getId().startsWith(UIViewRoot.UNIQUE_ID_PREFIX))
+    public boolean supportsComponentType(UIComponent component)
     {
-      clientId = component.getClientId(context);
+        return (component instanceof org.sakaiproject.jsf.component.ToolBarComponent);
     }
 
-    ResponseWriter writer = context.getResponseWriter();
-
-    if (clientId != null)
+    public void encodeBegin(FacesContext context, UIComponent component) throws IOException
     {
-      writer.startElement("ul", component);
-      //writer.append(" class=\"jsfToolbar\" "); // we don't seem to get here
+        if(!component.isRendered()){
+            //tool_bar tag is not to be rendered, return now
+            return;
+        }
+        ResponseWriter writer = context.getResponseWriter();
+        writer.write("<ul class=\"navIntraTool actionToolbar\">");
     }
 
-    @SuppressWarnings("unchecked")
-    List<UIComponent> children = component.getChildren();
-
-    // this is a special separator attribute, not supported by UIData
-    String separator = (String) RendererUtil.getAttribute(context, component, "separator");
-    if (separator==null) separator="";
-
-    boolean first = true;
-    boolean foundCurrent = false;
-    for (Iterator<UIComponent> iter = children.iterator(); iter.hasNext();)
+    /**
+     * We put all our processing in the encodeChildren method
+     * @param context
+     * @param component
+     * @throws IOException
+     */
+    public void encodeChildren(FacesContext context, UIComponent component) throws IOException
     {
-      UIComponent child = (UIComponent)iter.next();
-      // should instead leave the span open, and the item should then add class and aria attributes
-      // depending on the item is (disabled or not) and then close
-      if (child.isRendered()) {
-         if (!first)   
-         {
-        	 writer.write("<li>");
-         }
-         else
-         {
-        	 writer.write("<li class=\"firstToolBarItem\">");
-         }
-         // SAK-23062 improve JSF options menu
-         boolean current = false;
-         if (!foundCurrent) {
-             // check for the "current" attribute on the custom tag, mark that item as current if it set to true
-             boolean hasCurrentIndicated = (child.getAttributes().get("current") != null); // NOTE: child.getAttributes().containsKey("current") will NOT work here
-             current = (hasCurrentIndicated && ((Boolean)child.getAttributes().get("current")).booleanValue());
-             /* this breaks too many other things
-             if (!hasCurrentIndicated && !"javax.faces.Link".equals(child.getRendererType())) {
-                 // basically - if it is not a link, it is probably the current item
-                 current = true;
-             }
-             */
-         }
-         if (current) {
-             foundCurrent = true;
-             writer.write("<span class=\"current\">");
-         } else {
-             writer.write("<span>");
-         }
-         RendererUtil.encodeRecursive(context, child);
-    	 writer.write("</span></li> ");
-         first = false;
-      }
-    } 
-      if (clientId != null)
+        if (!component.isRendered())
         {
-        writer.endElement("ul");
-      }
+            return;
+        }
 
-  }
+        String clientId = null;
 
-  public void encodeEnd(FacesContext context, UIComponent component) throws IOException
-  {
-    ResponseWriter writer = context.getResponseWriter();
-    writer.write("</ul>");
-  }
+        if (component.getId() != null && !component.getId().startsWith(UIViewRoot.UNIQUE_ID_PREFIX))
+        {
+            clientId = component.getClientId(context);
+        }
+
+        ResponseWriter writer = context.getResponseWriter();
+
+        if (clientId != null)
+        {
+            writer.startElement("ul", component);
+            //writer.append(" class=\"jsfToolbar\" "); // we don't seem to get here
+        }
+
+        @SuppressWarnings("unchecked")
+        List<UIComponent> children = component.getChildren();
+
+        // this is a special separator attribute, not supported by UIData
+        String separator = (String) RendererUtil.getAttribute(context, component, "separator");
+        if (separator == null)
+        {
+            separator = "";
+        }
+
+        boolean first = true;
+        boolean foundCurrent = false;
+        for( UIComponent child : children )
+        {
+            // should instead leave the span open, and the item should then add class and aria attributes
+            // depending on the item is (disabled or not) and then close
+            if (child.isRendered()) {
+                if (!first)
+                {
+                    writer.write("<li>");
+                }
+                else
+                {
+                    writer.write("<li class=\"firstToolBarItem\">");
+                }
+                // SAK-23062 improve JSF options menu
+                boolean current = false;
+                if (!foundCurrent) {
+                    // check for the "current" attribute on the custom tag, mark that item as current if it set to true
+                    boolean hasCurrentIndicated = (child.getAttributes().get("current") != null); // NOTE: child.getAttributes().containsKey("current") will NOT work here
+                    current = (hasCurrentIndicated && ((Boolean)child.getAttributes().get("current")));
+                    /* this breaks too many other things
+                     * if (!hasCurrentIndicated && !"javax.faces.Link".equals(child.getRendererType())) {
+                     * // basically - if it is not a link, it is probably the current item
+                     * current = true;
+                     * }
+                     */
+                }
+                if (current) {
+                    foundCurrent = true;
+                    writer.write("<span class=\"current\">");
+                } else {
+                    writer.write("<span>");
+                }
+                RendererUtil.encodeRecursive(context, child);
+                writer.write("</span></li> ");
+                first = false;
+            }
+        }
+        if (clientId != null)
+        {
+             writer.endElement("ul");
+        }
+    }
+
+    public void encodeEnd(FacesContext context, UIComponent component) throws IOException
+    {
+        ResponseWriter writer = context.getResponseWriter();
+        writer.write("</ul>");
+    }
 }
-
-
-


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30585

https://docs.google.com/document/d/18XDuDF4xNsEF0F-5D7s7eWc9qEXSxPbJj0vpI9mlb3M/edit?pref=2&pli=1

Preferences-2: Styling of tabs is different...and odd.

This actually affects all JSF tools that utilize the custom tags sakai:tool_bar and sakai:tool_bar_item.

The problem is that it's doing the default rendering for the 'current' toolbar item, which wraps the text in an anchor and gives it the extra 'box'. The current item should not be rendered as a link, just text within the `<span class="current">`.