### PR TITLE
SAK-26637 - NPE from gradebook on DAC sites (and some manually create…

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -62,6 +62,7 @@ import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameExcept
 import org.sakaiproject.service.gradebook.shared.ConflictingCategoryNameException;
 import org.sakaiproject.service.gradebook.shared.GradeDefinition;
 import org.sakaiproject.service.gradebook.shared.GradeMappingDefinition;
+import org.sakaiproject.service.gradebook.shared.GradebookFrameworkService;
 import org.sakaiproject.service.gradebook.shared.GradebookInformation;
 import org.sakaiproject.service.gradebook.shared.GradebookNotFoundException;
 import org.sakaiproject.service.gradebook.shared.GradebookPermissionService;
@@ -98,7 +99,25 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 
     private Authz authz;
     private GradebookPermissionService gradebookPermissionService;
+    private GradebookFrameworkService gradebookFrameworkService;
+    
     protected SiteService siteService;
+
+    public Gradebook addOrGetGradebook(String uid) throws GradebookNotFoundException {
+    	try {
+    		Gradebook gb = super.getGradebook(uid);
+    	}
+    	catch (GradebookNotFoundException e) {
+    		if (gradebookFrameworkService != null) {
+    			gradebookFrameworkService.addGradebook(uid,uid);
+    		}
+    		else {
+    			log.warn("Attempted to add non-existant gradebook but gradebookFrameworkService at this point == null");
+    		}
+    		
+    	}
+    	return super.getGradebook(uid);
+    }
 	
     @Override
 	public boolean isAssignmentDefined(final String gradebookUid, final String assignmentName)
@@ -3368,6 +3387,14 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		this.gradebookPermissionService = gradebookPermissionService;
 	}
 	
+	public GradebookFrameworkService getGradebookFrameworkService() {
+		return gradebookFrameworkService;
+	}
+
+	public void setGradebookFrameworkService(GradebookFrameworkService gradebookFrameworkService) {
+		this.gradebookFrameworkService = gradebookFrameworkService;
+	}
+
 	public void setSiteService(SiteService siteService) {
 		this.siteService = siteService;
 	}

--- a/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
+++ b/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
@@ -88,6 +88,9 @@
         <property name="gradebookPermissionService">
             <ref bean="org_sakaiproject_service_gradebook_GradebookPermissionService"/>
         </property>
+        <property name="gradebookFrameworkService">
+            <ref bean="org_sakaiproject_service_gradebook_GradebookFrameworkService"/>
+        </property>
         <property name="siteService">
             <ref bean="org.sakaiproject.site.api.SiteService" />
         </property>

--- a/gradebook/app/business/src/java/org/sakaiproject/tool/gradebook/business/GradebookManager.java
+++ b/gradebook/app/business/src/java/org/sakaiproject/tool/gradebook/business/GradebookManager.java
@@ -78,6 +78,14 @@ public interface GradebookManager {
      */
     public Gradebook getGradebook(String uid) throws GradebookNotFoundException;
 
+    /**
+     * Fetches a gradebook based on its unique string id, will create it if it doesn't exist. Required to get around readOnly method
+     *
+     * @param uid The UID of the gradebook
+     * @return The gradebook
+     */
+    public Gradebook addOrGetGradebook(String uid) throws GradebookNotFoundException;
+
     public Gradebook getGradebookWithGradeMappings(Long id);
 
     /**

--- a/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/GradebookBean.java
+++ b/gradebook/app/ui/src/java/org/sakaiproject/tool/gradebook/ui/GradebookBean.java
@@ -93,7 +93,7 @@ public class GradebookBean extends InitializableBean {
         if (newGradebookUid != null) {
             Gradebook gradebook = null;
             try {
-                gradebook = getGradebookManager().getGradebook(newGradebookUid);
+                gradebook = getGradebookManager().addOrGetGradebook(newGradebookUid);
             } catch (GradebookNotFoundException gnfe) {
                 logger.error("Request made for inaccessible gradebookUid=" + newGradebookUid);
                 newGradebookUid = null;

--- a/gradebook/app/ui/src/webapp/WEB-INF/spring-beans.xml
+++ b/gradebook/app/ui/src/webapp/WEB-INF/spring-beans.xml
@@ -35,6 +35,9 @@
 				<property name="authn">
 					<ref bean="org_sakaiproject_tool_gradebook_facades_Authn" />
 				</property>
+				<property name="gradebookFrameworkService">
+					<ref bean="org_sakaiproject_service_gradebook_GradebookFrameworkService" />
+				</property>
                 <property name="eventTrackingService">
                     <ref bean="org_sakaiproject_tool_gradebook_facades_EventTrackingService"/>
                 </property>


### PR DESCRIPTION
I tested this as an admin, instructor and a student and it worked fine. It didn't seem to cause any permission issue.

The comments say
     \* Since this is coming from the client, the application should NOT
     \* trust that the current user actually has access to the gradebook
     \* with this UID. This design assumes that authorization will come

But it seems like the only thing that might happen if someone passes in a gradebook that doesn't exist would be to create a gradebook and then just have basically no access to an empty gradebook.

I kind of hate doing this much logic in a "setter" but there already is logic there that just says "sorry no gradebook return null" and the only way it creates it now is when the tool is placed on a Observer event. 
