### PR TITLE
2284: student grade summary sorting

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -159,6 +159,7 @@ column.header.studentsummary.duedate = Due Date
 column.header.studentsummary.grade = Grade
 column.header.studentsummary.weight = Weight
 column.header.studentsummary.comments = Comments
+column.header.studentsummary.category = Category
 
 importExport.export.heading = Export
 importExport.export.description = Export your Gradebook as a .csv file in order to enter grades/structure your Gradebook in the spreadsheet application of your choice.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -693,6 +693,14 @@ public class GradebookPage extends BasePage {
 		response.render(JavaScriptHeaderItem
 				.forUrl(String.format("/library/js/lang-datepicker/lang-datepicker.js?version=%s", version)));
 
+		// tablesorted used by student grade summary
+		response.render(CssHeaderItem
+			.forUrl(String.format("/library/js/jquery/tablesorter/2.1.17/css/theme.bootstrap.css?version=%s", version)));
+		response.render(JavaScriptHeaderItem
+			.forUrl(String.format("/library/js/jquery/tablesorter/2.1.17/jquery.tablesorter.min.js?version=%s", version)));
+		response.render(JavaScriptHeaderItem
+			.forUrl(String.format("/library/js/jquery/tablesorter/2.1.17/jquery.tablesorter.widgets.min.js?version=%s", version)));
+
 		// GradebookNG Grade specific styles and behaviour
 		response.render(CssHeaderItem
 				.forUrl(String.format("/gradebookng-tool/styles/gradebook-grades.css?version=%s", version)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
@@ -41,6 +41,14 @@ public class StudentPage extends BasePage {
 
 		final String version = ServerConfigurationService.getString("portal.cdn.version", "");
 
+		// tablesorted used by student grade summary
+		response.render(CssHeaderItem
+			.forUrl(String.format("/library/js/jquery/tablesorter/2.1.17/css/theme.bootstrap.css?version=%s", version)));
+		response.render(JavaScriptHeaderItem
+			.forUrl(String.format("/library/js/jquery/tablesorter/2.1.17/jquery.tablesorter.min.js?version=%s", version)));
+		response.render(JavaScriptHeaderItem
+			.forUrl(String.format("/library/js/jquery/tablesorter/2.1.17/jquery.tablesorter.widgets.min.js?version=%s", version)));
+
 		// GradebookNG Grade specific styles and behaviour
 		response.render(
 				CssHeaderItem.forUrl(String.format("/gradebookng-tool/styles/gradebook-grades.css?version=%s", version)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
@@ -23,11 +23,11 @@
 			<table class="table table-bordered table-striped table-hover table-condensed">
 				<thead>
 				<tr>
-					<th class="col-md-5"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
+					<th class="col-md-4"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 					<th class="col-md-2"><wicket:message key="column.header.studentsummary.grade" /></th>
 					<th class="col-md-1 weight-col"><wicket:message key="column.header.studentsummary.weight" /></th>
-					<th class="col-md-1"><wicket:message key="column.header.studentsummary.duedate" /></th>
-					<th><wicket:message key="column.header.studentsummary.comments" /></th>
+					<th class="col-md-2"><wicket:message key="column.header.studentsummary.duedate" /></th>
+					<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
 				</tr>
 				</thead>
 				<tbody wicket:id="categoriesList">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
@@ -30,7 +30,8 @@
 					<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
 				</tr>
 				</thead>
-				<tbody wicket:id="categoriesList">
+				<wicket:container wicket:id="categoriesList">
+				<tbody class="gb-summary-category-tbody">
 				<tr wicket:id="categoryRow" class="gb-summary-category-row">
 					<td>
 						<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
@@ -41,6 +42,8 @@
 					<td></td>
 					<td></td>
 				</tr>
+				</tbody>
+				<tbody class="gb-summary-assignments-tbody">
 				<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
 					<td>
 						<span class="gb-summary-grade-flags" wicket:id="flags">
@@ -59,6 +62,7 @@
 					<td class="gb-summary-grade-comments" wicket:id="comments"></td>
 				</tr>
 				</tbody>
+				</wicket:container>
 			</table>
 			<div class="col-md-12">
 				<p><small wicket:id="categoryScoreNotReleased"></small></p>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
@@ -174,8 +174,12 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 								.setVisible(!assignment.isReleased()));
 						assignmentItem.add(flags);
 
-						assignmentItem.add(new Label("dueDate",
-								FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate"))));
+						Label dueDate = new Label("dueDate",
+							FormatHelper.formatDate(assignment.getDueDate(),
+								getString("label.studentsummary.noduedate")));
+						dueDate.add(new AttributeModifier("data-sort-key",
+							assignment.getDueDate() == null ? 0 : assignment.getDueDate().getTime()));
+						assignmentItem.add(dueDate);
 						assignmentItem.add(new Label("grade", FormatHelper.formatGrade(rawGrade)));
 						assignmentItem.add(new Label("outOf",
 								new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -31,7 +31,8 @@
 							<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
 						</tr>
 					</thead>
-					<tbody wicket:id="categoriesList">
+					<wicket:container wicket:id="categoriesList">
+					<tbody class="gb-summary-category-tbody">
 						<tr wicket:id="categoryRow" class="gb-summary-category-row">
 							<td>
 								<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
@@ -42,6 +43,8 @@
 							<td></td>
 							<td></td>
 						</tr>
+					</tbody>
+					<tbody class="gb-summary-assignments-tbody">
 						<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
 							<td>
 								<span class="gb-summary-grade-flags" wicket:id="flags">
@@ -59,6 +62,7 @@
 							<td class="gb-summary-grade-comments" wicket:id="comments"></td>
 						</tr>
 					</tbody>
+					</wicket:container>
 				</table>
 			</wicket:enclosure>
 			

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -24,11 +24,11 @@
 				<table class="table table-bordered table-striped table-hover table-condensed">
 					<thead>
 						<tr>
-							<th class="col-md-5"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
+							<th class="col-md-4"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 							<th class="col-md-2"><wicket:message key="column.header.studentsummary.grade" /></th>
 							<th class="col-md-1 weight-col"><wicket:message key="column.header.studentsummary.weight" /></th>
-							<th class="col-md-1"><wicket:message key="column.header.studentsummary.duedate" /></th>
-							<th><wicket:message key="column.header.studentsummary.comments" /></th>
+							<th class="col-md-2"><wicket:message key="column.header.studentsummary.duedate" /></th>
+							<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
 						</tr>
 					</thead>
 					<tbody wicket:id="categoriesList">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -16,12 +16,13 @@
 			<wicket:enclosure child="categoriesList">
 				<div wicket:id="toggleActions" class="col-md-12">
 					<div class="pull-right">
-						<a href="javascript:void(0);" class="gb-summary-expand-all"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
-						<a href="javascript:void(0);" class="gb-summary-collapse-all"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
+						<a href="javascript:void(0);" class="button" id="toggleCategories" wicket:id="toggleCategoriesLink" aria-controls="gradeSummaryTable">Group By Category</a>
+						<a href="javascript:void(0);" class="gb-summary-expand-all" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
+						<a href="javascript:void(0);" class="gb-summary-collapse-all" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
 					</div>
 				</div>
 
-				<table class="table table-bordered table-striped table-hover table-condensed">
+				<table id="gradeSummaryTable" class="table table-bordered table-striped table-hover table-condensed">
 					<thead>
 						<tr>
 							<th class="col-md-4"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
@@ -29,21 +30,24 @@
 							<th class="col-md-1 weight-col"><wicket:message key="column.header.studentsummary.weight" /></th>
 							<th class="col-md-2"><wicket:message key="column.header.studentsummary.duedate" /></th>
 							<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
+							<th class="col-md-1 category-col" wicket:id="categoryColumnHeader"><wicket:message key="column.header.studentsummary.category" /></th>
 						</tr>
 					</thead>
 					<wicket:container wicket:id="categoriesList">
-					<tbody class="gb-summary-category-tbody">
-						<tr wicket:id="categoryRow" class="gb-summary-category-row">
-							<td>
-								<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
-								<span wicket:id="category" class="gb-summary-category-name"></span>
-							</td>
-							<td class="gb-summary-category-grade" wicket:id="categoryGrade"></td>
-							<td class="gb-summary-category-weight weight-col" wicket:id="categoryWeight"></td>
-							<td></td>
-							<td></td>
-						</tr>
-					</tbody>
+						<wicket:enclosure child="categoryRow">
+							<tbody class="gb-summary-category-tbody">
+								<tr wicket:id="categoryRow" class="gb-summary-category-row">
+									<td>
+										<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
+										<span wicket:id="category" class="gb-summary-category-name"></span>
+									</td>
+									<td class="gb-summary-category-grade" wicket:id="categoryGrade"></td>
+									<td class="gb-summary-category-weight weight-col" wicket:id="categoryWeight"></td>
+									<td></td>
+									<td></td>
+								</tr>
+							</tbody>
+						</wicket:enclosure>
 					<tbody class="gb-summary-assignments-tbody">
 						<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
 							<td>
@@ -60,6 +64,7 @@
 							<td class="weight-col"><!-- empty --></td>
 							<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
 							<td class="gb-summary-grade-comments" wicket:id="comments"></td>
+							<td class="gb-summary-grade-category" wicket:id="category"></td>
 						</tr>
 					</tbody>
 					</wicket:container>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -8,11 +8,14 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -45,6 +48,11 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 
 	// used as a visibility flag. if any are released, show the table
 	boolean someAssignmentsReleased = false;
+	boolean isGroupedByCategory = false;
+	boolean categoriesEnabled = false;
+	boolean isAssignmentsDisplayed = false;
+
+	CourseGradeFormatter courseGradeFormatter;
 
 	public StudentGradeSummaryGradesPanel(final String id, final IModel<Map<String, Object>> model) {
 		super(id, model);
@@ -54,6 +62,27 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
+		final Gradebook gradebook = this.businessService.getGradebook();
+
+		this.setOutputMarkupId(true);
+
+		this.configuredCategoryType = GbCategoryType.valueOf(gradebook.getCategory_type());
+		this.isGroupedByCategory = this.configuredCategoryType != GbCategoryType.NO_CATEGORY;
+		this.categoriesEnabled = this.configuredCategoryType != GbCategoryType.NO_CATEGORY;
+		this.isAssignmentsDisplayed = gradebook.isAssignmentsDisplayed();
+
+		courseGradeFormatter = new CourseGradeFormatter(
+			gradebook,
+			GbRole.STUDENT,
+			gradebook.isCourseGradeDisplayed(),
+			gradebook.isCoursePointsDisplayed(),
+			true);
+	}
+
+	@Override
+	public void onBeforeRender() {
+		super.onBeforeRender();
+
 		// unpack model
 		final Map<String, Object> modelData = (Map<String, Object>) getDefaultModelObject();
 		final String userId = (String) modelData.get("userId");
@@ -62,19 +91,13 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		final Map<Assignment, GbGradeInfo> grades = this.businessService.getGradesForStudent(userId);
 		final List<Assignment> assignments = new ArrayList(grades.keySet());
 
-		// get gradebook
-		final Gradebook gradebook = this.businessService.getGradebook();
-
-		// get configured category type
-		this.configuredCategoryType = GbCategoryType.valueOf(gradebook.getCategory_type());
-
 		// setup
 		final List<String> categoryNames = new ArrayList<String>();
 		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<String, List<Assignment>>();
 		final Map<String, String> categoryAverages = new HashMap<>();
 
 		// if gradebook release setting disabled, no work to do
-		if (gradebook.isAssignmentsDisplayed()) {
+		if (isAssignmentsDisplayed) {
 
 			// iterate over assignments and build map of categoryname to list of assignments as well as category averages
 			for (final Assignment assignment : assignments) {
@@ -109,12 +132,43 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		}
 
 		final WebMarkupContainer toggleActions = new WebMarkupContainer("toggleActions");
-		toggleActions.setVisible(this.configuredCategoryType != GbCategoryType.NO_CATEGORY);
-		add(toggleActions);
+		toggleActions.setVisible(this.categoriesEnabled);
+
+		final AjaxLink toggleCategoriesLink = new AjaxLink("toggleCategoriesLink") {
+			@Override
+			protected void onInitialize() {
+				super.onInitialize();
+				if (StudentGradeSummaryGradesPanel.this.isGroupedByCategory) {
+					add(new AttributeAppender("class", " on"));
+				}
+				add(new AttributeModifier("aria-pressed", StudentGradeSummaryGradesPanel.this.isGroupedByCategory));
+			}
+
+			@Override
+			public void onClick(AjaxRequestTarget target) {
+				StudentGradeSummaryGradesPanel.this.isGroupedByCategory = !StudentGradeSummaryGradesPanel.this.isGroupedByCategory;
+
+				target.add(StudentGradeSummaryGradesPanel.this);
+				target.appendJavaScript(
+					String.format("new GradebookGradeSummary($(\"#%s\"), %s);",
+						StudentGradeSummaryGradesPanel.this.getMarkupId(),
+						true));
+
+				if (!StudentGradeSummaryGradesPanel.this.isGroupedByCategory) {
+					// hide the weight column if categories are disabled
+					target.appendJavaScript("$('.weight-col').hide();");
+				}
+			}
+		};
+		toggleActions.add(toggleCategoriesLink);
+		addOrReplace(toggleActions);
+
+		addOrReplace(new WebMarkupContainer("categoryColumnHeader").
+			setVisible(this.categoriesEnabled && !this.isGroupedByCategory));
 
 		// output all of the categories
 		// within each we then add the assignments in each category
-		add(new ListView<String>("categoriesList", categoryNames) {
+		addOrReplace(new ListView<String>("categoriesList", categoryNames) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -124,7 +178,9 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 				final List<Assignment> categoryAssignments = categoryNamesToAssignments.get(categoryName);
 
 				final WebMarkupContainer categoryRow = new WebMarkupContainer("categoryRow");
-				categoryRow.setVisible(StudentGradeSummaryGradesPanel.this.configuredCategoryType != GbCategoryType.NO_CATEGORY);
+				categoryRow.setVisible(
+					StudentGradeSummaryGradesPanel.this.categoriesEnabled
+						&& StudentGradeSummaryGradesPanel.this.isGroupedByCategory);
 				categoryItem.add(categoryRow);
 				categoryRow.add(new Label("category", categoryName));
 				categoryRow.add(new Label("categoryGrade", categoryAverages.get(categoryName)));
@@ -190,6 +246,10 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 							}
 						});
 						assignmentItem.add(new Label("comments", comment));
+						assignmentItem.add(
+							new Label("category", assignment.getCategoryName()).
+								setVisible(StudentGradeSummaryGradesPanel.this.categoriesEnabled
+									&& !StudentGradeSummaryGradesPanel.this.isGroupedByCategory));
 					}
 
 					@Override
@@ -221,18 +281,12 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 				return !StudentGradeSummaryGradesPanel.this.someAssignmentsReleased;
 			}
 		};
-		add(noAssignments);
+		addOrReplace(noAssignments);
 
 		// course grade, via the formatter
 		final CourseGrade courseGrade = this.businessService.getCourseGrade(userId);
 
-		final CourseGradeFormatter courseGradeFormatter = new CourseGradeFormatter(
-				gradebook,
-				GbRole.STUDENT,
-				gradebook.isCourseGradeDisplayed(),
-				gradebook.isCoursePointsDisplayed(),
-				true);
-		add(new Label("courseGrade", courseGradeFormatter.format(courseGrade)).setEscapeModelStrings(false));
+		addOrReplace(new Label("courseGrade", this.courseGradeFormatter.format(courseGrade)).setEscapeModelStrings(false));
 
 		add(new AttributeModifier("data-studentid", userId));
 	}
@@ -244,8 +298,8 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private String getCategoryName(final Assignment assignment) {
-		if (this.configuredCategoryType == GbCategoryType.NO_CATEGORY) {
-			return getString("gradebookpage.uncategorised");
+		if (!this.categoriesEnabled || !this.isGroupedByCategory) {
+			return getString(GradebookPage.UNCATEGORISED);
 		}
 		return StringUtils.isBlank(assignment.getCategoryName()) ? getString(GradebookPage.UNCATEGORISED) : assignment.getCategoryName();
 	}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -176,8 +176,11 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 								.setVisible(!assignment.isCounted()));
 						assignmentItem.add(flags);
 
-						assignmentItem.add(new Label("dueDate",
-								FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate"))));
+						Label dueDate = new Label("dueDate",
+							FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate")));
+						dueDate.add(new AttributeModifier("data-sort-key",
+							assignment.getDueDate() == null ? 0 : assignment.getDueDate().getTime()));
+						assignmentItem.add(dueDate);
 						assignmentItem.add(new Label("grade", FormatHelper.formatGrade(rawGrade)));
 						assignmentItem.add(new Label("outOf",
 								new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -39,6 +39,7 @@ GradebookGradeSummary.prototype.setupWicketModal = function() {
     this.setupTabs();
     this.setupStudentNavigation();
     this.setupFixedFooter();
+    this.setupTableSorting();
     this.setupMask();
     this.setupModalPrint();
     this.bindModalClose();
@@ -228,6 +229,8 @@ GradebookGradeSummary.prototype.setupStudentView = function() {
     $("body").find(".portletBody h2:first"),
     $("body").find("#studentGradeSummary"),
     $("body"));
+
+  this.setupTableSorting();
 };
 
 
@@ -260,7 +263,24 @@ GradebookGradeSummary.prototype._setupPrint = function($button, $header, $conten
       updateIframeContentAndPrint();
     }
   });
-}
+};
+
+
+GradebookGradeSummary.prototype.setupTableSorting = function() {
+  var $table = this.$content.find(".gb-summary-grade-panel table");
+
+  $table.tablesorter({
+    theme : "bootstrap",
+    widthFixed: true,
+    headerTemplate : '{content} {icon}',
+    widgets : [ "uitheme", "zebra" ],
+    widgetOptions : {
+      zebra : ["even", "odd"],
+      filter_reset : ".reset",
+      filter_hideFilters : true
+    }
+  });
+};
 
 
 var GradebookGradeSummaryUtils = {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -278,6 +278,31 @@ GradebookGradeSummary.prototype.setupTableSorting = function() {
       zebra : ["even", "odd"],
       filter_reset : ".reset",
       filter_hideFilters : true
+    },
+    //sort by due date descending by default
+    sortList: [[3, 0]],
+    textExtraction: function(node) {
+      var $node = $(node);
+      // sort dates by data-sort-key
+      if ($node.is(".gb-summary-grade-duedate")) {
+        var time = $node.data("sort-key");
+        if (time == 0) {
+          // max integer value so assignments with no due date
+          // appear after those with due dates (to match GB1)
+          return Math.pow(2, 53)-1;
+        }
+        return time;
+      // sort grades by their raw grade
+      } else if ($node.is(".gb-summary-grade-score")) {
+        var grade = $node.find(".gb-summary-grade-score-raw").text().trim();
+        if (grade == "") {
+          return -1;
+        } else {
+          return grade;
+        }
+      }
+
+      return $(node).text().trim();
     }
   });
 };

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -87,9 +87,9 @@ GradebookGradeSummary.prototype.setupCategoryToggles = function() {
   this.$content.find(".gb-summary-category-toggle").click(function() {
     var $toggle = $(this);
     if ($toggle.is(".collapsed")) {
-      $toggle.closest("tbody").find(".gb-summary-grade-row").show();
+      $toggle.closest("tbody").next(".gb-summary-assignments-tbody").find(".gb-summary-grade-row").show();
     } else {
-      $toggle.closest("tbody").find(".gb-summary-grade-row").hide();
+      $toggle.closest("tbody").next(".gb-summary-assignments-tbody").find(".gb-summary-grade-row").hide();
     }
     $toggle.toggleClass("collapsed");
   });
@@ -303,7 +303,8 @@ GradebookGradeSummary.prototype.setupTableSorting = function() {
       }
 
       return $(node).text().trim();
-    }
+    },
+    cssInfoBlock: "gb-summary-category-tbody"
   });
 };
 

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -1050,6 +1050,15 @@ ul.feedbackPanel li span {
   content: '\f02f';
   padding-right: 4px;
 }
+#studentGradeSummary .table>tbody+tbody {
+  border-width: 1px;
+}
+#studentGradeSummary .table>tbody.gb-summary-assignments-tbody+tbody.gb-summary-category-tbody {
+  border-width: 2px;
+}
+.gb-summary-category-row td {
+  background-color: #F4F4F4;
+}
 /* Hidden column visual cue */
 .gb-hidden-column-visual-cue {
   position: absolute;

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -502,12 +502,14 @@
 #toggleGradeItemsToolbarItem.on:after {
   content: '\f077';
 }
+#toggleCategories:before,
 #toggleCategoriesToolbarItem:before {
   font-family: 'gradebook-icons';
   content: '\f096';
   font-size: 0.9em;
   margin-right: 6px
 }
+#toggleCategories.on:before,
 #toggleCategoriesToolbarItem.on:before {
   content: '\f046';
 }

--- a/gradebookng/tool/src/webapp/styles/gradebook-print.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-print.css
@@ -4,6 +4,7 @@
  
  .gb-summary-expand-all,
  .gb-summary-collapse-all,
- .gb-summary-category-toggle {
+ .gb-summary-category-toggle,
+ #toggleCategories {
   display: none;
  }


### PR DESCRIPTION
Delivers #2284 with some compromises...

Hi @steveswinsburg, @kyleblythe, @jeffpasch,

Unfortunately it's not going to be easy to duplicate the behaviour from the Gradebook Classic with JavaScript client-side sorting.  I actually found the GB1 sorting quite confusing when assignments where within their category groupings - I don't think there's a logical way to outer sort those categories when focusing on ordering the items within the grouping 😕 

Instead, I've applied the tablesorter jQuery plugin to the table, which works lovely when categories are disabled and otherwise allows sorting of the assignments within their category.  To offer something more useful to students, I've added a "Group by Category" button that allows the student to disable the grouping and sort the assignments as a flat list (it also adds a category column to the end of the table).

No Categories:

<img width="862" alt="screen shot 2016-05-16 at 4 43 19 pm" src="https://cloud.githubusercontent.com/assets/608337/15282269/738a4192-1b85-11e6-92f3-88f3e6d6af6a.png">

Grouped:

<img width="1134" alt="screen shot 2016-05-16 at 4 43 46 pm" src="https://cloud.githubusercontent.com/assets/608337/15282274/7b3e7c0a-1b85-11e6-8966-74bb36a39657.png">

Ungrouped:

<img width="1134" alt="screen shot 2016-05-16 at 4 43 58 pm" src="https://cloud.githubusercontent.com/assets/608337/15282276/836b6d20-1b85-11e6-8310-a878403893a5.png">

This feature works on the Instructor's grade summary preview and also plays nice with the print version of the summary.

If this doesn't *feel* right, then we're going to need to push the sorting back to the service/backend and attempt to re-use the Gradebook Classic logic.  Happy to investigate that path.

Thanks! 🍰 🐸 