### PR TITLE
SAK-31481 turn on MathJax support by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4204,15 +4204,15 @@
 #sitemanage.join.allowedJoinableAccountTypes (count + list) 
 #sitemanage.join.allowedJoinableAccountTypeLabels (count + list) 
 
-# SAK-22384 - MathJax. All of these are default to not set. (No default)
-# You have to specify all of them. 
+# SAK-22384 - MathJax support is enabled by default
 # See https://jira.sakaiproject.org/browse/SAK-22384 for more details and a demo.
 
-# URL to MathJax.js, you can use the one on the mathjax CDN or put one locally. Currently this is not included with Sakai
-#portal.mathjax.src.path=https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe 
+# URL to MathJax.js, you can use the one on the mathjax CDN or put one locally. Currently this is not included with Sakai.
+# The current default is the MathJax CDN latest (https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe)
+#portal.mathjax.src.path=
 
-# Whether to allow useres to enable or disable MathJAX, this still has to be enabled on a per site basis
-#portal.mathjax.enabled=true
+# Whether to allow useres to enable or disable MathJAX, this still has to be enabled on a per site basis (default is true)
+#portal.mathjax.enabled=false
 
 # ######
 # Kerberos Provider

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -195,9 +195,11 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
     // SAK-22384
     private static final String MATHJAX_ENABLED = "mathJaxEnabled";
     private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
-    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, "");
     private static final String MATHJAX_ENABLED_SAKAI_PROP = "portal.mathjax.enabled";
-    private static final boolean MATHJAX_ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(MATHJAX_ENABLED_SAKAI_PROP, false) && !MATHJAX_SRC_PATH.trim().isEmpty();
+    private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
+    private static final boolean ENABLED_SAKAI_PROP_DEFAULT = true;
+    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+    private static final boolean MATHJAX_ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(MATHJAX_ENABLED_SAKAI_PROP, ENABLED_SAKAI_PROP_DEFAULT) && !MATHJAX_SRC_PATH.trim().isEmpty();
     
 	private PortalSiteHelper siteHelper = null;
 

--- a/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
+++ b/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
@@ -70,9 +70,11 @@ public class ToolPortal extends HttpServlet
     // SAK-22384
     private static final String MATHJAX_ENABLED = "mathJaxEnabled";
     private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
-    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, "");
     private static final String MATHJAX_ENABLED_SAKAI_PROP = "portal.mathjax.enabled";
-    private static final boolean MATHJAX_ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(MATHJAX_ENABLED_SAKAI_PROP, false) && !MATHJAX_SRC_PATH.trim().isEmpty();
+    private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
+    private static final boolean ENABLED_SAKAI_PROP_DEFAULT = true;
+    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+    private static final boolean MATHJAX_ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(MATHJAX_ENABLED_SAKAI_PROP, ENABLED_SAKAI_PROP_DEFAULT) && !MATHJAX_SRC_PATH.trim().isEmpty();
     
 	/**
 	 * Access the Servlet's information display.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -113,7 +113,8 @@ public class DeliveryBean
   
   private static final String MATHJAX_ENABLED = "mathJaxEnabled";
   private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
-  private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, "");
+  private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
+  private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
   
   private String assessmentId;
   private String assessmentTitle;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MathJaxEnabler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MathJaxEnabler.java
@@ -43,6 +43,8 @@ public class MathJaxEnabler
     private static final String SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
     private static final String VERSION_SERVICE_SAKAI_PROP = "version.service";
     private static final String VERSION_SERVICE_DEFAULT = "Sakai";
+    private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
+    private static final boolean ENABLED_SAKAI_PROP_DEFAULT = true;
     
     private static final String SITE_PROP_MATHJAX_ENABLED = "mathJaxEnabled";
     private static final String SITE_PROP_MATHJAX_ALLOWED = "mathJaxAllowed";
@@ -58,8 +60,8 @@ public class MathJaxEnabler
     private static final String PARAM_MATHJAX_ALLOWED_KEY = "allowMathJax";
     private static final String TOOL_DELIM = ",";
         
-    private static final String SRC_PATH = ServerConfigurationService.getString(SRC_PATH_SAKAI_PROP, "");
-    private static final boolean ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(ENABLED_SAKAI_PROP, false) && !SRC_PATH.trim().isEmpty();
+    private static final String SRC_PATH = ServerConfigurationService.getString(SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+    private static final boolean ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(ENABLED_SAKAI_PROP, ENABLED_SAKAI_PROP_DEFAULT) && !SRC_PATH.trim().isEmpty();
     private static final String SAKAI_SERVICE = ServerConfigurationService.getString(VERSION_SERVICE_SAKAI_PROP, VERSION_SERVICE_DEFAULT);
     
     /**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31481

Core Team decision was to have this as one of the highlighted features of Sakai 11. As such, it should be enabled in sakai.properties by default.