### PR TITLE
SAK-31363 Positioned timeout dialog to appear in the centre of the screen no matter where on the page you've scrolled

### DIFF
--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.session.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.session.js
@@ -125,7 +125,6 @@ function show_timeout_alert(min){
   if ($PBJQ("#timeout_alert_body").get(0)) {
     //its there, just update the min
     $PBJQ("#timeout_alert_body span").html(min);
-    $PBJQ("#timeout_alert_body span").css('top', (f_scrollTop() + 100) + "px");
   }
   else {
     var dialog = timeoutDialogFragment.replace("{0}", min);

--- a/reference/library/src/morpheus-master/sass/modules/timeout-alert/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/timeout-alert/_base.scss
@@ -1,15 +1,17 @@
-#timeout_alert_body{
+#timeout_alert_body
+{
 	z-index: 1001;
 	background: $background-color;
-	position: absolute;
-	top: 10em;
-	left: 10em;
-	width: calc(100% - 20em);
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	width: 50%;
 	padding: 2em;
 	font-size: 1.2em;
-	@media #{$phone}{
-		top: 5em;
-		left: 1em;
+	text-align: center;
+	@include transform( translate(-50%,-50%) ); /* perfect centering */
+	@media #{$phone}
+	{
 		padding: 1em;
 		width: calc(100% - 2em);
 		font-size: 1.05em;


### PR DESCRIPTION
If you are on a long page in Sakai and near the bottom (or just further down than the height of your screen) when the session timeout dialog appears, the page just goes dark - the message remains at the top of the page out of sight.

This patch makes the dialog always appear in the middle of the screen, so the user will always know what's going on. I've also centred things a bit better in the dialog. Works on wide (desktop) and narrow (mobile) views.

![fixeddialogposition](https://cloud.githubusercontent.com/assets/12685096/16058152/036383f6-324b-11e6-8af7-63e662a79448.png)
