### PR TITLE
SAK-31353 Minor updates to tutorial

### DIFF
--- a/help/help-component/src/bundle/TutorialMessages.properties
+++ b/help/help-component/src/bundle/TutorialMessages.properties
@@ -14,6 +14,9 @@
 next=Next
 previous=Back
 
+#End Tutorial text:
+endTutorial=OK, Got it
+
 
 
 #Welcome panel

--- a/help/help-component/src/java/org/sakaiproject/component/app/help/TutorialEntityProviderImpl.java
+++ b/help/help-component/src/java/org/sakaiproject/component/app/help/TutorialEntityProviderImpl.java
@@ -73,10 +73,11 @@ public class TutorialEntityProviderImpl implements TutorialEntityProvider, AutoR
 		}
 		String previousUrl = tutorialProps.getString(ref.getId() + ".previousUrl");
 		String nextUrl = tutorialProps.getString(ref.getId() + ".nextUrl");
-                String sakaiInstanceName = ServerConfigurationService.getString("ui.service", "Sakai");
-                
+		String sakaiInstanceName = ServerConfigurationService.getString("ui.service", "Sakai");
+		String selection = tutorialProps.getString(ref.getId() + ".selection");
+
 		Map valuesMap = new HashMap<String, String>();
-		valuesMap.put("selection", tutorialProps.getString(ref.getId() + ".selection"));
+		valuesMap.put("selection", selection);
 		valuesMap.put("title", msgs.getFormattedMessage(ref.getId() + ".title", sakaiInstanceName));
 		valuesMap.put("dialog", tutorialProps.getString(ref.getId() + ".dialog"));
 		valuesMap.put("positionTooltip", tutorialProps.getString(ref.getId() + ".positionTooltip"));
@@ -97,6 +98,8 @@ public class TutorialEntityProviderImpl implements TutorialEntityProvider, AutoR
 		}
 		if(nextUrl != null && !"".equals(nextUrl)){
 			footerHtml += "<div class='tut-next'><a href='#' class='qtipLinkButton' onclick='showTutorialPage(\"" + nextUrl + "\");'>" + msgs.getString("next") + "&nbsp;<i class='fa fa-arrow-right'></i></a></div>";
+		}else{
+			footerHtml += "<a href='#' class='btn-primary tut-close' onclick='endTutorial(\"" + selection + "\");' >"+ msgs.getString("endTutorial") +"</a>";
 		}
 		footerHtml += "</div>";
 		body += footerHtml;

--- a/help/help-component/src/tutorial/Tutorial.config
+++ b/help/help-component/src/tutorial/Tutorial.config
@@ -83,7 +83,7 @@ introToSakai_refreshTool.selection=.Mrphs-hierarchy--toolName
 introToSakai_refreshTool.previousUrl=/direct/tutorial/introToSakai_toolMenuNarrowView.json
 introToSakai_refreshTool.nextUrl=/direct/tutorial/introToSakai_helpIcon.json
 introToSakai_refreshTool.dialog=
-introToSakai_refreshTool.positionTooltip=topMiddle
+introToSakai_refreshTool.positionTooltip=topLeft
 introToSakai_refreshTool.positionTarget=bottomMiddle
 introToSakai_refreshTool.fadeout=
 

--- a/reference/library/src/morpheus-master/sass/modules/tutorial/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tutorial/_base.scss
@@ -68,6 +68,11 @@
 			margin-left:auto;
 			
 		}
+		
+		.tut-close
+		{
+			margin: -5px 0 0 0;
+		}
 	}
 /*
 	.qtip-shadow {

--- a/reference/library/src/webapp/js/jquery/qtip/tutorial.js
+++ b/reference/library/src/webapp/js/jquery/qtip/tutorial.js
@@ -20,6 +20,10 @@ function startTutorial(opts){
 	}
 }
 
+function endTutorial(selection){
+	$(selection).qtip('destroy');
+}
+
 function showTutorialPage(url, opts){
 	//store options in cache so we can use the same options from start to end of the tutorial:
 	if(opts != null)
@@ -48,6 +52,14 @@ function showTutorialPage(url, opts){
 						showTutorialPage(response.data.nextUrl);
 					}
 				}else{
+					var selection;
+					
+					if ($(response.data.selection).length > 1 ){
+						selection = $(response.data.selection).first(); 
+					}else{
+						selection = $(response.data.selection); 
+					}
+					
 					previousClicked = false;
 					var mxWidth = maxWidth;
 					var totalWidth = $(document).width();
@@ -56,7 +68,7 @@ function showTutorialPage(url, opts){
 						mxWidth = totalWidth;
 					}
 
-					$(response.data.selection).qtip(
+					selection.qtip(
 							{ 
 								content: {
 									title: response.data.title,


### PR DESCRIPTION
Just a few minor updates to the tutorial:
 Point the "Breadcrumb" modal to breadcrumb itself. Currently it's pointing to an empty space on the bar, which feels a bit like it's pointing at nothing. (image1)

![qtip01](https://cloud.githubusercontent.com/assets/16644575/16185435/1cc302f4-36c4-11e6-9a3d-3b60b575e4b2.png)

 Point the help modal to the help button for MOTD. It feels odd for it to be low on the screen and not at the first instance of the help button that user would see. (image2)

![qtip02](https://cloud.githubusercontent.com/assets/16644575/16185437/20e32c4c-36c4-11e6-9ad6-62ca22e90bfe.png)

At the end of the tutorial, add an "Ok, Got it." button for quitting the tutorial, in the same position that the "Next" link/button appears in previous steps of the tutorial. This just feels smoother and more intuitive – vs figuring out you need to click the small X in the upper right to get out of this. (image3)

![qtip03](https://cloud.githubusercontent.com/assets/16644575/16185439/24541ae4-36c4-11e6-952e-7576dc8db6d6.png)



