### PR TITLE
SAK-31482 Fixed the height difference of selected sites in the topNav bar

### DIFF
--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -123,7 +123,10 @@ $sites-nav-menu-item-border-left:           none !default;
 $sites-nav-menu-item-selected-background:   $primary-color !default;
 $sites-nav-menu-item-selected-color:        #fff !default;
 $sites-nav-menu-item-selected-color-hover:  $sites-nav-menu-item-selected-color !default;
-$sites-nav-menu-item-selected-border:       none !default;
+$sites-nav-menu-item-selected-border-top:   $sites-nav-menu-item-border-top !default; /* to pre-allocate space for dropdown top border needed for illusion */
+$sites-nav-menu-item-selected-border-right: none !default;
+$sites-nav-menu-item-selected-border-bottom:$sites-nav-menu-item-selected-border-top !default; /* to pre-allocate space for dropdown top border needed for illusion */
+$sites-nav-menu-item-selected-border-left:  none !default;
 $sites-nav-submenu-background:              $sites-nav-menu-item-background !default;
 $sites-nav-submenu-item-background:         $sites-nav-menu-item-background !default;
 $sites-nav-submenu-item-background-hover:   $sites-nav-menu-item-background !default;

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -695,7 +695,10 @@ body.is-logged-out{
 				a{
 					background: $sites-nav-menu-item-selected-background;
 					color: $sites-nav-menu-item-selected-color;
-					border: $sites-nav-menu-item-selected-border;
+					border-top: $sites-nav-menu-item-selected-border-top; /* to balance bottom border for vertical centering */
+					border-right: $sites-nav-menu-item-selected-border-right;
+					border-bottom: $sites-nav-menu-item-selected-border-bottom; /* to pre-allocate space for dropdown top border needed for illusion */
+					border-left: $sites-nav-menu-item-selected-border-left;
 				}
 				ul{
 					background: $sites-nav-menu-item-selected-background;


### PR DESCRIPTION
I've noticed a small regression in my styles for SAK-31470 when I merged it with the variables written for SAK-31402: there is a 2px-height difference for the link of a selected site in the topNav bar:

![01-heightdifferenceofselectedsite](https://cloud.githubusercontent.com/assets/12685096/16702703/cf4f1500-4535-11e6-9bc6-d4c49f4d370b.png)
![02-heightdifferenceofselectedsite](https://cloud.githubusercontent.com/assets/12685096/16702704/cf5c6700-4535-11e6-96fb-2009ce8e139c.png)

This causes the sites at the top to bounce around when you switch from site to site. 

I have fixed this issue in this simple PR by setting the value of the border:

![03-heightdifferenceofselectedsite-fixed](https://cloud.githubusercontent.com/assets/12685096/16702722/f5f0127c-4535-11e6-9614-954e75ad3d62.png)

(Relies on SAK-31470 and SAK-31402.)
