### PR TITLE
SAK-31130 - improved performance for retrieving submissions on the Grade Report tab of Assignments

### DIFF
--- a/assignment/assignment-api/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/assignment-api/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -730,6 +730,14 @@ public interface AssignmentService extends EntityProducer
 	 *         if the current user is not allowed to read this.
 	 */
 	public AssignmentSubmission getSubmission(String assignmentReference, String submitterId);
+
+	/**
+	 * Access a mapping of users to their corresponding submission on the specified assignment for the specified users
+	 * @param assignment the assignment with which the submissions should be associated
+	 * @param users the returned map's keys will contain only members of this list of users who have submissions on the specified assignment
+	 * @return a mapping of Users to their corresponding submissions, never null
+	 */
+	public Map<User, AssignmentSubmission> getUserSubmissionMap(Assignment assignment, List<User> users);
 	
 	/**
 	 * Access a User's AssignmentSubmission inside a list of AssignmentSubmission object.

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -3515,7 +3515,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 			}
 			else
 			{
-				// SAK-31130 - get all submissions for these users with a single query
+				// Get all submissions for these users with a single query
 				return m_submissionStorage.getUserSubmissionMap(a, users);
 			}
 		}
@@ -4895,7 +4895,6 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 			if (!rvUsers.isEmpty())
 			{
 				List<String> groupRefs = new ArrayList<String>();
-				// SAK-31130 - created getUserSubmissionMap precisely to turn this into a single query for non-group assignments
 				Map<User, AssignmentSubmission> userSubmissionMap = getUserSubmissionMap(a, rvUsers);
 				for (Iterator uIterator = rvUsers.iterator(); uIterator.hasNext();)
 				{

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/DbAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/DbAssignmentService.java
@@ -25,9 +25,12 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.assignment.api.Assignment;
@@ -44,6 +47,7 @@ import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.db.api.SqlReader;
 import org.sakaiproject.db.api.SqlService;
 import org.sakaiproject.entity.api.Entity;
+import org.sakaiproject.user.api.User;
 import org.sakaiproject.util.BaseDbSingleStorage;
 import org.sakaiproject.util.Xml;
 import org.w3c.dom.Document;
@@ -76,6 +80,9 @@ public class DbAssignmentService extends BaseAssignmentService
 	
 	/** Extra fields to store in the db with the XML in ASSIGNMENT_SUBMISSION table */
 	protected static final String[] SUBMISSION_FIELDS = { "CONTEXT", "SUBMITTER_ID", "SUBMIT_TIME", "SUBMITTED", "GRADED"};
+
+	/** Oracle in clause limit */
+	protected static final int MAX_IN_CLAUSE_SIZE = 1000;
 
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * Constructors, Dependencies and their setter methods
@@ -433,6 +440,85 @@ public class DbAssignmentService extends BaseAssignmentService
 			{
 				return null;
 			}
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public Map<User, AssignmentSubmission> getUserSubmissionMap(Assignment assignment, List<User> users)
+		{
+			if (assignment == null || assignment.isGroup())
+			{
+				throw new IllegalArgumentException("getSubmissionForUsers invoked with null of group assignment");
+			}
+
+			Map<User, AssignmentSubmission> userSubmissionMap = new HashMap<>();
+
+			if (CollectionUtils.isEmpty(users))
+			{
+				return userSubmissionMap;
+			}
+
+			// Work in batches of 1000 users (due to Oracle's in clause limit)
+			int minUser = 0;
+			int maxUser = Math.min(users.size(), MAX_IN_CLAUSE_SIZE);
+			while (minUser < users.size())
+			{
+				List<User> userSublist = users.subList(minUser, maxUser);
+
+				/* 
+				 * Build a query like: 
+				 * select XML from assignment_submission where (CONTEXT = ? AND SUBMITTER_ID in (?, ?, ...));
+				 */
+				// The sql string
+				StringBuilder sql = new StringBuilder();
+				// fields are the values to be passed in. 1st param is assignment ID, the rest are userIDs
+				String fields[] = new String[1 + userSublist.size()];
+
+				String param = "?";
+				sql.append("select XML from ").append(m_submissionsTableName)
+					.append(" where (").append(SUBMISSION_FIELDS[0]).append(" = ").append(param).append(" AND ")
+					.append(SUBMISSION_FIELDS[1]).append(" in (");
+				fields[0] = caseId(assignment.getId());
+
+				// This map will be useful to retrieve Users from submission.getSubmitterId()
+				Map<String, User> userIdUserMap = new HashMap<>();
+				for (int i = 0; i < userSublist.size(); i++)
+				{
+					User u = userSublist.get(i);
+					String userId = u.getId();
+					userIdUserMap.put(userId, u);
+
+					sql.append(param);
+					// compiler optimizes this (first iteration appends "?", subsequent iterations append ",?")
+					param = ",?";
+					// first field is assignmentId, all userId fields' indices are shifted up 1
+					fields[i + 1] = userId;
+				}
+				// append "))" to close "in (" and "where("
+				sql.append("))");
+
+				List xmlResources = m_sql.dbRead(sql.toString(), fields, null);
+				for (Object xml : xmlResources)
+				{
+					AssignmentSubmission submission = (AssignmentSubmission) readResource((String) xml);
+					String submitterId = submission.getSubmitterId();
+					User u = userIdUserMap.get(submitterId);
+					if (u == null)
+					{
+						M_log.warn("getUserSubmissionMap() - submission's submitterId not found in the original user list");
+					}
+					else
+					{
+						userSubmissionMap.put(u, submission);
+					}
+				}
+
+				minUser += MAX_IN_CLAUSE_SIZE;
+				maxUser = Math.min(users.size(), minUser + MAX_IN_CLAUSE_SIZE);
+			}
+
+			return userSubmissionMap;
 		}
 		
 		/**


### PR DESCRIPTION
Improve the loading time

Note when testing:
If you create a new assignment, visit the 'Grades' page before visiting the 'Grade Report' tab - the first time you view grades, dummy submission objects are created for all the assignments, so it will be slow no matter what. This ticket is only concerned with speeding up the retrieval of the submission objects on the Grade Report tab