### PR TITLE
SAK-31187 fix primary and secondary button size differences

### DIFF
--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -136,42 +136,6 @@
 	}
 }
 
-@mixin sakai_button_color( $button-color-background-color, $button-color-border-color, $button-color-text-color, $button-color-background-secondary-color ){
-	background: $button-color-background-color;
-	border: 1px solid $button-color-border-color;
-	color: $button-color-text-color !important;
-	cursor: pointer;
-	font-family: $font-family;
-	font-size: #{$default-font-size - 2 };
-	letter-spacing: 0.8px;
-	line-height: 18px;
-	margin: 0.5em 0.8em 0.5em 0;
-	padding: 6px 10px 7px 12px;
-	position: relative;
-	text-decoration: none !important;
-	@include appearance(none);
-	@include border-radius(3px);
-	&:hover{
-		text-decoration: none;
-		background: linear-gradient( $button-color-background-color, $button-color-background-secondary-color );
-	}
-	&:active{
-		text-decoration: none;
-		outline: 0;
-		background: linear-gradient( $button-color-background-secondary-color, $button-color-background-color );
-	}
-	&[disabled="disabled"],&[disabled],&[disabled="true"]{
-		background: $button-color-background-color;
-		color: darken($button-background-color, 30% );
-		cursor: not-allowed;
-		opacity: 0.7;
-	}
-}
-
-.button_color, button {
-	@include sakai_button_color( $button-color-background-color, $button-color-border-color, $button-color-text-color, $button-color-background-secondary-color );
-}
-
 @mixin sakai_button( $button-background-color, $button-border-color, $button-text-color, $button-background-secondary-color ){
 	background: $button-background-color;
 	border: 1px solid $button-border-color;
@@ -202,6 +166,21 @@
 		cursor: not-allowed;
 		opacity: 0.7;
 	}
+}
+
+@mixin sakai_button_color( $button-color-background-color, $button-color-border-color, $button-color-text-color, $button-color-background-secondary-color ){
+	@include sakai_button( $button-color-background-color, $button-color-border-color, $button-color-text-color, $button-color-background-secondary-color );
+	position: relative;
+	&:hover{
+		background: linear-gradient( $button-color-background-color, $button-color-background-secondary-color );
+	}
+	&:active{
+		background: linear-gradient( $button-color-background-secondary-color, $button-color-background-color );
+	}
+}
+
+.button_color, button, button.btn-primary {
+	@include sakai_button_color( $button-color-background-color, $button-color-border-color, $button-color-text-color, $button-color-background-secondary-color );
 }
 
 .button, button.ui-state-default, .btn.btn-default {


### PR DESCRIPTION
Hi @juanjmerono.  This PR continues on the work done in https://jira.sakaiproject.org/browse/SAK-31187.  It'd be great to have the Morpheus team give it a once over. Thanks!

I've refactored sakai_button_color slightly so it shares padding/margin etc with sakai_button but still maintains it's custom background gradients...  Plus we also force button.btn-primary to use sakai_button_color so bootstrap buttons style as native Sakai color buttons which will fix the discrepancies reported in GradebookNG.

Also delivers #1858.