### PR TITLE
KNL-1234 Enable MathJax on content in resources.

### DIFF
--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -262,6 +262,9 @@ memory.org.sakaiproject.user.api.UserDirectoryService=maxElementsInMemory=100000
 #KNL-1306 default
 content.mimeMagic.ignorecontent.extensions=js
 
+# KNL-1234 Enable MathJax on content in resources
+portal.mathjax.src.path=https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe
+
 # KNL-1399
 copyright.type.default=
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
@@ -22,6 +22,8 @@ package org.sakaiproject.content.impl;
 
 import java.text.MessageFormat;
 
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentFilter;
 import org.sakaiproject.content.api.ContentResource;
@@ -30,6 +32,7 @@ import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.util.Validator;
 
 /**
@@ -40,6 +43,9 @@ import org.sakaiproject.util.Validator;
  *
  */
 public class HtmlPageFilter implements ContentFilter {
+
+	private static final String MATHJAX_ENABLED = "mathJaxEnabled";
+	private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
 
 	private EntityManager entityManager;
 	
@@ -56,6 +62,7 @@ public class HtmlPageFilter implements ContentFilter {
 "    <link href=\"{0}/tool_base.css\" type=\"text/css\" rel=\"stylesheet\" media=\"all\" />\n" +
 "    <link href=\"{0}/{1}/tool.css\" type=\"text/css\" rel=\"stylesheet\" media=\"all\" />\n" +
 "    <script type=\"text/javascript\" language=\"JavaScript\" src=\"/library/js/headscripts.js\"></script>\n" +
+"{3}"+
 "    <style>body '{ padding: 5px !important; }'</style>\n" +
 "  </head>\n" +
 "  <body>\n";
@@ -63,6 +70,10 @@ public class HtmlPageFilter implements ContentFilter {
 	private String footerTemplate = "\n" +
 "  </body>\n" +
 "</html>\n";
+
+	private String mathjaxTemplate =
+"    <script type=\"text/x-mathjax-config\">\nMathJax.Hub.Config('{'\ntex2jax: '{' inlineMath: [[''\\\\('',''\\\\)'']] '}'\n'}');\n</script>\n" +
+"    <script src=\"{0}\"  language=\"JavaScript\" type=\"text/javascript\"></script>\n" ;
 
 	public void setEntityManager(EntityManager entityManager) {
 		this.entityManager = entityManager;
@@ -94,7 +105,7 @@ public class HtmlPageFilter implements ContentFilter {
 			return content;
 		}
 		Reference contentRef = entityManager.newReference(content.getReference());
-		Reference siteRef = entityManager.newReference(contentRef.getContext());
+		Reference siteRef = entityManager.newReference(Entity.SEPARATOR+ SiteService.SITE_SUBTYPE+ Entity.SEPARATOR+ contentRef.getContext());
 		Entity entity = siteRef.getEntity();
 		
 		String addHtml = content.getProperties().getProperty(ResourceProperties.PROP_ADD_HTML);
@@ -110,7 +121,15 @@ public class HtmlPageFilter implements ContentFilter {
 			String docType = serverConfigurationService.getString("content.html.doctype", "<!DOCTYPE html>");
 			header.append(docType + "\n");
 		}
-		header.append(MessageFormat.format(headerTemplate, skinRepo, siteSkin, title));
+		StringBuilder additionalScripts = new StringBuilder();
+		if (isMathJaxEnabled(entity)) {
+			additionalScripts.append(MessageFormat.format(mathjaxTemplate,
+				serverConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP,
+					"https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe"
+				)
+			));
+		}
+		header.append(MessageFormat.format(headerTemplate, skinRepo, siteSkin, title, additionalScripts));
         
 		return new WrappedContentResource(content, header.toString(), footerTemplate, detectHtml);
 	}
@@ -136,8 +155,30 @@ public class HtmlPageFilter implements ContentFilter {
 				siteSkin = site.getSkin();
 			}
 		}
-
 		return siteSkin;
+	}
+
+	/**
+	 * Check if MathJax should be enabled for this site.
+	 * @param entity The Site that the content is in.
+	 * @return <code>true</code> if we should enabled MathJax
+     */
+	private boolean isMathJaxEnabled(Entity entity) {
+		if (serverConfigurationService.getBoolean("portal.mathjax.enabled", true)) {
+			if (entity instanceof Site) {
+				Site site = (Site)entity;
+				String strMathJaxEnabled = site.getProperties().getProperty(MATHJAX_ENABLED);
+				if (!StringUtils.isBlank(strMathJaxEnabled))
+				{
+					String[] mathJaxTools = strMathJaxEnabled.split(",");
+					if (ArrayUtils.contains(mathJaxTools, "sakai.resources"))
+					{
+						return true;
+					}
+				}
+			}
+		}
+		return false;
 	}
 
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
@@ -124,8 +124,7 @@ public class HtmlPageFilter implements ContentFilter {
 		StringBuilder additionalScripts = new StringBuilder();
 		if (isMathJaxEnabled(entity)) {
 			additionalScripts.append(MessageFormat.format(mathjaxTemplate,
-				serverConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP,
-					"https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe"
+				serverConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP
 				)
 			));
 		}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -196,9 +196,8 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
     private static final String MATHJAX_ENABLED = "mathJaxEnabled";
     private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
     private static final String MATHJAX_ENABLED_SAKAI_PROP = "portal.mathjax.enabled";
-    private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
     private static final boolean ENABLED_SAKAI_PROP_DEFAULT = true;
-    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP);
     private static final boolean MATHJAX_ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(MATHJAX_ENABLED_SAKAI_PROP, ENABLED_SAKAI_PROP_DEFAULT) && !MATHJAX_SRC_PATH.trim().isEmpty();
     
 	private PortalSiteHelper siteHelper = null;

--- a/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
+++ b/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
@@ -71,9 +71,8 @@ public class ToolPortal extends HttpServlet
     private static final String MATHJAX_ENABLED = "mathJaxEnabled";
     private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
     private static final String MATHJAX_ENABLED_SAKAI_PROP = "portal.mathjax.enabled";
-    private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
     private static final boolean ENABLED_SAKAI_PROP_DEFAULT = true;
-    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+    private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP);
     private static final boolean MATHJAX_ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(MATHJAX_ENABLED_SAKAI_PROP, ENABLED_SAKAI_PROP_DEFAULT) && !MATHJAX_SRC_PATH.trim().isEmpty();
     
 	/**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -113,8 +113,7 @@ public class DeliveryBean
   
   private static final String MATHJAX_ENABLED = "mathJaxEnabled";
   private static final String MATHJAX_SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
-  private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
-  private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+  private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP);
   
   private String assessmentId;
   private String assessmentTitle;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MathJaxEnabler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MathJaxEnabler.java
@@ -44,7 +44,6 @@ public class MathJaxEnabler
     private static final String SRC_PATH_SAKAI_PROP = "portal.mathjax.src.path";
     private static final String VERSION_SERVICE_SAKAI_PROP = "version.service";
     private static final String VERSION_SERVICE_DEFAULT = "Sakai";
-    private static final String SRC_PATH_SAKAI_PROP_DEFAULT = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=default,Safe";
     private static final boolean ENABLED_SAKAI_PROP_DEFAULT = true;
     private static final boolean ENABLED_SAKAI_NEW_SITE_DEFAULT = false;
     
@@ -62,7 +61,7 @@ public class MathJaxEnabler
     private static final String PARAM_MATHJAX_ALLOWED_KEY = "allowMathJax";
     private static final String TOOL_DELIM = ",";
         
-    private static final String SRC_PATH = ServerConfigurationService.getString(SRC_PATH_SAKAI_PROP, SRC_PATH_SAKAI_PROP_DEFAULT);
+    private static final String SRC_PATH = ServerConfigurationService.getString(SRC_PATH_SAKAI_PROP);
     private static final boolean ENABLED_AT_SYSTEM_LEVEL = ServerConfigurationService.getBoolean(ENABLED_SAKAI_PROP, ENABLED_SAKAI_PROP_DEFAULT) && !SRC_PATH.trim().isEmpty();
     private static final boolean ENABLED_AT_NEW_SITE_CREATION_LEVEL = ServerConfigurationService.getBoolean(ENABLED_SAKAI_PROP_NEW_SITE, ENABLED_SAKAI_NEW_SITE_DEFAULT) && ENABLED_AT_SYSTEM_LEVEL;
     private static final String SAKAI_SERVICE = ServerConfigurationService.getString(VERSION_SERVICE_SAKAI_PROP, VERSION_SERVICE_DEFAULT);


### PR DESCRIPTION
Ideally this should be extracted out so that tools/plugins can contribute to the scripts, but to get it working we’re just putting the MathJax code in the kernel.
This also fixes a but where a site local skin wasn't getting picked up.