### PR TITLE
Change .#{$namespace}toolTitleNav__title z-index

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/_base.scss
@@ -10,7 +10,7 @@
 			position: relative;
 			text-transform: uppercase;
 			width: calc(100% - 90px);
-			z-index: 21;
+			z-index: 1;
 			a{
 				color: rgba(21,21,21,0.5);
 				font-weight: 400;


### PR DESCRIPTION
Previous z-index of 21  was causing the element to display above the banner and navigation on mobile. Possible typo since rgba value below it contains several 21 variables?
