### PR TITLE
SAK-31187,1858,2176: Add morpheus styles for btn-default and btn-link

### DIFF
--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -48,6 +48,14 @@ $breadcrumbs-color:			 $text-color !default;
 $breadcrumbs-tool-color:		 #185878 !default;
 $breadcrumbs-hover-color:		 #0F4461 !default;
 
+/* Link colors */
+$link-color: $primary-color !default;
+$link-active-color: $primary-color !default;
+$link-hover-color: $primary-color !default;
+$link-background-color: transparent !default;
+$link-active-background-color: transparent !default;
+$link-hover-background-color: transparent !default;
+
 /* Linknav button colors */
 $button-text-color:	 #777 !default;
 $button-border-color: #C0C0C0 !default;

--- a/reference/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/base/_defaults.scss
@@ -24,12 +24,19 @@ a{
 		text-decoration: none;
 	}
 	&[href]{  // This means a[href]
-		color: $primary-color;
+		color: $link-color;
+		background-color: $link-background-color;
 		&:focus, &::-moz-focus-inner{ // This would compile to -> a[href]:focus, a[href]::moz-focus-inner
 			outline-color: invert;
 		}
 		&:hover{
+			color: $link-hover-color;
+			background-color: $link-hover-background-color;
 			text-decoration:underline;
+		}
+		&:active{
+			color: $link-active-color;
+			background-color: $link-active-background-color;
 		}
 		&.btn{
 			text-decoration: none;

--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -209,7 +209,7 @@
 }
 
 .button.link, a.btn-link, button.btn-link {
-	@include sakai_button( #FFF, #FFF, $primary-color, #FFF );
+	@include sakai_button( $link-background-color, $link-background-color, $link-color, $link-hover-background-color );
 }
 
 .btn-group .btn {

--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -204,8 +204,20 @@
 	}
 }
 
-.button, button.ui-state-default{
+.button, button.ui-state-default, .btn.btn-default {
 	@include sakai_button( $button-background-color, $button-border-color, $button-text-color, $button-background-secondary-color );
+}
+
+.button.link, a.btn-link, button.btn-link {
+	@include sakai_button( #FFF, #FFF, $primary-color, #FFF );
+}
+
+.btn-group .btn {
+  margin: 0;
+}
+
+.input-group-btn .btn {
+  margin: 0 0 0 -1px;
 }
 
 a.noPointers, input.noPointers {

--- a/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -206,10 +206,4 @@
  		display: block;
  		margin-top: 1.4rem;
  	}
-
- 	button.btn-default.btn{
- 		@include sakai_button( $button-background-color, $button-border-color, $button-text-color, $button-background-secondary-color );
- 	}
-	
-	
 }


### PR DESCRIPTION
… for all tools. Also remove margin for bootstrap input-append and btn-groups so they display as expected.

Delivers #1858, #2176 and ~~tinkers with SAK-30481~~ SAK-31187.

As `btn-default` is currently used by basiclti, pasystem and gradebookng tools, I've moved the btn-default styling from the resource specific stylesheet and to the more general extendables stylesheet.

I've also added some styles to ensure `btn-link` buttons, currently used by content and gradebookng tools, also renders more like their bootstrap counterpart. 