### PR TITLE
#2666 log any stack trace that results in the ErrorPage being shown

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ErrorPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ErrorPage.java
@@ -1,10 +1,11 @@
 package org.sakaiproject.gradebookng.tool.pages;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.StringResourceModel;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Page displayed when an internal error occurred.
@@ -18,11 +19,15 @@ public class ErrorPage extends BasePage {
 	private static final long serialVersionUID = 1L;
 
 	public ErrorPage(final Exception e) {
-
+		
+		final String stacktrace = ExceptionUtils.getStackTrace(e);
+		
+		//log the stacktrace
+		log.error(stacktrace);
+		
 		// generate an error code so we can log the exception with it without giving the user the stacktrace
 		// note that wicket will already have logged the stacktrace so we aren't going to bother logging it again
 		final String code = RandomStringUtils.randomAlphanumeric(10);
-
 		log.error("User supplied error code for the above stacktrace: " + code);
 
 		final Label error = new Label("error", new StringResourceModel("errorpage.text", null, new Object[] { code }));
@@ -30,7 +35,6 @@ public class ErrorPage extends BasePage {
 		add(error);
 
 		// show the stacktrace. This should be configurable at some point
-		final String stacktrace = ExceptionUtils.getStackTrace(e);
 		add(new Label("stacktrace", stacktrace));
 
 	}


### PR DESCRIPTION
Fixed #2666 

To test, in GradebookPage.java, replace
`throw new RestartResponseException(StudentPage.class);`
with
`throw new RuntimeException();`

and then login as a student.