### PR TITLE
SAK-29176 - Allow samigo when publishing a test, to link it to an existing non-externally maintained gradebook item.

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/EvaluationModelIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/EvaluationModelIfc.java
@@ -33,13 +33,14 @@ public interface EvaluationModelIfc
     extends java.io.Serializable
 {
 
-  public static final Integer ANONYMOUS_GRADING = Integer.valueOf(1);
-  public static final Integer NON_ANONYMOUS_GRADING = Integer.valueOf(2);
-  public static final Integer GRADEBOOK_NOT_AVAILABLE = Integer.valueOf(0);
-  public static final Integer TO_DEFAULT_GRADEBOOK = Integer.valueOf(1);
+  public static final Integer ANONYMOUS_GRADING = 1;
+  public static final Integer NON_ANONYMOUS_GRADING = 2;
+  public static final Integer GRADEBOOK_NOT_AVAILABLE = 0;
+  public static final Integer TO_DEFAULT_GRADEBOOK = 1;
   //public static Integer TO_SELECTED_GRADEBOOK = new Integer(2);  // this is confusing, we are using 2 for 'None' but the name is confusing, 
-  public static final Integer NOT_TO_GRADEBOOK = Integer.valueOf(2);		// so now we added this new constant, SAK-7162
-  public static final Integer TO_SELECTED_GRADEBOOK = Integer.valueOf(3);  // not used, but leave it for now 
+  public static final Integer NOT_TO_GRADEBOOK = 2;		// so now we added this new constant, SAK-7162
+  public static final Integer TO_SELECTED_GRADEBOOK = 3;  // not used, but leave it for now
+  public static final Integer TO_EXISTING_GRADEBOOK_ITEM = 4;
 
   // scoring type 
   public static final Integer HIGHEST_SCORE = Integer.valueOf(1);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -165,6 +165,10 @@ student_identity=Hide student identity from grader
 gradebook_options=Gradebook Options
 gradebook_options_help=Send assessment score to Gradebook immediately, regardless of options below
 
+to_no_gradebook=Do not link this test with gradebook
+to_associate_existing_gradebook_item=Associate this test with the Gradebook item with the same name.
+to_default_gradebook=Create a new Gradebook item
+
 recorded_score=If multiple submissions, record the
 highest_score=highest score
 average_score=average score

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -40,6 +40,7 @@ import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.exception.IdUnusedException;
@@ -48,10 +49,12 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.tool.assessment.api.SamigoApiFactory;
 import org.sakaiproject.tool.assessment.data.dao.authz.AuthorizationData;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.content.api.FilePickerHelper;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.TypeException;
+import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.section.api.SectionAwareness;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
 import org.sakaiproject.section.api.facade.Role;
@@ -73,6 +76,7 @@ import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
 import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceHelper;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.PublishingTargetHelper;
+import org.sakaiproject.tool.assessment.services.GradingService;
 import org.sakaiproject.tool.assessment.services.PersistenceService;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
@@ -86,6 +90,7 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.FormattedText;
 import org.sakaiproject.time.cover.TimeService;
 import org.sakaiproject.tool.assessment.util.ExtendedTimeService;
+import org.sakaiproject.service.gradebook.shared.Assignment;
 
 public class PublishedAssessmentSettingsBean
   implements Serializable {
@@ -169,11 +174,12 @@ public class PublishedAssessmentSettingsBean
   // properties of PublishedEvaluationModel
   private boolean anonymousGrading;
   private boolean gradebookExists;
-  private boolean toDefaultGradebook;
+  private String toDefaultGradebook;
   private String scoringType;
   private String bgColor;
   private String bgImage;
   private HashMap values = new HashMap();
+  private boolean gradebookLinkeable;
 
   // extra properties
   private String publishedUrl;
@@ -361,7 +367,7 @@ public class PublishedAssessmentSettingsBean
         if (evaluation.getAnonymousGrading()!=null)
           this.anonymousGrading = evaluation.getAnonymousGrading().toString().equals("1");
         if (evaluation.getToGradeBook()!=null )
-          this.toDefaultGradebook = evaluation.getToGradeBook().equals("1");
+          this.toDefaultGradebook = String.valueOf(evaluation.getToGradeBook());
         if (evaluation.getScoringType()!=null)
           this.scoringType = evaluation.getScoringType().toString();
         
@@ -370,17 +376,8 @@ public class PublishedAssessmentSettingsBean
         
         this.extendedTimeTargets = initExtendedTimeTargets();
         
-        /*
-        GradebookService g = null;
-        if (integrated)
-        {
-          g = (GradebookService) SpringBeanLocator.getInstance().
-            getBean("org.sakaiproject.service.gradebook.GradebookService");
-        }
-
-        this.gradebookExists = gbsHelper.gradebookExists(
-          GradebookFacade.getGradebookUId(), g);
-        */
+        GradingService gService = new GradingService();
+        this.gradebookLinkeable = gService.isGradebookItemAvailable(this.title); // true if there exist an empty GB item with same name as the assignment.
       }
 
       //set IPAddresses
@@ -834,11 +831,11 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
     this.anonymousGrading = anonymousGrading;
   }
 
-  public boolean getToDefaultGradebook() {
+  public String getToDefaultGradebook() {
     return this.toDefaultGradebook;
   }
 
-  public void setToDefaultGradebook(boolean toDefaultGradebook) {
+  public void setToDefaultGradebook(String toDefaultGradebook) {
     this.toDefaultGradebook = toDefaultGradebook;
   }
 
@@ -1653,6 +1650,14 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
   
  	public void setDisplayScoreDuringAssessments(String displayScoreDuringAssessments){
  		this.displayScoreDuringAssessments = displayScoreDuringAssessments;
+ 	}
+ 	
+ 	public boolean isGradebookLinkeable() {
+ 		return this.gradebookLinkeable;
+ 	}
+
+ 	public void setGradebookLinkeable(boolean pLinkeable) {
+ 		this.gradebookLinkeable = pLinkeable;
  	}
 }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -301,7 +301,9 @@ public class ConfirmPublishAssessmentListener
     }
     
     //Gradebook right now only excep if total score >0 check if total score<=0 then throw error.
-    if(assessmentSettings.getToDefaultGradebook())
+    String toDefaultGradebook = String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK);
+    String toExistingGradebookItem = String.valueOf(EvaluationModelIfc.TO_EXISTING_GRADEBOOK_ITEM);
+    if(StringUtils.equals(assessmentSettings.getToDefaultGradebook(), toDefaultGradebook))
 	{
  	    if(assessmentBean.getTotalScore()<=0)
 		{
@@ -317,12 +319,18 @@ public class ConfirmPublishAssessmentListener
       g = (GradebookExternalAssessmentService) SpringBeanLocator.getInstance().
             getBean("org.sakaiproject.service.gradebook.GradebookExternalAssessmentService");
     }
+    String toGradebook = assessmentSettings.getToDefaultGradebook();
     try{
-	if (assessmentSettings.getToDefaultGradebook() && gbsHelper.isAssignmentDefined(assessmentSettings.getTitle(), g)){
-        String gbConflict_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "gbConflict_error");
-        context.addMessage(null,new FacesMessage(gbConflict_err));
-        error=true;
-      }
+    	if (StringUtils.equals(toGradebook, toDefaultGradebook) &&
+    			gbsHelper.isAssignmentDefined(assessmentSettings.getTitle(), g)) {
+    		String gbConflict_err=ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "gbConflict_error");
+    		context.addMessage(null,new FacesMessage(gbConflict_err));
+    		error=true;
+    	} else if (StringUtils.equals(toGradebook, toExistingGradebookItem) &&
+    			!gbsHelper.isAssignmentDefined(assessmentSettings.getTitle(), g)) {
+    		context.addMessage(null,new FacesMessage("The empty gradebook item is no longer available, please select a new option"));
+    		error=true;
+    	}
     }
     catch(Exception e){
       log.warn("external assessment in GB has the same title:"+e.getMessage());

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/EditPublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/EditPublishedSettingsListener.java
@@ -38,7 +38,10 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentBaseIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
+import org.sakaiproject.tool.assessment.facade.GradebookFacade;
 import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
+import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
+import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceHelper;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.tool.assessment.ui.bean.author.AssessmentBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
@@ -47,6 +50,8 @@ import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.util.FormattedText;
 import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
+import org.sakaiproject.spring.SpringBeanLocator;
 
 /**
  * <p>Title: Samigo</p>
@@ -59,6 +64,10 @@ public class EditPublishedSettingsListener
     implements ActionListener
 {
   private static Logger log = LoggerFactory.getLogger(EditPublishedSettingsListener.class);
+  private static final GradebookExternalAssessmentService g = (GradebookExternalAssessmentService) SpringBeanLocator.getInstance().
+			getBean("org.sakaiproject.service.gradebook.GradebookExternalAssessmentService");
+  private static final GradebookServiceHelper gbsHelper =
+				IntegrationContextFactory.getInstance().getGradebookServiceHelper();
 
   public EditPublishedSettingsListener()
   {
@@ -137,6 +146,8 @@ public class EditPublishedSettingsListener
 	boolean isRetractedForEdit = isRetractedForEdit(assessment);
 	log.debug("isRetractedForEdit = " + isRetractedForEdit);
 	author.setIsRetractedForEdit(isRetractedForEdit);
+	
+	assessmentSettings.setGradebookExists(gbsHelper.gradebookExists(GradebookFacade.getGradebookUId(),g));
 	
 	String editPubAnonyGradingRestricted = ServerConfigurationService.getString("samigo.editPubAnonyGrading.restricted");
     if (editPubAnonyGradingRestricted != null && editPubAnonyGradingRestricted.equals("true")) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
@@ -43,14 +43,16 @@ import javax.faces.event.ActionListener;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.CalendarServiceHelper;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
-import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.spring.SpringBeanLocator;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedMetaData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
@@ -267,7 +269,7 @@ public class PublishAssessmentListener
     }
     String toGradebook = assessment.getEvaluationModel().getToGradeBook();
     try{
-      if (toGradebook!=null && toGradebook.equals(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK.toString()) &&
+    	if (StringUtils.equals(toGradebook, String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK)) &&
           gbsHelper.isAssignmentDefined(assessmentName, g)){
         error=true;
         String gbConflict_error=ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages","gbConflict_error");
@@ -475,4 +477,5 @@ public class PublishAssessmentListener
 	  
 	  return message.toString();
   }
+  
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -54,6 +54,7 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessCont
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
 import org.sakaiproject.tool.assessment.facade.AuthzQueriesFacadeAPI;
@@ -282,26 +283,32 @@ public class SaveAssessmentSettings
     
     String firstTargetSelected = assessmentSettings.getFirstTargetSelected();
 	if ("Anonymous Users".equals(firstTargetSelected)) {
-		evaluation.setAnonymousGrading(Integer.valueOf("1"));
-		evaluation.setToGradeBook("2");
+		evaluation.setAnonymousGrading(EvaluationModelIfc.ANONYMOUS_GRADING);
+		evaluation.setToGradeBook(String.valueOf(EvaluationModelIfc.NON_ANONYMOUS_GRADING));
 	}
 	else {
 		if (assessmentSettings.getAnonymousGrading()) {
-		      evaluation.setAnonymousGrading(1);
+		      evaluation.setAnonymousGrading(EvaluationModelIfc.ANONYMOUS_GRADING);
 		}
 		else {
-			evaluation.setAnonymousGrading(2);
+			evaluation.setAnonymousGrading(EvaluationModelIfc.NON_ANONYMOUS_GRADING);
 		}
-		if (assessmentSettings.getToDefaultGradebook()) {
-			evaluation.setToGradeBook("1");
+		String toDefaultGradebook = String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK);
+	    String toExistingGradebookItem = String.valueOf(EvaluationModelIfc.TO_EXISTING_GRADEBOOK_ITEM);
+		if (StringUtils.equals(assessmentSettings.getToDefaultGradebook(), toDefaultGradebook)) {
+			evaluation.setToGradeBook(toDefaultGradebook);
+		} else if (StringUtils.equals(assessmentSettings.getToDefaultGradebook(), toExistingGradebookItem)) {
+			evaluation.setToGradeBook(toExistingGradebookItem);
 		}
 		else {
-			evaluation.setToGradeBook("2");
+			evaluation.setToGradeBook(String.valueOf(EvaluationModelIfc.NOT_TO_GRADEBOOK));
 		}
 	}
     
-    if (assessmentSettings.getScoringType()!=null)
+    if (assessmentSettings.getScoringType()!=null) {
       evaluation.setScoringType(new Integer(assessmentSettings.getScoringType()));
+    }
+    
     assessment.setEvaluationModel(evaluation);
 
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
@@ -33,6 +33,7 @@ import javax.faces.event.AbortProcessingException;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.ActionListener;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.tool.assessment.api.SamigoApiFactory;
@@ -151,7 +152,7 @@ public class SaveAssessmentSettingsListener
      boolean ipErr=false;
      for(int a=0;a<arraysIp.length;a++){
 	 String currentString=arraysIp[a];
-	 if(!currentString.trim().equals("")){
+	 if(!StringUtils.equals(currentString.trim(), "")){
 	     if(a<(arraysIp.length-1))
 		 currentString=currentString.substring(0,currentString.length()-1);           
 	     if(!s.isIpValid(currentString)){

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -4,6 +4,7 @@
 <%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t" %>
 <%@ taglib uri="http://www.sakaiproject.org/samigo" prefix="samigo" %>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -502,12 +503,22 @@
       </div>
     </h:panelGroup>
     
+    <f:verbatim><br /><br /></f:verbatim>
+    
     <!-- GRADEBOOK OPTION -->
     <h:panelGroup styleClass="row" layout="block" rendered="#{assessmentSettings.valueMap.toGradebook_isInstructorEditable==true && assessmentSettings.gradebookExists==true}">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.gradebook_options}"/>
       <div class="col-md-10 samigo-checkbox">
-        <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{assessmentSettings.toDefaultGradebook}"/>
-        <h:outputLabel value="#{assessmentSettingsMessages.gradebook_options_help}" for="toDefaultGradebook"/>
+	      	<h:selectOneRadio id="toDefaultGradebook1" value="#{assessmentSettings.toDefaultGradebook}"  layout="pageDirection" rendered="#{assessmentSettings.gradebookLinkeable == true}">
+	     	 	<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	      		<f:selectItem itemValue="4" itemLabel="#{assessmentSettingsMessages.to_associate_existing_gradebook_item}"/>
+	        </h:selectOneRadio>
+	        <h:selectOneRadio id="toDefaultGradebook2" value="#{assessmentSettings.toDefaultGradebook}"  layout="pageDirection" rendered="#{assessmentSettings.gradebookLinkeable == false}">
+	  			<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	      		<f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.to_default_gradebook}"/>
+	        </h:selectOneRadio>
+          <f:verbatim><br /></f:verbatim>
+          <h:outputLabel styleClass="help-block info-text small" value="#{assessmentSettingsMessages.gradebook_options_help}" />
       </div>
     </h:panelGroup>
 

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -499,15 +499,25 @@
       </div>
     </h:panelGroup>
     
-    <!-- GRADEBOOK OPTION -->
+    <f:verbatim><br /><br /></f:verbatim>
+    
+   <!-- GRADEBOOK OPTION -->
     <h:panelGroup styleClass="row" layout="block" rendered="#{publishedSettings.valueMap.toGradebook_isInstructorEditable==true && publishedSettings.gradebookExists==true}">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.gradebook_options}"/>
       <div class="col-md-10 samigo-checkbox">
-        <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{publishedSettings.toDefaultGradebook}" disabled="#{publishedSettings.firstTargetSelected == 'Anonymous Users'}"/>
-        <h:outputLabel value="#{assessmentSettingsMessages.gradebook_options_help}" for="toDefaultGradebook" />
+	      	<h:selectOneRadio id="toDefaultGradebook1" value="#{publishedSettings.toDefaultGradebook}"  layout="pageDirection" rendered="#{publishedSettings.gradebookLinkeable == true}">
+	      	 	<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	       		<f:selectItem itemValue="4" itemLabel="#{assessmentSettingsMessages.to_associate_existing_gradebook_item}"/>
+	        </h:selectOneRadio>
+	        <h:selectOneRadio id="toDefaultGradebook2" value="#{publishedSettings.toDefaultGradebook}"  layout="pageDirection" rendered="#{publishedSettings.gradebookLinkeable == false}">
+	   			<f:selectItem itemValue="2" itemLabel="#{assessmentSettingsMessages.to_no_gradebook}"/>
+	       		<f:selectItem itemValue="1" itemLabel="#{assessmentSettingsMessages.to_default_gradebook}"/>
+	        </h:selectOneRadio>
+          <f:verbatim><br /></f:verbatim>
+          <h:outputLabel styleClass="help-block info-text small" value="#{assessmentSettingsMessages.gradebook_options_help}" />
       </div>
     </h:panelGroup>
-
+    
     </div>
 
     <!-- *** FEEDBACK *** -->

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -36,19 +36,24 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.sakaiproject.authz.cover.SecurityService;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.TypeException;
+import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
+import org.sakaiproject.service.gradebook.shared.GradebookService;
+import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.cover.SiteService;
@@ -767,13 +772,29 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport
 			GradebookServiceHelper gbsHelper = IntegrationContextFactory
 					.getInstance().getGradebookServiceHelper();
 
-			if (gbsHelper.gradebookExists(GradebookFacade.getGradebookUId(), g)
-					&& toGradebook != null
-					&& toGradebook
-							.equals(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK
-									.toString())) {
+			if (gbsHelper.gradebookExists(GradebookFacade.getGradebookUId(), g) && toGradebook != null) {
 				try {
-					gbsHelper.addToGradebook(publishedAssessment, null, g);
+					boolean addToGradebook = false;
+					if(StringUtils.equals(toGradebook, EvaluationModelIfc.TO_DEFAULT_GRADEBOOK.toString()) ||
+							toGradebook.equals(EvaluationModelIfc.TO_EXISTING_GRADEBOOK_ITEM.toString())) {
+						GradebookService gS = (GradebookService) ComponentManager.get("org.sakaiproject.service.gradebook.GradebookService");
+						String gradebookUid = GradebookFacade.getGradebookUId();
+						Assignment gbItem = gS.getAssignment(gradebookUid, assessment.getTitle());
+						Long categoryId = null;
+						if(gbItem != null) {
+							if(gbItem.getCategoryName() != null) {
+								List<CategoryDefinition> l = gS.getCategoryDefinitions(gradebookUid);
+								for(CategoryDefinition cat : l) {
+									if(StringUtils.equals(cat.getName(), gbItem.getCategoryName())) {
+										categoryId = cat.getId();
+									}
+								}
+							}
+							gS.removeAssignment(gbItem.getId());
+						}
+						publishedAssessment.getEvaluationModel().setToGradeBook(String.valueOf(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK));
+						gbsHelper.addToGradebook(publishedAssessment, categoryId, g);
+					}
 				} catch (Exception e) {
 					log.error("Removing published assessment: " + e);
 					delete(publishedAssessment);


### PR DESCRIPTION
[SAK-29176](https://jira.sakaiproject.org/browse/SAK-29176)

This applies when:

A non-externally maintained GB item exists and can be linked to an assesment when:
    1) Is being published
    2) It was published and has or not, grades already submitted into it
    3) Is retracted and republishes with or without any submissions in it

Should the assessment is disassociated with the GB item, this will be removed.

For retracting the exam, the property "samigo.editPubAssessment.restricted" must be enabled for the code in ActionAuthorListener (~164) defaults to true
