### PR TITLE
SAK-30371 : Plugin tools -> option to have expanded by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4544,3 +4544,11 @@
 basiclti.tool.site.attribution.key=Department
 #title for the column header, can be a text or a translation key
 basiclti.tool.site.attribution.name=content.attribution
+
+# ######################################################
+# SAK-30371 - Custom expand for groups in site manage tools
+# ######################################################
+#comma separated list of groups to expand in the tool list
+#allowed values : systoolgroups.lti,systoolgroups.ungrouped
+#default is empty, so all groups are collapsed by default
+#sitemanage.tools.groups.expanded=systoolgroups.lti

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1782,6 +1782,21 @@ public class SiteAction extends PagedResourceActionII {
 			context.put("toolsByGroup", (LinkedHashMap<String,List>) state.getAttribute(STATE_TOOL_GROUP_LIST));
 			
 			context.put("toolGroupMultiples", getToolGroupMultiples(state, (List) state.getAttribute(STATE_TOOL_REGISTRATION_LIST)));
+			
+			//get expanded groups
+			List<String> expandedGroups_lst = new ArrayList<>();
+			String[] tokens = ServerConfigurationService.getStrings("sitemanage.tools.groups.expanded");
+			if(tokens != null) {
+				for(String token : tokens) {
+					if(StringUtils.isNotEmpty(token)) {
+						String groupName = getGroupName(token);
+						if(StringUtils.isNotEmpty(groupName)) {
+							expandedGroups_lst.add(groupName);
+						}
+					}
+				}
+			}
+			context.put("expandedGroups", expandedGroups_lst);
 
 			return (String) getContext(data).get("template") + TEMPLATE[4];
 

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/toolGroupMultipleDisplay.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/toolGroupMultipleDisplay.vm
@@ -30,7 +30,7 @@
                 #set ($escapedKey = $mapEntry.key.replaceAll(" ", "_"))
                     <li id="$escapedKey" class="">
                         <h4 class="$escapedKey specialLink">
-                            <a  #if ($groupCount ==1) class="open toggleNone"#else href="#" #end>
+                            <a  #if ($groupCount ==1) class="open toggleNone"#elseif ($!expandedGroups.contains($mapEntry.key)) class="open" #end href="#" #end>
                                 <span class="catTitle">$mapEntry.key</span>
                                 <span class="checkedCount"></span>
                                 #if ($groupCount == 1) 
@@ -41,7 +41,7 @@
                                 #end
                             </a>
                         </h4>
-                        <ul class="toolGroup">
+                        <ul class="toolGroup" #if ($!expandedGroups.contains($mapEntry.key)) style="display:block" #end>
                             ## list those extra tools (added outside Site Info tool with tool id not listed as the allowed tool for current site type) as hidded input
                             #foreach($tool in $!extraSelectedToolList)
                                 <input type="hidden" name="selectedTools" value="$tool" />


### PR DESCRIPTION
Added new sakai property : sitemanage.tools.groups.expanded
All groups IDs listed in this property, will be expanded by default.
Valid IDs : systoolgroups.lti and systoolgroups.ungrouped

Signed-off-by: Miguel Carro Pellicer <mcarro@entornosdeformacion.com>