### PR TITLE
SAM-2930 Refactored extendedTime implementation

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TimeZone;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -66,7 +65,6 @@ import org.sakaiproject.tool.assessment.ui.bean.author.AssessmentSettingsBean;
 import org.sakaiproject.tool.cover.ToolManager;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.util.ResourceLoader;
-import org.sakaiproject.time.cover.TimeService;
 import org.sakaiproject.tool.assessment.util.ExtendedTimeService;
 
 /**
@@ -79,8 +77,6 @@ import org.sakaiproject.tool.assessment.util.ExtendedTimeService;
 public class SaveAssessmentSettings
 {
   private static final Logger LOG = LoggerFactory.getLogger(SaveAssessmentSettings.class);
-  
-  private static final String EXTENDED_TIME_KEY = "extendedTime";
 
   public AssessmentFacade save(AssessmentSettingsBean assessmentSettings, boolean isFromConfirmPublishAssessmentListener)
   {
@@ -567,36 +563,14 @@ public class SaveAssessmentSettings
 	 * This will clear out the old extended time values and update them with new
 	 * ones.
 	 * 
-	 * @param assessment
-	 * @param assessmentSettings
-	 * @return
+	 * @param assessment AssessmentFacade
+	 * @param assessmentSettings AssessmentSettingsBean settings
+     * @param metaDataMap MetaDataMap
 	 */
-	private HashMap addExtendedTimeValuesToMetaData(AssessmentFacade assessment,
+	private void addExtendedTimeValuesToMetaData(AssessmentFacade assessment,
 			AssessmentSettingsBean assessmentSettings, HashMap metaDataMap) {
 
-		String[] allExtendedTimeEntries = assessmentSettings.getExtendedTimes().split("\\^");
-		String metaKey;
-
-		// clear out the old extended Time values
-		int itemNum = 1;
-		String extendedTimeData = assessment.getAssessmentMetaDataByLabel(EXTENDED_TIME_KEY + itemNum);
-		while ((extendedTimeData != null) && (!extendedTimeData.equals(""))) {
-			metaKey = EXTENDED_TIME_KEY + itemNum;
-			metaDataMap.put(metaKey, ""); // set to empty string TODO: actually
-											// delete it.
-			extendedTimeData = assessment.getAssessmentMetaDataByLabel(EXTENDED_TIME_KEY + itemNum);
-			itemNum++;
-		}
-
-		for (itemNum = 0; itemNum < allExtendedTimeEntries.length; itemNum++) {
-			String extendedTimeEntry = ExtendedTimeService.convertZones(allExtendedTimeEntries[itemNum], TimeService.getLocalTimeZone(), TimeZone.getDefault());
-			metaKey = "extendedTime" + (itemNum + 1);
-
-			// Add in the new extended time values
-			metaDataMap.put(metaKey, extendedTimeEntry);
-		}
-
-		return metaDataMap;
+		ExtendedTimeService.addExtendedTimeValuesToMetaData(assessmentSettings.getExtendedTimes(), metaDataMap, assessment, null);
 	}
 
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -97,8 +97,7 @@ implements ActionListener
 		IntegrationContextFactory.getInstance().isIntegrated();
 	private CalendarServiceHelper calendarService = IntegrationContextFactory.getInstance().getCalendarServiceHelper();
 	private final ResourceLoader rb= new ResourceLoader("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages");
-	
-	private static final String EXTENDED_TIME_KEY = "extendedTime";
+
 	
 	public SavePublishedSettingsListener()
 	{
@@ -636,8 +635,8 @@ implements ActionListener
 		// hasRetractDate, hasAnonymous, hasAuthenticatedUser, hasIpAddress,
 		// hasUsernamePassword, hasTimeAssessment,hasAutoSubmit, hasPartMetaData, 
 		// hasQuestionMetaData
-		HashMap h;
-		h = addExtendedTimeValuesToMetaData(assessment, assessmentSettings);
+		HashMap<String, String> h = assessment.getAssessmentMetaDataMap();
+		addExtendedTimeValuesToMetaData(assessment, assessmentSettings, h);
 		saveAssessmentSettings.updateMetaWithValueMap(assessment, h);
 		
 		// i. set Graphics
@@ -810,38 +809,14 @@ implements ActionListener
 	 * This will clear out the old extended time values and update them with new
 	 * ones.
 	 * 
-	 * @param assessment
-	 * @param assessmentSettings
-	 * @return
+	 * @param assessment the PublishedAssessmentFacade
+	 * @param assessmentSettings settings
+	 * @param metaDataMap hashMap of the metaData
 	 */
-	private HashMap addExtendedTimeValuesToMetaData(PublishedAssessmentFacade assessment,
-			PublishedAssessmentSettingsBean assessmentSettings) {
+	private void addExtendedTimeValuesToMetaData(PublishedAssessmentFacade assessment,
+			PublishedAssessmentSettingsBean assessmentSettings, HashMap<String, String> metaDataMap) {
 
-		String[] allExtendedTimeEntries = assessmentSettings.getExtendedTimes().split("\\^");
-		HashMap<String, String> metaDataMap = assessment.getAssessmentMetaDataMap();
-		String metaKey;
-
-		// clear out the old extended Time values
-		int itemNum = 1;
-		String extendedTimeData = assessment.getAssessmentMetaDataByLabel(EXTENDED_TIME_KEY + itemNum);
-		while ((extendedTimeData != null) && (!extendedTimeData.equals(""))) {
-			metaKey = EXTENDED_TIME_KEY + itemNum;
-			metaDataMap.put(metaKey, ""); // set to empty string TODO: actually
-											// delete it.
-			extendedTimeData = assessment.getAssessmentMetaDataByLabel(EXTENDED_TIME_KEY + itemNum);
-			itemNum++;
-		}
-
-		for (itemNum = 0; itemNum < allExtendedTimeEntries.length; itemNum++) {
-			// server stores in JVM's time one, convert from user's zone to that
-			String extendedTimeEntry = ExtendedTimeService.convertZones(allExtendedTimeEntries[itemNum], TimeService.getLocalTimeZone(), TimeZone.getDefault());
-			metaKey = "extendedTime" + (itemNum + 1);
-
-			// Add in the new extended time values
-			metaDataMap.put(metaKey, extendedTimeEntry);
-		}
-
-		return metaDataMap;
+		ExtendedTimeService.addExtendedTimeValuesToMetaData(assessmentSettings.getExtendedTimes(), metaDataMap, null, assessment);
 	}
 }
 

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/AssessmentBase.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/AssessmentBase.hbm.xml
@@ -46,7 +46,7 @@
       class="org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentFeedback"
       cascade="all" />
 
-    <set name="assessmentMetaDataSet" table="SAM_ASSESSMETADATA_T" cascade="all"
+    <set name="assessmentMetaDataSet" table="SAM_ASSESSMETADATA_T" cascade="all-delete-orphan"
       inverse="true">
       <key column="ASSESSMENTID"/>
       <one-to-many class="org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentMetaData"/>

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessment.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessment.hbm.xml
@@ -43,7 +43,7 @@
       class="org.sakaiproject.tool.assessment.data.dao.assessment.PublishedFeedback"
       cascade="all" />
 
-    <set name="assessmentMetaDataSet" table="SAM_PUBLISHEDMETADATA_T" cascade="all"
+    <set name="assessmentMetaDataSet" table="SAM_PUBLISHEDMETADATA_T" cascade="all-delete-orphan"
       inverse="true" lazy="false">
       <key column="ASSESSMENTID"/>
       <one-to-many class="org.sakaiproject.tool.assessment.data.dao.assessment.PublishedMetaData"/>

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentBaseFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentBaseFacade.java
@@ -786,6 +786,25 @@ public class AssessmentBaseFacade
     addAssessmentMetaData(label,entry);
   }
 
+  public void removeAssessmentMetaData(String label) {
+    if(label == null || label.isEmpty()) {
+      throw new IllegalArgumentException("Label must not be null or empty.");
+    }
+
+    this.assessmentMetaDataMap = getAssessmentMetaDataMap();
+    if (this.assessmentMetaDataMap.get(label) != null) {
+      this.assessmentMetaDataMap.remove(label);
+      for (Object obj : this.assessmentMetaDataSet) {
+        AssessmentMetaData metaData = (AssessmentMetaData) obj;
+        if(metaData.getLabel().equals(label)) {
+          this.assessmentMetaDataSet.remove(metaData);
+          break;
+        }
+      }
+      setAssessmentMetaDataSet(this.assessmentMetaDataSet);
+    }
+  }
+
   public void addAssessmentAttachmentMetaData(String entry) {
 	  assessmentAttachmentMetaData = entry;
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
@@ -541,6 +541,25 @@ public class PublishedAssessmentFacade
     addAssessmentMetaData(label, entry);
   }
 
+  public void removeAssessmentMetaData(String label) {
+    if(label == null || label.isEmpty()) {
+      throw new IllegalArgumentException("Label may not be null or empty.");
+    }
+
+    this.publishedMetaDataMap = getAssessmentMetaDataMap();
+    if (this.publishedMetaDataMap.get(label) != null) {
+      this.publishedMetaDataMap.remove(label);
+      for (Object obj : this.publishedMetaDataSet) {
+        PublishedMetaData metaData = (PublishedMetaData) obj;
+        if(metaData.getLabel().equals(label)) {
+          this.publishedMetaDataSet.remove(metaData);
+          break;
+        }
+      }
+      setAssessmentMetaDataSet(this.publishedMetaDataSet);
+    }
+  }
+
 /** not tested this method -daisy 11/16/04
   public void removeAssessmentMetaDataByLabel(String label) {
     HashSet set = new HashSet();


### PR DESCRIPTION
Refactored the extendedTimeMetaValues to actually delete the
extendedTime values in the database. Consolidated this
function into the ExtendedTimeService.

Added the ability to remove AssessmentMetaData (in published and
un-published assessments). This ability was added that so extra
extended time entries are also removed.