### PR TITLE
SAK-30842 fix JavaScript for cancelling student submission and presenting confirmation dialogue

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
@@ -1,24 +1,25 @@
 var ASN_SVS = ASN_SVS || {};
 
 /* For the cancel button - if the user made progress, we need them to confirm that they want to discard their progress */
-ASN_SVS.confirmDiscardOrSubmit = function(attachmentsModified)
+ASN_SVS.confirmDiscardOrSubmit = function(editorInstanceName, attachmentsModified)
 {
 	var inlineProgress = false;
-	var ckEditor = CKEDITOR.instances["$name_submission_text"];
+	var ckEditor = CKEDITOR.instances[editorInstanceName];
 	if (ckEditor)
 	{
-		inlineProgress = CKEDITOR.instances["$name_submission_text"].checkDirty();
+		inlineProgress = ckEditor.checkDirty();
 	}
 	var showDiscardDialog = inlineProgress || attachmentsModified;
 	var submitPanel = document.getElementById("submitPanel");
 	var confirmationDialogue = document.getElementById("confirmationDialogue");
 	if (showDiscardDialog)
 	{
-		submitPanel.setAttribute('style', 'display:none;');
-		confirmationDialogue.removeAttribute('style');
+		submitPanel.style.display = "none"
+		confirmationDialogue.style.display = "block";
 	}
 	else
 	{
+		SPNR.disableControlsAndSpin( this, null );
 		ASN.submitForm( 'addSubmissionForm', 'cancel', null, null );
 	}
 };
@@ -27,6 +28,6 @@ ASN_SVS.undoCancel = function()
 {
 	var submitPanel = document.getElementById("submitPanel");
 	var confirmationDialogue = document.getElementById("confirmationDialogue");
-	submitPanel.removeAttribute('style');
-	confirmationDialogue.setAttribute('style', 'display:none;');
+	submitPanel.style.display = "block";
+	confirmationDialogue.style.display = "none";
 };

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -1078,7 +1078,7 @@ $(document).ready(function(){
 				<div id="submitPanel"
 					#if ($!deleted.equalsIgnoreCase("true") || !$!canSubmit)
 					 class="act">
-						<input type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.don")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.confirmDiscardOrSubmit(); return false;" />
+						<input type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.don")" onclick="ASN_SVS.confirmDiscardOrSubmit( '$name_submission_text', $!new_attachments ); return false;" />
 					#else
 					 class="act messageInformation">
 								#if ($submitted && $!timeSubmitted)
@@ -1103,7 +1103,7 @@ $(document).ready(function(){
 								<input class="disableme" type="submit" accesskey="x" onClick="SPNR.disableControlsAndSpin( this, null ); window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" />
 							#else
 								<input class="disableme" type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.can")"
-									onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.confirmDiscardOrSubmit(); return false;" />
+									onclick="ASN_SVS.confirmDiscardOrSubmit( '$name_submission_text', $!new_attachments ); return false;" />
 							#end
 
                             #if ($submitted && ($submissionType == 2 || $submissionType == 5) && !$!new_attachments)
@@ -1118,7 +1118,7 @@ $(document).ready(function(){
 			<div id="confirmationDialogue" class="act messageInformation" style="display:none;">
 				$tlang.getString("gen.can.discard")
 				<input class="disableme" type="button" name="yes" accesskey="y" id="yes" value="$tlang.getString("gen.yes")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'cancel', null, null );" />
-				<input class="active" type="button" name="no" accesskey="n" id="no" value="$tlang.getString("gen.no")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.undoCancel();" />
+				<input class="active" type="button" name="no" accesskey="n" id="no" value="$tlang.getString("gen.no")" onclick="ASN_SVS.undoCancel();" />
 			</div>
 		#else
 				#if ($submission.getGradeReleased() && $!submission.FeedbackText && ($submission.FeedbackText.length()>0))
@@ -1248,8 +1248,7 @@ $(document).ready(function(){
 			<input type="submit" accesskey="x" onClick="SPNR.disableControlsAndSpin( this, null ); window.close();" name="eventSubmit_doConfirm_assignment_submission" value="$tlang.getString("gen.closeexit")" class="disableme"/>
 		#else
 			<p class="act">
-				<input type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.don")"
-					onclick="SPNR.disableControlsAndSpin( this, null ); ASN_SVS.confirmDiscardOrSubmit(); return false;" />
+				<input type="button" name="cancel" accesskey="x" id="cancel" value="$tlang.getString("gen.don")" onclick="ASN_SVS.confirmDiscardOrSubmit( '$name_submission_text', $!new_attachments ); return false;" />
 			</p>
 		#end
 		#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30842

Clicking Cancel during an assignment submission where you have started to enter information prompts you with an are you sure confirmation. However, both buttons are disabled. Sometimes the confirmation panel is not displayed at all.