### PR TITLE
SAK-31099 Padding/spacing in "add" screen

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/signup/_signup.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/signup/_signup.scss
@@ -1,29 +1,18 @@
 .#{$namespace}sakai-signup {
 
 	.form-required{
-		label{
-			&:after{
-				content: "*";
-				color: darken($errorcolor, 30%);
-				position: relative;
-				top: 3px;
-			}
-		}
+		&:after{
+			content: "*";
+			color: darken($errorcolor, 30%);
+			position: relative;
+			top: 3px;
+		}		
 	}
 	
 	#meeting{
 		input{
 			margin-right: 0.5em;
 		}
-
-		input[type="radio"]{
-			float:left;
-			margin-right:10px !important;
-		}		
-
-		input[type="radio"] + label{
-			display:block;	
-		}	
 
 		&\:startTime\.minutes, &\:endTime\.minutes{
 			margin-left: 0.5em;
@@ -61,7 +50,7 @@
 		&\:emailAttendeeOnly{
 			margin-top: 0.5em;
 			margin-left: 0.5em;
-		}		
+		}
 	}
 
 	#userdef-add{
@@ -74,4 +63,8 @@
 		margin-left: 3px;
 		margin-right: 7px;
 	}
+
+	#imageOpen_otherSites,#imageClose_otherSites{
+		margin-right: 0.3em;
+	}	
 }

--- a/signup/tool/src/webapp/css/signupStyle.css
+++ b/signup/tool/src/webapp/css/signupStyle.css
@@ -248,8 +248,7 @@ table.organizer td {
 
 .mi {
 	vertical-align: top;
-	margin-left: 30px;
-	background: #e7eef5;
+	margin-left: 30px;	
 	width: 350px;
 }
 
@@ -262,8 +261,6 @@ table.organizer td {
 }
 
 .longtext_red{
-	border: 0px;
-	margin: 0px;
 	color:#b11;
 }
 
@@ -273,8 +270,7 @@ table.organizer td {
 
 .si {
 	vertical-align: top;
-	margin-left: 30px;
-	background: #e7eef5;
+	margin-left: 30px;	
 	width: 350px;
 }
 

--- a/signup/tool/src/webapp/signup/newMeeting/step1.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step1.jsp
@@ -55,8 +55,8 @@
           	    <h:inputHidden id="iframeId" value="#{NewSignupMeetingBean.iframeId}" />
             <div onmouseover="delayedRecalculateDateTime();" class="container-fluid">
                 <%-- Title --%>
-                <div class="form-group row form-required">
-                    <h:outputLabel value="#{msgs.event_name}" for="name" styleClass="col-lg-2 form-control-label"/>
+                <div class="form-group row">
+                    <h:outputLabel value="#{msgs.event_name}" for="name" styleClass="col-lg-2 form-control-label form-required"/>
                     <div class="col-lg-6">
                         <h:inputText id="name" size="40" value="#{NewSignupMeetingBean.signupMeeting.title}" 
                                     styleClass="editText form-control" required="true"  >
@@ -78,8 +78,8 @@
                 </div>
                 
                 <%-- Location --%>
-                <div class="form-group row form-required">
-                        <h:outputLabel value="#{msgs.event_location}" styleClass="col-lg-2 form-control-label"/>
+                <div class="form-group row ">
+                        <h:outputLabel value="#{msgs.event_location}" styleClass="col-lg-2 form-control-label form-required"/>
                         
                     <div class="col-lg-6">
                         <!-- Displays all the locations in the dropdown -->
@@ -162,8 +162,8 @@
                 </div>
 
                 <%-- Start time --%>
-                <div class="form-group row form-required">
-                    <h:outputLabel value="#{msgs.event_start_time}" for="startTime"  escape="false" styleClass="col-lg-2 form-control-label"/>
+                <div class="form-group row ">
+                    <h:outputLabel value="#{msgs.event_start_time}" for="startTime"  escape="false" styleClass="col-lg-2 form-control-label form-required"/>
                     <div class="col-lg-6">
                        <t:inputDate id="startTime" type="both" ampm="true" value="#{NewSignupMeetingBean.signupMeeting.startTime}" timeZone="#{UserTimeZone.userTimeZoneStr}"
                            style="color:black;" popupCalendar="true" onkeyup="setEndtimeMonthDateYear(); getSignupDuration(); sakai.updateSignupBeginsExact(); return false;" onchange="sakai.updateSignupBeginsExact();">
@@ -173,8 +173,8 @@
                 </div>
 
                 <%-- End time --%>
-                <div class="form-group row form-required">
-                    <h:outputLabel value="#{msgs.event_end_time}" for="endTime" escape="false" styleClass="col-lg-2 form-control-label"/>
+                <div class="form-group row ">
+                    <h:outputLabel value="#{msgs.event_end_time}" for="endTime" escape="false" styleClass="col-lg-2 form-control-label form-required"/>
                     <div class="col-lg-6">
                         <t:inputDate id="endTime" type="both" ampm="true" value="#{NewSignupMeetingBean.signupMeeting.endTime}" timeZone="#{UserTimeZone.userTimeZoneStr}"
                             style="color:black;" popupCalendar="true" onkeyup="getSignupDuration(); sakai.updateSignupEndsExact(); return false;" onchange="sakai.updateSignupEndsExact();">
@@ -184,8 +184,8 @@
                 </div>
                 
                 <%--  Meeting frequency --%>
-                <div class="form-group row form-required">
-                    <h:outputLabel value="#{msgs.event_recurrence}" for="recurSelector" styleClass="col-lg-2 form-control-label"/>
+                <div class="form-group row ">
+                    <h:outputLabel value="#{msgs.event_recurrence}" for="recurSelector" styleClass="col-lg-2 form-control-label form-required"/>
 
                     <div class="col-lg-6">
                         <h:selectOneMenu id="recurSelector" value="#{NewSignupMeetingBean.repeatType}" styleClass="titleText" onchange="isShowCalendar(value); sakai.toggleExactDateVisibility(); return false;">
@@ -227,7 +227,7 @@
                     <h:panelGroup layout="block" styleClass="signupBDeadline" id="signup_beginDeadline_1">
                         <h:outputLabel value="#{msgs.event_signup_begins}" styleClass="titleText col-lg-2 form-control-label" for="signupBegins"/>
                     </h:panelGroup>
-                    <h:panelGroup layout="block" styleClass="signupBDeadline col-lg-8" id="signup_beginDeadline_2">
+                    <h:panelGroup layout="block" styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_2">
                         <h:inputText id="signupBegins" value="#{NewSignupMeetingBean.signupBegins}" size="2" required="true" onkeyup="sakai.updateSignupBeginsExact();">
                             <f:validateLongRange minimum="0" maximum="99999"/>
                         </h:inputText>
@@ -251,7 +251,7 @@
                     <h:panelGroup layout="block" styleClass="signupBDeadline" id="signup_beginDeadline_3">
                         <h:outputLabel value="#{msgs.event_signup_deadline2}" styleClass="titleText col-lg-2 form-control-label" for="signupDeadline"/>
                    	</h:panelGroup>
-                    <h:panelGroup layout="block" styleClass="signupBDeadline col-lg-8" id="signup_beginDeadline_4">
+                    <h:panelGroup layout="block" styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_4">
                         <h:inputText id="signupDeadline" value="#{NewSignupMeetingBean.deadlineTime}" size="2" required="true" onkeyup="sakai.updateSignupEndsExact();">
                             <f:validateLongRange minimum="0" maximum="99999"/>
                         </h:inputText>
@@ -278,9 +278,9 @@
                 </div>
 
                 <%-- Display site/groups --%>
-                <div class="form-group row form-required">
+                <div class="form-group row ">
 
-                    <h:outputLabel value ="#{msgs.event_publish_to}" styleClass="col-lg-2 form-control-label"/>
+                    <h:outputLabel value ="#{msgs.event_publish_to}" styleClass="col-lg-2 form-control-label form-required"/>
 
                     <div class="col-lg-6" >
                         <h:panelGroup>
@@ -330,8 +330,8 @@
                 </div>
                 
                 <%-- Handle meeting types --%>
-                <div class="form-group row form-required">
-                    <h:outputLabel value ="#{msgs.event_type_title}" styleClass="col-lg-2 form-control-label"/>
+                <div class="form-group row ">
+                    <h:outputLabel value ="#{msgs.event_type_title}" styleClass="col-lg-2 form-control-label form-required"/>
 
                     <div class="col-lg-6" >
                         <h:panelGroup id="radios" styleClass="rs">

--- a/signup/tool/src/webapp/signup/organizer/copyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/copyMeeting.jsp
@@ -149,9 +149,9 @@
 				<div onmouseover="delayedRecalculateDateTime();" class="container-fluid">
 
 					<%-- Title --%>
-					<div class="form-group row form-required">
+					<div class="form-group row ">
 						<h:outputLabel value="#{msgs.event_name}" for="meetingTitle" escape="false" 
-									styleClass="col-lg-2 form-control-label"/>
+									styleClass="col-lg-2 form-control-label form-required"/>
 						<div class="col-lg-6">
 							<h:inputText id="meetingTitle" value="#{CopyMeetingSignupMBean.signupMeeting.title}" 
 								required="true" size="40" styleClass="editText form-control">
@@ -174,8 +174,8 @@
 					</div>
 
 					<%-- Location --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_location}"  escape="false" styleClass="col-lg-2 form-control-label"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_location}"  escape="false" styleClass="col-lg-2 form-control-label form-required"/>
 						<div class="col-lg-6">
 							<!-- Displays all the locations in the dropdown -->
 							<h:selectOneMenu id="selectedLocation" value="#{CopyMeetingSignupMBean.selectedLocation}">
@@ -255,8 +255,8 @@
 					</div>
 
 					<%-- Start time --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_start_time}"  styleClass="col-lg-2 form-control-label" escape="false"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_start_time}"  styleClass="col-lg-2 form-control-label form-required" escape="false"/>
 						<h:panelGroup styleClass="editText col-lg-6" rendered="#{!CopyMeetingSignupMBean.customTsType}" layout="block" >
 							<t:inputDate id="startTime" type="both"  ampm="true" value="#{CopyMeetingSignupMBean.signupMeeting.startTime}" timeZone="#{UserTimeZone.userTimeZoneStr}"
 										style="color:black;" popupCalendar="true" onkeyup="setEndtimeMonthDateYear();getSignupDuration();sakai.updateSignupBeginsExact();return false;"
@@ -277,8 +277,8 @@
 					</div>
 
 					<%-- End time --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_end_time}" escape="false" styleClass="col-lg-2 form-control-label"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_end_time}" escape="false" styleClass="col-lg-2 form-control-label form-required"/>
 						<h:panelGroup styleClass="editText col-lg-6" rendered="#{!CopyMeetingSignupMBean.customTsType}" layout="block">
 							<t:inputDate id="endTime" type="both" ampm="true" value="#{CopyMeetingSignupMBean.signupMeeting.endTime}" timeZone="#{UserTimeZone.userTimeZoneStr}" style="color:black;" popupCalendar="true" 
 								onkeyup="getSignupDuration(); sakai.updateSignupEndsExact(); return false;" onchange="sakai.updateSignupEndsExact();"/>
@@ -343,7 +343,7 @@
 					<div class="form-group row">
 						<h:outputLabel value="#{msgs.event_signup_start}" styleClass="form-control-label col-lg-2"
 								rendered="#{!CopyMeetingSignupMBean.announcementType}" escape="false"/>
-						<h:panelGroup layout="block" rendered="#{!CopyMeetingSignupMBean.announcementType}" styleClass="col-lg-6">
+						<h:panelGroup layout="block" rendered="#{!CopyMeetingSignupMBean.announcementType}" styleClass="col-lg-10">
 							<h:panelGroup>
 								<h:inputText id="signupBegins" value="#{CopyMeetingSignupMBean.signupBegins}" size="3" required="true" onkeyup="sakai.updateSignupBeginsExact();">
 									<f:validateLongRange minimum="0" maximum="99999"/>
@@ -368,7 +368,7 @@
 					<div class="form-group row">
 						<h:outputLabel value="#{msgs.event_signup_deadline}" styleClass="form-control-label col-lg-2"
 								rendered="#{!CopyMeetingSignupMBean.announcementType}" escape="false"/>
-						<h:panelGroup layout="block" styleClass="col-lg-6" rendered="#{!CopyMeetingSignupMBean.announcementType}">
+						<h:panelGroup layout="block" styleClass="col-lg-10" rendered="#{!CopyMeetingSignupMBean.announcementType}">
 							<h:panelGroup>
 								<h:inputText id="signupDeadline" value="#{CopyMeetingSignupMBean.deadlineTime}" size="3" required="true" onkeyup="sakai.updateSignupEndsExact();">
 									<f:validateLongRange minimum="0" maximum="99999"/>
@@ -389,8 +389,8 @@
 					</div>
 
 					<%-- Display site/groups --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value ="#{msgs.event_publish_to}" styleClass="form-control-label col-lg-2"/>
+					<div class="form-group row ">
+						<h:outputLabel value ="#{msgs.event_publish_to}" styleClass="form-control-label col-lg-2 form-required"/>
 						<div class="col-lg-6">
 							<h:panelGroup rendered="#{CopyMeetingSignupMBean.missingSitGroupWarning}" layout="block">
 								<h:panelGrid columns="1">
@@ -485,8 +485,8 @@
 					</h:panelGroup>
 
 					<%-- Handle meeting types --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value ="#{msgs.event_type_title}" styleClass="col-lg-2 form-control-label"/>
+					<div class="form-group row ">
+						<h:outputLabel value ="#{msgs.event_type_title}" styleClass="col-lg-2 form-control-label form-required"/>
 						<div class="col-lg-6">
 							<h:outputText value="#{msgs.label_custom_timeslots}"  escape="false" rendered="#{CopyMeetingSignupMBean.customTsType}"/>
 							<h:panelGroup rendered="#{!CopyMeetingSignupMBean.customTsType}">                
@@ -496,7 +496,7 @@
 									</h:selectOneRadio> 
 								</h:panelGroup>
 								<div class="table-responsive">
-								<h:panelGrid columns="1" columnClasses="miCol1" styleClass="table">
+								<h:panelGrid columns="1" columnClasses="miCol1">
 									<%-- multiple: --%>
 									<h:panelGroup rendered="#{CopyMeetingSignupMBean.individualType}">            
 										<h:panelGrid columns="2" id="mutipleCh" styleClass="mi" columnClasses="miCol1,miCol2"> 

--- a/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
@@ -96,8 +96,8 @@
 				
 				<div onmouseover="delayedRecalculateDateTime();" class="container-fluid">
 
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_modify_option}" escape="false" styleClass="col-lg-2 form-control-label"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_modify_option}" escape="false" styleClass="col-lg-2 form-control-label form-required"/>
 						<div class="col-lg-6">
 							<h:selectOneRadio  value="#{EditMeetingSignupMBean.convertToNoRecurrent}" layout="pageDirection" styleClass="rs" rendered="#{EditMeetingSignupMBean.signupMeeting.recurredMeeting}">
 								<f:selectItem id="modify_all" itemValue="#{false}" itemLabel="#{msgs.modify_all}"/>
@@ -107,8 +107,8 @@
 					</div>
 
 					<%-- Title --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_name}" for="title" escape="false" styleClass="col-lg-2 form-control-label"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_name}" for="title" escape="false" styleClass="col-lg-2 form-control-label form-required"/>
 						<div class="col-lg-6">
 							<h:inputText id="title" value="#{EditMeetingSignupMBean.signupMeeting.title}" required="true" size="40" 
 										styleClass="editText form-control">
@@ -130,8 +130,8 @@
 					</div>
 					
 					<%-- Location --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_location}" escape="false" styleClass="col-lg-2 form-control-label"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_location}" escape="false" styleClass="col-lg-2 form-control-label form-required"/>
 						<div class="col-lg-6">
 							<!-- Displays all the locations in the dropdown -->
 							<h:selectOneMenu id="selectedLocation" value="#{EditMeetingSignupMBean.selectedLocation}">
@@ -211,8 +211,8 @@
 					<h:outputText id="rescheduleWarnLabel_2" value="#{msgs.warn_reschedule_event}" styleClass="alertMessage" style="display:none;width:95%" escape="false" rendered="#{EditMeetingSignupMBean.someoneSignedUp}"/>
 
 					<%-- Start time --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_start_time}"  styleClass="col-lg-2 form-control-label" escape="false"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_start_time}"  styleClass="col-lg-2 form-control-label form-required" escape="false"/>
 						<h:panelGroup styleClass="col-lg-6" rendered="#{!EditMeetingSignupMBean.customTsType}" layout="block">
 							<t:inputDate id="startTime" type="both"  ampm="true" value="#{EditMeetingSignupMBean.signupMeeting.startTime}" timeZone="#{UserTimeZone.userTimeZoneStr}"
 										style="color:black;" popupCalendar="true" onfocus="showRescheduleWarning();" onkeyup="setEndtimeMonthDateYear(); getSignupDuration(); sakai.updateSignupBeginsExact(); return false;"
@@ -233,8 +233,8 @@
 					</div>
 
 					<%-- End time --%>
-					<div class="form-group row form-required">
-						<h:outputLabel value="#{msgs.event_end_time}" styleClass="col-lg-2 form-control-label" escape="false"/>
+					<div class="form-group row ">
+						<h:outputLabel value="#{msgs.event_end_time}" styleClass="col-lg-2 form-control-label form-required" escape="false"/>
 						<h:panelGroup styleClass="col-lg-6" rendered="#{!EditMeetingSignupMBean.customTsType}" layout="block">
 							<t:inputDate id="endTime" type="both" ampm="true" value="#{EditMeetingSignupMBean.signupMeeting.endTime}" timeZone="#{UserTimeZone.userTimeZoneStr}" style="color:black;" popupCalendar="true" 
 										onfocus="showRescheduleWarning();" onkeyup="getSignupDuration(); sakai.updateSignupEndsExact(); return false;" onchange="sakai.updateSignupEndsExact();"/>
@@ -258,7 +258,7 @@
 						<h:panelGroup styleClass="signupBDeadline col-lg-2" id="signup_beginDeadline_1" layout="block">
 							<h:outputLabel value="#{msgs.event_signup_start}" escape="false" styleClass="form-control-label "/>
 						</h:panelGroup>
-						<h:panelGroup styleClass="signupBDeadline col-lg-6" id="signup_beginDeadline_2" layout="block">
+						<h:panelGroup styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_2" layout="block">
 							<h:inputText id="signupBegins" value="#{EditMeetingSignupMBean.signupBegins}" size="3" required="true" onkeyup="sakai.updateSignupBeginsExact();">
 								<f:validateLongRange minimum="0" maximum="99999"/>
 							</h:inputText>
@@ -281,7 +281,7 @@
 						<h:panelGroup styleClass="signupBDeadline col-lg-2" id="signup_beginDeadline_3" layout="block">
 							<h:outputLabel value="#{msgs.event_signup_deadline}" escape="false" styleClass="form-control-label"/>
 						</h:panelGroup>
-						<h:panelGroup styleClass="signupBDeadline col-lg-6" id="signup_beginDeadline_4" layout="block">
+						<h:panelGroup styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_4" layout="block">
 							<h:inputText id="signupDeadline" value="#{EditMeetingSignupMBean.deadlineTime}" size="3" required="true" onkeyup="sakai.updateSignupEndsExact();">
 								<f:validateLongRange minimum="0" maximum="99999"/>
 							</h:inputText>
@@ -309,8 +309,8 @@
 					</h:panelGroup>
 					
 					<%-- Handle meeting types --%>
-					<h:panelGroup styleClass="form-group row form-required"  layout="block">
-						<h:outputLabel value ="#{msgs.event_type_title}"  styleClass="col-lg-2 form-control-label"/>
+					<h:panelGroup styleClass="form-group row "  layout="block">
+						<h:outputLabel value ="#{msgs.event_type_title}"  styleClass="col-lg-2 form-control-label form-required"/>
 						<h:panelGroup layout="block" styleClass="col-lg-6" rendered="#{EditMeetingSignupMBean.customTsType}">
 							<h:outputText value="#{msgs.label_custom_timeslots}"  escape="false"/>
 						</h:panelGroup>


### PR DESCRIPTION
There are a few issues still (Padding.png):
1. the + icon and Other Sites needs padding
2. "Open meeting..." wraps all the way back to the radio buttons, should
wrap to the beginning of the text
3. Open meeting, Single slot, and Multiple slot don't need * icons
(Available to gets a * because ONE of the options MUST be selected, but
not all of them)
4. The number of slots setup is inconsistent with other parts of Sakai



![](https://jira.sakaiproject.org/secure/attachment/45359/Padding.png)


![signup](https://cloud.githubusercontent.com/assets/16644575/15241566/36984f0e-18f1-11e6-9c6b-4987f542469d.png)
