### PR TITLE
SAK-30832 Display user's displayId when multiple found.

### DIFF
--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -878,12 +878,12 @@ public class SiteAddParticipantHandler {
 									// multiple matches
 									for (User user : usersWithEmail)
 									{
-										String eid = user.getEid();
-										eidsForAllMatches.append(eid).append("\n");
-										eidsForAllMatchesAlertBuffer.append(eid).append(", ");
+										String displayId = user.getDisplayId();
+										eidsForAllMatches.append(displayId).append("\n");
+										eidsForAllMatchesAlertBuffer.append(displayId).append(", ");
 										
 										// this is to mark the eid so that it won't be used again for email lookup in the future
-										officialAccountEidOnly.add(eid);
+										officialAccountEidOnly.add(user.getEid());
 									}
 									// trim the alert message
 									String eidsForAllMatchesAlert = eidsForAllMatchesAlertBuffer.toString();


### PR DESCRIPTION
For systems that don’t use displayId the EID is returned instead by the `getDisplayId()` call.