### PR TITLE
1361: sort course grade by the letter and then calculatedGrade

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -2004,9 +2004,15 @@ public class GradebookNgBusinessService {
 				letterGrade2 = cg2.getEnteredGrade();
 			}
 
+			int gradeIndex1 = ascendingGrades.indexOf(letterGrade1);
+			int gradeIndex2 = ascendingGrades.indexOf(letterGrade2);
+
+			Double calculatedGrade1 = Double.valueOf(cg1.getCalculatedGrade());
+			Double calculatedGrade2 = Double.valueOf(cg2.getCalculatedGrade());
+
 			return new CompareToBuilder()
-					.append(ascendingGrades.indexOf(letterGrade1), ascendingGrades.indexOf(letterGrade2))
-					.append(ascendingGrades.indexOf(cg1.getPointsEarned()), ascendingGrades.indexOf(cg2.getPointsEarned()))
+					.append(gradeIndex1, gradeIndex2)
+					.append(calculatedGrade1, calculatedGrade2)
 					.toComparison();
 		}
 	}


### PR DESCRIPTION
.. rather than the pointsEarned, as pointsEarned includes extra credit scores which doesn't match the course grade display string.

I've changed the sorting algorithm to first sort on the index of the letter grade within the grading scheme and then by the calculated score.   

Delivers #1361.