### PR TITLE
1361: course grade sorting things

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -946,7 +946,7 @@ public class GradebookNgBusinessService {
 
 		if (settings.getCourseGradeSortOrder() != null) {
 			// sort
-			Collections.sort(items, new CourseGradeComparator());
+			Collections.sort(items, new CourseGradeComparator(getGradebookSettings()));
 
 			// reverse if required
 			if (settings.getCourseGradeSortOrder() == SortDirection.DESCENDING) {
@@ -1956,15 +1956,45 @@ public class GradebookNgBusinessService {
 	}
 
 	/**
-	 * Comparator class for sorting by course grade
+	 * Comparator class for sorting by course grade, first by the letter grade's
+	 * index in the gradebook's grading scale and then by the number of points
+	 * the student has earned.
 	 *
 	 */
 	class CourseGradeComparator implements Comparator<GbStudentGradeInfo> {
 
+		private List<String> ascendingGrades;
+
+		public CourseGradeComparator(GradebookInformation gradebookInformation) {
+			final Map<String, Double> gradeMap = gradebookInformation.getSelectedGradingScaleBottomPercents();
+			this.ascendingGrades = new ArrayList<>(gradeMap.keySet());
+			this.ascendingGrades.sort(new Comparator<String>() {
+				@Override
+				public int compare(final String a, final String b) {
+					return new CompareToBuilder()
+						.append(gradeMap.get(a), gradeMap.get(b))
+						.toComparison();
+				}
+			});
+		}
+
 		@Override
 		public int compare(final GbStudentGradeInfo g1, final GbStudentGradeInfo g2) {
+			CourseGrade cg1 = g1.getCourseGrade().getCourseGrade();
+			CourseGrade cg2 = g2.getCourseGrade().getCourseGrade();
+
+			String letterGrade1 = cg1.getMappedGrade();
+			if (cg1.getEnteredGrade() != null) {
+				letterGrade1 = cg1.getEnteredGrade();
+			}
+			String letterGrade2 = cg2.getMappedGrade();
+			if (cg2.getEnteredGrade() != null) {
+				letterGrade2 = cg2.getEnteredGrade();
+			}
+
 			return new CompareToBuilder()
-					.append(g1.getCourseGrade().getDisplayString(), g2.getCourseGrade().getDisplayString())
+					.append(ascendingGrades.indexOf(letterGrade1), ascendingGrades.indexOf(letterGrade2))
+					.append(ascendingGrades.indexOf(cg1.getPointsEarned()), ascendingGrades.indexOf(cg2.getPointsEarned()))
 					.toComparison();
 		}
 	}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -41,7 +41,6 @@ public class GradebookUiSettings implements Serializable {
 	 * For sorting based on assignment grades
 	 */
 	@Getter
-	@Setter
 	private GbAssignmentGradeSortOrder assignmentSortOrder;
 
 	@Getter
@@ -63,7 +62,6 @@ public class GradebookUiSettings implements Serializable {
 	 * For sorting based on category
 	 */
 	@Getter
-	@Setter
 	private GbCategoryAverageSortOrder categorySortOrder;
 
 	/**
@@ -72,7 +70,6 @@ public class GradebookUiSettings implements Serializable {
 	 * TODO this could be its own class to bring it in to line with the others
 	 */
 	@Getter
-	@Setter
 	private SortDirection courseGradeSortOrder;
 
 	/**
@@ -145,6 +142,27 @@ public class GradebookUiSettings implements Serializable {
 		final int b = rand.nextInt((max - min) + 1) + min;
 
 		return String.format("rgb(%d,%d,%d)", r, g, b);
+	}
+
+	public void setCourseGradeSortOrder(SortDirection direction) {
+		resetSortOrder();
+		this.courseGradeSortOrder = direction;
+	}
+
+	public void setCategorySortOrder(GbCategoryAverageSortOrder sortOrder) {
+		resetSortOrder();
+		this.categorySortOrder = sortOrder;
+	}
+
+	public void setAssignmentSortOrder(GbAssignmentGradeSortOrder sortOrder) {
+		resetSortOrder();
+		this.assignmentSortOrder = sortOrder;
+	}
+
+	private void resetSortOrder() {
+		this.courseGradeSortOrder = null;
+		this.categorySortOrder = null;
+		this.assignmentSortOrder = null;
 	}
 
 	@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -88,9 +88,6 @@ public class AssignmentColumnHeaderPanel extends Panel {
 					settings.setAssignmentSortOrder(sortOrder);
 				}
 
-				// clear any category sort order to prevent conflicts
-				settings.setCategorySortOrder(null);
-
 				// save settings
 				gradebookPage.setUiSettings(settings);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnHeaderPanel.java
@@ -61,9 +61,6 @@ public class CategoryColumnHeaderPanel extends Panel {
 					settings.setCategorySortOrder(sortOrder);
 				}
 
-				// clear any assignment sort order to prevent conflicts
-				settings.setAssignmentSortOrder(null);
-
 				// save settings
 				gradebookPage.setUiSettings(settings);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
@@ -64,10 +64,6 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 					settings.setCourseGradeSortOrder(sortOrder.toggle());
 				}
 
-				// clear any category or assignment sort order to prevent conflicts in ordering
-				settings.setCategorySortOrder(null);
-				settings.setAssignmentSortOrder(null);
-
 				// save settings
 				gradebookPage.setUiSettings(settings);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
@@ -43,6 +43,8 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
+		final GradebookPage gradebookPage = (GradebookPage) getPage();
+
 		getParentCellFor(this).setOutputMarkupId(true);
 
 		final Link<String> title = new Link<String>("title") {
@@ -52,7 +54,6 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 			public void onClick() {
 
 				// toggle the sort direction on each click
-				final GradebookPage gradebookPage = (GradebookPage) getPage();
 				final GradebookUiSettings settings = gradebookPage.getUiSettings();
 
 				// if null, set a default sort, otherwise toggle, save, refresh.
@@ -75,12 +76,17 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 			}
 
 		};
+
+		final GradebookUiSettings settings = gradebookPage.getUiSettings();
 		title.add(new AttributeModifier("title", new ResourceModel("column.header.coursegrade")));
 		title.add(new Label("label", new ResourceModel("column.header.coursegrade")));
+		if (settings != null && settings.getCourseGradeSortOrder() != null) {
+			title.add(
+				new AttributeModifier("class", "gb-sort-" + settings.getCourseGradeSortOrder().toString().toLowerCase()));
+		}
 		add(title);
 
 		final Gradebook gradebook = this.businessService.getGradebook();
-		final GradebookPage gradebookPage = (GradebookPage) getPage();
 		final GbRole role = this.businessService.getUserRole();
 
 		final GbCategoryType categoryType = GbCategoryType.valueOf(gradebook.getCategory_type());

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -344,9 +344,6 @@
 #gradebookGrades .gb-category-item-column-cell > div {
   line-height: 2.6em;
 }
-#gradebookGrades .gb-course-grade > div {
-  padding: 6px 0;
-}
 #gradebookGrades .gb-course-grade > div > span {
   display: block;
   line-height: 1.25em;


### PR DESCRIPTION
Delivers #1361. Namely:

- show the sort arrows when course grade is sorting
- ensure other sorts are being applied when course grade is sorting (slightly refactored so setting a sort order clears the sort order for other columns)
- removed extra padding on the course grade header cell
- tinker with the CourseGradeComparator to use the grade letter (or more accurately the index of the grade letter within the gradebook's grade scale) and then by the points earned by the student.  No padded strings needed.. I was in a JavaScript mindset and Java comparators rulez.