### PR TITLE
Feature/1367 settings mutual exclusive

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -279,7 +279,8 @@ settingspage.displaycoursegrade.preview-percentage-first = 88%
 settingspage.displaycoursegrade.preview-percentage-second = (88%)
 settingspage.displaycoursegrade.preview-points-first = 176/200
 settingspage.displaycoursegrade.preview-points-second = [176/200]
-settingspage.displaycoursegrade.instructions = Choose the options for formatting the course grade. You must choose at least one option.
+settingspage.displaycoursegrade.instructions.1 = Choose the options for formatting the course grade. You must choose at least one option.
+settingspage.displaycoursegrade.instructions.2 = Note that you cannot choose 'Points' if the gradebook is setup with 'Categories & weighting'.
 settingspage.displaycoursegrade.notenough = Display course grade is selected but you didn't select any formatting options.
 settingspage.displaycoursegrade.incompatible = Points can not be displayed as a course grade when weighted categories are enabled. Please select different course grade display options.
 
@@ -305,6 +306,7 @@ settingspage.categories.total = Total:
 settingspage.categories.instructions.1 = Categories will only be visible if there are Gradebook items assigned to them.
 settingspage.categories.instructions.2 = To use drop highest, drop lowest, or keep highest, all items in the category must have the same score value.
 settingspage.categories.instructions.3 = Extra credit categories do not participate in the overall weightings.
+settingspage.categories.instructions.4 = Note that you cannot choose 'Categories & weighting' if the final course grade is setup with 'Points'.
 
 settingspage.categories.runningtotalerror=Weighting for the categories must equal 100%
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -2,7 +2,6 @@ package org.sakaiproject.gradebookng.tool.pages;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.ArrayList;
 
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -39,12 +38,17 @@ public class SettingsPage extends BasePage {
 	private boolean categoryExpanded = false;
 	private boolean gradingSchemaExpanded = false;
 
+	SettingsGradeEntryPanel gradeEntryPanel;
+	SettingsGradeReleasePanel gradeReleasePanel;
+	SettingsCategoryPanel categoryPanel;
+	SettingsGradingSchemaPanel gradingSchemaPanel;
+
 	public SettingsPage() {
 		disableLink(this.settingsPageLink);
 	}
 
 	public SettingsPage(final boolean gradeEntryExpanded, final boolean gradeReleaseExpanded,
-											final boolean categoryExpanded, final boolean gradingSchemaExpanded) {
+			final boolean categoryExpanded, final boolean gradingSchemaExpanded) {
 		disableLink(this.settingsPageLink);
 		this.gradeEntryExpanded = gradeEntryExpanded;
 		this.gradeReleaseExpanded = gradeReleaseExpanded;
@@ -63,10 +67,10 @@ public class SettingsPage extends BasePage {
 		final GbSettings gbSettings = new GbSettings(settings);
 		final CompoundPropertyModel<GbSettings> formModel = new CompoundPropertyModel<GbSettings>(gbSettings);
 
-		final SettingsGradeEntryPanel gradeEntryPanel = new SettingsGradeEntryPanel("gradeEntryPanel", formModel, gradeEntryExpanded);
-		final SettingsGradeReleasePanel gradeReleasePanel = new SettingsGradeReleasePanel("gradeReleasePanel", formModel, gradeReleaseExpanded);
-		final SettingsCategoryPanel categoryPanel = new SettingsCategoryPanel("categoryPanel", formModel, categoryExpanded);
-		final SettingsGradingSchemaPanel gradingSchemaPanel = new SettingsGradingSchemaPanel("gradingSchemaPanel", formModel, gradingSchemaExpanded);
+		this.gradeEntryPanel = new SettingsGradeEntryPanel("gradeEntryPanel", formModel, this.gradeEntryExpanded);
+		this.gradeReleasePanel = new SettingsGradeReleasePanel("gradeReleasePanel", formModel, this.gradeReleaseExpanded);
+		this.categoryPanel = new SettingsCategoryPanel("categoryPanel", formModel, this.categoryExpanded);
+		this.gradingSchemaPanel = new SettingsGradingSchemaPanel("gradingSchemaPanel", formModel, this.gradingSchemaExpanded);
 
 		// form
 		final Form<GbSettings> form = new Form<GbSettings>("form", formModel) {
@@ -137,18 +141,20 @@ public class SettingsPage extends BasePage {
 
 				final GbSettings model = getModelObject();
 
-				Page responsePage = new SettingsPage(gradeEntryPanel.isExpanded(), gradeReleasePanel.isExpanded(), categoryPanel.isExpanded(), gradingSchemaPanel.isExpanded());
+				Page responsePage = new SettingsPage(SettingsPage.this.gradeEntryPanel.isExpanded(),
+						SettingsPage.this.gradeReleasePanel.isExpanded(), SettingsPage.this.categoryPanel.isExpanded(),
+						SettingsPage.this.gradingSchemaPanel.isExpanded());
 
 				// update settings
 				try {
 					SettingsPage.this.businessService.updateGradebookSettings(model.getGradebookInformation());
 					getSession().info(getString("settingspage.update.success"));
-				} catch (ConflictingCategoryNameException e) {
+				} catch (final ConflictingCategoryNameException e) {
 					getSession().error(getString("settingspage.update.failure.categorynameconflict"));
-					responsePage = this.getPage();
-				} catch (IllegalArgumentException e) {
+					responsePage = getPage();
+				} catch (final IllegalArgumentException e) {
 					getSession().error(e.getMessage());
-					responsePage = this.getPage();
+					responsePage = getPage();
 				}
 
 				setResponsePage(responsePage);
@@ -168,10 +174,10 @@ public class SettingsPage extends BasePage {
 		form.add(cancel);
 
 		// panels
-		form.add(gradeEntryPanel);
-		form.add(gradeReleasePanel);
-		form.add(categoryPanel);
-		form.add(gradingSchemaPanel);
+		form.add(this.gradeEntryPanel);
+		form.add(this.gradeReleasePanel);
+		form.add(this.categoryPanel);
+		form.add(this.gradingSchemaPanel);
 
 		add(form);
 
@@ -205,4 +211,16 @@ public class SettingsPage extends BasePage {
 				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/scripts/gradebook-settings.js?version=%s", version)));
 
 	}
+
+	/**
+	 * Getters for these panels as we need to interact with them from the child panels
+	 */
+	public SettingsGradeReleasePanel getSettingsGradeReleasePanel() {
+		return this.gradeReleasePanel;
+	}
+
+	public SettingsCategoryPanel getSettingsCategoryPanel() {
+		return this.categoryPanel;
+	}
+
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.html
@@ -32,6 +32,7 @@
 						<div><wicket:message key="settingspage.categories.instructions.1" /></div>
 						<div><wicket:message key="settingspage.categories.instructions.2" /></div>
 						<div><wicket:message key="settingspage.categories.instructions.3" /></div>
+						<div><wicket:message key="settingspage.categories.instructions.4" /></div>
 					</div>
 
 					<table class="table table-striped table-bordered table-hover">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.html
@@ -31,7 +31,11 @@
 
 				<div class="form-group" wicket:id="courseGradeType">
 				
-					<p class="instruction"><wicket:message key="settingspage.displaycoursegrade.instructions" /></p>
+					<div class="instruction">
+						<div><wicket:message key="settingspage.displaycoursegrade.instructions.1" /></div>
+						<div><wicket:message key="settingspage.displaycoursegrade.instructions.2" /></div>
+					</div>
+					
 					<p class="messageError" wicket:id="minimumOptions">minimum options message</p>
 					
 					<div class="col-sm-offset-1 col-sm-20">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.java
@@ -11,14 +11,17 @@ import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Radio;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.tool.model.GbSettings;
+import org.sakaiproject.gradebookng.tool.pages.SettingsPage;
 import org.sakaiproject.service.gradebook.shared.GradebookInformation;
 
 public class SettingsGradeReleasePanel extends Panel {
@@ -35,6 +38,8 @@ public class SettingsGradeReleasePanel extends Panel {
 
 	private boolean expanded;
 
+	AjaxCheckBox points;
+
 	public SettingsGradeReleasePanel(final String id, final IModel<GbSettings> model, final boolean expanded) {
 		super(id, model);
 		this.model = model;
@@ -45,23 +50,25 @@ public class SettingsGradeReleasePanel extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
+		final SettingsPage settingsPage = (SettingsPage) getPage();
+
 		final WebMarkupContainer settingsGradeReleasePanel = new WebMarkupContainer("settingsGradeReleasePanel");
 		// Preserve the expand/collapse state of the panel
 		settingsGradeReleasePanel.add(new AjaxEventBehavior("shown.bs.collapse") {
 			@Override
 			protected void onEvent(final AjaxRequestTarget ajaxRequestTarget) {
 				settingsGradeReleasePanel.add(new AttributeModifier("class", "panel-collapse collapse in"));
-				expanded = true;
+				SettingsGradeReleasePanel.this.expanded = true;
 			}
 		});
 		settingsGradeReleasePanel.add(new AjaxEventBehavior("hidden.bs.collapse") {
 			@Override
 			protected void onEvent(final AjaxRequestTarget ajaxRequestTarget) {
 				settingsGradeReleasePanel.add(new AttributeModifier("class", "panel-collapse collapse"));
-				expanded = false;
+				SettingsGradeReleasePanel.this.expanded = false;
 			}
 		});
-		if (expanded) {
+		if (this.expanded) {
 			settingsGradeReleasePanel.add(new AttributeModifier("class", "panel-collapse collapse in"));
 		}
 		add(settingsGradeReleasePanel);
@@ -137,7 +144,7 @@ public class SettingsGradeReleasePanel extends Panel {
 		courseGradeType.add(percentage);
 
 		// points
-		final AjaxCheckBox points = new AjaxCheckBox("points",
+		this.points = new AjaxCheckBox("points",
 				new PropertyModel<Boolean>(this.model, "gradebookInformation.coursePointsDisplayed")) {
 			private static final long serialVersionUID = 1L;
 
@@ -146,10 +153,22 @@ public class SettingsGradeReleasePanel extends Panel {
 				// update preview and validation
 				target.add(SettingsGradeReleasePanel.this.preview);
 				target.add(SettingsGradeReleasePanel.this.minimumOptions);
+
+				// if points selected, disable categories and weighting
+				final GradebookInformation settings = SettingsGradeReleasePanel.this.model.getObject().getGradebookInformation();
+
+				final Radio<Integer> categoriesAndWeightingRadio = settingsPage.getSettingsCategoryPanel().getCategoriesAndWeightingRadio();
+				if (settings.isCoursePointsDisplayed()) {
+					categoriesAndWeightingRadio.setEnabled(false);
+				} else {
+					categoriesAndWeightingRadio.setEnabled(true);
+				}
+				target.add(categoriesAndWeightingRadio);
+
 			}
 		};
-		points.setOutputMarkupId(true);
-		courseGradeType.add(points);
+		this.points.setOutputMarkupId(true);
+		courseGradeType.add(this.points);
 
 		// minimum options label. only shows if we have too few selected
 		this.minimumOptions = new Label("minimumOptions", new ResourceModel("settingspage.displaycoursegrade.notenough")) {
@@ -256,9 +275,21 @@ public class SettingsGradeReleasePanel extends Panel {
 			}
 		});
 
+		// if weighted category, disable points
+		final GbCategoryType type = GbCategoryType.valueOf(this.model.getObject().getGradebookInformation().getCategoryType());
+		if (type == GbCategoryType.WEIGHTED_CATEGORY) {
+			this.points.setEnabled(false);
+		}
+
 	}
 
 	public boolean isExpanded() {
-		return expanded;
+		return this.expanded;
 	}
+
+	// to enable inter panel comms
+	AjaxCheckBox getPointsCheckBox() {
+		return this.points;
+	}
+
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.java
@@ -191,7 +191,6 @@ public class SettingsGradeReleasePanel extends Panel {
 						displayOptions++;
 					}
 					if (displayOptions == 0) {
-						System.out.println("visible");
 						return true;
 					}
 				}


### PR DESCRIPTION
Delivers #1367 

Makes the course poitns and categories and weighting mutually exclusive settings
Added instruction text to both existing boxes. I have not added it as a conditionally appearing item as both of these are in separate panels and we already need to expose a few components out, exposing a Label out as well seemed a bit messy.

There is an existing onSubmit validation that will catch an attempt to save the settings if they are in the conflicting state.