### PR TITLE
SAK-30315: add styles for invisible tools 

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -43,6 +43,11 @@ body.#{$namespace}toolMenu-collapsed{
 						    z-index: 10;
 						}
 					}
+					&.is-invisible {
+						&:after {
+							display: none;
+						}
+					}
 				}
 				.#{$namespace}toolsNav__menuitem--title{
 					display: none;
@@ -232,6 +237,22 @@ nav#subSites{
 					text-overflow: ellipsis;
 					white-space: pre-wrap;
 					overflow: hidden;
+				}
+				&.is-invisible {
+					color: #AAAAAA;
+					font-style: italic;
+					position: relative;
+					&:after {
+						@extend .fa-lg;
+						@extend .fa;
+						content: '\f070';
+						position: absolute;
+						top: 4px;
+						right: 4px;
+					}
+					.#{$namespace}toolsNav__menuitem--icon{
+						font-style: italic;
+					}
 				}
 			}
 			&.is-current{


### PR DESCRIPTION
... including an icon visible in the righthand corner of the tool menu item.

Delivers [SAK-30315](https://jira.sakaiproject.org/browse/SAK-30315) so that invisible tools will look like this:

<img width="731" alt="screen shot 2016-05-13 at 4 05 47 pm" src="https://cloud.githubusercontent.com/assets/608337/15239307/ce8f4226-1924-11e6-9ae9-4460cd0ca913.png">