### PR TITLE
SAK-30903 Make sure that new folders appear.

### DIFF
--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
@@ -120,14 +120,21 @@ public class ContentSiteVolumeFactory implements SiteVolumeFactory {
         public void createFolder(FsItem fsi) throws IOException {
             String id = asId(fsi);
             try {
-                String collectionId = asId(getParent(fsi));
-                String path = asId(fsi);
-                String name = lastPathSegment(path);
-                ContentCollectionEdit edit = contentHostingService.addCollection(collectionId, name);
-                ResourcePropertiesEdit props = edit.getPropertiesEdit();
-                props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
-
-                contentHostingService.commitCollection(edit);
+                if (fsi instanceof ContentFsItem) {
+                    ContentFsItem cfsi = (ContentFsItem)fsi;
+                    String collectionId = asId(getParent(cfsi));
+                    String path = asId(cfsi);
+                    String name = lastPathSegment(path);
+                    ContentCollectionEdit edit = contentHostingService.addCollection(collectionId, name);
+                    ResourcePropertiesEdit props = edit.getPropertiesEdit();
+                    props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
+                    contentHostingService.commitCollection(edit);
+                    // Directories always end with a trailing slash
+                    // The creation appends this if missing, so make sure the item is in sync
+                    cfsi.setId(edit.getId());
+                } else {
+                    throw new IllegalArgumentException("Can only pass ContentFsItem");
+                }
             } catch (SakaiException se) {
                 throw new IOException("Failed to create new folder: " + id, se);
             }


### PR DESCRIPTION
When creating a new folder from elfinder it would be passed in without a trailing slash (unless the user added it). The ContentHostingService would copy with this and add the trailing slash, however the data returned to the client would be incomplete (missing mime type) because we were looking up the details based on the wrong id.