### PR TITLE
SAK-31414 : Calendar change, subscribe to external calendars is enabled by default

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
@@ -217,7 +217,7 @@ public class BaseExternalCalendarSubscriptionService implements
 	public void init()
 	{
 		// external calendar subscriptions: enable?
-		enabled = m_configurationService.getBoolean(SAK_PROP_EXTSUBSCRIPTIONS_ENABLED, false);
+		enabled = m_configurationService.getBoolean(SAK_PROP_EXTSUBSCRIPTIONS_ENABLED, true);
 		mergeIntoMyworkspace = m_configurationService.getBoolean(SAK_PROP_EXTSUBSCRIPTIONS_MERGEINTOMYWORKSPACE, true); 
 		m_log.info("init(): enabled: " + enabled + ", merge from other sites into My Workspace? "+mergeIntoMyworkspace);
 

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -7653,7 +7653,7 @@ extends VelocityPortletStateAction
 		bar.add( new MenuEntry(mergedCalendarPage.getButtonText(), null, allow_merge_calendars, MenuItem.CHECKED_NA, mergedCalendarPage.getButtonHandlerID()) );
 		
 		// See if we are allowed to configure external calendar subscriptions
-		if ( allow_subscribe && ServerConfigurationService.getBoolean(ExternalCalendarSubscriptionService.SAK_PROP_EXTSUBSCRIPTIONS_ENABLED,false))
+		if ( allow_subscribe && ServerConfigurationService.getBoolean(ExternalCalendarSubscriptionService.SAK_PROP_EXTSUBSCRIPTIONS_ENABLED,true))
 			{
 				bar.add( new MenuEntry(rb.getString("java.subscriptions"), rb.getString("java.subscriptions.title"), null, allow_subscribe, MenuItem.CHECKED_NA, "doSubscriptions") );
 			}

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2028,8 +2028,8 @@
 
 # EXTERNAL CALENDAR SUBSCRIPTION
 # Enable External iCal Subscriptions
-# DEFAULT: false
-# calendar.external.subscriptions.enable=true
+# DEFAULT: true
+# calendar.external.subscriptions.enable=false
 
 # Merge External iCal Subscriptions from other sites into Home?
 # DEFAULT: false


### PR DESCRIPTION
Change the default configuration in sakai 11.0 so that the option for
maintainers to subscribe to external calendars is enabled by default