### PR TITLE
SAM-2934 Option overlaps with Link/Help buttons in the Print assesment

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/print/printAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/printAssessment.jsp
@@ -111,7 +111,7 @@ document.links[newindex].onclick();
     <h:messages/>
     
     <div id="header">
-      <p class="navModeAction"> 
+      <div class="navModeAction"> 
         
         <label>
           <h:selectBooleanCheckbox id="showKeys" value="#{printSettings.showKeys}" />
@@ -140,22 +140,24 @@ document.links[newindex].onclick();
 		</label>
 		      
 		&nbsp;&nbsp;&nbsp;
-
-        <h:outputLabel for="fontSize" value="#{printMessages.font_size}:" />
-        <h:selectOneMenu id="fontSize" value="#{printSettings.fontSize}">
-          <f:selectItem itemLabel="#{printMessages.size_xsmall}" itemValue="1" />
-          <f:selectItem itemLabel="#{printMessages.size_small}" itemValue="2" />
-          <f:selectItem itemLabel="#{printMessages.size_medium}" itemValue="3" />
-          <f:selectItem itemLabel="#{printMessages.size_large}" itemValue="4" />
-          <f:selectItem itemLabel="#{printMessages.size_xlarge}" itemValue="5" />
-        </h:selectOneMenu>
+        
+        <div>
+            <h:outputLabel for="fontSize" value="#{printMessages.font_size}:" />
+            <h:selectOneMenu id="fontSize" value="#{printSettings.fontSize}">
+                <f:selectItem itemLabel="#{printMessages.size_xsmall}" itemValue="1" />
+                <f:selectItem itemLabel="#{printMessages.size_small}" itemValue="2" />
+                <f:selectItem itemLabel="#{printMessages.size_medium}" itemValue="3" />
+                <f:selectItem itemLabel="#{printMessages.size_large}" itemValue="4" />
+                <f:selectItem itemLabel="#{printMessages.size_xlarge}" itemValue="5" />
+            </h:selectOneMenu>
+        </div>
         
         <br />
         
         <h:commandButton action="#{pdfAssessment.prepDocumentPDF}" value="#{printMessages.apply_settings}" styleClass="noActionButton" />
         <h:outputText value="<input type='button' onclick='print(); return false;' value='#{printMessages.print_html}' class='noActionButton' />" escape="false" />
         <h:commandButton action="#{pdfAssessment.getPDFAttachment}" value="#{printMessages.print_pdf}" styleClass="noActionButton" />
-      </p>
+      </div>
     </div>
     <!-- END HEADINGS -->
     


### PR DESCRIPTION
screen

The label and dropdown for "Font size" were shown on separate lines
depending on screen size.



![](https://jira.sakaiproject.org/secure/attachment/45720/FontSize.png)


![fontsizefixed](https://cloud.githubusercontent.com/assets/16644575/16220531/c0273dd8-378d-11e6-989b-636ae00e820f.png)
