### PR TITLE
SAM-2918 Use StringUtils.isNotBlank when Saving Display score option in

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -484,7 +484,7 @@ implements ActionListener
 		if (assessmentSettings.getItemNumbering() != null) {
 			control.setItemNumbering(new Integer(assessmentSettings.getItemNumbering()));
 		}
-		if (assessmentSettings.getDisplayScoreDuringAssessments() != null) {
+		if (StringUtils.isNotBlank(assessmentSettings.getDisplayScoreDuringAssessments())) {
 			control.setDisplayScoreDuringAssessments(new Integer(assessmentSettings.getDisplayScoreDuringAssessments()));
 		}
 		


### PR DESCRIPTION
published assessments

During some test we had problems saving published assessments settings from SAKAI 10.x in SAKAI 11. This new property "Display Score" did not exists in SAKAI 10 so i might be a good idea to use StringUtils.isNotBlank (just like it´s done when you save the settings for a unpublished assessment)

Saving settings in an unpublished assessment
`
    if (StringUtils.isNotBlank(assessmentSettings.getAssessmentFormat())) {
      control.setAssessmentFormat(new Integer(assessmentSettings.getAssessmentFormat()));
    }`

Saving settings in an published assessment

`if (assessmentSettings.getDisplayScoreDuringAssessments() != null) {
	control.setDisplayScoreDuringAssessments(new Integer(assessmentSettings.getDisplayScoreDuringAssessments()));
		}`

IMO both should use StringUtils.isNotBlank
This new property was added in SAM-1117