### PR TITLE
SAK-30751 <ol> bullet points are misaligned and missing their numbers

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
+++ b/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
@@ -816,8 +816,15 @@ h6 {
 }
 /* wiki lists */
 ul {padding:.5em;list-style-position:inside;}
+.rwikiRenderedContent ul,.rwiki_renderedContent ul{
+	padding: 0 0 0 2em;
+}
 ul.minus { list-style-type: square }
 ul.star { list-style-type: circle }
+ol {
+	padding: 0 0 0 2em !important;
+}
+ol.decimal { list-style-type: decimal}
 ol.roman { list-style-type: lower-roman }
 ol.ROMAN { list-style-type: upper-roman }
 ol.alpha { list-style-type: lower-alpha }

--- a/rwiki/rwiki-util/radeox/src/java/org/radeox/filter/ListFilter.java
+++ b/rwiki/rwiki-util/radeox/src/java/org/radeox/filter/ListFilter.java
@@ -70,7 +70,7 @@ public class ListFilter extends LocaleRegexTokenFilter implements CacheFilter
 		super();
 		openList.put(new Character('-'), "<ul class=\"minus\">");
 		openList.put(new Character('*'), "<ul class=\"star\">");
-		openList.put(new Character('#'), "<ol>");
+		openList.put(new Character('#'), "<ol class=\"decimal\">");
 		openList.put(new Character('i'), "<ol class=\"roman\">");
 		openList.put(new Character('I'), "<ol class=\"ROMAN\">");
 		openList.put(new Character('a'), "<ol class=\"alpha\">");


### PR DESCRIPTION
This also resolves SAK-30750 bullet points appear outside of page area

![wiki](https://cloud.githubusercontent.com/assets/16644575/14635226/c2da5270-0625-11e6-9cb4-355427ccf412.png)

![wiki2](https://cloud.githubusercontent.com/assets/16644575/14635232/c97ee186-0625-11e6-94f4-7786edc8d079.png)
