### PR TITLE
SAM-2783 Fix Assessment Template Settings Page

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/template/templateEditor.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/template/templateEditor.jsp
@@ -302,6 +302,7 @@
     </h:selectOneRadio>
     </h:panelGroup>
     </h:panelGrid>
+          </div>
 
 <!-- Display Scores -->
       <div class="longtext"><h:outputLabel value="#{templateMessages.displayScores}"/></div>


### PR DESCRIPTION
Previously the page was not being built correctly resulting in a
poorly formatted layout and missing save / cancel buttons. This change
fixes that issue.