### PR TITLE
SAK-30926 Formatting of "Previous Folder / Next Folder" buttons is off

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/msgHeader.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/msgHeader.jsp
@@ -14,7 +14,7 @@
 		<h:commandButton styleClass="button_search" value="#{msgs.pvt_search}" action="#{PrivateMessagesTool.processSearch}" onkeypress="document.forms[0].submit;"/>
 		
 		<f:verbatim><span id='adv_button'></f:verbatim>
-		  <h:commandLink styleClass="button" value="#{msgs.pvt_advsearch}" onmousedown="javascript:toggleDisplay('adv_input','adv_button');setMainFrameHeight('#{PrivateMessagesTool.placementId}');" title="#{msgs.pvt_advsearch}"/>
+		  <h:commandButton styleClass="button_search" value="#{msgs.pvt_advsearch}" onmousedown="javascript:toggleDisplay('adv_input','adv_button');setMainFrameHeight('#{PrivateMessagesTool.placementId}');" title="#{msgs.pvt_advsearch}"/>
 		<f:verbatim></span></f:verbatim>
 		<f:verbatim></div></f:verbatim>
   </h:panelGroup>
@@ -28,9 +28,9 @@
 			<h:outputText value=" " />
 			<h:outputText value=" " />
 			<h:panelGroup styleClass="itemNav specialLink">
-	      <h:commandLink styleClass="button" value="#{msgs.pvt_clear_search}" action="#{PrivateMessagesTool.processClearSearch}" onkeypress="document.forms[0].submit;"
+	      	<h:commandButton styleClass="button_search" value="#{msgs.pvt_clear_search}" action="#{PrivateMessagesTool.processClearSearch}" onkeypress="document.forms[0].submit;"
 	                     title="#{msgs.pvt_clear_search}"/>
-				<h:commandLink  styleClass="button" value="#{msgs.pvt_normal_search}" onmousedown="javascript:toggleDisplay('adv_button','adv_input');" 
+				<h:commandButton  styleClass="button_search" value="#{msgs.pvt_normal_search}" onmousedown="javascript:toggleDisplay('adv_button','adv_input');" 
 				               title="#{msgs.pvt_normal_search}" />
 			</h:panelGroup>
 			<%-- gsilver:jsf problem - all these h:selectBooleanCheckbox produce input[type="checkbox"] missing name and/or value attributes--%>

--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsg.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsg.jsp
@@ -103,7 +103,6 @@
     	         <f:param name="sortColumn" value="subject"/>
     	       </h:commandLink>
 		    </f:facet>
-			  <f:verbatim><h4></f:verbatim>
 			<h:commandLink action="#{PrivateMessagesTool.processPvtMsgDetail}" title="#{rcvdItems.msg.title}" immediate="true">
 
             <h:outputText value=" #{rcvdItems.msg.title}" rendered="#{rcvdItems.hasRead}"/>
@@ -111,7 +110,6 @@
 			<h:outputText styleClass="skip" value="#{msgs.pvt_openb}#{msgs.pvt_unread}#{msgs.pvt_closeb}" rendered="#{!rcvdItems.hasRead}"/>
             <f:param value="#{rcvdItems.msg.id}" name="current_msg_detail"/>
           </h:commandLink>
-		  			<f:verbatim></h4></f:verbatim>
 		  </h:column>			
 		  <h:column rendered="#{PrivateMessagesTool.selectedTopic.topic.title != 'pvt_sent'}">
 		    <f:facet name="header">

--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsgDetail.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsgDetail.jsp
@@ -47,18 +47,22 @@
 				<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.title}" />
 			<f:verbatim></h3></div></f:verbatim>
 	</h:panelGroup>
-	<h:panelGroup styleClass="itemNav " rendered="#{!PrivateMessagesTool.detailMsg.isPreview && !PrivateMessagesTool.detailMsg.isPreviewReply && !PrivateMessagesTool.detailMsg.isPreviewReplyAll && !PrivateMessagesTool.detailMsg.isPreviewForward}">			
-       			
-								<h:outputText value="#{msgs.pvt_prev_msg}"  rendered="#{!PrivateMessagesTool.detailMsg.hasPre}" />
-								<h:commandLink action="#{PrivateMessagesTool.processDisplayPreviousMsg}" value="#{msgs.pvt_prev_msg}"  
-								               rendered="#{PrivateMessagesTool.detailMsg.hasPre}" title=" #{msgs.pvt_prev_msg}">
-								</h:commandLink>
-								<h:outputText value=" | " /><h:outputText value=" " />
-								<h:outputText   value="#{msgs.pvt_next_msg}" rendered="#{!PrivateMessagesTool.detailMsg.hasNext}" />
-								<h:commandLink action="#{PrivateMessagesTool.processDisplayNextMsg}" value="#{msgs.pvt_next_msg}" 
-								               rendered="#{PrivateMessagesTool.detailMsg.hasNext}" title=" #{msgs.pvt_next_msg}">
-								</h:commandLink>
-        </h:panelGroup>
+	<h:panelGroup styleClass="itemNav " rendered="#{!PrivateMessagesTool.detailMsg.isPreview && !PrivateMessagesTool.detailMsg.isPreviewReply && !PrivateMessagesTool.detailMsg.isPreviewReplyAll && !PrivateMessagesTool.detailMsg.isPreviewForward}">
+		<h:panelGroup rendered="#{!PrivateMessagesTool.detailMsg.hasPre}" styleClass="button formButtonDisabled">
+			<h:outputText value="#{msgs.pvt_prev_msg}"   />
+		</h:panelGroup>
+		<h:commandLink action="#{PrivateMessagesTool.processDisplayPreviousMsg}" value="#{msgs.pvt_prev_msg}"  
+						rendered="#{PrivateMessagesTool.detailMsg.hasPre}" title=" #{msgs.pvt_prev_msg}" styleClass="btn-primary" >
+		</h:commandLink>
+		
+		<h:panelGroup styleClass="button formButtonDisabled" rendered="#{!PrivateMessagesTool.detailMsg.hasNext}">
+			<h:outputText value="#{msgs.pvt_next_msg}"  />
+		</h:panelGroup>
+		<h:commandLink action="#{PrivateMessagesTool.processDisplayNextMsg}" value="#{msgs.pvt_next_msg}" 
+					rendered="#{PrivateMessagesTool.detailMsg.hasNext}" title=" #{msgs.pvt_next_msg}" styleClass="btn-primary" >
+		</h:commandLink>
+	</h:panelGroup>
+	
       </h:panelGrid>
       <f:verbatim>
       <h3>
@@ -67,33 +71,15 @@
       <f:verbatim>
       </h3>
       </f:verbatim>
-      <sakai:button_bar rendered="#{!PrivateMessagesTool.deleteConfirm && !PrivateMessagesTool.detailMsg.isPreview && !PrivateMessagesTool.detailMsg.isPreviewReply && !PrivateMessagesTool.detailMsg.isPreviewReplyAll && !PrivateMessagesTool.detailMsg.isPreviewForward}" >
 
-                   <table style="width: 100%;">
-				
-				<tr>
-				<td text-align="left">
-
-  <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReply}" value="#{msgs.pvt_repmsg}" accesskey="r" />
-          
-          <%--SAK-10505 add forward --%>
+        <sakai:button_bar rendered="#{!PrivateMessagesTool.deleteConfirm && !PrivateMessagesTool.detailMsg.isPreview && !PrivateMessagesTool.detailMsg.isPreviewReply && !PrivateMessagesTool.detailMsg.isPreviewReplyAll && !PrivateMessagesTool.detailMsg.isPreviewForward}" >
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReply}" value="#{msgs.pvt_repmsg}" accesskey="r" />
+            <%--SAK-10505 add forward --%>
             <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReplyAll}" value="#{msgs.pvt_repmsg_ALL}" accesskey="r" /><sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgForward}" value="#{msgs.pvt_forwardmsg}" accesskey="r"/>
-          
-				</td>
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgMove}" value="#{msgs.pvt_move}" accesskey="m" />
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgDeleteConfirm}" value="#{msgs.pvt_delete}"  />
+        </sakai:button_bar>
 
-
-				<td text-align="right">
-				 
-                 
-          <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgMove}" value="#{msgs.pvt_move}" accesskey="m" />
-          <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgDeleteConfirm}" value="#{msgs.pvt_delete}"  />
-				</td>				
-				</tr>	  
-     
-				</table>
-
-          
-        </sakai:button_bar>        
         <sakai:button_bar rendered="#{PrivateMessagesTool.deleteConfirm}" >
           <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgDeleteConfirmYes}" value="#{msgs.pvt_delete}" accesskey="s" styleClass="active"/>
           <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgCancelToDetailView}" value="#{msgs.pvt_cancel}" accesskey="x" />
@@ -116,132 +102,115 @@
         </sakai:button_bar>
           
          
-        <table class="itemSummary">
-         	  <%-- author image --%>
-         	  <f:subview id="authorImage" rendered="#{PrivateMessagesTool.showProfileInfoMsg}">
-	         	  <f:verbatim>
-          <tr>
-			            <td rowspan="7">
-							<h:panelGroup styleClass="authorImage">
-								<h:outputLink value="#{PrivateMessagesTool.serverUrl}/direct/profile/#{PrivateMessagesTool.detailMsg.msg.authorId}/formatted" styleClass="authorProfile" rendered="#{PrivateMessagesTool.showProfileLink}">
-									<h:graphicImage value="#{PrivateMessagesTool.serverUrl}/direct/profile/#{PrivateMessagesTool.detailMsg.msg.authorId}/image/thumb" alt="#{message.message.author}" />
-								</h:outputLink>
-								<h:graphicImage value="#{PrivateMessagesTool.serverUrl}/direct/profile/#{PrivateMessagesTool.detailMsg.msg.authorId}/image/thumb" alt="#{message.message.author}" rendered="#{!PrivateMessagesTool.showProfileLink}"/>
-							</h:panelGroup>
-			            </td>
-			          </tr>
-	         	  </f:verbatim>
-         	  </f:subview>
-	          <tr>
-            <th>
-	              <h:outputText value="#{msgs.pvt_authby}"/>
-	            </th>
-	            <td>
-	            	<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.author}" />  
-	            	<h:outputText value="#{msgs.pvt_openb}" />  
-	            	<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.created}" >
-	                	<f:convertDateTime pattern="#{msgs.date_format}" timeZone="#{PrivateMessagesTool.userTimeZone}" locale="#{PrivateMessagesTool.userLocale}"/>  
-	                </h:outputText>
-	            	<h:outputText value=" #{msgs.pvt_closeb}" /> 
-	            </td>
-	          </tr>
-	          <tr>
-	            <th>
-            	 <h:outputText value="#{msgs.pvt_to}" />
-            </th>
-            <td>           	
-            	 <h:outputText value="#{PrivateMessagesTool.detailMsg.recipientsAsText}" />
-            	 <h:outputText value=", (#{msgs.pvt_sent_as_email})" rendered="#{PrivateMessagesTool.detailMsg.msg.externalEmail}"/>
-            </td>
-          </tr>
-          <f:subview id="bccRecipients" rendered="#{ForumTool.userId == PrivateMessagesTool.detailMsg.msg.createdBy && PrivateMessagesTool.detailMsg.recipientsAsTextBcc != null && PrivateMessagesTool.detailMsg.recipientsAsTextBcc != ''}">
-	          <f:verbatim>
-	          <tr>
-	            <th>
-	            </f:verbatim>
-	            	 <h:outputText value="#{msgs.pvt_bcc}" />
-	            <f:verbatim>
-	            </th>
-	            <td>        
-	            </f:verbatim>   	
-	            	 <h:outputText value="#{PrivateMessagesTool.detailMsg.recipientsAsTextBcc}" />
-	            <f:verbatim>
-	            </td>
-	          </tr>
-	          </f:verbatim>
-          </f:subview>
-          <tr>
-            <th>
-              <h:outputText value="#{msgs.pvt_subject}"/>
-            </th>
-            <td>
-            	<h:outputText value="#{PrivateMessagesTool.detailMsg.msg.title}" />  
-            </td>  
-          </tr>          
-          <tr>
-            <th>
-              <h:outputText value="#{msgs.pvt_label} "/>
-            </th>
-            <td>
-            	<h:outputText value="#{PrivateMessagesTool.detailMsg.label}" />  
-            </td>
-          </tr> 
-          <tr>
-            <th>
-              <h:outputText value="#{msgs.pvt_att}" rendered="#{!empty PrivateMessagesTool.detailMsg.attachList}" />
-            </th>
-            <td>
-              <%-- Attachments --%>
-			  <%-- gsilver:copying the rendered attribute from the column to the dataTable - do not want a table rendered without children (is not xhtml)--%>
-              <h:dataTable value="#{PrivateMessagesTool.detailMsg.attachList}" var="eachAttach"  styleClass="attachListJSF"  rendered="#{!empty PrivateMessagesTool.detailMsg.attachList}">
-					  		<h:column rendered="#{!empty PrivateMessagesTool.detailMsg.attachList}">
-									<sakai:contentTypeMap fileType="#{eachAttach.attachment.attachmentType}" mapType="image" var="imagePath" pathPrefix="/library/image/"/>									
-									<h:graphicImage id="exampleFileIcon" value="#{imagePath}" />								  
-<%--								  <h:outputLink value="#{eachAttach.attachmentUrl}" target="_blank">
-								  	<h:outputText value="#{eachAttach.attachmentName}"/>
-									</h:outputLink>--%>
-								  <h:outputLink value="#{eachAttach.url}" target="_blank">
-								  	<h:outputText value="#{eachAttach.attachment.attachmentName}"/>
-									</h:outputLink>
-									
-								</h:column>
-							</h:dataTable>   
-              <%-- Attachments --%>
-            </td>
-          </tr>
-                                        
-        </table>    
+         
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-2">
+                    <%-- author image --%>
+                    <f:subview id="authorImage" rendered="#{PrivateMessagesTool.showProfileInfoMsg}">
+                        <h:panelGroup styleClass="authorImage">
+                            <h:outputLink value="#{PrivateMessagesTool.serverUrl}/direct/profile/#{PrivateMessagesTool.detailMsg.msg.authorId}/formatted" styleClass="authorProfile" rendered="#{PrivateMessagesTool.showProfileLink}">
+                                <h:graphicImage value="#{PrivateMessagesTool.serverUrl}/direct/profile/#{PrivateMessagesTool.detailMsg.msg.authorId}/image/thumb" alt="#{message.message.author}" />
+                            </h:outputLink>
+                            <h:graphicImage value="#{PrivateMessagesTool.serverUrl}/direct/profile/#{PrivateMessagesTool.detailMsg.msg.authorId}/image/thumb" alt="#{message.message.author}" rendered="#{!PrivateMessagesTool.showProfileLink}"/>
+                        </h:panelGroup>
+                    </f:subview>
+                </div>
+                <div class="col-md-10">
+                    <table class="itemSummary">
+                    <tr>
+                        <th>
+                            <h:outputText value="#{msgs.pvt_authby}"/>
+                        </th>
+                        <td>
+                            <h:outputText value="#{PrivateMessagesTool.detailMsg.msg.author}" />  
+                            <h:outputText value="#{msgs.pvt_openb}" />  
+                            <h:outputText value="#{PrivateMessagesTool.detailMsg.msg.created}" >
+                                <f:convertDateTime pattern="#{msgs.date_format}" timeZone="#{PrivateMessagesTool.userTimeZone}" locale="#{PrivateMessagesTool.userLocale}"/>  
+                            </h:outputText>
+                            <h:outputText value=" #{msgs.pvt_closeb}" /> 
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
+                            <h:outputText value="#{msgs.pvt_to}" />
+                        </th>
+                        <td>
+                            <h:outputText value="#{PrivateMessagesTool.detailMsg.recipientsAsText}" />
+                            <h:outputText value=", (#{msgs.pvt_sent_as_email})" rendered="#{PrivateMessagesTool.detailMsg.msg.externalEmail}"/>
+                        </td>
+                    </tr>
+                    <f:subview id="bccRecipients" rendered="#{ForumTool.userId == PrivateMessagesTool.detailMsg.msg.createdBy && PrivateMessagesTool.detailMsg.recipientsAsTextBcc != null && PrivateMessagesTool.detailMsg.recipientsAsTextBcc != ''}">
+                    <f:verbatim>
+                    <tr>
+                        <th>
+                    </f:verbatim>
+                        <h:outputText value="#{msgs.pvt_bcc}" />
+                    <f:verbatim>
+                        </th>
+                        <td>
+                    </f:verbatim>
+                        <h:outputText value="#{PrivateMessagesTool.detailMsg.recipientsAsTextBcc}" />
+                    <f:verbatim>
+                        </td>
+                    </tr>
+                    </f:verbatim>
+                    </f:subview>
+                    <tr>
+                        <th>
+                            <h:outputText value="#{msgs.pvt_subject}"/>
+                        </th>
+                        <td>
+                            <h:outputText value="#{PrivateMessagesTool.detailMsg.msg.title}" />  
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
+                            <h:outputText value="#{msgs.pvt_label} "/>
+                        </th>
+                        <td>
+                            <h:outputText value="#{PrivateMessagesTool.detailMsg.label}" />  
+                        </td>
+                    </tr> 
+                    <tr>
+                        <th>
+                            <h:outputText value="#{msgs.pvt_att}" rendered="#{!empty PrivateMessagesTool.detailMsg.attachList}" />
+                        </th>
+                        <td>
+                            <%-- Attachments --%>
+                            <%-- gsilver:copying the rendered attribute from the column to the dataTable - do not want a table rendered without children (is not xhtml)--%>
+                            <h:dataTable value="#{PrivateMessagesTool.detailMsg.attachList}" 
+                                        var="eachAttach"  styleClass="attachListJSF"  rendered="#{!empty PrivateMessagesTool.detailMsg.attachList}">
+                                <h:column rendered="#{!empty PrivateMessagesTool.detailMsg.attachList}">
+                                    <sakai:contentTypeMap fileType="#{eachAttach.attachment.attachmentType}" mapType="image" var="imagePath" pathPrefix="/library/image/"/>                                 
+                                        <h:graphicImage id="exampleFileIcon" value="#{imagePath}" />                                  
+                                        <%--<h:outputLink value="#{eachAttach.attachmentUrl}" target="_blank">
+                                            <h:outputText value="#{eachAttach.attachmentName}"/>
+                                            </h:outputLink>--%>
+                                    <h:outputLink value="#{eachAttach.url}" target="_blank">
+                                        <h:outputText value="#{eachAttach.attachment.attachmentName}"/>
+                                    </h:outputLink>
+                                </h:column>
+                            </h:dataTable>   
+                            <%-- Attachments --%>
+                        </td>
+                    </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+
 		<hr class="itemSeparator" />
 		
         	  <mf:htmlShowArea value="#{PrivateMessagesTool.detailMsg.msg.body}" id="htmlMsgText" hideBorder="true" />
         
         <sakai:button_bar rendered="#{!PrivateMessagesTool.deleteConfirm && !PrivateMessagesTool.detailMsg.isPreview && !PrivateMessagesTool.detailMsg.isPreviewReply && !PrivateMessagesTool.detailMsg.isPreviewReplyAll && !PrivateMessagesTool.detailMsg.isPreviewForward}" >
-        
-                   <table style="width: 100%;">
-				
-				<tr>
-				<td text-align="left">
-  <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReply}" value="#{msgs.pvt_repmsg}" accesskey="r"/>
-          <%--SAKAI-10505 add forward--%>
-          <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReplyAll}" value="#{msgs.pvt_repmsg_ALL}" accesskey="r" /><sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgForward}" value="#{msgs.pvt_forwardmsg}" accesskey="r"/>
-          
-
-				</td>
-
-
-				<td text-align="right">
-				 
-               
-          <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgMove}" value="#{msgs.pvt_move}" accesskey="m" />
-          <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgDeleteConfirm}" value="#{msgs.pvt_delete}"  />
-				</td>				
-				</tr>	  
-     
-				</table>
-        
-        
-          
-        </sakai:button_bar>        
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReply}" value="#{msgs.pvt_repmsg}" accesskey="r"/>
+            <%--SAKAI-10505 add forward--%>
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgReplyAll}" value="#{msgs.pvt_repmsg_ALL}" accesskey="r" /><sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgForward}" value="#{msgs.pvt_forwardmsg}" accesskey="r"/>
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgMove}" value="#{msgs.pvt_move}" accesskey="m" />
+            <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgDeleteConfirm}" value="#{msgs.pvt_delete}"  />
+        </sakai:button_bar>
         <sakai:button_bar rendered="#{PrivateMessagesTool.deleteConfirm}" >
           <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgDeleteConfirmYes}" value="#{msgs.pvt_delete}" accesskey="s" styleClass="active"/>
           <sakai:button_bar_item action="#{PrivateMessagesTool.processPvtMsgCancelToDetailView}" value="#{msgs.pvt_cancel}" accesskey="x" />

--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/topNav.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/topNav.jsp
@@ -25,16 +25,20 @@
 	</h:panelGroup>
 	<h:panelGroup styleClass="itemNav specialLink">
 		<%-- gsilver:huh? renders anyway - because it is looking at topics instead of at folders?--%>
-		<h:commandLink styleClass="button" action="#{PrivateMessagesTool.processDisplayPreviousTopic}" value="#{msgs.pvt_prev_folder}"  
+		<h:commandLink styleClass="btn-primary" action="#{PrivateMessagesTool.processDisplayPreviousTopic}" value="#{msgs.pvt_prev_folder}"  
 			                rendered="#{PrivateMessagesTool.selectedTopic.hasPreviousTopic}" title=" #{msgs.pvt_prev_folder}">
 			<f:param value="#{PrivateMessagesTool.selectedTopic.previousTopicTitle}" name="previousTopicTitle"/>
 		</h:commandLink>
-		<h:outputText value="#{msgs.pvt_prev_folder}" rendered="#{!PrivateMessagesTool.selectedTopic.hasPreviousTopic}" />
-	
-		<h:commandLink styleClass="button" action="#{PrivateMessagesTool.processDisplayNextTopic}" value="#{msgs.pvt_next_folder}" 
+		<h:panelGroup rendered="#{!PrivateMessagesTool.selectedTopic.hasPreviousTopic}" styleClass="button formButtonDisabled">
+			<h:outputText value="#{msgs.pvt_prev_folder}"/>
+		</h:panelGroup>
+		
+		<h:commandLink styleClass="btn-primary" action="#{PrivateMessagesTool.processDisplayNextTopic}" value="#{msgs.pvt_next_folder}" 
 				  		                  rendered="#{PrivateMessagesTool.selectedTopic.hasNextTopic}" title=" #{msgs.pvt_next_folder}">
 			<f:param value="#{PrivateMessagesTool.selectedTopic.nextTopicTitle}" name="nextTopicTitle"/>
 		</h:commandLink>
-		<h:outputText value="#{msgs.pvt_next_folder}" rendered="#{!PrivateMessagesTool.selectedTopic.hasNextTopic}" />
+		<h:panelGroup  rendered="#{!PrivateMessagesTool.selectedTopic.hasNextTopic}" styleClass="button formButtonDisabled">
+			<h:outputText value="#{msgs.pvt_next_folder}" />
+		</h:panelGroup>
 	</h:panelGroup>
 </h:panelGrid>

--- a/reference/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/base/_defaults.scss
@@ -42,7 +42,7 @@ a{
 			text-decoration: none;
 		}
 		&.btn-primary{
-			color: #FFF;
+			@include sakai_button_color( $button-color-background-color, $button-color-border-color, $button-color-text-color, $button-color-background-secondary-color );
 		}
 		text-decoration:underline;	
 	}


### PR DESCRIPTION
This also solves:
SAK-30929 In folder, "subject" text is slightly too large, "Check All"
column too wide
SAK-30930 Viewing messages on mobile is messy


![](https://jira.sakaiproject.org/secure/attachment/45085/Captura_de_pantalla_042816_125819_PM.jpg)

![messagebuttons](https://cloud.githubusercontent.com/assets/16644575/15219960/00a78e04-1866-11e6-91b9-c50a1ad591cd.png)

![](https://jira.sakaiproject.org/secure/attachment/45087/Captura_de_pantalla_042816_010202_PM.jpg)

![messagetable](https://cloud.githubusercontent.com/assets/16644575/15219971/0c8bb9fc-1866-11e6-91d5-5d348f195ba6.png)



![](https://jira.sakaiproject.org/secure/attachment/45037/2016-04-23_13-22-16_png_-_KyleBlythe_s_library.jpg)

![messagedetail](https://cloud.githubusercontent.com/assets/16644575/15219978/15914832-1866-11e6-81c7-a7eb5a59e485.png)


