### PR TITLE
SAK-30952 Show instructions for the hidden sites preference

### DIFF
--- a/user/user-tool-prefs/tool/src/bundle/user-tool-prefs.properties
+++ b/user/user-tool-prefs/tool/src/bundle/user-tool-prefs.properties
@@ -126,3 +126,4 @@ userPrefs=User Preference Values
 userPrefs.action.key=The action takes user id, and key value, and returns user preference property settings for that key. Here is the request url pattern: /direct/userPrefs/key/{user_id}/{key_value}.json with parameters
 
 hidden_really_hide_confirm=Hiding a favorite site will remove it from your favorites. Do you wish to continue?
+hidden_instructions=Select a site or grouping of sites to hide from the Site Drawer.<br /><b>NOTE:</b> This will <b>not</b> affect the visibility of a site to students.

--- a/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
@@ -61,6 +61,7 @@
                                 </h:panelGroup>
                         </h3>
 
+                        <p class="instruction"><h:outputText value="#{msgs.hidden_instructions}" escape="false" /></p>
 
                         <h:outputText value="#{Portal.latestJQuery}" escape="false"/>
 


### PR DESCRIPTION
Introduces a new `hidden_instructions` I18N key that will need
localization.