### PR TITLE
SAK-31449 Quick way to skip deployment of components/webapps

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -223,6 +223,25 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>deploy-skip</id>
+      <activation>
+        <file>
+          <exists>${basedir}/src/webapp</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <pluginRepositories>


### PR DESCRIPTION
This means if we want to deploy SNAPSHOT artifacts we don’t include all the bundles which are very large. Quick local test shows it’s about 94MB for a full build.