### PR TITLE
Bugfix/1839 TA permission fixes

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -1739,17 +1739,13 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				  }
 			  }
 			  
-			  for (Iterator stIter = studentIds.iterator(); stIter.hasNext();) {
-				  String studentId = (String) stIter.next();
-				  if (studentId != null) {
-					  if (!studentIdEnrRecMap.containsKey(studentId)) {
-						  throw new SecurityException("User " + authn.getUserUid() + 
-						  " attempted to access grade information for student " + studentId + 
-						  " without permission in gb " + gradebook.getUid() + 
-						  " using gradebookService.getGradesForStudentsForItem");
-					  }
+			  //filter the provided studentIds if user doesn't have permissions
+			  studentIds.removeIf(studentId -> {
+				  if (!studentIdEnrRecMap.containsKey(studentId)) {
+					  return true;
 				  }
-			  }
+				  return false;
+			  });
 			  
 			  // retrieve the grading comments for all of the students
 			  List<Comment> commentRecs = getComments(gbItem, studentIds);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -405,3 +405,6 @@ feedback.saving = Saving...
 feedback.saved = All changes saved.
 feedback.error = Errors were detected. See cell notifications below.
 feedback.connectiontimeout = Unable to connect. Changes cannot be saved while offline.
+
+ta.nopermission = You do not have permission to view the gradebook. Please contact your instructor.
+ta.roleswapped = TA view of gradebook cannot be displayed.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -40,7 +40,6 @@ import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
 import org.sakaiproject.gradebookng.business.util.Temp;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
-import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.service.gradebook.shared.AssessmentNotFoundException;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
@@ -1825,6 +1824,30 @@ public class GradebookNgBusinessService {
 	public Locale getUserPreferredLocale() {
 		final ResourceLoader rl = new ResourceLoader();
 		return rl.getLocale();
+	}
+	
+	/**
+	 * Helper to check if a user is roleswapped
+	 * 
+	 * @return true if ja, false if nay.
+	 */
+	public boolean isUserRoleSwapped() {
+		
+		final String siteId = getCurrentSiteId();
+		
+		try {
+			Site site = this.siteService.getSite(siteId);
+				
+			//they are roleswapped if they have an 'effective role'
+			String effectiveRole = this.securityService.getUserEffectiveRole(site.getReference());
+			if(StringUtils.isNotBlank(effectiveRole)) {
+				return true;
+			}
+		} catch (IdUnusedException e) {
+			//something has happened between getting the siteId and getting the site.
+			throw new GbException("An error occurred checking some bits and pieces, please try again.", e);
+		}
+		return false;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/AccessDeniedPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/AccessDeniedPage.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd" >
+<body>
+<wicket:extend>
+  
+	<div wicket:id="message" class="messageInformation"></div>
+
+</wicket:extend>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/AccessDeniedPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/AccessDeniedPage.java
@@ -1,0 +1,30 @@
+package org.sakaiproject.gradebookng.tool.pages;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+
+/**
+ * Access denied page.
+ *
+ * @author Steve Swinsburg (steve.swinsburg@gmail.com)
+ *
+ */
+public class AccessDeniedPage extends BasePage {
+
+	private static final long serialVersionUID = 1L;
+
+	private String message;
+	
+	public AccessDeniedPage(PageParameters params) {
+		this.message = params.get("message").toString();
+	}
+	
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+	
+		add(new Label("message", this.message));
+	}
+
+	
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -39,6 +39,7 @@ import org.apache.wicket.markup.repeater.data.ListDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.string.StringValue;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.gradebookng.business.GbGradingType;
@@ -62,6 +63,7 @@ import org.sakaiproject.gradebookng.tool.panels.StudentNameColumnHeaderPanel;
 import org.sakaiproject.gradebookng.tool.panels.ToggleGradeItemsToolbarPanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
+import org.sakaiproject.service.gradebook.shared.PermissionDefinition;
 import org.sakaiproject.service.gradebook.shared.SortType;
 import org.sakaiproject.tool.gradebook.Gradebook;
 
@@ -98,9 +100,20 @@ public class GradebookPage extends BasePage {
 	public GradebookPage() {
 		disableLink(this.gradebookPageLink);
 
-		// students cannot access this page
+		// students cannot access this page, they have their own
 		if (this.role == GbRole.STUDENT) {
 			throw new RestartResponseException(StudentPage.class);
+		}
+				
+		//TAs with no permissions or in a roleswap situation
+		if(this.role == GbRole.TA){
+			
+			List<PermissionDefinition> permissions = this.businessService.getPermissionsForUser(this.currentUserUuid);
+			if(permissions.isEmpty()) {
+				PageParameters params = new PageParameters();
+				params.add("message", getString("ta.nopermission"));
+				throw new RestartResponseException(AccessDeniedPage.class, params);
+			}
 		}
 
 		final StopWatch stopwatch = new StopWatch();

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -108,6 +108,14 @@ public class GradebookPage extends BasePage {
 		//TAs with no permissions or in a roleswap situation
 		if(this.role == GbRole.TA){
 			
+			//roleswapped?
+			if(this.businessService.isUserRoleSwapped()) {
+				PageParameters params = new PageParameters();
+				params.add("message", getString("ta.roleswapped"));
+				throw new RestartResponseException(AccessDeniedPage.class, params);
+			}
+			
+			// no perms
 			List<PermissionDefinition> permissions = this.businessService.getPermissionsForUser(this.currentUserUuid);
 			if(permissions.isEmpty()) {
 				PageParameters params = new PageParameters();


### PR DESCRIPTION
Delivers #1839 and will need some serious scenario testing.

1. If TA and no permissions, show message instead of GB
2. If roleswapped to TA, show message instead of GB.
3. Don't throw an exception if the lists mismatch, just filter it down. Achieves an identical outcome, user still cannot see grade if they don't have permissions.

