### PR TITLE
SAK-30667: Polls fails on Oracle migrated database

### DIFF
--- a/reference/docs/conversion/sakai_10_6-10_7_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_10_6-10_7_oracle_conversion.sql
@@ -1,0 +1,7 @@
+-- SAK-30667 Polls fails on Oracle migrated database
+-- You should execute this only if you have not the column poll_poll.poll_details in CLOB datatype
+ALTER TABLE poll_poll ADD (tmpdetails CLOB);
+UPDATE poll_poll SET tmpdetails=poll_details;
+ALTER TABLE poll_poll DROP COLUMN poll_details;
+ALTER TABLE poll_poll RENAME COLUMN tmpdetails TO poll_details;
+-- END SAK-30667 Polls fails on Oracle migrated database


### PR DESCRIPTION
SAK-30667: Polls fails on Oracle migrated database