### PR TITLE
#2783 Implement restrictions when using Drop Highest / Drop Lowest / Keep Highest

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -799,7 +799,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 
 				// external assessments are supported, but not these fields
 				if (!assignmentDefinition.isExternallyMaintained()) {
-					assignment.setName(assignmentDefinition.getName().trim());
+					assignment.setName(StringUtils.trim(assignmentDefinition.getName()));
 					assignment.setPointsPossible(assignmentDefinition.getPoints());
 					assignment.setDueDate(assignmentDefinition.getDueDate());
 				}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -437,3 +437,5 @@ feedback.connectiontimeout = Unable to connect. Changes cannot be saved while of
 
 ta.nopermission = You do not have permission to view the gradebook. Please contact your instructor.
 ta.roleswapped = TA view of gradebook cannot be displayed.
+
+error.addeditgradeitem.categorypoints = This assignment is configured with a category that has drop highest/drop lowest/keep highest enabled. The points for this assignment must match the current maximum of {0}.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
@@ -1,6 +1,7 @@
 package org.sakaiproject.gradebookng.tool.panels;
 
 import java.text.MessageFormat;
+import java.util.List;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
@@ -19,6 +20,7 @@ import org.sakaiproject.gradebookng.tool.component.GbFeedbackPanel;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
+import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameException;
 import org.sakaiproject.service.gradebook.shared.ConflictingExternalIdException;
 import org.sakaiproject.service.gradebook.shared.GradebookService;
@@ -92,46 +94,76 @@ public class AddOrEditGradeItemPanel extends Panel {
 			public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
 				final Assignment assignment = (Assignment) form.getModelObject();
 
-				if (AddOrEditGradeItemPanel.this.mode == Mode.EDIT) {
+				boolean validated = true;
 
-					// TODO validation of the fields here
+				// PRE VALIDATION
+				// 1. if category selected and drop/keep highest/lowest selected for that category,
+				// ensure points match the already established maximum for the category.
+				if (assignment.getCategoryId() != null) {
+					final List<CategoryDefinition> categories = AddOrEditGradeItemPanel.this.businessService.getGradebookCategories();
+					final CategoryDefinition category = categories
+							.stream()
+							.filter(c -> (c.getId() == assignment.getCategoryId())
+									&& (c.getDropHighest() > 0 || c.getKeepHighest() > 0 || c.getDrop_lowest() > 0))
+							.filter(c -> (c.getDropHighest() > 0 || c.getKeepHighest() > 0 || c.getDrop_lowest() > 0))
+							.findFirst()
+							.orElse(null);
 
-					final boolean success = AddOrEditGradeItemPanel.this.businessService.updateAssignment(assignment);
-
-					if (success) {
-						getSession().success(MessageFormat.format(getString("message.edititem.success"), assignment.getName()));
-						setResponsePage(getPage().getPageClass());
-					} else {
-						error(new ResourceModel("message.edititem.error").getObject());
-						target.addChildren(form, FeedbackPanel.class);
+					if (category != null) {
+						final Assignment mismatched = category.getAssignmentList()
+								.stream()
+								.filter(a -> Double.compare(a.getPoints().doubleValue(), assignment.getPoints().doubleValue()) != 0)
+								.findFirst()
+								.orElse(null);
+						if (mismatched != null) {
+							validated = false;
+							error(MessageFormat.format(getString("error.addeditgradeitem.categorypoints"), mismatched.getPoints()));
+							target.addChildren(form, FeedbackPanel.class);
+						}
 					}
+				}
 
-				} else {
+				if (validated) {
+					if (AddOrEditGradeItemPanel.this.mode == Mode.EDIT) {
 
-					Long assignmentId = null;
+						final boolean success = AddOrEditGradeItemPanel.this.businessService.updateAssignment(assignment);
 
-					boolean success = true;
-					try {
-						assignmentId = AddOrEditGradeItemPanel.this.businessService.addAssignment(assignment);
-					} catch (final AssignmentHasIllegalPointsException e) {
-						error(new ResourceModel("error.addgradeitem.points").getObject());
-						success = false;
-					} catch (final ConflictingAssignmentNameException e) {
-						error(new ResourceModel("error.addgradeitem.title").getObject());
-						success = false;
-					} catch (final ConflictingExternalIdException e) {
-						error(new ResourceModel("error.addgradeitem.exception").getObject());
-						success = false;
-					} catch (final Exception e) {
-						error(new ResourceModel("error.addgradeitem.exception").getObject());
-						success = false;
-					}
-					if (success) {
-						getSession().success(MessageFormat.format(getString("notification.addgradeitem.success"), assignment.getName()));
-						setResponsePage(getPage().getPageClass(),
-								new PageParameters().add(GradebookPage.CREATED_ASSIGNMENT_ID_PARAM, assignmentId));
+						if (success) {
+							getSession().success(MessageFormat.format(getString("message.edititem.success"), assignment.getName()));
+							setResponsePage(getPage().getPageClass());
+						} else {
+							error(new ResourceModel("message.edititem.error").getObject());
+							target.addChildren(form, FeedbackPanel.class);
+						}
+
 					} else {
-						target.addChildren(form, FeedbackPanel.class);
+
+						Long assignmentId = null;
+
+						boolean success = true;
+						try {
+							assignmentId = AddOrEditGradeItemPanel.this.businessService.addAssignment(assignment);
+						} catch (final AssignmentHasIllegalPointsException e) {
+							error(new ResourceModel("error.addgradeitem.points").getObject());
+							success = false;
+						} catch (final ConflictingAssignmentNameException e) {
+							error(new ResourceModel("error.addgradeitem.title").getObject());
+							success = false;
+						} catch (final ConflictingExternalIdException e) {
+							error(new ResourceModel("error.addgradeitem.exception").getObject());
+							success = false;
+						} catch (final Exception e) {
+							error(new ResourceModel("error.addgradeitem.exception").getObject());
+							success = false;
+						}
+						if (success) {
+							getSession()
+									.success(MessageFormat.format(getString("notification.addgradeitem.success"), assignment.getName()));
+							setResponsePage(getPage().getPageClass(),
+									new PageParameters().add(GradebookPage.CREATED_ASSIGNMENT_ID_PARAM, assignmentId));
+						} else {
+							target.addChildren(form, FeedbackPanel.class);
+						}
 					}
 				}
 


### PR DESCRIPTION
Delivers #2783.

Settings page now prevents user from setting up drop/keep highest/lowest if the categories assignment points differ.
Add/edit page now prevents changing the points if the category for the assignment is configured with drop/keep highest/lowest and has points that differ.