### PR TITLE
SAK-29304 Fix for missing labels in Syllabus

### DIFF
--- a/syllabus/syllabus-app/src/webapp/js/syllabus.js
+++ b/syllabus/syllabus-app/src/webapp/js/syllabus.js
@@ -229,6 +229,7 @@ function setupEditable(msgs, iframId){
 	$(".bodyInput").editable({
 		name: "body",
 		type: 'textarea',
+		title: msgs.syllabus_content,
 		emptytext: msgs.clickToAddBody,
 		onblur: "ignore",
 		display: function(value, sourceData) {

--- a/syllabus/syllabus-app/src/webapp/syllabus/main.jsp
+++ b/syllabus/syllabus-app/src/webapp/syllabus/main.jsp
@@ -52,6 +52,7 @@
 				syllabus_content: $("#messages #syllabus_content").html(),
 				clickToAddTitle: $("#messages #clickToAddTitle").html(),
 				startdatetitle: $("#messages #startdatetitle").html(),
+				enddatetitle: $("#messages #enddatetitle").html(),
 				clickToAddStartDate: $("#messages #clickToAddStartDate").html(),
 				clickToAddEndDate: $("#messages #clickToAddEndDate").html(),
 				clickToAddBody: $("#messages #clickToAddBody").html(),
@@ -348,6 +349,7 @@
                 <span id="syllabus_content"></f:verbatim><h:outputText value="#{msgs.syllabus_content}"/><f:verbatim></span>
 				<span id="clickToAddTitle"></f:verbatim><h:outputText value="#{msgs.clickToAddTitle}"/><f:verbatim></span>
 				<span id="startdatetitle"></f:verbatim><h:outputText value="#{msgs.startdatetitle}"/><f:verbatim></span>
+				<span id="enddatetitle"></f:verbatim><h:outputText value="#{msgs.enddatetitle}"/><f:verbatim></span>
 				<span id="clickToAddStartDate"></f:verbatim><h:outputText value="#{msgs.clickToAddStartDate}"/><f:verbatim></span>
 				<span id="clickToAddEndDate"></f:verbatim><h:outputText value="#{msgs.clickToAddEndDate}"/><f:verbatim></span>
 				<span id="clickToAddBody"></f:verbatim><h:outputText value="#{msgs.clickToAddBody}"/><f:verbatim></span>


### PR DESCRIPTION
The problem was a mix of the title(s) not being defined in the .js file AND in the main.jsp file.