### PR TITLE
SAM-2979 Statistics for Calculated Questions not showing the right data

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/HistogramListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/HistogramListener.java
@@ -1837,7 +1837,7 @@ public class HistogramListener
 private void getCalculatedQuestionScores(List<ItemGradingData> scores, HistogramQuestionScoresBean qbean, List labels) {
     final String CORRECT = "Correct";
     final String INCORRECT = "Incorrect";
-    final int COLUMN_MAX_HEIGHT = 600;
+    final int COLUMN_MAX_HEIGHT = 100;
     
     ResourceLoader rb = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.EvaluationMessages");
     ResourceLoader rc = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.CommonMessages");
@@ -3025,6 +3025,13 @@ private void getCalculatedQuestionScores(List<ItemGradingData> scores, Histogram
 	  }
 	  if (typeId == TypeIfc.MATRIX_CHOICES_SURVEY.intValue()) {
 		  return rb.getString("q_matrix_choices_surv");
+	  }
+	  if (typeId == TypeIfc.CALCULATED_QUESTION.intValue()) {
+	      return rb.getString("q_cq");
+	  }
+	  
+	  if (typeId == TypeIfc.IMAGEMAP_QUESTION.intValue()) {
+	      return rb.getString("q_imq");
 	  }
 	  return "";
   }

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/histogramScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/histogramScores.jsp
@@ -282,13 +282,12 @@ $Id$
           <h:column>
             <h:panelGrid styleClass="table table-striped" columns="1">
               <h:panelGroup rendered="#{item.questionType !='13'}">
-                <h:graphicImage id="image8" rendered="#{bar.isCorrect}" width="12" height="12" alt="#{evaluationMessages.alt_correct}" url="/images/delivery/checkmark.gif" />
                 <h4>
                   <h:outputText value="#{bar.title}" escape="false" rendered="#{bar.title ne ''}"/>
                 </h4>
-                <h:graphicImage id="image8_b" rendered="#{bar.isCorrect}" width="12" height="12" alt="#{evaluationMessages.alt_correct}" url="/images/delivery/checkmark.gif" />
                 <div class="progress">
-                  <h:outputText value="<div class=\"progress-bar\" role=\"progressbar\" aria-valuenow=\"#{bar.columnHeight}\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width: #{bar.columnHeight}%;\">" escape="false" />
+                  <h:outputText rendered="#{bar.isCorrect}" value="<div class=\"progress-bar progress-bar-success\" role=\"progressbar\" aria-valuenow=\"#{bar.columnHeight}\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width: #{bar.columnHeight}%;\">" escape="false" />
+                  <h:outputText rendered="#{!bar.isCorrect}" value="<div class=\"progress-bar\" role=\"progressbar\" aria-valuenow=\"#{bar.columnHeight}\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width: #{bar.columnHeight}%;\">" escape="false" />
                     <h:outputText value="#{bar.numStudentsText}" />
                   </div>
                 </div>


### PR DESCRIPTION
This also solves SAM-2980 Double checkmark displayed in Statistics


![stat01](https://cloud.githubusercontent.com/assets/16644575/17048731/86ad0c18-4fe8-11e6-9f73-ca4fbaf8f5f7.png)
![stat02](https://cloud.githubusercontent.com/assets/16644575/17048732/86b283e6-4fe8-11e6-9d76-dc2f1156fef6.png)


![stat04fixed](https://cloud.githubusercontent.com/assets/16644575/17048729/78c72340-4fe8-11e6-9a94-1fe730e333b4.png)
