### PR TITLE
SAK-31449 Quick way to skip deployment of components/webapps

### DIFF
--- a/gradebook/grades-rest/pom.xml
+++ b/gradebook/grades-rest/pom.xml
@@ -20,6 +20,10 @@
       <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
 
         <!-- Sakai dependencies -->

--- a/kernel/kernel-component/pom.xml
+++ b/kernel/kernel-component/pom.xml
@@ -19,6 +19,7 @@
   <packaging>sakai-component</packaging>
   <properties>
     <deploy.target>components</deploy.target>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -223,6 +223,17 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>deploy-skip</id>
+      <activation>
+        <file>
+          <exists>${basedir}/src/webapp</exists>
+        </file>
+      </activation>
+      <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+      </properties>
+    </profile>
   </profiles>
 
   <pluginRepositories>

--- a/simple-rss-portlet/pom.xml
+++ b/simple-rss-portlet/pom.xml
@@ -123,6 +123,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.sourceVersion>1.6</project.build.sourceVersion>
 		<project.build.targetVersion>1.6</project.build.targetVersion>
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
   
 	<build>

--- a/site/admin-perms-tool/pom.xml
+++ b/site/admin-perms-tool/pom.xml
@@ -18,6 +18,9 @@
   </organization>
   <inceptionYear>2008</inceptionYear>
   <packaging>war</packaging>
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
 
   <dependencies>
     <!-- we are running a webapp in a servlet container so we need the servlet API -->

--- a/site/sakai-message-bundle-manager-tool/pom.xml
+++ b/site/sakai-message-bundle-manager-tool/pom.xml
@@ -11,6 +11,11 @@
 	<artifactId>sakai-message-bundle-manager-tool</artifactId>
 	<packaging>war</packaging>
 
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>


### PR DESCRIPTION
This means if we want to deploy SNAPSHOT artifacts we don’t include all the bundles which are very large. Quick local test shows it’s about 94MB for a full build.