### PR TITLE
SAK-31343 Disable search for elFinder.

### DIFF
--- a/textarea/elfinder-sakai/pom.xml
+++ b/textarea/elfinder-sakai/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.github.bluejoe2008</groupId>
             <artifactId>elfinder-servlet-2</artifactId>
-            <version>1.1</version>
+            <version>1.2</version>
             <classifier>classes</classifier>
             <type>jar</type>
         </dependency>

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/ReadOnlyFsVolume.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/ReadOnlyFsVolume.java
@@ -6,6 +6,8 @@ import cn.bluejoe.elfinder.service.FsVolume;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * A FsVolume that doesn't allow changes, this can be extended by volumes that aren't like normal filesystems.
@@ -39,6 +41,11 @@ public abstract class ReadOnlyFsVolume  implements FsVolume {
     @Override
     public void rename(FsItem src, FsItem dst) throws IOException {
         throw new UnsupportedOperationException("Can't rename here.");
+    }
+
+    @Override
+    public void filterOptions(FsItem item, Map<String, Object> map) {
+        map.put("disabled", Arrays.asList(new String[]{"create", "rm", "duplicate", "rename", "mkfile", "mkdir", "search", "zipdl"}));
     }
 
 }

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
@@ -21,9 +21,7 @@ import org.sakaiproject.site.api.SiteService;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 /**
  * This is the creator of ContentHosting FsVolumes.
@@ -410,6 +408,12 @@ public class ContentSiteVolumeFactory implements SiteVolumeFactory {
         public String getURL(FsItem fsItem) {
             String id = asId(fsItem);
             return contentHostingService.getUrl(id);
+        }
+
+        @Override
+        public void filterOptions(FsItem fsItem, Map<String, Object> map) {
+            // The preview isn't working properly
+            map.put("disabled", Arrays.asList(new String[]{"search", "zipdl"}));
         }
     }
 }


### PR DESCRIPTION
Currently search isn’t working well do disable it in elfinder. This also disabled Zip Download in newer versions of elfinder and disables modifications in the ReadOnly volumes.