### PR TITLE
1376: add section awareness to Set Score for Empty Cells

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -126,10 +126,11 @@ label.updateungradeditems.instructions.2 = <b>Note:</b> The value below will onl
 
 label.updateungradeditems.grade = Grade Override
 
-label.updateungradeditems.extracreditconfirmation.title=Extra Credit?
-label.updateungradeditems.extracreditconfirmation.content=The supplied score is in excess of the maximum point value for this Gradebook item. Do you want to continue?
-label.updateungradeditems.extracreditconfirmation.continue=Continue
-label.updateungradeditems.extracreditconfirmation.cancel=Cancel
+label.updateungradeditems.confirmation.title=Set Score Confirmation
+label.updateungradeditems.confirmation.general=This action will apply the score <strong>{0}</strong> to students in <strong>{1}</strong>.
+label.updateungradeditems.confirmation.extracredit=The supplied score is in excess of the maximum point value for this Gradebook item. Do you want to continue?
+label.updateungradeditems.confirmation.continue=Continue
+label.updateungradeditems.confirmation.cancel=Cancel
 label.updateungradeditems.groups=Group / Section
 
 label.studentsummary.coursegrade = Course Grade:

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -130,6 +130,7 @@ label.updateungradeditems.extracreditconfirmation.title=Extra Credit?
 label.updateungradeditems.extracreditconfirmation.content=The supplied score is in excess of the maximum point value for this Gradebook item. Do you want to continue?
 label.updateungradeditems.extracreditconfirmation.continue=Continue
 label.updateungradeditems.extracreditconfirmation.cancel=Cancel
+label.updateungradeditems.groups=Group / Section
 
 label.studentsummary.coursegrade = Course Grade:
 label.studentsummary.gradeitems = Gradebook Items

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1301,11 +1301,25 @@ public class GradebookNgBusinessService {
 	 * @return
 	 */
 	public boolean updateUngradedItems(final long assignmentId, final double grade) {
+		return updateUngradedItems(assignmentId, grade, null);
+	}
+
+
+	/**
+	 * Updates ungraded items in the given assignment for students
+	 * within a particular group and with the given grade
+	 *
+	 * @param assignmentId
+	 * @param grade
+	 * @param group
+	 * @return
+	 */
+	public boolean updateUngradedItems(final long assignmentId, final double grade, final GbGroup group) {
 		final String siteId = getCurrentSiteId();
 		final Gradebook gradebook = getGradebook(siteId);
 
 		// get students
-		final List<String> studentUuids = this.getGradeableUsers();
+		final List<String> studentUuids = (group == null) ? this.getGradeableUsers() : this.getGradeableUsers(group);
 
 		// get grades (only returns those where there is a grade)
 		final List<GradeDefinition> defs = this.gradebookService.getGradesForStudentsForItem(gradebook.getUid(), assignmentId,

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
@@ -13,7 +13,18 @@
 					<p><wicket:message key="label.updateungradeditems.instructions.1" /></p>
 					<p><wicket:message key="label.updateungradeditems.instructions.2" /></p>
 				</div>
-				 
+
+				<div class="form-group form-group-sm">
+					<label wicket:for="group" class="col-xs-4 control-label">
+						<wicket:message key="label.updateungradeditems.groups" />
+					</label>
+					<div class="col-xs-5">
+						<select wicket:id="group">
+							<option value="1">Section 1</option>
+						</select>
+					</div>
+				</div>
+
 				<div class="form-group form-group-sm">
 					<label wicket:for="grade" class="col-xs-4 control-label">
 						<wicket:message key="label.updateungradeditems.grade" />

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
@@ -19,7 +19,7 @@
 						<wicket:message key="label.updateungradeditems.groups" />
 					</label>
 					<div class="col-xs-5">
-						<select wicket:id="group">
+						<select wicket:id="group" class="gb-update-ungraded-group">
 							<option value="1">Section 1</option>
 						</select>
 					</div>
@@ -29,8 +29,11 @@
 					<label wicket:for="grade" class="col-xs-4 control-label">
 						<wicket:message key="label.updateungradeditems.grade" />
 					</label>
-					<div class="col-xs-2">
-						<input wicket:id="grade" type="text" class="form-control gb-update-ungraded-value" placeholder="100" />
+					<div class="col-xs-4">
+						<div class="input-group">
+							<input wicket:id="grade" type="text" class="form-control gb-update-ungraded-value" placeholder="100" />
+							<span class="input-group-addon"><small>/<wicket:container wicket:id="points"/></small></span>
+						</div>
 					</div>
 				</div>
 
@@ -45,20 +48,23 @@
 			<input wicket:id="gradePoints" type="hidden" id="gradePoints"/>
 		</form>
 
-		<script id="extraCreditModalTemplate" type="text/template">
-			<div class="modal gb-update-ungraded-extracredit-confirmation">
+		<script id="updateUngradedConfirmationModalTemplate" type="text/template">
+			<div class="modal gb-update-ungraded-confirmation">
 				<div class="modal-dialog">
 					<div class="modal-content">
 						<div class="modal-header">
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h3 class="modal-title"><wicket:message key="label.updateungradeditems.extracreditconfirmation.title" /></h3>
+							<h3 class="modal-title"><wicket:message key="label.updateungradeditems.confirmation.title" /></h3>
 						</div>
 						<div class="modal-body">
-							<p><wicket:message key="label.updateungradeditems.extracreditconfirmation.content" /></p>
+							<p><wicket:container wicket:id="confirmationMessage"/></p>
+							{if isExtraCredit}
+								<p><wicket:message key="label.updateungradeditems.confirmation.extracredit" /></p>
+							{/if}
 						</div>
 						<div class="modal-footer">
-							<button type="button" class="btn btn-primary gb-update-ungraded-extracredit-continue" data-dismiss="modal"><wicket:message key="label.updateungradeditems.extracreditconfirmation.continue" /></button>
-							<button type="button" class="btn btn-default gb-update-ungraded-extracredit-cancel" data-dismiss="modal"><wicket:message key="label.updateungradeditems.extracreditconfirmation.cancel" /></button>
+							<button type="button" class="btn btn-primary gb-update-ungraded-continue" data-dismiss="modal"><wicket:message key="label.updateungradeditems.confirmation.continue" /></button>
+							<button type="button" class="btn btn-default gb-update-ungraded-cancel" data-dismiss="modal"><wicket:message key="label.updateungradeditems.confirmation.cancel" /></button>
 						</div>
 					</div>
 				</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -8,6 +8,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
@@ -16,8 +17,8 @@ import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGroup;
@@ -61,6 +62,8 @@ public class UpdateUngradedItemsPanel extends Panel {
 
 		// unpack model
 		final Long assignmentId = this.model.getObject();
+
+		final Assignment assignment = this.businessService.getAssignment(assignmentId);
 
 		// form model
 		final GradeOverride override = new GradeOverride();
@@ -123,6 +126,12 @@ public class UpdateUngradedItemsPanel extends Panel {
 
 		form.add(new TextField<Double>("grade").setRequired(true));
 
+		form.add(new Label("points", assignment.getPoints()));
+
+		final WebMarkupContainer hiddenGradePoints = new WebMarkupContainer("gradePoints");
+		hiddenGradePoints.add(new AttributeModifier("value", assignment.getPoints()));
+		form.add(hiddenGradePoints);
+
 		final List<GbGroup> groups = this.businessService.getSiteSectionsAndGroups();
 		final GradebookUiSettings settings = ((GradebookPage) getPage()).getUiSettings();
 
@@ -156,10 +165,11 @@ public class UpdateUngradedItemsPanel extends Panel {
 		// feedback panel
 		form.add(new GbFeedbackPanel("updateGradeFeedback"));
 
-		final Assignment assignment = this.businessService.getAssignment(assignmentId);
-		final WebMarkupContainer hiddenGradePoints = new WebMarkupContainer("gradePoints");
-		hiddenGradePoints.add(new AttributeModifier("value", assignment.getPoints()));
-		form.add(hiddenGradePoints);
+		// confirmation dialog
+		add(new Label("confirmationMessage",
+			new StringResourceModel(
+				"label.updateungradeditems.confirmation.general", null,
+				new Object[]{"${score}", "${group}"})).setEscapeModelStrings(false));
 	}
 
 	/**

--- a/gradebookng/tool/src/webapp/scripts/gradebook-update-ungraded.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-update-ungraded.js
@@ -8,10 +8,10 @@
 function GradebookUpdateUngraded($content) {
   this.$content = $content;
 
-  this.setupExtraCreditCheck();
+  this.setupConfirmation();
 };
 
-GradebookUpdateUngraded.prototype.setupExtraCreditCheck = function(){
+GradebookUpdateUngraded.prototype.setupConfirmation = function(){
   var self = this;
 
   function isExtraCreditValue() {
@@ -21,16 +21,27 @@ GradebookUpdateUngraded.prototype.setupExtraCreditCheck = function(){
     return updateValue > gradePoints;
   };
 
+  function buildConfirmationModal() {
+    var templateHtml = $("#updateUngradedConfirmationModalTemplate").html().trim();
+    var modalTemplate = TrimPath.parseTemplate(templateHtml);
+    return $(modalTemplate.process({
+      score: self.$content.find(".gb-update-ungraded-value").val(),
+      group: self.$content.find(".gb-update-ungraded-group :selected").text().trim(),
+      isExtraCredit: isExtraCreditValue()
+    }));
+  };
+
   function showConfirmation() {
-      var $confirmationModal = $($("#extraCreditModalTemplate").html());
-      $confirmationModal.on("click", ".gb-update-ungraded-extracredit-continue", function() {
+      var $confirmationModal = buildConfirmationModal();
+
+      $confirmationModal.on("click", ".gb-update-ungraded-continue", function() {
         performRealSubmit();
       });
       $(document.body).append($confirmationModal);
 
       $confirmationModal.on("hidden.bs.modal", function() {
         $confirmationModal.remove();
-        self.$content.find(".gb-update-ungraded-value").focus();
+        self.$content.find(".gb-update-ungraded-group").focus();
       });
       $confirmationModal.on("show.bs.modal", function() {
         var $formModal = self.$content.closest(".wicket-modal");
@@ -38,7 +49,7 @@ GradebookUpdateUngraded.prototype.setupExtraCreditCheck = function(){
       });
 
       $confirmationModal.on("shown.bs.modal", function() {
-        $confirmationModal.find(".gb-update-ungraded-extracredit-cancel").focus();
+        $confirmationModal.find(".gb-update-ungraded-cancel").focus();
       });
 
       $confirmationModal.modal().modal('show');
@@ -54,11 +65,7 @@ GradebookUpdateUngraded.prototype.setupExtraCreditCheck = function(){
     event.preventDefault();
     event.stopPropagation();
 
-    if (isExtraCreditValue()) {
-      showConfirmation();
-    } else {
-      performRealSubmit();
-    }
+    showConfirmation();
 
     return false;
   };

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -1068,7 +1068,7 @@ ul.feedbackPanel li span {
   float: right;
 }
 /* Update Ungraded modal */
-.gb-update-ungraded-extracredit-confirmation.in {
+.gb-update-ungraded-confirmation.in {
   position: absolute;
   right:0;
   bottom: auto;
@@ -1076,10 +1076,10 @@ ul.feedbackPanel li span {
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }
-.gb-update-ungraded-extracredit-confirmation {
+.gb-update-ungraded-confirmation {
   z-index: 50000 !important;
 }
-.gb-update-ungraded-extracredit-confirmation .modal-dialog {
+.gb-update-ungraded-confirmation .modal-dialog {
   z-index: 50001 !important;
 }
 


### PR DESCRIPTION
Delivers #1376.

This PR adds the section/group dropdown list to the set score modal form and updates the businesService API to take the group and only apply the action to students within that group.

I've also added a confirmation popup which alerts the user to the score and group, and also includes the previous extra credit message (if score is greater than the assignment points).