### PR TITLE
SAK-30768 Fixup group display in site info

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
+++ b/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
@@ -1,12 +1,13 @@
 /*
 toggler needs
 */
-.toggleAnchor {
+h4.toggleAnchor {
     border: 1px solid #cef;
     background: #cef !important;
     padding: 5px !important;
     cursor: pointer;
     outline:none;
+    color: black;
 }
  .toggleAnchor:hover{
     border: 1px solid #9cf;


### PR DESCRIPTION
The group display heading text is now black (previously, when expanded it was white).