### PR TITLE
SAK-31467 Hid the Go-to-accessibility link in mobile view

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
@@ -2,8 +2,8 @@
     <ul role="menu" class="Mrphs-skipNav__menu">
 
         #if ($siteNavHasAccessibilityURL)
-            <li role="menuitem" class="Mrphs-skipNav__menuitem">
-                <a href="$siteNavAccessibilityURL" class="Mrphs-skipNav__link Mrphs-skipNav__link--accessibility" title="${rloader.sit_accessibility}" accesskey="0">
+            <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--accessibility">
+                <a href="$siteNavAccessibilityURL" class="Mrphs-skipNav__link" title="${rloader.sit_accessibility}" accesskey="0">
                     ${rloader.sit_accessibility}
                     <span class="accesibility_key">[0]</span>
                 </a>

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_skipnav.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_skipnav.scss
@@ -56,7 +56,9 @@
 			    border-right: 0 none;
 			}
 			
-			&.#{$namespace}skipNav__menuitem--content{
+			&.#{$namespace}skipNav__menuitem--content,
+				&.#{$namespace}skipNav__menuitem--accessibility
+			{
 				display: none;
 			}
 			a{


### PR DESCRIPTION
To fix the issue that was identified in SAK-31467 when the property `accessibility.url` is set, I've hidden the skipnav list item that appears, similar to how we hide the Content quick link. I had to change a bit of the markup to achieve this by making it comply with the other list items.