### PR TITLE
2272: if categories are disabled, then we only need to check the group scope when evaluating TA permissions

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -159,8 +159,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 								gradableGroupIds.add(permission.getGroupReference());
 							}
 						}
-					} else if (!categoriesEnabled && permission.getCategoryId() == null
-						&& permission.getGroupReference() == null) {
+					} else if (!categoriesEnabled && permission.getGroupReference() == null) {
 						canGradeAllGroups = true;
 						break;
 					} else {


### PR DESCRIPTION
Delivers #2272.  Fixes a bug in my code which picks out permissible groups for a TA user.