### PR TITLE
SAM-2805 improvements for Samigo submission email receipts and notifications

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -564,3 +564,8 @@ additional_instructions_label=Click to see additional instructions
 
 qprogress=Question Progress
 qprogress_questions=question(s)
+
+receiptEmail_none = You have elected not to receive an email receipt for Tests & Quizzes submissions.
+receiptEmail_digest = You will receive a receipt for this submission as part of your daily Tests & Quizzes submission summary email.
+receiptEmail_immediate = You will receive an email receipt for this submission.
+receiptEmail_changeSetting = You can change your email notification settings via My Workspaces -> Preferences -> Notifications.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -105,7 +105,7 @@ import org.apache.commons.lang.StringUtils;
 public class DeliveryBean
   implements Serializable
 {
-  private static Log log = LogFactory.getLog(DeliveryBean.class);
+  private static final Log log = LogFactory.getLog(DeliveryBean.class);
 
   //SAM-2517
   private ServerConfigurationService serverConfigurationService;
@@ -141,6 +141,7 @@ public class DeliveryBean
   private String url;
   private String confirmation;
   private String outcome;
+  private String receiptEmailSetting;
 
   //Settings
   private String questionLayout;
@@ -367,6 +368,24 @@ public class DeliveryBean
   }
 
   /**
+   * 
+   * @return 
+   */
+  public String getReceiptEmailSetting()
+  {
+      return receiptEmailSetting;
+  }
+
+  /**
+   * 
+   * @param receiptEmailSetting 
+   */
+  public void setReceiptEmailSetting( String receiptEmailSetting )
+  {
+      this.receiptEmailSetting = receiptEmailSetting;
+  }
+
+  /**
    *
    *
    * @return
@@ -469,8 +488,7 @@ public class DeliveryBean
 	    }
 	    catch (Exception ex) {
 	      // we will leave it as an empty string
-	      log.warn("Unable to format date.");
-	      ex.printStackTrace();
+	      log.warn("Unable to format date.", ex);
 	    }
 	    return beginTimeString;
   }
@@ -605,13 +623,13 @@ public class DeliveryBean
     try{
       if (timeElapse!=null && !("").equals(timeElapse)
           && getTimeLimit()!=null && !("").equals(getTimeLimit())){
-        double limit = (new Double(getTimeLimit())).doubleValue();
-        double elapsed = (new Double(timeElapse)).doubleValue();
+        double limit = (new Double(getTimeLimit()));
+        double elapsed = (new Double(timeElapse));
         if (limit > elapsed)
           this.timeElapse = timeElapse;
         else
           this.timeElapse = getTimeLimit();
-        setTimeElapseDouble((new Double(timeElapse)).doubleValue());
+        setTimeElapseDouble((new Double(timeElapse)));
       }
     }
     catch (Exception e){
@@ -1008,7 +1026,7 @@ public class DeliveryBean
   }
 
   /**
-   * @param bean
+   * @param settings
    */
   public void setSettings(SettingsDeliveryBean settings)
   {
@@ -1081,8 +1099,7 @@ public class DeliveryBean
     }
     catch (Exception ex) {
       // we will leave it as an empty string
-      log.warn("Unable to format date.");
-      ex.printStackTrace();
+      log.warn("Unable to format date.", ex);
     }
     return dateString;
   }
@@ -1100,8 +1117,7 @@ public class DeliveryBean
     }
     catch (Exception ex) {
       // we will leave it as an empty string
-      log.warn("Unable to format date.");
-      ex.printStackTrace();
+      log.warn("Unable to format date.", ex);
     }
     return dateString;
   }
@@ -1127,8 +1143,7 @@ public class DeliveryBean
 	    }
 	    catch (Exception ex) {
 	      // we will leave it as an empty string
-	      log.warn("Unable to format date.");
-	      ex.printStackTrace();
+	      log.warn("Unable to format date.", ex);
 	    }
 	    return adjustedTimedAssesmentDueDateString;
   }
@@ -1155,8 +1170,7 @@ public class DeliveryBean
     }
     catch (Exception ex) {
       // we will leave it as an empty string
-      log.warn("Unable to format date.");
-      ex.printStackTrace();
+      log.warn("Unable to format date.", ex);
     }
     return dateString;
   }
@@ -1316,8 +1330,7 @@ public class DeliveryBean
     }
     catch (Exception ex) {
       // we will leave it as an empty string
-      log.warn("Unable to format date.");
-      ex.printStackTrace();
+      log.warn("Unable to format date.", ex);
     }
     return dateString;
   }
@@ -1551,7 +1564,7 @@ public class DeliveryBean
    
   private String submitForGrade(boolean isFromTimer, boolean submitFromTimeoutPopup) {
 	try{
-	  Map<String, Object> notificationValues = new HashMap<String, Object>();
+	  Map<String, Object> notificationValues = new HashMap<>();
 	  Long local_assessmentGradingID = adata.getAssessmentGradingId();
 	  if (this.actionMode == PREVIEW_ASSESSMENT) {
 		  return "editAssessment";
@@ -1590,12 +1603,8 @@ public class DeliveryBean
 	  try {
 		  listener.processAction(null);
 	  }
-	  catch (FinFormatException e) {
+	  catch (FinFormatException | SaLengthException e) {
 		  log.debug(e.getMessage());
-		  return "takeAssessment";
-	  }
-	  catch (SaLengthException sae) {
-		  log.debug(sae.getMessage());
 		  return "takeAssessment";
 	  }
 	  
@@ -1664,10 +1673,10 @@ public class DeliveryBean
 	 	  eventLogData.setErrorMsg(eventLogMessages.getString("no_error"));
 	 	  Date endDate = new Date();
 	 	  eventLogData.setEndDate(endDate);
-	 	  if(endDate != null && eventLogData.getStartDate() != null) {
+	 	  if(eventLogData.getStartDate() != null) {
 	 	      double minute= 1000*60;
 	 	      int eclipseTime = (int)Math.ceil(((endDate.getTime() - eventLogData.getStartDate().getTime())/minute));
-	 	      eventLogData.setEclipseTime(Integer.valueOf(eclipseTime));
+	 	      eventLogData.setEclipseTime(eclipseTime);
 	 	  } else {
 	 	      eventLogData.setEclipseTime(null);
 	 	      eventLogData.setErrorMsg(eventLogMessages.getString("error_take"));
@@ -1679,6 +1688,7 @@ public class DeliveryBean
 	  notificationValues.put("userID", adata.getAgentId());
 	  notificationValues.put("submissionDate", getSubmissionDateString());
 	  notificationValues.put("publishedAssessmentID", adata.getPublishedAssessmentId());
+	  notificationValues.put("confirmationNumber", confirmation);
 
 	  EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED, notificationValues.toString(), AgentFacade.getCurrentSiteId(), true, SamigoConstants.NOTI_EVENT_ASSESSMENT_SUBMITTED));
  
@@ -1687,7 +1697,7 @@ public class DeliveryBean
 	  catch(Exception e) {
 		  EventLogService eventService = new EventLogService();
 		  EventLogFacade eventLogFacade = new EventLogFacade();
-		  EventLogData eventLogData = null;
+		  EventLogData eventLogData;
 
 		  List eventLogDataList = eventService.getEventLogData(adata.getAssessmentGradingId());
 		  if(eventLogDataList != null && eventLogDataList.size() > 0) {
@@ -1734,12 +1744,8 @@ public class DeliveryBean
 		  try {
 			  listener.processAction(null);
 		  }
-		  catch (FinFormatException fine) {
+		  catch (FinFormatException | SaLengthException fine) {
 			  log.debug(fine.getMessage());
-			  return "takeAssessment";
-		  }
-		  catch (SaLengthException sae) {
-			  log.debug(sae.getMessage());
 			  return "takeAssessment";
 		  }
 	  }
@@ -1780,12 +1786,8 @@ public class DeliveryBean
 		  try {
 			  listener.processAction(null);
 		  }
-		  catch (FinFormatException e) {
+		  catch (FinFormatException | SaLengthException e) {
 			  log.debug(e.getMessage());
-			  return "takeAssessment";
-		  }
-		  catch (SaLengthException sae) {
-			  log.debug(sae.getMessage());
 			  return "takeAssessment";
 		  }
 	  }
@@ -1830,17 +1832,13 @@ public class DeliveryBean
     	try {
     		listener.processAction(null);
     	}
-    	catch (FinFormatException e) {
+    	catch (FinFormatException | SaLengthException e) {
   		  log.debug(e.getMessage());
   		  return "takeAssessment";
     	}
-		  catch (SaLengthException sae) {
-			  log.debug(sae.getMessage());
-			  return "takeAssessment";
-		  }
     }
     
-    String returnValue = "saveForLaterWarning";
+    String returnValue;
     if (needToCheck) {
     	if (this.actionMode == TAKE_ASSESSMENT_VIA_URL) {
     		returnValue = "anonymousQuit";
@@ -1901,12 +1899,8 @@ public class DeliveryBean
       try {
         listener.processAction(null);
       }
-      catch (FinFormatException e) {
+      catch (FinFormatException | SaLengthException e) {
 		  log.debug(e.getMessage());
-		  return "takeAssessment";
-	  }
-	  catch (SaLengthException sae) {
-		  log.debug(sae.getMessage());
 		  return "takeAssessment";
 	  }
     }
@@ -1969,12 +1963,8 @@ public class DeliveryBean
       try {
     	  listener.processAction(null);
       }
-	  catch (FinFormatException e) {
+	  catch (FinFormatException | SaLengthException e) {
 		  log.debug(e.getMessage());
-		  return "takeAssessment";
-	  }
-	  catch (SaLengthException sae) {
-		  log.debug(sae.getMessage());
 		  return "takeAssessment";
 	  }
     }
@@ -2012,12 +2002,8 @@ public class DeliveryBean
 		  try {
 			  listener.processAction(null);
 		  }
-		  catch (FinFormatException e) {
+		  catch (FinFormatException | SaLengthException e) {
 			  log.debug(e.getMessage());
-			  return "takeAssessment";
-		  }
-		  catch (SaLengthException sae) {
-			  log.debug(sae.getMessage());
 			  return "takeAssessment";
 		  }
 	  }
@@ -2058,12 +2044,8 @@ public class DeliveryBean
       try {
     	  listener.processAction(null);
       }
-	  catch (FinFormatException e) {
+	  catch (FinFormatException | SaLengthException e) {
 		  log.debug(e.getMessage());
-		  return "takeAssessment";
-	  }
-	  catch (SaLengthException sae) {
-		  log.debug(sae.getMessage());
 		  return "takeAssessment";
 	  }
     }
@@ -2166,7 +2148,7 @@ public class DeliveryBean
     {
       String next = ( (PublishedSecuredIPAddress) addresses.next()).
         getIpAddress();
-      if (next != null && next.indexOf("*") > -1)
+      if (next != null && next.contains( "*" ))
       {
         next = next.substring(0, next.indexOf("*"));
       }
@@ -2393,18 +2375,13 @@ public class DeliveryBean
       int i;
       int size = 0;
       mediaStream = new FileInputStream(mediaLocation);
-      if (mediaStream != null)
+      while ( (i = mediaStream.read()) != -1)
       {
-        while ( (i = mediaStream.read()) != -1)
-        {
-          size++;
-        }
+        size++;
       }
       mediaStream2 = new FileInputStream(mediaLocation);
       mediaByte = new byte[size];
-      if (mediaStream2 != null) {
-    	  mediaStream2.read(mediaByte, 0, size);
-      }
+      mediaStream2.read(mediaByte, 0, size);
     }
     catch (FileNotFoundException ex)
     {
@@ -2446,6 +2423,7 @@ public class DeliveryBean
    *     target="/jsf/upload_tmp/assessment#{delivery.assessmentId}/
    *             question#{question.itemData.itemId}/admin"
    *     valueChangeListener="#{delivery.addMediaToItemGrading}" />
+     * @param e
    */
   public void addMediaToItemGrading(javax.faces.event.ValueChangeEvent e)
   {
@@ -2557,7 +2535,7 @@ public class DeliveryBean
     String mimeType = MimeTypesLocator.getInstance().getContentType(media);
     boolean SAVETODB = getSaveToDb();
     log.debug("**** SAVETODB=" + SAVETODB);
-    MediaData mediaData = null;
+    MediaData mediaData;
     log.debug("***6a. addMediaToItemGrading, itemGradinDataId=" +
               itemGradingData.getItemGradingId());
     // 1b. get filename
@@ -2580,7 +2558,7 @@ public class DeliveryBean
       mediaData = new MediaData(itemGradingData, mediaByte,
                                 Long.valueOf(mediaByte.length + ""),
                                 mimeType, "description", null,
-                                updatedFilename, false, false,  Integer.valueOf(1),
+                                updatedFilename, false, false, 1,
                                 agent, new Date(),
                                 agent, new Date(), null);
     }
@@ -2589,7 +2567,7 @@ public class DeliveryBean
       mediaData = new MediaData(itemGradingData, null,
     		  					Long.valueOf(mediaByte.length + ""),
                                 mimeType, "description", mediaLocation,
-                                updatedFilename, false, false, Integer.valueOf(1),
+                                updatedFilename, false, false, 1,
                                 agent, new Date(),
                                 agent, new Date(), null);
 
@@ -2732,8 +2710,7 @@ public class DeliveryBean
     }
     catch (Exception ex) {
       // we will leave it as an empty string
-      log.warn("Unable to format date.");
-      ex.printStackTrace();
+      log.warn("Unable to format date.", ex);
     }
     return dateString;
   }
@@ -2878,6 +2855,7 @@ public class DeliveryBean
 
   /**
    * Used for a JavaScript enable check.
+   * @return 
    */
   public String getJavaScriptEnabledCheck()
   {
@@ -2886,6 +2864,7 @@ public class DeliveryBean
 
   /**
    * Used for a JavaScript enable check.
+   * @param javaScriptEnabledCheck
    */
   public void setJavaScriptEnabledCheck(String javaScriptEnabledCheck)
   {
@@ -2919,10 +2898,7 @@ public class DeliveryBean
     FacesContext context = FacesContext.getCurrentInstance();
     ExternalContext external = context.getExternalContext();
     String saveToDb = (String)((ServletContext)external.getContext()).getAttribute("FILEUPLOAD_SAVE_MEDIA_TO_DB");
-    if (("true").equals(saveToDb))
-      return true;
-    else
-      return false;
+    return ("true").equals(saveToDb);
   }
 
   public void attachToItemContentBean(ItemGradingData itemGradingData, String questionId){
@@ -2981,22 +2957,28 @@ public class DeliveryBean
     setFeedback("false");
     setNoFeedback("true");
 
-    if (("previewAssessment").equals(actionString)){
-      setActionMode(PREVIEW_ASSESSMENT);
-    }
-    else if (("reviewAssessment").equals(actionString)){
-      setActionMode(REVIEW_ASSESSMENT);
-    }
-    else if (("gradeAssessment").equals(actionString)){
-      setFeedback("true");
-      setNoFeedback("false");
-      setActionMode(GRADE_ASSESSMENT);
-    }
-    else if (("takeAssessment").equals(actionString)){
-      setActionMode(TAKE_ASSESSMENT);
-    }
-    else if (("takeAssessmentViaUrl").equals(actionString)){
-      setActionMode(TAKE_ASSESSMENT_VIA_URL);
+    if (null != actionString)
+    {
+        switch( actionString )
+        {
+          case "previewAssessment":
+              setActionMode(PREVIEW_ASSESSMENT);
+              break;
+          case "reviewAssessment":
+              setActionMode(REVIEW_ASSESSMENT);
+              break;
+          case "gradeAssessment":
+              setFeedback("true");
+              setNoFeedback("false");
+              setActionMode(GRADE_ASSESSMENT);
+              break;
+          case "takeAssessment":
+              setActionMode(TAKE_ASSESSMENT);
+              break;
+          case "takeAssessmentViaUrl":
+              setActionMode(TAKE_ASSESSMENT_VIA_URL);
+              break;
+        }
     }
   }
 
@@ -3080,7 +3062,7 @@ public class DeliveryBean
 	      if (timedAG != null){
 	        int timeElapsed  = Math.round((new Date().getTime() - adata.getAttemptDate().getTime())/1000.0f);
 	        log.debug("***setTimeElapsed="+timeElapsed);
-		    adata.setTimeElapsed( Integer.valueOf(timeElapsed));
+		    adata.setTimeElapsed(timeElapsed);
 	        GradingService gradingService = new GradingService();
 	        gradingService.saveOrUpdateAssessmentGrading(adata);
 	        setTimeElapse(adata.getTimeElapsed().toString());
@@ -3104,7 +3086,7 @@ public class DeliveryBean
 		      TimedAssessmentGradingModel timedAG = queue.get(adata.getAssessmentGradingId());
 		      if (timedAG != null){
 		    	int timeElapsed  = Math.round((new Date().getTime() - adata.getAttemptDate().getTime())/1000.0f);
-		        adata.setTimeElapsed(Integer.valueOf(timeElapsed));
+		        adata.setTimeElapsed(timeElapsed);
 		        GradingService gradingService = new GradingService();
 		        gradingService.saveOrUpdateAssessmentGradingOnly(adata);
 		        setTimeElapse(adata.getTimeElapsed().toString());
@@ -3125,7 +3107,7 @@ public class DeliveryBean
   {
     this.timeElapseAfterFileUpload = timeElapseAfterFileUpload;
     if (timeElapseAfterFileUpload!=null && !("").equals(timeElapseAfterFileUpload))
-      setTimeElapseAfterFileUploadDouble(( Double.valueOf(timeElapseAfterFileUpload)).doubleValue());
+      setTimeElapseAfterFileUploadDouble(( Double.valueOf(timeElapseAfterFileUpload)));
   }
 
   private double timeElapseDouble=0;
@@ -3167,7 +3149,7 @@ public class DeliveryBean
 
   private HashMap publishedItemHash = new HashMap();
   public HashMap getPublishedItemHash(){
-    if (this.publishedItemHash.size() ==0){
+    if (this.publishedItemHash.isEmpty()){
       PublishedAssessmentService pubService = new PublishedAssessmentService();
       this.publishedItemHash = pubService.preparePublishedItemHash(getPublishedAssessment());
     }
@@ -3180,7 +3162,7 @@ public class DeliveryBean
 
   private HashMap publishedItemTextHash = new HashMap();
   public HashMap getPublishedItemTextHash(){
-    if (this.publishedItemTextHash.size() == 0){
+    if (this.publishedItemTextHash.isEmpty()){
       PublishedAssessmentService pubService = new PublishedAssessmentService();
       this.publishedItemTextHash = pubService.preparePublishedItemTextHash(getPublishedAssessment());
     }
@@ -3193,7 +3175,7 @@ public class DeliveryBean
 
   private HashMap publishedAnswerHash = new HashMap();
   public HashMap getPublishedAnswerHash(){
-    if (this.publishedAnswerHash.size() == 0){
+    if (this.publishedAnswerHash.isEmpty()){
       PublishedAssessmentService pubService = new PublishedAssessmentService();
       this.publishedAnswerHash = pubService.preparePublishedAnswerHash(getPublishedAssessment());
     }
@@ -3415,7 +3397,7 @@ public class DeliveryBean
     boolean hasSubmissionLeft = false;
     int maxSubmissionsAllowed = 9999;
     if ( (Boolean.FALSE).equals(publishedAssessment.getAssessmentAccessControl().getUnlimitedSubmissions())){
-      maxSubmissionsAllowed = publishedAssessment.getAssessmentAccessControl().getSubmissionsAllowed().intValue();
+      maxSubmissionsAllowed = publishedAssessment.getAssessmentAccessControl().getSubmissionsAllowed();
       if ("takeAssessmentViaUrl".equals(actionString) && !anonymousLogin && settings == null) {
     	  SettingsDeliveryBean settingsDeliveryBean = new SettingsDeliveryBean();
     	  settingsDeliveryBean.setAssessmentAccessControl(publishedAssessment);
@@ -3432,7 +3414,7 @@ public class DeliveryBean
   private boolean isAvailable(){
 	  boolean isAvailable = true;
 	  Date currentDate = new Date();
-		Date startDate = new Date();
+		Date startDate;
 		if (extendedTimeService.hasExtendedTime()) {
 			startDate = extendedTimeService.getStartDate();
 		} else {
@@ -3447,7 +3429,7 @@ public class DeliveryBean
   private boolean pastDueDate(){
     boolean pastDue = true;
     Date currentDate = new Date();
-		Date dueDate = new Date();
+		Date dueDate;
 		if (extendedTimeService.hasExtendedTime()) {
 			dueDate = extendedTimeService.getDueDate();
 		} else {
@@ -3462,7 +3444,7 @@ public class DeliveryBean
   private boolean isRetracted(boolean isSubmitForGrade){
     boolean isRetracted = true;
     Date currentDate = new Date();
-    Date retractDate = null;
+    Date retractDate;
     if (extendedTimeService.hasExtendedTime()) {
     	retractDate = extendedTimeService.getRetractDate();
     }
@@ -3477,18 +3459,12 @@ public class DeliveryBean
 
   private boolean isRemoved(){
 	  Integer status = publishedAssessment.getStatus();
-	  if (status.equals(AssessmentBaseIfc.DEAD_STATUS)) {
-		  return true;
-	  }
-	  return false;
+	  return status.equals(AssessmentBaseIfc.DEAD_STATUS);
   }
   
   private boolean isRetractedForEdit(){
 	  Integer status = publishedAssessment.getStatus();
-	  if (status.equals(AssessmentBaseIfc.RETRACT_FOR_EDIT_STATUS)) {
-		  return true;
-	  }
-	  return false;
+	  return status.equals(AssessmentBaseIfc.RETRACT_FOR_EDIT_STATUS);
   }
   
   private boolean isNeedResubmit(){
@@ -3496,10 +3472,7 @@ public class DeliveryBean
 		  return false;
 	  }
 	  Integer status = adata.getStatus();
-	  if (status.equals(AssessmentGradingData.ASSESSMENT_UPDATED_NEED_RESUBMIT)) {
-		  return true;
-	  }
-	  return false;
+	  return status.equals(AssessmentGradingData.ASSESSMENT_UPDATED_NEED_RESUBMIT);
   }
   
   private boolean checkDataIntegrity(AssessmentGradingData assessmentGrading){
@@ -3542,7 +3515,7 @@ public class DeliveryBean
     // get assessmentGrading from DB, this is to avoid same assessment being
     // opened in the differnt browser
     if (assessmentGrading !=null){
-      return assessmentGrading.getForGrade().booleanValue();
+      return assessmentGrading.getForGrade();
     }
     else return false;
   }
@@ -3583,8 +3556,7 @@ public class DeliveryBean
 		try {
 			site = SiteService.getSite(id);
 		} catch (IdUnusedException e) {
-			log.error(e.getMessage());
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		}
 		return site;
 	}
@@ -3594,8 +3566,8 @@ public class DeliveryBean
 		if (currentSite == null) {
 			return "";
 		}
-		SitePage page = null;
-		String toolId = null;
+		SitePage page;
+		String toolId;
 		try {
 			// get page
 			List pageList = currentSite.getPages();
@@ -3669,8 +3641,7 @@ public class DeliveryBean
 		    }
 		    catch (Exception ex) {
 		      // we will leave it as an empty string
-		      log.warn("Unable to format date.");
-		      ex.printStackTrace();
+		      log.warn("Unable to format date.", ex);
 		    }
 		    return deadlineString;
 	  }
@@ -3784,10 +3755,7 @@ public class DeliveryBean
 	  
 	  
 	  private boolean isTimedAssessment() {
-		  if (this.getPublishedAssessment().getAssessmentAccessControl().getTimeLimit().equals(Integer.valueOf(0))) {
-			  return false;
-		  }
-		  return true;
+		  return !this.getPublishedAssessment().getAssessmentAccessControl().getTimeLimit().equals(0);
 	  }
 	  
 	  public String cleanRadioButton() {
@@ -3836,15 +3804,10 @@ public class DeliveryBean
 					  }
 					  
 					  ArrayList itemGradingData = new ArrayList();
-					  Iterator iter = item.getItemGradingDataArray().iterator();
-					  while (iter.hasNext())
-					  {
-						  ItemGradingData itemgrading = (ItemGradingData) iter.next();
-						  if (itemgrading.getItemGradingId() != null
-									&& itemgrading.getItemGradingId().intValue() > 0) {
+					  for( ItemGradingData itemgrading : item.getItemGradingDataArray() ){
+						  if (itemgrading.getItemGradingId() != null && itemgrading.getItemGradingId().intValue() > 0) {
 							  itemGradingData.add(itemgrading);
 							  itemgrading.setPublishedAnswerId(null);
-
 						  }
 					  }
 					  item.setItemGradingDataArray(itemGradingData);
@@ -3867,7 +3830,7 @@ public class DeliveryBean
 		  syncTimeElapsedWithServer();
 		  
 		  // Set the anchor
-		  setRedrawAnchorName(tmpAnchorName.toString());
+		  setRedrawAnchorName(tmpAnchorName);
 		  
 		  return "takeAssessment";
 	  }
@@ -3884,8 +3847,7 @@ public class DeliveryBean
 
 	  /**
 	   *
-	   *
-	   * @param reviewMarked
+	   * @param displayMardForReview
 	   */
 	  public void setDisplayMardForReview(boolean displayMardForReview)
 	  {
@@ -4012,9 +3974,9 @@ public class DeliveryBean
 	/**
 	 * Return the time limit as a String
 	 * 
-	 * @param delivery
-	 * @param publishedAssessment
+	 * @param pubAssessment
 	 * @param fromBeginAssessment
+	 * @param extTimeVal
 	 * @return
 	 */
 	public int evaluateTimeLimit(PublishedAssessmentFacade pubAssessment, Boolean fromBeginAssessment, int extTimeVal) {
@@ -4145,4 +4107,3 @@ public class DeliveryBean
       return questionProgressMardPath;
     }
 }
-

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -37,11 +37,13 @@ import javax.faces.event.ActionEvent;
 import javax.faces.event.ActionListener;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.entity.api.EntityPropertyNotDefinedException;
+import org.sakaiproject.entity.api.EntityPropertyTypeException;
+import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.event.api.Event;
 import org.sakaiproject.event.api.LearningResourceStoreService;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Actor;
@@ -51,7 +53,9 @@ import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Result;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Statement;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb.SAKAI_VERB;
+import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
@@ -72,6 +76,9 @@ import org.sakaiproject.tool.assessment.ui.bean.delivery.SectionContentsBean;
 import org.sakaiproject.tool.assessment.ui.bean.shared.PersonBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.util.TextFormat;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.user.api.UserDirectoryService;
 
 /**
  * <p>
@@ -86,13 +93,16 @@ import org.sakaiproject.tool.assessment.util.TextFormat;
  */
 
 public class SubmitToGradingActionListener implements ActionListener {
-	private static Log log = LogFactory
+	private static final Log log = LogFactory
 			.getLog(SubmitToGradingActionListener.class);
 	
 	/**
 	 * The publishedAssesmentService
 	 */
-	private PublishedAssessmentService publishedAssesmentService = new PublishedAssessmentService();
+	private final PublishedAssessmentService publishedAssesmentService = new PublishedAssessmentService();
+
+	private final PreferencesService preferencesService = ComponentManager.get( PreferencesService.class );
+	private final UserDirectoryService userDirectoryService = ComponentManager.get( UserDirectoryService.class );
 
 	/**
 	 * ACTION.
@@ -116,7 +126,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 
 			
 			// get assessment
-			PublishedAssessmentFacade publishedAssessment = null;
+			PublishedAssessmentFacade publishedAssessment;
 			if (delivery.getPublishedAssessment() != null)
 				publishedAssessment = delivery.getPublishedAssessment();
 			else {
@@ -140,20 +150,23 @@ public class SubmitToGradingActionListener implements ActionListener {
                 }
             }
 			// set url & confirmation after saving the record for grade
-			if (adata != null && delivery.getForGrade())
+			if (delivery.getForGrade())
+			{
 				setConfirmation(adata, publishedAssessment, delivery);
+				setReceiptEmailSetting( delivery );
+			}
 
 			if (isForGrade(adata) && !isUnlimited(publishedAssessment)) {
 				delivery.setSubmissionsRemaining(delivery
 						.getSubmissionsRemaining() - 1);
 			}
 
-			if (invalidFINMap.size() != 0) {
+			if (!invalidFINMap.isEmpty()) {
 				delivery.setIsAnyInvalidFinInput(true);
 				throw new FinFormatException ("Not a valid FIN input");
 			}
 			
-			if (invalidSALengthList.size() != 0) {
+			if (!invalidSALengthList.isEmpty()) {
 				delivery.setIsAnyInvalidFinInput(true);
 				throw new SaLengthException ("Short Answer input is too long");
 			}
@@ -161,14 +174,12 @@ public class SubmitToGradingActionListener implements ActionListener {
 			delivery.setIsAnyInvalidFinInput(false);
 
 		} catch (GradebookServiceException ge) {
-			ge.printStackTrace();
+			log.warn( ge );
 			FacesContext context = FacesContext.getCurrentInstance();
 			String err = (String) ContextUtil.getLocalizedString(
 					"org.sakaiproject.tool.assessment.bundle.AuthorMessages",
 					"gradebook_exception_error");
 			context.addMessage(null, new FacesMessage(err));
-			return;
-
 		}
 	}
 
@@ -182,6 +193,46 @@ public class SubmitToGradingActionListener implements ActionListener {
 	private boolean isUnlimited(PublishedAssessmentFacade publishedAssessment) {
 		return (Boolean.TRUE).equals(publishedAssessment
 				.getAssessmentAccessControl().getUnlimitedSubmissions());
+	}
+
+	/**
+	 * This method sets the submitting user's receipt email setting from Preferences.
+	 * It will either be, 'None', 'Digest', or 'Immediate'.
+	 * 
+	 * @param delivery 
+	 */
+	private void setReceiptEmailSetting( DeliveryBean delivery )
+	{
+		int submitterEmailReceiptPref = SamigoConstants.NOTI_PREF_DEFAULT;
+		Preferences submitterPrefs = preferencesService.getPreferences( userDirectoryService.getCurrentUser().getId() );
+		ResourceProperties props = submitterPrefs.getProperties( NotificationService.PREFS_TYPE + SamigoConstants.NOTI_PREFS_TYPE_SAMIGO );
+		try
+		{
+			submitterEmailReceiptPref = (int) props.getLongProperty( "2" );
+		}
+		catch( EntityPropertyNotDefinedException | EntityPropertyTypeException ex ) { /* User hasn't changed preference */ }
+
+		switch( submitterEmailReceiptPref )
+		{
+			case NotificationService.PREF_IGNORE:
+			{
+				delivery.setReceiptEmailSetting( (String) ContextUtil.getLocalizedString( 
+						"org.sakaiproject.tool.assessment.bundle.DeliveryMessages", "receiptEmail_none") );
+				break;
+			}
+			case NotificationService.PREF_DIGEST:
+			{
+				delivery.setReceiptEmailSetting( (String) ContextUtil.getLocalizedString( 
+						"org.sakaiproject.tool.assessment.bundle.DeliveryMessages", "receiptEmail_digest") );
+				break;
+			}
+			case NotificationService.PREF_IMMEDIATE:
+			{
+				delivery.setReceiptEmailSetting( (String) ContextUtil.getLocalizedString( 
+						"org.sakaiproject.tool.assessment.bundle.DeliveryMessages", "receiptEmail_immediate") );
+				break;
+			}
+		}
 	}
 
 	/**
@@ -257,14 +308,14 @@ public class SubmitToGradingActionListener implements ActionListener {
 			ActionEvent ae, PublishedAssessmentFacade publishedAssessment, DeliveryBean delivery, HashMap invalidFINMap, ArrayList invalidSALengthList) throws FinFormatException {
 		log.debug("****1a. inside submitToGradingService ");
 		String submissionId = "";
-		HashSet<ItemGradingData> itemGradingHash = new HashSet<ItemGradingData>();
+		HashSet<ItemGradingData> itemGradingHash = new HashSet<>();
 		// daisyf decoding: get page contents contains SectionContentsBean, a
 		// wrapper for SectionDataIfc
 		Iterator<SectionContentsBean> iter = delivery.getPageContents().getPartsContents()
 				.iterator();
 		log.debug("****1b. inside submitToGradingService, iter= " + iter);
-		HashSet<ItemGradingData> adds = new HashSet<ItemGradingData>();
-		HashSet<ItemGradingData> removes = new HashSet<ItemGradingData>();
+		HashSet<ItemGradingData> adds = new HashSet<>();
+		HashSet<ItemGradingData> removes = new HashSet<>();
 
 		// we go through all the answer collected from JSF form per each
 		// publsihedItem and
@@ -290,7 +341,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 				itemGradingHash, publishedAssessment, adds, removes, invalidFINMap, invalidSALengthList);
 
 		
-		StringBuffer redrawAnchorName = new StringBuffer("p");
+		StringBuilder redrawAnchorName = new StringBuilder("p");
 		String tmpAnchorName = "";
 
 		Iterator<SectionContentsBean> iterPart = delivery.getPageContents().getPartsContents().iterator();
@@ -347,7 +398,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 		
 		
 		if (tmpAnchorName != null && !tmpAnchorName.equals("")) {
-			delivery.setRedrawAnchorName(tmpAnchorName.toString());
+			delivery.setRedrawAnchorName(tmpAnchorName);
 		}
 		else {
 			delivery.setRedrawAnchorName("");
@@ -426,16 +477,16 @@ public class SubmitToGradingActionListener implements ActionListener {
 		
 		adata.setSubmitFromTimeoutPopup(delivery.getsubmitFromTimeoutPopup());
 		adata.setIsLate(isLate(publishedAssessment, delivery.getsubmitFromTimeoutPopup()));
-		adata.setForGrade(Boolean.valueOf(delivery.getForGrade()));
+		adata.setForGrade(delivery.getForGrade());
 		
 		// If this assessment grading data has been updated (comments or adj. score) by grader and then republic and allow student to resubmit
 		// when the student submit his answers, we update the status back to 0 and remove the grading entry/info.
 		if (AssessmentGradingData.ASSESSMENT_UPDATED_NEED_RESUBMIT.equals(adata.getStatus()) || AssessmentGradingData.ASSESSMENT_UPDATED.equals(adata.getStatus())) {
-			adata.setStatus(Integer.valueOf(0));
+			adata.setStatus(0);
 			adata.setGradedBy(null);
 			adata.setGradedDate(null);
 			adata.setComments(null);
-			adata.setTotalOverrideScore(Double.valueOf(0d));
+			adata.setTotalOverrideScore(0d);
 		}
 	
 		log.debug("*** 2b. before storingGrades, did all the removes and adds "
@@ -511,9 +562,9 @@ public class SubmitToGradingActionListener implements ActionListener {
 				+ oldItemGradingSet.size());
 		log.debug("Submitforgrading: newItemGradingSet.size = "
 				+ newItemGradingSet.size());
-		HashSet<ItemGradingData> updateItemGradingSet = new HashSet<ItemGradingData>();
+		HashSet<ItemGradingData> updateItemGradingSet = new HashSet<>();
 		Iterator iter = oldItemGradingSet.iterator();
-		HashMap<Long, ItemGradingData> map = new HashMap<Long, ItemGradingData>();
+		HashMap<Long, ItemGradingData> map = new HashMap<>();
 		while (iter.hasNext()) { // create a map with old itemGrading
 			ItemGradingData item = (ItemGradingData) iter.next();
 			map.put(item.getItemGradingId(), item);
@@ -578,11 +629,11 @@ public class SubmitToGradingActionListener implements ActionListener {
 		adata.setAgentId(person.getId());
 		adata.setPublishedAssessmentId(publishedAssessment
 				.getPublishedAssessmentId());
-		adata.setForGrade(Boolean.valueOf(delivery.getForGrade()));
+		adata.setForGrade(delivery.getForGrade());
 		adata.setItemGradingSet(itemGradingHash);
 		adata.setAttemptDate(new Date());
 		adata.setIsLate(Boolean.FALSE);
-		adata.setStatus(Integer.valueOf(0));
+		adata.setStatus(0);
 		adata.setTotalOverrideScore(Double.valueOf(0));
 		adata.setTimeElapsed(Integer.valueOf("0"));
 		return adata;
@@ -604,7 +655,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 		//no matter what kinds of type questions, if it marks as review, add it in.
 		for (int m = 0; m < grading.size(); m++) {
 			ItemGradingData itemgrading = grading.get(m);
-			if (itemgrading.getItemGradingId() == null && (itemgrading.getReview() != null && itemgrading.getReview().booleanValue())  == true) {
+			if (itemgrading.getItemGradingId() == null && (itemgrading.getReview() != null && itemgrading.getReview())  == true) {
 				adds.add(itemgrading);
 			} 
 		}
@@ -853,7 +904,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 			log.debug("ae is null");
 		}
 		
-		if ("1".equals(delivery.getNavigation()) && adds.size() ==0 && !"showFeedback".equals(actionCommand)) {
+		if ("1".equals(delivery.getNavigation()) && adds.isEmpty() && !"showFeedback".equals(actionCommand)) {
 			log.debug("enter here");
 			Long assessmentGradingId = delivery.getAssessmentGrading().getAssessmentGradingId();
 			Long publishedItemId = item.getItemData().getItemId();
@@ -893,9 +944,9 @@ public class SubmitToGradingActionListener implements ActionListener {
 	 * @return a list of ItemGradings to be removed
 	 */
     private Collection<ItemGradingData> identifyOrphanedEMIAnswers(List<ItemGradingData> grading, Long publishedItemId, Long assessmentGradingId) {
-	Set<ItemGradingData> ret = new HashSet<ItemGradingData>();
+	Set<ItemGradingData> ret = new HashSet<>();
 		
-	List<Long> itemsInGrading = new ArrayList<Long>();
+	List<Long> itemsInGrading = new ArrayList<>();
 	for (int i = 0; i < grading.size(); i++) {
 		ItemGradingData data = grading.get(i);
 		itemsInGrading.add(data.getItemGradingId());
@@ -947,10 +998,10 @@ public class SubmitToGradingActionListener implements ActionListener {
             PublishedAssessmentFacade publishedAssessment) {
         LRS_Verb verb = new LRS_Verb(SAKAI_VERB.scored);
         LRS_Object lrsObject = new LRS_Object(ServerConfigurationService.getPortalUrl() + "/assessment", "received-grade-assessment");
-        HashMap<String, String> nameMap = new HashMap<String, String>();
+        HashMap<String, String> nameMap = new HashMap<>();
         nameMap.put("en-US", "User received a grade");
         lrsObject.setActivityName(nameMap);
-        HashMap<String, String> descMap = new HashMap<String, String>();
+        HashMap<String, String> descMap = new HashMap<>();
         descMap.put("en-US", "User received a grade for their assessment: " + publishedAssessment.getTitle() + "; Submitted: "
                 + (gradingData.getIsLate() ? "late" : "on time"));
         lrsObject.setDescription(descMap);
@@ -961,7 +1012,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 
     private LRS_Result getLRS_Result(AssessmentGradingData gradingData, PublishedAssessmentFacade publishedAssessment) {
         double score = gradingData.getFinalScore();
-        LRS_Result result = new LRS_Result(new Double(score), new Double(0.0), new Double(publishedAssessment.getTotalScore()), null);
+        LRS_Result result = new LRS_Result(score, 0.0, publishedAssessment.getTotalScore(), null);
         result.setCompletion(true);
         return result;
     }

--- a/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
@@ -127,6 +127,8 @@ window.close();
 
 </div>
 
+<p><h:outputText value="#{delivery.receiptEmailSetting} #{deliveryMessages.receiptEmail_changeSetting}" escape="false" /></p>
+
 <div class="tier1">
   <h:panelGrid columns="2" cellpadding="3" cellspacing="3">
     <h:commandButton type="submit" value="#{deliveryMessages.button_continue}" action="select"

--- a/samigo/samigo-impl/pom.xml
+++ b/samigo/samigo-impl/pom.xml
@@ -80,4 +80,15 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/java/org/sakaiproject/samigo/impl/bundle</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/bundle/EmailNotificationMessages.properties
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/bundle/EmailNotificationMessages.properties
@@ -1,0 +1,2 @@
+changeSetting_student = Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+changeSetting_instructor = You are receiving this message because this assessment has been set to send submission notifications via email.

--- a/samigo/samigo-pack/src/bundle/template-assessmentAutoSubmission.xml
+++ b/samigo/samigo-pack/src/bundle/template-assessmentAutoSubmission.xml
@@ -10,13 +10,14 @@
     Student             : ${userName} (${userDisplayID})
     Submission ID       : ${assessmentGradingID}
     Submitted on        : ${submissionDate}
+    Confirmation Number : ${confirmationNumber}
 
     Assessment Due Date : ${assessmentDueDate}
     Site ID             : ${siteID}
 
 ---
 This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
-Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+${changeSettingInstructions}
         </message>
         <messagehtml>&lt;pre&gt;
 The following assessment auto submission was recorded by ${localSakaiName}:
@@ -27,13 +28,14 @@ The following assessment auto submission was recorded by ${localSakaiName}:
     Student             : ${userName} (${userDisplayID})
     Submission ID       : ${assessmentGradingID}
     Submitted Date      : ${submissionDate}
+    Confirmation Number : ${confirmationNumber}
 
     Assessment Due Date : ${assessmentDueDate}
     Site ID             : ${siteID}
 
 ---
 This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
-Control what email notifications you receive at My Workspace -&gt; Preferences -&gt; Notifications
+${changeSettingInstructions}
 &lt;/pre&gt;
         </messagehtml>
         <version>1</version>

--- a/samigo/samigo-pack/src/bundle/template-assessmentSubmission.xml
+++ b/samigo/samigo-pack/src/bundle/template-assessmentSubmission.xml
@@ -10,13 +10,14 @@
     Student             : ${userName} (${userDisplayID})
     Submission ID       : ${assessmentGradingID}
     Submitted on        : ${submissionDate}
+    Confirmation Number : ${confirmationNumber}
 
     Assessment Due Date : ${assessmentDueDate}
     Site ID             : ${siteID}
 
 ---
 This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
-Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+${changeSettingInstructions}
         </message>
         <messagehtml>&lt;pre&gt;
 The following assessment submission was recorded by ${localSakaiName}:
@@ -27,13 +28,14 @@ The following assessment submission was recorded by ${localSakaiName}:
     Student             : ${userName} (${userDisplayID})
     Submission ID       : ${assessmentGradingID}
     Submitted Date      : ${submissionDate}
+    Confirmation Number : ${confirmationNumber}
 
     Assessment Due Date : ${assessmentDueDate}
     Site ID             : ${siteID}
 
 ---
 This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
-Control what email notifications you receive at My Workspace -&gt; Preferences -&gt; Notifications
+${changeSettingInstructions}
 &lt;/pre&gt;
         </messagehtml>
         <version>1</version>

--- a/samigo/samigo-pack/src/bundle/template-assessmentTimedSubmission.xml
+++ b/samigo/samigo-pack/src/bundle/template-assessmentTimedSubmission.xml
@@ -10,13 +10,14 @@
     Student             : ${userName} (${userDisplayID})
     Submission ID       : ${assessmentGradingID}
     Submitted on        : ${submissionDate}
+    Confirmation Number : ${confirmationNumber}
 
     Assessment Due Date : ${assessmentDueDate}
     Site ID             : ${siteID}
 
 ---
 This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
-Control what email notifications you receive at My Workspace -> Preferences -> Notifications
+${changeSettingInstructions}
         </message>
         <messagehtml>&lt;pre&gt;
 The timer has expired and the following timed assessment has been automatically submitted:
@@ -27,13 +28,14 @@ The timer has expired and the following timed assessment has been automatically 
     Student             : ${userName} (${userDisplayID})
     Submission ID       : ${assessmentGradingID}
     Submitted Date      : ${submissionDate}
+    Confirmation Number : ${confirmationNumber}
 
     Assessment Due Date : ${assessmentDueDate}
     Site ID             : ${siteID}
 
 ---
 This automatic notification message was sent by ${localSakaiName} (${localSakaiUrl})
-Control what email notifications you receive at My Workspace -&gt; Preferences -&gt; Notifications
+${changeSettingInstructions}
 &lt;/pre&gt;
         </messagehtml>
         <version>1</version>

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -23,6 +23,7 @@
 package org.sakaiproject.tool.assessment.facade;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -60,6 +61,7 @@ import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Expression;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
+import org.sakaiproject.antivirus.api.VirusFoundException;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -69,15 +71,11 @@ import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.content.api.ContentResourceEdit;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
-import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
-import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
-import org.sakaiproject.service.gradebook.shared.GradebookService;
-import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.spring.SpringBeanLocator;
 import org.sakaiproject.tool.assessment.data.dao.assessment.EvaluationModel;
 import org.sakaiproject.tool.assessment.data.dao.assessment.EventLogData;
@@ -102,8 +100,6 @@ import org.sakaiproject.tool.assessment.data.ifc.grading.StudentGradingSummaryIf
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceHelper;
-import org.sakaiproject.tool.assessment.services.AutoSubmitAssessmentsJob;
-import org.sakaiproject.tool.assessment.services.GradebookServiceException;
 import org.sakaiproject.tool.assessment.services.ItemService;
 import org.sakaiproject.tool.assessment.services.PersistenceHelper;
 import org.sakaiproject.tool.assessment.services.assessment.EventLogService;
@@ -113,9 +109,15 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.exception.IdInvalidException;
+import org.sakaiproject.exception.IdUsedException;
+import org.sakaiproject.exception.InUseException;
+import org.sakaiproject.exception.InconsistentException;
+import org.sakaiproject.exception.OverQuotaException;
+import org.sakaiproject.exception.ServerOverloadException;
 
 public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implements AssessmentGradingFacadeQueriesAPI{
-  private Log log = LogFactory.getLog(AssessmentGradingFacadeQueries.class);
+  private static final Log log = LogFactory.getLog(AssessmentGradingFacadeQueries.class);
 
   /**
    * Default empty Constructor
@@ -151,10 +153,13 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	this.persistenceHelper = persistenceHelper;
   }
 
-/**
-   * Class Methods
+
+  /**
+   * 
+   * @param publishedId
+   * @param which
+   * @return 
    */
-  
   public List getTotalScores(final String publishedId, String which) {
 	  return getTotalScores(publishedId, which, true);
   }
@@ -178,7 +183,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
       final HibernateCallback hcb = new HibernateCallback(){
       	public Object doInHibernate(Session session) throws HibernateException, SQLException {
-      		Query q = null;
+      		Query q;
       		if (getSubmittedOnly) {
       			q = session.createQuery(
       					"from AssessmentGradingData a where a.publishedAssessmentId=? " +
@@ -196,13 +201,13 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       			q.setLong(0, Long.parseLong(publishedId));
       			q.setBoolean(1, true);
       			q.setBoolean(2, false);
-      			q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+      			q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
       		}
       		return q.list();
       	};
       };
       List list = getHibernateTemplate().executeFind(hcb);
-      Map<Long, List<AssessmentGradingAttachment>> attachmentMap = new HashMap<>();
+      Map<Long, List<AssessmentGradingAttachment>> attachmentMap;
       //if (loadItemGradingAttachment) {
     	  attachmentMap = getAssessmentGradingAttachmentMap(Long.valueOf(publishedId));
       //}
@@ -215,7 +220,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     			  data.setAssessmentGradingAttachmentList(attachmentMap.get(data.getAssessmentGradingId()));
     		  }
     		  else {
-    			  data.setAssessmentGradingAttachmentList(new ArrayList<>());
+    			  data.setAssessmentGradingAttachmentList(new ArrayList<AssessmentGradingAttachment>());
     		  }
     	  //}
       }
@@ -228,7 +233,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       if (which.equals(EvaluationModelIfc.LAST_SCORE.toString())) {
     	  final HibernateCallback hcb2 = new HibernateCallback(){
     		  public Object doInHibernate(Session session) throws HibernateException, SQLException {
-    	    	Query q = null;
+    	    	Query q;
 	      		if (getSubmittedOnly) {
 	    			q = session.createQuery(
 	    					"from AssessmentGradingData a where a.publishedAssessmentId=? " +
@@ -245,7 +250,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	      			q.setLong(0, Long.parseLong(publishedId));
 	      			q.setBoolean(1, true);
 	      			q.setBoolean(2, false);
-	      			q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+	      			q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
 	      		}
 	    		return q.list();
     	    };
@@ -267,7 +272,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
         // only take highest or latest
         Iterator items = list.iterator();
         ArrayList newlist = new ArrayList();
-        String agentid = null;
+        String agentid;
         AssessmentGradingData data = (AssessmentGradingData) items.next();
         // daisyf add the following line on 12/15/04
         data.setPublishedAssessmentId(Long.valueOf(publishedId));
@@ -286,7 +291,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
         return newlist;
       }
     } catch (RuntimeException e) {
-      e.printStackTrace();
+      log.warn( e );
       return new ArrayList();
     }
   }
@@ -320,8 +325,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       	public Object doInHibernate(Session session) throws HibernateException, SQLException {
       		Query q = session.createQuery(
       				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.status <> ? order by a.agentId asc, a.submittedDate desc");
-      		q.setLong(0, publishedId.longValue());
-    		q.setInteger(1, AssessmentGradingData.NO_SUBMISSION.intValue());
+      		q.setLong(0, publishedId);
+    		q.setInteger(1, AssessmentGradingData.NO_SUBMISSION);
       		return q.list();
       	};
       };
@@ -373,7 +378,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
           }
 
           /** create or disjunctive expression for (in clauses) */
-          List tempList = new ArrayList();
+          List tempList;
         for (int i = 0; i < gradingIdList.size(); i += 50){
           if (i + 50 > gradingIdList.size()){
               tempList = gradingIdList.subList(i, gradingIdList.size());
@@ -406,9 +411,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       };
       List temp = (List) getHibernateTemplate().execute(hcb);
 
-      HashMap<Long,ArrayList<ItemGradingAttachment>> attachmentMap = new HashMap<Long,ArrayList<ItemGradingAttachment>> ();
+      HashMap<Long,ArrayList<ItemGradingAttachment>> attachmentMap = new HashMap<> ();
       if (loadItemGradingAttachment) {
-    	  attachmentMap = getItemGradingAttachmentMap(Long.valueOf(itemId));
+    	  attachmentMap = getItemGradingAttachmentMap(itemId);
       }
       Iterator iter2 = temp.iterator();
       while (iter2.hasNext())
@@ -431,7 +436,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       }
       return map;
     } catch (Exception e) {
-      e.printStackTrace();
+      log.warn( e );
       return new HashMap();
     }
   }
@@ -439,7 +444,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   /**
    * This returns a hashmap of all the latest item entries, keyed by
    * item id for easy retrieval.
-   * return (Long publishedItemId, ArrayList itemGradingData)
+   * @param publishedId
+   * @param agentId
+   * @return 
    */
   public HashMap getLastItemGradingData(final Long publishedId, final String agentId)
   {
@@ -458,10 +465,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       		Query q = session.createQuery("from AssessmentGradingData a where a.publishedAssessmentId=? " +
       				"and a.agentId=? and a.forGrade=? and a.status<>? " +
       				"order by a.submittedDate DESC");
-      		q.setLong(0, publishedId.longValue());
+      		q.setLong(0, publishedId);
       		q.setString(1, agentId);
       		q.setBoolean(2, false);
-    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
       		return q.list();
       	};
       };
@@ -474,12 +481,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       AssessmentGradingData gdata = (AssessmentGradingData) scores.toArray()[0];
       // initialize itemGradingSet
       gdata.setItemGradingSet(getItemGradingSet(gdata.getAssessmentGradingId()));
-      if (gdata.getForGrade().booleanValue())
+      if (gdata.getForGrade())
         return new HashMap();
-      Iterator iter = gdata.getItemGradingSet().iterator();
-      while (iter.hasNext())
+      for( ItemGradingData data : gdata.getItemGradingSet() )
       {
-        ItemGradingData data = (ItemGradingData) iter.next();
         ArrayList thisone = (ArrayList) map.get(data.getPublishedItemId());
         if (thisone == null)
           thisone = new ArrayList();
@@ -488,7 +493,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       }
       return map;
     } catch (Exception e) {
-      e.printStackTrace();
+      log.warn( e );
       return new HashMap();
     }
   }
@@ -498,6 +503,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   /**
    * This returns a hashmap of all the submitted items, keyed by
    * item id for easy retrieval.
+   * @param assessmentGradingId
+   * @return 
    */
   public HashMap getStudentGradingData(String assessmentGradingId)
   {
@@ -511,10 +518,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       AssessmentGradingData gdata = load(new Long(assessmentGradingId), loadGradingAttachment);
       log.debug("****#6, gdata="+gdata);
       //log.debug("****#7, item size="+gdata.getItemGradingSet().size());
-      Iterator iter = gdata.getItemGradingSet().iterator();
-      while (iter.hasNext())
+      for( ItemGradingData data : gdata.getItemGradingSet() )
       {
-        ItemGradingData data = (ItemGradingData) iter.next();
         ArrayList thisone = (ArrayList)
           map.get(data.getPublishedItemId());
         if (thisone == null)
@@ -524,7 +529,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       }
       return map;
     } catch (Exception e) {
-      e.printStackTrace();
+      log.warn( e );
       return new HashMap();
     }
   }
@@ -548,16 +553,16 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       		log.debug("scoringoption = " + scoringoption);
       		if (EvaluationModelIfc.LAST_SCORE.equals(scoringoption)){
       			// last submission
-      			Query q = null;
+      			Query q;
       			if (assessmentGradingId == null) {
       				q = session.createQuery("from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? order by a.submittedDate DESC");
-      				q.setLong(0, publishedId.longValue());
+      				q.setLong(0, publishedId);
       				q.setString(1, agentId);
       				q.setBoolean(2, true);
       			}
       			else {
       				q = session.createQuery("from AssessmentGradingData a where a.assessmentGradingId=? ");
-      				q.setLong(0, assessmentGradingId.longValue());
+      				q.setLong(0, assessmentGradingId);
       			}
       			return q.list();
       		}
@@ -566,13 +571,13 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       			Query q1 = null;
       			if (assessmentGradingId == null) {
       				q1 = session.createQuery("from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? order by a.finalScore DESC, a.submittedDate DESC");
-      				q1.setLong(0, publishedId.longValue());
+      				q1.setLong(0, publishedId);
       				q1.setString(1, agentId);
       				q1.setBoolean(2, true);
       			}
       			else {
       				q1 = session.createQuery("from AssessmentGradingData a where a.assessmentGradingId=? ");
-      				q1.setLong(0, assessmentGradingId.longValue());
+      				q1.setLong(0, assessmentGradingId);
       			}
       			return q1.list();          			
       		}
@@ -587,10 +592,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       AssessmentGradingData gdata = (AssessmentGradingData) scores.toArray()[0];
       HashMap attachmentMap = getItemGradingAttachmentMapByAssessmentGradingId(gdata.getAssessmentGradingId());
       gdata.setItemGradingSet(getItemGradingSet(gdata.getAssessmentGradingId()));
-      Iterator iter = gdata.getItemGradingSet().iterator();
-      while (iter.hasNext())
+      for( ItemGradingData data : gdata.getItemGradingSet() )
       {
-        ItemGradingData data = (ItemGradingData) iter.next();
         if (attachmentMap.get(data.getItemGradingId()) != null) {
     		data.setItemGradingAttachmentList((ArrayList<ItemGradingAttachment>) attachmentMap.get(data.getItemGradingId()));
     	}
@@ -607,13 +610,13 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       }
       return map;
     } catch (Exception e) {
-      e.printStackTrace();
+      log.warn( e );
       return new HashMap();
     }
   }
 
   public Long add(AssessmentGradingData a) {
-    int retryCount = persistenceHelper.getRetryCount().intValue();
+    int retryCount = persistenceHelper.getRetryCount();
     while (retryCount > 0){ 
       try {
         getHibernateTemplate().save(a);
@@ -628,12 +631,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   }
 
   public int getSubmissionSizeOfPublishedAssessment(Long publishedAssessmentId){
-	Object [] values = {Boolean.valueOf(true), publishedAssessmentId};
+	Object [] values = {true, publishedAssessmentId};
 	List size = getHibernateTemplate().find(
         "select count(a) from AssessmentGradingData a where a.forGrade=? and a.publishedAssessmentId=?", values);
     Iterator iter = size.iterator();
     if (iter.hasNext()){
-      int i = ((Integer)iter.next()).intValue();
+      int i = ((Integer)iter.next());
       return i;
     }
     else{
@@ -663,7 +666,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		pushAdvisor();
 		try {
 			contentHostingService.checkCollection(id);
-		} catch (Exception e) {
+		} catch (IdUnusedException | TypeException | PermissionException e) {
 			return false;
 		} finally {
 			popAdvisor();
@@ -688,11 +691,11 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				ResourcePropertiesEdit props = edit.getPropertiesEdit();
 				props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
 				contentHostingService.commitCollection(edit);
-			} catch (Exception collex) {
+			} catch (IdUsedException | IdInvalidException | PermissionException | InconsistentException collex) {
 				log.warn("[Samigo Media Attachments] Exception while creating collection (" + id + "): " + collex.toString());
 				return false;
 			}
-		} catch (Exception e) {
+		} catch (TypeException | PermissionException e) {
 			log.warn("[Samigo Media Attachments] General exception while ensuring collection: " + e.toString());
 		} finally {
 			popAdvisor();
@@ -739,12 +742,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			try {
 				contentHostingService.checkResource(mediaPath);
 				newResource = false;
-			} catch (Exception e) {
+			} catch (PermissionException | IdUnusedException | TypeException e) {
 				// Just a check, no handling
 			}
 
 			try {
-				ContentResource chsMedia = null;
+				ContentResource chsMedia;
 				if (newResource) {
 					ContentResourceEdit edit = contentHostingService.addResource(mediaPath);
 					edit.setContentType(mediaData.getMimeType());
@@ -760,7 +763,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				mediaData.setDbMedia(null);
 				mediaData.setContentResource(chsMedia);
 				return mediaPath;
-			} catch (Exception e) {
+			} catch (PermissionException | IdUsedException | IdInvalidException | InconsistentException | ServerOverloadException | OverQuotaException | VirusFoundException | IdUnusedException | TypeException | InUseException e) {
 				log.warn("Exception while saving media to content: " + e.toString());
 			} finally {
 				popAdvisor();
@@ -783,7 +786,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				return res;
 			} catch (IdUnusedException ie) {
 				log.info("Nonexistent resource when trying to load media (id: " + mediaData.getMediaId() + "): " + id);
-			} catch (Exception e) {
+			} catch (PermissionException | TypeException e) {
 				log.debug("Exception while reading media from content ("+ mediaData.getMediaId() + "):" + e.toString());
 			} finally {
 				popAdvisor();
@@ -818,9 +821,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
   public Long saveMedia(MediaData mediaData){
     log.debug("****"+mediaData.getFilename()+" saving media...size="+mediaData.getFileSize()+" "+(new Date()));
-    int retryCount = persistenceHelper.getRetryCount().intValue();
+    int retryCount = persistenceHelper.getRetryCount();
 
-    String mediaPath = getMediaPath(mediaData);
+    getMediaPath(mediaData);
 
     while (retryCount > 0){ 
       try {
@@ -853,7 +856,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       log.debug("****Connection="+conn);
       String query0="select LOCATION from SAM_MEDIA_T where MEDIAID=?";
       statement0 = conn.prepareStatement(query0);
-      statement0.setLong(1, mediaId.longValue());
+      statement0.setLong(1, mediaId);
       rs =statement0.executeQuery();
       if (rs.next()){
         mediaLocation = rs.getString("LOCATION");
@@ -862,13 +865,13 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
       String query="delete from SAM_MEDIA_T where MEDIAID=?";
       statement = conn.prepareStatement(query);
-      statement.setLong(1, mediaId.longValue());
+      statement.setLong(1, mediaId);
       statement.executeUpdate();
       if (!conn.getAutoCommit()) {
     	  conn.commit();
       }
     }
-    catch(Exception e){
+    catch(HibernateException | SQLException e){
       log.warn(e.getMessage());
     }
     finally{
@@ -876,28 +879,28 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     		try {
     			session.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
     	if (rs !=null){
     		try {
     			rs.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
     	if (statement !=null){
     		try {
     			statement.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
        	if (statement0 !=null){
     		try {
     			statement0.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
 
@@ -905,7 +908,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     		try {
     			conn.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	} 
     }
@@ -942,7 +945,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery("from MediaData m where m.itemGradingData.itemGradingId=?");
-    		q.setLong(0, itemGradingId.longValue());
+    		q.setLong(0, itemGradingId);
     		return q.list();
     	};
     };
@@ -964,7 +967,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery("select new MediaData(m.mediaId, m.filename, m.fileSize, m.duration, m.createdDate) "+
 	    		         " from MediaData m where m.itemGradingData.itemGradingId=?");
-	    		q.setLong(0, itemGradingId.longValue());
+	    		q.setLong(0, itemGradingId);
 	    		return q.list();
 	    	};
 	    };
@@ -988,7 +991,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			  Query q = session.createQuery("select i from MediaData m, ItemGradingData i " +
 			  		"where m.itemGradingData.itemGradingId = i.itemGradingId " +
 			  		"and i.assessmentGradingId = ? ");
-			  q.setLong(0, assessmentGradingId.longValue());
+			  q.setLong(0, assessmentGradingId);
 			  return q.list();
 		  };
 	  };
@@ -1040,7 +1043,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     			}
 
     			/** create or disjunctive expression for (in clauses) */
-    			List tempList = new ArrayList();
+    			List tempList;
     			for (int i = 0; i < itemGradingIdList.size(); i += 50){
     				if (i + 50 > itemGradingIdList.size()){
     					tempList = itemGradingIdList.subList(i, itemGradingIdList.size());
@@ -1068,7 +1071,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
        return a;
 
     	} catch (Exception e) {
-    		e.printStackTrace();
+    		log.warn( e );
     		return new ArrayList();
     	}
   }
@@ -1084,7 +1087,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		return getHibernateTemplate().execute(hcb);
 	}
 
-	public boolean markMediaForConversion(List<Long> mediaIds) {
+	public boolean markMediaForConversion(final List<Long> mediaIds) {
 		final HibernateCallback hcb = new HibernateCallback() {
 			public Integer doInHibernate(Session session) throws HibernateException, SQLException {
 				Query q = session.createQuery("UPDATE MediaData SET location = 'CONVERTING' WHERE id in (:ids)");
@@ -1121,7 +1124,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery("from ItemGradingData i where i.publishedItemId=? and i.agentId=?");
-	    		q.setLong(0, publishedItemId.longValue());
+	    		q.setLong(0, publishedItemId);
 	    		q.setString(1, agentId);
 	    		return q.list();
 	    	};
@@ -1132,7 +1135,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 //        "from ItemGradingData i where i.publishedItemId=? and i.agentId=?",
 //        new Object[] { publishedItemId, agentId },
 //        new org.hibernate.type.Type[] { Hibernate.LONG, Hibernate.STRING });
-    if (itemGradings.size() == 0)
+    if (itemGradings.isEmpty())
       return null;
     return (ItemGradingData) itemGradings.get(0);
   }
@@ -1146,7 +1149,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       };
     };
     List itemGradings = getHibernateTemplate().executeFind(hcb);
-    if (itemGradings.size() == 0)
+    if (itemGradings.isEmpty())
       return null;
     return (ItemGradingData) itemGradings.get(0);
   }
@@ -1161,8 +1164,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(
     				"from ItemGradingData i where i.assessmentGradingId = ? and i.publishedItemId=?");
-    		q.setLong(0, assessmentGradingId.longValue());
-    		q.setLong(1, publishedItemId.longValue());
+    		q.setLong(0, assessmentGradingId);
+    		q.setLong(1, publishedItemId);
     		return q.list();
     	};
     };
@@ -1172,7 +1175,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 //        "from ItemGradingData i where i.assessmentGradingId = ? and i.publishedItemId=?",
 //        new Object[] { assessmentGradingId, publishedItemId },
 //        new org.hibernate.type.Type[] { Hibernate.LONG, Hibernate.LONG });
-    if (itemGradings.size() == 0)
+    if (itemGradings.isEmpty())
       return null;
     return (ItemGradingData) itemGradings.get(0);
   }
@@ -1226,10 +1229,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(
     				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? and a.status<>? order by a.submittedDate desc");
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		q.setString(1, agentIdString);
     		q.setBoolean(2, false);
-    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
     		return q.list();
     	};
     };
@@ -1239,7 +1242,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 //        "from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? order by a.submittedDate desc",
 //         new Object[] { publishedAssessmentId, agentIdString, Boolean.FALSE },
 //         new org.hibernate.type.Type[] { Hibernate.LONG, Hibernate.STRING, Hibernate.BOOLEAN });
-    if (assessmentGradings.size() != 0){
+    if (!assessmentGradings.isEmpty()){
       ag = (AssessmentGradingData) assessmentGradings.get(0);
       ag.setItemGradingSet(getItemGradingSet(ag.getAssessmentGradingId()));
     }  
@@ -1253,7 +1256,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(
 	    				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? order by a.submittedDate desc");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentIdString);
 	    		q.setBoolean(2, true);
 	    		return q.list();
@@ -1284,7 +1287,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	ag.setAssessmentGradingAttachmentList(attachments);
 	    }
 	    else {
-	    	ag.setAssessmentGradingAttachmentList(new ArrayList<>());
+	    	ag.setAssessmentGradingAttachmentList(new ArrayList<AssessmentGradingAttachment>());
 	    }
 	    
 	    return ag;
@@ -1297,7 +1300,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(
     				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? order by a.submittedDate desc");
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		q.setString(1, agentIdString);
     		return q.list();
     	};
@@ -1308,7 +1311,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 //        "from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? order by a.submittedDate desc",
 //         new Object[] { publishedAssessmentId, agentIdString },
 //         new org.hibernate.type.Type[] { Hibernate.LONG, Hibernate.STRING });
-    if (assessmentGradings.size() != 0){
+    if (!assessmentGradings.isEmpty()){
       ag = (AssessmentGradingData) assessmentGradings.get(0);
       ag.setItemGradingSet(getItemGradingSet(ag.getAssessmentGradingId()));
     }  
@@ -1317,7 +1320,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
 
   public void saveItemGrading(ItemGradingData item) {
-    int retryCount = persistenceHelper.getRetryCount().intValue();
+    int retryCount = persistenceHelper.getRetryCount();
     while (retryCount > 0){ 
       try {
         getHibernateTemplate().saveOrUpdate((ItemGradingData)item);
@@ -1331,7 +1334,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   }
 
   public void saveOrUpdateAssessmentGrading(AssessmentGradingData assessment) {
-    int retryCount = persistenceHelper.getRetryCount().intValue();
+    int retryCount = persistenceHelper.getRetryCount();
     while (retryCount > 0){ 
       try {
         /* for testing the catch block - daisyf 
@@ -1361,7 +1364,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       log.debug("****Connection="+conn);
       String query="select MEDIA from SAM_MEDIA_T where MEDIAID=?";
       statement = conn.prepareStatement(query);
-      statement.setLong(1, mediaId.longValue());
+      statement.setLong(1, mediaId);
       rs = statement.executeQuery();
       if (rs.next()){
         java.lang.Object o = rs.getObject("MEDIA");
@@ -1379,7 +1382,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
         }
       }
     }
-    catch(Exception e){
+    catch(HibernateException | SQLException | IOException e){
       log.warn(e.getMessage());
     }
     
@@ -1388,35 +1391,35 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     		try {
     			session.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
     	if (rs !=null){
     		try {
     			rs.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
     	if (statement !=null){
     		try {
     			statement.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	}
        	if (in !=null){
     		try {
     			in.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	} 
     	if (conn !=null){
     		try {
     			conn.close();
     		} catch (Exception e1) {
-    			e1.printStackTrace();
+    			log.warn( e1 );
     		}
     	} 
     }
@@ -1429,7 +1432,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery("select g.assessmentGradingId from "+
 	    		         " ItemGradingData g where g.publishedItemId=?");
-	    		q.setLong(0, publishedItemId.longValue());
+	    		q.setLong(0, publishedItemId);
 	    		return q.list();
 	    	};
 	    };
@@ -1453,7 +1456,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		q.setString(1, agentId);
     		return q.list();
     	};
@@ -1463,7 +1466,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 //    List assessmentGradings = getHibernateTemplate().find(query,
 //        new Object[] { publishedAssessmentId, agentId },
 //        new org.hibernate.type.Type[] { Hibernate.LONG, Hibernate.STRING });
-    if (assessmentGradings.size() != 0){
+    if (!assessmentGradings.isEmpty()){
       ag = (AssessmentGradingData) assessmentGradings.get(0);
       ag.setItemGradingSet(getItemGradingSet(ag.getAssessmentGradingId()));
     }  
@@ -1481,7 +1484,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(query);
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentId);
 	    		q.setBoolean(2, true);
 	    		return q.list();
@@ -1512,7 +1515,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	ag.setAssessmentGradingAttachmentList(attachments);
 	    }
 	    else {
-	    	ag.setAssessmentGradingAttachmentList(new ArrayList<>());
+	    	ag.setAssessmentGradingAttachmentList(new ArrayList<AssessmentGradingAttachment>());
 	    }
 	    
 	    return ag;
@@ -1524,7 +1527,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		return q.list();
     	};
     };
@@ -1552,7 +1555,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(query);
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setBoolean(1, true);
 	    		return q.list();
 	    	};
@@ -1577,10 +1580,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(query);
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setBoolean(1, true);
 	    		q.setBoolean(2, false);
-	    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+	    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
 	    		return q.list();
 	    	};
 	    };
@@ -1604,7 +1607,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		return q.list();
     	};
     };
@@ -1633,10 +1636,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(query);
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setBoolean(1, true);
 	    		q.setBoolean(2, false);
-	    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+	    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
 	    		return q.list();
 	    	};
 	    };
@@ -1670,7 +1673,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		return q.list();
     	};
     };
@@ -1729,7 +1732,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		return q.list();
     	};
     };
@@ -1777,7 +1780,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, assessmentGradingId.longValue());
+    		q.setLong(0, assessmentGradingId);
     		return q.list();
     	};
     };
@@ -1795,12 +1798,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(query);
-	    		q.setLong(0, assessmentGradingId.longValue());
+	    		q.setLong(0, assessmentGradingId);
 	    		return q.list();
 	    	};
 	    };
 	    List itemGradingList = getHibernateTemplate().executeFind(hcb);
-	    HashMap<Long, ItemGradingData> m = new HashMap<Long, ItemGradingData>();
+	    HashMap<Long, ItemGradingData> m = new HashMap<>();
 	    for (int i=0; i<itemGradingList.size();i++){
 	      m.put(((ItemGradingData)itemGradingList.get(i)).getItemGradingId(), (ItemGradingData) itemGradingList.get(i));
 	    }
@@ -1823,7 +1826,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, publishedAssessmentId.longValue());
+    		q.setLong(0, publishedAssessmentId);
     		return q.list();
     	};
     };
@@ -1842,7 +1845,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   }
 
   public void deleteAll(Collection c){
-    int retryCount = persistenceHelper.getRetryCount().intValue();
+    int retryCount = persistenceHelper.getRetryCount();
     while (retryCount > 0){ 
       try {
         getHibernateTemplate().deleteAll(c);
@@ -1857,7 +1860,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
 
   public void saveOrUpdateAll(Collection<ItemGradingData> c) {
-    int retryCount = persistenceHelper.getRetryCount().intValue();
+    int retryCount = persistenceHelper.getRetryCount();
     
     c.removeAll(Collections.singleton(null));
     while (retryCount > 0){ 
@@ -1882,7 +1885,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     final HibernateCallback hcb = new HibernateCallback(){
     	public Object doInHibernate(Session session) throws HibernateException, SQLException {
     		Query q = session.createQuery(query);
-    		q.setLong(0, assessmentGradingId.longValue());
+    		q.setLong(0, assessmentGradingId);
     		return q.list();
     	};
     };
@@ -1905,7 +1908,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    final HibernateCallback hcb = new HibernateCallback(){
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(query);
-	    		q.setLong(0, publishedItemId.longValue());
+	    		q.setLong(0, publishedItemId);
 	    		return q.list();
 	    	};
 	    };
@@ -1931,14 +1934,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 						  " group by i.publishedItemId, s.sequence, pi.sequence " + 
 						  " order by s.sequence desc , pi.sequence desc");
 				  q.setString(0, agentId);
-				  q.setLong(1, assessmentGradingId.longValue());
+				  q.setLong(1, assessmentGradingId);
 				  return q.list();
 			  };
 		  };
 		  List list = getHibernateTemplate().executeFind(hcb);
-		  if ( list.size() == 0) {
-			  position.add(Integer.valueOf(0));
-			  position.add(Integer.valueOf(0));
+		  if ( list.isEmpty()) {
+			  position.add(0);
+			  position.add(0);
 		  }
 		  else {
 			  Integer sequence = (Integer) list.get(0);
@@ -1958,14 +1961,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			  log.debug("sequence = " + sequence);
 			  log.debug("count = " + count);
 			  position.add(sequence);
-			  position.add(Integer.valueOf(count));
+			  position.add(count);
 		  }
 		  return position;
 	  } 
 	  catch (Exception e) {
-		  e.printStackTrace();
-		  position.add(Integer.valueOf(0));
-		  position.add(Integer.valueOf(0));
+		  log.warn( e );
+		  position.add(0);
+		  position.add(0);
 		  return position;
 	  }
   }
@@ -1975,7 +1978,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery("select i.publishedItemId from "+
 	    		         " ItemGradingData i where i.assessmentGradingId=?");
-	    		q.setLong(0, assessmentGradingId.longValue());
+	    		q.setLong(0, assessmentGradingId);
 	    		return q.list();
 	    	};
 	    };
@@ -1987,7 +1990,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery("select i.itemGradingId from "+
 	    		         " ItemGradingData i where i.assessmentGradingId=?");
-	    		q.setLong(0, assessmentGradingId.longValue());
+	    		q.setLong(0, assessmentGradingId);
 	    		return q.list();
 	    	};
 	    };
@@ -2006,15 +2009,15 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    				"and i.assessmentGradingId = a.assessmentGradingId " +
 	    				"and p.itemId = i.publishedItemId ");
 
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setBoolean(1, true);
-	    		q.setLong(2, sectionId.longValue());
+	    		q.setLong(2, sectionId);
 	    		return q.list();
 	    	};
 	    };
 	    List assessmentGradings = getHibernateTemplate().executeFind(hcb);
 
-	    final Collection<Long> itemIds = new ArrayList<Long>();
+	    final Collection<Long> itemIds = new ArrayList<>();
 	    Iterator iter = assessmentGradings.iterator();
 	    while(iter.hasNext()) {
     		itemIds.add((Long) iter.next());
@@ -2027,7 +2030,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    			    		
 	    		final Criteria criteria = session.createCriteria( PublishedItemData.class );
 	    		if( itemIds.size() > 1000 ) {
-	    			final Set<Long> ids = new HashSet<Long>();
+	    			final Set<Long> ids = new HashSet<>();
 	    			Disjunction disjunction = Restrictions.disjunction();
 	    			
 	    			for( Long id : itemIds ) {
@@ -2070,7 +2073,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    				"from PublishedItemData p, ItemGradingData i " +
 	    				"where i.itemGradingId=? " +
 	    				"and p.itemId = i.publishedItemId ");
-	    		q.setLong(0, itemGradingId.longValue());
+	    		q.setLong(0, itemGradingId);
 	    		return q.list();
 	    	};
 	    };
@@ -2089,7 +2092,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(
 	    				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? order by a.submittedDate desc");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentIdString);
 	    		q.setBoolean(2, true);
 	    		return q.list();
@@ -2136,7 +2139,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    
 	    List countList = getHibernateTemplate().executeFind(hcb);
 		Iterator iter = countList.iterator();
-		Long lastPublishedAssessmentId = Long.valueOf(-1l);
+		Long lastPublishedAssessmentId = -1l;
 		HashMap numberSubmissionPerStudentHash = new HashMap();
 		while (iter.hasNext()) {
 			Object o[] = (Object[]) iter.next(); 
@@ -2178,7 +2181,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    
 	    List countList = getHibernateTemplate().executeFind(hcb);
 		Iterator iter = countList.iterator();
-		Long lastPublishedAssessmentId = Long.valueOf(-1l);
+		Long lastPublishedAssessmentId = -1l;
 		HashMap numberInProgressPerStudentHash = new HashMap();
 		while (iter.hasNext()) {
 			Object o[] = (Object[]) iter.next(); 
@@ -2206,7 +2209,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    				" where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? " +
 	    				" and a.publishedAssessmentId = s.publishedAssessmentId and a.agentId = s.agentId " +
 	    				" and a.submittedDate > s.createdDate");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentIdString);
 	    		q.setBoolean(2, true);
 	    		return q.list();
@@ -2215,7 +2218,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    List countList = getHibernateTemplate().executeFind(hcb);
 	    Iterator iter = countList.iterator();
 	    if (iter.hasNext()){
-	      int i = ((Integer)iter.next()).intValue();
+	      int i = ((Integer)iter.next());
 	      return i;
 	    }
 	    else{
@@ -2245,7 +2248,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    };
 	    List countList = getHibernateTemplate().executeFind(hcb);
 		Iterator iter = countList.iterator();
-		Long lastPublishedAssessmentId = Long.valueOf(-1l);
+		Long lastPublishedAssessmentId = -1l;
 		HashMap actualNumberRetakePerStudentHash = new HashMap();
 		while (iter.hasNext()) {
 			Object o[] = (Object[]) iter.next(); 
@@ -2296,7 +2299,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    				"select s " +
 	    				"from StudentGradingSummaryData s " +
 	    				"where s.publishedAssessmentId=? and s.agentId=?");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentIdString);
 	    		return q.list();
 	    	};
@@ -2313,19 +2316,19 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    				"select s.numberRetake " +
 	    				"from StudentGradingSummaryData s " +
 	    				"where s.publishedAssessmentId=? and s.agentId=?");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentIdString);
 	    		return q.list();
 	    	};
 	    };
 	    List numberRetakeList = getHibernateTemplate().executeFind(hcb);
 
-	    if (numberRetakeList.size() == 0) {
+	    if (numberRetakeList.isEmpty()) {
 	    	return 0;
 	    }
 	    else {
 	    	Integer numberRetake = (Integer) numberRetakeList.get(0);
-	    	return numberRetake.intValue();
+	    	return numberRetake;
 	    }
   }
   
@@ -2366,11 +2369,11 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    };
 	    List countList = getHibernateTemplate().executeFind(hcb);
 	    Iterator iter = countList.iterator();
-		Long lastPublishedAssessmentId = Long.valueOf(-1l);
+		Long lastPublishedAssessmentId = -1l;
 		HashMap numberRetakePerStudentHash = null;
 		while (iter.hasNext()) {
 			StudentGradingSummaryData s = (StudentGradingSummaryData) iter.next();
-			Long publishedAssessmentid = (Long) s.getPublishedAssessmentId();
+			Long publishedAssessmentid = s.getPublishedAssessmentId();
 			
 			if (lastPublishedAssessmentId.equals(publishedAssessmentid)) {
 				numberRetakePerStudentHash.put(s.getAgentId(), s.getNumberRetake());
@@ -2387,7 +2390,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
   }
   
   public void saveStudentGradingSummaryData(StudentGradingSummaryIfc studentGradingSummaryData) {
-	    int retryCount = persistenceHelper.getRetryCount().intValue();
+	    int retryCount = persistenceHelper.getRetryCount();
 	    while (retryCount > 0){ 
 	      try {
 	        getHibernateTemplate().saveOrUpdate((StudentGradingSummaryData) studentGradingSummaryData);
@@ -2405,7 +2408,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(
 	    				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? and a.submittedDate>?");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		q.setString(1, agentIdString);
 	    		q.setBoolean(2, true);
 	    		q.setDate(3, dueDate);
@@ -2427,7 +2430,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       		q.setLong(0, Long.parseLong(publishedId));
       		q.setBoolean(1, true);
       		q.setBoolean(2, false);
-    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
       		return q.list();
       	};
       };
@@ -2442,7 +2445,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	  PublishedAssessmentService pubService = new PublishedAssessmentService();
 	  
 	  HashSet publishedAssessmentSections = pubService.getSectionSetForAssessment(Long.valueOf(publishedAssessmentId));
-	  Double zeroDouble = new Double(0.0);
+	  Double zeroDouble = 0.0;
 	  HashMap publishedAnswerHash = pubService.preparePublishedAnswerHash(pubService.getPublishedAssessment(publishedAssessmentId));
 	  HashMap publishedItemTextHash = pubService.preparePublishedItemTextHash(pubService.getPublishedAssessment(publishedAssessmentId));
 	  HashMap publishedItemHash = pubService.preparePublishedItemHash(pubService.getPublishedAssessment(publishedAssessmentId));
@@ -2452,14 +2455,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
       publishItemSet.addAll(publishedItemHash.values());
           
 	  int numSubmission = 1;
-	  String numSubmissionText = noSubmissionMessage;
+	  String numSubmissionText;
 	  String lastAgentId = "";
 	  String agentEid = "";
 	  String firstName = "";
 	  String lastName = "";
 	  Set useridSet = new HashSet(useridMap.keySet());
-	  ArrayList responseList = null;
-	  boolean canBeExported = false;
+	  ArrayList responseList;
+	  boolean canBeExported;
 	  boolean fistItemGradingData = true;
 	  List list = getAllOrderedSubmissions(publishedAssessmentId);
 	  Iterator assessmentGradingIter = list.iterator();	  
@@ -2533,7 +2536,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			  if (showPartAndTotalScoreSpreadsheetColumns) {
 				  Double finalScore = assessmentGradingData.getFinalScore();
 				  if (finalScore != null) {
-                      responseList.add((Double)finalScore.doubleValue()); // gopal - cast for spreadsheet numerics
+                      responseList.add(finalScore); // gopal - cast for spreadsheet numerics
 				  } else {
 					  log.debug("finalScore is NULL");
 					  responseList.add(0d); 
@@ -2599,14 +2602,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
                   //Add the missing sequences!
                                   //To manage emi answers, could help with others too
-                                  Map<Long, String> emiAnswerText = new TreeMap<Long, String>();
+                                  Map<Long, String> emiAnswerText = new TreeMap<>();
 				  for (Object ooo: l) {
 					  grade = (ItemGradingData)ooo;
 					  if (grade == null || EmptyItemGrading.class.isInstance(grade)) {
 						  continue;
 					  }
-					  if (grade!=null && grade.getAutoScore()!=null) {
-						  itemScore += grade.getAutoScore().doubleValue();
+					  if (grade.getAutoScore()!=null) {
+						  itemScore += grade.getAutoScore();
 					  }
 
 					  // now print answer data
@@ -2618,7 +2621,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 					  if (typeId.equals(TypeIfc.FILL_IN_BLANK) || typeId.equals(TypeIfc.FILL_IN_NUMERIC) || typeId.equals(TypeIfc.CALCULATED_QUESTION)) {
 						  log.debug("FILL_IN_BLANK, FILL_IN_NUMERIC");
 						  isFinFib = true;
-						  String thistext = "";
+						  String thistext;
 
 						  Long answerid = grade.getPublishedAnswerId();
 						  Long sequence = null;
@@ -2644,7 +2647,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 					  }
 					  else if (typeId.equals(TypeIfc.MATCHING)) {
 						  log.debug("MATCHING");
-						  String thistext = "";
+						  String thistext;
 
 						  // for some question types we have another text field
 						  Long answerid = grade.getPublishedAnswerId();
@@ -2727,7 +2730,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 					  }
 					  else if (typeId.equals(TypeIfc.EXTENDED_MATCHING_ITEMS)) { 
 						  log.debug("EXTENDED_MATCHING_ITEMS");
-						  String thistext = "";
+						  String thistext;
 
 						  // for some question types we have another text field
 						  Long answerid = grade.getPublishedAnswerId();
@@ -2773,8 +2776,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 						  // for this kind of question a responsesMap is generated
 						  matrixChoices = true;
 						  Long answerid = grade.getPublishedAnswerId();
-						  String temptext = "No Answer";
-						  Long sequence = null;
+						  String temptext;
+						  Long sequence;
 						  if (answerid != null) {
 							  AnswerIfc answer  = (AnswerIfc)publishedAnswerHash.get(answerid);
 							  temptext = answer.getText();
@@ -2869,7 +2872,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
                                         maintext = maintext.substring(1);
                                     }
                                   }
-                  Integer sectionSequenceNumber = null;
+                  Integer sectionSequenceNumber;
                   if(grade == null || EmptyItemGrading.class.isInstance(grade)){
                   	sectionSequenceNumber = EmptyItemGrading.class.cast(grade).getSectionSequence();
                     questionNumber = EmptyItemGrading.class.cast(grade).getItemSequence();
@@ -2879,7 +2882,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
                   	sectionSequenceNumber = updateSectionScore(sectionItems, sectionScores, grade.getPublishedItemId(), itemScore);
                   }
                   
-				  if (isFinFib && maintext.indexOf("No Answer") >= 0 && count == 1) {
+				  if (isFinFib && maintext.contains( "No Answer" ) && count == 1) {
 					  maintext = "No Answer";
 				  }
 				  else if ("".equals(maintext)) {
@@ -2970,7 +2973,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				  if (sectionScores.size() > 1) {
 					  Iterator keys = sectionScores.keySet().iterator();
 					  while (keys.hasNext()) {
-						  Double partScore = (Double) ((Double) sectionScores.get(keys.next())).doubleValue() ;
+						  Double partScore = (Double) (sectionScores.get(keys.next()));
 						  responseList.add(sectionScoreColumnStart++, partScore);
 					  }
 				  }
@@ -2984,7 +2987,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  }
 	  } // while
 
-	  if (!anonymous && useridSet.size() != 0) {
+	  if (!anonymous && !useridSet.isEmpty()) {
 		  Iterator iter = useridSet.iterator();
 		  while (iter.hasNext()) {
 			  String id = (String) iter.next();
@@ -3024,9 +3027,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  HashMap itemsForSection = (HashMap) entry.getValue();
 
 		  if (itemsForSection.get(publishedItemId)!=null) {
-			  Double score = Double.valueOf( ((Double)sectionScores.get(sectionSequence)).doubleValue() + itemScore);
+			  Double score = ((Double)sectionScores.get(sectionSequence)) + itemScore;
 			  sectionScores.put(sectionSequence, score);
-                          return ((Integer)sectionSequence).intValue();
+                          return ((Integer)sectionSequence);
 		  }
 	  }
           return 0;
@@ -3060,8 +3063,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			Long aanswerid = agrade.getPublishedAnswerId();
 			Long banswerid = bgrade.getPublishedAnswerId();
 
-			AnswerIfc aanswer=null;
-			AnswerIfc banswer=null;
+			AnswerIfc aanswer;
+			AnswerIfc banswer;
 			
 			if (aanswerid != null && banswerid != null) {
 				aanswer = (AnswerIfc) publishedAnswerHash
@@ -3159,7 +3162,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	 */
 	private static class ResponsesComparator implements Comparator {
 		boolean anonymous;
-		private Log log = LogFactory.getLog(ResponsesComparator.class);
+		private static final Log log = LogFactory.getLog(ResponsesComparator.class);
 		
 		public ResponsesComparator(boolean anony) {
 			anonymous = anony;
@@ -3240,15 +3243,15 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		    				"from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? " +
 		    				"and a.forGrade=? and a.status=? " +
 		    				"order by a.submittedDate desc");
-		    		q.setLong(0, data.getPublishedAssessmentId().longValue());
+		    		q.setLong(0, data.getPublishedAssessmentId());
 		    		q.setString(1, data.getAgentId());
 		    		q.setBoolean(2, false);
-		    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION.intValue());
+		    		q.setInteger(3, AssessmentGradingData.NO_SUBMISSION);
 		    		return q.list();
 		    	};
 		    };
 		    List assessmentGradings = getHibernateTemplate().executeFind(hcb);
-		    if (assessmentGradings.size() != 0) { 
+		    if (!assessmentGradings.isEmpty()) { 
 		    	deleteAll(assessmentGradings);
 		    }
 	  }
@@ -3258,17 +3261,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(
 	    				"from AssessmentGradingData a where a.publishedAssessmentId=? ");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		return q.list();
 	    	};
 	    };
 	    List assessmentGradings = getHibernateTemplate().executeFind(hcb);
-	    if (assessmentGradings.size() == 0) {
-	    	return false;
-	    }
-	    else {
-	    	return true;
-	    }
+	    return !assessmentGradings.isEmpty();
   }
   
   public ArrayList getHasGradingDataAndHasSubmission(final Long publishedAssessmentId) {
@@ -3276,14 +3274,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	public Object doInHibernate(Session session) throws HibernateException, SQLException {
 	    		Query q = session.createQuery(
 	    				"from AssessmentGradingData a where a.publishedAssessmentId=? order by a.agentId asc, a.submittedDate desc");
-	    		q.setLong(0, publishedAssessmentId.longValue());
+	    		q.setLong(0, publishedAssessmentId);
 	    		return q.list();
 	    	};
 	    };
 	    List assessmentGradings = getHibernateTemplate().executeFind(hcb);
 	    // first element represents hasGradingData
 	    // second element represents hasSubmission
-	    ArrayList<Boolean> al = new ArrayList<Boolean>(); 
+	    ArrayList<Boolean> al = new ArrayList<>(); 
 	    if (assessmentGradings.size() ==0) {
 	    	al.add(Boolean.FALSE); // no gradingData
 	    	al.add(Boolean.FALSE); // no submission
@@ -3296,7 +3294,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			while (iter.hasNext()) {
 				AssessmentGradingData adata = (AssessmentGradingData) iter.next();
 				if (!currentAgent.equals(adata.getAgentId())){
-					if (adata.getForGrade().booleanValue()) {
+					if (adata.getForGrade()) {
 						al.add(Boolean.TRUE); // has submission
 						hasSubmission = true;
 						break;
@@ -3324,35 +3322,35 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	}
 
 	private String getFilenameWOExtesion(Long itemGradingId, String agentId, String filename) {
-		StringBuffer bindVar = new StringBuffer(filename);
+		StringBuilder bindVar = new StringBuilder(filename);
 		bindVar.append("%");
 		
-   	    Object [] values = {itemGradingId.longValue(), agentId, bindVar.toString()};
+   	    Object [] values = {itemGradingId, agentId, bindVar.toString()};
 	    List list = getHibernateTemplate().find(
 	    		"select filename from MediaData m where m.itemGradingData.itemGradingId=? and m.createdBy=? and m.filename like ?", values);
-   	    if (list.size() == 0) {
+   	    if (list.isEmpty()) {
 	    	return filename;
 	    }
    	    
    	    HashSet hs = new HashSet();
    	    Iterator iter = list.iterator();
-   	    String name = "";
+   	    String name;
    	    // Only add the filename which
    	    // 1. with no extension because the newly updated one has no extention
    	    // 2. name is same to filename or name like filename(...
    	    // For example, if the filename is ab. We only want ab, ab(1), ab(2)... and don't want abc to be in
    	    while(iter.hasNext()) {
    	    	name = ((String) iter.next()).trim();
-   	    	if (name.indexOf(".") < 0 && (name.equals(filename) || name.startsWith(filename + "("))) {
+   	    	if (!name.contains( "." ) && (name.equals(filename) || name.startsWith(filename + "("))) {
    	    		hs.add(name);
    	    	}
    	    }
    	    
-   	    if (hs.size() == 0) {
+   	    if (hs.isEmpty()) {
    	    	return filename;
    	    }
    	    
-   	    StringBuffer testName = new StringBuffer(filename);
+   	    StringBuilder testName = new StringBuilder(filename);
 	    int i = 1;
 	    while(true) {
 	    	if (!hs.contains(testName.toString())) {
@@ -3360,7 +3358,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    	}
 	    	else {
 	    		i++;
-	    		testName = new StringBuffer(filename);
+	    		testName = new StringBuilder(filename);
 	    	    testName.append("(");
 	    		testName.append(i);
 	    		testName.append(")");
@@ -3370,21 +3368,21 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	
 	private String getFilenameWExtesion(Long itemGradingId, String agentId, String filename, int dotIndex) {
 		String filenameWithoutExtension = filename.substring(0, dotIndex);
-		StringBuffer bindVar = new StringBuffer(filenameWithoutExtension);
+		StringBuilder bindVar = new StringBuilder(filenameWithoutExtension);
 		bindVar.append("%");
 		bindVar.append(filename.substring(dotIndex));
    	       	    
-		Object [] values = {itemGradingId.longValue(), agentId, bindVar.toString()};
+		Object [] values = {itemGradingId, agentId, bindVar.toString()};
 	    List list = getHibernateTemplate().find(
 	    		"select filename from MediaData m where m.itemGradingData.itemGradingId=? and m.createdBy=? and m.filename like ?", values);
-   	    if (list.size() == 0) {
+   	    if (list.isEmpty()) {
 	    	return filename;
 	    }
    	    
    	    HashSet hs = new HashSet();
    	    Iterator iter = list.iterator();
-   	    String name = "";
-   	    int nameLenght = 0;
+   	    String name;
+   	    int nameLenght;
    	    String extension = filename.substring(dotIndex);
    	    int extensionLength = extension.length();
    	    while(iter.hasNext()) {
@@ -3395,7 +3393,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
    	    	}
    	    }
    	    
-   	    if (hs.size() == 0) {
+   	    if (hs.isEmpty()) {
    	    	return filename;
    	    }
    	    
@@ -3429,7 +3427,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 						" and az.qualifierId=a.publishedAssessmentId and a.forGrade=? and (a.status=? or a.status=?) " +
 						" order by a.status", values);
 		
-		if (list.size() == 0) {
+		if (list.isEmpty()) {
 			return updatedAssessmentList;
 		}
 
@@ -3500,10 +3498,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			gbsHelper = IntegrationContextFactory.getInstance().getGradebookServiceHelper();
 			updateGrades = true;
 		}
-		boolean updateCurrentGrade = false;
+		boolean updateCurrentGrade;
 	    while (iter.hasNext()) {
 	    	updateCurrentGrade = false;
-            Map<String, Object> notiValues = new HashMap<String, Object>();
+            Map<String, Object> notiValues = new HashMap<>();
 	    	try{
 	    		adata = (AssessmentGradingData) iter.next();
 	    		adata.setHasAutoSubmissionRun(Boolean.TRUE);
@@ -3562,10 +3560,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     					//will do the i18n issue later.
     					eventLogData.setErrorMsg("No Errors (Auto submit)");
     					eventLogData.setEndDate(endDate);
-    					if(endDate != null && eventLogData.getStartDate() != null) {
+    					if(eventLogData.getStartDate() != null) {
     						double minute= 1000*60;
     						int eclipseTime = (int)Math.ceil(((endDate.getTime() - eventLogData.getStartDate().getTime())/minute));
-    						eventLogData.setEclipseTime(Integer.valueOf(eclipseTime)); 
+    						eventLogData.setEclipseTime(eclipseTime); 
     					} else {
     						eventLogData.setEclipseTime(null); 
     						eventLogData.setErrorMsg("Error during auto submit");
@@ -3583,6 +3581,11 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     				notiValues.put("userID", adata.getAgentId());
     				notiValues.put("submissionDate", adata.getSubmittedDate());
 
+    				PublishedAssessmentFacade publishedAssessment = publishedAssessmentService.getPublishedAssessment( adata.getPublishedAssessmentId().toString() );
+    				String confirmationNumber = adata.getAssessmentGradingId() + "-" + publishedAssessment.getPublishedAssessmentId() + "-"
+    					+ adata.getAgentId() + "-" + adata.getSubmittedDate().toString();
+    				notiValues.put( "confirmationNumber", confirmationNumber );
+
     				EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_AUTO_SUBMITTED, notiValues.toString(), AgentFacade.getCurrentSiteId(), false, SamigoConstants.NOTI_EVENT_ASSESSMENT_SUBMITTED));
     			}
 
@@ -3595,11 +3598,11 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
     			if(updateGrades && updateCurrentGrade && toGradebookPublishedAssessmentSiteIdMap.containsKey(adata.getPublishedAssessmentId())) {
     				String currentSiteId = (String) toGradebookPublishedAssessmentSiteIdMap.get(adata.getPublishedAssessmentId());
     				if (gbsHelper.gradebookExists(GradebookFacade.getGradebookUId(currentSiteId), g)){
-    					int retryCount = persistenceHelper.getRetryCount().intValue();
+    					int retryCount = persistenceHelper.getRetryCount();
     					while (retryCount > 0){
     						try {
-    							Map<String, Double> studentScore = new HashMap<String, Double>();
-    							studentScore.put(adata.getAgentId(),Double.valueOf(adata.getFinalScore()));
+    							Map<String, Double> studentScore = new HashMap<>();
+    							studentScore.put(adata.getAgentId(),adata.getFinalScore());
     							gbsHelper.updateExternalAssessmentScores(adata.getPublishedAssessmentId(), studentScore, g);
     							retryCount = 0;
     						}
@@ -3628,7 +3631,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	}
 
 	private String makeHeader(String section, int sectionNumber, String question, String headerType, int questionNumber, String pool, String poolName) {
-		StringBuffer sb = new StringBuffer(section);
+		StringBuilder sb = new StringBuilder(section);
                 sb.append(" ");
                 sb.append(sectionNumber);
                 sb.append(", ");
@@ -3647,7 +3650,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	}
 	
 	private String makeHeaderMatrix(String section, int sectionNumber, String question, String headerType, int questionNumber, int questionRow, String pool, String poolName) {
-		StringBuffer sb = new StringBuffer(section);
+		StringBuilder sb = new StringBuilder(section);
 		sb.append(" ");
 		sb.append(sectionNumber);
 		sb.append(", ");
@@ -3670,18 +3673,14 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	public ItemGradingAttachment createItemGradingtAttachment(ItemGradingData itemGrading, String resourceId, String filename, String protocol) {
 		GradingAttachmentData attach = createGradingtAttachment(resourceId, filename, protocol);
 		ItemGradingAttachment itemAttach = new ItemGradingAttachment(attach, itemGrading);
-		if (itemAttach != null) {
-			itemAttach.setItemGrading(itemGrading);
-		}
+		itemAttach.setItemGrading(itemGrading);
 		return itemAttach;
 	}
 	
 	public AssessmentGradingAttachment createAssessmentGradingtAttachment(AssessmentGradingData assessmentGrading, String resourceId, String filename, String protocol) {
 		GradingAttachmentData attach = createGradingtAttachment(resourceId, filename, protocol);
 		AssessmentGradingAttachment assessAttach = new AssessmentGradingAttachment(attach, assessmentGrading);
-		if (assessAttach != null) {
-			assessAttach.setAssessmentGrading(assessmentGrading);
-		}
+		assessAttach.setAssessmentGrading(assessmentGrading);
 		return assessAttach;
 	}
 	
@@ -3718,12 +3717,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				attach.setLastModifiedDate(new Date());
 				attach.setLocation(assessmentFacadeQueries.getRelativePath(cr.getUrl(), protocol));
 			}
-		} catch (PermissionException pe) {
-			pe.printStackTrace();
-		} catch (IdUnusedException ie) {
-			ie.printStackTrace();
-		} catch (TypeException te) {
-			te.printStackTrace();
+		} catch (PermissionException | IdUnusedException | TypeException pe) {
+			log.warn( pe );
 		}
 		return attach;
 	}
@@ -3733,8 +3728,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				.load(ItemGradingAttachment.class, attachmentId);
 		ItemGradingData itemGrading = itemGradingAttachment.getItemGrading();
 		// String resourceId = assessmentAttachment.getResourceId();
-		int retryCount = persistenceHelper.getRetryCount()
-				.intValue();
+		int retryCount = persistenceHelper.getRetryCount();
 		while (retryCount > 0) {
 			try {
 				if (itemGrading != null) {
@@ -3757,8 +3751,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 				.load(AssessmentGradingAttachment.class, attachmentId);
 		AssessmentGradingData assessmentGrading = assessmentGradingAttachment.getAssessmentGrading();
 		// String resourceId = assessmentAttachment.getResourceId();
-		int retryCount = persistenceHelper.getRetryCount()
-				.intValue();
+		int retryCount = persistenceHelper.getRetryCount();
 		while (retryCount > 0) {
 			try {
 				if (assessmentGrading != null) {
@@ -3825,7 +3818,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  ArrayList answeredPublishedItemIdList = new ArrayList();
 		  List publishedItemIds = getPublishedItemIds(assessmentGradingData.getAssessmentGradingId());
 		  Iterator iter = publishedItemIds.iterator();
-		  Long answeredPublishedItemId = Long.valueOf(0l);
+		  Long answeredPublishedItemId;
 		  while (iter.hasNext()) {
 			  answeredPublishedItemId = (Long) iter.next();
 			  log.debug("answeredPublishedItemId = " + answeredPublishedItemId);
@@ -3834,7 +3827,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
 		  PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
 		  Long publishedAssessmentId = assessmentGradingData.getPublishedAssessmentId();
-		  HashSet sectionSet = null;
+		  HashSet sectionSet;
 		  if (sectionSetMap == null || !sectionSetMap.containsKey(publishedAssessmentId)) {
 			  sectionSet = publishedAssessmentService.getSectionSetForAssessment(publishedAssessmentId);
 			  if (sectionSetMap != null) {
@@ -3849,10 +3842,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			  return;
 		  }
 
-		  PublishedSectionData publishedSectionData = null;
-		  ArrayList itemArrayList = null;
-		  Long publishedItemId = Long.valueOf(0l);
-		  PublishedItemData publishedItemData = null;
+		  PublishedSectionData publishedSectionData;
+		  ArrayList itemArrayList;
+		  Long publishedItemId;
+		  PublishedItemData publishedItemData;
 		  iter = sectionSet.iterator();
 		  while (iter.hasNext()) {
 			  publishedSectionData = (PublishedSectionData) iter.next();
@@ -3869,12 +3862,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
 				  Collections.shuffle(itemArrayList,  new Random(seed));
 
-				  Integer numberToBeDrawn = Integer.valueOf(0);
+				  Integer numberToBeDrawn = 0;
 				  if (publishedSectionData.getSectionMetaDataByLabel(SectionDataIfc.NUM_QUESTIONS_DRAWN) !=null ) {
 					  numberToBeDrawn= Integer.valueOf(publishedSectionData.getSectionMetaDataByLabel(SectionDataIfc.NUM_QUESTIONS_DRAWN));
 				  }
 
-				  int samplesize = numberToBeDrawn.intValue();
+				  int samplesize = numberToBeDrawn;
 				  for (int i=0; i < samplesize; i++){
 					  publishedItemData = (PublishedItemData) itemArrayList.get(i);
 					  publishedItemId = publishedItemData.getItemId();
@@ -3919,10 +3912,13 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	  /***
 	   * 
 	   *@author Mustansar Mehmood
+	   * @param publishedAssessmentId
+	   * @param agentId
+	   * @return 
 	   */
 	  public Double getAverageSubmittedAssessmentGrading( final Long publishedAssessmentId, final String agentId)
 	  {
-		  Double averageScore= new Double(0.0);
+		  Double averageScore= 0.0;
 		  AssessmentGradingData ag = null;
 		  final String query ="from AssessmentGradingData a "+
 		  " where a.publishedAssessmentId=? and a.agentId=? and "+
@@ -3931,7 +3927,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  final HibernateCallback hcb = new HibernateCallback(){
 			  public Object doInHibernate(Session session) throws HibernateException, SQLException {
 				  Query q = session.createQuery(query);
-				  q.setLong(0, publishedAssessmentId.longValue());
+				  q.setLong(0, publishedAssessmentId);
 				  q.setString(1, agentId);
 				  q.setBoolean(2, true);
 				  return q.list();
@@ -3939,8 +3935,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  };
 		  List assessmentGradings = getHibernateTemplate().executeFind(hcb);
 
-		  if (assessmentGradings.size() != 0){
-			  AssessmentGradingData agd=null;
+		  if (!assessmentGradings.isEmpty()){
+			  AssessmentGradingData agd;
 			  Double cumulativeScore=new Double(0);
 			  Iterator i = assessmentGradings.iterator();
 
@@ -3966,7 +3962,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  final HibernateCallback hcb = new HibernateCallback(){
 			  public Object doInHibernate(Session session) throws HibernateException, SQLException {
 				  Query q = session.createQuery(query);
-				  q.setLong(0, publishedAssessmentId.longValue());
+				  q.setLong(0, publishedAssessmentId);
 				  q.setBoolean(1, true);
 				  return q.list();
 			  };
@@ -3987,6 +3983,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 
 	  /**
 	   * @author Mustansar Mehmood mustansar@rice.edu
+	   * @param publishedAssessmentId
+	   * @return 
 	   * */
 	  public HashMap getAverageAssessmentGradingByPublishedItem(final Long publishedAssessmentId){
 		  HashMap h = new HashMap();
@@ -4002,7 +4000,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 		  final HibernateCallback hcb = new HibernateCallback(){
 			  public Object doInHibernate(Session session) throws HibernateException, SQLException {
 				  Query q = session.createQuery(query);
-				  q.setLong(0, publishedAssessmentId.longValue());
+				  q.setLong(0, publishedAssessmentId);
 				  return q.list();
 			  };
 		  };
@@ -4176,7 +4174,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			  public Object doInHibernate(Session session) throws HibernateException, SQLException {
 				  Query q = session.createQuery(
 						  "from AssessmentGradingData a where a.publishedAssessmentId=? and a.agentId=? and a.forGrade=? order by a.attemptDate desc");
-				  q.setLong(0, publishedAssessmentId.longValue());
+				  q.setLong(0, publishedAssessmentId);
 				  q.setString(1, agentIdString);
 				  q.setBoolean(2, false);
 				  return q.list();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2805

* The submission information page does not tell the student they will receive an email receipt. This page has been updated to tell tell the student if they should expect an email receipt based on their current setting in Preferences (either immediate, digest, or none). It also informs them where to change the setting.
* The submission information page gives the student a confirmation number that is not included in the email for comparison/verification. The email templates and substitution values have been updated to include this information.
* As the same email templates are used for sending receipts to students AND notifications to instructors, the last sentence in these templates is inaccurate in the context of Instructor notifications. This hard-coded sentence has been replaced by a substitution variable that is now specific to both Instructors and Students. The student's will stay the same, informing them they can change their receipt settings in Preferences. The Instructor's has changed to inform them they are receiving the notification because the quiz is set to do so. As the default setting for notifications is 'None', the Instructor must already be aware of this setting. Therefore, re-iterating how to find the quiz setting is not necessary.

**CC:** @master-bob 

Also cleaned up a few of the files while I was there, but kept it to safe changes like removing unnecessary boxing/unboxing, redundant if/else statements, un-used variable assignments, un-used imports, replace print stack traces with loggers, Java7 syntax, etc