### PR TITLE
2686: Custom export options take 2

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -168,7 +168,9 @@ importExport.export.description = Export your Gradebook as a .csv file in order 
 importExport.import.heading = Import
 importExport.import.description = Selectively import new grades/gradebook items into the Gradebook by uploading an edited .csv version of your Gradebook below.
 importExport.template.description = Note: The formatting of the uploaded spreadsheet must match the conventions in the downloadable Gradebook file above.
-importExport.template.button.fullGradebook = Download Gradebook
+importExport.template.button.fullGradebook = Export Gradebook
+importExport.template.button.customGradebook = Download Custom Export
+importExport.template.button.advancedOptions = Custom Export
 
 importExport.selection.heading = Gradebook Item Import Selection
 importExport.selection.description = The system has analyzed the contents of your file upload and has identified new/updated \

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.html
@@ -5,7 +5,6 @@
 
 <wicket:extend>
   <div id="gradebookImportExport">
-    <div wicket:id="export">[export panel will be placed here]</div>
     <div wicket:id="wizard">[wizard will be placed here]</div>
   </div>
 </wicket:extend>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.java
@@ -20,7 +20,6 @@ public class ImportExportPage extends BasePage {
 	public ImportExportPage() {
 		disableLink(this.importExportPageLink);
 
-		add(new ExportPanel("export"));
 		add(new GradeImportUploadStep("wizard"));
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <div id="customExportModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="customExportModalTitle">
+        <div id="customExportModal" class="modal" tabindex="-1" role="dialog" aria-labelledby="customExportModalTitle">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -10,10 +10,24 @@
         </div>
 
         <div class="row">
-            <div class="collapse col-sm-8" id="advancedOptions">
-                <br>
-                <div class="panel panel-default">
-                    <div class="panel-body">
+            <div class="col-sm-12">
+                <p>
+                    <input type="button" wicket:id="downloadFullGradebook" wicket:message="value:importExport.template.button.fullGradebook"/>
+                    <a role="button" data-toggle="modal" href="#advancedOptions" data-target="#customExportModal">
+                        <wicket:message key="importExport.template.button.advancedOptions"/>
+                    </a>
+                </p>
+            </div>
+        </div>
+
+        <div id="customExportModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="customExportModalTitle">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title" id="customExportModalTitle"><wicket:message key="importExport.template.button.advancedOptions"/></h4>
+                    </div>
+                    <div class="modal-body">
                         <div class="row">
                             <div class="col-sm-12">
                                 <p><wicket:message key="importExport.export.advancedOption.description"/></p>
@@ -24,7 +38,6 @@
                                 <p><wicket:message key="importExport.export.advancedOption.warning"/></p>
                             </div>
                         </div>
-                        <br>
                         <div class="row">
                             <div class="col-sm-6">
                                 <div class="checkbox">
@@ -88,18 +101,15 @@
                             </div>
                         </div>
                     </div>
+                    <div class="modal-footer">
+                        <button wicket:id="downloadCustomGradebook" type="button" class="btn btn-primary pull-left">
+                            <wicket:message key="importExport.template.button.customGradebook"/>
+                        </button>
+                        <button type="button" class="btn btn-default pull-right" data-dismiss="modal">
+                            <wicket:message key="importExport.button.cancel"/>
+                        </button>
+                    </div>
                 </div>
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-sm-12">
-                <p>
-                    <input type="button" wicket:id="downloadFullGradebook" wicket:message="value:importExport.template.button.fullGradebook"/>
-                    <a role="button" data-toggle="collapse" href="#advancedOptions" aria-expanded="false" aria-controls="advancedOptions">
-                        Advanced Options
-                    </a>
-                </p>
             </div>
         </div>
     </section>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -26,18 +26,6 @@
                         </div>
                         <br>
                         <div class="row">
-                            <!-- div class="col-sm-12 form-inline">
-                                <div class="form-group">
-                                    <label for="exportFormat">
-                                        <wicket:message key="importExport.export.advancedOption.exportFormat"/>
-                                    </label>
-                                    <select class="select" id="exportFormat" wicket:id="exportFormat">
-                                        <option>CSV</option>
-                                        <option>Excel</option>
-                                        <option>PDF</option>
-                                    </select>
-                                </div>
-                            </div -->
                             <div class="col-sm-6">
                                 <div class="checkbox">
                                     <label>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -61,28 +61,6 @@ public class ExportPanel extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
-		add(new DropDownChoice("exportFormat", Model.of(exportFormat), Arrays.asList(ExportFormat.values()), new IChoiceRenderer<ExportFormat>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public Object getDisplayValue(final ExportFormat value) {
-				return getString(String.format("importExport.export.format.%s", value.toString().toLowerCase()));
-			}
-
-			@Override
-			public String getIdValue(final ExportFormat object, final int index) {
-				return object.toString();
-			}
-
-		}).add(new AjaxFormComponentUpdatingBehavior("onchange") {
-
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			protected void onUpdate(AjaxRequestTarget target) {
-				exportFormat = (ExportFormat)getComponent().getDefaultModelObject();
-			}
-		}));
 		add(new AjaxCheckBox("includeStudentName", Model.of(includeStudentName)) {
 			@Override
 			protected void onUpdate(AjaxRequestTarget ajaxRequestTarget) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -37,6 +37,8 @@ public class ExportPanel extends Panel {
 	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
 	protected GradebookNgBusinessService businessService;
 
+	private static final String CUSTOM_EXPORT_COLUMN_PREFIX = "# ";
+
 	enum ExportFormat {
 		CSV
 	}
@@ -185,19 +187,27 @@ public class ExportPanel extends Panel {
 			});
 
 			if (isCustomExport && includePoints) {
-				header.add(getString("importExport.export.csv.headers.points"));
+				header.add(String.format("%s%s",
+					CUSTOM_EXPORT_COLUMN_PREFIX,
+					getString("importExport.export.csv.headers.points")));
 			}
 			if (isCustomExport && includeCalculatedGrade) {
-				header.add(getString("importExport.export.csv.headers.calculatedGrade"));
+				header.add(String.format("%s%s",
+					CUSTOM_EXPORT_COLUMN_PREFIX,
+					getString("importExport.export.csv.headers.calculatedGrade")));
 			}
-			if (isCustomExport && includeCourseGrade) {
+			if (!isCustomExport || includeCourseGrade) {
 				header.add(getString("importExport.export.csv.headers.courseGrade"));
 			}
 			if (isCustomExport && includeGradeOverride) {
-				header.add(getString("importExport.export.csv.headers.gradeOverride"));
+				header.add(String.format("%s%s",
+					CUSTOM_EXPORT_COLUMN_PREFIX,
+					getString("importExport.export.csv.headers.gradeOverride")));
 			}
 			if (isCustomExport && includeLastLogDate) {
-				header.add(getString("importExport.export.csv.headers.lastLogDate"));
+				header.add(String.format("%s%s",
+					CUSTOM_EXPORT_COLUMN_PREFIX,
+					getString("importExport.export.csv.headers.lastLogDate")));
 			}
 
 			csvWriter.writeNext(header.toArray(new String[] {}));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.html
@@ -1,5 +1,7 @@
 <wicket:panel xmlns:wicket="http://wicket.apache.org">
 
+    <div wicket:id="export">[export panel will be placed here]</div>
+
     <section class="gb-import-export-section">
         <h2><wicket:message key="importExport.import.heading" /></h2>
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -64,6 +64,7 @@ public class GradeImportUploadStep extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
+		add(new ExportPanel("export"));
 		add(new UploadForm("form"));
 	}
 


### PR DESCRIPTION
Delivers #2686.

Namely:
- fix export showing on all import wizard pages
- show custom export in a modal
- original button is not affected by the custom options
- CUSTOM_EXPORT_COLUMN_PREFIX appended to custom (course grade) columns

@steveswinsburg I've added a static constant `CUSTOM_EXPORT_COLUMN_PREFIX` which you might be able to reuse when filtering columns in the import.