### PR TITLE
SAK-31450 'Announcements View' shows ALL announcements grayed out when

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -18,25 +18,25 @@
 		#set($retractdate = $props.getTimeProperty("retractDate"))
 		#set($retdateset = $now.after($retractdate))
 	#end
+
+	#if ($reorder)
+		#set($rowClass = "row")
+	#end 
 	
 	## message marked as hidden, current date is before release date, or current date is after retract date
 	#if ($hidden || $reldateset || $retdateset)
 		#if ($displayOptions.isShowAnnouncementBody())
-			#set($class="lightHighLightRow inactive")
+			class="lightHighLightRow inactive $rowClass"
 		#else
-			#set($class="inactive")
+			class="inactive $rowClass"
 		#end
 	#else
 		#if ($displayOptions.isShowAnnouncementBody())
-			#set($class="lightHighLightRow")
+			class="lightHighLightRow $rowClass"
+		#elseif ($reorder)
+			class="$rowClass"
 		#end	
 	#end
-	
-	#if ($reorder)
-		#set($class = $class + " row")
-	#end
-	
-	class="$class"
 
 #end
 ############################################# Check if message hidden macro end


### PR DESCRIPTION
only ONE announcement is set as a Draft

![](https://jira.sakaiproject.org/secure/attachment/45795/announcements%203.jpg)


![announcments](https://cloud.githubusercontent.com/assets/16644575/16648158/fde3af1a-4432-11e6-865e-df430b81ae6d.png)
