### PR TITLE
SAK-30896: "Web site" should be "website" in Resources Upload page

### DIFF
--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -185,13 +185,13 @@ instr.uploads		 = Files can be uploaded individually or in ZIP archives. Expand 
 file''s Action menu. To remove files before completing the upload, click X next to them. Click Upload Files Now when \
 ready to complete the upload. Note that you cannot upload more than {0} MB of material at once.<br /><br />\
 Copyright: It is your personal responsibility to verify that you have permission from the copyright holder \
-to upload the file(s) to this web site. Text, graphics and other media files may all be subject to copyright control \
+to upload the file(s) to this website. Text, graphics and other media files may all be subject to copyright control \
 even if your site is restricted to site members.
 instr.dnd.uploads		 = Files can be uploaded individually or in ZIP archives. Expand ZIPs after uploading via the \
 file''s Action menu. Click Continue when ready to complete the upload. Note that you cannot upload more than {0} MB of \
 material at once.<br /> \
 Copyright: It is your personal responsibility to verify that you have permission from the copyright holder \
-to upload the file(s) to this web site. Text, graphics and other media files may all be subject to copyright control \
+to upload the file(s) to this website. Text, graphics and other media files may all be subject to copyright control \
 even if your site is restricted to site members.
 instr.url			 = Copy-and-paste or type in the web address (URL) and then click 'Continue' at the bottom.
 instr.urls		 	= Add as many web links (URLs) as you like. If you change your mind about needing one of your web links, click the 'X' icon beside it. Press the 'Add Web Links Now' button when you have finished.


### PR DESCRIPTION
Changed "web site" to "website". This displays in the Upload page of the Resources section.