### PR TITLE
SAK-31027 Tablet view - Edit Class Roster(s) table shows extra column

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/css/GroupList.css
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/css/GroupList.css
@@ -262,3 +262,7 @@ input[type="checkbox"] ~ label{
 input[type="checkbox"]{
 	vertical-align: top !important;
 }
+
+th.check, td.check{
+	width: 5%;
+}

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
@@ -25,34 +25,35 @@
                 <p rsf:id="msg=group.autocreate.instructions" class="instruction">Select a course roster to create a separate group for that roster.</p>
                 <div rsf:id="roster_options:">
                     <h4 rsf:id="msg=instruction.header.roster">From Rosters</h4>
-                    <table id="rosterList" width="80%" border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines centerLines" summary="placeholder summary">
-                        <thead>
-                            <tr>
-                                <th class="attach">
-                                    <input id="rosterSelectAllNone" type="checkbox" /><span rsf:id="roster-select-header" class="skip">Select</span>
-                                </th>
-                                <th rsf:id="roster-title-header">
-                                    Course Roster
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr rsf:id="roster-row:">
-                                <td class="attach">
-                                    <input class="rostercheckbox " id="roster-checkbox" rsf:id="roster-checkbox" type="checkbox" />
-                                </td>
-                                <td>
-                                    <label rsf:id="roster-title">
-                                        Provider Title
-                                    </label>
-                                    <span rsf:id="exist-group-roster" class="highlight">
-                                        A site with this roster already exist
-                                    </span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-
+                    <div class="table-responsive">
+                        <table id="rosterList" class="table table-striped table-bordered table-hover" summary="placeholder summary">
+                            <thead>
+                                <tr>
+                                    <th class="attach check">
+                                        <input id="rosterSelectAllNone" type="checkbox" /><span rsf:id="roster-select-header" class="skip">Select</span>
+                                    </th>
+                                    <th rsf:id="roster-title-header">
+                                        Course Roster
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr rsf:id="roster-row:">
+                                    <td class="attach check">
+                                        <input class="rostercheckbox " id="roster-checkbox" rsf:id="roster-checkbox" type="checkbox" />
+                                    </td>
+                                    <td>
+                                        <label rsf:id="roster-title">
+                                            Provider Title
+                                        </label>
+                                        <span rsf:id="exist-group-roster" class="highlight">
+                                            A site with this roster already exist
+                                        </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                      <fieldset class="fieldsetVis" id="rosterOptionsFieldset" style="display:none">
                         <span rsf:id="roster-option-radios" />
                         <p class="checkbox">
@@ -131,34 +132,35 @@
                 </div>
                 <div rsf:id="role_options:" class="autoGroupsRoleContainer">
                 	<h4 rsf:id="msg=instruction.header.role">From Roles</h4>
-	                    <table id ="roleList" width="80%" border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines centerLines labelizeMe" summary="placeholder summary">
-	                        <thead>
-	                            <tr>
-	                                <th class="attach">
-	                                    <input id="roleSelectAllNone" type="checkbox" /><span rsf:id="role-select-header" class="skip">Select</span>
-	                                </th>
-	                                <th rsf:id="role-title-header">
-	                                    Role
-	                                </th>
-	                            </tr>
-	                        </thead>
-	                        <tbody>
-	                            <tr rsf:id="role-row:">
-	                                <td class="attach">
-	                                    <input class="rolecheckbox " id="role-checkbox" rsf:id="role-checkbox" type="checkbox"/>
-	                                </td>
-	                                <td>
-	                                    <label rsf:id="role-title">
+                        <div class="table-responsive">
+                            <table id ="roleList" class="table table-bordered table-hover table-striped" summary="placeholder summary">
+                                <thead>
+                                    <tr>
+	                                   <th class="attach check">
+	                                       <input id="roleSelectAllNone" type="checkbox" /><span rsf:id="role-select-header" class="skip">Select</span>
+	                                   </th>
+	                                   <th rsf:id="role-title-header">
+	                                       Role
+	                                   </th>
+	                               </tr>
+                                </thead>
+	                           <tbody>
+	                               <tr rsf:id="role-row:">
+	                                   <td class="attach check">
+	                                       <input class="rolecheckbox " id="role-checkbox" rsf:id="role-checkbox" type="checkbox"/>
+	                                   </td>
+	                                   <td>
+                                        <label rsf:id="role-title">
 	                                        Role Title
 	                                    </label>
 	                                    <span rsf:id="exist-group-role" class="highlight">
 	                                        A group with this role already exist
 	                                    </span>
-	                                </td>
-	                            </tr>
-	                        </tbody>
-	                    </table>
-                
+	                                   </td>
+	                               </tr>
+	                           </tbody>
+	                       </table>
+                        </div>
                     <fieldset class="fieldsetVis" id="roleOptionsFieldset" style="display:none">          
 	                	<span rsf:id="option-radios" />
 	                	<p class="checkbox">

--- a/site-manage/site-manage-link-helper/src/bundle/link.properties
+++ b/site-manage/site-manage-link-helper/src/bundle/link.properties
@@ -3,6 +3,8 @@ gen.save = Set Link
 gen.cancel = Cancel
 gen.remove = Remove Link
 
+title=Link to Parent Site
+
 java.selectparent=Linking this site to a parent site does not affect membership or permission or tool behavior or tool content in either the parent or child sites.  Linking to a parent site simply means that for users who are members of both sites and have permission to view both sites, they will see navigation hints and breadcrumb navigation showing site links between the parent and child sites.  A site can have many child sites pointing to it, but a child site can have only one parent.
 
 java.please.select=---- Please Select Parent Site----

--- a/site-manage/site-manage-link-helper/src/webapp/vm/sakai_link.vm
+++ b/site-manage/site-manage-link-helper/src/webapp/vm/sakai_link.vm
@@ -1,5 +1,6 @@
 <script type="text/javascript" src="/library/js/spinner.js"></script>
 <div class="portletBody">
+<h3>$tlang.getString('title')</h3>
 #if ($alertMessage)
     <div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div><div style="display:block;clear:both" ></div>
 #end

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Confirm.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Confirm.html
@@ -23,24 +23,26 @@
 		<span rsf:id="emailnoti"></span>
 		<form rsf:id="confirm" action="Add.html">
 			<input rsf:id="csrfToken" name="csrfToken" id="csrfToken" type="hidden"/>
-			<table class="listHier" border="0" cellspacing="0">
-			  <thead>
-			    <tr>
-			      <th rsf:id="msg=confirm.name">Name</th>
-			      <th rsf:id="msg=confirm.id">Id</th>
-			      <th rsf:id="msg=confirm.role">Role</th>
-			      <th rsf:id="msg=confirm.status">Status</th>
-			    </tr>
-			  </thead>
-			  <tbody>
-			    <tr rsf:id="user-row:">
-			      <td rsf:id="user-name"></td>
-			      <td rsf:id="user-eid"></td>
-			      <td rsf:id="user-role"></td>
-			      <td rsf:id="user-status"></td>
-			    </tr>
-			  </tbody>
-			</table>
+			<div class="table-responsive">
+				<table class="table table-bordered table-hover table-striped" border="0" cellspacing="0">
+					<thead>
+						<tr>
+							<th rsf:id="msg=confirm.name">Name</th>
+							<th rsf:id="msg=confirm.id">Id</th>
+							<th rsf:id="msg=confirm.role">Role</th>
+							<th rsf:id="msg=confirm.status">Status</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr rsf:id="user-row:">
+							<td rsf:id="user-name"></td>
+							<td rsf:id="user-eid"></td>
+							<td rsf:id="user-role"></td>
+							<td rsf:id="user-status"></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 			<p class="act">
 				<input accesskey ="s" rsf:id="continue" class="active" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				<input accesskey ="b" rsf:id="back" value="Back" type="submit" onclick="SPNR.disableControlsAndSpin( this, null );" />

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/DifferentRole.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/DifferentRole.html
@@ -24,32 +24,36 @@
 		<h3 rsf:id="msg=adddif.choose">Choose a Role for Participants</h3>
 		<form rsf:id="differentRole-form">
 			<input rsf:id="csrfToken" name="csrfToken" id="csrfToken" type="hidden"/>
-			<table class="listHier lines nolines" style="width:100%" summary="">
-				<tr rsf:id="role-row:">
-					<td rsf:id="role-id"></td>
-					<td rsf:id="role-description"></td>		
-				</tr>
-			</table>
-			<table class="listHier" border="0" cellspacing="0">
-			  <thead>
-			    <tr>
-			      <th rsf:id="msg=addconf.username">UserName</th>
-			      <th rsf:id="msg=addconf.role">Role</th>
-			    </tr>
-			  </thead>
-			  <tbody>
-			    <tr rsf:id="user-row:">
-			      <td rsf:id="user-name"></td>
-			      <td width="10%">
-						<select size="1" rsf:id="role-select" id="role-select" style="valign:top">
-						  <option value="" selected="selected">Please choose a role:</option>
-				          <option value="access" >access</option>
-				          <option value="maintain">maintain</option>
-				        </select>
-				      </td>
-			    </tr>
-			  </tbody>
-			</table>
+			<div class="table-responsive">
+				<table class="table table-bordered table-hover table-striped" summary="">
+					<tr rsf:id="role-row:">
+						<td rsf:id="role-id"></td>
+						<td rsf:id="role-description"></td>		
+					</tr>
+				</table>
+			</div>
+			<div class="table-responsive">
+				<table class="table table-bordered table-hover table-striped" border="0" cellspacing="0">
+					<thead>
+						<tr>
+							<th rsf:id="msg=addconf.username">UserName</th>
+							<th rsf:id="msg=addconf.role">Role</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr rsf:id="user-row:">
+							<td rsf:id="user-name"></td>
+							<td width="10%">
+								<select size="1" rsf:id="role-select" id="role-select" style="valign:top">
+									<option value="" selected="selected">Please choose a role:</option>
+									<option value="access" >access</option>
+									<option value="maintain">maintain</option>
+								</select>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 			<p class="act">
 				<input accesskey ="s" rsf:id="continue" class="active" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				<input accesskey ="b" rsf:id="back" value="Back" type="submit" onclick="SPNR.disableControlsAndSpin( this, null );" />

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/SameRole.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/SameRole.html
@@ -24,34 +24,37 @@
 			<!-- roles -->
 			<h4 rsf:id="msg=addsame.roles"></h4>
 			<span rsf:id="select-roles"></span>
-			<table class="listHier lines nolines" style="width:auto" summary="">
-				<tr rsf:id="role-row:">
-					<td>
-					  <input rsf:id="role-select" title="Select role type" type="radio" id="radio" name="roleChoice" value=""/>
-					</td>		
-					<td>
-					  <label rsf:id="role-label" for = "role-select">
-					  	label
-					  </label>
-					</td>		
-					<td>
-					  <label rsf:id="role-descr-label">
-					  	label
-					  </label>
-					</td>		
-				</tr>
-			</table>
-			
-			<h4 rsf:id="msg=addsame.participants"></h4> 
-			<table class="listHier lines nolines" style="width:auto" summary="">
-				<tr rsf:id="user-row:">
-					<td>
-					  <h5 rsf:id="user-label">
-					  	user
-					  </h5>
-					</td>		
-				</tr>
-			</table>
+			<div class="table-responsive">
+				<table class="table table-bordered table-hover table-striped" summary="">
+					<tr rsf:id="role-row:">
+						<td>
+							<input rsf:id="role-select" title="Select role type" type="radio" id="radio" name="roleChoice" value=""/>
+						</td>
+						<td>
+							<label rsf:id="role-label" for = "role-select">
+								label
+							</label>
+						</td>
+						<td>
+							<label rsf:id="role-descr-label">
+								label
+							</label>
+						</td>
+					</tr>
+				</table>
+			</div>
+			<h4 rsf:id="msg=addsame.participants"></h4>
+			<div class="table-responsive"> 
+				<table class="table table-bordered table-hover table-striped" summary="">
+					<tr rsf:id="user-row:">
+						<td>
+							<h5 rsf:id="user-label">
+								user
+							</h5>
+						</td>
+					</tr>
+				</table>
+			</div>
 			<p class="act">
 				<input accesskey ="s" rsf:id="continue" class="active" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				<input accesskey ="b" rsf:id="back" value="Back" type="submit" onclick="SPNR.disableControlsAndSpin( this, null );" />

--- a/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
+++ b/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
@@ -592,6 +592,10 @@ input#btnSearch {
 	font-weight: bold;
 }
 
-.listNav{
-	text-align:center;
+#removeClass{
+	max-width: 800px;
+}
+
+#removeClass #remove{
+	width: 5%;
 }

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
@@ -47,85 +47,86 @@
 	
 	
 	<form name="importSitesForm" action="#toolForm("$action")" method="post">
-		<table class ="listHier lines nolines" cellspacing="0" summary="$tlang.getString("import.choose.list.summary")" border="0">
-			<tr>
-				<th>
-					&nbsp;
-				</th>
-				#foreach($site in $importSites.keys())
+		<div class="table-responsive">
+			<table class ="table table-bordered table-hover table-striped"  summary="$tlang.getString("import.choose.list.summary")" >
+				<tr>
 					<th>
-						$validator.escapeHtml($site.getTitle())
+						&nbsp;
 					</th>
-				#end
-			</tr>
-			#set ($toolCount=0)
-			#foreach($toolId in $selectedTools)
-					#set($selectedSites = $!importSitesTools.get($toolId))
-					#set ($toolCount=$toolCount + 1)
-					#if ($importSupportedTools.contains($toolId))
-					<tr>					
-						<td>
-								#set($toolTitle = "")
-								#set($alternateToolTitles = "")
+					#foreach($site in $importSites.keys())
+						<th>
+							$validator.escapeHtml($site.getTitle())
+						</th>
+					#end
+				</tr>
+				#set ($toolCount=0)
+				#foreach($toolId in $selectedTools)
+						#set($selectedSites = $!importSitesTools.get($toolId))
+						#set ($toolCount=$toolCount + 1)
+						#if ($importSupportedTools.contains($toolId))
+						<tr>					
+							<td>
+									#set($toolTitle = "")
+									#set($alternateToolTitles = "")
 								
-								#foreach($t in $toolRegistrationList)
-									#if ($t.getId() == $toolId)
-										#set($toolTitle = $t.getTitle())
+									#foreach($t in $toolRegistrationList)
+										#if ($t.getId() == $toolId)
+											#set($toolTitle = $t.getTitle())
+										#end
 									#end
-								#end
-								#if($toolId == "sakai.iframe.site")
-									#set($toolTitle = $siteInfoToolTitle)
-								#end
+									#if($toolId == "sakai.iframe.site")
+										#set($toolTitle = $siteInfoToolTitle)
+									#end
 								
-								#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
+									#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
 								
-								<h4>$toolTitle
+									<h5>$toolTitle
 									
-									#if ($alternateToolTitles != "")
-										<span class="instruction">($alternateToolTitles)</span>
-									#end
+										#if ($alternateToolTitles != "")
+											<span class="instruction">($alternateToolTitles)</span>
+										#end
 								
-    								#if ($addMissingTools)
-    									## if the tool doesnt exist in the selected site, output icon
-    									#if(!$toolsInDestinationSite.contains($toolId))
-											<sup>+</sup>
+    									#if ($addMissingTools)
+    										## if the tool doesnt exist in the selected site, output icon
+    										#if(!$toolsInDestinationSite.contains($toolId))
+												<sup>+</sup>
+    										#end
     									#end
-    								#end
-								
-								</h4>
-							</td>
-							#set ($siteCount=0)
-							#foreach($site in $importSites.keys())
-								#set ($siteCount=$siteCount + 1)
-									<td>
-										#set($toolFound = false)
-										#set($allPages = $site.getPages())
-										#foreach ($page in $allPages)
-											#set($pageTools = $page.getTools())
-											#foreach ($pageTool in $pageTools)
-												#if ($pageTool.getTool().getId() == $toolId)
-													#set($toolFound = true)
+									</h5>
+								</td>
+								#set ($siteCount=0)
+								#foreach($site in $importSites.keys())
+									#set ($siteCount=$siteCount + 1)
+										<td>
+											#set($toolFound = false)
+											#set($allPages = $site.getPages())
+											#foreach ($page in $allPages)
+												#set($pageTools = $page.getTools())
+												#foreach ($pageTool in $pageTools)
+													#if ($pageTool.getTool().getId() == $toolId)
+														#set($toolFound = true)
+													#end
 												#end
 											#end
-										#end
 										
-										#set ($toolsWithContent = $!siteToolsWithContent.get($site.getId()))
-										#if(!$toolsWithContent.contains($toolId))
-											#set($toolFound = false)
-    									#end
+											#set ($toolsWithContent = $!siteToolsWithContent.get($site.getId()))
+											#if(!$toolsWithContent.contains($toolId))
+												#set($toolFound = false)
+    										#end
 										
-										#if ($toolFound)
-											<input type="checkbox" id="toolSite$toolCount$siteCount" name="$toolId" value="$site.Id" #if($!selectedSites.contains($site.Id))checked="checked"#end />
-											<label  class="skip" for="toolSite$toolCount$siteCount">$tlang.getString('import.choose.label1')  $toolTitle $tlang.getString('import.choose.label2') $validator.escapeHtml($site.getTitle())</label>
-										#else
-											<input type="checkbox" id="toolSite$toolCount$siteCount"  name="$toolId" value="$site.Id" disabled="disabled" />
-										#end
-									</td>
-							#end
-						</tr>	
-					#end
-			#end
-		</table>
+											#if ($toolFound)
+												<input type="checkbox" id="toolSite$toolCount$siteCount" name="$toolId" value="$site.Id" #if($!selectedSites.contains($site.Id))checked="checked"#end />
+												<label  class="skip" for="toolSite$toolCount$siteCount">$tlang.getString('import.choose.label1')  $toolTitle $tlang.getString('import.choose.label2') $validator.escapeHtml($site.getTitle())</label>
+											#else
+												<input type="checkbox" id="toolSite$toolCount$siteCount"  name="$toolId" value="$site.Id" disabled="disabled" />
+											#end
+										</td>
+								#end
+							</tr>	
+						#end
+				#end
+			</table>
+		</div>
 		
 		#if ($addMissingTools)
 			<p class="messageConfirmation">$tlang.getString("import.newtool")</p>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
@@ -14,85 +14,87 @@
 	$tlang.getString("sitinfimp.choose")
 	</p>
 	<form name="importSitesForm" action="#toolForm("$action")" method="post">
-		<table class ="listHier lines nolines" cellspacing="0" summary="$tlang.getString("import.choose.list.summary")" border="0">
-			<tr>
-				<th>
-					&nbsp;
-				</th>
-				#foreach($site in $importSites.keys())
+		<div class="table-responsive">
+			<table class ="table table-bordered table-hover table-striped" summary="$tlang.getString("import.choose.list.summary")">
+				<tr>
 					<th>
-						$validator.escapeHtml($site.getTitle())
+						&nbsp;
 					</th>
-				#end
-			</tr>
-			#set ($toolCount=0)
-			#foreach($toolId in $selectedTools)
-			#set($selectedSites = $!importSitesTools.get($toolId))
-			#set ($toolCount=$toolCount + 1)
-				#if ($importSupportedTools.contains($toolId))
-					<tr>
-						<td>
-							#set($toolTitle = "")
-							#set($alternateToolTitles = "")
+					#foreach($site in $importSites.keys())
+						<th>
+							$validator.escapeHtml($site.getTitle())
+						</th>
+					#end
+				</tr>
+				#set ($toolCount=0)
+				#foreach($toolId in $selectedTools)
+				#set($selectedSites = $!importSitesTools.get($toolId))
+				#set ($toolCount=$toolCount + 1)
+					#if ($importSupportedTools.contains($toolId))
+						<tr>
+							<td>
+								#set($toolTitle = "")
+								#set($alternateToolTitles = "")
 
-							#foreach($t in $toolRegistrationList)
-								#if ($t.getId() == $toolId)
-									#set($toolTitle = $t.getTitle())
-								#end
-							#end
-							#if($toolId == "sakai.iframe.site")
-								#set($toolTitle = $siteInfoToolTitle)
-							#end
-							
-							#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
-							
-							<h4>$toolTitle
-								
-								#if ($alternateToolTitles != "")
-									<span class="instruction">($alternateToolTitles)</span>
-								#end
-								
-								#if ($addMissingTools)
-									## if the tool doesnt exist in the selected site, output icon
-									#if(!$toolsInDestinationSite.contains($toolId))
-										<sup>+</sup>
+								#foreach($t in $toolRegistrationList)
+									#if ($t.getId() == $toolId)
+										#set($toolTitle = $t.getTitle())
 									#end
 								#end
-							</h4>
-						</td>
-						#set ($siteCount=0)
-						#foreach($site in $importSites.keys())
-						#set ($siteCount=$siteCount + 1)
-							<td>
-								#set($toolFound = false)
-								#set($allPages = $site.getPages())
-								#foreach ($page in $allPages)
-									#set($pageTools = $page.getTools())
-									#foreach ($pageTool in $pageTools)
-										#if ($pageTool.getTool().getId() == $toolId)
-											#set($toolFound = true)
+								#if($toolId == "sakai.iframe.site")
+									#set($toolTitle = $siteInfoToolTitle)
+								#end
+							
+								#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
+							
+								<h5>$toolTitle
+								
+									#if ($alternateToolTitles != "")
+										<span class="instruction">($alternateToolTitles)</span>
+									#end
+								
+									#if ($addMissingTools)
+										## if the tool doesnt exist in the selected site, output icon
+										#if(!$toolsInDestinationSite.contains($toolId))
+											<sup>+</sup>
 										#end
 									#end
-								#end
-								
-								#set ($toolsWithContent = $!siteToolsWithContent.get($site.getId()))
-								#if(!$toolsWithContent.contains($toolId))
-									#set($toolFound = false)
-								#end
-								
-								#if ($toolFound)
-									<input type="checkbox" id="toolSite$toolCount$siteCount" name="$toolId" value="$site.Id" #if($!selectedSites.contains($site.Id))checked="checked"#end />
-									<label  class="skip" for="toolSite$toolCount$siteCount">$tlang.getString('import.choose.label1')  $toolTitle $tlang.getString('import.choose.label2') $validator.escapeHtml($site.getTitle())</label>
-									#if ($toolId.indexOf("sakai.rwiki") != -1) $tlang.getString("sitinfimp.wikinote") #end
-								#else
-									<input type="checkbox" id="toolSite$toolCount$siteCount"  name="$toolId" value="$site.Id" disabled="disabled" />
-								#end
+								</h5>
 							</td>
-						#end
-					</tr>
+							#set ($siteCount=0)
+							#foreach($site in $importSites.keys())
+							#set ($siteCount=$siteCount + 1)
+								<td>
+									#set($toolFound = false)
+									#set($allPages = $site.getPages())
+									#foreach ($page in $allPages)
+										#set($pageTools = $page.getTools())
+										#foreach ($pageTool in $pageTools)
+											#if ($pageTool.getTool().getId() == $toolId)
+												#set($toolFound = true)
+											#end
+										#end
+									#end
+								
+									#set ($toolsWithContent = $!siteToolsWithContent.get($site.getId()))
+									#if(!$toolsWithContent.contains($toolId))
+										#set($toolFound = false)
+									#end
+								
+									#if ($toolFound)
+										<input type="checkbox" id="toolSite$toolCount$siteCount" name="$toolId" value="$site.Id" #if($!selectedSites.contains($site.Id))checked="checked"#end />
+										<label  class="skip" for="toolSite$toolCount$siteCount">$tlang.getString('import.choose.label1')  $toolTitle $tlang.getString('import.choose.label2') $validator.escapeHtml($site.getTitle())</label>
+										#if ($toolId.indexOf("sakai.rwiki") != -1) $tlang.getString("sitinfimp.wikinote") #end
+									#else
+										<input type="checkbox" id="toolSite$toolCount$siteCount"  name="$toolId" value="$site.Id" disabled="disabled" />
+									#end
+								</td>
+							#end
+						</tr>
+					#end
 				#end
-			#end
-		</table>
+			</table>
+		</div>
 		
 		#if ($addMissingTools)
 			<p class="messageConfirmation">$tlang.getString("import.newtool")</p>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -11,7 +11,8 @@
 	#end
 	<form name="removeClassForm" id="removeClassForm" action="#toolForm("$action")" method="post">
 	#if ($!providerCourseList && !$!providerCourseList.isEmpty()|| $!manualCourseList && !$!manualCourseList.isEmpty() || $!cmRequestedCourseList && !$!cmRequestedCourseList.isEmpty())
-			<table class ="listHier lines nolines" cellpadding="0" cellspacing="0" summary ="$tlang.getString("sitedicla.tabhol")" style="width:70%">
+			<div class="table-responsive">
+			<table id="removeClass" class ="table table-bordered table-striped table-hover" cellpadding="0" cellspacing="0" summary ="$tlang.getString("sitedicla.tabhol")">
 				<tr>
 					<th id="class">
 						$tlang.getString("sitedicla.class")
@@ -25,9 +26,9 @@
 				#set ($providerCourseListNum =$providerCourseListNum + 1)	
 					<tr>
 						<td headers="class">
-							<h4><label for="pcl$providerCourseListNum" title="$id">
+							<h5><label for="pcl$providerCourseListNum" title="$id">
 								$!providerCourseTitles.get($id)
-							</label></h4>
+							</label></h5>
 						</td>
 						<td headers="remove" class="screenOnly">
 							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="providerClassDeletes" value="$id" id="pcl$providerCourseListNum" onclick="checkEnableRemove();" />
@@ -39,11 +40,11 @@
 				#set ($cmRequestedCourseListNum =$cmRequestedCourseListNum + 1)
 					<tr>
 						<td headers="class">
-							<h4>
+							<h5>
 								<label for="cmrcl$cmRequestedCourseListNum">
 									$id.title $tlang.getString("sitedicla.requested")
 								</label>
-							</h4>
+							</h5>
 						</td>
 						<td headers="remove" class="screenOnly">
 							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="cmRequestedClassDeletes" value="$id.eid" id="cmrcl$cmRequestedCourseListNum" onclick="checkEnableRemove();" />
@@ -55,11 +56,11 @@
 				#set ($manualCourseListNum =$manualCourseListNum + 1)
 					<tr>
 						<td headers="class">
-							<h4>
+							<h5>
 								<label for="mcl$manualCourseListNum">
 									$id $tlang.getString("sitedicla.requested")
 								</label>
-							</h4>
+							</h5>
 						</td>
 						<td headers="remove" class="screenOnly">
 							<span class="skip">$tlang.getString("sitedicla.rem")</span><input type="checkbox" name="manualClassDeletes" value="$id" id="mcl$manualCourseListNum" onclick="checkEnableRemove();" />
@@ -67,6 +68,7 @@
 					</tr>
 				#end
 			</table>
+			</div>
 			<p class="act">
 				<input type="hidden" name="continue" value="$!templateIndex" />
 				<input type="hidden" name="back" value="12" />

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -541,7 +541,8 @@
 		<a href="$printParticipantUrl" title="$!tlang.getString('print')">$!tlang.getString('print')</a><i class="icon-sakai-pdf"></i>
 		<hr />
 		<form name="participantForm" id="participantForm" action="#toolForm("SiteAction")" method="post">
-			<table class ="listHier lines nolines"  cellpadding="0" cellspacing="0" border="0" summary ="$tlang.getString("sitegen.siteinfolist.partlist.summary")" id="siteMembers">
+			<div class="table-responsive">
+			<table class ="table table-responsive table-bordered table-striped table-hover" summary ="$tlang.getString("sitegen.siteinfolist.partlist.summary")" id="siteMembers">
 				<tr>
 					<th id="name" scope="col">
 						<a href="#toolLinkParam("SiteAction" "doSort_roster" "criterion=participant_name")" title ="$tlang.getString("sitegen.siteinfolist.sortname")"> 
@@ -734,7 +735,7 @@
 						#end
 					</tr>
 				#end
-			</table>
+			</table></div>
 			<hr />
 			<div class="act" style="padding: 0 0">
 				<input type="submit" accesskey="s" class="active" name="eventSubmit_doUpdate_participant" value="$tlang.getString("sitegen.siteinfolist.update")" onclick="SPNR.disableControlsAndSpin( this, null );" />

--- a/userauditservice/tool/src/webapp/eventLog.jsp
+++ b/userauditservice/tool/src/webapp/eventLog.jsp
@@ -20,16 +20,15 @@ response.setContentType("text/html; charset=UTF-8");
 				pageSize="#{eventLog.pageSize}"
 				accesskeys="true"
 				immediate="true" />
-			
-			<t:dataTable cellpadding="0" cellspacing="0"
-	                        id="userauditTable"
+			<div class="table-responsive">
+			<t:dataTable    id="userauditTable"
 	                        value="#{eventLog.eventLog}"
 	                        var="audit"
 	                        sortColumn="#{eventLog.sortColumn}"
 	                        sortAscending="#{eventLog.sortAscending}"
 	                        first="#{eventLog.firstItem}"
 	                        rows="#{eventLog.rowsNumber}"
-	                        styleClass="listHier userauditTable">
+	                        styleClass="table table-responsive table-hover table-striped">
 	               <h:column>
 					<f:facet name="header">
 						<t:commandSortHeader columnName="userDisplayName" immediate="true" arrow="true">
@@ -79,6 +78,7 @@ response.setContentType("text/html; charset=UTF-8");
 	                   <h:outputText value="#{audit.sourceText}" />
 	               </h:column>
 	           </t:dataTable>
+	           </div>
 	       </h:form>
 	</sakai:view>
 </f:view>


### PR DESCRIPTION
This also solves SAK-31024 Participant list "view x - y of z items"
dropdown appears centered

SAK-31030 Mobile - Auto Groups - table of user roles has extra column

SAK-31031 Link to Parent Site - link/help buttons overlap text

SAK-31032 Mobile - User Audit Log table messy

SAK-31033 Mobile - Import From Site table has extra column

![](https://jira.sakaiproject.org/secure/attachment/45088/Captura_de_pantalla_042816_010854_PM.jpg)

![sak-31027 tablet view - edit class roster s table shows extra column](https://cloud.githubusercontent.com/assets/16644575/15282037/b8c340b4-1b40-11e6-901a-9bacacb84737.png)


![](https://jira.sakaiproject.org/secure/attachment/45089/Captura_de_pantalla_042816_010954_PM.jpg)


![sak-31024](https://cloud.githubusercontent.com/assets/16644575/15282063/daeae7dc-1b40-11e6-98ca-53676a098d0b.png)

![](https://jira.sakaiproject.org/secure/attachment/45100/Captura_de_pantalla_042816_013400_PM.jpg)

![sak-31031 link to parent site - linkhelp buttons overlap text](https://cloud.githubusercontent.com/assets/16644575/15282077/f4163496-1b40-11e6-86a4-4a1e9e1e3edf.png)

![](https://jira.sakaiproject.org/secure/attachment/45099/Captura_de_pantalla_042816_013143_PM.jpg)

![sak-31032 mobile - user audit log table messy](https://cloud.githubusercontent.com/assets/16644575/15282098/1576cb46-1b41-11e6-97fd-3c3b13d034c8.png)

![](https://jira.sakaiproject.org/secure/attachment/45097/Captura_de_pantalla_042816_012918_PM.jpg)

![sak-31033 mobile - import from site table has extra column](https://cloud.githubusercontent.com/assets/16644575/15282109/27bed1d6-1b41-11e6-8ce2-d39260c86d3c.png)


