### PR TITLE
1701: add less obtrusive message for saving..., saved, and when there's an error setting a score value

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -397,3 +397,7 @@ coursegrade.option.hidepoints = Hide points
 
 link.coursegradeoverride.revert.tooltip = Removes the course grade override and reverts to the calculated course grade
 link.coursegradeoverride.reverttocalculated = Revert to calculated course grade
+
+feedback.saving = Saving...
+feedback.saved = All changes saved.
+feedback.error = Errors were detected. See cell notifications below.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -12,6 +12,7 @@
 
     <div wicket:id="noAssignments" class="messageInformation"><wicket:message key="no-assignments.label" /></div>
     <div wicket:id="noStudents" class="messageInformation"><wicket:message key="no-students.label" /></div>
+    <p wicket:id="liveGradingFeedback" class="gb-live-feedback"></p>
 
     <div wicket:id="addOrEditGradeItemWindow" />
     <div wicket:id="studentGradeSummaryWindow" />

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -88,6 +88,8 @@ public class GradebookPage extends BasePage {
 	GbModalWindow gradeStatisticsWindow;
 	GbModalWindow updateCourseGradeDisplayWindow;
 
+	Label liveGradingFeedback;
+
 	Form<Void> form;
 
 	@SuppressWarnings({ "rawtypes", "unchecked", "serial" })
@@ -797,5 +799,31 @@ public class GradebookPage extends BasePage {
 				}
 			}
 		}
+	}
+
+	@Override
+	public void onBeforeRender() {
+		super.onBeforeRender();
+
+		// add simple feedback nofication to sit above the table
+		// which is reset every time the page renders
+		this.liveGradingFeedback = new Label("liveGradingFeedback");
+		// hide by default
+		this.liveGradingFeedback.add(new AttributeModifier("style", "display: none;"));
+		this.liveGradingFeedback.setOutputMarkupId(true);
+		this.liveGradingFeedback.setOutputMarkupPlaceholderTag(true);
+
+		// add the 'saving...' message to the DOM as the JavaScript will
+		// need to be the one that displays this message (Wicket will handle
+		// the 'saved' and 'error' messages when a grade is changed
+		this.liveGradingFeedback.add(new AttributeModifier("data-saving-message", getString("feedback.saving")));
+		this.form.addOrReplace(liveGradingFeedback);
+	}
+
+	public Component updateLiveGradingMessage(String message) {
+		this.liveGradingFeedback.setDefaultModel(Model.of(message));
+		this.liveGradingFeedback.add(new AttributeModifier("style", ""));
+
+		return this.liveGradingFeedback;
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -191,6 +191,8 @@ public class GradeItemCellPanel extends Panel {
 				protected void onUpdate(final AjaxRequestTarget target) {
 					final String rawGrade = GradeItemCellPanel.this.gradeCell.getValue();
 
+					GradebookPage page = (GradebookPage)getPage();
+
 					clearNotifications();
 
 					// perform validation here so we can bypass the backend
@@ -199,7 +201,7 @@ public class GradeItemCellPanel extends Panel {
 					if (StringUtils.isNotBlank(rawGrade) && (!validator.isValid(rawGrade) || Double.parseDouble(rawGrade) < 0)) {
 						// show warning and revert button
 						markWarning(getComponent());
-						warn(getString("grade.notifications.error"));
+						target.add(page.updateLiveGradingMessage(getString("feedback.error")));
 					} else {
 						final String newGrade = FormatHelper.formatGrade(rawGrade);
 
@@ -213,12 +215,12 @@ public class GradeItemCellPanel extends Panel {
 								markSuccessful(GradeItemCellPanel.this.gradeCell);
 								GradeItemCellPanel.this.originalGrade = newGrade;
 								refreshCourseGradeAndCategoryAverages(target);
-								success(getString("grade.notifications.saved"));
+								target.add(page.updateLiveGradingMessage(getString("feedback.saved")));
 								break;
 							case ERROR:
 								markError(getComponent());
 								// show the error message
-								error(getString("grade.notifications.error"));
+								target.add(page.updateLiveGradingMessage(getString("feedback.error")));
 								// and the invalid score message, just to be helpful
 								GradeItemCellPanel.this.notifications.add(GradeCellNotification.INVALID);
 								break;
@@ -226,14 +228,14 @@ public class GradeItemCellPanel extends Panel {
 								markOverLimit(GradeItemCellPanel.this.gradeCell);
 								refreshCourseGradeAndCategoryAverages(target);
 								GradeItemCellPanel.this.originalGrade = newGrade;
-								success(getString("grade.notifications.saved"));
+								target.add(page.updateLiveGradingMessage(getString("feedback.saved")));
 								break;
 							case NO_CHANGE:
 								handleNoChange(GradeItemCellPanel.this.gradeCell);
 								break;
 							case CONCURRENT_EDIT:
 								markError(GradeItemCellPanel.this.gradeCell);
-								error(getString("grade.notifications.error"));
+								target.add(page.updateLiveGradingMessage(getString("feedback.error")));
 								GradeItemCellPanel.this.notifications.add(GradeCellNotification.CONCURRENT_EDIT);
 								break;
 							default:

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -1593,6 +1593,14 @@ GradebookSpreadsheet.prototype.positionModalAtTop = function($modal) {
   $modal.css('top', 30 + $(window).scrollTop() + "px");
 };
 
+
+GradebookSpreadsheet.prototype.setLiveFeedbackAsSaving = function() {
+  var $liveFeedback = this.$spreadsheet.closest("#gradebookSpreadsheet").find(".gb-live-feedback");
+  $liveFeedback.html($liveFeedback.data("saving-message"));
+  $liveFeedback.show()
+};
+
+
 /*************************************************************************************
  * AbstractCell - behaviour inherited by all cells
  */
@@ -1803,6 +1811,7 @@ GradebookEditableCell.prototype.getStudentName = function() {
 
 GradebookEditableCell.prototype.handleBeforeSave = function() {
   this.$cell.addClass("gb-cell-saving");
+  this.gradebookSpreadsheet.setLiveFeedbackAsSaving();
 };
 
 

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -1133,3 +1133,17 @@ and (max-device-width : 736px) {
 	font-weight: bold;
 	line-height: 3em;
 }
+
+/* Live feedback message container */
+.gb-live-feedback {
+  position: absolute;
+  top: 20px;
+  width: 200px;
+  margin-left: -100px;
+  left: 50%;
+  background-color: #EEE;
+  text-align: center;
+  padding: 4px;
+  font-size: 12px;
+  line-height: 14px;
+}


### PR DESCRIPTION
Delivers #1701.  I've introduced a new less obtrusive message container for notifying users of "Saving...", "Saved" and "Errors were detected." messages. This is different to the standard session feedback component is tied to the grade editing only.  It looks like this:

![screen shot 2016-04-29 at 4 21 12 pm](https://cloud.githubusercontent.com/assets/608337/14909411/6cdd6e26-0e26-11e6-980a-11e130336a69.png)
