### PR TITLE
SAK-30749 Link & help icons are not on same line as tool tabs

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
@@ -113,22 +113,6 @@ LOG-LOG-LOG-LOG-LOG
 
 #macro( commandlinks $useHomeLink $usePrinterLink $useViewLink $viewLinkName $useEditLink $useInfoLink $useHistoryLink $useWatchLink $withNotification $homeBean $viewBean $resourceLoaderBean )
 ## <span class="rwiki_pageLinks">
-#if ($usePrinterLink) 
-<li><div class="printLinks">
-<span style="border:none">
-<a href="${util.escapeHtml($viewBean.getRssAccessUrl())}"
-	target="rssfeed" 
-	id="rssLink"  
-	title="${resourceLoaderBean.getString("jsp_rss_feed_changes")}" >&nbsp;</a> 
-</span>
-<span>
-<a href="${util.escapeHtml($viewBean.getPrintViewUrl())}"
-	target="_blank" 
-	id="printerFriendlyLink"  
-	title="${resourceLoaderBean.getString("jsp_printer_friendly")}" >&nbsp;</a> 
-</span></div></li>
-
-#end
 
 #if ( !$viewLinkName )
 #set( $viewLinkName = $resourceLoaderBean.getString("jsp_view"));


### PR DESCRIPTION

![](https://jira.sakaiproject.org/secure/attachment/44611/rwiki1.png)

![wiki02](https://cloud.githubusercontent.com/assets/16644575/14879466/b4607c50-0d29-11e6-9379-0fe6514b23ed.png)
