### PR TITLE
SAK-29427: Add properties to it if webdav-copying a reading list

### DIFF
--- a/citations/citations-api/api/src/java/org/sakaiproject/citation/api/CitationService.java
+++ b/citations/citations-api/api/src/java/org/sakaiproject/citation/api/CitationService.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.osid.repository.Asset;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
+import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.exception.IdUnusedException;
 
 import org.sakaiproject.citation.api.Citation;
@@ -190,6 +191,11 @@ public interface CitationService extends EntityProducer
      * @param citation
      */
     public void save(Citation citation);
+	/**
+	 * This method copies a collection and all the citations it contains.
+	 * @param reference The reference of the content resource to copy
+	 */
+	public void copyCitationCollection(Reference reference);
 
 	/**
      * 

--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -5703,7 +5703,7 @@ public abstract class BaseCitationService implements CitationService
 	/**
      * @param reference
      */
-    private void copyCitationCollection(Reference reference)
+    public void copyCitationCollection(Reference reference)
     {
         ContentHostingService contentService = (ContentHostingService) ComponentManager.get(ContentHostingService.class);
 		try

--- a/dav/dav/pom.xml
+++ b/dav/dav/pom.xml
@@ -37,6 +37,10 @@
             <groupId>org.sakaiproject</groupId>
             <artifactId>sakai-dav-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.sakaiproject</groupId>
+            <artifactId>sakai-citations-api</artifactId>
+        </dependency>
         <!-- in tomcat common, so no need to bundle -->
 <!--
         <dependency>

--- a/dav/dav/src/java/org/sakaiproject/dav/DavServlet.java
+++ b/dav/dav/src/java/org/sakaiproject/dav/DavServlet.java
@@ -118,6 +118,8 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.catalina.util.DOMWriter;
 import org.apache.tomcat.util.buf.UDecoder;
+import org.sakaiproject.citation.api.CitationService;
+import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.dav.MD5Encoder;
 import org.apache.catalina.util.XMLWriter;
 import org.apache.commons.logging.Log;
@@ -547,6 +549,10 @@ public class DavServlet extends HttpServlet
 
 	private ContentHostingService contentHostingService;
 
+	private CitationService citationService;
+
+	private org.sakaiproject.entity.api.EntityManager entityManager;
+
 	private AliasService aliasService;
 
 	// --------------------------------------------------------- Public Methods
@@ -557,6 +563,8 @@ public class DavServlet extends HttpServlet
 	public void init() throws ServletException
 	{
 		contentHostingService = (ContentHostingService) ComponentManager.get(ContentHostingService.class.getName());
+		citationService = ComponentManager.get(CitationService.class);
+		entityManager = ComponentManager.get(org.sakaiproject.entity.api.EntityManager.class);
 		aliasService = ComponentManager.get(AliasService.class);
 
 		// Set our properties from the initialization parameters
@@ -1879,7 +1887,9 @@ public class DavServlet extends HttpServlet
 				else
 				{
 					// Similar to handleAccessResource() in BaseContentService.java
-					
+
+					req.getSession().setAttribute("resourceType", resource.getResourceType());
+
 					contentStream = resource.streamContent();
 
 					if (contentStream == null || len == 0)
@@ -2777,6 +2787,13 @@ public class DavServlet extends HttpServlet
 			if (newfile)
 			{
 				edit = contentHostingService.addResource(resourcePath);
+
+				String resourceType = (String) req.getSession().getAttribute("resourceType");
+				if ("org.sakaiproject.citation.impl.CitationList".equalsIgnoreCase(resourceType))
+				{
+					edit.setResourceType(resourceType);
+					edit.getProperties().addProperty(ContentHostingService.PROP_ALTERNATE_REFERENCE, "/citation");
+				}
 				final ResourcePropertiesEdit p = edit.getPropertiesEdit();
 				p.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
 
@@ -2799,6 +2816,13 @@ public class DavServlet extends HttpServlet
 
 			// commit the change
 			contentHostingService.commitResource(edit, NotificationService.NOTI_NONE);
+
+			if ("org.sakaiproject.citation.impl.CitationList".equalsIgnoreCase(edit.getResourceType()))
+			{
+				Reference reference = entityManager.newReference(edit.getReference());
+				citationService.copyCitationCollection(reference);
+			}
+
 
 		}
 		catch (IdUsedException e)


### PR DESCRIPTION
This is really two related changes to allow a reading list to be copied by webdav.  When you drag a reading list from one webdav client to another (e.g., in an attempt to copy it from one site to another), the doContent() method in DavServlet.java is first called, then the doPut() method.  I'm putting the resourceType in the session in the doContent() method (which might say that it's a reading list we're dealing with) and then in the doPut() method I'm reading this value and if it's a reading list, then I'm adding various properties to it to make it a reading list like adding '/citation' in the URL for accessing it and adding the CITATION_COLLECTION and CITATION_CITATIONs that accompany it.    