### PR TITLE
SAK-31321 Allow tools to be rendered inline when in a multi column layout

### DIFF
--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -110,6 +110,10 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -111,9 +111,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 
     </dependencies>
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/BufferedContentRenderResult.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/BufferedContentRenderResult.java
@@ -1,0 +1,54 @@
+
+package org.sakaiproject.portal.charon;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.sakaiproject.portal.render.api.RenderResult;
+import org.sakaiproject.portal.render.api.ToolRenderException;
+import org.sakaiproject.site.api.ToolConfiguration;
+
+/**
+ * Impl of {@link RenderResult} for a buffered content response
+ */
+public class BufferedContentRenderResult implements RenderResult {
+
+	ToolConfiguration config;
+	String content;
+	String body;
+	
+	public BufferedContentRenderResult(final ToolConfiguration config, final String content) {
+		this.config = config;
+		this.content = content;
+	}
+	
+	@Override
+	public String getTitle() throws ToolRenderException {
+		return StringEscapeUtils.escapeHtml4(this.config.getTitle());
+	}
+
+	@Override
+	public String getContent() throws ToolRenderException {
+		return this.content;
+	}
+
+	@Override
+	public void setContent(String content) {
+		return; // N/A
+	}
+
+	@Override
+	public String getJSR168HelpUrl() throws ToolRenderException {
+		return null;
+	}
+
+	@Override
+	public String getJSR168EditUrl() throws ToolRenderException {
+		return null;
+	}
+
+	@Override
+	public String getHead() {
+		return null;
+	}
+
+}
+

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/BufferedContentRenderResult.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/BufferedContentRenderResult.java
@@ -12,12 +12,13 @@ import org.sakaiproject.site.api.ToolConfiguration;
 public class BufferedContentRenderResult implements RenderResult {
 
 	ToolConfiguration config;
-	String content;
+	String head;
 	String body;
 	
-	public BufferedContentRenderResult(final ToolConfiguration config, final String content) {
+	public BufferedContentRenderResult(final ToolConfiguration config, final String head, final String body) {
 		this.config = config;
-		this.content = content;
+		this.head = head;
+		this.body = body;
 	}
 	
 	@Override
@@ -27,7 +28,7 @@ public class BufferedContentRenderResult implements RenderResult {
 
 	@Override
 	public String getContent() throws ToolRenderException {
-		return this.content;
+		return this.body;
 	}
 
 	@Override
@@ -47,7 +48,7 @@ public class BufferedContentRenderResult implements RenderResult {
 
 	@Override
 	public String getHead() {
-		return null;
+		return this.head;
 	}
 
 }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -22,6 +22,7 @@ package org.sakaiproject.portal.charon;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
-import java.text.SimpleDateFormat;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -41,11 +41,10 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sakaiproject.authz.api.SecurityAdvisor;
-import org.sakaiproject.authz.api.SecurityAdvisor.SecurityAdvice;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
@@ -62,6 +61,7 @@ import org.sakaiproject.portal.api.PortalChatPermittedHelper;
 import org.sakaiproject.portal.api.PortalHandler;
 import org.sakaiproject.portal.api.PortalRenderContext;
 import org.sakaiproject.portal.api.PortalRenderEngine;
+import org.sakaiproject.portal.api.PortalService;
 import org.sakaiproject.portal.api.PortalSiteHelper;
 import org.sakaiproject.portal.api.SiteNeighbourhoodService;
 import org.sakaiproject.portal.api.SiteView;
@@ -79,6 +79,7 @@ import org.sakaiproject.portal.charon.handlers.LogoutHandler;
 import org.sakaiproject.portal.charon.handlers.NavLoginHandler;
 import org.sakaiproject.portal.charon.handlers.OpmlHandler;
 import org.sakaiproject.portal.charon.handlers.PageHandler;
+import org.sakaiproject.portal.charon.handlers.PageResetHandler;
 import org.sakaiproject.portal.charon.handlers.PresenceHandler;
 import org.sakaiproject.portal.charon.handlers.ReLoginHandler;
 import org.sakaiproject.portal.charon.handlers.RoleSwitchHandler;
@@ -91,18 +92,18 @@ import org.sakaiproject.portal.charon.handlers.StaticStylesHandler;
 import org.sakaiproject.portal.charon.handlers.TimeoutDialogHandler;
 import org.sakaiproject.portal.charon.handlers.ToolHandler;
 import org.sakaiproject.portal.charon.handlers.ToolResetHandler;
-import org.sakaiproject.portal.charon.handlers.PageResetHandler;
 import org.sakaiproject.portal.charon.handlers.WorksiteHandler;
 import org.sakaiproject.portal.charon.handlers.WorksiteResetHandler;
 import org.sakaiproject.portal.charon.handlers.XLoginHandler;
+import org.sakaiproject.portal.charon.site.PortalSiteHelperImpl;
 import org.sakaiproject.portal.render.api.RenderResult;
 import org.sakaiproject.portal.render.cover.ToolRenderService;
-import org.sakaiproject.portal.util.ErrorReporter;
-import org.sakaiproject.portal.util.ToolURLManagerImpl;
-import org.sakaiproject.portal.util.URLUtils;
 import org.sakaiproject.portal.util.CSSUtils;
-import org.sakaiproject.portal.util.ToolUtils;
+import org.sakaiproject.portal.util.ErrorReporter;
 import org.sakaiproject.portal.util.PortalUtils;
+import org.sakaiproject.portal.util.ToolURLManagerImpl;
+import org.sakaiproject.portal.util.ToolUtils;
+import org.sakaiproject.portal.util.URLUtils;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
@@ -129,10 +130,8 @@ import org.sakaiproject.util.EditorConfiguration;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
-
-import org.apache.commons.lang.ArrayUtils;
-import org.sakaiproject.portal.api.PortalService;
-import org.sakaiproject.portal.charon.site.PortalSiteHelperImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -586,15 +585,44 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 	public Map includeTool(HttpServletResponse res, HttpServletRequest req,
 			ToolConfiguration placement) throws IOException
 	{
-		boolean toolInline = "true".equals(ThreadLocalManager.get("sakai:inline-tool"));
+		boolean toolInline = "true".equals(ThreadLocalManager.get("sakai:inline-tool"));		
 		return includeTool(res, req, placement, toolInline);
 	}
 
 	// This will be called twice in the buffered scenario since we need to set
+	@Override
 	// the session for neo tools with the sessio reset, helpurl and reseturl
+	@SuppressWarnings("unchecked")
 	public Map includeTool(HttpServletResponse res, HttpServletRequest req,
-			ToolConfiguration placement, boolean toolInline) throws IOException
-	{
+			ToolConfiguration placement, boolean toolInline) throws IOException {
+		
+		Map<String,String> bufferMap = null;
+		if(!toolInline) {
+			
+			// allow a final chance for a tool to be inlined, based on it's tool configuration
+			// set renderInline = true to enable this
+			boolean renderInline = BooleanUtils.toBoolean(placement.getConfig().getProperty("renderInline"));
+				
+			if(renderInline) {
+				String[] parts = getParts(req);
+				
+				//build tool context path directly to the tool
+				String toolContextPath = req.getContextPath() + req.getServletPath() + "/site/" + parts[2] + "/tool/" + placement.getId();
+				
+				String toolPathInfo = Web.makePath(parts, 5, parts.length);
+				Session session = SessionManager.getCurrentSession();
+
+				Object buffer = this.siteHandler.bufferContent(req, res, session, placement.getId(), toolContextPath, toolPathInfo, placement);
+				
+				if (buffer instanceof Map) {
+					bufferMap = (Map<String,String>) buffer;
+					toolInline = true;
+				}
+				
+			}
+		}
+		
+		
 		// find the tool registered for this
 		ActiveTool tool = ActiveToolManager.getActiveTool(placement.getToolId());
 		if (tool == null)
@@ -705,6 +733,14 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		RenderResult result = ToolRenderService.render(this, placement, req, res,
 				getServletContext());
 
+		//overwrite the content from the buffer
+		if(bufferMap != null) {
+			System.out.println("overriding content");
+			result.setContent(bufferMap.get("responseHead") + bufferMap.get("responseBody"));
+		}
+		
+		System.out.println("result 1: " + result.getContent());
+		
 		if (result.getJSR168HelpUrl() != null)
 		{
 			toolMap.put("toolJSR168Help", Web.serverUrl(req) + result.getJSR168HelpUrl());
@@ -723,7 +759,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		}
 
 		toolMap.put("toolRenderResult", result);
-		toolMap.put("hasRenderResult", Boolean.valueOf(true));
+		toolMap.put("hasRenderResult", Boolean.TRUE);
 		toolMap.put("toolUrl", toolUrl);
 
 		Session s = SessionManager.getCurrentSession();

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -730,17 +730,17 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		// For JSR-168 portlets - this gets the content
 		// For legacy tools, this returns the "<iframe" bit
 		// For buffered legacy tools - the buffering is done outside of this
-		RenderResult result = ToolRenderService.render(this, placement, req, res,
-				getServletContext());
-
-		//overwrite the content from the buffer
+		RenderResult result;
+		
 		if(bufferMap != null) {
-			System.out.println("overriding content");
-			result.setContent(bufferMap.get("responseHead") + bufferMap.get("responseBody"));
+			M_log.debug("Using buffered content rendering");
+			result = new BufferedContentRenderResult(placement, bufferMap.get("responseBody"));
+		} else {
+			//standard iframe
+			M_log.debug("Using standard iframe rendering");
+			result = ToolRenderService.render(this, placement, req, res, getServletContext());
 		}
-		
-		System.out.println("result 1: " + result.getContent());
-		
+				
 		if (result.getJSR168HelpUrl() != null)
 		{
 			toolMap.put("toolJSR168Help", Web.serverUrl(req) + result.getJSR168HelpUrl());

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -618,7 +618,6 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 					bufferMap = (Map<String,String>) buffer;
 					toolInline = true;
 				}
-				
 			}
 		}
 		
@@ -733,8 +732,10 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		RenderResult result;
 		
 		if(bufferMap != null) {
+			// use the inlined content
 			M_log.debug("Using buffered content rendering");
-			result = new BufferedContentRenderResult(placement, bufferMap.get("responseBody"));
+			//this could do  with a bit of reorganisation...
+			result = new BufferedContentRenderResult(placement, bufferMap.get("responseHead"), bufferMap.get("responseBody"));
 		} else {
 			//standard iframe
 			M_log.debug("Using standard iframe rendering");

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageHandler.java
@@ -33,8 +33,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
@@ -42,13 +40,15 @@ import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.portal.api.PortalRenderContext;
 import org.sakaiproject.portal.api.StoredState;
+import org.sakaiproject.portal.util.URLUtils;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.ToolException;
-import org.sakaiproject.portal.util.URLUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author ieb
@@ -227,14 +227,11 @@ public class PageHandler extends BasePortalHandler
 
 					if (site != null)
 					{
-						boolean thisTool = portal.getSiteHelper().allowTool(site,
-								placement);
-						// System.out.println(" Allow Tool Display -" +
-						// placement.getTitle() + " retval = " + thisTool);
-						if (!thisTool) continue; // Skip this tool if not
-						// allowed
+						boolean thisTool = portal.getSiteHelper().allowTool(site,placement);
+						if (!thisTool) continue; // Skip this tool if not allowed
 					}
 
+					//Get the tool data map.
 					Map m = portal.includeTool(res, req, placement);
 					if (m != null)
 					{
@@ -259,6 +256,8 @@ public class PageHandler extends BasePortalHandler
 					boolean thisTool = portal.getSiteHelper().allowTool(site,
 								placement);
 					if (!thisTool) continue; // Skip this tool if not allowed
+					
+					//Get the tool data map.
 					Map m = portal.includeTool(res, req, placement);
 					if (m != null)
 					{

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -55,4 +55,18 @@
                 "portalCDNQuery" : "$!{portalCDNQuery}"
             };
         </script>
+        
+		<!-- inlined tool header contribution -->
+        ## if any of the tools requested an inline render, their header content gets aggregated here
+        #foreach ( $tool in $pageColumn0Tools )
+       		#if (${tool.hasRenderResult})
+       			${tool.toolRenderResult.getHead()}
+       		#end
+        #end
+        #foreach ( $tool in $pageColumn1Tools )
+        	#if (${tool.hasRenderResult})
+				${tool.toolRenderResult.getHead()}
+       		#end
+        #end
+		<!-- end inlined tool header contribution -->
     </head>

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -56,17 +56,17 @@
             };
         </script>
         
-		<!-- inlined tool header contribution -->
+        <!-- inlined tool header contribution -->
         ## if any of the tools requested an inline render, their header content gets aggregated here
         #foreach ( $tool in $pageColumn0Tools )
-       		#if (${tool.hasRenderResult})
-       			${tool.toolRenderResult.getHead()}
-       		#end
+        	#if (${tool.hasRenderResult})
+        		${tool.toolRenderResult.getHead()}
+        	#end
         #end
         #foreach ( $tool in $pageColumn1Tools )
         	#if (${tool.hasRenderResult})
-				${tool.toolRenderResult.getHead()}
-       		#end
+        		${tool.toolRenderResult.getHead()}
+        	#end
         #end
-		<!-- end inlined tool header contribution -->
+        <!-- end inlined tool header contribution -->
     </head>

--- a/portal/portal-render-impl/impl/src/java/org/sakaiproject/portal/render/iframe/IFrameToolRenderService.java
+++ b/portal/portal-render-impl/impl/src/java/org/sakaiproject/portal/render/iframe/IFrameToolRenderService.java
@@ -28,30 +28,18 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sakaiproject.component.cover.ServerConfigurationService;
-import org.sakaiproject.exception.IdUnusedException;
-import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.api.PortalService;
 import org.sakaiproject.portal.api.StoredState;
 import org.sakaiproject.portal.render.api.RenderResult;
 import org.sakaiproject.portal.render.api.ToolRenderException;
 import org.sakaiproject.portal.render.api.ToolRenderService;
-import org.sakaiproject.portal.util.ByteArrayServletResponse;
 import org.sakaiproject.portal.util.URLUtils;
-import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.ToolConfiguration;
-import org.sakaiproject.site.cover.SiteService;
-import org.sakaiproject.tool.api.ActiveTool;
-import org.sakaiproject.tool.api.Session;
-import org.sakaiproject.tool.api.Tool;
-import org.sakaiproject.tool.api.ToolException;
-import org.sakaiproject.tool.api.ToolSession;
-import org.sakaiproject.tool.cover.ActiveToolManager;
-import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.util.Web;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * I Frame tool renderer, renders the iframe header to contain the tool content
@@ -134,8 +122,10 @@ public class IFrameToolRenderService implements ToolRenderService
 
 		sb.append("\">") .append("\n").append("</iframe>");
 		
-		RenderResult result = new RenderResult()
-		{
+		RenderResult result = new RenderResult() {
+			
+			private String content = sb.toString();
+			
 			public String getHead() {
 				return "";
 			}
@@ -146,12 +136,12 @@ public class IFrameToolRenderService implements ToolRenderService
 
 			public String getContent()
 			{
-				return sb.toString();
+				return content;
 			}
 
 			public void setContent(String content)
 			{
-				return; // Not allowed
+				this.content = content;
 			}
 
 			public String getJSR168EditUrl()
@@ -164,7 +154,7 @@ public class IFrameToolRenderService implements ToolRenderService
 				return null;
 			}
 		};
-
+		
 		return result;
 	}
 

--- a/portal/portal-render-impl/impl/src/java/org/sakaiproject/portal/render/iframe/IFrameToolRenderService.java
+++ b/portal/portal-render-impl/impl/src/java/org/sakaiproject/portal/render/iframe/IFrameToolRenderService.java
@@ -123,9 +123,7 @@ public class IFrameToolRenderService implements ToolRenderService
 		sb.append("\">") .append("\n").append("</iframe>");
 		
 		RenderResult result = new RenderResult() {
-			
-			private String content = sb.toString();
-			
+						
 			public String getHead() {
 				return "";
 			}
@@ -136,12 +134,12 @@ public class IFrameToolRenderService implements ToolRenderService
 
 			public String getContent()
 			{
-				return content;
+				return sb.toString();
 			}
 
 			public void setContent(String content)
 			{
-				this.content = content;
+				return; // Not allowed
 			}
 
 			public String getJSR168EditUrl()


### PR DESCRIPTION
In Sakai 11+, tools can only be rendered inline (ie without iframes) if they are on a page on their own.

The portal creates a special URL directly to the tool `/portal/site/SITE_ID/tool/TOOL_ID` which treats these tools differently to tools that are on a page with other tools, and tries to render them inline, without an iframe.

When there are multiple tools on a page (which get a URL of the form `/portal/site/SITE_ID/page/PAGE_ID`), the PageHandler figures out what tools are in each column on that page and renders them within an iframe.

This contributed patch allows any tool to declare that it is able to be rendered inline and gives the portal a final chance to render that tool inline. If it can be rendered inline, its header content will be aggregated into the main HTML `<head>` section, and its body content emitted in the normal place in the page, otherwise it falls back to an iframe.

This is activated via the tool configuration property:
`<configuration name="renderInline" value="true" />`

which can be added to the tool registration XML or overridden as a tool property for each placement.

See also https://jira.sakaiproject.org/browse/SAK-31321