### PR TITLE
SAK-31346 adding exception catch on createEntity and use getEntity me…

### DIFF
--- a/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -316,7 +316,14 @@ public class ZipContentUtil {
 			ZipEntry nextElement, ZipFile zipFile) throws Exception {
 		String resourceId = rootCollectionId + nextElement.getName();
 		String resourceName = extractName(nextElement.getName());
-		ContentResourceEdit resourceEdit = ContentHostingService.addResource(resourceId);	
+		ContentResourceEdit resourceEdit;
+		try {
+			resourceEdit = ContentHostingService.addResource(resourceId);
+		} catch (IdUsedException iue) {
+			// resource exists, update instead
+			LOG.debug("Content resource with ID " + resourceId + " exists. Editing instead.");
+			resourceEdit = ContentHostingService.editResource(resourceId);
+		}
 		resourceEdit.setContent(zipFile.getInputStream(nextElement));
 		resourceEdit.setContentType(mime.getContentType(resourceName));
 		ResourcePropertiesEdit props = resourceEdit.getPropertiesEdit();
@@ -335,7 +342,14 @@ public class ZipContentUtil {
 			ZipEntry element) throws Exception {
 		String resourceId = rootCollectionId + element.getName();
 		String resourceName = extractName(element.getName());
-		ContentCollectionEdit collection = ContentHostingService.addCollection(resourceId);										
+		ContentCollectionEdit collection;
+		try {
+			collection = ContentHostingService.addCollection(resourceId);
+		} catch (IdUsedException iue) {
+			// collection exists, update instead
+			LOG.debug("Content collection with ID " + resourceId + " exists. Editing instead.");
+			collection = ContentHostingService.editCollection(resourceId);
+		}
 		ResourcePropertiesEdit props = collection.getPropertiesEdit();
 		props.addProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME, resourceName);
 		ContentHostingService.commitCollection(collection);


### PR DESCRIPTION
…thod if thrown

Sometimes, when unzipping an archive in resources, the content collections and resources are created in an illogical order, causing an IdUsedException to be thrown.

For example, in one file I have a structure like:

mobile/1.pdf
mobile/2.pdf
mobile/

It creates the entities in top-down order. When it gets to "mobile/" it already exists, therefore the error is thrown.

This will get the content entity edit object instead if IdUsedException is thrown.