### PR TITLE
SAK-31203 typo in authz tool

### DIFF
--- a/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
+++ b/authz/authz-tool/tool/src/webapp/vm/helper/chef_permissions.vm
@@ -28,7 +28,7 @@
 					$thelp.getString("per.lis.selectgrp")
 					</label>
 					<select id="authzGroupSelection" name="authzGroupSelection" onchange="SPNR.insertSpinnerAfter( this, null, null );document.viewForm.submit();">
-						<option value ="$siteRef" #if ($!viewRealmId.equals($!siteId)) selected = "selected" #end>$thelp.getString("per.lis.site")</option>
+						<option value ="$siteRef" #if ($!viewRealmIds.contains($!siteId)) selected = "selected" #end>$thelp.getString("per.lis.site")</option>
 						## for each group
 						#set($groupCount=0)
 						 #foreach ($group in $!groups)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31203

A typo was introduced in SAK-30069, changing "viewRealmIds" to "viewRealmId", which is not in the context.

Thanks again to @buckett for finding this.