### PR TITLE
SAK-30890 - /direct results in an error page

### DIFF
--- a/entitybroker/utils/src/java/org/sakaiproject/entitybroker/util/servlet/DirectServlet.java
+++ b/entitybroker/utils/src/java/org/sakaiproject/entitybroker/util/servlet/DirectServlet.java
@@ -146,12 +146,16 @@ public abstract class DirectServlet extends HttpServlet {
     protected void handleRequest(HttpServletRequest req, HttpServletResponse res)
             throws ServletException, IOException {
         // catch the login helper posts
-        String option = req.getPathInfo();
-        String[] parts = option.split("/");
-        if ((parts.length == 2) && ((parts[1].equals("login")))) {
-            handleUserLogin(req, res, null);
-        } else {
-            dispatch(req, res);
+        // Note that with wrapped requests, URLUtils.getSafePathInfo may return null
+        // so we use the request URI
+        String uri = req.getRequestURI();
+        if ( uri != null ) {
+            String[] parts = uri.split("/");
+            if ((parts.length == 2) && ((parts[1].equals("login")))) {
+                handleUserLogin(req, res, null);
+            } else {
+                dispatch(req, res);
+            }
         }
     }
 


### PR DESCRIPTION
There are some other calls to req.getPathInfo in entitybroker (And elsewhere) and I'm not sure if those are problematic either. I guess if any call tries to call this and dereference it without a null check it could be an issue.