### PR TITLE
SAK-31217: Fix bug with savecite clients

### DIFF
--- a/citations/citations-tool/tool/src/webapp/js/new_resource.js
+++ b/citations/citations-tool/tool/src/webapp/js/new_resource.js
@@ -420,7 +420,7 @@ citations_new_resource.init = function() {
 	
 	
 	
-	$('.saveciteClient a').on('click', function(eventObject) {
+	$('.saveciteClient input').on('click', function(eventObject) {
 		$('#saveciteClientId').val($(eventObject.target).attr('id'));
 		var successObj = {
 			citationCollectionId: $('#citationCollectionId').val(),


### PR DESCRIPTION
External citation search tools no longer open due to a minor issue in the js that binds the onclick event.