### PR TITLE
SAK-30562 - Portal chat header colour contrast too low

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/chat/_chat_variables.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/chat/_chat_variables.scss
@@ -11,7 +11,7 @@ $footerApp__chat__a__color: 	 		$primary-color;
 $footerApp__chat__a--hover__color: 		lighten( $primary-color, 10%);
 
 $footerApp__chat__header__color: 	  	$background-color !default;
-$footerApp__chat__header__background: 	$primary-color !default;
+$footerApp__chat__header__background: 	$text-color !default;
 
 $footerApp__chat__message__left__background: 	#C9EADD;
 $footerApp__chat__message__left__border: 		darken( $footerApp__chat__message__left__background, 10%); 


### PR DESCRIPTION
I've modified the header color. I've tried to change every single place that colour was showed but Sakai has become a dark dark place to browse.