### PR TITLE
Revert SAK-30715: Use mail.support for boxes 2+3 if no technicalAddress

### DIFF
--- a/feedback/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
+++ b/feedback/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
@@ -236,7 +236,6 @@ public class FeedbackTool extends HttpServlet {
             siteEmail = site.getProperties().getProperty(Site.PROP_SITE_CONTACT_EMAIL);
         }
 
-        String mailSupport = sakaiProxy.getConfigString(Constants.MAIL_SUPPORT, "support@"+ sakaiProxy.getServerName());
         if (siteEmail!=null && !siteEmail.isEmpty() && siteExists){
             contactName = site.getProperties().getProperty(Site.PROP_SITE_CONTACT_NAME);
         }
@@ -246,7 +245,6 @@ public class FeedbackTool extends HttpServlet {
             contactName = String.format("%s <%s>" ,serviceContactName, serviceContactEmail);
         }
         setStringAttribute(request, "contactName", contactName);
-        setStringAttribute(request, "mailSupport", mailSupport);
 
         response.setContentType("text/html");
         request.getRequestDispatcher("/WEB-INF/bootstrap.jsp").include(request, response);

--- a/feedback/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
+++ b/feedback/src/java/org/sakaiproject/feedback/tool/entityproviders/FeedbackEntityProvider.java
@@ -298,9 +298,6 @@ public class FeedbackEntityProvider extends AbstractEntityProvider implements Au
             toAddress = sakaiProxy.getConfigString(Constants.PROP_SUPPLEMENTAL_B_ADDRESS, null);
         } else {
             toAddress = sakaiProxy.getConfigString(Constants.PROP_TECHNICAL_ADDRESS, null);
-            if (toAddress==null){
-               toAddress = sakaiProxy.getConfigString(Constants.MAIL_SUPPORT, null);
-            }
         }
         return toAddress;
     }

--- a/feedback/src/java/org/sakaiproject/feedback/util/Constants.java
+++ b/feedback/src/java/org/sakaiproject/feedback/util/Constants.java
@@ -31,7 +31,6 @@ public class Constants {
 	public final static String SUPPLEMENTAL_B = "supplementalb";
 
     public final static String PROP_TECHNICAL_ADDRESS = "feedback.technicalAddress";
-    public final static String MAIL_SUPPORT = "mail.support";
 	public final static String PROP_HELP_ADDRESS = "feedback.helpAddress";
 	public final static String PROP_SUGGESTIONS_ADDRESS = "feedback.suggestionsAddress";
 	public final static String PROP_SUPPLEMENTAL_A_ADDRESS = "feedback.supplementalAAddress";

--- a/feedback/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/feedback/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -342,8 +342,4 @@ public class SakaiProxy {
     public Locale getLocale() {
         return rb.getLocale();
     }
-
-    public String getServerName() {
-        return serverConfigurationService.getServerName();
-    }
 }

--- a/feedback/src/webapp/WEB-INF/bootstrap.jsp
+++ b/feedback/src/webapp/WEB-INF/bootstrap.jsp
@@ -46,7 +46,6 @@
                 maxAttachmentsMB: ${maxAttachmentsMB},
                 showContentPanel: ${showContentPanel},
                 showHelpPanel: ${showHelpPanel},
-                mailSupport: '${mailSupport}',
                 showTechnicalPanel: ${showTechnicalPanel},
                 showSuggestionsPanel: ${showSuggestionsPanel},
                 showSupplementalAPanel: ${showSupplementalAPanel},

--- a/feedback/src/webapp/WEB-INF/templates/home.handlebars
+++ b/feedback/src/webapp/WEB-INF/templates/home.handlebars
@@ -44,17 +44,6 @@
 
     {{#if showHelpPanel}}
         <div class="feedback-box" id="feedback-ask-help">
-            <h3>{{translate 'ask_title'}}</h3>
-            <ul>{{translate 'ask_explanation'}}</ul>
-        	{{#if enableTechnical}}
-            	<p><a id="feedback-report-helpdesk-link" href="javascript:;">{{translate 'technical_link'}}</a></p>
-            {{else}}
-                {{#if mailSupport}}
-                    <p><a id="feedback-report-helpdesk-link" href="javascript:;">{{translate 'technical_link'}}</a></p>
-                {{else}}
-                    <p class='information'>{{translate 'no_technical_address'}}</p>
-                {{/if}}
-            {{/if}}
             <div class="feedback-box-header">
                 <span class="fa fa-fw {{translate 'ask_icon_no_translate'}}" aria-hidden="true"></span>
                 <h3>{{translate 'ask_title'}}</h3>
@@ -79,17 +68,6 @@
 
     {{#if showTechnicalPanel}}
         <div class="feedback-box" id="feedback-tech-problem">
-            <h3>{{translate 'technical_title'}}</h3>
-            <ul>{{translate 'technical_explanation'}}</ul>
-        	{{#if enableTechnical}}
-        		<p><a id="feedback-report-technical-link" href="javascript:;">{{translate 'technical_link'}}</a></p>
-            {{else}}
-                {{#if mailSupport}}
-                    <p><a id="feedback-report-technical-link" href="javascript:;">{{translate 'technical_link'}}</a></p>
-                {{else}}
-                    <p class='information'>{{translate 'no_technical_address'}}</p>
-                {{/if}}
-            {{/if}}
             <div class="feedback-box-header">
                 <span class="fa fa-fw {{translate 'technical_icon_no_translate'}}" aria-hidden="true"></span>
                 <h3>{{translate 'technical_title'}}</h3>

--- a/feedback/src/webapp/js/feedback.js
+++ b/feedback/src/webapp/js/feedback.js
@@ -64,7 +64,6 @@
                                                     supplementaryInfo: feedback.supplementaryInfo,
                                                     helpPagesUrl: feedback.helpPagesUrl,
                                                     helpPagesTarget: feedback.helpPagesTarget,
-                                                    mailSupport: feedback.mailSupport,
                                                     loggedIn: loggedIn, showContentPanel : feedback.showContentPanel,
                                                     showHelpPanel : feedback.showHelpPanel,
                                                     showTechnicalPanel : feedback.showTechnicalPanel,
@@ -124,7 +123,7 @@
                     });
                 }
 
-                if (feedback.supplementaryInfo.length == 0 && feedback.mailSupport==null) {
+                if (feedback.supplementaryInfo.length > 0) {
                     $('#feedback-supplementary-info').show();
                 }
 


### PR DESCRIPTION
This is a revert of the PR here: https://github.com/sakaiproject/sakai/pull/2220.

SAK-30715 has been superseded by SAK-31184