### PR TITLE
2791: Add handling for double clicks on Wicket ajax components

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbAjaxButton.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbAjaxButton.java
@@ -1,0 +1,25 @@
+package org.sakaiproject.gradebookng.tool.component;
+
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+
+/**
+ * A GradebookNG implementation of Wicket's AjaxButton that
+ * disables the button on click to reduce the likelihood of
+ * double-clicks resulting in double actions.
+ */
+public class GbAjaxButton extends AjaxButton {
+
+	public GbAjaxButton(String id) {
+		super(id);
+	}
+
+	@Override
+	protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
+		super.updateAjaxAttributes(attributes);
+		attributes.getAjaxCallListeners().add(new AjaxCallListener()
+			.onBefore("$('#" + getMarkupId() + "').prop('disabled',true);")
+			.onComplete("$('#" + getMarkupId() + "').prop('disabled',false);"));
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbAjaxButton.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbAjaxButton.java
@@ -19,7 +19,12 @@ public class GbAjaxButton extends AjaxButton {
 	protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
 		super.updateAjaxAttributes(attributes);
 		attributes.getAjaxCallListeners().add(new AjaxCallListener()
-			.onBefore("$('#" + getMarkupId() + "').prop('disabled',true);")
-			.onComplete("$('#" + getMarkupId() + "').prop('disabled',false);"));
+			// disable the button right away after clicking it
+			.onBefore(String.format("$('#%s').prop('disabled',true);", getMarkupId()))
+			// add a slight delay in re-enabling it, just in case it succeeded and there's
+			// a delay in closing a parent modal
+			.onComplete(
+				String.format("setTimeout(function() { $('#%s').prop('disabled',false); }, 1000);",
+					getMarkupId())));
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbAjaxLink.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbAjaxLink.java
@@ -1,0 +1,29 @@
+package org.sakaiproject.gradebookng.tool.component;
+
+import org.apache.wicket.ajax.AjaxChannel;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.model.IModel;
+
+/**
+ * A GradebookNG implementation of Wicket's AjaxLink that
+ * disables the link on click to reduce the likelihood of
+ * double-clicks resulting in double actions.
+ */
+abstract public class GbAjaxLink<T> extends AjaxLink {
+
+	public GbAjaxLink(String id) {
+		this(id, (IModel)null);
+	}
+
+	public GbAjaxLink(String id, IModel<T> model) {
+		super(id, model);
+	}
+
+	@Override
+	protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
+		super.updateAjaxAttributes(attributes);
+		attributes.setChannel(new AjaxChannel("blocking", AjaxChannel.Type.ACTIVE));
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbModalWindow.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbModalWindow.java
@@ -100,6 +100,11 @@ public class GbModalWindow extends ModalWindow {
 
 			@Override
 			public void onClose(final AjaxRequestTarget target) {
+				// Disable all buttons with in the modal in case it takes a moment to close
+				target.appendJavaScript(
+					String.format("$('#%s :input').prop('disabled', true);",
+						GbModalWindow.this.getContent().getMarkupId()));
+
 				// Ensure the date picker is hidden
 				target.appendJavaScript("$('#ui-datepicker-div').hide();");
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -17,7 +17,6 @@ import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.Session;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.DataTable;
@@ -49,6 +48,7 @@ import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbGroup;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
 import org.sakaiproject.gradebookng.business.util.Temp;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.component.GbHeadersToolbar;
 import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
@@ -167,7 +167,7 @@ public class GradebookPage extends BasePage {
 		this.updateCourseGradeDisplayWindow = new GbModalWindow("updateCourseGradeDisplayWindow");
 		this.form.add(this.updateCourseGradeDisplayWindow);
 
-		final AjaxButton addGradeItem = new AjaxButton("addGradeItem") {
+		final GbAjaxButton addGradeItem = new GbAjaxButton("addGradeItem") {
 			@Override
 			public void onSubmit(final AjaxRequestTarget target, final Form form) {
 				final GbModalWindow window = getAddOrEditGradeItemWindow();
@@ -184,7 +184,6 @@ public class GradebookPage extends BasePage {
 				}
 				return true;
 			}
-
 		};
 		addGradeItem.setDefaultFormProcessing(false);
 		addGradeItem.setOutputMarkupId(true);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/PermissionsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/PermissionsPage.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -29,6 +28,7 @@ import org.apache.wicket.model.StringResourceModel;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.gradebookng.business.model.GbGroup;
 import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.GraderPermission;
 import org.sakaiproject.service.gradebook.shared.PermissionDefinition;
@@ -363,7 +363,7 @@ public class PermissionsPage extends BasePage {
 				item.add(groupChooser);
 
 				// remove button
-				final AjaxButton remove = new AjaxButton("remove") {
+				final GbAjaxButton remove = new GbAjaxButton("remove") {
 					private static final long serialVersionUID = 1L;
 
 					@Override
@@ -390,7 +390,7 @@ public class PermissionsPage extends BasePage {
 		form.add(permissionsView);
 
 		// 'add a rule' button
-		final AjaxButton addRule = new AjaxButton("addRule") {
+		final GbAjaxButton addRule = new GbAjaxButton("addRule") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
@@ -14,6 +13,7 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.gradebookng.business.GbCategoryType;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GbSettings;
 import org.sakaiproject.gradebookng.tool.panels.SettingsCategoryPanel;
 import org.sakaiproject.gradebookng.tool.panels.SettingsGradeEntryPanel;
@@ -182,7 +182,7 @@ public class SettingsPage extends BasePage {
 		add(form);
 
 		// expand/collapse panel actions
-		add(new AjaxLink<String>("expandAll") {
+		add(new GbAjaxLink("expandAll") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -190,7 +190,7 @@ public class SettingsPage extends BasePage {
 				target.appendJavaScript("$('#settingsAccordion .panel-collapse').collapse('show');");
 			}
 		});
-		add(new AjaxLink<String>("collapseAll") {
+		add(new GbAjaxLink("collapseAll") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
@@ -3,7 +3,6 @@ package org.sakaiproject.gradebookng.tool.panels;
 import java.text.MessageFormat;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
@@ -15,6 +14,7 @@ import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.component.GbFeedbackPanel;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
@@ -85,7 +85,7 @@ public class AddOrEditGradeItemPanel extends Panel {
 		// form
 		final Form<Assignment> form = new Form<Assignment>("addOrEditGradeItemForm", formModel);
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -149,7 +149,7 @@ public class AddOrEditGradeItemPanel extends Panel {
 		form.add(new GbFeedbackPanel("addGradeFeedback"));
 
 		// cancel button
-		final AjaxButton cancel = new AjaxButton("cancel") {
+		final GbAjaxButton cancel = new GbAjaxButton("cancel") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
@@ -26,6 +25,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.SortDirection;
 import org.sakaiproject.gradebookng.business.model.GbAssignmentGradeSortOrder;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -174,7 +174,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 		// menu
 		final WebMarkupContainer menu = new WebMarkupContainer("menu");
 
-		menu.add(new AjaxLink<Long>("editAssignmentDetails", Model.of(assignment.getId())) {
+		menu.add(new GbAjaxLink<Long>("editAssignmentDetails", Model.of(assignment.getId())) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -194,7 +194,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 			}
 		});
 
-		menu.add(new AjaxLink<Long>("viewAssignmentGradeStatistics", Model.of(assignment.getId())) {
+		menu.add(new GbAjaxLink<Long>("viewAssignmentGradeStatistics", Model.of(assignment.getId())) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -289,17 +289,17 @@ public class AssignmentColumnHeaderPanel extends Panel {
 			}
 		});
 
-		menu.add(new AjaxLink<Long>("hideAssignment", Model.of(assignment.getId())) {
+		menu.add(new GbAjaxLink<Long>("hideAssignment", Model.of(assignment.getId())) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
 			public void onClick(final AjaxRequestTarget target) {
-				final long assignmentId = getModelObject();
+				final Long assignmentId = (Long)getModelObject();
 				target.appendJavaScript("sakai.gradebookng.spreadsheet.hideGradeItemAndSyncToolbar('" + assignmentId + "');");
 			}
 		});
 
-		menu.add(new AjaxLink<Long>("setUngraded", Model.of(assignment.getId())) {
+		menu.add(new GbAjaxLink<Long>("setUngraded", Model.of(assignment.getId())) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -329,7 +329,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 		});
 
 		// delete item
-		menu.add(new AjaxLink<Long>("deleteGradeItem", Model.of(assignment.getId())) {
+		menu.add(new GbAjaxLink<Long>("deleteGradeItem", Model.of(assignment.getId())) {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
@@ -20,6 +19,7 @@ import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.SortDirection;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -111,7 +111,7 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 				return role == GbRole.INSTRUCTOR;
 			}
 		};
-		menu.add(new AjaxLink<Void>("setUngraded") {
+		menu.add(new GbAjaxLink("setUngraded") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -125,7 +125,7 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 			}
 		});
 
-		final AjaxLink<Boolean> showHidePoints = new AjaxLink<Boolean>("showHidePoints", this.model) {
+		final GbAjaxLink<Boolean> showHidePoints = new GbAjaxLink("showHidePoints", this.model) {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeItemCellPanel.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.event.IEvent;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -16,6 +15,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.ScoreChangedEvent;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -112,7 +112,7 @@ public class CourseGradeItemCellPanel extends Panel {
 				return role == GbRole.INSTRUCTOR;
 			}
 		};
-		menu.add(new AjaxLink<String>("courseGradeOverride", Model.of(studentUuid)) {
+		menu.add(new GbAjaxLink("courseGradeOverride", Model.of(studentUuid)) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -124,7 +124,7 @@ public class CourseGradeItemCellPanel extends Panel {
 				window.show(target);
 			}
 		});
-		menu.add(new AjaxLink<String>("courseGradeOverrideLog", Model.of(studentUuid)) {
+		menu.add(new GbAjaxLink<String>("courseGradeOverrideLog", Model.of(studentUuid)) {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverrideLogPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverrideLogPanel.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -19,6 +18,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeLog;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 
 /**
@@ -89,7 +89,7 @@ public class CourseGradeOverrideLogPanel extends Panel {
 		add(emptyLabel);
 
 		// done button
-		add(new AjaxLink<Void>("done") {
+		add(new GbAjaxLink("done") {
 
 			private static final long serialVersionUID = 1L;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.basic.Label;
@@ -22,6 +21,7 @@ import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.component.GbFeedbackPanel;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.service.gradebook.shared.GradebookInformation;
@@ -90,7 +90,7 @@ public class CourseGradeOverridePanel extends Panel {
 		overrideField.setOutputMarkupId(true);
 		form.add(overrideField);
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -129,7 +129,7 @@ public class CourseGradeOverridePanel extends Panel {
 		form.add(new GbFeedbackPanel("feedback"));
 
 		// cancel button
-		final AjaxButton cancel = new AjaxButton("cancel") {
+		final GbAjaxButton cancel = new GbAjaxButton("cancel") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/DeleteItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/DeleteItemPanel.java
@@ -3,7 +3,6 @@ package org.sakaiproject.gradebookng.tool.panels;
 import java.text.MessageFormat;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -11,6 +10,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
@@ -36,7 +36,7 @@ public class DeleteItemPanel extends Panel {
 
 		final Form<Long> form = new Form("form", Model.of(assignmentId));
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -55,7 +55,7 @@ public class DeleteItemPanel extends Panel {
 		};
 		form.add(submit);
 
-		final AjaxButton cancel = new AjaxButton("cancel") {
+		final GbAjaxButton cancel = new GbAjaxButton("cancel") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextArea;
@@ -17,6 +16,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.validator.StringValidator;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 import lombok.Getter;
@@ -65,7 +65,7 @@ public class EditGradeCommentPanel extends Panel {
 		// modal window forms must be submitted via AJAX so we do not specify an onSubmit here
 		final Form<GradeComment> form = new Form<GradeComment>("form", formModel);
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -91,7 +91,7 @@ public class EditGradeCommentPanel extends Panel {
 		};
 		form.add(submit);
 
-		final AjaxButton cancel = new AjaxButton("cancel") {
+		final GbAjaxButton cancel = new GbAjaxButton("cancel") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -18,6 +17,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeLog;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 
 /**
  * Panel for the grade log window
@@ -81,7 +81,7 @@ public class GradeLogPanel extends Panel {
 		add(emptyLabel);
 
 		// done button
-		add(new AjaxLink<Void>("done") {
+		add(new GbAjaxLink("done") {
 
 			private static final long serialVersionUID = 1L;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
@@ -13,7 +13,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.MarkupStream;
@@ -42,6 +41,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 public class GradeStatisticsPanel extends Panel {
@@ -188,7 +188,7 @@ public class GradeStatisticsPanel extends Panel {
 			add(new Label("deviation", "-"));
 		}
 
-		add(new AjaxLink<Void>("done") {
+		add(new GbAjaxLink("done") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/HeaderFlagPopoverPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/HeaderFlagPopoverPanel.java
@@ -1,7 +1,6 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.core.util.string.ComponentRenderer;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -12,6 +11,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.pages.SettingsPage;
 
 import java.util.Map;
@@ -75,7 +75,7 @@ public class HeaderFlagPopoverPanel extends Panel {
 				link.add(new Label("linkText", getString("label.coursegrade.editsettings")));
 				add(link);
 			} else if (this.assignmentId != null) {
-				final AjaxLink link = new AjaxLink("link") {
+				final GbAjaxLink link = new GbAjaxLink("link") {
 					@Override
 					public void onClick(final AjaxRequestTarget target) {
 						// do nothing

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
@@ -16,7 +16,6 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
@@ -41,6 +40,7 @@ import org.apache.wicket.util.convert.IConverter;
 import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.model.GbSettings;
 import org.sakaiproject.gradebookng.tool.pages.SettingsPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
@@ -400,7 +400,7 @@ public class SettingsCategoryPanel extends Panel {
 				item.add(categoryKeepHighest);
 
 				// remove button
-				final AjaxButton remove = new AjaxButton("remove") {
+				final GbAjaxButton remove = new GbAjaxButton("remove") {
 					private static final long serialVersionUID = 1L;
 
 					@Override
@@ -476,7 +476,7 @@ public class SettingsCategoryPanel extends Panel {
 		settingsCategoriesPanel.add(categoriesWrap);
 
 		// add category button
-		final AjaxButton addCategory = new AjaxButton("addCategory") {
+		final GbAjaxButton addCategory = new GbAjaxButton("addCategory") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -9,13 +9,11 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -28,6 +26,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.pages.BasePage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
@@ -137,7 +136,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		final WebMarkupContainer toggleActions = new WebMarkupContainer("toggleActions");
 		toggleActions.setVisible(this.categoriesEnabled);
 
-		final AjaxLink toggleCategoriesLink = new AjaxLink("toggleCategoriesLink") {
+		final GbAjaxLink toggleCategoriesLink = new GbAjaxLink("toggleCategoriesLink") {
 			@Override
 			protected void onInitialize() {
 				super.onInitialize();

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -14,6 +13,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 
 /**
@@ -49,7 +49,7 @@ public class StudentGradeSummaryPanel extends Panel {
 		// final String displayName = (String) modelData.get("displayName");
 
 		// done button
-		add(new AjaxLink<Void>("done") {
+		add(new GbAjaxLink("done") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameCellPanel.java
@@ -5,13 +5,13 @@ import java.util.HashMap;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.sakaiproject.gradebookng.business.model.GbStudentNameSortOrder;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GbModalWindow;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -47,7 +47,7 @@ public class StudentNameCellPanel extends Panel {
 		final GbStudentNameSortOrder nameSortOrder = (GbStudentNameSortOrder) modelData.get("nameSortOrder");
 
 		// link
-		final AjaxLink<String> link = new AjaxLink<String>("link") {
+		final GbAjaxLink<String> link = new GbAjaxLink<String>("link") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.java
@@ -2,7 +2,6 @@ package org.sakaiproject.gradebookng.tool.panels;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -13,6 +12,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.SortDirection;
 import org.sakaiproject.gradebookng.business.model.GbStudentNameSortOrder;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 
@@ -82,7 +82,7 @@ public class StudentNameColumnHeaderPanel extends Panel {
 		add(title);
 
 		// sort by first/last name link
-		final AjaxLink<GbStudentNameSortOrder> sortByName = new AjaxLink<GbStudentNameSortOrder>("sortByName", this.model) {
+		final GbAjaxLink<GbStudentNameSortOrder> sortByName = new GbAjaxLink<GbStudentNameSortOrder>("sortByName", this.model) {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -25,6 +24,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGroup;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.component.GbFeedbackPanel;
 import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -79,7 +79,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 		// modal window forms must be submitted via AJAX so we do not specify an onSubmit here
 		final Form<GradeOverride> form = new Form<GradeOverride>("form", formModel);
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -118,7 +118,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 		};
 		form.add(submit);
 
-		final AjaxButton cancel = new AjaxButton("cancel") {
+		final GbAjaxButton cancel = new GbAjaxButton("cancel") {
 			private static final long serialVersionUID = 1L;
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.java
@@ -3,12 +3,12 @@ package org.sakaiproject.gradebookng.tool.panels;
 import java.util.List;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
@@ -37,7 +37,7 @@ public class ZeroUngradedItemsPanel extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -57,7 +57,7 @@ public class ZeroUngradedItemsPanel extends Panel {
 		};
 		add(submit);
 
-		final AjaxButton cancel = new AjaxButton("cancel") {
+		final GbAjaxButton cancel = new GbAjaxButton("cancel") {
 			private static final long serialVersionUID = 1L;
 
 			@Override


### PR DESCRIPTION
Delivers #2791, #1915.

Introduce `GbAjaxButton` and `GbAjaxLink` to offer some kind of double-click handling for each.

- `GbAjaxButton` disables the button on click and re-enables upon complete.
- `GbAjaxLink` introduces a link channel so if another request of the same type comes through it is ignored (http://apache-wicket.1842946.n4.nabble.com/How-to-prevent-a-concurrent-click-on-ajax-links-AjaxFallbackLink-td4660226.html)
- Also disable all inputs on a modal as it is closing, just in case it takes a moment for the modal to close.

