### PR TITLE
SAK-31466 - Following menu if tools do not overflow view port and auto adjustable width tabs

### DIFF
--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
@@ -30,9 +30,12 @@ function toggleMinimizeNav(){
 $PBJQ(".js-toggle-nav").on("click", toggleMinimizeNav);
 
 var collapsed = false;
+
 var initialOffset;
 var $window = $PBJQ(window),
-	offset 	= $("#toolMenu").offset();
+	offset 	= $("#toolMenu").offset(),
+	$tools	= $("#toolMenu"),
+	padding	= $(".Mrphs-siteHierarchy").height() + $(".Mrphs-topHeader").height();
 
 $PBJQ(document).ready(function(){
 	if(getCookieVal('sakai_nav_minimized') === 'true') {
@@ -41,8 +44,9 @@ $PBJQ(document).ready(function(){
 	}
 	initialOffset = $("#toolMenu").offset().top - $window.scrollTop();
 	$PBJQ(window).scroll(function(){
-		if($("#toolMenuWrap").css('position') !== 'fixed') {
-			var fromTop = $("#toolMenu").offset().top - $window.scrollTop();
+		var follow = ($window.height()- padding) > $tools.height();
+		if($("#toolMenuWrap").css('position') !== 'fixed'
+			&& follow) {
 			if($window.scrollTop() > offset.top) {
 				$("#toolMenu").stop().animate({
 	                top: $window .scrollTop() - offset.top

--- a/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -50,6 +50,9 @@ body.#{$namespace}toolMenu-collapsed{
 							display: none;
 						}
 					}
+					span.#{$namespace}toolsNav__menuitem--title{
+						white-space: pre;
+					}
 				}
 				.#{$namespace}toolsNav__menuitem--title{
 					display: none;
@@ -237,10 +240,9 @@ nav#subSites{
 				}
 				.#{$namespace}toolsNav__menuitem--title{
 					display: block;
-					max-width: 100%;
 					width: 100%;
 					text-overflow: ellipsis;
-					white-space: pre;
+					white-space: pre-wrap;
 					overflow: hidden;
 				}
 				&.is-invisible {


### PR DESCRIPTION
[Video Demo](https://goo.gl/JtZP1S)

[JIRA](https://jira.sakaiproject.org/browse/SAK-31466)