### PR TITLE
SAK-31562 Use Locale.ROOT when normalizing case for enumerations

### DIFF
--- a/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/AcknowledgementType.java
+++ b/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/AcknowledgementType.java
@@ -24,14 +24,16 @@
 
 package org.sakaiproject.pasystem.api;
 
+import java.util.Locale;
+
 public enum AcknowledgementType {
     TEMPORARY, PERMANENT;
 
     public String dbValue() {
-        return toString().toLowerCase();
+        return toString().toLowerCase(Locale.ROOT);
     }
 
     public static AcknowledgementType of(String value) {
-        return valueOf(value.toUpperCase());
+        return valueOf(value.toUpperCase(Locale.ROOT));
     }
 }

--- a/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/Banner.java
+++ b/pasystem/pasystem-api/api/src/java/org/sakaiproject/pasystem/api/Banner.java
@@ -26,6 +26,7 @@ package org.sakaiproject.pasystem.api;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 import lombok.Getter;
 
 import static org.sakaiproject.pasystem.api.ValidationHelper.*;
@@ -71,7 +72,7 @@ public class Banner implements Comparable<Banner> {
         this.isActive = active;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.type = BannerType.valueOf(type.toUpperCase());
+        this.type = BannerType.valueOf(type.toUpperCase(Locale.ROOT));
         this.isDismissed = isDismissed;
     }
 
@@ -79,7 +80,7 @@ public class Banner implements Comparable<Banner> {
      * The type of this banner (high, medium, low).
      */
     public String getType() {
-        return this.type.toString().toLowerCase();
+        return this.type.toString().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/pasystem/pasystem-impl/impl/src/java/org/sakaiproject/pasystem/impl/acknowledgements/AcknowledgementStorage.java
+++ b/pasystem/pasystem-impl/impl/src/java/org/sakaiproject/pasystem/impl/acknowledgements/AcknowledgementStorage.java
@@ -25,12 +25,13 @@
 package org.sakaiproject.pasystem.impl.acknowledgements;
 
 import java.sql.SQLException;
+import java.util.Locale;
 import java.util.UUID;
+import org.sakaiproject.pasystem.api.AcknowledgementType;
 import org.sakaiproject.pasystem.api.Acknowledger;
 import org.sakaiproject.pasystem.impl.common.DB;
 import org.sakaiproject.pasystem.impl.common.DBAction;
 import org.sakaiproject.pasystem.impl.common.DBConnection;
-import org.sakaiproject.pasystem.api.AcknowledgementType;
 
 /**
  * Mark a popup or banner as acknowledged by a user.
@@ -45,7 +46,7 @@ public class AcknowledgementStorage {
     private final String tableName;
 
     public AcknowledgementStorage(NotificationType type) {
-        tableName = ("PASYSTEM_" + type + "_dismissed").toLowerCase();
+        tableName = ("PASYSTEM_" + type + "_dismissed").toLowerCase(Locale.ROOT);
     }
 
     /**


### PR DESCRIPTION
Otherwise we fail when the Turkish locale is set.