### PR TITLE
The default skin is now `morpheus-default`

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -624,8 +624,8 @@
 # ########################################################################
 
 # The default skin for sites without a skin setting
-# DEFAULT: default
-# skin.default=default
+# DEFAULT: morpheus-default
+# skin.default=morpheus-default
 
 # the path to the skin files
 # DEFAULT: /library/skin


### PR DESCRIPTION
With changes in kernel.properties the default skin is now `morpheus-default` and not `default`