### PR TITLE
SAM-2842 Add documentation for samigo.convertMedia

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2976,6 +2976,18 @@
 # DEFAULT: true
 # samigo.saveMediaToDb=false
 
+# If saveMediaToDb has been set to false but there are existing Samigo media
+# files stored in the database, set samigo.convertMedia to true to trigger a
+# conversion on startup that moves those files out of the database and onto
+# the file system.
+# This uses batching to be safe for restarts or multiple
+# nodes. Records are processed in batches of 10. If a batch is
+# interrupted, records may be left with the value of "CONVERTING" in the
+# location field. To re-initiate these, that field should be set to null
+# for those records.
+# DEFAULT: false
+# samigo.convertMedia=true
+
 # DEFAULT: {sakai.home}/samigo/answerUploadRepositoryPath/
 # samigo.answerUploadRepositoryPath=${sakai.home}/samigo/answerUploadRepositoryPath/
 


### PR DESCRIPTION
A brief explanation was added to default.sakai.properties to inform
users how to migrate existing samigo media files out of the database.