### PR TITLE
SAK-30228 Citation with a link to file in FilePicker will be of type

### DIFF
--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -4022,7 +4022,8 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 						ContentResource resource = contentService.getResource(resourceId);
 						ResourceProperties props = resource.getProperties();
 						String displayName = props.getProperty(ResourceProperties.PROP_DISPLAY_NAME);
-						citation = citationService.addCitation("unknown");
+						//As this citation will always have resource url so it should be of type 'electronic' not 'unknown'
+						citation = citationService.addCitation("electronic");
 						citation.setDisplayName(displayName);
 						citation.setCitationProperty("resourceId", resourceId);
 						String urlId = citation.addCustomUrl(resource.getUrl(), resource.getUrl());


### PR DESCRIPTION
electronic.

Previous fix got overridden because of the reimplementation of citations
Picker to use Resources's Picker Helper.