### PR TITLE
SAK-31198 Upgrade CAS Client to allow new CAS 4 servers.

### DIFF
--- a/login/login-tool/tool/pom.xml
+++ b/login/login-tool/tool/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
           <groupId>org.jasig.cas.client</groupId>
           <artifactId>cas-client-core</artifactId>
-          <version>3.3.3</version>
+          <version>3.4.1</version>
       </dependency>
       <dependency>
           <groupId>org.springframework</groupId>

--- a/login/login-tool/tool/src/java/org/sakaiproject/login/filter/SakaiCasAuthenticationFilter.java
+++ b/login/login-tool/tool/src/java/org/sakaiproject/login/filter/SakaiCasAuthenticationFilter.java
@@ -21,10 +21,19 @@
 
 package org.sakaiproject.login.filter;
 
+import org.jasig.cas.client.Protocol;
+import org.jasig.cas.client.authentication.AuthenticationRedirectStrategy;
+import org.jasig.cas.client.authentication.ContainsPatternUrlPatternMatcherStrategy;
+import org.jasig.cas.client.authentication.DefaultAuthenticationRedirectStrategy;
 import org.jasig.cas.client.authentication.DefaultGatewayResolverImpl;
+import org.jasig.cas.client.authentication.ExactUrlPatternMatcherStrategy;
 import org.jasig.cas.client.authentication.GatewayResolver;
+import org.jasig.cas.client.authentication.RegexUrlPatternMatcherStrategy;
+import org.jasig.cas.client.authentication.UrlPatternMatcherStrategy;
+import org.jasig.cas.client.configuration.ConfigurationKeys;
 import org.jasig.cas.client.util.AbstractCasFilter;
 import org.jasig.cas.client.util.CommonUtils;
+import org.jasig.cas.client.util.ReflectUtils;
 import org.jasig.cas.client.validation.Assertion;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -38,6 +47,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -66,25 +77,65 @@ public class SakaiCasAuthenticationFilter extends AbstractCasFilter {
 
     private GatewayResolver gatewayStorage = new DefaultGatewayResolverImpl();
 
+    private AuthenticationRedirectStrategy authenticationRedirectStrategy = new DefaultAuthenticationRedirectStrategy();
+    
+    private UrlPatternMatcherStrategy ignoreUrlPatternMatcherStrategyClass = null;
+    
+    private static final Map<String, Class<? extends UrlPatternMatcherStrategy>> PATTERN_MATCHER_TYPES =
+            new HashMap<String, Class<? extends UrlPatternMatcherStrategy>>();
+    
+    static {
+        PATTERN_MATCHER_TYPES.put("CONTAINS", ContainsPatternUrlPatternMatcherStrategy.class);
+        PATTERN_MATCHER_TYPES.put("REGEX", RegexUrlPatternMatcherStrategy.class);
+        PATTERN_MATCHER_TYPES.put("EXACT", ExactUrlPatternMatcherStrategy.class);
+    }
+
+    public SakaiCasAuthenticationFilter() {
+    	// By default use CAS2 for compatibility
+        this(Protocol.CAS2);
+    }
+
+    public SakaiCasAuthenticationFilter(final Protocol protocol) {
+        super(protocol);
+    }
+    
     protected void initInternal(final FilterConfig filterConfig) throws ServletException {
         if (!isIgnoreInitConfiguration()) {
             super.initInternal(filterConfig);
-            setCasServerLoginUrl(getPropertyFromInitParams(filterConfig, "casServerLoginUrl", null));
-            logger.trace("Loaded CasServerLoginUrl parameter: " + this.casServerLoginUrl);
-            setRenew(parseBoolean(getPropertyFromInitParams(filterConfig, "renew", "false")));
-            logger.trace("Loaded renew parameter: " + this.renew);
-            setGateway(parseBoolean(getPropertyFromInitParams(filterConfig, "gateway", "false")));
-            logger.trace("Loaded gateway parameter: " + this.gateway);
-
-            final String gatewayStorageClass = getPropertyFromInitParams(filterConfig, "gatewayStorageClass", null);
+            setCasServerLoginUrl(getString(ConfigurationKeys.CAS_SERVER_LOGIN_URL));
+            setRenew(getBoolean(ConfigurationKeys.RENEW));
+            setGateway(getBoolean(ConfigurationKeys.GATEWAY));
+                       
+            final String ignorePattern = getString(ConfigurationKeys.IGNORE_PATTERN);
+            final String ignoreUrlPatternType = getString(ConfigurationKeys.IGNORE_URL_PATTERN_TYPE);
+            
+            if (ignorePattern != null) {
+                final Class<? extends UrlPatternMatcherStrategy> ignoreUrlMatcherClass = PATTERN_MATCHER_TYPES.get(ignoreUrlPatternType);
+                if (ignoreUrlMatcherClass != null) {
+                    this.ignoreUrlPatternMatcherStrategyClass = ReflectUtils.newInstance(ignoreUrlMatcherClass.getName());
+                } else {
+                    try {
+                        logger.trace("Assuming {} is a qualified class name...", ignoreUrlPatternType);
+                        this.ignoreUrlPatternMatcherStrategyClass = ReflectUtils.newInstance(ignoreUrlPatternType);
+                    } catch (final IllegalArgumentException e) {
+                        logger.error("Could not instantiate class [{}]", ignoreUrlPatternType, e);
+                    }
+                }
+                if (this.ignoreUrlPatternMatcherStrategyClass != null) {
+                    this.ignoreUrlPatternMatcherStrategyClass.setPattern(ignorePattern);
+                }
+            }
+            
+            final Class<? extends GatewayResolver> gatewayStorageClass = getClass(ConfigurationKeys.GATEWAY_STORAGE_CLASS);
 
             if (gatewayStorageClass != null) {
-                try {
-                    this.gatewayStorage = (GatewayResolver) Class.forName(gatewayStorageClass).newInstance();
-                } catch (final Exception e) {
-                    logger.error("Could not retrieve gatewayStorageClass", e);
-                    throw new ServletException(e);
-                }
+                setGatewayStorage(ReflectUtils.newInstance(gatewayStorageClass));
+            }
+            
+            final Class<? extends AuthenticationRedirectStrategy> authenticationRedirectStrategyClass = getClass(ConfigurationKeys.AUTHENTICATION_REDIRECT_STRATEGY_CLASS);
+
+            if (authenticationRedirectStrategyClass != null) {
+                this.authenticationRedirectStrategy = ReflectUtils.newInstance(authenticationRedirectStrategyClass);
             }
         }
     }
@@ -97,8 +148,14 @@ public class SakaiCasAuthenticationFilter extends AbstractCasFilter {
     public final void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
+        
+        if (isRequestUrlExcluded(request)) {
+            logger.debug("Request is ignored.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+        
         final HttpSession session = request.getSession(false);
-        final String serviceUrl = constructServiceUrl(request, response);
         final Assertion assertion = session != null ? (Assertion) session.getAttribute(CONST_CAS_ASSERTION) : null;
 
         if (assertion != null && loggedOutOfSakai()) {
@@ -109,8 +166,9 @@ public class SakaiCasAuthenticationFilter extends AbstractCasFilter {
             return;
         }
 
-        final String ticket = CommonUtils.safeGetParameter(request,getArtifactParameterName());
-        final boolean wasGatewayed = this.gatewayStorage.hasGatewayedAlready(request, serviceUrl);
+        final String serviceUrl = constructServiceUrl(request, response);
+        final String ticket = retrieveTicketFromRequest(request);
+        final boolean wasGatewayed = this.gateway && this.gatewayStorage.hasGatewayedAlready(request, serviceUrl);
 
         if (CommonUtils.isNotBlank(ticket) || wasGatewayed) {
             filterChain.doFilter(request, response);
@@ -128,16 +186,15 @@ public class SakaiCasAuthenticationFilter extends AbstractCasFilter {
         }
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Constructed service url: " + modifiedServiceUrl);
+        	logger.debug("Constructed service url: {}", modifiedServiceUrl);
         }
 
-        final String urlToRedirectTo = CommonUtils.constructRedirectUrl(this.casServerLoginUrl, getServiceParameterName(), modifiedServiceUrl, this.renew, this.gateway);
+        final String urlToRedirectTo = CommonUtils.constructRedirectUrl(this.casServerLoginUrl, getProtocol().getServiceParameterName(), modifiedServiceUrl, this.renew, this.gateway);
 
         if (logger.isDebugEnabled()) {
-            logger.debug("redirecting to \"" + urlToRedirectTo + "\"");
+        	logger.debug("redirecting to \"{}\"", urlToRedirectTo);
         }
-
-        response.sendRedirect(urlToRedirectTo);
+        this.authenticationRedirectStrategy.redirect(request, response, urlToRedirectTo);
     }
 
     private boolean loggedOutOfSakai() {
@@ -165,4 +222,18 @@ public class SakaiCasAuthenticationFilter extends AbstractCasFilter {
     public final void setGatewayStorage(final GatewayResolver gatewayStorage) {
     	this.gatewayStorage = gatewayStorage;
     }
+        
+    private boolean isRequestUrlExcluded(final HttpServletRequest request) {
+        if (this.ignoreUrlPatternMatcherStrategyClass == null) {
+            return false;
+        }
+        
+        final StringBuffer urlBuffer = request.getRequestURL();
+        if (request.getQueryString() != null) {
+            urlBuffer.append("?").append(request.getQueryString());
+        }
+        final String requestUri = urlBuffer.toString();
+        return this.ignoreUrlPatternMatcherStrategyClass.matches(requestUri);
+    }
+
 }

--- a/login/login-tool/tool/src/webapp/WEB-INF/xlogin-context.cas3.xml
+++ b/login/login-tool/tool/src/webapp/WEB-INF/xlogin-context.cas3.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:sec="http://www.springframework.org/schema/security"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+                               http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-2.0.xsd"
+       default-lazy-init="false">
+
+    <bean
+            id="org.sakaiproject.login.filter.SakaiCasAuthenticationFilter"
+            class="org.sakaiproject.login.filter.SakaiCasAuthenticationFilter">
+        <!-- the cas server location browsers should be redirected to for logon -->
+        <constructor-arg type="org.jasig.cas.client.Protocol" value="CAS3"/>
+        <property name="casServerLoginUrl" value="https://cas.tappakegga.edu/cas/login"/>
+        <property name="renew" value="false"/>
+        <property name="gateway" value="false"/>
+        <!-- the serv-->
+        <property name="service" value="https://smartsite-stage.tappakegga.edu/sakai-login-tool/container"/>
+    </bean>
+
+    <bean id="org.jasig.cas.client.validation.Cas30ServiceTicketValidator.serverUrl" class="java.lang.String">
+        <constructor-arg value="https://cas.tappakegga.edu/cas"/>
+    </bean>
+
+    <bean
+            id="org.jasig.cas.client.validation.Cas30ProxyReceivingTicketValidationFilter"
+            class="org.jasig.cas.client.validation.Cas30ProxyReceivingTicketValidationFilter">
+        <property name="service" value="https://smartsite-stage.tappakegga.edu/sakai-login-tool/container"/>
+        <property name="redirectAfterValidation" value="false"/>
+        <property name="ticketValidator">
+            <bean class="org.jasig.cas.client.validation.Cas30ServiceTicketValidator">
+                <constructor-arg ref="org.jasig.cas.client.validation.Cas30ServiceTicketValidator.serverUrl"/>
+            </bean>
+        </property>
+    </bean>
+
+    <bean id="org.jasig.cas.client.util.HttpServletRequestWrapperFilter" class="org.jasig.cas.client.util.HttpServletRequestWrapperFilter"></bean> 
+
+    <bean id="springSecurityFilterChain"
+          class="org.springframework.security.web.FilterChainProxy">
+        <sec:filter-chain-map path-type="ant">
+            <sec:filter-chain pattern="/container/**"
+                              filters="org.sakaiproject.login.filter.SakaiCasAuthenticationFilter,org.jasig.cas.client.validation.Cas30ProxyReceivingTicketValidationFilter,org.jasig.cas.client.util.HttpServletRequestWrapperFilter"/>
+        </sec:filter-chain-map>
+    </bean>
+
+
+</beans>


### PR DESCRIPTION
The changes are based in the AuthenticationFilter original class from 3.4.1 client:
https://github.com/apereo/java-cas-client/blob/cas-client-3.4.1/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java

By default Sakai will keep using CAS2 protocol to allow people update without change anything, CAS3 only works for CAS servers v4. I've added a new cas3.xml file to show you how to use CAS3 protocol in case you have a CAS v4 server available.