### PR TITLE
SAK-30593 Broaden the search to find properties files in other standard locations

### DIFF
--- a/user/user-util/src/java/org/sakaiproject/user/util/ConvertUserFavoriteSitesSakai11.java
+++ b/user/user-util/src/java/org/sakaiproject/user/util/ConvertUserFavoriteSitesSakai11.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import javax.xml.bind.DatatypeConverter;
@@ -95,26 +96,23 @@ class ConvertUserFavoriteSitesSakai11 {
 
     public static void main(String args[]) {
         String tomcatDir = System.getProperty("tomcat.dir");
+        String dbPropertiesPath = System.getProperty("db.properties");
 
-        if (tomcatDir == null) {
-            info("You must set the tomcat.dir system property.\n");
+        if (tomcatDir == null && dbPropertiesPath == null) {
+            info("You must either set the tomcat.dir system property, or the db.properties system property.\n");
             showUsage();
 
             System.exit(1);
         }
 
         try {
-            Properties sakaiProperties = loadSakaiProperties(tomcatDir + File.separator + "sakai" + File.separator + "sakai.properties");
-
-            Class.forName(getProperty(sakaiProperties, "driverClassName@javax.sql.BaseDataSource"));
-
-            String jdbcUrl = getProperty(sakaiProperties, "url@javax.sql.BaseDataSource");
+            DBConfig config = new DBConfig(dbPropertiesPath, tomcatDir);
 
             Connection db = null;
             try {
-                db = DriverManager.getConnection(jdbcUrl,
-                                                 getProperty(sakaiProperties, "username@javax.sql.BaseDataSource"),
-                                                 getProperty(sakaiProperties, "password@javax.sql.BaseDataSource"));
+                db = DriverManager.getConnection(config.getUrl(),
+                        config.getUsername(),
+                        config.getPassword());
 
                 migrateFavoriteSites(db);
             } finally  {
@@ -229,27 +227,6 @@ class ConvertUserFavoriteSitesSakai11 {
         info("Migration complete!");
     }
 
-    private static Properties loadSakaiProperties(String sakaiProperties)
-        throws IOException {
-        Properties result = new Properties();
-
-        FileInputStream fh = new FileInputStream(sakaiProperties);
-        result.load(fh);
-        fh.close();
-
-        return result;
-    }
-
-    private static String getProperty(Properties properties, String key) {
-        String result = properties.getProperty(key);
-
-        if (result == null) {
-            throw new IllegalStateException("No entry for key: " + key);
-        }
-
-        return result;
-    }
-
     private static void showUsage() {
         info("Usage:\n");
         info("  cd /path/to/my/tomcat/directory");
@@ -259,6 +236,10 @@ class ConvertUserFavoriteSitesSakai11 {
 
         info("\nOr Windows:\n");
         info("  java -cp \"lib\\*\" -Dtomcat.dir=%cd% org.sakaiproject.user.util.ConvertUserFavoriteSitesSakai11\n");
+
+        info("\nIf the properties file containing your database connection details is stored in a non-standard location, you can explicitly select it with:\n");
+        info("  java -cp \"lib\\*\" -Ddb.properties=my_database.properties org.sakaiproject.user.util.ConvertUserFavoriteSitesSakai11\n");
+
     }
 
 
@@ -380,6 +361,81 @@ class ConvertUserFavoriteSitesSakai11 {
             public String toString() {
                 return userId + " - " + sites;
             }
+        }
+    }
+
+
+    //
+    // Find the user's database connection settings
+    //
+    private static class DBConfig {
+        private String username;
+        private String password;
+        private String url;
+
+        public DBConfig(String propertiesFile, String tomcatDir) {
+            if (propertiesFile != null) {
+                loadFromProperties(propertiesFile);
+            } else {
+                for (String possibleProperties : findPropertiesFiles(tomcatDir)) {
+                    loadFromProperties(possibleProperties);
+                }
+            }
+
+            if (username == null || password == null || url == null) {
+                throw new RuntimeException("Could not locate your database connection settings!");
+            }
+        }
+
+        public String getUrl() { return url; }
+        public String getUsername() { return username; }
+        public String getPassword() { return password; }
+
+
+        private void loadFromProperties(String file) {
+            Properties properties = new Properties();
+
+            try {
+                FileInputStream fh = new FileInputStream(file);
+                properties.load(fh);
+                fh.close();
+            } catch (IOException e) {
+                ConvertUserFavoriteSitesSakai11.info("Failed to read properties from: " + file);
+            }
+
+            for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+                String prop = (String) entry.getKey();
+                String value = (String) entry.getValue();
+
+                if ("driverClassName@javax.sql.BaseDataSource".equals(prop)) {
+                    try {
+                        Class.forName(value);
+                    } catch (ClassNotFoundException e) {
+                        ConvertUserFavoriteSitesSakai11.info("*** Failed to load database driver!");
+                        throw new RuntimeException(e);
+                    }
+                } else if ("url@javax.sql.BaseDataSource".equals(prop)) {
+                    this.url = value;
+                } else if ("username@javax.sql.BaseDataSource".equals(prop)) {
+                    this.username = value;
+                } else if ("password@javax.sql.BaseDataSource".equals(prop)) {
+                    this.password = value;
+                }
+            }
+        }
+
+        private List<String> findPropertiesFiles(String tomcatDir) {
+            List<String> result = new ArrayList();
+
+            for (String path : new String[] { "sakai" + File.separator + "sakai.properties",
+                                              "sakai" + File.separator + "local.properties",
+                                              "sakai" + File.separator + "instance.properties" }) {
+                if (new File(tomcatDir + File.separator + path).exists()) {
+                    result.add(path);
+                }
+            }
+
+            return result;
         }
     }
 


### PR DESCRIPTION
Also added a `db.properties` parameter to let people with more exotic
setups provide an explicit path to their database configuration.