### PR TITLE
KNL-1434 - Update hikaricp to 2.4.6

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -130,7 +130,7 @@
       <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>2.4.5</version>
+        <version>2.4.6</version>
         <scope>compile</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Changes in 2.4.6

 * Added Oracle SQL error code 61000 (exceeded maximum connect time) to evict connections
   when it is encountered.

 * issue 621: fix NPE in shutdown if invoked during initialization.

 * issue 606, 610: housekeeper thread was running before all class members were
   initialized, causing an unrecoverable exception and disabling idle connection
   retirement (maximumLifetime still applied).
