### PR TITLE
SAK-31096 Limit permissions to .anon/.auth by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4242,11 +4242,26 @@
 # realm.frozen.access=content.delete.own
 
 # Only allow a limited set of permissions to be changed for a role.
-# DEFAULT: null
+# Bt default we limit the .auth and .anon roles.
+# DEFAULT:
+# realm.allowed.roles=.auth,.anon
+# realm.allowed..anon=annc.read,calendar.read,content.read,content.hidden,read,mail.read,poll.vote,roster.viewallmembers,\
+#   roster.viewprofile,rwiki.read,rwiki.update,site.visit,usermembership.view,lessonbuilder.read
+# realm.allowed..auth=annc.all.groups,annc.read,asn.read,asn.receive.notifications,asn.submit,\
+#   assessment.questionpool.copy.own,assessment.questionpool.delete.own,assessment.questionpool.edit.own,\
+#   assessment.submitAssessmentForGrade,assessment.takeAssessment,calendar.read,chat.delete.own,chat.new,\
+#   chat.read,content.delete.own,content.new,content.hidden,content.read,content.revise.own,dropbox.own,\
+#   gradebook.viewOwnGrades,mail.new,mail.read,mailtool.send,poll.vote,roster.export,roster.viewallmembers,\
+#   roster.viewenrollmentstatus,roster.viewgroup,roster.viewofficialphoto,roster.viewprofile,rwiki.create,rwiki.read,\
+#   rwiki.update,signup.attend,signup.attend.all,signup.view,signup.view.all,site.viewRoster,site.visit,sitestats.view,\
+#  usermembership.view,lessonbuilder.read
+
 # # List of roles separated by commas
 # realm.allowed.roles=access
 # # For each role a list of permissions that can be changed.
 # realm.allowed.access=annc.read,poll.vote
+
+
 
 # SAK-29695
 # Should the .auth role be assignable to a realm? Defaults to false.

--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -264,3 +264,16 @@ content.mimeMagic.ignorecontent.extensions=js
 
 # KNL-1399
 copyright.type.default=
+
+# Limit grantable permissions to some roles. SAK-29403
+realm.allowed.roles=.auth,.anon
+realm.allowed..anon=annc.read,calendar.read,content.read,content.hidden,read,mail.read,poll.vote,roster.viewallmembers,\
+  roster.viewprofile,rwiki.read,rwiki.update,site.visit,usermembership.view,lessonbuilder.read
+realm.allowed..auth=annc.all.groups,annc.read,asn.read,asn.receive.notifications,asn.submit,\
+  assessment.questionpool.copy.own,assessment.questionpool.delete.own,assessment.questionpool.edit.own,\
+  assessment.submitAssessmentForGrade,assessment.takeAssessment,calendar.read,chat.delete.own,chat.new,\
+  chat.read,content.delete.own,content.new,content.hidden,content.read,content.revise.own,dropbox.own,\
+  gradebook.viewOwnGrades,mail.new,mail.read,mailtool.send,poll.vote,roster.export,roster.viewallmembers,\
+  roster.viewenrollmentstatus,roster.viewgroup,roster.viewofficialphoto,roster.viewprofile,rwiki.create,rwiki.read,\
+  rwiki.update,signup.attend,signup.attend.all,signup.view,signup.view.all,site.viewRoster,site.visit,sitestats.view,\
+  usermembership.view,lessonbuilder.read


### PR DESCRIPTION
This means that if you enable .anon or .auth access to sites maintainers can only grant a limited set of permissions by default.