### PR TITLE
KNL-1426 allow Sharestream and Kaltura LTI URLs

### DIFF
--- a/kernel/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
+++ b/kernel/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
@@ -120,7 +120,7 @@
         Add in your site (e.g. "new.site.host.com/path": with escaped ".": "new\.site\.host\.com/path|"
         Like shown here: (new\.site\.host\.com/path|download\.macromedia\.com/pub|
     -->
-    <regexp name="flashSites" value="(((https?:)?//(download\.macromedia\.com/pub|www\.macromedia\.com/(go|shockwave)|c\.brightcove\.com/services|gamevideos\.1up\.com/swf|(www\.)?youtube(\-nocookie)?\.com/(v|embed)|(www\.)?youtu\.be|(www\.|player\.)?vimeo\.com|www\.gametrailers\.com|videomedia\.ign\.com/ev|image\.com\.com/gamespot|www\.hulu\.com/embed|embed\.break\.com|player\.ordienetworks\.com/flash|www\.adultswim\.com/video/vplayer|www\.dailymotion\.com/swf|www\.ustream\.tv/flash/video|cdn-i\.dmdentertainment\.com|media\.mtvnservices\.com|www\.justin\.tv/widgets|www\.viddler\.com/(player|simple_on_site)|static\.twitter\.com/flash|www\.gamepro\.com/bin|cdn\.knightlab\.com|(www|cdnapisec|cdnapi)\.kaltura\.com/p|www\.divshare\.com/flash|www\.facebook\.com/v)/.*)|(/library/(?!.*\.\.[/|\\]).*)/.+)" />
+    <regexp name="flashSites" value="(((https?:)?//(download\.macromedia\.com/pub|www\.macromedia\.com/(go|shockwave)|c\.brightcove\.com/services|gamevideos\.1up\.com/swf|(www\.)?youtube(\-nocookie)?\.com/(v|embed)|(www\.)?youtu\.be|(www\.|player\.)?vimeo\.com|www\.gametrailers\.com|videomedia\.ign\.com/ev|image\.com\.com/gamespot|www\.hulu\.com/embed|embed\.break\.com|player\.ordienetworks\.com/flash|www\.adultswim\.com/video/vplayer|www\.dailymotion\.com/swf|www\.ustream\.tv/flash/video|cdn-i\.dmdentertainment\.com|media\.mtvnservices\.com|www\.justin\.tv/widgets|www\.viddler\.com/(player|simple_on_site)|static\.twitter\.com/flash|www\.gamepro\.com/bin|cdn\.knightlab\.com|(www|cdnapisec|cdnapi)\.sharestream\.com/p|(www|cdnapisec|cdnapi)\.kaltura\.com/p|www\.divshare\.com/flash|www\.facebook\.com/v)/.*)|(/library/(?!.*\.\.[/|\\]).*)/.+)" />
 
     <!-- This is a basic alphanumeric and punctuation string -->
     <regexp name="basicAlphaNumeric" value="^[a-zA-Z0-9\s\-_.\?!,]*$" />
@@ -1055,6 +1055,20 @@
                 <regexp name="onsiteURL"/>
             </regexp-list>
         </attribute>
+
+        <!-- custom attribute to support ShareStream LTI -->
+        <attribute name="sharestream-lti-url" description="used by the IMG tag inside of CKEditor to support ShareStream LTI media embedding">
+            <regexp-list>
+                <regexp name="anything" />
+            </regexp-list>
+        </attribute>
+
+        <!-- custom attribute to support Kaltura LTI -->
+        <attribute name="kaltura-lti-url" description="used by the IMG tag inside of CKEditor to support Kaltura LTI media embedding">
+            <regexp-list>
+                <regexp name="anything" />
+            </regexp-list>
+         </attribute>
     </common-attributes>
 
 
@@ -1626,6 +1640,10 @@
                 <regexp name="anything" />
               </regexp-list>
             </attribute>
+
+            <!-- KNL-1426 sharestream and kaltura -->
+            <attribute name="sharestream-lti-url"/>
+            <attribute name="kaltura-lti-url"/>
         </tag>
 
         <!-- no way to do this safely without hooking up the same code to @import to embed the remote stylesheet (malicious user could change offsite resource to be malicious after validation -->

--- a/kernel/kernel-impl/src/main/resources/antisamy/low-security-policy.xml
+++ b/kernel/kernel-impl/src/main/resources/antisamy/low-security-policy.xml
@@ -1050,6 +1050,20 @@
                 <regexp name="onsiteURL"/>
             </regexp-list>
         </attribute>
+
+        <!-- custom attribute to support ShareStream LTI -->
+        <attribute name="sharestream-lti-url" description="used by the IMG tag inside of CKEditor to support ShareStream LTI media embedding">
+            <regexp-list>
+                <regexp name="anything" />
+            </regexp-list>
+        </attribute>
+
+        <!-- custom attribute to support Kaltura LTI -->
+        <attribute name="kaltura-lti-url" description="used by the IMG tag inside of CKEditor to support Kaltura LTI media embedding">
+            <regexp-list>
+                <regexp name="anything" />
+            </regexp-list>
+         </attribute>
     </common-attributes>
 
 
@@ -1621,6 +1635,10 @@
                 <regexp name="anything" />
               </regexp-list>
             </attribute>
+
+            <!-- KNL-1426 sharestream and kaltura -->
+            <attribute name="sharestream-lti-url"/>
+            <attribute name="kaltura-lti-url"/>
         </tag>
 
         <!-- no way to do this safely without hooking up the same code to @import to embed the remote stylesheet (malicious user could change offsite resource to be malicious after validation -->


### PR DESCRIPTION
 instead of making Sakai institutions customize their AntiSamy policies