### PR TITLE
SAK-30631; Ajax not working, displays link rather than calling it

### DIFF
--- a/mailsender/tool/src/webapp/content/js/mailsender.js
+++ b/mailsender/tool/src/webapp/content/js/mailsender.js
@@ -284,7 +284,7 @@ var RcptSelect = function()
 	 */
 	function _safeId(type, id)
 	{
-	    return type + '[id=' + id + ']';
+	    return type + '[id="' + id + '"]';
 	}
 
 	return {


### PR DESCRIPTION
subtle change in jquery, requires quotes in selectors of form [id="foo"]. Apparently they used to be optional.