### PR TITLE
SAK-30248 Font for stats label text is white.

### DIFF
--- a/sitestats/sitestats-tool/src/webapp/css/sitestats.css
+++ b/sitestats/sitestats-tool/src/webapp/css/sitestats.css
@@ -84,20 +84,17 @@
 /** STAT WIDGET: Mini panels */
 .widget .ministatContainer {
     margin-left: 100px;
+    display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
+    display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
+    display: -ms-flexbox;      /* TWEENER - IE 10 */
+    display: -webkit-flex;     /* NEW - Chrome */
+    display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
+    flex-direction: row;
 }
 .widget .ministat {
-    min-width: 60px;
-    max-width: 120px;
-    width: auto;
-    width: expression(this.clientWidth<62 ? "60px" :   this.clientWidth>122 ? "120px" : "auto");
-    min-height: 60px;
-    max-height: 60px;
-    height: auto;
-    height: expression(this.clientHeight<62 ? "60px" : "auto");
     padding: 0 10px;
     border-left: 1px solid #CCC;
     text-align: center;
-    float: left;
 }
 .widget .load {
     text-align: center;
@@ -135,12 +132,13 @@
 .widget .ministat .label {
     font-size: 12px;
     font-style:normal;
-    /*color: #777;*//* STAT-224 */
 }
 .widget .ministat a {
     text-decoration: none !important;
     /*color: #777;*//* STAT-224 */
-    line-height: 13px !important;
+    line-height: 1 !important;
+    font-size: 0.9em;
+    display:inline-block;
 }
 .widget .ministat a.extlink,
 .widget .ministat a.extlink span {

--- a/sitestats/sitestats-tool/src/webapp/html/widget/Widget.html
+++ b/sitestats/sitestats-tool/src/webapp/html/widget/Widget.html
@@ -81,7 +81,7 @@
 	        <div wicket:id="value">
 	           <span wicket:id="valueLabel">931</span><span wicket:id="secvalue" class="secvalue">89%</span>
 	        </div>
-	        <a wicket:id="report" class="label">
+	        <a wicket:id="report">
 	          <span wicket:id="label">Visits</span>
 	        </a>
 	      </div>


### PR DESCRIPTION
![statsoverlap](https://cloud.githubusercontent.com/assets/16644575/14602119/7d7b734a-0566-11e6-89c6-473e7e5fa680.png)


![statsfixed](https://cloud.githubusercontent.com/assets/16644575/14602123/849fe37c-0566-11e6-9b50-915f96a49406.png)
