### PR TITLE
SAK-31218 use grader ID and date from grade definition, if it exists

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2112,10 +2112,10 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 
 			  String studentId = gradeDef.getStudentUid();
 
-              // use the grader ID from the definition if it is not null, otherwise use the current user ID
-              String graderUid = gradeDef.getGraderUid() != null ? gradeDef.getGraderUid() : graderId;
-              // use the grade date from the definition if it is not null, otherwise use the current date
-              Date gradedDate = gradeDef.getDateRecorded() != null ? gradeDef.getDateRecorded() : now;
+			  // use the grader ID from the definition if it is not null, otherwise use the current user ID
+			  String graderUid = gradeDef.getGraderUid() != null ? gradeDef.getGraderUid() : graderId;
+			  // use the grade date from the definition if it is not null, otherwise use the current date
+			  Date gradedDate = gradeDef.getDateRecorded() != null ? gradeDef.getDateRecorded() : now;
 
 			  // check specific grading privileges if user does not have
 			  // grade all perm

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2112,6 +2112,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 
 			  String studentId = gradeDef.getStudentUid();
 
+              // use the grader ID from the definition if it is not null, otherwise use the current user ID
+              String graderUid = gradeDef.getGraderUid() != null ? gradeDef.getGraderUid() : graderId;
+              // use the grade date from the definition if it is not null, otherwise use the current date
+              Date gradedDate = gradeDef.getDateRecorded() != null ? gradeDef.getDateRecorded() : now;
+
 			  // check specific grading privileges if user does not have
 			  // grade all perm
 			  if (!userHasGradeAllPerm) {
@@ -2135,14 +2140,14 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 								  !convertedGrade.equals(gradeRec.getPointsEarned()))) {
 					  
 					  gradeRec.setPointsEarned(convertedGrade);
-					  gradeRec.setGraderId(graderId);
-					  gradeRec.setDateRecorded(now);
+					  gradeRec.setGraderId(graderUid);
+					  gradeRec.setDateRecorded(gradedDate);
 
 					  agrToUpdate.add(gradeRec);
 
 					  // we also need to add a GradingEvent
 					  // the event stores the actual input grade, not the converted one
-					  GradingEvent event = new GradingEvent(assignment, graderId, studentId, gradeDef.getGrade());
+					  GradingEvent event = new GradingEvent(assignment, graderUid, studentId, gradeDef.getGrade());
 					  eventsToAdd.add(event);
 				  }
 			  } else {
@@ -2150,14 +2155,14 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				  if (gradeDef.getGrade() != null && !gradeDef.getGrade().trim().equals("")) {
 					  gradeRec =  new AssignmentGradeRecord(assignment, studentId, convertedGrade);
 					  gradeRec.setPointsEarned(convertedGrade);
-					  gradeRec.setGraderId(graderId);
-					  gradeRec.setDateRecorded(now);
+					  gradeRec.setGraderId(graderUid);
+					  gradeRec.setDateRecorded(gradedDate);
 
 					  agrToUpdate.add(gradeRec);
 
 					  // we also need to add a GradingEvent
 					  // the event stores the actual input grade, not the converted one
-					  GradingEvent event = new GradingEvent(assignment, graderId, studentId, gradeDef.getGrade());
+					  GradingEvent event = new GradingEvent(assignment, graderUid, studentId, gradeDef.getGrade());
 					  eventsToAdd.add(event);
 				  }
 			  }
@@ -2174,8 +2179,8 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 								  !gradeDef.getGradeComment().equals(comment.getCommentText()))) {
 					  // update this comment
 					  comment.setCommentText(gradeDef.getGradeComment());
-					  comment.setGraderId(graderId);
-					  comment.setDateRecorded(now);
+					  comment.setGraderId(graderUid);
+					  comment.setDateRecorded(gradedDate);
 
 					  commentsToUpdate.add(comment);
 				  }
@@ -2183,8 +2188,8 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				  // if there is a comment, add it
 				  if (gradeDef.getGradeComment() != null && !gradeDef.getGradeComment().trim().equals("")) {
 					  comment = new Comment(studentId, gradeDef.getGradeComment(), assignment);
-					  comment.setGraderId(graderId);
-					  comment.setDateRecorded(now);
+					  comment.setGraderId(graderUid);
+					  comment.setDateRecorded(gradedDate);
 
 					  commentsToUpdate.add(comment);
 				  }


### PR DESCRIPTION
Previously, no matter what params were set in the GradeDefinition object, the current user and current date and time would be used to set the grade object. Now, if those params are set, it will use them instead, but default to the current user and date if not found.