### PR TITLE
SAK-31068 Add Forums Import As Draft setting

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -1258,7 +1258,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 						nMessageHeader.setDate(oMessageHeader.getDate());
 						nMessageHeader.setMessage_order(oMessageHeader.getMessage_order());
 						// when importing, refer to property to determine draft status
-						if ("false".equalsIgnoreCase(m_serverConfigurationService.getString("import.importAsDraft")))
+						if (!m_serverConfigurationService.getBoolean("import.importAsDraft", true))
 						{
 							nMessageHeader.setDraft(oMessageHeader.getDraft());
 						}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -6601,7 +6601,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 							} // for
 
  							// when importing, refer to property to determine draft status
-							if ("false".equalsIgnoreCase(m_serverConfigurationService.getString("import.importAsDraft")))
+							if (!m_serverConfigurationService.getBoolean("import.importAsDraft", true))
 							{
 								String draftAttribute = el2clone.getAttribute("draft");
 								if (draftAttribute.equalsIgnoreCase("true") || draftAttribute.equalsIgnoreCase("false"))
@@ -6767,7 +6767,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 							nAssignment.setContext(toContext);
 							
  							// when importing, refer to property to determine draft status
-							if ("false".equalsIgnoreCase(m_serverConfigurationService.getString("import.importAsDraft")))
+							if (!m_serverConfigurationService.getBoolean("import.importAsDraft", true))
 							{
 								nAssignment.setDraft(oAssignment.getDraft());
 							}

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1772,6 +1772,12 @@
 # DEFAULT: use the categories defined in the tool xml file 
 # tool.categories.{toolid}=category1,category2,category3 
 
+# Controls whether when importing / duplicating a site to have them be as draft
+# Applies to announcements, assignments, and messages
+# msgcntr has own property of msgcntr.forums.import.importAsDraft
+# DEFAULT: true
+# import.importAsDraft=false
+
 # GRADEBOOK 1
 # Controls the display of the number of decimal points for the class average. 
 # In Gradebook Items -> {click on an item}. 
@@ -3845,6 +3851,11 @@
 # Setting to true risks abuse by maintainers.
 # DEFAULT: false
 # msgcntr.forums.revealIDsToRoles.revisable=false
+
+# SAK-31068 Configure forums Import / Duplication behavior
+# By default, will set imported objects in Draft mode
+# DEFAULT: true
+# msgcntr.forums.import.importAsDraft=false
 
 ## SAK-19178
 # Should we load the initial jobs on startup.

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -1979,7 +1979,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 												}
 												// TODO: reall want a draft? -ggolden
 												// set draft status based upon property setting
-												if ("false".equalsIgnoreCase(m_serverConfigurationService.getString("import.importAsDraft")))
+												if (!m_serverConfigurationService.getBoolean("import.importAsDraft", true))
 												{
 													String draftAttribute = element4.getAttribute("draft");
 													if (draftAttribute.equalsIgnoreCase("true") || draftAttribute.equalsIgnoreCase("false"))

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -517,7 +517,7 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 						Area area = areaManager.getDiscussionArea(toContext, false);
 						newForum.setArea(area);
 
-						if ("false".equalsIgnoreCase(ServerConfigurationService.getString("import.importAsDraft")))
+						if (getImportAsDraft())
 						{
 							forumManager.saveDiscussionForum(newForum, newForum.getDraft().booleanValue());
 						}
@@ -923,7 +923,7 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 													{
 														Area area = areaManager.getDiscussionArea(siteId);
 														dfForum.setArea(area);
-														if ("false".equalsIgnoreCase(ServerConfigurationService.getString("import.importAsDraft")))
+														if (getImportAsDraft())
 														{
 															forumManager.saveDiscussionForum(dfForum, dfForum.getDraft().booleanValue());
 														}
@@ -944,7 +944,7 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 										{
 											Area area = areaManager.getDiscussionArea(siteId);
 											dfForum.setArea(area);
-											if ("false".equalsIgnoreCase(ServerConfigurationService.getString("import.importAsDraft")))
+											if (getImportAsDraft())
 											{
 												forumManager.saveDiscussionForum(dfForum, dfForum.getDraft().booleanValue());
 											}
@@ -1360,5 +1360,8 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 		return msgBody;		
 	}
 
+	private Boolean getImportAsDraft() {
+		return ServerConfigurationService.getBoolean("msgcntr.forums.import.importAsDraft", true);
+	}
 
 }

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -517,7 +517,7 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 						Area area = areaManager.getDiscussionArea(toContext, false);
 						newForum.setArea(area);
 
-						if (getImportAsDraft())
+						if (!getImportAsDraft())
 						{
 							forumManager.saveDiscussionForum(newForum, newForum.getDraft().booleanValue());
 						}
@@ -923,7 +923,7 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 													{
 														Area area = areaManager.getDiscussionArea(siteId);
 														dfForum.setArea(area);
-														if (getImportAsDraft())
+														if (!getImportAsDraft())
 														{
 															forumManager.saveDiscussionForum(dfForum, dfForum.getDraft().booleanValue());
 														}
@@ -944,7 +944,7 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 										{
 											Area area = areaManager.getDiscussionArea(siteId);
 											dfForum.setArea(area);
-											if (getImportAsDraft())
+											if (!getImportAsDraft())
 											{
 												forumManager.saveDiscussionForum(dfForum, dfForum.getDraft().booleanValue());
 											}

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -1361,7 +1361,8 @@ public class DiscussionForumServiceImpl  implements DiscussionForumService, Enti
 	}
 
 	private Boolean getImportAsDraft() {
-		return ServerConfigurationService.getBoolean("msgcntr.forums.import.importAsDraft", true);
+		boolean importAsDraft = ServerConfigurationService.getBoolean("import.importAsDraft", true);
+		return ServerConfigurationService.getBoolean("msgcntr.forums.import.importAsDraft", importAsDraft);
 	}
 
 }


### PR DESCRIPTION
This feature allows the forums tool to have it's own importAsDraft
functionality.

I also added the import.importAsDraft property into the default.sakai.properties as it was missing.
