### PR TITLE
SAK-31340 Wrong time shown in elfinder on files.

### DIFF
--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
@@ -207,7 +207,7 @@ public class ContentSiteVolumeFactory implements SiteVolumeFactory {
                     contentEntity = contentHostingService.getResource(id);
                 }
                 Date date = contentEntity.getProperties().getDateProperty(ResourceProperties.PROP_MODIFIED_DATE);
-                return date.getTime();
+                return date.getTime() / 1000;
             } catch (SakaiException se) {
                 LOG.warn("Failed to get last modified date for: " + id, se);
             } catch (EntityPropertyTypeException e) {


### PR DESCRIPTION
The elfinder code returns the time since epoch in seconds and date.getTime() returns the time since epoch in milliseconds which resulted in incorrect times.