### PR TITLE
2381: if no category, then don't ask the service for the category average

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -90,11 +90,15 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 						categoryNames.add(categoryName);
 						categoryNamesToAssignments.put(categoryName, new ArrayList<Assignment>());
 
-						final Double categoryAverage = this.businessService.getCategoryScoreForStudent(assignment.getCategoryId(), userId);
-						if (categoryAverage == null || categoryName.equals(GradebookPage.UNCATEGORISED)) {
+						if (assignment.getCategoryId() == null) {
 							categoryAverages.put(categoryName, getString("label.nocategoryscore"));
 						} else {
-							categoryAverages.put(categoryName, FormatHelper.formatDoubleAsPercentage(categoryAverage));
+							final Double categoryAverage = this.businessService.getCategoryScoreForStudent(assignment.getCategoryId(), userId);
+							if (categoryAverage == null) {
+								categoryAverages.put(categoryName, getString("label.nocategoryscore"));
+							} else {
+								categoryAverages.put(categoryName, FormatHelper.formatDoubleAsPercentage(categoryAverage));
+							}
 						}
 					}
 


### PR DESCRIPTION
Delivers #2381.

I've fixed this in the GradebookNG panel by not bothering to ask the service for a category average when the category is `null`.

It turns out `private Double calculateCategoryScore(String studentUuid, Long categoryId, List<AssignmentGradeRecord> gradeRecords)` returns average of all categorised assignments when `categoryId` is null.  My guess is that nobody ever hits this endpoint with `null`, but I was hesitant to jump in and patch it.  I'm happy to explore a patch if you think it's worthwhile?  

... this seems to fix the service:
```
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3066,7 +3066,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
                        log.debug("No grade records for student: " + studentUuid + ". Nothing to do.");
                        return null;
                }

+               if (categoryId == null) {
+                       return null;
+               }
+
                //setup
                int numScored = 0;
                int numOfAssignments = 0;
```
Let me know if you think it's worth the risk.. I assume this endpoint is hit by other consumers?