### PR TITLE
SAK-30996 Reorder screen - display issues with column headers

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
@@ -1,6 +1,6 @@
 <script type="text/javascript" src="/library/js/fluid/1.5/MyInfusion.js"></script>
 <script type="text/javascript" src="/library/js/reorderer.js"></script>
-<div class="portletBody">
+<div class="portletBody container-fluid">
 	#if($menu && $EnabledMenuItemExists)
 			#toolbar($menu)
 	#end
@@ -43,7 +43,8 @@
 		<span id="lastMoveArrayInit" style="display:none"></span>
 		<span id="lastItemMoved"  style="display:none"></span>
 		<form name="announcementListForm" action="#toolForm("AnnouncementAction")" method="post">
-			<div id="reorder-list-sortingToolBar" class=" itemAction">
+			<div id="reorder-list-sortingToolBar" class=" row itemAction">
+				<div class="col-md-4 col-sm-4 col-xs-12">
 					#if (!$currentSortedBy.equals("subject"))
 						<a href="#" class="title" onclick="location='#toolLink("AnnouncementAction" "doSortbysubject")';return false;"  title ="$tlang.getString('gen.sortby')">$tlang.getString('gen.sortby')</a>
 					#else
@@ -53,7 +54,8 @@
 							<a href="#"  class="title" onclick="location='#toolLink("AnnouncementAction" "doSortbysubject")';return false;"  title ="$tlang.getString('gen.sortbydesc')">$tlang.getString('gen.sortby') <img src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString('gen.sortbydesc')"/></a>
 						#end
 					#end
-					|
+				</div>
+				<div class="col-md-2 col-sm-2 col-xs-12">
 					#if (!$currentSortedBy.equals("from"))
 						<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyfrom")';return false;"  title ="$tlang.getString('gen.sortbyauth')">$tlang.getString('gen.sortbyauth')</a>
 					#else
@@ -63,7 +65,8 @@
 							<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyfrom")';return false;"  title ="$tlang.getString('gen.sortbyauthdesc')">$tlang.getString('gen.sortbyauth') <img src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString('gen.sortbyauthdesc')"/></a>
 						#end
 					#end
-					|
+				</div>
+				<div class="col-md-2 col-sm-2 col-xs-12">
 					#if (!$currentSortedBy.equals("releasedate"))
 						<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyreleasedate")';return false;"  title="$tlang.getString('gen.sortbyreleasedate')">$tlang.getString('gen.sortbyreleasedate')</a>
 					#else
@@ -73,7 +76,8 @@
 							<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyreleasedate")';return false;"  title="$tlang.getString('gen.sortbyreleasedatedesc')">$tlang.getString('gen.sortbyreleasedate') <img src = "#imageLink("sakai/sortdescending.gif")" border="0" alt ="$tlang.getString('gen.sortbyreleasedatedesc')" /></a>
 						#end
 					#end
-					|
+				</div>
+				<div class="col-md-2 col-sm-2 col-xs-12">
 					#if (!$currentSortedBy.equals("retractdate"))
 						<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyretractdate")';return false;"  title="$tlang.getString('gen.sortbyretractdate')">$tlang.getString('gen.sortbyretractdate')</a>
 					#else
@@ -83,7 +87,8 @@
 							<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyretractdate")';return false;"  title="$tlang.getString('gen.sortbyretractdatedesc')">$tlang.getString('gen.sortbyretractdate') <img src = "#imageLink("sakai/sortdescending.gif")" border="0" alt ="$tlang.getString('gen.sortbyretractdatedesc')" /></a>
 						#end
 					#end
-					|
+				</div>
+				<div class="col-md-2 col-sm-2 col-xs-12">
 					#if (!$currentSortedBy.equals("date"))
 						<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbydate")';return false;"  title="$tlang.getString('gen.sortbydate')">$tlang.getString('gen.sortbydate')</a>
 					#else
@@ -94,23 +99,24 @@
 						#end
 					#end
 				</div>
+			</div>
 				<ul id="reorder-list">
 
 				#set($count = 0)
 				#foreach ($ann_item in $showMessagesList)
 					#set($ann_item_props=$ann_item.getProperties())
-					<li #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft) id="listitem.orderable$count">
+					<li #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft) id="listitem.orderable$count" class="row">
 							<span style="display:none" class="grabHandle">
 							<input type="text" size="3" value="$count" id="index$count" style="z-index:5"/>
 							<input type="hidden" size="3" id="holder$count"  value="$count"/>
 						</span>	
-						<span class="title">
+						<span class="title col-md-4 col-sm-4 col-xs-12">
 							$validator.escapeHtml($validator.limit($ann_item.Header.subject, 45))
 						</span>
-						<span class="author">
+						<span class="author col-md-2 col-sm-2 col-xs-12">
 							$validator.escapeHtml($ann_item.Header.From.DisplayName)
 						</span>
-						<span  class="date"> 
+						<span  class="date col-md-2 col-sm-2 col-xs-12"> 
 							$ann_item.Header.Date.toStringLocalFull()
 						</span>
 						#set ($ref = $entityManager.newReference($ann_item.Reference))

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
@@ -47,61 +47,65 @@
 		<span id="lastMoveArrayInit" style="display:none"></span>
 		<span id="lastItemMoved"  style="display:none"></span>
 
-		<div id="reorder-list-sortingToolBar" class="itemAction">
-			<a class="title" id="sortByTitle" href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
-					$tlang.getString("listassig.sorbytit")
-					#if ($sortedBy.equals("title"))
-						#if ($sortedAsc.equals("true"))
-							<img id="sortascendingtitle" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
-						#else
-							<img id="sortdescendingtitle" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
+		<div id="reorder-list-sortingToolBar" class="itemAction row">
+			<div class="col-md-6 col-sm-6 col-xs-12">
+				<a class="title" id="sortByTitle" href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
+						$tlang.getString("listassig.sorbytit")
+						#if ($sortedBy.equals("title"))
+							#if ($sortedAsc.equals("true"))
+								<img id="sortascendingtitle" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
+							#else
+								<img id="sortdescendingtitle" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
+							#end
 						#end
-					#end
-				</a>
-				|
-				<a href="javascript:void(0)" id="sortByOpenDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=opendate")'; return false;"  title="$tlang.getString("listassig.sorbyope")">
-					$tlang.getString("listassig.sorbyope")
-					#if ($sortedBy.equals("opendate"))
-						#if ($sortedAsc.equals("true"))
-							<img id="sortascendingopendate" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
-						#else
-							<img id="sortdescendingopendate" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
-						#end
-					#end
-				</a>
-				|
-				<a href="javascript:void(0)" id="sortByDueDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=duedate")'; return false;"  title="$tlang.getString("gen.sorbydue")">
-					$tlang.getString("gen.sorbydue") ##$tlang.getString("gen.due1")
-					#if ($sortedBy.equals("duedate"))
-						#if ($sortedAsc.equals("true"))
-							<img id="sortascendingduedate" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
-						#else
-							<img id="sortdescendingduedate" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
-						#end
-					#end
 				</a>
 			</div>
+			<div class="col-md-3 col-sm-3 col-xs-12">
+					<a href="javascript:void(0)" id="sortByOpenDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=opendate")'; return false;"  title="$tlang.getString("listassig.sorbyope")">
+						$tlang.getString("listassig.sorbyope")
+						#if ($sortedBy.equals("opendate"))
+							#if ($sortedAsc.equals("true"))
+								<img id="sortascendingopendate" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
+							#else
+								<img id="sortdescendingopendate" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
+							#end
+						#end
+					</a>
+			</div>
+			<div class="col-md-3 col-sm-3 col-xs-12">
+					<a href="javascript:void(0)" id="sortByDueDate" onclick="location='#toolLinkParam("$action" "doSort" "criteria=duedate")'; return false;"  title="$tlang.getString("gen.sorbydue")">
+						$tlang.getString("gen.sorbydue") ##$tlang.getString("gen.due1")
+						#if ($sortedBy.equals("duedate"))
+							#if ($sortedAsc.equals("true"))
+								<img id="sortascendingduedate" src = "#imageLink("sakai/sortascending.gif")" border="0" alt="$tlang.getString("gen.sorasc")" />
+							#else
+								<img id="sortdescendingduedate" src = "#imageLink("sakai/sortdescending.gif")" border="0" alt="$tlang.getString("gen.sordes")" />
+							#end
+						#end
+					</a>
+			</div>
+		</div>
 
 		<ul id="reorder-list">
 
 			#set($count = 1)
 			#foreach($assignment in $assignments)
 
-			<li class="sortable"  id="listitem.orderable$count">
+			<li class="sortable row"  id="listitem.orderable$count">
 				<span style="display:none" class="grabHandle">
 					<input type="text" size="3" value="$count" id="index$count"/>
 					<input type="hidden"  size="3" id="holder$count"  value="$count" tabindex="-2"/>
 				</span>
-				<span class="title">
+				<span class="title col-md-6 col-sm-6 col-xs-12">
 					#if ($!assignment.draft)
 						<em class="highlight" style="font-style:normal">$tlang.getString("gen.dra2")</em>
 					#end
 					$validator.escapeHtml($validator.limit($!assignment.getTitle(), 45))
 				</span>
-				<span class="open">
+				<span class="col-md-3 col-sm-3 col-xs-12">
 					$!assignment.openTime.toStringLocalFull()
 				</span>
-				<span class="close">
+				<span class="col-md-3 col-sm-3 col-xs-12">
 					$!assignment.dueTime.toStringLocalFull()
 					<select name="position_$validator.escapeUrl("$assignment.id")" class="selectSet">
 						#foreach($i in [1..$assignmentsize])

--- a/reference/library/src/morpheus-master/sass/modules/tool/announcements/_announcements.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/announcements/_announcements.scss
@@ -29,4 +29,8 @@
 	.merge-list{
 		max-width: 1000px;
 	}
+	
+	#reorder-list-sortingToolBar, #reorder-list{
+		max-width: 1200px;
+	}	
 }

--- a/reference/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
@@ -43,4 +43,8 @@
 			display: inline-block;
 		}		
 	}
+	
+	#reorder-list-sortingToolBar, #reorder-list{
+		max-width: 1200px;
+	}
 }

--- a/reference/library/src/webapp/skin/tool_base.css
+++ b/reference/library/src/webapp/skin/tool_base.css
@@ -759,7 +759,6 @@ span.nil a{
 	background:#ffe;
 	margin:1em 0;
 	padding:5px;
-	width:90%
 }
 #reorder-list-sortingToolBar a{
 	outline:none;
@@ -768,7 +767,6 @@ span.nil a{
 	font-size:.9em;	
 	margin:0;
 	padding:0;
-	width:90%
 }
 #reorder-list li {
 	list-style:none;
@@ -794,9 +792,7 @@ span.nil a{
 #reorder-list li .title{
 	display:block;
 	float:left;
-	width:45%;
-    overflow: hidden;
-    white-space: nowrap;
+	white-space: nowrap;
 	}
 #reorder-list li span{
 	padding-right:2em;


### PR DESCRIPTION
This also solves SAK-31016 Reorder screen (Announcements)- display issues with column headers, due date text

![assign01](https://cloud.githubusercontent.com/assets/16644575/14780329/bb3dfdbc-0adc-11e6-9b0e-9969445772b0.png)

![assign02](https://cloud.githubusercontent.com/assets/16644575/14780332/bebb4166-0adc-11e6-9965-17f834c228c3.png)

![announ01](https://cloud.githubusercontent.com/assets/16644575/14780338/c1fa232e-0adc-11e6-9f57-cb6bf40b8df2.png)

![announ02](https://cloud.githubusercontent.com/assets/16644575/14780342/c50ddca4-0adc-11e6-81ac-58396d0dae9c.png)
