### PR TITLE
SAK-31206 allow /direct/calendar/my events to be filtered by date range

### DIFF
--- a/calendar/calendar-bundles/resources/calendar.properties
+++ b/calendar/calendar-bundles/resources/calendar.properties
@@ -502,7 +502,10 @@ Optional query params: \
 firstDate, ISO-8601 yyyy-MM-dd format. Used for filtering. \
 lastDate, ISO-8601 yyyy-MM-dd format. Used for filtering.
 calendar.action.event=Retrieve a calendar event details specified by the site id and event id. The request url pattern: /direct/calendar/event/{siteId}/{eventId}.{format}
-calendar.action.my=Retrieve all my calendar events for all of my sites. The request url pattern: /direct/calendar/my.{format}
+calendar.action.my=Retrieve all my calendar events for all of my sites. The request url pattern: /direct/calendar/my.{format} \
+Optional query params: \
+firstDate, ISO-8601 yyyy-MM-dd format. Used for filtering. \
+lastDate, ISO-8601 yyyy-MM-dd format. Used for filtering.
 
 # Monday/Wednesday/Friday
 set.MWF.fm= {0}/{1}/{2}

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/entityproviders/CalendarEventEntityProvider.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/entityproviders/CalendarEventEntityProvider.java
@@ -224,21 +224,19 @@ public class CalendarEventEntityProvider extends AbstractEntityProvider
 
 				rval.add(new CalendarEventSummary(event));
 			}
-
-			return rval;
 		} catch (final IdUnusedException e) {
-			throw new EntityNotFoundException("Invalid siteId: " + siteId,
-					siteId);
+			// may not have a calendar, skip it
 		} catch (final PermissionException e) {
-			throw new EntityNotFoundException("No access to site: " + siteId,
-					siteId);
+			// may not have access, skip it
 		}
+
+		return rval;
 	}
 
 	/**
 	 * Build a {@link TimeRange} from the supplied request parameters. If the parameters are supplied but invalid, an
 	 * {@link IllegalArgumentException} will be thrown.
-	 * 
+	 *
 	 * @param params the request params
 	 * @return {@link TimeRange} if valid or null if not
 	 */


### PR DESCRIPTION
Extends #2557 and adds the same behaviour to the `/direct/calendar/my` provider and a bit of a refactor for common bits.