### PR TITLE
SAM-2911 Bullets do not display in Multiple Choice Answers to Students

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -65,11 +65,15 @@
 		text-decoration: line-through;
 	}
 
-	#assessmentSettingsAction,#itemForm,.mcscFixUp{
+	#assessmentSettingsAction,#itemForm{
 		ul{
 			list-style: none;
 			padding: 0 0 0 0;
 		}
+	}
+	.mcscFixUp > ul{
+		list-style: none;
+		padding: 0 0 0 0;
 	}
 
 	#itemForm\:partialCredit_toggle.tier3,

--- a/samigo/samigo-app/src/webapp/jsf/author/confirmEditPublishedAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/confirmEditPublishedAssessment.jsp
@@ -38,7 +38,7 @@
  <div class="portletBody">
   <h3><h:outputText value="#{authorMessages.edit_published_assessment_heading_conf}"/></h3>
  <h:form id="editPublishedAssessmentForm">
-     <div class="messageSamigo2 tier1">
+     <div class="bs-callout-danger tier1">
        <h:outputText value="#{authorMessages.warning}" />
    	   <br/>
        <h:outputText value="#{authorMessages.edit_published_assessment_heading_conf_info_1}" />

--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -76,7 +76,7 @@ $(window).load( function() {
 <!-- some back end stuff stubbed -->
 <h:form id="assessmentForm">
 
-  <h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow}" styleClass="messageSamigo2">
+  <h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow}" styleClass="bs-callout-danger">
     <h:panelGrid  columns="1">
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_1}" />
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_21}" rendered="#{assessmentBean.hasGradingData}"/>
@@ -513,7 +513,7 @@ $(window).load( function() {
 	    <f:param value="#{author.editPoolName}" />
 	</h:outputFormat>
 </h:panelGrid>
-<h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow}" styleClass="messageSamigo2">
+<h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow}" styleClass="bs-callout-danger">
     <h:panelGrid  columns="1">
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_1}" />
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_21}" rendered="#{assessmentBean.hasGradingData}"/>


### PR DESCRIPTION

![](https://jira.sakaiproject.org/secure/attachment/45611/Screen%20Shot%202016-06-03%20at%203.50.06%20PM.png)

![bulletpoints](https://cloud.githubusercontent.com/assets/16644575/15827220/f2038a34-2c0a-11e6-9148-950d93d6fe0d.png)


This also solves SAM-2912 Warning panel when editing a published
assesment overlaps with the navbar

![](https://jira.sakaiproject.org/secure/attachment/45616/Republish.png)
![republishfixed](https://cloud.githubusercontent.com/assets/16644575/15827229/ff3754ce-2c0a-11e6-9024-e97fe77cc5ff.png)








