### PR TITLE
1336: Fix issue with drag-and-drop reordering

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3484,7 +3484,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		final Long gradebookId = getGradebook(gradebookUid).getId();
 
 		//get all assignments for this gradebook
-		List<Assignment> assignments = getAssignments(gradebookId, SortType.SORT_BY_SORTING, true);
+		List<Assignment> assignments = getAssignments(gradebookId, SortType.SORT_BY_CATEGORY, true);
 		List<Assignment> assignmentsInNewCategory = new ArrayList<Assignment>();
 		for (Assignment assignment : assignments) {
 			if (assignment.getCategory() == null) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -165,8 +165,6 @@ public class AssignmentColumnHeaderPanel extends Panel {
 
 		add(new AttributeModifier("data-assignmentId", assignment.getId()));
 		add(new AttributeModifier("data-category", assignment.getCategoryName()));
-		add(new AttributeModifier("data-sort-order", assignment.getSortOrder()));
-		add(new AttributeModifier("data-categorized-sort-order", assignment.getCategorizedSortOrder()));
 		if (GbCategoryType.WEIGHTED_CATEGORY.equals(this.businessService.getGradebookCategoryType()) && assignment.getWeight() != null) {
 			add(new AttributeModifier("data-category-weight", String.format("%s%%", Math.round(assignment.getWeight() * 100))));
 		}

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -1023,10 +1023,6 @@ GradebookSpreadsheet.prototype._refreshColumnOrder = function() {
     return self.getCellModel($(this));
   });
 
-  self_COLUMN_ORDER = self._COLUMN_ORDER.sort(function(a, b) {
-    return a.getSortOrder() > b.getSortOrder();
-  });
-
   $.each(self._COLUMN_ORDER, function(i, model) {
     var category = model.getCategory();
 
@@ -1071,26 +1067,6 @@ GradebookSpreadsheet.prototype._refreshColumnOrder = function() {
     }
 
     return self._CATEGORY_DATA[a].order > self._CATEGORY_DATA[b].order;
-  });
-
-  $.each(self._CATEGORIES_MAP, function(category, models) {
-    self._CATEGORIES_MAP[category] = models.sort(function(a, b) {
-      var order_a = a.getCategorizedOrder();
-      var order_b = b.getCategorizedOrder();
-
-      var id_a = a.columnKey;
-      var id_b = b.columnKey;
-
-      if (order_a == order_b) {
-        return id_a > id_b;
-      } else if (order_a == -1) {
-        return 1;
-      } else if (order_b == -1) {
-        return -1;
-      }
-
-      return order_a > order_b
-    });
   });
 }
 
@@ -2043,16 +2019,6 @@ GradebookHeaderCell.prototype.hide = function() {
     }
   }
 };
-
-
-GradebookHeaderCell.prototype.getSortOrder = function() {
-  return this.$cell.find("[data-sort-order]").data("sort-order");
-}
-
-
-GradebookHeaderCell.prototype.getCategorizedOrder = function() {
-  return this.$cell.find("[data-categorized-sort-order]").data("categorized-sort-order");
-}
 
 
 GradebookHeaderCell.prototype.setupTooltip = function() {


### PR DESCRIPTION
Delivers #1336.

- Fixes categorized drag-and-drop sorting.  This was due to a bug in the service handling the udpate.. we needed to pre-sort the assignments by their category sorting rather than their "standard" sort order.

- Fixes uncategorized drag-and-drop sorting. This was due to the JavaScript not trusting the order in which the headers were rendered on the page.  Wicket renders the headers in the correct order so the JavaScript doesn't need to.  I've updated the JavaScript to completely trust the HTML and not try and re-order based on what it thinks should be the correct order (especially as this order changes as the user drags and drops things around).