### PR TITLE
SAK-30900 Tutorial stops after Step 2

### DIFF
--- a/reference/library/src/webapp/js/jquery/qtip/tutorial.js
+++ b/reference/library/src/webapp/js/jquery/qtip/tutorial.js
@@ -38,10 +38,10 @@ function showTutorialPage(url, opts){
 				if(response.data.dialog == 'true'){
 					response.data.selection = 'div#tutorial';
 				}
-				if(!$(response.data.selection).length 
+				if( (!$(response.data.selection).length || $(response.data.selection).offset().left < 0 || $(response.data.selection).offset().top < 0)
 						&& ((!previousClicked && response.data.nextUrl) 
 								|| (previousClicked && response.data.previousUrl))){
-					//this item doesn't exist, go to the next page if it exists
+					//This item doesn't exist or it´s outside the viewport, go to the next page if it exists
 					if(previousClicked){
 						showTutorialPage(response.data.previousUrl);
 					}else{


### PR DESCRIPTION
The tutorial uses JQuery selectors to position the QTip panel.

The problem was when using this selector for the Sites panel

.Mrphs-skipNav__menu:visible .Mrphs-skipNav__menuitem--worksite a

.Mrphs-skipNav__menu was hidden before but now it´s visible but outside of the viewport. This was modified due to accesibility changes in https://jira.sakaiproject.org/browse/SAK-29771

So, what i did is add two new conditions to check if the element it´s outside the viewport to jump to the next Tutorial panel.

You can see the file with the JQuery selectors and properties for the panel here 

https://github.com/sakaiproject/sakai/blob/master/help/help-component/src/tutorial/Tutorial.config