### PR TITLE
[1376] Add TA rules for filtering the group select list when setting ungraded scores

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -401,10 +401,14 @@ public class AssignmentColumnHeaderPanel extends Panel {
 		} else {
 			final List<PermissionDefinition> permissions = this.businessService.getPermissionsForUser(
 					this.businessService.getCurrentUser().getId());
+			final boolean categoriesEnabled = this.businessService.categoriesAreEnabled();
 			for (PermissionDefinition permission : permissions) {
-				if (assignment.getCategoryId() != null &&
-						assignment.getCategoryId().equals(permission.getCategoryId())) {
-					if (permission.getFunction().equals(GraderPermission.GRADE.toString())) {
+				boolean gradePermission = permission.getFunction().equals(GraderPermission.GRADE.toString());
+ 
+				if (gradePermission) {
+					if ((assignment.getCategoryId() == null && permission.getCategoryId() == null) ||
+						(assignment.getCategoryId() != null &&
+							assignment.getCategoryId().equals(permission.getCategoryId()))) {
 						canEdit = true;
 						break;
 					}


### PR DESCRIPTION
Delivers #1376.

Also fixed "Set Score for Ungraded" menu option not displaying for TAs with GRADE access to an assignment when categories are disabled.