### PR TITLE
SAK-31493 Harmonise maven project versions

### DIFF
--- a/access/access-tool/tool/pom.xml
+++ b/access/access-tool/tool/pom.xml
@@ -25,8 +25,6 @@
     <dependency>
       <groupId>org.sakaiproject.oauth</groupId>
       <artifactId>oauth-api</artifactId>
-      <version>1.2-SNAPSHOT</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/common/ddl/pom.xml
+++ b/common/ddl/pom.xml
@@ -11,7 +11,7 @@
     <parent>
 		<groupId>org.sakaiproject.common</groupId>
 		<artifactId>common</artifactId>
-	    <version>1.2-SNAPSHOT</version>
+	    <version>12-SNAPSHOT</version>
 	</parent>
 	
     <properties>
@@ -24,30 +24,30 @@
          <dependency>
         <groupId>org.sakaiproject.common</groupId>
         <artifactId>sakai-common-edu-person-api</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
       </dependency>
       <dependency>
       <groupId>org.sakaiproject.common</groupId>
       <artifactId>sakai-common-composite-component-data</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>12-SNAPSHOT</version>
     </dependency>
     <dependency>
         <groupId>org.sakaiproject.common</groupId>
         <artifactId>sakai-common-composite-component</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
       </dependency>
       
      
       <dependency>
         <groupId>org.sakaiproject.common</groupId>
         <artifactId>sakai-common-manager-api</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.sakaiproject.common</groupId>
         <artifactId>sakai-common-type-api</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
         <scope>provided</scope>
       </dependency>
      

--- a/entitybroker/tool/pom.xml
+++ b/entitybroker/tool/pom.xml
@@ -42,8 +42,6 @@
         <dependency>
             <groupId>org.sakaiproject.oauth</groupId>
             <artifactId>oauth-api</artifactId>
-            <version>1.2-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Kernel dependencies -->
         <dependency>

--- a/jsf/jsf-widgets-sun-depend/pom.xml
+++ b/jsf/jsf-widgets-sun-depend/pom.xml
@@ -8,8 +8,7 @@
         <version>12-SNAPSHOT</version>
     </parent>
 
-    <name>Sakai JSF widget dependencies for Sun's RI
-        (sakai-depend-jsf-widgets-sun)</name>
+    <name>Sakai JSF widget dependencies for Sun's RI (sakai-depend-jsf-widgets-sun)</name>
     <groupId>org.sakaiproject.jsf</groupId>
     <artifactId>jsf-widgets-sun-depend</artifactId>
     <organization>

--- a/jsf/myfaces-widgets-depend/pom.xml
+++ b/jsf/myfaces-widgets-depend/pom.xml
@@ -8,8 +8,7 @@
         <version>12-SNAPSHOT</version>
     </parent>
 
-    <name>Sakai JSF Widgets Dependencies for MyFaces
-        (sakai-depend-jsf-widgets-myfaces)</name>
+    <name>Sakai JSF Widgets Dependencies for MyFaces (sakai-depend-jsf-widgets-myfaces)</name>
     <groupId>org.sakaiproject.jsf</groupId>
     <artifactId>myfaces-widgets-depend</artifactId>
     <organization>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1538,6 +1538,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>org.sakaiproject.oauth</groupId>
+        <artifactId>oauth-api</artifactId>
+        <version>${sakai.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>org.sakaiproject.jsf</groupId>
         <artifactId>jsf-app</artifactId>
         <version>${sakai.version}</version>

--- a/oauth/api/pom.xml
+++ b/oauth/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
     </parent>
 
     <artifactId>oauth-api</artifactId>

--- a/oauth/dao-hbm/pom.xml
+++ b/oauth/dao-hbm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/oauth/dao-memory/pom.xml
+++ b/oauth/dao-memory/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/oauth/dao-server-config/pom.xml
+++ b/oauth/dao-server-config/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/oauth/impl/pom.xml
+++ b/oauth/impl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
     </parent>
 
     <artifactId>oauth-impl</artifactId>
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>oauth-api</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/oauth/pack/pom.xml
+++ b/oauth/pack/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
     </parent>
 
     <artifactId>oauth-pack</artifactId>
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>oauth-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -5,7 +5,6 @@
 
     <groupId>org.sakaiproject.oauth</groupId>
     <artifactId>oauth-base</artifactId>
-    <version>1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <parent>

--- a/oauth/tool/pom.xml
+++ b/oauth/tool/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject.oauth</groupId>
         <artifactId>oauth-base</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>12-SNAPSHOT</version>
     </parent>
 
     <artifactId>oauth-tool</artifactId>

--- a/simple-rss-portlet/pom.xml
+++ b/simple-rss-portlet/pom.xml
@@ -8,7 +8,6 @@
   	<description>An RSS/Atom feed reader.</description>
   	<url>https://wiki.jasig.org/display/PLT/Simple+RSS+Portlet</url>
   	
-  	<version>1.2.3-SNAPSHOT</version>
   	<packaging>war</packaging>
   	
     <parent>


### PR DESCRIPTION
oauth - this was at 1.2-SNAPSHOT
simple-rss-portlet  - this was at 1.2.3-SNAPSHOT

Also marked the oauth-api as provided and set a version in the master pom so it doesn’t get deployed in other versions.
Put jsf dependency names onto one line to make them easier to parse.