### PR TITLE
#2141 prevent null/null and 0/-1 from being displayed in the course grade

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -372,8 +372,15 @@ public class GradebookNgBusinessService {
 	public CourseGrade getCourseGrade(final String studentUuid) {
 
 		final Gradebook gradebook = this.getGradebook();
-		final CourseGrade rval = this.gradebookService.getCourseGradeForStudent(gradebook.getUid(), studentUuid);
-		return rval;
+		final CourseGrade courseGrade = this.gradebookService.getCourseGradeForStudent(gradebook.getUid(), studentUuid);
+		
+		// handle the special case in the gradebook service where totalPointsPossible = -1
+		if(courseGrade.getTotalPointsPossible() == -1) {
+			courseGrade.setTotalPointsPossible(null);
+			courseGrade.setPointsEarned(null);
+		}
+		
+		return courseGrade;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/CourseGradeFormatter.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/CourseGradeFormatter.java
@@ -144,17 +144,25 @@ public class CourseGradeFormatter {
 			// don't display points for weighted category type
 			final GbCategoryType categoryType = GbCategoryType.valueOf(this.gradebook.getCategory_type());
 			if (categoryType != GbCategoryType.WEIGHTED_CATEGORY) {
-
-				final Double pointsEarned = courseGrade.getPointsEarned();
-				final Double totalPointsPossible = courseGrade.getTotalPointsPossible();
+				
+				Double pointsEarned = courseGrade.getPointsEarned();
+				Double totalPointsPossible = courseGrade.getTotalPointsPossible();
+				
+				// handle the special case in the gradebook service where totalPointsPossible = -1
+				if(totalPointsPossible != null && totalPointsPossible == -1) {
+					pointsEarned = null;
+					totalPointsPossible = null;
+				}
 
 				// if instructor, show the points if requested
 				// otherwise check the settings
 				if (this.currentUserRole == GbRole.INSTRUCTOR || this.gradebook.isCoursePointsDisplayed()) {
-					if (parts.isEmpty()) {
-						parts.add(MessageHelper.getString("coursegrade.display.points-first", pointsEarned, totalPointsPossible));
-					} else {
-						parts.add(MessageHelper.getString("coursegrade.display.points-second", pointsEarned, totalPointsPossible));
+					if(pointsEarned != null && totalPointsPossible != null) {
+						if (parts.isEmpty()) {
+							parts.add(MessageHelper.getString("coursegrade.display.points-first", pointsEarned, totalPointsPossible));
+						} else {
+							parts.add(MessageHelper.getString("coursegrade.display.points-second", pointsEarned, totalPointsPossible));
+						}
 					}
 				}
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
@@ -176,18 +176,26 @@ public class CourseGradeOverridePanel extends Panel {
 	 */
 	private String formatPoints(final CourseGrade courseGrade, final Gradebook gradebook) {
 
+		String rval;
+		
 		// only display points if not weighted category type
 		final GbCategoryType categoryType = GbCategoryType.valueOf(gradebook.getCategory_type());
 		if (categoryType != GbCategoryType.WEIGHTED_CATEGORY) {
 
 			final Double pointsEarned = courseGrade.getPointsEarned();
 			final Double totalPointsPossible = courseGrade.getTotalPointsPossible();
-
-			return new StringResourceModel("coursegrade.display.points-first", null,
-					new Object[] { pointsEarned, totalPointsPossible }).getString();
+			
+			if(pointsEarned != null && totalPointsPossible != null) {
+				rval = new StringResourceModel("coursegrade.display.points-first", null,
+						new Object[] { pointsEarned, totalPointsPossible }).getString();
+			} else {
+				rval = getString("coursegrade.display.points-none");
+			}
 		} else {
-			return getString("coursegrade.display.points-none");
+			rval = getString("coursegrade.display.points-none");
 		}
+		
+		return rval;
 
 	}
 


### PR DESCRIPTION
The gradebookservice can return -1 under certain conditions. This is now handled in the business service and formatter. Also, if we end up with null values, exclude those from being turned into strings in the UI and return the dash instead.

Delivers #2141