### PR TITLE
SAK 31330 Problem in opening an assessment from elFinder

### DIFF
--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/samigo/SamSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/samigo/SamSiteVolumeFactory.java
@@ -34,9 +34,7 @@ import org.sakaiproject.component.api.ServerConfigurationService;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * Created by ddelblanco on 03/16.
@@ -242,6 +240,12 @@ public class SamSiteVolumeFactory implements SiteVolumeFactory {
 
         public boolean isWriteable(FsItem fsi) {
             return false;
+        }
+
+        @Override
+        public void filterOptions(FsItem fsItem, Map<String, Object> map) {
+            // The preview isn't working properly
+            map.put("disabled", Arrays.asList(new String[]{"open", "download", "getfile", "copy", "cut", "paste"}));
         }
     }
 }


### PR DESCRIPTION
Disable the:
"open", "download", "getfile", "copy", "cut", "paste"
buttons using the new connector.