### PR TITLE
SAK-30597 preferences multi-row selects (time zone and languages) still shows the drop down arrow

### DIFF
--- a/user/user-tool-prefs/tool/src/webapp/css/prefs.css
+++ b/user/user-tool-prefs/tool/src/webapp/css/prefs.css
@@ -51,7 +51,7 @@
 }
 .colTitle h4{
      padding:5px 0;
-     color:#000
+     color:#000;
      background:#fff
  }
 .colTitle {
@@ -320,4 +320,8 @@
     margin-top: 1em;
     width: 100%;
     clear: both;
+}
+
+select.multiLine {
+    background: none;
 }

--- a/user/user-tool-prefs/tool/src/webapp/prefs/locale.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/locale.jsp
@@ -71,7 +71,8 @@
 				
     			 <h:selectOneListbox 
                       value="#{UserPrefsTool.selectedLocaleString}"
-                      size="20">
+                      size="20"
+                      styleClass="multiLine">
 				    <f:selectItems value="#{UserPrefsTool.prefLocales}" />
 				 </h:selectOneListbox>
 			    <div class="act">

--- a/user/user-tool-prefs/tool/src/webapp/prefs/timezone.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/timezone.jsp
@@ -77,7 +77,8 @@
 					
     			 <h:selectOneListbox 
                       value="#{UserPrefsTool.selectedTimeZone}"
-                      size="20">
+                      size="20"
+                      styleClass="multiLine">
 				    <f:selectItems value="#{UserPrefsTool.prefTimeZones}" />
 				 </h:selectOneListbox>
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30597

https://docs.google.com/document/d/18XDuDF4xNsEF0F-5D7s7eWc9qEXSxPbJj0vpI9mlb3M/edit?pref=2&pli=1

Preferences-3: Time zone menu is out of position and has an odd arrow on it. The issue with the arrow displaying affects all browsers, but is more evident in IE. The positioning has been fixed since the creation of this document, and is no longer an issue.

Preferences-4: Languages menu is out of position and has an odd arrow on it. The issue with the arrow displaying affects all browsers, but is more evident in IE. The positioning has been fixed since the creation of this document, and is no longer an issue.

The solution to this is to set "background: none" for the select tags, which tells the browsers to not display the drop down arrow.