### PR TITLE
SAK-30619 Add "Entire Site" to Assignment View

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_assignment.vm
@@ -121,6 +121,9 @@
 							#set($count=$count+1)
 						#end
 					#end
+					#if($count==1)
+						#set($for=$tlang.getString("gen.viewallgroupssections"))
+					#end
 					$validator.escapeHtml($!for)
 				</td>
 			</tr>


### PR DESCRIPTION
When viewing a published assignment, this change shows that an
assignment is released to the Entire Site (when it is). Previously,
there would be a label "For" with an empty value when an assignment
is released to the Entire Site.