### PR TITLE
1336 Added in the ONE_PASS_RENDER to make sure the refreshes don't re…

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
@@ -7,6 +7,7 @@ import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.cycle.AbstractRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.settings.IExceptionSettings;
+import org.apache.wicket.settings.IRequestCycleSettings.RenderStrategy;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 import org.sakaiproject.gradebookng.tool.pages.ErrorPage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -24,13 +25,14 @@ public class GradebookNgApplication extends WebApplication {
 		super.init();
 
 		// page mounting for bookmarkable URLs
-		// mountPage("/gradebook", GradebookPage.class);
+		// not really compatible with the ONE_PASS_RENDER as the mountpoints are always one previous to current page
+		// mountPage("/grades", GradebookPage.class);
 		// mountPage("/settings", SettingsPage.class);
 		// mountPage("/importexport", ImportExportPage.class);
 		// mountPage("/permissions", PermissionsPage.class);
 
 		// remove the version number from the URL so that browser refreshes re-render the page
-		// getRequestCycleSettings().setRenderStrategy(IRequestCycleSettings.RenderStrategy.ONE_PASS_RENDER);
+		getRequestCycleSettings().setRenderStrategy(RenderStrategy.ONE_PASS_RENDER);
 
 		// Configure for Spring injection
 		getComponentInstantiationListeners().add(new SpringComponentInjector(this));


### PR DESCRIPTION
…set the state of data that was updated asynchronously. Adds some state info to the URL though. Do we care about this?

Delivers #1336.

````
/portal/site/e28205e1-b965-4d16-8051-c428ca461286/tool/dab1f1ce-7c05-4b95-9f4c-4fa41709a568/wicket/page?13-1.ILinkListener-gradebookPageNav-gradebookPageLink
````