### PR TITLE
SAK-26254 Duplicate site button now has focus

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-duplicate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-duplicate.vm
@@ -91,7 +91,7 @@
 		<div class="act">
 			#if (!$!siteDuplicated)
 				<input
-					type="button"
+					type="submit"
 					class="active"
 					name="$tlang.getString("sitdup.dup")"
 					id="duplicateSite" 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-26254
The duplicate button will now be pressed when the enter key is clicked instead of the cancel button.