### PR TITLE
SAK-31413 Calendar - update default configuration for private url

### DIFF
--- a/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/MenuBean.java
+++ b/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/MenuBean.java
@@ -43,6 +43,6 @@ public class MenuBean implements Serializable {
 	}
 
 	public boolean isSubscribeEnabled() {
-		return serverConfigurationService.getBoolean("ical.opaqueurl.subscribe", true);
+		return serverConfigurationService.getBoolean("ical.public.secureurl.subscribe", serverConfigurationService.getBoolean("ical.opaqueurl.subscribe", true));
 	}
 }

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -7668,7 +7668,7 @@ extends VelocityPortletStateAction
 		
 		
 		// A link for subscribing to the implicit calendar
-		if ( ServerConfigurationService.getBoolean("ical.opaqueurl.subscribe", true) )
+		if ( ServerConfigurationService.getBoolean("ical.public.secureurl.subscribe", ServerConfigurationService.getBoolean("ical.opaqueurl.subscribe", true)) )
 		{
 			bar.add( new MenuEntry(rb.getString("java.opaque_subscribe"), rb.getString("java.opaque_subscribe.title"), null, allow_subscribe_this, MenuItem.CHECKED_NA, "doOpaqueUrl") );
 		}

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2009,8 +2009,9 @@
 
 ## iCAL
 # Allows iCal/ics subscriptions to calendar via impossible-to-guess (opaque) url. Introduced in SAK-21497
+#--- SAK-31413 : new property added ical.public.secureurl.subscribe to replace ical.opaqueurl.subscribe. Both will be supported. ical.public.secureurl.subscribe has priority.
 # DEFAULT: true
-# ical.opaqueurl.subscribe=false
+# ical.public.secureurl.subscribe=false
 
 # Enable iCal import/export via instructor-named ICS file. This is legacy: recommend using ical.opaqueurl.subscribe instead
 # DEFAULT: false


### PR DESCRIPTION
Change the default configuration in sakai 11.0 so that the option for
users to generate a private URL for a calendar is enabled by default,
create an additional property: ical.public.secureurl.subscribe