### PR TITLE
SAK-30583 Fix buttons for End Date box.

### DIFF
--- a/syllabus/syllabus-app/src/webapp/syllabus/css/jqueryui-editable.css
+++ b/syllabus/syllabus-app/src/webapp/syllabus/css/jqueryui-editable.css
@@ -14,7 +14,6 @@
 }
 
 .editable-buttons {
-   display: inline-block; /* should be inline to take effect of parent's white-space: nowrap */
    vertical-align: top;
    margin-left: 7px;
    /* inline-block emulation for IE7*/


### PR DESCRIPTION
Got rid of the inline-block css rule for the buttons for End Date.

Also, someone **needs** to redo the form for entering dates. Having 6 unlabeled dropdown menus for putting in dates is extremely unintuitive.

If no one objects, I'd like to replace it with a date-picker type control.

@ottenhoff @ncaidin Thoughts on the date picker? Just for reference sake, I'll create a JIRA to track it before I start.