### PR TITLE
2297 if a TA only has one group, don't show the dropdown, 

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -247,6 +247,7 @@ sortbyname.option.last = Order By Last Name
 students.menulabel = Open menu for the students column
 
 groups.all = All Sections/Groups
+groups.available = Available Sections/Groups
 categories.all = All Categories
 
 label.nocategoryscore = -

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -28,6 +28,9 @@
             <option value="2">Section 2</option>
           </select>
         </li>
+        <wicket:enclosure>
+        	<li><span wicket:id="groupFilterOnlyOne" class="gb-group-title" role="status">Section 001</span></li>
+        </wicket:enclosure>
         <li><span wicket:id="studentSummary" class="gradebook-student-summary" role="status">Showing 20 of 25 Students</span></li>
       </ul>
       <ul class="gb-toolbar-right">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -512,8 +512,26 @@ public class GradebookPage extends BasePage {
 		// section and group dropdown
 		final List<GbGroup> groups = this.businessService.getSiteSectionsAndGroups();
 
-		// add the default ALL group to the list
-		groups.add(0, new GbGroup(null, getString("groups.all"), null, GbGroup.Type.ALL));
+		// if only one group, just show the title
+		// otherwise add the 'all groups' option
+		if (groups.size() == 1) {
+			this.form.add(new Label("groupFilterOnlyOne", Model.of(groups.get(0).getTitle())));
+		} else {
+			this.form.add(new EmptyPanel("groupFilterOnlyOne").setVisible(false));
+
+			// add the default ALL group to the list
+			String allGroupsTitle = getString("groups.all");
+			if (this.role == GbRole.TA) {
+
+				// does the TA have any permissions set?
+				// we can assume that if they have any then there is probably some sort of group restriction so we can change the label
+				if (!this.businessService.getPermissionsForUser(this.currentUserUuid).isEmpty()) {
+					allGroupsTitle = getString("groups.available");
+				}
+			}
+			groups.add(0, new GbGroup(null, allGroupsTitle, null, GbGroup.Type.ALL));
+
+		}
 
 		final DropDownChoice<GbGroup> groupFilter = new DropDownChoice<GbGroup>("groupFilter", new Model<GbGroup>(), groups,
 				new ChoiceRenderer<GbGroup>() {
@@ -552,6 +570,12 @@ public class GradebookPage extends BasePage {
 		// set selected group, or first item in list
 		groupFilter.setModelObject((settings.getGroupFilter() != null) ? settings.getGroupFilter() : groups.get(0));
 		groupFilter.setNullValid(false);
+
+		// if only one item, hide the dropdown
+		if (groups.size() == 1) {
+			groupFilter.setVisible(false);
+		}
+
 		this.form.add(groupFilter);
 
 		final ToggleGradeItemsToolbarPanel gradeItemsTogglePanel = new ToggleGradeItemsToolbarPanel("gradeItemsTogglePanel",

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -1113,3 +1113,8 @@ and (max-device-width : 736px) {
     display: none !important;
   }
 }
+
+.gb-group-title {
+	font-weight: bold;
+	line-height: 3em;
+}


### PR DESCRIPTION
... show the group title as a label instead. if a TA has any permissions, assume restricted access so show 'Available Sections/Groups' as the all groups title instead.

Fixes #2297

![screen shot 2016-04-21 at 11 24 38 pm](https://cloud.githubusercontent.com/assets/129129/14710373/7ae3504e-0818-11e6-8a93-d5712a434799.png)

