### PR TITLE
SAM-2781 fix issue with new QUESTIONS_ORDERING metadata 

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import javax.faces.model.SelectItem;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.math.util.MathUtils;
@@ -496,10 +497,12 @@ public class SectionContentsBean
 
       setSectionAuthorType(SectionDataIfc.QUESTIONS_AUTHORED_ONE_BY_ONE);
     }
-    if (section.getSectionMetaDataByLabel(SectionDataIfc.QUESTIONS_ORDERING) != null)
+
+    // SAM-2781 this was added in Sakai 11 so need to be sure this is a real numeric value
+    String qorderString = section.getSectionMetaDataByLabel(SectionDataIfc.QUESTIONS_ORDERING);
+    if (StringUtils.isNotBlank(qorderString) && StringUtils.isNumeric(qorderString))
     {
-      Integer questionorder = new Integer(section.getSectionMetaDataByLabel(
-        SectionDataIfc.QUESTIONS_ORDERING));
+      Integer questionorder = new Integer(section.getSectionMetaDataByLabel(SectionDataIfc.QUESTIONS_ORDERING));
       setQuestionOrdering(questionorder);
     }
     else

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/ExtractionHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/ExtractionHelper.java
@@ -40,6 +40,7 @@ import java.util.TreeSet;
 import javax.activation.MimetypesFileTypeMap;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.component.cover.ServerConfigurationService;
@@ -1517,7 +1518,18 @@ public class ExtractionHelper
     section.addSectionMetaData(SectionMetaDataIfc.KEYWORDS, (String) sectionMap.get("keyword"));
     section.addSectionMetaData(SectionMetaDataIfc.OBJECTIVES, (String) sectionMap.get("objective"));
     section.addSectionMetaData(SectionMetaDataIfc.RUBRICS, (String) sectionMap.get("rubric"));
-    section.addSectionMetaData(SectionDataIfc.QUESTIONS_ORDERING, (String) sectionMap.get("questions-ordering"));
+
+    // SAM-2781: if you are importing from before Sakai 11, this will be null
+    String qorderString = (String) sectionMap.get("questions-ordering");
+    if (StringUtils.isNotBlank(qorderString) && StringUtils.isNumeric(qorderString))
+    {
+      section.addSectionMetaData(SectionDataIfc.QUESTIONS_ORDERING, qorderString);
+    }
+    else
+    {
+      section.addSectionMetaData(SectionDataIfc.QUESTIONS_ORDERING, SectionDataIfc.AS_LISTED_ON_ASSESSMENT_PAGE.toString());
+    }
+
   }
 
   /**


### PR DESCRIPTION
as pre-Sakai 11 wont have this metadata. So set a default if it doesn't exist.

Bug seemed to be introduced in #1853 