### PR TITLE
SAK-31150 - Clicking on full details link for external calendar item in synoptic calendar leads to site unavailable

### DIFF
--- a/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/CalendarBean.java
+++ b/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/CalendarBean.java
@@ -819,7 +819,32 @@ public class CalendarBean {
 	
 	private String buildEventUrl(Site site, String eventRef) {
 		StringBuilder url = new StringBuilder();
-		ToolConfiguration tc = site.getToolForCommonId(SCHEDULE_TOOL_ID);
+		ToolConfiguration tc = null;
+		if ("!worksite".equals(site.getId()))
+		{
+			// Institutional Calendar events are set up in "!worksite", but users can't view these events.
+			// Get the schedule tool from the current context, if none found, take them to their workspace
+			String siteId = M_tm.getCurrentPlacement().getContext();
+			try
+			{
+				Site currentSite = M_ss.getSite(siteId);
+				tc = currentSite.getToolForCommonId(SCHEDULE_TOOL_ID);
+				if (tc == null)
+				{
+					String myWorkspaceId = M_ss.getUserSiteId(getUserId());
+					Site myWorkspace = M_ss.getSite(myWorkspaceId);
+					tc = myWorkspace.getToolForCommonId(SCHEDULE_TOOL_ID);
+				}
+			}
+			catch (IdUnusedException e)
+			{
+				LOG.error("IdUnusedException: " + e.getMessage());
+			}
+		}
+		if (tc == null)
+		{
+			tc = site.getToolForCommonId(SCHEDULE_TOOL_ID);
+		}
 		if(tc != null) {
 			url.append(ServerConfigurationService.getPortalUrl());
 			url.append("/directtool/");


### PR DESCRIPTION
1. In a site's calendar, subscribe to an institutional calendar via the Merge External Calendars tab (see https://jira.sakaiproject.org/browse/SAK-12852 and calendar.external.subscriptions.* properties in https://qa11-oracle.nightly.sakaiproject.org/sakai/sakai.properties)
2. From the Home tool in the site, click on the day of an external event in the synoptic calendar
3. You should see the event, and there should be a link. Visit the link. Note: the data provided in https://weblearn.ox.ac.uk/access/content/public/misc/oxdate.ics does not appear to have text for the link, so you will have to use your browser's developer tools to edit the html and provide text for the link. The link appears between "Academic Calendar -" and "(worksite)". Perhaps a separate ticket should be created to put the event's full title in the place of this link if "event.truncatedDisplayName" is empty.
4. Now there should be a link that says "Full Details". Clicking this link will take you to "Site Unavailable"