### PR TITLE
SAK-31470 Re-styled the positioning and layout of the topNav bar and associated views

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
@@ -17,6 +17,7 @@
         </li>
         <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--tools">
             <a href="#totoolmenu" class="Mrphs-skipNav__link js-toggle-tools-nav" title="${rloader.sit_jumptools}" accesskey="l">
+                <i class="fa fa-cubes tools-icon"></i>
                 ${rloader.sit_menutools}
                 <span class="accesibility_key">[l]</span>
             </a>

--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -24,16 +24,16 @@ $font-family-url: "//fonts.googleapis.com/css?family=Noto Sans:400,700" !default
 //Typography variables
 $font-family: "Noto Sans", "Helvetica Neue", Arial, sans-serif !default;
 $default-font-size: 14px !default;
-$default-font-weight: 400 !default;										// 300, 400 or 700 as you wish
+$default-font-weight: 400 !default;										// 400 or 700 as you wish
 $header-font-family: $font-family;
-$header-font-weight: 700 !default;										// 300, 400 or 700 as you wish
+$header-font-weight: 700 !default;										// 400 or 700 as you wish
 
 /* Color palette */
 $background-color: 			 #FFFFFF !default;
 $background-color-secondary: #444444 !default;
 
 $primary-color:    			 #2a94c0 !default;
-$primary-color-shadow:		 	 #2A87C0 !default;
+$primary-color-shadow:			 #2A87C0 !default;
 $secondary-color:  			 #F00 !default;
 $alt-colour: 				 #d36f00 !default;
 
@@ -108,29 +108,33 @@ $header-gradient-b: #d9cdcd !default;
 $header-gradient-c: #c4ccd7 !default;
 $header-gradient-d: #a6c2df !default;
 
-/* Main Menu */
-$header-size : 3.8em !default;
-$sites-nav-menu-item-background: $background-color !default;
-$sites-nav-menu-item-color: $text-color !default;
-$sites-nav-menu-item-color-hover: $primary-color !default;
-$sites-nav-menu-item-border: none !default;
-$sites-nav-menu-item-selected-background: $primary-color !default;
-$sites-nav-menu-item-selected-color: $background-color !default;
-$sites-nav-menu-item-selected-border: none !default;
-$site-name-my-workspace-background: transparent !default;
-$site-name-my-workspace-color: $background-color !default;
-$sites-nav-submenu-background: $background-color !default;
-$sites-nav-submenu-item-background: $sites-nav-menu-item-background !default;
-$sites-nav-submenu-item-color: $sites-nav-menu-item-color !default;
-$sites-nav-submenu-item-border: none !default;
-$sites-nav-submenu-item-background-hover: inherit !default;
-$sites-nav-submenu-item-color-hover: $sites-nav-menu-item-color-hover !default;
-$sites-nav-submenu-item-border-hover: none !default;
-$sites-nav-submenu-item-border: none !default;
-$sites-nav-submenu-selected-background: $sites-nav-menu-item-selected-background !default;
-$sites-nav-submenu-item-selected-background: $sites-nav-menu-item-selected-background !default;
-$sites-nav-submenu-item-selected-color: $sites-nav-menu-item-selected-color !default;
-$sites-nav-submenu-item-selected-border: none !default;
+/* topNav Main Menu */
+$header-size : 50px !default;
+$topNav-text-color:                         #fff !default; /* used for links and text in the topNav */
+$topNav-text-alt-color:                     #ccc !default;
+
+$sites-nav-menu-item-background:            #666 !default;
+$sites-nav-menu-item-color:                 #fff !default;
+$sites-nav-menu-item-color-hover:           $sites-nav-menu-item-color !default;
+$sites-nav-menu-item-border-top:            1px solid transparent !default; /* to pre-allocate space for dropdown top border needed for illusion */
+$sites-nav-menu-item-border-right:          none !default;
+$sites-nav-menu-item-border-bottom:         $sites-nav-menu-item-border-top !default; /* to pre-allocate space for dropdown top border needed for illusion */
+$sites-nav-menu-item-border-left:           none !default;
+$sites-nav-menu-item-selected-background:   $primary-color !default;
+$sites-nav-menu-item-selected-color:        #fff !default;
+$sites-nav-menu-item-selected-color-hover:  $sites-nav-menu-item-selected-color !default;
+$sites-nav-menu-item-selected-border:       none !default;
+$sites-nav-submenu-background:              $sites-nav-menu-item-background !default;
+$sites-nav-submenu-item-background:         $sites-nav-menu-item-background !default;
+$sites-nav-submenu-item-background-hover:   $sites-nav-menu-item-background !default;
+$sites-nav-submenu-item-color:              $sites-nav-menu-item-color !default;
+$sites-nav-submenu-item-color-hover:        $sites-nav-submenu-item-color !default;
+$sites-nav-submenu-item-border:             none !default;
+$sites-nav-submenu-item-border-hover:       none !default;
+$sites-nav-submenu-selected-background:     $sites-nav-menu-item-selected-background !default;
+$sites-nav-submenu-item-selected-background:$sites-nav-menu-item-selected-background !default;
+$sites-nav-submenu-item-selected-color:     $sites-nav-menu-item-selected-color !default;
+$sites-nav-submenu-item-selected-border:    none !default;
 
 /* Tool Menu */
 $tool-menu-width: 7.5em !default;

--- a/reference/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/reference/library/src/morpheus-master/sass/base/_extendables.scss
@@ -315,3 +315,10 @@ label.panelGridLabel{
 	display: block;
 	margin-top: 1.4rem;
 }
+
+@mixin flex-wrap($p: nowrap)
+{
+	-moz-flex-wrap: $p;
+	-webkit-flex-wrap: $p;
+	flex-wrap: $p;
+}

--- a/reference/library/src/morpheus-master/sass/base/_responsive.scss
+++ b/reference/library/src/morpheus-master/sass/base/_responsive.scss
@@ -5,7 +5,7 @@ body{
 		&.toolsNav--displayed{
 			#toolMenuWrap{
 				width: 100%;
-				top: 5.5em;
+				top: 6.3em;
 				left: 0px;
 				box-shadow: 0px 0em 1em rgba(0,0,0,0.5);
 				.Mrphs-toolsNav__menuitem--title{

--- a/reference/library/src/morpheus-master/sass/modules/_main.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_main.scss
@@ -5,7 +5,7 @@
 	#content, .#{$namespace}container--footer{
 		margin: 0 0 0 0;
 		@media #{$phone}{
-			margin: 6em 0 0 0;
+			margin: 6.5em 0 0 0;
 		}
 	}
 	.#{$namespace}topHeader {
@@ -38,7 +38,7 @@
 	width: 100%;
 
 	@media #{$phone}{
-		margin: 5.6em 0 0 0;
+		margin: 6.5em 0 0 0;
 	}
 	
 	#col1of2, #col2of2{

--- a/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -23,7 +23,7 @@ body.active-more-sites{
 		@media #{$phone}{
 			width: 100%;
 			height: 100%;
-			top: 2.7em;
+			top: 3.6em;
 			left: 0;
 			overflow: visible;
 			position: absolute;
@@ -57,7 +57,7 @@ body.active-more-sites{
 	}
 	&:after{
 	        bottom: 100%;
-		left: 97%;
+		left: 95%;
 		border: solid transparent;
 		content: " ";
 		height: 0;
@@ -65,7 +65,7 @@ body.active-more-sites{
 		position: absolute;
 		pointer-events: none;
 		border-color: rgba(255, 255, 255, 0);
-		border-bottom-color: $tool-tab-background-color;
+		border-bottom-color: $tool-menu-background-color;
 		border-width: 7px;
 		margin-left: -7px;
 		outline: 0;

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -8,9 +8,6 @@ body.is-logged-out{
 			}
 		}
 	}
-	.Mrphs-mainHeader .Mrphs-headerLogo .Mrphs-headerLogo--institution{
-		//margin: 0.6em 1.5em 0 1em;
-	}
 	.#{$namespace}topHeader{
 		@media #{$phone}{
 			min-height: $header-size;
@@ -21,10 +18,12 @@ body.is-logged-out{
 .#{$namespace}mainHeader{
 	
 	.#{$namespace}headerLogo{
-		overflow: 	hidden;
+		@include display-flex( flex );
+		@include justify-content( center );
+		overflow: hidden;
 		padding: 0 1em;
-		text-align: left;
-		width: 		auto;
+		text-align: center;
+		width: $tool-menu-width;
 		@include flex-shrink( 0 );
 		@include transition( width 0.5s linear 0s );
 		.#{$namespace}headerLogo--institution{
@@ -32,15 +31,11 @@ body.is-logged-out{
 			width: 		$logo-width;
 			height: 	$logo-height;
 			display:	inline-block;
-			@media #{$phone}{
-				margin: 0.2em 0 0 0.2em;
-				float: none;
-			}
 		}
 	}
 	
 	.#{$namespace}loginUser{
-		display: inline-flex;
+		@include display-flex( inline-flex );
 		li{
 			display: inline-block;
 			margin: 0 0.8em 0 0;
@@ -48,8 +43,8 @@ body.is-logged-out{
 				margin: 0 0.2em 0 0;
 			}
 			.#{$namespace}loginUser__message{
-			    display: inline-block;
-			    margin: 0 1em 0 0;
+				display: inline-block;
+				margin: 0 1em 0 0;
 			}
 			a{
 				.login-Icon{
@@ -72,16 +67,13 @@ body.is-logged-out{
 
 	&.is-maximized{
 		.siteNavWrap{
+			@include display-flex(flex);
+			@include align-items(center);
 			@include flex-grow( 1 );
 			@media #{$phone}{
 				display: none;
 			}
 			background: $sites-nav-background;
-		}
-	}
-	&.is-minimized{
-		.#{$namespace}headerLogo{
-			padding: 0.5em 1em 0 1em;
 		}
 	}
 	@media #{$phone}{
@@ -112,7 +104,7 @@ body.is-logged-out{
 	font-family: $header-font-family;
 	position: absolute;
 	right: 0em;
-	width: #{ $tool-menu-width * 2.5 };
+	width: 20em;
 	z-index: 99;
 	box-shadow: 0 0 4px rgba( $text-color ,0.35);
 	list-style: none;
@@ -128,10 +120,12 @@ body.is-logged-out{
 			display: block;
 			padding: 0.5em 0.65em;
 			text-decoration: none;
-			&:hover{
+			&:hover, &:active
+			{
 				text-decoration: underline;
 			}
 			.toolMenuIcon{
+				@extend .fa-fw;
 				vertical-align: sub;
 				margin: 0 0.5em 0 0;
 			}
@@ -156,6 +150,8 @@ body.is-logged-out{
 		.#{$namespace}userNav__submenuitem--fullname{
 			font-weight: $header-font-weight;
 			font-size: 120%;
+			line-height: 1.2;
+			padding: 2px 0;
 		}
 
 		.#{$namespace}userNav__submenuitem--displayid{
@@ -166,16 +162,19 @@ body.is-logged-out{
 	.#{$namespace}userData{
 		border-bottom: 1px solid $tool-border-color;
 		margin-bottom: 0.5em;
+		background-color: $tool-menu-background-color;
 	}
 
 	.#{$namespace}userNav__submenuitem--profile-and-image{
 		display: inline-block;
 		vertical-align: top;
-		padding: 0.5em 0 0 1em;
+		padding: 1em 1em 0 1em;
+		
 		.#{$namespace}userNav__submenuitem--profilepicture{
-                    width: 64px;
-                    height: 64px;
-                }
+			width: 64px;
+			height: 64px;
+			margin: 0; /* to override, within the dropdown panel */
+		}
 
 		.#{$namespace}userNav__submenuitem--profile{
 			display: block;
@@ -187,16 +186,20 @@ body.is-logged-out{
 .#{$namespace}topHeader{
 	background: $top-header-background;
 	color: $background-color;
-	font-size: 0.9em;
-	min-height: 45px;
+	font-size: 1em;
+	min-height: $header-size;
 	width: 100%;
 	@include display-flex(inline-flex);
 	@include align-items(center);
 	@include justify-content( space-between );
 	@include transition( top 0.25s linear 0s );
-	a{
-		color: $background-color;
-		font-weight: 300;
+	
+	a
+	{
+		@include display-flex( flex );
+		@include align-items( center );
+		
+		color: $topNav-text-color;
 	}
 	> * {
 		@media #{$phone}{
@@ -207,14 +210,19 @@ body.is-logged-out{
 		float: right;
 		margin: 0 1em 0 0px;
 		@include flex-shrink( 0 );
-		@include align-self( flex-start );
+		@include display-flex( flex );
+		@include align-items( center );
+		@include justify-content( flex-end );
 	}
 
 	@media #{$phone}{
-		display: block;
+		@include display-flex( flex );
 		position: fixed;
 		width: 100%;
 		top: 0;
+		font-size: 12px;
+		min-height: $header-size;
+		
 		&.moving{
 			top: -4.2em;
 			#mastLogin #loginLinks ul.#{$namespace}userNav__subnav{
@@ -228,8 +236,7 @@ body.is-logged-out{
 #mastLogin{
 	
 	@media #{$phone}{
-		margin: 0 0 0 0;
-		width: auto;
+		width: 50%;
 	}
 
 	ul{
@@ -246,36 +253,41 @@ body.is-logged-out{
 
 
 	#loginForm{
-		margin: 0.15em 0.8em 0 0;
-		@media #{$phone}{
-			margin: 0 0 0 0;
-		}
+		
+		@include display-flex( flex );
+		@include align-items( center );
+		@include justify-content( flex-end );
+
 		label{
+			margin: 0 0.5em 0 0;
+			font-weight: normal;
+			text-transform: capitalize;
+						
 			@media #{$phone}{
 				display: none;
 			}
 		}
 		input[type="text"],input[type="password"],input[type="email"]{
-			margin: 0 0.3em 0 0.15em;
-			padding: 0.15em 0.15em;
-			font-size: 12px;
+			margin: 0 1em 0 0;
+			padding: 0.25em;
 			border: 0px none;
 			@media #{$phone}{
-				max-width: 31%;
+				width: 40%;
+				margin-right: 0.6em;
+				font-size: $default-font-size - 2px;
 			}
 		}
 		#submit{
-			font-size: 12px;
-			padding: 0.3em 0.5em;
+			margin: 0;
+			padding: 0.4em 1em;
+			font-size: $default-font-size;
 			color: #333333;
 			position: relative;
-			top: 1px;
-			left: 9px;
-			letter-spacing: 1.5px;
-			@media #{$phone}{
-				left: 0px;
-				letter-spacing: 1px;
-
+			
+			@media #{$phone}
+			{
+				font-size: $default-font-size - 2px;
+				padding: 0.25em 1em;
 			}
 		}
 		.#{$namespace}loginForm__button{
@@ -283,11 +295,32 @@ body.is-logged-out{
 		}
 	}
 
+	#loginUser{
+		@include display-flex( flex );
+		@include align-items( center );
+		
+		&.has-avatar:hover .#{$namespace}userNav__submenuitem--profilepicture,
+			&.has-avatar:active .#{$namespace}userNav__submenuitem--profilepicture
+		{
+			box-shadow: 0px 0px 5px 1px rgba(165, 165, 165, 0.95);
+		}
+		
+		&.has-avatar:hover .#{$namespace}userNav__submenuitem--username, 
+			&.has-avatar:hover .has-avatar .#{$namespace}userNav__submenuitem--userid
+		&.has-avatar:active .#{$namespace}userNav__submenuitem--username, 
+			&.has-avatar:active .has-avatar .#{$namespace}userNav__submenuitem--userid,
+		&.has-avatar .#{$namespace}userNav__submenuitem--username:hover,
+			&.has-avatar .#{$namespace}userNav__submenuitem--username:active
+		{
+			color: $topNav-text-color;
+			text-decoration: underline;
+		}
+	}
+
+
 	.has-avatar, .no-avatar{
-		display: inline-block;
-		padding: 0em 1.5em 0.2em 0px;
 		position: relative;
-		margin-top: -0.8em;
+		
 		.#{$namespace}userNav__submenuitem--username, .#{$namespace}userNav__submenuitem--userid{
 			display: inline-block;
 			max-width: 100px;
@@ -295,19 +328,44 @@ body.is-logged-out{
 			position: relative;
 			text-overflow: ellipsis;
 			text-decoration: none;
-			top: 0.6em;
 			white-space: nowrap;
 		}
 	}
 
-	.no-avatar{
-		padding-top: 1em;
-		.#{$namespace}userNav__submenuitem--username{
-			@media #{$phone}{
-				display: none;
-			}
+	.no-avatar
+	{
+		text-decoration: none;
+				
+		&::after
+		{
+			content: "\f0d7"; /* fa-carrot-down */			
+			margin-top: 2px;
+			margin-left: 0.5em;
+			font-family: FontAwesome;
+			font-size: 1em;
+			color: $topNav-text-color;
 		}
 
+		span
+		{
+			line-height: 1.2;
+		}
+
+		&:hover .#{$namespace}userNav__submenuitem--username, &:active .#{$namespace}userNav__submenuitem--username
+		{
+			text-decoration: none;
+			color: $topNav-text-color;
+		}
+		
+		.#{$namespace}userNav__submenuitem--userid
+		{
+			display: none;
+		}		
+		
+		@media #{$phone}
+		{
+			padding: 1em; /* provide a bigger hit area for this link */
+		}
 	}
 
 	.has-avatar{
@@ -321,12 +379,16 @@ body.is-logged-out{
 			background-size: auto 100%;
 			background-position: 50%;
 			border-radius:50%;
-			margin:5px auto 0px;
+			margin: 0 4px 0 0;
 			position: relative;
-			top: 0.8em;
 
-			&:hover{
+			&:hover, &:active 
+			{
 				box-shadow: 0px 0px 5px 1px rgba(165, 165, 165, 0.95);
+			}
+			@media #{$phone}
+			{
+				margin-right: 1em;
 			}
 		}
 		.#{$namespace}userNav__submenuitem--username, .#{$namespace}userNav__submenuitem--userid{
@@ -334,10 +396,6 @@ body.is-logged-out{
 				display: none;
 			}
 		}
-	}
-
-	#loginUser{
-		display: block;
 	}
 
 	.#{$namespace}loginUser{
@@ -356,7 +414,7 @@ body.is-logged-out{
 			@include transform( rotate(180deg) );
 			position: relative;
 			top: -0.2em;
-    		left: 1.3em;
+			left: 1.3em;
 			outline: 0;
 		}
 		@media #{$phone}{
@@ -366,44 +424,70 @@ body.is-logged-out{
 
 	#loginLinks{
 		font-family: $header-font-family;
-		font-weight: $header-font-weight;
-		margin-left: 0.5em;
+		margin: 0;
 		list-style: none;
-		padding: 0 0 0 0;
+		padding: 0 0 0 1em;
+		
+		@media #{$phone}
+		{
+			border: 0 none;
+		}
+		
+		.no-avatar ~ ul:after
+		{
+			left: 91.5%;
+			
+			@media #{$phone}
+			{
+				margin-top: 3.3em;
+				left: auto;
+				right: 1.65em;
+			}
+		}
+		
 		ul{
 			background-color: $tool-tab-background-color;
 			text-align: left;
 			padding: 0 0 0 0;
-			margin: 0.18em 0 0 0.9em;
+			margin: 0.48em 0 0 0.9em;
 			@extend .userNav__subnav;
 			&:after {
 				bottom: 100%;
-				left: 82%;
+				left: 85%;
 				border: solid transparent;
 				content: " ";
 				height: 0;
 				width: 0;
 				position: absolute;
 				pointer-events: none;
-				border-color: rgba(255, 255, 255, 0);
-				border-bottom-color: $tool-tab-background-color;
+				border-color: transparent;
+				border-bottom-color: $tool-menu-background-color;
 				border-width: 7px;
-				margin-left: -7px;
 				outline: 0;
 				@media #{$phone}{
-					left: 85%;
+					left: auto;
+					right: 2.65em;
 				}
 			}
+			li:last-of-type
+			{
+				margin-bottom: 0.5em; /* to match the top of the dropdown */
+			}			
 			.#{$namespace}userNav__submenuitem-indented{
 				padding-left: 1.5em;
+				
+				@media #{$phone}
+				{
+					padding-left: 2em;
+				}
 			}
 			@media #{$phone}{
-				margin: 3.3em 0 0 -9.8em;
+				margin: 3.9em 0 0 -9.8em;
 				position: fixed;
-			    top: 0.3em;
-			    z-index: 61;
+				top: 0.3em;
+				z-index: 61;
 			}
-			.Mrphs-loginUser{
+			.#{$namespace}loginUser{
 				padding: 0 0 0 0;
 				width: 100%;
 				p{
@@ -412,8 +496,6 @@ body.is-logged-out{
 			}
 			.#{$namespace}userData{
 				@media #{$phone}{
-					border-top: 7px solid $primary-color;
-					background-color: $tool-menu-background-color;
 					color: $text-color;
 					display: block;
 					font-weight: 400;
@@ -423,7 +505,8 @@ body.is-logged-out{
 			a{
 				color: $primary-color;
 				padding: 0.25em 0.25em;
-				&:hover{
+				&:hover, &:active
+				{
 					color: lighten( $primary-color, 10% );
 				}
 			}
@@ -431,8 +514,8 @@ body.is-logged-out{
 		.#{$namespace}userNav__drop-btn{
 			i {
 				position: relative;
-	    		top: -0.6em;
-	    		left: 0.4em;
+				top: -0.6em;
+				left: 0.4em;
 			}
 		}
 	}
@@ -441,6 +524,13 @@ body.is-logged-out{
 		font-style: italic;
 	}
 }
+
+/* because #loginLinks appears on the Gateway page when two log-in links are available (e.g. for CAS), the following applies only when you are logged in: */
+.is-maximized #loginLinks
+{
+	border-left: 1px solid $tool-border-color; 
+}
+
 .#{$namespace}sitesNav__menu{
 	list-style: none;
 	padding: 0 0 0 0;
@@ -450,8 +540,7 @@ body.is-logged-out{
 .view-all-sites-btn{
 	position: relative;
 	display: inline-block;
-	padding-right: 1em;
-	border-right: 1px solid $tool-border-color;
+	padding: 0 1em;
 
 	@media #{$phone}{
 		display: none;
@@ -460,8 +549,20 @@ body.is-logged-out{
 
 .view-all-sites-btn a{
 	text-decoration: none;
-	&:hover{
+	&:hover, &:active
+	{
 		text-decoration: none;
+		color: $topNav-text-color;
+		
+		i
+		{
+			text-shadow: 0 0 5px rgba(165, 165, 165, 0.95); /* same as profile picture hover */
+		}
+		
+		span.all-sites-label
+		{
+			text-decoration: underline; /* just underline the text */
+		}
 	}
 }
 
@@ -470,57 +571,77 @@ body.is-logged-out{
 	vertical-align: middle;
 }
 
-.all-sites-icon{
+.all-sites-icon, .tools-icon
+{
 	/* Using !important here because CKEditor pulls in its own
-           fontawesome.css which adjusts the size of our icon unless
-           we override it. */
+		fontawesome.css which adjusts the size of our icon unless
+		we override it. */
 	font-size: 16pt !important;
-	padding-right: 2px;
+	padding-right: 4px;
+}
+#topnav_container
+{
+	@include display-flex(flex);
 }
 
 #linkNav{
 	ul{
+		@include display-flex(flex);
+		@include flex-wrap( wrap );
 		font-family: $header-font-family;
-		margin: 0 0 0 0;
-		padding: 5px;
+		margin: 0.5em 0 0 0;
+		padding: 0;
 		li.#{$namespace}sitesNav__menuitem{
-			display: inline-block;
-			margin: 0.5em 0 0 0;
-			padding: 0.4em;
-			a{
-				background: $sites-nav-menu-item-background;
-				color: $sites-nav-menu-item-color;
-				border: $sites-nav-menu-item-border;
-				display: block;
-				padding: 0.35em 0.45em 0.35em 0.55em;
+			margin: 0 0.5em 0.5em 0;
+			padding: 0;
+			
+			> a{
+				@include display-flex(flex);
+				@include align-items(center);
+				@include justify-content( space-between );
+				padding: 0.5em;
 				position: relative;
+				border-top: $sites-nav-menu-item-border-top; /* to balance bottom border for vertical centering */
+				border-right: $sites-nav-menu-item-border-right;
+				border-bottom: $sites-nav-menu-item-border-bottom; /* to pre-allocate space for dropdown top border needed for illusion */
+				border-left: $sites-nav-menu-item-border-left;
+				background: $sites-nav-menu-item-background; /* color */
+				color: $sites-nav-menu-item-color;
 				text-decoration: none;
-				top: -3px;
-
-				&:hover{
-					color: $sites-nav-menu-item-color-hover;
-				}
+			}
+				
+			&:not(.dropdown-is-visible) > a:hover, &:not(.dropdown-is-visible) > a:active /* hover for sites when tool quick-menu isn't open */
+			{
+				box-shadow: 0 0 10px 10px rgba(255, 255, 255, 0.1) inset;
+				color: $sites-nav-menu-item-color-hover;
+			}
+			
+			span
+			{
+				line-height: 1;
 			}
 			.#{$namespace}sitesNav__drop, .#{$namespace}sitesNav__dropdown{
 				outline: 0;
+				text-align: right;
+				margin-left: 0.2em;
+				
 				@extend .fa-angle-down;
 				@extend .fa;
 				@extend .fa-lg;
 				@extend .sitesNav__drop;
+				
 				&.is-clicked{
-					@include transform( rotate(180deg) );
-					left: -5px;
+					@include transform( scaleY(-1) );
 					position: relative;
-					top: -2px;
 				}
 			}
 			ul{
-				background: $background-color;
+				background: $sites-nav-menu-item-background;
 				display: none;
 				font-family: $header-font-family;
 				position: absolute;
 				border-top: 1px solid black;
-				margin-top: -4px;
+				margin-top: -1px;
 				width: 26rem;
 				z-index: 99;
 				box-shadow: 0 3px 2px rgba( $text-color, 0.35);
@@ -531,11 +652,20 @@ body.is-logged-out{
 					margin: 0 0 0 0;
 					padding: 0 0 0 0;
 					min-height: 15px;
+					
+					&:hover a, &:active a
+					{
+						text-decoration: underline;
+					}
+					
 					a{
 						display: block;
 						padding: 0.5em 0.65em;
 						text-decoration: none;
-						&:hover{
+						color: $sites-nav-submenu-item-color;
+						&:hover, &:active
+						{
+							color: $sites-nav-submenu-item-color; /* to override default link hover color */
 							text-decoration: underline;
 						}
 						.toolMenuIcon{
@@ -566,10 +696,14 @@ body.is-logged-out{
 					background: $sites-nav-menu-item-selected-background;
 					color: $sites-nav-menu-item-selected-color;
 					border: $sites-nav-menu-item-selected-border;
-					//padding: 0.8em 0.9em 0.8em 0.9em;
 				}
 				ul{
 					background: $sites-nav-menu-item-selected-background;
+					
+					a:hover, a:active
+					{
+						color: $sites-nav-menu-item-selected-color; /* to override default link hover color */
+					}
 				}
 			}
 
@@ -578,34 +712,26 @@ body.is-logged-out{
 					display: none;
 				}
 
-				&:not(.is-selected){
-					a{
-						background-color: $site-name-my-workspace-background;
-						color: $site-name-my-workspace-color;
-
-						&:hover{
-							color: $primary-color;
-						}
-					}
-				}
-
 				a{
 					i{
-						font-size: 1.3em;
+						margin-top: 1px; /* to compensate for an issue with the icon */
+						margin-bottom: -1px; /* to compensate for an issue with the icon */
+						margin-right:0.35em;
+						font-size: 1em;
 					}
 				}
 			}
 
 			&.dropdown-is-visible {
 				> a{
-					border-bottom: 1px solid $background-color;
+					border-bottom: 1px solid $sites-nav-menu-item-background;
 					z-index: 150;
 				}
 			}
 
 			&.dropdown-is-visible.is-selected {
 				> a{
-					border-bottom: 1px solid $primary-color;
+					border-bottom: 1px solid $sites-nav-menu-item-selected-background;
 				}
 			}
 
@@ -616,7 +742,9 @@ body.is-logged-out{
 						background: $sites-nav-submenu-item-background;
 						color: $sites-nav-submenu-item-color;
 						border: $sites-nav-submenu-item-border;
-						&:hover {
+						
+						&:hover, &:active 
+						{
 							background: $sites-nav-submenu-item-background-hover;
 							color: $sites-nav-submenu-item-color-hover;
 							border: $sites-nav-submenu-item-border-hover;
@@ -633,6 +761,11 @@ body.is-logged-out{
 							background: $sites-nav-submenu-item-selected-background;
 							color: $sites-nav-submenu-item-selected-color;
 							border: $sites-nav-submenu-item-selected-border;
+							
+							&:hover, &:active
+							{
+								color: $sites-nav-menu-item-selected-color-hover;
+							}
 						}
 					}
 				}

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_breadCrumbs.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_breadCrumbs.scss
@@ -88,7 +88,7 @@
 		background-image: none;
 		color: $background-color;
 		position: fixed;
-		top: 5.5em;
+		top: 6.3em;
 		width: 100%;
 		z-index: 2;
 		@include transition( top 0.25s linear 0s );

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_skipnav.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_skipnav.scss
@@ -17,6 +17,7 @@
 				padding: 7px 5px;
 				position: fixed;
 				text-decoration: none;
+				text-transform: capitalize;
 				top: 9px;
 				z-index: 100000;
 			}
@@ -28,7 +29,7 @@
 	@media #{$phone}{
 		position: fixed;
 		z-index: 20;
-		top: 3.2em;
+		top: 3.6em;
 		left: 0;
 		background: lighten($tool-menu-color, 15% );
 		width: 100%;
@@ -48,17 +49,23 @@
 		}
 		li{
 			@include flex-basis( 50% );
+			border-right: 1px solid #999;
+			
+			&:last-of-type
+			{
+			    border-right: 0 none;
+			}
+			
 			&.#{$namespace}skipNav__menuitem--content{
 				display: none;
 			}
-			&.#{$namespace}skipNav__menuitem--tools{
-				border-right: 1px solid #999;
-			}
 			a{
+				@include display-flex( flex );
+				@include justify-content( center );
+				@include align-items( center );
 				color: $background-color;
-				display: block;
 				text-align: center;
-				font-size: 11px;
+				font-size: 12px;
 				padding: 0.7em 0.5em;
 				text-decoration: none;
 				text-transform: uppercase;
@@ -66,6 +73,13 @@
 				max-width: 100%;
 				overflow: hidden;
 				text-overflow: ellipsis;
+				
+				&:hover, &:active
+				{
+				    color: $background-color;
+				    text-decoration: none;
+				    box-shadow: 0 0 0 20px rgba(255, 255, 255, 0.15) inset;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
There are a number of issues with the alignment and positioning of the items in the top bar. They should be vertically centred across the bar to present balance. I have gone through the topNav bar piece by piece and fixed the positioning, spacing, and sizing to make everything centred, equal, and balanced. 

I also fixed an issue with the colours of the sites across the top to fix accessibility contrast issues and ambiguity of the selected site. 

Here are the before and after screenshots:

Before:
![01-gateway-before](https://cloud.githubusercontent.com/assets/12685096/16590568/1f247c74-42a6-11e6-8eb3-ddf94eb34fab.png)

After:
![02-gateway-after](https://cloud.githubusercontent.com/assets/12685096/16590584/331b2142-42a6-11e6-9951-397fee61b28a.png)

Before:
![03-gatewaymobile-before](https://cloud.githubusercontent.com/assets/12685096/16590587/37df5c20-42a6-11e6-81a4-14a882c89ba9.png)

After:
![04-gatewaymobile-after](https://cloud.githubusercontent.com/assets/12685096/16590594/3d69cbda-42a6-11e6-9caf-09ff1dff7330.png)

Before:
![05-topnav-before](https://cloud.githubusercontent.com/assets/12685096/16590599/42e2f474-42a6-11e6-8b98-da940214928a.png)

After:
![06-topnav-after](https://cloud.githubusercontent.com/assets/12685096/16590601/45b4aaee-42a6-11e6-841b-6d728c58ed4a.png)

Before:
![07-topnavinsite-before](https://cloud.githubusercontent.com/assets/12685096/16590606/4905c250-42a6-11e6-8b80-aa2238a88b14.png)

After:
![08-topnavinsite-after](https://cloud.githubusercontent.com/assets/12685096/16590612/4e1e05b8-42a6-11e6-8917-e488cd3121d7.png)

Before:
![09-accountmenu-before](https://cloud.githubusercontent.com/assets/12685096/16590617/50ddfdb2-42a6-11e6-9944-86306631c755.png)

After:
![10-accountmenu-after](https://cloud.githubusercontent.com/assets/12685096/16590624/53ff5b12-42a6-11e6-8133-4f9fb5891d8a.png)

Before:
![11-sitesmenu-before](https://cloud.githubusercontent.com/assets/12685096/16590626/57a0352a-42a6-11e6-8b10-d88644b53191.png)

After:
![12-sitesmenu-after](https://cloud.githubusercontent.com/assets/12685096/16590629/5a82f2f0-42a6-11e6-9b80-f2174a1456ae.png)

Before:
![13-selectedsitequicktoolsmenu-before](https://cloud.githubusercontent.com/assets/12685096/16590631/5ce8ea9a-42a6-11e6-8645-dfb02b98df9f.png)

After:
![14-selectedsitequicktoolsmenu-after](https://cloud.githubusercontent.com/assets/12685096/16590634/5f795de4-42a6-11e6-8a53-1c52c7c7b266.png)

Before:
![15-othersitequicktoolsmenu-before](https://cloud.githubusercontent.com/assets/12685096/16590635/625d8dbe-42a6-11e6-8b1a-f6c38f99d03e.png)

After:
![16-othersitequicktoolsmenu-after](https://cloud.githubusercontent.com/assets/12685096/16590637/64ee57f2-42a6-11e6-903c-d45f4d1aaad6.png)

Before:
![17-accountmenuwithprofilemobile-before](https://cloud.githubusercontent.com/assets/12685096/16590641/67fd3134-42a6-11e6-9c68-b4a2a2dbf565.png)

After:
![18-accountmenuwithprofilemobile-after](https://cloud.githubusercontent.com/assets/12685096/16590647/6cda7a9a-42a6-11e6-9a61-74b9a60b0c0a.png)

Before:
![19-toolsmenumobile-before](https://cloud.githubusercontent.com/assets/12685096/16590655/7483bc2a-42a6-11e6-9106-4ebb5a720dbc.png)

After:
![20-toolsmenumobile-after](https://cloud.githubusercontent.com/assets/12685096/16590665/78083916-42a6-11e6-847b-d22bfa10ffe9.png)

Before:
![21-sitesmenumobile-before](https://cloud.githubusercontent.com/assets/12685096/16590668/7ab57ffc-42a6-11e6-8559-cf89ff579306.png)

After:
![22-sitesmenumobile-after](https://cloud.githubusercontent.com/assets/12685096/16590669/7d7ae524-42a6-11e6-8956-cf8aa7cbe04d.png)

Before:
![23-mobilenoprofile-before](https://cloud.githubusercontent.com/assets/12685096/16590678/8180fdde-42a6-11e6-9e8d-c90c3f140e91.png)

After:
![24-mobilenoprofile-after](https://cloud.githubusercontent.com/assets/12685096/16590683/859dbb82-42a6-11e6-9efb-056d5063ea04.png)

Before:
![25-accountmenunoprofilemobile-before](https://cloud.githubusercontent.com/assets/12685096/16590687/8bb30752-42a6-11e6-91ba-6cd41c4d3bc8.png)

After:
![26-accountmenunoprofilemobile-after](https://cloud.githubusercontent.com/assets/12685096/16590690/8eae0042-42a6-11e6-85a6-223f445aadeb.png)

Before:
![27-accountmenunoprofile-before](https://cloud.githubusercontent.com/assets/12685096/16590693/90e2c258-42a6-11e6-90b8-ed4eaaf439bd.png)

After:
![28-accountmenunoprofile-after](https://cloud.githubusercontent.com/assets/12685096/16590698/9387cf44-42a6-11e6-8388-3871ed2988fc.png)

**Please note: the Tools Menu in the mobile view, the All Sites drawer in both views, and the Breadcrumbs in both view are out of scope for this PR and will be fixed too in a future contribution.**