### PR TITLE
SAK-31356 Fix maven warnings about relocations

### DIFF
--- a/jobscheduler/scheduler-tool/pom.xml
+++ b/jobscheduler/scheduler-tool/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-            <version>2.0.2</version>
         </dependency>
     </dependencies>
 

--- a/jsf/jsf-tool-sun/pom.xml
+++ b/jsf/jsf-tool-sun/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-            <version>2.0.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/jsf/myfaces-tool/pom.xml
+++ b/jsf/myfaces-tool/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-            <version>2.0.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -238,7 +238,6 @@
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-            <version>2.0.2</version>
         </dependency>
         <!-- test -->
         <dependency>

--- a/textarea/FCKeditor/connector/pom.xml
+++ b/textarea/FCKeditor/connector/pom.xml
@@ -50,11 +50,11 @@
       <artifactId>entitybroker-api</artifactId>
       <scope>provided</scope>
     </dependency>
-         <dependency>    
-             <groupId>jdom</groupId>
-             <artifactId>jdom</artifactId>
-             <version>1.1</version>
-          </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom</artifactId>
+      <version>1.1</version>
+    </dependency>
     <dependency>
       <groupId>org.sakaiproject.msgcntr</groupId>
       <artifactId>messageforums-api</artifactId>

--- a/textarea/calendar/pom.xml
+++ b/textarea/calendar/pom.xml
@@ -46,11 +46,11 @@
       <artifactId>entitybroker-api</artifactId>
       <scope>provided</scope>
     </dependency>
-         <dependency>    
-             <groupId>jdom</groupId>
-             <artifactId>jdom</artifactId>
-             <version>1.1</version>
-          </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom</artifactId>
+      <version>1.1</version>
+    </dependency>
   </dependencies>
   <build>
     <resources />


### PR DESCRIPTION
xml-apis - This is defined in the master pom with a version so all the versions can be dropped and we can just pull in the version from master.
jdom - The package is different so just updated, also fixed indentation to match surrounding lines.