### PR TITLE
SAM-2745 - Hotspot question doesn't save image

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
@@ -1345,12 +1345,11 @@ public class ItemAuthorBean
 			try {
 				ResourcePropertiesEdit resourceProperties = AssessmentService.getContentHostingService().newResourceProperties();
 				resourceProperties.addProperty(ResourceProperties.PROP_DISPLAY_NAME, ToolManager.getCurrentPlacement().getContext());
-				//resourceProperties.addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
+				resourceProperties.addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
 				
 				ContentCollectionEdit edit = (ContentCollectionEdit)AssessmentService.getContentHostingService().addCollection(collectionId, resourceProperties);
 				
-				edit.setPublicAccess();
-				AssessmentService.getContentHostingService().commitCollection(edit);
+				AssessmentService.getContentHostingService().setPubView(collectionId,true);
 			}catch(Exception ee){
 				log.warn(ee.getMessage());
 			}
@@ -1360,15 +1359,14 @@ public class ItemAuthorBean
 		}
 
 		try {
-			if(/*!"true".equals(AssessmentService.getContentHostingService().getProperties(Entity.SEPARATOR + "private"+ Entity.SEPARATOR).get(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT)) || */!AssessmentService.getContentHostingService().isPubView(collectionId))
+			if(!"true".equals(AssessmentService.getContentHostingService().getProperties(Entity.SEPARATOR + "private"+ Entity.SEPARATOR).get(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT)) || !AssessmentService.getContentHostingService().isPubView(collectionId))
 			{
 			
 				ContentCollectionEdit edit = AssessmentService.getContentHostingService().editCollection(collectionId);
 				ResourcePropertiesEdit resourceProperties = edit.getPropertiesEdit();
-				//resourceProperties.addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
-
+				resourceProperties.addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
 				edit.setPublicAccess();
-				
+
 				AssessmentService.getContentHostingService().commitCollection(edit);
 				
 			}


### PR DESCRIPTION
I believe this issue was only that calling this version of addCollection was returning a ContentCollection rather than a ContentCollecitonEdit which was closing the edit. So it possibly was just a bug here. I'm not sure what was going on with this? Calling setPubView on the service worked, but it also was supposed to be in a hidden collection so that was fixed too. 