### PR TITLE
SAM-2856 - Various problems with timed assessments and due dates

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -310,8 +310,8 @@ public class SaveAssessmentSettings
     // hasRetractDate, hasAnonymous, hasAuthenticatedUser, hasIpAddress,
     // hasUsernamePassword,
     // hasTimeAssessment,hasAutoSubmit, hasPartMetaData, hasQuestionMetaData
-    HashMap h;
-    h = addExtendedTimeValuesToMetaData(assessment, assessmentSettings);
+    HashMap <String, String> h = assessmentSettings.getValueMap();
+    addExtendedTimeValuesToMetaData(assessment, assessmentSettings, h);
     updateMetaWithValueMap(assessment, h);
 
     // i. set Graphics
@@ -572,10 +572,9 @@ public class SaveAssessmentSettings
 	 * @return
 	 */
 	private HashMap addExtendedTimeValuesToMetaData(AssessmentFacade assessment,
-			AssessmentSettingsBean assessmentSettings) {
+			AssessmentSettingsBean assessmentSettings, HashMap metaDataMap) {
 
 		String[] allExtendedTimeEntries = assessmentSettings.getExtendedTimes().split("\\^");
-		HashMap<String, String> metaDataMap = assessment.getAssessmentMetaDataMap();
 		String metaKey;
 
 		// clear out the old extended Time values

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
@@ -374,8 +374,7 @@ public class BeginDeliveryActionListener implements ActionListener
     }
 
     // #3 - if this is a timed assessment, set the time limit in hr, min & sec.
-//    setTimedAssessment(delivery, pubAssessment, extTimeService);
-//    delivery.setDeadline();
+    delivery.setDeadline();
   }
 
   private void setTimedAssessment(DeliveryBean delivery, PublishedAssessmentIfc pubAssessment, ExtendedTimeService extTimeService, AssessmentGradingData unSubmittedAssessmentGrading){
@@ -383,7 +382,6 @@ public class BeginDeliveryActionListener implements ActionListener
     AssessmentAccessControlIfc control = pubAssessment.getAssessmentAccessControl();
     // check if we need to time the assessment, i.e.hasTimeassessment="true"
     String hasTimeLimit = pubAssessment.getAssessmentMetaDataByLabel("hasTimeAssessment");
-    hasTimeLimit="true"; //TODO: figure out why this isn't giving me the right value
     if (hasTimeLimit!=null && hasTimeLimit.equals("true") && control.getTimeLimit() != null){
 
     	delivery.setHasTimeLimit(true);


### PR DESCRIPTION
So this looks like it's working better but I can't tell if it's 100% correct yet (needs more testing)

Basically some commits on SAM-1408 (#915) looks like it broke functionality that persisted data that was in the assessment settings value map and switched it with the another map. This seemed like it resulted in nothing getting saved for a number of values in Samigo. 

Also the code to set the correct deadline wasn't being run and it had hardcoded hasTimeLimit which was completely incorrect because this value and others weren't set anymore.

I'll test some more to make sure SAM-1408 still works but I think this is going to result in a number of critical and blockers eventually being resolved.