### PR TITLE
#1369 hide the revert link until there is a value to actually revert

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
@@ -157,6 +157,11 @@ public class CourseGradeOverridePanel extends Panel {
 					target.addChildren(form, FeedbackPanel.class);
 				}
 			}
+
+			@Override
+			public boolean isVisible() {
+				return StringUtils.isNotBlank(formModel.getObject());
+			}
 		};
 		revertLink.setDefaultFormProcessing(false);
 		form.add(revertLink);


### PR DESCRIPTION
Fixes the bug found in #1369 to hide the revert link until it's needed.