### PR TITLE
SAK-31442 Include the git SHA in build.

### DIFF
--- a/config/configuration/bundles/pom.xml
+++ b/config/configuration/bundles/pom.xml
@@ -22,7 +22,7 @@
 		<!-- These can be overwritten by profiles and the profiles allow setting from
 		  the command line, eg mvn -Dlocal.service=MySakaiService install -->
 		<version.sakai>${sakai.version}</version.sakai>
-		<version.service>TRUNK</version.service>
+		<version.service>${git.commit.id.abbrev}</version.service>
 	</properties>
 	<profiles>
 		<profile>
@@ -60,6 +60,18 @@
 			</resource>
 		</resources>
 		<plugins>
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.6</version>


### PR DESCRIPTION
This includes the currently checked out SHA by default in the version information.