### PR TITLE
SAK-30934 Mobile - Clicking on dropdown causes dropdown to appear at top

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -132,16 +132,16 @@
 
 	.dropdown-menu{
 
+		padding: 1em 0;
+
 		@media #{$phone}{
 			position: fixed;
 			top: 2%;
 			left: 2%;
 			width: 96% !important;
-			height: 96% !important;
 			z-index: 1000;
 			float: left;
 			min-width: 160px;
-			padding: 5px 0;
 			list-style: none;
 			font-size: 1em;
 			text-align: left;


### PR DESCRIPTION
of screen with white space at bottom
This also solves SAK-30937 "Add" in Folder/item missing top padding



![](https://jira.sakaiproject.org/secure/attachment/45104/Captura_de_pantalla_042816_013944_PM.jpg)

![resourcesfixed1](https://cloud.githubusercontent.com/assets/16644575/15390596/d3c3a51a-1dbc-11e6-8bb0-df914a2c6f35.png)



![](https://jira.sakaiproject.org/secure/attachment/45091/Captura_de_pantalla_042816_012235_PM.jpg)


![resourcesfixed2](https://cloud.githubusercontent.com/assets/16644575/15390602/ddd4c2dc-1dbc-11e6-9c15-42a31b6cc310.png)
