### PR TITLE
SAK-31115 Permission error while accessing the user workspace folder

### DIFF
--- a/reference/library/src/webapp/editor/ckeditor.launch.js
+++ b/reference/library/src/webapp/editor/ckeditor.launch.js
@@ -85,7 +85,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             '.html?connector=elfinder-connector/elfinder-servlet/connector';
 
         // Add tilde to userId in order to avoid permission error while getting resources from user workspace
-        collentionId = collectionId.replace('/user/','/user/~');
+        collectionId = collectionId.replace('/user/','/user/~');
 
         var filebrowser = {
             browseUrl :      elfinderUrl + '&startdir=' + collectionId,


### PR DESCRIPTION
Permission error while accessing the user workspace folder: Small typo
in the variable name