### PR TITLE
SAK-30606 Styled the tool menu toggle button to work for mouse and finger

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -49,8 +49,7 @@ body.#{$namespace}toolMenu-collapsed{
 				}
 				&.#{$namespace}collapseTools{
 					i{
-					   @include rotate(180deg);
-						@include transform( rotate(180deg) );
+						@include transform( scaleX(-1) ); /* flip horizontally */
 					}
 				}
 			}
@@ -162,10 +161,33 @@ nav#subSites{
 		padding: 0;
 		margin:  0;
 		li{
-			&.#{$namespace}collapseTools{
-				text-align: center;
+			&.#{$namespace}collapseTools
+			{
+				display:flex;
+				align-items:center;
+				justify-content:flex-end; /* right-align the arrows when expanded */
+				height:3em;
+				padding: 0 1em;
+				border-right: 1px solid $toolMenuBGColor;
+				border-bottom: 1px solid darken( $toolMenuBGColor, 10% );
+				cursor:pointer;
 				font-size: 1.2em;
-				padding: 0.3em;
+				background-color: $toolTabBGColor;
+				&:hover
+				{
+					background: $primary-color;
+					color: $tool-background-color;
+				}
+				&.min
+				{
+					justify-content:center; /* center the arrows when collapsed */
+				}
+				
+				i
+				{
+					@include transition( transform, 0.25s, ease-out, 0s ); /* animate the arrow direction change */
+				}
+				
 				@media #{$phone}{
 					display: none;
 				}


### PR DESCRIPTION
The toggle button in the tool menu lacked distinction from the tools in the menu.

I've made the following changes:

- added subtle differences to the look of the button to make it visually distinct from the tools in the tool menu
- moved the arrow icon out of the vertical alignment of the tool icons in the menu
- added a slight animation to show the change to the icon's orientation between the two states
- gave the button a hover state for mouse users
- made the button slightly larger for touch users
- fixed alignment issues of the icon caused by rotating the arrow

See my "before" and "after" screenshots below for visual representation of the changes.

**Tool menu maximized**

Before:
![01-before](https://cloud.githubusercontent.com/assets/12685096/14126183/4ed260fa-f5dd-11e5-896a-80a2b29123a1.png)

After:
![02-after](https://cloud.githubusercontent.com/assets/12685096/14126187/4f003b4c-f5dd-11e5-8a37-5a92db104648.png)

**Tool menu minimized**

Before:
![03-before-minimized](https://cloud.githubusercontent.com/assets/12685096/14126184/4ed4e92e-f5dd-11e5-8563-7879f7c8e34d.png)

After:
![04-after-minimized](https://cloud.githubusercontent.com/assets/12685096/14126185/4ed52600-f5dd-11e5-8e5b-040bbfda75e6.png)


