### PR TITLE
SAK-31289 Label does not wrap when text too long in Permissions

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
@@ -52,7 +52,7 @@
 	
 	.permissionPanel{
 		input[type="checkbox"]{
-			@media #{$nonphone}{
+			@media #{$nonPhone}{
 				float:left;
 				& + label {
 					overflow:auto;
@@ -60,6 +60,7 @@
 					padding-top: 2px;
 				}
 			}
+		}
 	}
 
 	#msgForum{


### PR DESCRIPTION
Forgot to close a bracket