### PR TITLE
SAK-30639 Peer assessment information is offset by a column

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/css/assignment.css
+++ b/assignment/assignment-tool/tool/src/webapp/css/assignment.css
@@ -175,6 +175,10 @@ a.toggleAnchor > h3 {
     background: url('/library/image/sakai/expand.gif') no-repeat left !important;
 }
 
+.collapse{
+    display: block !important;
+}
+
 label.disabled {
     color: #aaa;
 }

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -84,6 +84,9 @@
 			<input type="hidden" name="source" value="0" />
 			<table class="table table-hover table-striped table-bordered" summary="$tlang.getString("gen.ass.lis.sum")">
 				<tr>
+					<th id="attachments" class="attach"> 
+						&nbsp;
+					</th>				
 					<th id="title">
 						<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
 							$tlang.getString("gen.asstit")
@@ -214,6 +217,24 @@
 					## no need to do permission check again, since it was done when the list was constructed
 						#set ($assignmentCount = $assignmentCount + 1)
 						<tr>
+							<td headers="attachments" class="attach">
+								#set ($attachments = $assignmentContent.getAttachments())
+								#set ($size = 0)
+								#set ($props = false)
+								#if (!$!attachments.isEmpty())
+									#foreach ($attachment in $attachments)
+										#set ($props = $attachment.Properties) 
+										#if ($!props)
+											#set ($size = $size + 1)
+										#end
+									#end
+								#end
+								#if ($size > 0)
+									<i class="icon-sakai-clip"></i>
+								#else
+									&nbsp;
+								#end
+							</td>						
 							<td headers="title">
 									#if (($!allowAddAssignment || $!allowUpdateAssignment || $!service.allowGradeSubmission($assignment.getReference())) && $!view.equals('lisofass1'))
 										<h4>

--- a/reference/library/src/morpheus-master/sass/base/_icons.scss
+++ b/reference/library/src/morpheus-master/sass/base/_icons.scss
@@ -80,4 +80,5 @@
 	.icon-sakai-home{                       @extend .fa-university;}
 	.icon-sakai-delete{                     @extend .fa-times;}
 	.icon-sakai-pdf{                        @extend .fa-file-pdf-o;}
+	.icon-sakai-clip{                       @extend .fa-paperclip;}
 }


### PR DESCRIPTION
This also resolves SAK-30184 Don't show anything in the column "for" in
"Assignment List" when the assignment is for several groups

![04](https://cloud.githubusercontent.com/assets/16644575/14425785/168aceb4-ffea-11e5-8307-048dde2d9ef6.png)
![05](https://cloud.githubusercontent.com/assets/16644575/14425790/1a7aef0e-ffea-11e5-82e4-4bd360fa7aee.png)
![06](https://cloud.githubusercontent.com/assets/16644575/14425795/1de1b47a-ffea-11e5-990a-6f4289d1cefe.png)
