### PR TITLE
SAM-2893 replaced spelling errors of asessment with assessment

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java
@@ -284,7 +284,7 @@ public class SamigoEntity implements LessonEntity, QuizEntity {
 
     public LessonEntity getEntity(String ref, SimplePageBean o) {
 	// if the site was copied, all sakaiids for tests are set to something like /sam_core/NNN
-	// the problem is that published asessments aren't copied. So all we can do is poitn to
+	// the problem is that published assessments aren't copied. So all we can do is poitn to
 	// the core assessment. Of course you can't really take that, so we try to find a published
 	// assessment based on that core. If we find one, we fix up the sakaiids, and we're ok.
 	if (o != null && ref.startsWith("/sam_core/")) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
@@ -1087,7 +1087,7 @@ public class ItemAuthorBean
 	  assessmentBean.setAssessment(assessment);
 	  assessdelegate.updateAssessmentLastModifiedInfo(assessment);
   	  //Assessment has been revised
-	  EventTrackingService.post(EventTrackingService.newEvent("sam.asessment.revise", "/sam/" +AgentFacade.getCurrentSiteId() + "/removed itemId=" + deleteId + "from assessmentId=" + assessmentBean.getAssessmentId(), true));
+	  EventTrackingService.post(EventTrackingService.newEvent("sam.assessment.revise", "/sam/" +AgentFacade.getCurrentSiteId() + "/removed itemId=" + deleteId + "from assessmentId=" + assessmentBean.getAssessmentId(), true));
 	  return "editAssessment";
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
@@ -532,7 +532,7 @@ public class BeginDeliveryActionListener implements ActionListener
         pub = delivery.getPublishedAssessment();
         if (pub == null)
           throw new AbortProcessingException(
-             "taking: publishedAsessmentId null or blank");
+             "taking: publishedAssessmentId null or blank");
         //else
           //publishedId = pub.getPublishedAssessmentId().toString();
         break;

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
@@ -335,7 +335,7 @@ public class AuthoringHelper
   }
 
   /**
-   * Get an object bank of asessments (asi) in Document form.
+   * Get an object bank of assessments (asi) in Document form.
    *
    * @param assessmentIds array of the the assessment ids
    * @return the Document with the item bank data

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/TestsAndQuizzes.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/TestsAndQuizzes.java
@@ -67,7 +67,7 @@ public class TestsAndQuizzes extends AbstractWebService {
 	private static final Logger LOG = LoggerFactory.getLogger(TestsAndQuizzes.class);
 
 	/** 
-	 * createAsessmentFromText - WS Endpoint, exposing the SamLite createImportedAssessment()
+	 * createAssessmentFromText - WS Endpoint, exposing the SamLite createImportedAssessment()
 	 *
 	 * @param	String sessionid		the id of a valid admin session
 	 * @param	String siteid			the enterprise/sakai id of the site to be archived
@@ -112,7 +112,7 @@ public class TestsAndQuizzes extends AbstractWebService {
 	}
 
 	/** 
-	 * createAsessmentFromExport - WS Endpoint, exposing the SamLite createImportedAssessment()
+	 * createAssessmentFromExport - WS Endpoint, exposing the SamLite createImportedAssessment()
 	 *
 	 * @param	String sessionid		the id of a valid admin session
 	 * @param	String siteid			the enterprise/sakai id of the site to be archived
@@ -169,7 +169,7 @@ public class TestsAndQuizzes extends AbstractWebService {
 	}
 
 	/** 
-	 * createAsessmentFromExportFile - WS Endpoint, exposing the SamLite createImportedAssessment()
+	 * createAssessmentFromExportFile - WS Endpoint, exposing the SamLite createImportedAssessment()
 	 *
 	 * @param	String sessionid		the id of a valid admin session
 	 * @param	String siteid			the enterprise/sakai id of the site to be archived
@@ -216,7 +216,7 @@ public class TestsAndQuizzes extends AbstractWebService {
 	}
 
 	/** 
-	 * createAsessment - WS Endpoint, exposing the SamLite createImportedAssessment()
+	 * createAssessment - WS Endpoint, exposing the SamLite createImportedAssessment()
 	 *
 	 * @param	String siteid			the enterprise/sakai id of the site to be archived
 	 * @param	String siteproperty		the property that holds the enterprise site id


### PR DESCRIPTION
This spelling error was creating sam.asessment.revise events instead of sam.assessment.revise events. Several other instances were in comments and one was in an abortProcessingException.