### PR TITLE
SAK-31106 Can Mark same message as read multiple times

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -5004,9 +5004,9 @@ private   int   getNum(char letter,   String   a)
 			if(decoMessage.getIsSelected())
 			{
 				msgSelected = true;
-				if (readStatus) {
+				if (readStatus && !decoMessage.isHasRead()) {
 					prtMsgManager.markMessageAsReadForUser(decoMessage.getMsg());
-				} else {
+				} else if(!readStatus && decoMessage.isHasRead()) {
 					prtMsgManager.markMessageAsUnreadForUser(decoMessage.getMsg());
 				}
 


### PR DESCRIPTION
Being able to select the "Mark Unread" or "Mark Read" buttons even when not every selected message would be affected seems like expected behavior and seems to be the standard in other applications. Instead, this change fixes the bug of being able to remark already unread or read messages and break the UI counter.