### PR TITLE
1840: fix the concurrent message not displaying correctly

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -1245,7 +1245,7 @@ GradebookSpreadsheet.prototype.setupConcurrencyCheck = function() {
       var $notification = model.$cell.find(".gb-cell-notification-out-of-date");
       if ($notification.length == 0) {
         $notification = $("<span>").addClass("gb-cell-notification").addClass("gb-cell-notification-out-of-date");
-        model.$cell.find(".btn-group").before($notification);
+        model.$cell.find("> div").prepend($notification);
       
         var $message = $("#gradeItemsConcurrentUserWarning").clone();
         $message.find(".gb-concurrent-edit-user").html(conflict.lastUpdatedBy);


### PR DESCRIPTION
.. despite the polled changes JSON being accurate.   This bug was introduced with the performance patches.

Delivers #1840.