### PR TITLE
KNL-1446 adding LRS actor identifiers for xAPI statements

### DIFF
--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -35,6 +35,10 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
     </dependency>

--- a/kernel/api/src/main/java/org/sakaiproject/event/api/LearningResourceStoreService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/api/LearningResourceStoreService.java
@@ -25,6 +25,8 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 /**
  * Provides support for Sakai to work with Learning Record Stores (LRS)
  * Allows centralized registration of LRS activity statements which Sakai
@@ -382,6 +384,20 @@ public interface LearningResourceStoreService {
          */
         String mbox;
         /**
+         * SHA1 encoded String in the form "mailto:email address" (mbox identifier).
+         * (Note: Only emails that have only ever been and will ever be assigned to this Agent, but no others, should be used for this property and mbox).
+         */
+        String mbox_sha1sum;
+        /**
+         * A user account on an existing system, such as a private system (LMS or intranet) or a public system (social networking site).
+         */
+        LRS_Account account;
+        /**
+         * The OpenID for this actor (Optional)
+         * This value should be used when available, instead of the {@link LRS_Account} object
+         */
+        String openid;
+        /**
          * @param email the user email address
          * @return an actor built using the given email address
          */
@@ -394,6 +410,7 @@ public interface LearningResourceStoreService {
          */
         protected LRS_Actor() {
             objectType = "Agent";
+            account = new LRS_Account();
         }
         /**
          * Construct an actor using an email address
@@ -405,12 +422,27 @@ public interface LearningResourceStoreService {
                 throw new IllegalArgumentException("LRS_Actor email cannot be null");
             }
             mbox = "mailto:"+email;
+            mbox_sha1sum = DigestUtils.sha1Hex(mbox);
         }
         /**
          * @param name OPTIONAL display value for this actor
          */
         public void setName(String name) {
             this.name = name;
+        }
+        /**
+         * @param openid OPTIONAL the OpenID for this actor
+         */
+        public void setOpenId(String openid) {
+            this.openid = openid;
+        }
+        /**
+         * @param name the unique identifier (EID, etc.)
+         * @param homePage the URL of the Sakai instance
+         */
+        public void setAccount(String name, String homePage) {
+            account.setName(name);
+            account.setHomePage(homePage);
         }
         // GETTERS
         /**
@@ -431,12 +463,67 @@ public interface LearningResourceStoreService {
         public String getMbox() {
             return mbox;
         }
+        /**
+         * @see #mbox_sha1sum
+         */
+        public String getMbox_sha1sum() {
+            return mbox_sha1sum;
+        }
+        /**
+         * @see #openid
+         */
+        public String getOpenid() {
+            return openid;
+        }
+        /**
+         * @see #account
+         */
+        public LRS_Account getAccount() {
+            return account;
+        }
         /* (non-Javadoc)
          * @see java.lang.Object#toString()
          */
         @Override
         public String toString() {
-            return "Actor[mbox=" + mbox + ", name=" + name + "]";
+            return "Actor[mbox=" + mbox + ", name=" + name + ", account=" + account + "]";
+        }
+    }
+
+    public static class LRS_Account {
+        /*
+         * A user account on an existing system, such as a private system (LMS or intranet) or a public system (social networking site).
+         * 
+         * If the system that provides the account Object uses OpenID, the Activity Provider SHOULD use the openid property instead of an account Object.
+         * 
+         * If the Activity Provider is concerned about revealing personally identifiable information about an Agent or Group, 
+         * it SHOULD use an opaque account name (for example an account number) to identify all Statements about a person while maintaining anonymity.
+         */
+        String name;
+        String homePage;
+        public LRS_Account() {
+            name = "";
+            homePage = "";
+        }
+        public LRS_Account(String name, String homePage) {
+            this.name = name;
+            this.homePage = homePage;
+        }
+        public String getName() {
+            return name;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+        public String getHomePage() {
+            return homePage;
+        }
+        public void setHomePage(String homePage) {
+            this.homePage = homePage;
+        }
+        @Override
+        public String toString() {
+            return "Account[name=" + name + ", homePage=" + homePage + "]";
         }
     }
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/BaseLearningResourceStoreService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/BaseLearningResourceStoreService.java
@@ -28,8 +28,6 @@ import java.util.Observer;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.event.api.Event;
 import org.sakaiproject.event.api.EventTrackingService;
@@ -41,6 +39,8 @@ import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -90,16 +90,15 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
         providers = new ConcurrentHashMap<String, LearningResourceStoreProvider>();
         // search for known providers
         if (isEnabled() && applicationContext != null) {
-            @SuppressWarnings("unchecked")
             Map<String, LearningResourceStoreProvider> beans = applicationContext.getBeansOfType(LearningResourceStoreProvider.class);
             for (LearningResourceStoreProvider lrsp : beans.values()) {
                 if (lrsp != null) { // should not be null but this avoids killing everything if it is
                     registerProvider(lrsp);
                 }
             }
-            log.info("LRS Registered "+beans.size()+" LearningResourceStoreProviders from the Spring AC during service INIT");
+            log.info("LRS Registered {} LearningResourceStoreProviders from the Spring AC during service INIT", beans.size());
         } else {
-            log.info("LRS did not search for existing LearningResourceStoreProviders in the system (ac="+applicationContext+", enabled="+isEnabled()+")");
+            log.info("LRS did not search for existing LearningResourceStoreProviders in the system (ac={}, enabled={})", applicationContext, isEnabled());
         }
         if (isEnabled() && serverConfigurationService != null) {
             String[] filters = serverConfigurationService.getStrings("lrs.origins.filter");
@@ -112,7 +111,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
                         originFilters.add(filters[i]);
                     }
                 }
-                log.info("LRS found "+originFilters.size()+" origin filters: "+originFilters);
+                log.info("LRS found {} origin filters: {}", originFilters.size(), originFilters);
             }
         }
         if (isEnabled() && eventTrackingService != null) {
@@ -120,7 +119,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
             eventTrackingService.addLocalObserver(this.experienceObserver);
             log.info("LRS registered local event tracking observer");
         }
-        log.info("LRS INIT: enabled="+isEnabled());
+        log.info("LRS INIT: enabled={}", isEnabled());
     }
 
     public void destroy() {
@@ -147,7 +146,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
             if (providers == null || providers.isEmpty()) {
                 if (noProvidersWarningTS < (System.currentTimeMillis() - 86400000)) { // check if we already warned in the last 24 hours
                     noProvidersWarningTS = System.currentTimeMillis();
-                    log.warn("LRS statement from ("+origin+") skipped because there are no providers to process it: "+statement);
+                    log.warn("LRS statement from ({}) skipped because there are no providers to process it: {}", origin, statement);
                 }
             } else {
                 // filter out certain tools and statement origins
@@ -155,7 +154,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
                 if (originFilters != null && !originFilters.isEmpty()) {
                     origin = StringUtils.trimToNull(origin);
                     if (origin != null && originFilters.contains(origin)) {
-                        if (log.isDebugEnabled()) log.debug("LRS statement skipped because origin ("+origin+") matches the originFilter");
+                        log.debug("LRS statement skipped because origin ({}) matches the originFilter", origin);
                         skip = true;
                     }
                 }
@@ -175,7 +174,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
                     }
                     if (valid) {
                         // process this statement
-                        if (log.isDebugEnabled()) log.debug("LRS statement being processed, origin="+origin+", statement="+statement);
+                        log.debug("LRS statement being processed, origin={}, statement={}", origin, statement);
                         for (LearningResourceStoreProvider lrsp : providers.values()) {
                             // run the statement processing in a new thread
                             String threadName = "LRS_"+lrsp.getID();
@@ -184,10 +183,10 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
                             t.start();
                         }
                     } else {
-                        log.warn("Invalid statment registered, statement will not be processed: "+statement);
+                        log.warn("Invalid statment registered, statement will not be processed: {}", statement);
                     }
                 } else {
-                    if (log.isDebugEnabled()) log.debug("LRS statement being skipped, origin="+origin+", statement="+statement);
+                    log.debug("LRS statement being skipped, origin={}, statement={}", origin, statement);
                 }
             }
         }
@@ -208,7 +207,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
             try {
                 lrsp.handleStatement(statement);
             } catch (Exception e) {
-                log.error("LRS Failure running LRS statement in provider ("+lrsp.getID()+"): statement=("+statement+"): "+e, e);
+                log.error("LRS Failure running LRS statement in provider ({}): statement=({}): ", lrsp.getID(), statement, e);
             }
         }
     };
@@ -319,7 +318,7 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
                 statement = null;
             }
         } catch (Exception e) {
-            if (log.isDebugEnabled()) log.debug("LRS Unable to convert event ("+event+") into statement: "+e);
+            log.debug("LRS Unable to convert event ({}) into statement.", event, e);
             statement = null;
         }
         return statement;
@@ -361,12 +360,15 @@ public class BaseLearningResourceStoreService implements LearningResourceStoreSe
                     server = serverConfigurationService.getServerId()+"."+server;
                 }
                 actorEmail = user.getId()+"@"+server;
-                if (log.isDebugEnabled()) log.debug("LRS Actor: No email set for user ("+user.getId()+"), using generated one: "+actorEmail);
+                log.debug("LRS Actor: No email set for user ({}), using generated one: {}", user.getId(), actorEmail);
             }
             actor = new LRS_Actor(actorEmail);
             if (StringUtils.isNotEmpty(user.getDisplayName())) {
                 actor.setName(user.getDisplayName());
             }
+            // set actor account object
+            actor.setAccount(user.getEid(), serverConfigurationService.getServerUrl());
+            // TODO implement OpenID support
         }
         return actor;
     }


### PR DESCRIPTION
Adding the mbox_sha1sum, account object (user's EID + Sakai instance URL), and OpenID identifiers to the xAPI Actor statement object:

```
"actor": {
"objectType": "Agent",
"name": "Joe Mama",
"mbox": "mailto:jmama@awesome.edu",
"mbox_sha1sum": "mbox_sha1_encoded",
"openid": "myOpenId",
"account": { "name": "jmama", "homePage": "https://awesome.edu" }
}
```

(BONUS: Also cleaned up the logging for org.slf4j) :)