### PR TITLE
SAM-2933 Footer misplaced in "Edit Assessment Type"

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/template/templateEditor.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/template/templateEditor.jsp
@@ -40,8 +40,6 @@
         $(document).ready(function() {
           // set up the accordion for settings
           $("#jqueryui-accordion").accordion({ heightStyle: "content",collapsible: true });
-          // adjust the height of the iframe to accomodate the expansion from the accordion
-          $("body").height($("body").outerHeight() + 800);
         });
       </script>
      


### PR DESCRIPTION

about:blankRemoved blank scrolling space below the footer/bottom of the page

![](https://jira.sakaiproject.org/secure/attachment/45730/ExtraSpace.png)


![templates](https://cloud.githubusercontent.com/assets/16644575/16265643/caffacb0-3880-11e6-9f37-9875e45cb6a5.png)
