### PR TITLE
LSNBLDR-601; load jquery UI css when loading js

### DIFF
--- a/reference/library/src/webapp/js/headscripts.js
+++ b/reference/library/src/webapp/js/headscripts.js
@@ -753,6 +753,7 @@ function includeLatestJQuery(where) {
 		}
 		if (typeof jQuery.ui == 'undefined') {
 			document.write('\x3Cscript type="text/javascript" src="'+webjars+'jquery-ui/1.11.3/jquery-ui.min.js'+ver+'">'+'\x3C/script>')
+			document.write('\x3Clink rel="stylesheet" href="'+webjars+'jquery-ui/1.11.3/jquery-ui.min.css'+ver+'"/>');
 			window.console && console.log('Adding jQuery UI');
 		}
 	} else {
@@ -760,6 +761,7 @@ function includeLatestJQuery(where) {
 		document.write('\x3Cscript type="text/javascript" src="'+webjars+'jquery-migrate/1.2.1/jquery-migrate.min.js'+ver+'">'+'\x3C/script>')
 		document.write('\x3Cscript type="text/javascript" src="'+webjars+'bootstrap/3.3.6/js/bootstrap.min.js'+ver+'">'+'\x3C/script>')
 		document.write('\x3Cscript type="text/javascript" src="'+webjars+'jquery-ui/1.11.3/jquery-ui.min.js'+ver+'">'+'\x3C/script>')
+		document.write('\x3Clink rel="stylesheet" href="'+webjars+'jquery-ui/1.11.3/jquery-ui.min.css'+ver+'"/>');
 		window.console && console.log("jQuery+migrate+BootStrap+UI Loaded by "+where+" from "+webjars);
 	}
 }


### PR DESCRIPTION
This is another instance of needing to load jquery UI css. Like the previous one, this raises QA issues. I'm checking into master, because the core team agreed on this approach. But I'm going to leave it to the 11 master whether to accept it for 11. If it's not accepted, I can do a patch that fixes just this one specific tool, and use that just for 11.
