### PR TITLE
SAK-31019 create input element of original type when applying spinner

### DIFF
--- a/reference/library/src/webapp/js/spinner.js
+++ b/reference/library/src/webapp/js/spinner.js
@@ -278,7 +278,7 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
 
     // Now create a new disabled button with the same attributes as the existing button
     var newElement;
-    if( activateSpinner )
+    if( element.type === "submit" )
     {
         newElement = document.createElement( "button" );
     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31019

The spinner algorithm was creating the new element as a type of button erroneously in certain situations. The fix is to create the new element of the same type as the original, except if the original type is 'submit'.