### PR TITLE
SAK-30660 Fixup Button Bar in New/Edit Assignment

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -35,7 +35,7 @@
 #end
 
 ## Defining macro to repeat buttons at the top and bottom of the page
-#macro( buttonBar $submitnotif )
+#macro( buttonBar )
     <div class="act">
         <input accesskey="s" type="button" class="active" name="post" value="$tlang.getString("gen.pos")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'newAssignmentForm', 'post', null, null ); return false;" />
         <input accesskey="v" type="button" name="preview" value="$tlang.getString("gen.pre")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'newAssignmentForm', 'preview', null, null ); return false;" />

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -121,7 +121,6 @@
 		</div>
 	#end
 
-	#set($submitnotif="submitnotifTop")
 
 	<form name="newAssignmentForm" id="newAssignmentForm" action="#toolForm("AssignmentAction")" method="post" onsubmit="return true;">
 		<input type="hidden" name="assignmentId" value="$!assignment.Reference" />
@@ -130,6 +129,9 @@
 		<input type="hidden" name="option" id="option" value="" />
 		<input type="hidden" name="view" id="view" value="" />
 		<input type="hidden" name="$name_order" id="$name_order" value="$!value_position_order" />
+		<div class="row col-sm-12">
+			#buttonBar()
+		</div>
 
 		<div class="form-group row form-required">
 			<label for="$name_title" class="col-sm-2 form-control-label">
@@ -1753,9 +1755,8 @@
 				<input class="extraNodeInput" type="button" id ="allPurpose_cancel" value="$tlang.getString("allPurpose_cancel")" />
 			</p>
 		</fieldset>
-		#set($submitnotif="submitnotifBottom")
 		<div class="row col-sm-12">
-			#buttonBar($submitnotif)
+			#buttonBar()
 		</div>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>


### PR DESCRIPTION
Add the "Post, Preview, Save Draft, & Cancel" buttons to the top of
the new/edit assignment page.

Also removed the parameter within the macro which adds the button bar
as it was no longer used.