### PR TITLE
2912: Fix NPE as courseGrade can be null if there are no released grade items

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -375,7 +375,7 @@ public class GradebookNgBusinessService {
 		final CourseGrade courseGrade = this.gradebookService.getCourseGradeForStudent(gradebook.getUid(), studentUuid);
 		
 		// handle the special case in the gradebook service where totalPointsPossible = -1
-		if(courseGrade.getTotalPointsPossible() == null || courseGrade.getTotalPointsPossible() == -1) {
+		if(courseGrade != null && (courseGrade.getTotalPointsPossible() == null || courseGrade.getTotalPointsPossible() == -1)) {
 			courseGrade.setTotalPointsPossible(null);
 			courseGrade.setPointsEarned(null);
 		}


### PR DESCRIPTION
Delivers #2912.

I think this is the fix @steveswinsburg... it does assume that consumers of the `getCourseGrade` can handle both `null` and an empty `CourseGrade`.