### PR TITLE
SAK-31180 Reorder screen - Wrong format for future-dated announcements

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
@@ -105,7 +105,7 @@
 				#set($count = 0)
 				#foreach ($ann_item in $showMessagesList)
 					#set($ann_item_props=$ann_item.getProperties())
-					<li #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft) id="listitem.orderable$count" class="row">
+					<li #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft true) id="listitem.orderable$count">
 							<span style="display:none" class="grabHandle">
 							<input type="text" size="3" value="$count" id="index$count" style="z-index:5"/>
 							<input type="hidden" size="3" id="holder$count"  value="$count"/>

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -3,7 +3,8 @@
 ##(gsilver - remaining issues: trimming body, <p> in body when produced with WYS, the fact that how thing look in the synopsys is still undefined - and finally - the permissions nightmare as well as the ling to Remove...
 
 ############################################# Check if message hidden macro begin
-#macro(rowTRconstruct $props $displayOptions $hidden)
+## SAK-31180 $reorder added. We need the bootstrap class "row" only for the Reorder Tab 
+#macro(rowTRconstruct $props $displayOptions $hidden $reorder)
 
 	#set($now = $timeservice.newTime())
 	#set($reldateset = false)
@@ -23,15 +24,19 @@
 	#if ($hidden || $reldateset || $retdateset)
 		#if ($displayOptions.isShowAnnouncementBody())
 			class="lightHighLightRow inactive"
-		#else
+		#elseif ($reorder)
+			class="inactive row"
+		#else 
 			class="inactive"
 		#end
 	#else
 		#if ($displayOptions.isShowAnnouncementBody())
 			class="lightHighLightRow"
+		#elseif ($reorder)
+			class="row"
 		#end	
 	#end
-
+	
 #end
 ############################################# Check if message hidden macro end
 		


### PR DESCRIPTION
1. future-dated announcements (greyed-out) do no properly appear in a well-formed row
2. something about #1 above causes content in the next row to start under the end date in the 1st row and wrap around to a newline, causing the data to be mismatched with column headings


![](https://jira.sakaiproject.org/secure/attachment/45327/AnnouncementsReorder.png)


![announreorderfixed](https://cloud.githubusercontent.com/assets/16644575/15146574/8b144222-16bc-11e6-9e1f-267ac91f483c.png)
