### PR TITLE
LSNBLDR-609; allow long names of items

### DIFF
--- a/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/SimplePageItemImpl.java
+++ b/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/SimplePageItemImpl.java
@@ -60,7 +60,7 @@ public class SimplePageItemImpl implements SimplePageItem  {
     public static final int BREAK = 14;
 
     // must agree with definition in hbm file
-	public static final int MAXNAME = 100;
+	public static final int MAXNAME = 255;
 
     // sakaiId used for an item copied from another site with no real content
 	public static final String DUMMY = "/dummy";
@@ -174,6 +174,9 @@ public class SimplePageItemImpl implements SimplePageItem  {
 		    attributes = simplePageToolDao.newJSONObject();
 	}
 
+    // this should seldom truncate anything. The UI makes sure the user can't enter namss that
+    // are too long. The main case this will happen is if we generate a name, which we do for URLs
+    // and uploaded files.
 	private String maxlength(String s, int maxlen) {
 	    if (s == null)
 		s = "";  // oracle turns "" into null


### PR DESCRIPTION
This change removes protection against unreasonably long names. There will be an additional Jira to make sure the UI never generates very long names automatically. Of course if the user adds a 255 char name manually, we'll do it. See the Jira for testing instructions.