### PR TITLE
2671: Match up behaviours of instructor grade summary view with student view

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1542,10 +1542,9 @@ public class GradebookNgBusinessService {
 	 * Get a map of grades for the given student. Safe to call when logged in as a student.
 	 *
 	 * @param studentUuid
-	 * @param assignments list of assignments the user can
 	 * @return map of assignment to GbGradeInfo
 	 */
-	public Map<Assignment, GbGradeInfo> getGradesForStudent(final String studentUuid) {
+	public Map<Long, GbGradeInfo> getGradesForStudent(final String studentUuid) {
 
 		final String siteId = getCurrentSiteId();
 		final Gradebook gradebook = getGradebook(siteId);
@@ -1553,7 +1552,7 @@ public class GradebookNgBusinessService {
 		// will apply permissions and only return those the student can view
 		final List<Assignment> assignments = this.getGradebookAssignments(siteId);
 
-		final Map<Assignment, GbGradeInfo> rval = new LinkedHashMap<>();
+		final Map<Long, GbGradeInfo> rval = new LinkedHashMap<>();
 
 		// iterate all assignments and get the grades
 		// if student, only proceed if grades are released for the site
@@ -1572,7 +1571,7 @@ public class GradebookNgBusinessService {
 		for (final Assignment assignment : assignments) {
 			final GradeDefinition def = this.gradebookService.getGradeDefinitionForStudentForItem(gradebook.getUid(),
 					assignment.getId(), studentUuid);
-			rval.put(assignment, new GbGradeInfo(def));
+			rval.put(assignment.getId(), new GbGradeInfo(def));
 		}
 
 		return rval;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -44,7 +44,6 @@ public class GradebookUiSettings implements Serializable {
 	private GbAssignmentGradeSortOrder assignmentSortOrder;
 
 	@Getter
-	@Setter
 	private boolean categoriesEnabled;
 
 	private final Map<Long, Boolean> assignmentVisibility;
@@ -85,6 +84,15 @@ public class GradebookUiSettings implements Serializable {
 	@Setter
 	private Boolean showPoints;
 
+
+	/**
+	 * For toggling the group by categories option in the course grade summary table 
+	 */
+	@Getter
+	@Setter
+	private boolean gradeSummaryGroupedByCategory;
+
+
 	public GradebookUiSettings() {
 		// defaults. Note there is no default for assignmentSortOrder as that
 		// requires an assignmentId which will differ between gradebooks
@@ -98,6 +106,7 @@ public class GradebookUiSettings implements Serializable {
 
 		this.categoryColors = new HashMap<String, String>();
 		this.showPoints = false;
+		this.gradeSummaryGroupedByCategory = false;
 	}
 
 	public boolean isAssignmentVisible(final Long assignmentId) {
@@ -137,6 +146,11 @@ public class GradebookUiSettings implements Serializable {
 				}
 			}
 		}
+	}
+
+	public void setCategoriesEnabled(final boolean categoriesEnabled){
+		this.categoriesEnabled = categoriesEnabled;
+		this.gradeSummaryGroupedByCategory = categoriesEnabled;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+<body>
+
+<wicket:panel>
+	<wicket:enclosure child="categoriesList">
+		<div wicket:id="toggleActions" class="col-md-12">
+			<div class="pull-right">
+				<a href="javascript:void(0);" class="button" id="toggleCategories" wicket:id="toggleCategoriesLink" aria-controls="gradeSummaryTable">Group By Category</a>
+				<a href="javascript:void(0);" class="gb-summary-expand-all" wicket:id="expandCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
+				<a href="javascript:void(0);" class="gb-summary-collapse-all" wicket:id="collapseCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
+			</div>
+		</div>
+
+		<table id="gradeSummaryTable" class="table table-bordered table-striped table-hover table-condensed">
+			<thead>
+				<tr>
+					<th class="col-md-4"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
+					<th class="col-md-2"><wicket:message key="column.header.studentsummary.grade" /></th>
+					<th class="col-md-1 weight-col"><wicket:message key="column.header.studentsummary.weight" /></th>
+					<th class="col-md-2"><wicket:message key="column.header.studentsummary.duedate" /></th>
+					<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
+					<th class="col-md-1 category-col" wicket:id="categoryColumnHeader"><wicket:message key="column.header.studentsummary.category" /></th>
+				</tr>
+			</thead>
+			<wicket:container wicket:id="categoriesList">
+				<wicket:enclosure child="categoryRow">
+					<tbody class="gb-summary-category-tbody">
+						<tr wicket:id="categoryRow" class="gb-summary-category-row">
+							<td>
+								<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
+								<span wicket:id="category" class="gb-summary-category-name"></span>
+							</td>
+							<td class="gb-summary-category-grade" wicket:id="categoryGrade"></td>
+							<td class="gb-summary-category-weight weight-col" wicket:id="categoryWeight"></td>
+							<td></td>
+							<td></td>
+						</tr>
+					</tbody>
+				</wicket:enclosure>
+				<tbody class="gb-summary-assignments-tbody">
+					<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
+						<td>
+							<span class="gb-summary-grade-flags" wicket:id="flags">
+								<span wicket:id="isExtraCredit" class="gb-flag-extra-credit"></span>
+								<span wicket:id="isNotCounted" class="gb-flag-not-counted"></span>
+								<span wicket:id="isNotReleased" class="gb-flag-not-released"></span>
+							</span>
+							<span class="gb-summary-grade-title" wicket:id="title"></span>
+						</td>
+						<td class="gb-summary-grade-score">
+							<span class="gb-summary-grade-score-raw" wicket:id="grade"></span>
+							<span class="gb-summary-grade-score-outof" wicket:id="outOf"></span>
+						</td>
+						<td class="weight-col"><!-- empty --></td>
+						<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
+						<td class="gb-summary-grade-comments" wicket:id="comments"></td>
+						<td class="gb-summary-grade-category" wicket:id="category"></td>
+					</tr>
+				</tbody>
+			</wicket:container>
+		</table>
+	</wicket:enclosure>
+</wicket:panel>
+
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -1,0 +1,208 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.StringResourceModel;
+import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
+import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
+import org.sakaiproject.gradebookng.tool.pages.BasePage;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.service.gradebook.shared.Assignment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class GradeSummaryTablePanel extends Panel {
+
+	boolean isGroupedByCategory;
+
+	public GradeSummaryTablePanel(final String id, final IModel<Map<String, Object>> model) {
+		super(id, model);
+	}
+
+	@Override
+	public void onInitialize() {
+		super.onInitialize();
+
+		setOutputMarkupId(true);
+	}
+
+	@Override
+	public void onBeforeRender() {
+		super.onBeforeRender();
+
+		Map<String, Object> data = (Map<String, Object>) getDefaultModelObject();
+
+		final Map<Long, GbGradeInfo> grades  = (Map<Long, GbGradeInfo>) data.get("grades");
+		final Map<String, List<Assignment>> categoryNamesToAssignments = (Map<String, List<Assignment>>) data.get("categoryNamesToAssignments");
+		final List<String> categoryNames = (List<String>) data.get("categoryNames");
+		final Map<Long, Double> categoryAverages = (Map<Long, Double>) data.get("categoryAverages");
+		final boolean categoriesEnabled = (boolean) data.get("categoriesEnabled");
+		final boolean isCategoryWeightEnabled = (boolean) data.get("isCategoryWeightEnabled");
+		final boolean showingStudentView = (boolean) data.get("showingStudentView");
+		isGroupedByCategory = (boolean) data.get("isGroupedByCategory");
+
+		if (getPage() instanceof GradebookPage) {
+			GradebookPage page = (GradebookPage) getPage();
+			GradebookUiSettings settings = page.getUiSettings();
+			isGroupedByCategory = settings.isGradeSummaryGroupedByCategory();
+		}
+
+		final WebMarkupContainer toggleActions = new WebMarkupContainer("toggleActions");
+		toggleActions.setVisible(categoriesEnabled);
+
+		final GbAjaxLink toggleCategoriesLink = new GbAjaxLink("toggleCategoriesLink") {
+			@Override
+			protected void onInitialize() {
+				super.onInitialize();
+				if (isGroupedByCategory) {
+					add(new AttributeAppender("class", " on"));
+				}
+				add(new AttributeModifier("aria-pressed", isGroupedByCategory));
+			}
+
+			@Override
+			public void onClick(AjaxRequestTarget target) {
+				if (getPage() instanceof GradebookPage) {
+					final GradebookPage page = (GradebookPage) getPage();
+					final GradebookUiSettings settings = page.getUiSettings();
+					settings.setGradeSummaryGroupedByCategory(!settings.isGradeSummaryGroupedByCategory());
+				}
+
+				isGroupedByCategory = !isGroupedByCategory;
+				data.put("isGroupedByCategory", isGroupedByCategory);
+
+				target.add(GradeSummaryTablePanel.this);
+				target.appendJavaScript(
+					String.format("new GradebookGradeSummary($(\"#%s\"), %s);",
+						GradeSummaryTablePanel.this.getParent().getMarkupId(),
+						showingStudentView));
+			}
+		};
+		toggleActions.add(toggleCategoriesLink);
+		toggleActions.addOrReplace(new WebMarkupContainer("expandCategoriesLink").setVisible(isGroupedByCategory));
+		toggleActions.addOrReplace(new WebMarkupContainer("collapseCategoriesLink").setVisible(isGroupedByCategory));
+		addOrReplace(toggleActions);
+
+		addOrReplace(new WebMarkupContainer("categoryColumnHeader").
+			setVisible(categoriesEnabled && !isGroupedByCategory));
+
+		// output all of the categories
+		// within each we then add the assignments in each category
+		// if not grouped by category, render all assignments in one go!
+		addOrReplace(new ListView<String>("categoriesList", isGroupedByCategory ? categoryNames : Arrays.asList(getString(GradebookPage.UNCATEGORISED))) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void populateItem(final ListItem<String> categoryItem) {
+				final String categoryName = categoryItem.getModelObject();
+
+				final List<Assignment> categoryAssignments;
+				if (isGroupedByCategory) {
+					categoryAssignments = categoryNamesToAssignments.get(categoryName);
+				} else {
+					categoryAssignments = new ArrayList<Assignment>();
+					categoryNamesToAssignments.values().forEach(categoryAssignments::addAll);
+				}
+
+				final WebMarkupContainer categoryRow = new WebMarkupContainer("categoryRow");
+				categoryRow.setVisible(categoriesEnabled && isGroupedByCategory);
+				categoryItem.add(categoryRow);
+				categoryRow.add(new Label("category", categoryName));
+
+				Double categoryAverage = categoryAverages.get(categoryAssignments.get(0).getCategoryId());
+				if (categoryAverage == null) {
+					categoryRow.add(new Label("categoryGrade", getString("label.nocategoryscore")));
+				} else {
+					categoryRow.add(new Label("categoryGrade", FormatHelper.formatDoubleAsPercentage(categoryAverage)));
+				}
+
+				String categoryWeight = "";
+				if (!categoryAssignments.isEmpty()) {
+					final Double weight = categoryAssignments.get(0).getWeight();
+					if (weight != null) {
+						categoryWeight = FormatHelper.formatDoubleAsPercentage(weight * 100);
+					}
+				}
+				categoryRow.add(new Label("categoryWeight", categoryWeight));
+
+				categoryItem.add(new ListView<Assignment>("assignmentsForCategory", categoryAssignments) {
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					protected void populateItem(final ListItem<Assignment> assignmentItem) {
+						final Assignment assignment = assignmentItem.getModelObject();
+
+						if (!categoriesEnabled) {
+							assignmentItem.add(new AttributeAppender("class", " gb-no-categories"));
+						}
+
+						final GbGradeInfo gradeInfo = grades.get(assignment.getId());
+
+						final String rawGrade;
+						String comment;
+						if (gradeInfo != null) {
+							rawGrade = gradeInfo.getGrade();
+							comment = gradeInfo.getGradeComment();
+						} else {
+							rawGrade = "";
+							comment = "";
+						}
+
+						final Label title = new Label("title", assignment.getName());
+						assignmentItem.add(title);
+
+						final BasePage page = (BasePage) getPage();
+						final WebMarkupContainer flags = new WebMarkupContainer("flags");
+						flags.add(page.buildFlagWithPopover("isExtraCredit", getString("label.gradeitem.extracredit"))
+							.add(new AttributeModifier("data-trigger", "focus"))
+							.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
+							.setVisible(assignment.getExtraCredit()));
+						flags.add(page.buildFlagWithPopover("isNotCounted", getString("label.gradeitem.notcounted"))
+							.add(new AttributeModifier("data-trigger", "focus"))
+							.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
+							.setVisible(!assignment.isCounted()));
+						flags.add(page.buildFlagWithPopover("isNotReleased", getString("label.gradeitem.notreleased"))
+							.add(new AttributeModifier("data-trigger", "focus"))
+							.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
+							.setVisible(!assignment.isReleased()));
+						assignmentItem.add(flags);
+
+						Label dueDate = new Label("dueDate",
+							FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate")));
+						dueDate.add(new AttributeModifier("data-sort-key",
+							assignment.getDueDate() == null ? 0 : assignment.getDueDate().getTime()));
+						assignmentItem.add(dueDate);
+						assignmentItem.add(new Label("grade", FormatHelper.formatGrade(rawGrade)));
+						assignmentItem.add(new Label("outOf",
+							new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {
+							@Override
+							public boolean isVisible() {
+								return StringUtils.isNotBlank(rawGrade);
+							}
+						});
+						assignmentItem.add(new Label("comments", comment));
+						assignmentItem.add(
+							new Label("category", assignment.getCategoryName()).
+								setVisible(categoriesEnabled && !isGroupedByCategory));
+					}
+				});
+			}
+		});
+
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.html
@@ -13,59 +13,9 @@
 				</div>
 			</div>
 
-			<div wicket:id="toggleActions" class="col-md-12">
-				<div class="pull-right">
-					<a href="javascript:void(0);" class="gb-summary-expand-all"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
-					<a href="javascript:void(0);" class="gb-summary-collapse-all"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
-				</div>
-			</div>
+			<div wicket:id="gradeSummaryTable"/>
 
-			<table class="table table-bordered table-striped table-hover table-condensed">
-				<thead>
-				<tr>
-					<th class="col-md-4"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
-					<th class="col-md-2"><wicket:message key="column.header.studentsummary.grade" /></th>
-					<th class="col-md-1 weight-col"><wicket:message key="column.header.studentsummary.weight" /></th>
-					<th class="col-md-2"><wicket:message key="column.header.studentsummary.duedate" /></th>
-					<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
-				</tr>
-				</thead>
-				<wicket:container wicket:id="categoriesList">
-				<tbody class="gb-summary-category-tbody">
-				<tr wicket:id="categoryRow" class="gb-summary-category-row">
-					<td>
-						<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
-						<span wicket:id="category" class="gb-summary-category-name"></span>
-					</td>
-					<td class="gb-summary-category-grade" wicket:id="categoryGrade"></td>
-					<td class="gb-summary-category-weight weight-col" wicket:id="categoryWeight"></td>
-					<td></td>
-					<td></td>
-				</tr>
-				</tbody>
-				<tbody class="gb-summary-assignments-tbody">
-				<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
-					<td>
-						<span class="gb-summary-grade-flags" wicket:id="flags">
-							<span wicket:id="isExtraCredit" class="gb-flag-extra-credit"></span>
-							<span wicket:id="isNotCounted" class="gb-flag-not-counted"></span>
-							<span wicket:id="isNotReleased" class="gb-flag-not-released"></span>
-						</span>
-						<span class="gb-summary-grade-title" wicket:id="title"></span>
-					</td>
-					<td class="gb-summary-grade-score">
-						<span class="gb-summary-grade-score-raw" wicket:id="grade"></span>
-						<span class="gb-summary-grade-score-outof" wicket:id="outOf"></span>
-					</td>
-					<td class="weight-col"><!-- empty --></td>
-					<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
-					<td class="gb-summary-grade-comments" wicket:id="comments"></td>
-				</tr>
-				</tbody>
-				</wicket:container>
-			</table>
 			<div class="col-md-12">
-				<p><small wicket:id="categoryScoreNotReleased"></small></p>
 				<p><small wicket:id="courseGradeNotReleasedMessage"></small></p>
 			</div>
 		</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
@@ -1,24 +1,11 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
-import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
-import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.list.ListItem;
-import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GbRole;
@@ -26,13 +13,18 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
-import org.sakaiproject.gradebookng.business.util.FormatHelper;
-import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.tool.gradebook.Gradebook;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class InstructorGradeSummaryGradesPanel extends Panel {
 
@@ -41,10 +33,10 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 	@SpringBean(name = "org.sakaiproject.gradebookng.business.GradebookNgBusinessService")
 	protected GradebookNgBusinessService businessService;
 
-	private GbStudentGradeInfo gradeInfo;
-	private List<CategoryDefinition> categories;
-
 	GbCategoryType configuredCategoryType;
+
+	boolean isGroupedByCategory = false;
+	boolean categoriesEnabled = false;
 
 	public InstructorGradeSummaryGradesPanel(final String id, final IModel<Map<String, Object>> model) {
 		super(id, model);
@@ -54,24 +46,50 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 	public void onInitialize() {
 		super.onInitialize();
 
+		final Gradebook gradebook = this.businessService.getGradebook();
+
+		this.setOutputMarkupId(true);
+
+		final Map<String, Object> modelData = (Map<String, Object>) getDefaultModelObject();
+		final boolean groupedByCategoryByDefault = (Boolean) modelData.get("groupedByCategoryByDefault");
+
+		this.configuredCategoryType = GbCategoryType.valueOf(gradebook.getCategory_type());
+		this.isGroupedByCategory =  groupedByCategoryByDefault && this.configuredCategoryType != GbCategoryType.NO_CATEGORY;
+		this.categoriesEnabled = this.configuredCategoryType != GbCategoryType.NO_CATEGORY;
+	}
+
+	@Override
+	public void onBeforeRender() {
+		super.onBeforeRender();
+
 		// unpack model
 		final Map<String, Object> modelData = (Map<String, Object>) getDefaultModelObject();
 		final String userId = (String) modelData.get("userId");
 
-		final GradebookPage gradebookPage = (GradebookPage) getPage();
+		final GradebookPage gradebookPage = (GradebookPage)getPage();
 
 		// build the grade matrix for the user
+		final Gradebook gradebook = this.businessService.getGradebook();
 		final List<Assignment> assignments = this.businessService.getGradebookAssignments();
+
+		final CourseGradeFormatter courseGradeFormatter = new CourseGradeFormatter(
+			gradebook,
+			GbRole.INSTRUCTOR,
+			true,
+			gradebook.isCoursePointsDisplayed(),
+			true);
 
 		// TODO catch if this is null, the get(0) will throw an exception
 		// TODO also catch the GbException
-		this.gradeInfo = this.businessService
-				.buildGradeMatrix(assignments, Arrays.asList(userId), gradebookPage.getUiSettings()).get(0);
-		this.categories = this.businessService.getGradebookCategories();
-
-		// get configured category type
-		// TODO this can be fetched from the Gradebook instead
-		this.configuredCategoryType = this.businessService.getGradebookCategoryType();
+		final GbStudentGradeInfo studentGradeInfo = this.businessService
+			.buildGradeMatrix(
+				assignments,
+				Arrays.asList(userId),
+				gradebookPage.getUiSettings())
+			.get(0);
+		final List<CategoryDefinition> categories = this.businessService.getGradebookCategories();
+		final Map<Long, Double> categoryAverages = studentGradeInfo.getCategoryAverages();
+		final Map<Long, GbGradeInfo> grades = studentGradeInfo.getGrades();
 
 		// setup
 		final List<String> categoryNames = new ArrayList<String>();
@@ -91,142 +109,39 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 		}
 		Collections.sort(categoryNames);
 
-		final boolean[] categoryScoreHidden = { false };
+		
 
-		final WebMarkupContainer toggleActions = new WebMarkupContainer("toggleActions");
-		toggleActions.setVisible(this.configuredCategoryType != GbCategoryType.NO_CATEGORY);
-		add(toggleActions);
+		// build the model for table
+		Map<String, Object> tableModel = new HashMap<>();
+		tableModel.put("grades", grades);
+		tableModel.put("categoryNamesToAssignments", categoryNamesToAssignments);
+		tableModel.put("categoryNames", categoryNames);
+		tableModel.put("categoryAverages", categoryAverages);
+		tableModel.put("categoriesEnabled", categoriesEnabled);
+		tableModel.put("isCategoryWeightEnabled", isCategoryWeightEnabled());
+		tableModel.put("isGroupedByCategory", isGroupedByCategory);
+		tableModel.put("showingStudentView", false);
 
-		add(new ListView<String>("categoriesList", categoryNames) {
-			private static final long serialVersionUID = 1L;
-
+		addOrReplace(new GradeSummaryTablePanel("gradeSummaryTable", new LoadableDetachableModel<Map<String,Object>>() {
 			@Override
-			protected void populateItem(final ListItem<String> categoryItem) {
-				final String categoryName = categoryItem.getModelObject();
-
-				final List<Assignment> categoryAssignments = categoryNamesToAssignments.get(categoryName);
-
-				final WebMarkupContainer categoryRow = new WebMarkupContainer("categoryRow");
-				categoryRow.setVisible(InstructorGradeSummaryGradesPanel.this.configuredCategoryType != GbCategoryType.NO_CATEGORY);
-				categoryItem.add(categoryRow);
-				categoryRow.add(new Label("category", categoryName));
-
-				CategoryDefinition categoryDefinition = null;
-				for (final CategoryDefinition aCategoryDefinition : InstructorGradeSummaryGradesPanel.this.categories) {
-					if (aCategoryDefinition.getName().equals(categoryName)) {
-						categoryDefinition = aCategoryDefinition;
-						break;
-					}
-				}
-
-				if (categoryDefinition != null) {
-					final Double score = InstructorGradeSummaryGradesPanel.this.gradeInfo.getCategoryAverages()
-							.get(categoryDefinition.getId());
-					String grade = "";
-					if (score != null) {
-						grade = FormatHelper.formatDoubleAsPercentage(score);
-					}
-					categoryRow.add(new Label("categoryGrade", grade));
-
-					String weight = "";
-					if (categoryDefinition.getWeight() == null) {
-						categoryRow.add(new Label("categoryWeight", ""));
-					} else {
-						weight = FormatHelper.formatDoubleAsPercentage(categoryDefinition.getWeight() * 100);
-						categoryRow.add(new Label("categoryWeight", weight));
-					}
-				} else {
-					categoryRow.add(new Label("categoryGrade", ""));
-					categoryRow.add(new Label("categoryWeight", ""));
-				}
-
-				categoryItem.add(new ListView<Assignment>("assignmentsForCategory", categoryAssignments) {
-					private static final long serialVersionUID = 1L;
-
-					@Override
-					protected void populateItem(final ListItem<Assignment> assignmentItem) {
-						final Assignment assignment = assignmentItem.getModelObject();
-
-						if (InstructorGradeSummaryGradesPanel.this.configuredCategoryType == GbCategoryType.NO_CATEGORY) {
-							assignmentItem.add(new AttributeAppender("class", " gb-no-categories"));
-						}
-
-						final GbGradeInfo gradeInfo = InstructorGradeSummaryGradesPanel.this.gradeInfo.getGrades().get(assignment.getId());
-
-						final String rawGrade;
-						String comment;
-						if (gradeInfo != null) {
-							rawGrade = gradeInfo.getGrade();
-							comment = gradeInfo.getGradeComment();
-						} else {
-							rawGrade = "";
-							comment = "";
-						}
-
-						final Label title = new Label("title", assignment.getName());
-						assignmentItem.add(title);
-
-						final WebMarkupContainer flags = new WebMarkupContainer("flags");
-						flags.add(gradebookPage.buildFlagWithPopover("isExtraCredit", getString("label.gradeitem.extracredit"))
-								.setVisible(assignment.getExtraCredit()));
-						flags.add(gradebookPage.buildFlagWithPopover("isNotCounted", getString("label.gradeitem.notcounted"))
-								.setVisible(!assignment.isCounted()));
-						flags.add(gradebookPage.buildFlagWithPopover("isNotReleased", getString("label.gradeitem.notreleased"))
-								.setVisible(!assignment.isReleased()));
-						assignmentItem.add(flags);
-
-						Label dueDate = new Label("dueDate",
-							FormatHelper.formatDate(assignment.getDueDate(),
-								getString("label.studentsummary.noduedate")));
-						dueDate.add(new AttributeModifier("data-sort-key",
-							assignment.getDueDate() == null ? 0 : assignment.getDueDate().getTime()));
-						assignmentItem.add(dueDate);
-						assignmentItem.add(new Label("grade", FormatHelper.formatGrade(rawGrade)));
-						assignmentItem.add(new Label("outOf",
-								new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {
-							@Override
-							public boolean isVisible() {
-								return StringUtils.isNotBlank(rawGrade);
-							}
-						});
-						assignmentItem.add(new Label("comments", comment));
-					}
-				});
+			public Map<String, Object> load() {
+				return tableModel;
 			}
-
-			@Override
-			public void renderHead(final IHeaderResponse response) {
-				super.renderHead(response);
-
-				// hide the weight column if weightings are not enabled
-				if (!isCategoryWeightEnabled()) {
-					response.render(OnDomReadyHeaderItem.forScript("$('.weight-col').hide();"));
-				}
-
-			}
-		});
+		}));
 
 		// course grade, via the formatter
-		final Gradebook gradebook = this.businessService.getGradebook();
 		final CourseGrade courseGrade = this.businessService.getCourseGrade(userId);
-		final GradebookUiSettings settings = gradebookPage.getUiSettings();
 
-		final CourseGradeFormatter courseGradeFormatter = new CourseGradeFormatter(
-				gradebook,
-				GbRole.INSTRUCTOR,
-				true,
-				settings.getShowPoints(),
-				true);
-		add(new Label("courseGrade", courseGradeFormatter.format(courseGrade)).setEscapeModelStrings(false));
+		addOrReplace(new Label("courseGrade", courseGradeFormatter.format(courseGrade)).setEscapeModelStrings(false));
 
-		add(new Label("courseGradeNotReleasedFlag", "*") {
+		addOrReplace(new Label("courseGradeNotReleasedFlag", "*") {
 			@Override
 			public boolean isVisible() {
 				return !gradebook.isCourseGradeDisplayed();
 			}
 		});
 
-		add(new Label("courseGradeNotReleasedMessage", getString("label.studentsummary.coursegradenotreleasedmessage")) {
+		addOrReplace(new Label("courseGradeNotReleasedMessage", getString("label.studentsummary.coursegradenotreleasedmessage")) {
 			@Override
 			public boolean isVisible() {
 				return !gradebook.isCourseGradeDisplayed();
@@ -234,13 +149,6 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 		});
 
 		add(new AttributeModifier("data-studentid", userId));
-
-		add(new Label("categoryScoreNotReleased", getString("label.studentsummary.categoryscorenotreleased")) {
-			@Override
-			public boolean isVisible() {
-				return categoryScoreHidden[0];
-			}
-		});
 	}
 
 	/**
@@ -250,9 +158,10 @@ public class InstructorGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private String getCategoryName(final Assignment assignment) {
-		if (this.configuredCategoryType == GbCategoryType.NO_CATEGORY) {
+		if (!this.categoriesEnabled) {
 			return getString(GradebookPage.UNCATEGORISED);
 		}
+
 		return StringUtils.isBlank(assignment.getCategoryName()) ? getString(GradebookPage.UNCATEGORISED) : assignment.getCategoryName();
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -13,64 +13,8 @@
 				</div>
 			</div>
 
-			<wicket:enclosure child="categoriesList">
-				<div wicket:id="toggleActions" class="col-md-12">
-					<div class="pull-right">
-						<a href="javascript:void(0);" class="button" id="toggleCategories" wicket:id="toggleCategoriesLink" aria-controls="gradeSummaryTable">Group By Category</a>
-						<a href="javascript:void(0);" class="gb-summary-expand-all" wicket:id="expandCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
-						<a href="javascript:void(0);" class="gb-summary-collapse-all" wicket:id="collapseCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
-					</div>
-				</div>
+			<div wicket:id="gradeSummaryTable"/>
 
-				<table id="gradeSummaryTable" class="table table-bordered table-striped table-hover table-condensed">
-					<thead>
-						<tr>
-							<th class="col-md-4"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
-							<th class="col-md-2"><wicket:message key="column.header.studentsummary.grade" /></th>
-							<th class="col-md-1 weight-col"><wicket:message key="column.header.studentsummary.weight" /></th>
-							<th class="col-md-2"><wicket:message key="column.header.studentsummary.duedate" /></th>
-							<th class="col-md-3"><wicket:message key="column.header.studentsummary.comments" /></th>
-							<th class="col-md-1 category-col" wicket:id="categoryColumnHeader"><wicket:message key="column.header.studentsummary.category" /></th>
-						</tr>
-					</thead>
-					<wicket:container wicket:id="categoriesList">
-						<wicket:enclosure child="categoryRow">
-							<tbody class="gb-summary-category-tbody">
-								<tr wicket:id="categoryRow" class="gb-summary-category-row">
-									<td>
-										<a href="javascript:void(0);" class="gb-summary-category-toggle"></a>
-										<span wicket:id="category" class="gb-summary-category-name"></span>
-									</td>
-									<td class="gb-summary-category-grade" wicket:id="categoryGrade"></td>
-									<td class="gb-summary-category-weight weight-col" wicket:id="categoryWeight"></td>
-									<td></td>
-									<td></td>
-								</tr>
-							</tbody>
-						</wicket:enclosure>
-					<tbody class="gb-summary-assignments-tbody">
-						<tr wicket:id="assignmentsForCategory" class="gb-summary-grade-row">
-							<td>
-								<span class="gb-summary-grade-flags" wicket:id="flags">
-									<span wicket:id="isExtraCredit" class="gb-flag-extra-credit"></span>
-									<span wicket:id="isNotCounted" class="gb-flag-not-counted"></span>
-								</span>
-								<span class="gb-summary-grade-title" wicket:id="title"></span>
-							</td>
-							<td class="gb-summary-grade-score">
-								<span class="gb-summary-grade-score-raw" wicket:id="grade"></span>
-								<span class="gb-summary-grade-score-outof" wicket:id="outOf"></span>
-							</td>
-							<td class="weight-col"><!-- empty --></td>
-							<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
-							<td class="gb-summary-grade-comments" wicket:id="comments"></td>
-							<td class="gb-summary-grade-category" wicket:id="category"></td>
-						</tr>
-					</tbody>
-					</wicket:container>
-				</table>
-			</wicket:enclosure>
-			
 			<div wicket:id="noAssignments" class="messageInformation"><wicket:message key="no-assignments.label" /></div>
 			
 		</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -1,37 +1,28 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.list.ListItem;
-import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
-import org.sakaiproject.gradebookng.business.util.FormatHelper;
-import org.sakaiproject.gradebookng.tool.component.GbAjaxLink;
-import org.sakaiproject.gradebookng.tool.pages.BasePage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.tool.gradebook.Gradebook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The panel that is rendered for students for both their own grades view, and also when viewing it from the instructor review tab
@@ -51,8 +42,6 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	boolean categoriesEnabled = false;
 	boolean isAssignmentsDisplayed = false;
 
-	CourseGradeFormatter courseGradeFormatter;
-
 	public StudentGradeSummaryGradesPanel(final String id, final IModel<Map<String, Object>> model) {
 		super(id, model);
 	}
@@ -63,8 +52,6 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 
 		final Gradebook gradebook = this.businessService.getGradebook();
 
-		this.setOutputMarkupId(true);
-
 		final Map<String, Object> modelData = (Map<String, Object>) getDefaultModelObject();
 		final boolean groupedByCategoryByDefault = (Boolean) modelData.get("groupedByCategoryByDefault");
 
@@ -73,12 +60,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		this.categoriesEnabled = this.configuredCategoryType != GbCategoryType.NO_CATEGORY;
 		this.isAssignmentsDisplayed = gradebook.isAssignmentsDisplayed();
 
-		courseGradeFormatter = new CourseGradeFormatter(
-			gradebook,
-			GbRole.STUDENT,
-			gradebook.isCourseGradeDisplayed(),
-			gradebook.isCoursePointsDisplayed(),
-			true);
+		this.setOutputMarkupId(true);
 	}
 
 	@Override
@@ -89,40 +71,40 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		final Map<String, Object> modelData = (Map<String, Object>) getDefaultModelObject();
 		final String userId = (String) modelData.get("userId");
 
-		// get grades
-		final Map<Assignment, GbGradeInfo> grades = this.businessService.getGradesForStudent(userId);
-		final List<Assignment> assignments = new ArrayList(grades.keySet());
+		final Gradebook gradebook = this.businessService.getGradebook();
+		final CourseGradeFormatter courseGradeFormatter = new CourseGradeFormatter(
+			gradebook,
+			GbRole.STUDENT,
+			gradebook.isCourseGradeDisplayed(),
+			gradebook.isCoursePointsDisplayed(),
+			true);
 
-		// setup
+		// build up table data
+		final Map<Long, GbGradeInfo> grades = this.businessService.getGradesForStudent(userId);
+		final List<Assignment> assignments = this.businessService.getGradebookAssignments();
+
 		final List<String> categoryNames = new ArrayList<String>();
 		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<String, List<Assignment>>();
-		final Map<String, String> categoryAverages = new HashMap<>();
+		final Map<Long, Double> categoryAverages = new HashMap<>();
 
 		// if gradebook release setting disabled, no work to do
 		if (isAssignmentsDisplayed) {
-
 			// iterate over assignments and build map of categoryname to list of assignments as well as category averages
 			for (final Assignment assignment : assignments) {
-
 				// if an assignment is released, update the flag (but don't set it false again)
 				// then build the category map. we don't do any of this for unreleased gradebook items
 				if (assignment.isReleased()) {
 					this.someAssignmentsReleased = true;
-
 					final String categoryName = getCategoryName(assignment);
 
 					if (!categoryNamesToAssignments.containsKey(categoryName)) {
 						categoryNames.add(categoryName);
 						categoryNamesToAssignments.put(categoryName, new ArrayList<Assignment>());
 
-						if (assignment.getCategoryId() == null) {
-							categoryAverages.put(categoryName, getString("label.nocategoryscore"));
-						} else {
+						if (assignment.getCategoryId() != null) {
 							final Double categoryAverage = this.businessService.getCategoryScoreForStudent(assignment.getCategoryId(), userId);
-							if (categoryAverage == null) {
-								categoryAverages.put(categoryName, getString("label.nocategoryscore"));
-							} else {
-								categoryAverages.put(categoryName, FormatHelper.formatDoubleAsPercentage(categoryAverage));
+							if (categoryAverage != null) {
+								categoryAverages.put(assignment.getCategoryId(), categoryAverage);
 							}
 						}
 					}
@@ -133,148 +115,23 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 			Collections.sort(categoryNames);
 		}
 
-		final WebMarkupContainer toggleActions = new WebMarkupContainer("toggleActions");
-		toggleActions.setVisible(this.categoriesEnabled);
+		// build the model for table
+		Map<String, Object> tableModel = new HashMap<>();
+		tableModel.put("grades", grades);
+		tableModel.put("categoryNamesToAssignments", categoryNamesToAssignments);
+		tableModel.put("categoryNames", categoryNames);
+		tableModel.put("categoryAverages", categoryAverages);
+		tableModel.put("categoriesEnabled", categoriesEnabled);
+		tableModel.put("isCategoryWeightEnabled", isCategoryWeightEnabled());
+		tableModel.put("isGroupedByCategory", isGroupedByCategory);
+		tableModel.put("showingStudentView", true);
 
-		final GbAjaxLink toggleCategoriesLink = new GbAjaxLink("toggleCategoriesLink") {
+		addOrReplace(new GradeSummaryTablePanel("gradeSummaryTable", new LoadableDetachableModel<Map<String,Object>>() {
 			@Override
-			protected void onInitialize() {
-				super.onInitialize();
-				if (StudentGradeSummaryGradesPanel.this.isGroupedByCategory) {
-					add(new AttributeAppender("class", " on"));
-				}
-				add(new AttributeModifier("aria-pressed", StudentGradeSummaryGradesPanel.this.isGroupedByCategory));
+			public Map<String, Object> load() {
+				return tableModel;
 			}
-
-			@Override
-			public void onClick(AjaxRequestTarget target) {
-				StudentGradeSummaryGradesPanel.this.isGroupedByCategory = !StudentGradeSummaryGradesPanel.this.isGroupedByCategory;
-
-				target.add(StudentGradeSummaryGradesPanel.this);
-				target.appendJavaScript(
-					String.format("new GradebookGradeSummary($(\"#%s\"), %s);",
-						StudentGradeSummaryGradesPanel.this.getMarkupId(),
-						true));
-
-				if (!StudentGradeSummaryGradesPanel.this.isGroupedByCategory) {
-					// hide the weight column if categories are disabled
-					target.appendJavaScript("$('.weight-col').hide();");
-				}
-			}
-		};
-		toggleActions.add(toggleCategoriesLink);
-		toggleActions.addOrReplace(new WebMarkupContainer("expandCategoriesLink").setVisible(isGroupedByCategory));
-		toggleActions.addOrReplace(new WebMarkupContainer("collapseCategoriesLink").setVisible(isGroupedByCategory));
-		addOrReplace(toggleActions);
-
-		addOrReplace(new WebMarkupContainer("categoryColumnHeader").
-			setVisible(this.categoriesEnabled && !this.isGroupedByCategory));
-
-		// output all of the categories
-		// within each we then add the assignments in each category
-		addOrReplace(new ListView<String>("categoriesList", categoryNames) {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			protected void populateItem(final ListItem<String> categoryItem) {
-				final String categoryName = categoryItem.getModelObject();
-
-				final List<Assignment> categoryAssignments = categoryNamesToAssignments.get(categoryName);
-
-				final WebMarkupContainer categoryRow = new WebMarkupContainer("categoryRow");
-				categoryRow.setVisible(
-					StudentGradeSummaryGradesPanel.this.categoriesEnabled
-						&& StudentGradeSummaryGradesPanel.this.isGroupedByCategory);
-				categoryItem.add(categoryRow);
-				categoryRow.add(new Label("category", categoryName));
-				categoryRow.add(new Label("categoryGrade", categoryAverages.get(categoryName)));
-
-				String categoryWeight = "";
-				if (!categoryAssignments.isEmpty()) {
-					final Double weight = categoryAssignments.get(0).getWeight();
-					if (weight != null) {
-						categoryWeight = FormatHelper.formatDoubleAsPercentage(weight * 100);
-					}
-				}
-				categoryRow.add(new Label("categoryWeight", categoryWeight));
-
-				categoryItem.add(new ListView<Assignment>("assignmentsForCategory", categoryAssignments) {
-					private static final long serialVersionUID = 1L;
-
-					@Override
-					protected void populateItem(final ListItem<Assignment> assignmentItem) {
-						final Assignment assignment = assignmentItem.getModelObject();
-
-						if (!assignment.isReleased()) {
-							assignmentItem.setVisible(false);
-						}
-
-						if (StudentGradeSummaryGradesPanel.this.configuredCategoryType == GbCategoryType.NO_CATEGORY) {
-							assignmentItem.add(new AttributeAppender("class", " gb-no-categories"));
-						}
-
-						final GbGradeInfo gradeInfo = grades.get(assignment);
-
-						final String rawGrade;
-						String comment;
-						if (gradeInfo != null) {
-							rawGrade = gradeInfo.getGrade();
-							comment = gradeInfo.getGradeComment();
-						} else {
-							rawGrade = "";
-							comment = "";
-						}
-
-						final Label title = new Label("title", assignment.getName());
-						assignmentItem.add(title);
-
-						final BasePage page = (BasePage) getPage();
-						final WebMarkupContainer flags = new WebMarkupContainer("flags");
-						flags.add(page.buildFlagWithPopover("isExtraCredit", getString("label.gradeitem.extracredit"))
-								.setVisible(assignment.getExtraCredit()));
-						flags.add(page.buildFlagWithPopover("isNotCounted", getString("label.gradeitem.notcounted"))
-								.setVisible(!assignment.isCounted()));
-						assignmentItem.add(flags);
-
-						Label dueDate = new Label("dueDate",
-							FormatHelper.formatDate(assignment.getDueDate(), getString("label.studentsummary.noduedate")));
-						dueDate.add(new AttributeModifier("data-sort-key",
-							assignment.getDueDate() == null ? 0 : assignment.getDueDate().getTime()));
-						assignmentItem.add(dueDate);
-						assignmentItem.add(new Label("grade", FormatHelper.formatGrade(rawGrade)));
-						assignmentItem.add(new Label("outOf",
-								new StringResourceModel("label.studentsummary.outof", null, new Object[] { assignment.getPoints() })) {
-							@Override
-							public boolean isVisible() {
-								return StringUtils.isNotBlank(rawGrade);
-							}
-						});
-						assignmentItem.add(new Label("comments", comment));
-						assignmentItem.add(
-							new Label("category", assignment.getCategoryName()).
-								setVisible(StudentGradeSummaryGradesPanel.this.categoriesEnabled
-									&& !StudentGradeSummaryGradesPanel.this.isGroupedByCategory));
-					}
-
-					@Override
-					public void renderHead(final IHeaderResponse response) {
-						super.renderHead(response);
-
-						// hide the weight column if weightings are not enabled
-						if (!isCategoryWeightEnabled()) {
-							response.render(OnDomReadyHeaderItem.forScript("$('.weight-col').hide();"));
-						}
-
-					}
-				});
-			}
-
-			// used as a general visiblity for the entire table. If no assignments, either there are none or none are released.
-			@Override
-			public boolean isVisible() {
-				return StudentGradeSummaryGradesPanel.this.someAssignmentsReleased;
-			}
-		});
+		}).setVisible(isAssignmentsDisplayed && someAssignmentsReleased));
 
 		// no assignments message
 		final WebMarkupContainer noAssignments = new WebMarkupContainer("noAssignments") {
@@ -290,7 +147,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 		// course grade, via the formatter
 		final CourseGrade courseGrade = this.businessService.getCourseGrade(userId);
 
-		addOrReplace(new Label("courseGrade", this.courseGradeFormatter.format(courseGrade)).setEscapeModelStrings(false));
+		addOrReplace(new Label("courseGrade", courseGradeFormatter.format(courseGrade)).setEscapeModelStrings(false));
 
 		add(new AttributeModifier("data-studentid", userId));
 	}
@@ -302,7 +159,7 @@ public class StudentGradeSummaryGradesPanel extends Panel {
 	 * @return
 	 */
 	private String getCategoryName(final Assignment assignment) {
-		if (!this.categoriesEnabled || !this.isGroupedByCategory) {
+		if (!this.categoriesEnabled) {
 			return getString(GradebookPage.UNCATEGORISED);
 		}
 		return StringUtils.isBlank(assignment.getCategoryName()) ? getString(GradebookPage.UNCATEGORISED) : assignment.getCategoryName();

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryPanel.java
@@ -94,7 +94,9 @@ public class StudentGradeSummaryPanel extends Panel {
 				target.add(studentNavigation);
 
 				target.appendJavaScript(
-						String.format("new GradebookGradeSummary($(\"#%s\"), %s);", getParent().getMarkupId(), showingStudentView));
+						String.format("new GradebookGradeSummary($(\"#%s\"), %s);",
+							getParent().getMarkupId(),
+							showingStudentView));
 			}
 		});
 	}

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -39,6 +39,7 @@ GradebookGradeSummary.prototype.setupWicketModal = function() {
     this.setupTabs();
     this.setupStudentNavigation();
     this.setupFixedFooter();
+    this.hideWeightColumn();
     this.setupTableSorting();
     this.setupMask();
     this.setupModalPrint();
@@ -230,6 +231,7 @@ GradebookGradeSummary.prototype.setupModalPrint = function() {
 
 GradebookGradeSummary.prototype.setupStudentView = function() {
   var self = this;
+  self.hideWeightColumn();
   self.setupTableSorting();
 
   var $button = $("body").find(".portletBody .gb-summary-print");
@@ -305,6 +307,14 @@ GradebookGradeSummary.prototype.setupTableSorting = function() {
     },
     cssInfoBlock: "gb-summary-category-tbody"
   });
+};
+
+
+GradebookGradeSummary.prototype.hideWeightColumn = function() {
+  // only hide the weight column if there are no categories being displayed
+  if (this.$content.find(".gb-summary-category-row").length == 0) {
+    this.$content.find(".weight-col").hide();
+  }
 };
 
 


### PR DESCRIPTION
Previously, the student and instructor each defined their own tables within the panels.  These tables were pretty much identical and it was only the mechanisms to get the table data that differed.  I've refactored these two panels to share a single table panel `GradeSummaryTablePanel`, so we only need to make future changes once!

I've also changed the table panel to use a `LoadableDetachableModel` for the model in the hope that it doesn't serialise all the grade data.. it doesn't need to as the panel can hit the service each time to grab the latest data.

Ultimately, this PR delivers #2671, which was to allow the 'Group by Category' feature to be available on both student and instructor views.  I store the 'Group by Category' state on the session `GradebookUISettings` so it is retained as the instructor navigates between users and tabs.
