### PR TITLE
SAM-2933 Footer misplaced in "Edit Assessment Type"

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/template/templateEditor.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/template/templateEditor.jsp
@@ -84,7 +84,7 @@
 <h3><h:outputText value="#{templateMessages.template_editor}"/>
      <h:outputText value="#{template.templateName}"/>
 </h3>
- <h:outputText escape="false" value="#{templateMessages.template_instructions}"/>
+ <p><h:outputText escape="false" value="#{templateMessages.template_instructions}"/></p>
  <h:messages styleClass="messageSamigo" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
   <!-- *** GENERAL TEMPLATE INFORMATION *** -->
   <div class="tier1" id="jqueryui-accordion">
@@ -131,7 +131,7 @@
     </h:panelGrid>
 	</div>
 
-    </div></div>
+    </div>
   </samigo:hideDivision>
 
   <!-- *** AUTHORSHIP *** -->


### PR DESCRIPTION
This also solves SAM-2915 Menu broken in Assessment Types

![](https://jira.sakaiproject.org/secure/attachment/45698/AssessmentTypeDetail.png)


![assessmenttypedetailfixed](https://cloud.githubusercontent.com/assets/16644575/16120116/c4d0bb50-33de-11e6-8582-42133d38a0d4.png)

