### PR TITLE
SAK-31530 Basic initial styling of the footer layout and colours

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -149,7 +149,7 @@
 # The keyword "currentYearFromServer" will be automatically substituted by Sakai to be set to by the server's end date. 
 # Using this keyword in the copyright statement can allow the copyright end date to automatically be updated to the current year.
 # If you do not wish to have the copyright end date to be automatically updated, do not include the keyword in bottom.copyrighttext.
-# bottom.copyrighttext=Copyright 2003-currentYearFromServer The Sakai Foundation. All rights reserved. Portions of Sakai are copyrighted by other parties as described in the Acknowledgments screen.
+# bottom.copyrighttext=Copyright 2003-currentYearFromServer The Sakai Foundation. All rights reserved.<br />Portions of Sakai are copyrighted by other parties as described in the Acknowledgments screen.
 
 ## VERSION - The are set in auto.sakai.properties at build time.
 # Format: ${ui.service} - \${version.service} - Sakai \${version.sakai}) - Server ${serverId}

--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -66,6 +66,10 @@ $main-content-background: $background-color !default;
 $top-header-background: $background-color-secondary !default;
 $sites-nav-background: $top-header-background !default;
 
+$footer-text-color:          #ccc !default;
+$footer-text-color-secondary:#fff !default;
+$footer-background-color:    #666 !default;
+
 $breadcrumbs-color:			 $text-color !default;
 $breadcrumbs-tool-color:		 #185878 !default;
 $breadcrumbs-hover-color:		 #0F4461 !default;

--- a/reference/library/src/morpheus-master/sass/modules/_main.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_main.scss
@@ -32,7 +32,10 @@
 		padding: 12px;
 	}
 }
-
+.#{$namespace}container--footer
+{
+	background-color: $footer-background-color;
+}
 #content, .#{$namespace}container--footer{
 	margin: 0 0 0 0;
 	width: 100%;
@@ -57,27 +60,87 @@
   background: $main-content-background;
 }
 
-.#{$namespace}pageColumns--single, .#{$namespace}footer{
+.#{$namespace}pageColumns--single
+{
 	margin: 0 1em 1em 1em;
 	clear: both;
-	@media #{$phone}{
+	@media #{$phone}
+	{
 		margin: 0 0 0 0;
 	}
 }
 
-.#{$namespace}container--footer{
-	background: $footer-background;
-}
-
-.#{$namespace}footer{
-	color: $footer-color;
-	padding: 0.8em;
-	font-size: 0.8em;
-	#footer-links{
+.#{$namespace}footer
+{
+	@include display-flex( flex );
+	@include align-items( center );
+	@include flex-direction( column );
+	padding: 1em;
+	font-size: 0.857em;
+	color: $footer-text-color;
+	text-align:center;
+	
+	#footer-links
+	{
+		display: flex;
+		justify-content: center;
 		list-style: none;
-		padding: 0 0 0 0;
-		li{
+		margin: 0;
+		padding: 0;
+		
+		li
+		{
 			display: inline-block;
+			padding: 0 1.5em;
+			border-right: 1px solid $footer-text-color;
+		}
+		li:last-child
+		{
+			border-right: 0 none;
+		}
+		a
+		{
+			color: $footer-text-color;
+			text-decoration: none;
+		}
+		a:hover, a:active
+		{
+			color: $footer-text-color-secondary;
+			text-decoration: underline;
 		}
 	}
+}
+.#{$namespace}footer--nav.Mrphs-footer--nav__project 
+{
+	margin-bottom: 0;
+	padding: 0;
+	list-style: none;
+}
+.#{$namespace}footer--nav__build__panel 
+{
+	margin: 0;
+}
+.#{$namespace}footer--nav__project--poweredby
+{
+	color: $footer-text-color-secondary;
+	text-decoration: underline; /* to pick up this font's color */
+}
+##{$namespace}footer--nav__project--sakai
+{
+	display: block;
+	margin: 2em;
+	text-align: center;
+	
+	a
+	{
+		text-decoration: none;
+	}
+}
+.#{$namespace}footer--nav__project--copyright 
+{
+	margin-bottom: 1.5em;
+}
+.#{$namespace}footer--nav__build__panel 
+{
+	margin: 0;
 }


### PR DESCRIPTION
The footer needs to be styled before we release.

In this patch, I have added a background colour to the footer, centred everything, and spaced the footer contents out. Please see the attached screenshots for the before shot and after shots.

It's not my favourite design, but it is a start for 11. (Better than no styling.)

I plan to come back a revise the footer later for 11.x, but I will submit that as a later design.

There is a small changed to the default.sakai.properties.

**Before:**
![01-footer-before](https://cloud.githubusercontent.com/assets/12685096/16987331/a545388e-4e59-11e6-80ce-acd9a5852db2.png)

**After:**
Desktop
![02-footer-after](https://cloud.githubusercontent.com/assets/12685096/16987332/a5502d3e-4e59-11e6-8a79-0761581d6b2a.png)

In Context of the page:
![04-footer-after-inpagecontext](https://cloud.githubusercontent.com/assets/12685096/16987333/a5521cb6-4e59-11e6-9720-e0c729344fae.png)

Mobile
![03-footer-after-mobile](https://cloud.githubusercontent.com/assets/12685096/16987334/a5531b16-4e59-11e6-95ec-2ff6c7c6a796.png)

