### PR TITLE
SAM-2784 selecting 'random draw from question pool' needs a spinner

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/editPart.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editPart.jsp
@@ -36,6 +36,7 @@
       <title><h:outputText value="#{authorMessages.create_modify_p}" /></title>
       <!-- AUTHORING -->
       <samigo:script path="/js/authoring.js"/>
+      <script src="/library/js/spinner.js" type="text/javascript"></script>
       </head>
       <body onload="<%= request.getAttribute("html.body.onload") %>">
 
@@ -69,9 +70,13 @@
         
         <%-- Type --%>
         <fieldset>
-            <legend><h:outputText value="#{authorMessages.type}" /></legend>
-            <h:selectOneRadio value="#{sectionBean.type}" layout="pageDirection" onclick="this.form.onsubmit();document.forms[0].submit();"
-                       onkeypress="this.form.onsubmit();document.forms[0].submit();" valueChangeListener="#{sectionBean.toggleAuthorType}"
+            <legend>
+                <h:outputText value="#{authorMessages.type}" />
+                <div id="typeSpinner" class="allocatedSpinPlaceholder"></div>
+            </legend>
+            <h:selectOneRadio id="typeTable" value="#{sectionBean.type}" layout="pageDirection" valueChangeListener="#{sectionBean.toggleAuthorType}"
+                       onclick="SPNR.insertSpinnerInPreallocated( null, null, 'typeSpinner' );this.form.onsubmit();document.forms[0].submit();"
+                       onkeypress="this.form.onsubmit();document.forms[0].submit();" 
                        disabled="#{!author.isEditPendingAssessmentFlow}" disabledClass="inactive">
                 <f:selectItems value="#{sectionBean.authorTypeList}" />
             </h:selectOneRadio>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2784

In Tests & Quizzes, when you add a part and select 'Random draw from question pool', it can take a while until the page reloads with a populated dropdown. It's very noticeable for users who have a lot of question pools. Add a spinner.