### PR TITLE
SAK-31394 Make the UI match the limitations.

### DIFF
--- a/signup/tool/src/webapp/signup/newMeeting/step1.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step1.jsp
@@ -228,7 +228,7 @@
                         <h:outputLabel value="#{msgs.event_signup_begins}" styleClass="titleText col-lg-2 form-control-label" for="signupBegins"/>
                     </h:panelGroup>
                     <h:panelGroup layout="block" styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_2">
-                        <h:inputText id="signupBegins" value="#{NewSignupMeetingBean.signupBegins}" size="2" required="true" onkeyup="sakai.updateSignupBeginsExact();">
+                        <h:inputText id="signupBegins" value="#{NewSignupMeetingBean.signupBegins}" size="5" required="true" onkeyup="sakai.updateSignupBeginsExact();">
                             <f:validateLongRange minimum="0" maximum="99999"/>
                         </h:inputText>
                         <h:selectOneMenu id="signupBeginsType" value="#{NewSignupMeetingBean.signupBeginsType}" onchange="isSignUpBeginStartNow(value); sakai.updateSignupBeginsExact();" style="padding-left:5px; margin-right:5px">
@@ -252,7 +252,7 @@
                         <h:outputLabel value="#{msgs.event_signup_deadline2}" styleClass="titleText col-lg-2 form-control-label" for="signupDeadline"/>
                    	</h:panelGroup>
                     <h:panelGroup layout="block" styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_4">
-                        <h:inputText id="signupDeadline" value="#{NewSignupMeetingBean.deadlineTime}" size="2" required="true" onkeyup="sakai.updateSignupEndsExact();">
+                        <h:inputText id="signupDeadline" value="#{NewSignupMeetingBean.deadlineTime}" size="5" required="true" onkeyup="sakai.updateSignupEndsExact();">
                             <f:validateLongRange minimum="0" maximum="99999"/>
                         </h:inputText>
                         <h:selectOneMenu id="signupDeadlineType" value="#{NewSignupMeetingBean.deadlineTimeType}" onchange="sakai.updateSignupEndsExact();" >

--- a/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
@@ -259,7 +259,7 @@
 							<h:outputLabel value="#{msgs.event_signup_start}" escape="false" styleClass="form-control-label "/>
 						</h:panelGroup>
 						<h:panelGroup styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_2" layout="block">
-							<h:inputText id="signupBegins" value="#{EditMeetingSignupMBean.signupBegins}" size="3" required="true" onkeyup="sakai.updateSignupBeginsExact();">
+							<h:inputText id="signupBegins" value="#{EditMeetingSignupMBean.signupBegins}" size="5" required="true" onkeyup="sakai.updateSignupBeginsExact();">
 								<f:validateLongRange minimum="0" maximum="99999"/>
 							</h:inputText>
 							<h:selectOneMenu id="signupBeginsType" value="#{EditMeetingSignupMBean.signupBeginsType}" onchange="isSignUpBeginStartNow(value); sakai.updateSignupBeginsExact();">
@@ -282,7 +282,7 @@
 							<h:outputLabel value="#{msgs.event_signup_deadline}" escape="false" styleClass="form-control-label"/>
 						</h:panelGroup>
 						<h:panelGroup styleClass="signupBDeadline col-lg-10" id="signup_beginDeadline_4" layout="block">
-							<h:inputText id="signupDeadline" value="#{EditMeetingSignupMBean.deadlineTime}" size="3" required="true" onkeyup="sakai.updateSignupEndsExact();">
+							<h:inputText id="signupDeadline" value="#{EditMeetingSignupMBean.deadlineTime}" size="5" required="true" onkeyup="sakai.updateSignupEndsExact();">
 								<f:validateLongRange minimum="0" maximum="99999"/>
 							</h:inputText>
 							<h:selectOneMenu id="signupDeadlineType" value="#{EditMeetingSignupMBean.deadlineTimeType}" onchange="sakai.updateSignupEndsExact();">


### PR DESCRIPTION
For signup begin/end dates we allowed values up to 99999 but only allow enough space to display values up to 99 or 999 (depending on the page). This allows the full value to be displayed. We could have limited this to a smaller number of characters but then existing values wouldn’t display.