### PR TITLE
SAK-31169 - Edit details page in resources scrolls to the top when URL is selected

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
@@ -607,7 +607,7 @@
 				</th>
 				<td>
 					<div class="form-group">
-						<a class="textPanelFooter" href="#" onclick="document.getElementById('fileURLHolder').style.overflow='auto';
+						<a class="textPanelFooter" href="#fileURLHolder" onclick="document.getElementById('fileURLHolder').style.overflow='auto';
 						document.getElementById('fileURLHolder').focus();document.getElementById('fileURLHolder').select();alert('$tlang.getString("props.select.help")');">$tlang.getString("props.select")</a>
 						|
 						<a class="textPanelFooter" href="$model.accessUrl" target ="_blank">$tlang.getString("props.open")</a>


### PR DESCRIPTION
Edit details page in resources scrolls to the top when URL is selected
on Edit Details page