### PR TITLE
SAK-31076 Mobile - Table is not fully responsive

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/sitestats/_sitestats.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/sitestats/_sitestats.scss
@@ -1,0 +1,20 @@
+.#{$namespace}sakai-sitestats{
+    .widget .ministatContainer {
+        display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
+        display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
+        display: -ms-flexbox;      /* TWEENER - IE 10 */
+        display: -webkit-flex;     /* NEW - Chrome */
+        display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
+        flex-direction: row;
+
+        @media #{$phone}{
+            flex-direction: column;
+        }
+    }
+    #prefsForm .halfSize{
+        @media #{$phone}{
+            display: block;
+            width:100%;
+        }
+    }
+}

--- a/reference/library/src/morpheus-master/sass/tool.scss
+++ b/reference/library/src/morpheus-master/sass/tool.scss
@@ -38,6 +38,7 @@
 @import "modules/tool/signup/signup";
 @import "modules/tool/sitesetup/sitesetup";
 @import "modules/tool/dropbox/dropbox";
+@import "modules/tool/sitestats/sitestats";
 
 
 @import "base/rtl";

--- a/sitestats/sitestats-tool/src/webapp/css/sitestats.css
+++ b/sitestats/sitestats-tool/src/webapp/css/sitestats.css
@@ -84,12 +84,6 @@
 /** STAT WIDGET: Mini panels */
 .widget .ministatContainer {
     margin-left: 100px;
-    display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
-    display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
-    display: -ms-flexbox;      /* TWEENER - IE 10 */
-    display: -webkit-flex;     /* NEW - Chrome */
-    display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
-    flex-direction: row;
 }
 .widget .ministat {
     padding: 0 10px;

--- a/sitestats/sitestats-tool/src/webapp/html/components/SakaiNavigationToolBar.html
+++ b/sitestats/sitestats-tool/src/webapp/html/components/SakaiNavigationToolBar.html
@@ -23,7 +23,7 @@
     <tr class="navigation" style="background: transparent !important;">
         <td wicket:id="span" class="nolines" style="background: transparent !important; border-top: 0px !important;">
             <div style="float: left;" class="viewNav"></div>
-            <div style="text-align: right;" class="listNav">
+            <div style="text-align: center;" class="listNav">
                 <div wicket:id="navigatorLabel" class="instruction">[navigator-label]</div>
                 <span wicket:id="navigator">[navigator]</span>
             </div>

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ReportDataPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ReportDataPage.html
@@ -169,7 +169,9 @@
 	            <form wicket:id="form">
 		            
 		            <!-- Report table -->
-		            <table class="listHier lines narrowTable" style="width: 99.9% !important" cellspacing="0" wicket:id="table">[table]</table>
+		            <div class="table-responsive">
+		              <table class="table table-hover table-bordered table-striped" style="width: 99.9% !important" cellspacing="0" wicket:id="table">[table]</table>
+		            </div>
 		                
 		            <!-- BUTTONS -->
 		            <p class="act">


### PR DESCRIPTION
This also solves



![](https://jira.sakaiproject.org/secure/attachment/45156/Captura_de_pantalla_042816_055725_PM.jpg)


![statsresponsivefixed](https://cloud.githubusercontent.com/assets/16644575/16330589/a966b718-39ea-11e6-8c56-4867e3f90742.png)


SAK-31077 Mobile - subpages - "viewing x - y of z" dropdown appears in
table, extra column



![](https://jira.sakaiproject.org/secure/attachment/45154/Captura_de_pantalla_042816_055541_PM.jpg)

![statstablefixed](https://cloud.githubusercontent.com/assets/16644575/16330598/b6f920d2-39ea-11e6-9a56-31c41555f85a.png)


SAK-31080 Mobile - Preferences not responsive



![](https://jira.sakaiproject.org/secure/attachment/45147/Captura_de_pantalla_042816_054645_PM.jpg)


![preferencesfixed](https://cloud.githubusercontent.com/assets/16644575/16330606/c48666ce-39ea-11e6-9ccd-c836986351a8.png)
