### PR TITLE
SAK-30638 Shading of items is confusing in student view of grades

### DIFF
--- a/gradebook/app/ui/src/webapp/css/gradebook.css
+++ b/gradebook/app/ui/src/webapp/css/gradebook.css
@@ -142,8 +142,8 @@ td.gbMessageAboveNumber {vertical-align:top; text-align:right; padding-right:2em
 }
 
 .categoryHeading {
-	font-size: 1.1em;
-	font-weight: bold;
+	font-size: 1.1em !important;
+	font-weight: bold !important;
 }
 
 .gradebookItem {


### PR DESCRIPTION
I think this is enough, background-color of the rows could be better but i think is not a priority right now. With this change it´s easy to see to wich category belongs each gradebook item.


![](https://jira.sakaiproject.org/secure/attachment/44429/03.28.2016-11.55.png)

![grade01](https://cloud.githubusercontent.com/assets/16644575/14817337/f03fe1e4-0bb6-11e6-846e-ceb8c58d4c22.png)
