### PR TITLE
SAK-31584 Allow auto wiring of Quartz Jobs.

### DIFF
--- a/jobscheduler/scheduler-api/pom.xml
+++ b/jobscheduler/scheduler-api/pom.xml
@@ -31,6 +31,11 @@
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.sakaiproject.kernel</groupId>
+      <artifactId>sakai-kernel-private</artifactId>
+      <version>12-SNAPSHOT</version>
+    </dependency>
   </dependencies>
   
   <build>

--- a/jobscheduler/scheduler-api/src/java/org/sakaiproject/api/app/scheduler/JobBeanWrapper.java
+++ b/jobscheduler/scheduler-api/src/java/org/sakaiproject/api/app/scheduler/JobBeanWrapper.java
@@ -20,22 +20,31 @@
 **********************************************************************************/
 package org.sakaiproject.api.app.scheduler;
 
+import org.quartz.Job;
+
 /**
- * Created by IntelliJ IDEA.
- * User: John Ellis
- * Date: Dec 1, 2005
- * Time: 12:35:51 PM
- * To change this template use File | Settings | File Templates.
+ * This is used to represent a job that can be run through the Sakai Scheduler tool.
  */
 public interface JobBeanWrapper {
 
-   public static final String SPRING_BEAN_NAME = "org.sakaiproject.api.app.scheduler.JobBeanWrapper.bean";
-   public static final String JOB_TYPE = "org.sakaiproject.api.app.scheduler.JobBeanWrapper.jobType";
+   String SPRING_BEAN_NAME = "org.sakaiproject.api.app.scheduler.JobBeanWrapper.bean";
+   String JOB_TYPE = "org.sakaiproject.api.app.scheduler.JobBeanWrapper.jobType";
 
-   public String getBeanId();
+   /**
+    * @return The Spring Bean ID to retrieve from the application context.
+     */
+   String getBeanId();
 
-   public Class getJobClass();
+   /**
+    * This is the class that will get registered with Quartz to be run.
+    * @return A Class that implements the Job interface.
+     */
+   Class<? extends Job> getJobClass();
 
-   public String getJobType();
+   /**
+    * This is the name that is displayed in the interface for the job.
+    * @return A summary of the job.
+     */
+   String getJobType();
 
 }

--- a/jobscheduler/scheduler-component-shared/README.beanjobs.md
+++ b/jobscheduler/scheduler-component-shared/README.beanjobs.md
@@ -1,0 +1,17 @@
+Autowiring Quartz Jobs
+======================
+
+To implement a quartz job now all you need todo is create a class that
+implements the org.quartz.Job interface and register this class with the
+scheuduler manager. The class doesn't need to be a spring bean as it
+can be autowired with any services it needs. The data from the job map
+is also available to the autowiring.
+
+See: org.springframework.scheduling.quartz.SpringBeanJobFactory
+See: org.sakaiproject.component.app.scheduler.jobs.AutowiredTestJob
+
+@Inject doesn't work unless the annotation is available when the main
+spring application context is setup. However @Autowired is always available
+so can be used.
+
+

--- a/jobscheduler/scheduler-component-shared/pom.xml
+++ b/jobscheduler/scheduler-component-shared/pom.xml
@@ -59,6 +59,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
         </dependency>
         <dependency>
@@ -75,11 +83,6 @@
             <artifactId>javassist</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutowiredJobBeanWrapper.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutowiredJobBeanWrapper.java
@@ -1,0 +1,35 @@
+package org.sakaiproject.component.app.scheduler;
+
+import org.quartz.Job;
+import org.sakaiproject.api.app.scheduler.JobBeanWrapper;
+
+/**
+ * This is a JobBeanWrapper that will just be registered with the Job Scheduler.
+ * This class isn't actually used when running the job as quartz will directly create an instance of the class.
+ */
+public class AutowiredJobBeanWrapper  implements JobBeanWrapper {
+
+    private String jobType;
+    private Class<? extends Job> aClass;
+
+    public AutowiredJobBeanWrapper(Class<? extends Job> aClass, String jobType) {
+        this.aClass = aClass;
+        this.jobType = jobType;
+    }
+
+    @Override
+    public String getBeanId() {
+        // We don't need a bean ID as a new instance will be created and will get autowired.
+        return null;
+    }
+
+    @Override
+    public Class<? extends Job> getJobClass() {
+        return aClass;
+    }
+
+    @Override
+    public String getJobType() {
+        return jobType;
+    }
+}

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutowiringSpringBeanJobFactory.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutowiringSpringBeanJobFactory.java
@@ -1,0 +1,31 @@
+package org.sakaiproject.component.app.scheduler;
+
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+
+/**
+ * This JobFactory autowires automatically the created quartz bean with spring @Autowired dependencies.
+ *
+ * @author jelies (thanks to Brian Matthews)
+ * @link http://webcache.googleusercontent.com/search?q=cache:FH-N1i--sDgJ:blog.btmatthews.com/2011/09/24/inject-application-context-dependencies-in-quartz-job-beans/+&cd=7&hl=en&ct=clnk&gl=es)
+ */
+public final class AutowiringSpringBeanJobFactory extends SpringBeanJobFactory implements
+        ApplicationContextAware {
+
+    private transient AutowireCapableBeanFactory beanFactory;
+
+    @Override
+    public void setApplicationContext(final ApplicationContext context) {
+        beanFactory = context.getAutowireCapableBeanFactory();
+    }
+
+    @Override
+    protected Object createJobInstance(final TriggerFiredBundle bundle) throws Exception {
+        final Object job = super.createJobInstance(bundle);
+        beanFactory.autowireBean(job);
+        return job;
+    }
+}

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/ConnectionProviderDelegate.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/ConnectionProviderDelegate.java
@@ -31,41 +31,29 @@ import org.slf4j.LoggerFactory;
 import org.quartz.utils.ConnectionProvider;
 import org.sakaiproject.component.cover.ComponentManager;
 
+/**
+ * This looks up the DataSource from Spring so that it will use the main Sakai connection.
+ */
 public class ConnectionProviderDelegate implements ConnectionProvider
 {
+  private final Logger LOG = LoggerFactory.getLogger(ConnectionProviderDelegate.class);
+  private DataSource ds;
 
-  private static final Logger LOG = LoggerFactory.getLogger(ConnectionProviderDelegate.class);
-  private static DataSource ds;
-
-
-  /**
-   * @see org.quartz.utils.ConnectionProvider#getConnection()
-   */
   @Override
   public Connection getConnection() throws SQLException {
-
      if (LOG.isDebugEnabled()){
        LOG.debug("quartz getConnection()");
-     }
-
-     if (ds == null){
-       ds = (DataSource) ComponentManager.get("javax.sql.DataSource");
      }
      return ds.getConnection();
   }
 
-  /**
-   * @see org.quartz.utils.ConnectionProvider#shutdown()
-   */
   @Override
   public void shutdown() throws SQLException {
   }
 
-  /** (non-Javadoc)
-   * @see org.quartz.utils.ConnectionProvider#initialize()
-   */
   @Override
   public void initialize() throws SQLException {
+      ds = ComponentManager.get(javax.sql.DataSource.class);
   }
 
 }

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/JobBeanWrapperRegistrar.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/JobBeanWrapperRegistrar.java
@@ -1,0 +1,28 @@
+package org.sakaiproject.component.app.scheduler;
+
+import org.sakaiproject.api.app.scheduler.JobBeanWrapper;
+import org.sakaiproject.api.app.scheduler.SchedulerManager;
+
+import java.util.List;
+
+/**
+ * Just registers JobBeanWrappers with the Schedule Manager, this is needed because the autowired
+ * jobs don't have to register themselves.
+ */
+public class JobBeanWrapperRegistrar {
+
+    private SchedulerManager schedulerManager;
+    private List<JobBeanWrapper> jobBeans;
+
+    public void setSchedulerManager(SchedulerManager schedulerManager) {
+        this.schedulerManager = schedulerManager;
+    }
+
+    public void setJobBeans(List<JobBeanWrapper> jobBeans) {
+        this.jobBeans = jobBeans;
+    }
+
+    public void init() {
+        jobBeans.stream().forEach(wrapper -> schedulerManager.registerBeanJob(wrapper.getJobType(), wrapper));
+    }
+}

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/ScheduledInvocationJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/ScheduledInvocationJob.java
@@ -1,0 +1,33 @@
+package org.sakaiproject.component.app.scheduler.jobs;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.quartz.*;
+import org.sakaiproject.api.app.scheduler.ScheduledInvocationCommand;
+import org.sakaiproject.component.cover.ComponentManager;
+
+@PersistJobDataAfterExecution
+@DisallowConcurrentExecution
+public class ScheduledInvocationJob implements Job {
+
+	private static final Log LOG = LogFactory.getLog(ScheduledInvocationJob.class);
+
+
+	/* (non-Javadoc)
+	 * @see org.quartz.Job#execute(org.quartz.JobExecutionContext)
+	 */
+	@SuppressWarnings("unchecked")
+	public void execute(JobExecutionContext jobContext) throws JobExecutionException {
+
+		String contextId = jobContext.getMergedJobDataMap().getString("contextId");
+		String componentId = jobContext.getJobDetail().getKey().getName();
+
+		try {
+			ScheduledInvocationCommand command = (ScheduledInvocationCommand) ComponentManager.get(componentId);
+			command.execute(contextId);
+		} catch (Exception e) {
+			LOG.error("Failed to execute component: [" + componentId + "]: ", e);
+		}
+	}
+
+}

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/SpringJobBeanWrapper.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/SpringJobBeanWrapper.java
@@ -40,7 +40,7 @@ public class SpringJobBeanWrapper implements JobBeanWrapper, Job {
    public SpringJobBeanWrapper() {
    }
 
-   public Class getJobClass() {
+   public Class<? extends Job> getJobClass() {
       return this.getClass();
    }
 

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -12,6 +12,14 @@
         </property>
     </bean>
 
+    <!-- This job bean factory attempts to autowire any jobs that the quartz scheduler creates, this means that
+         the job can be an ordinary Java class, rather than a special Job that looks up the spring bean in the
+         component manager. -->
+    <bean id="org.sakaiproject.component.app.scheduler.AutowiringSpringBeanJobFactory"
+          class="org.sakaiproject.component.app.scheduler.AutowiringSpringBeanJobFactory">
+    </bean>
+
+
     <bean id="org.sakaiproject.api.app.scheduler.events.TriggerEventManager.wrapped"
           class="org.sakaiproject.component.app.scheduler.events.hibernate.TriggerEventManagerHibernateImpl">
         <property name="sessionFactory" ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/>
@@ -80,6 +88,9 @@
         </property>
         <property name="autoDdl">
           <value>${auto.ddl}</value>
+        </property>
+        <property name="jobFactory">
+            <ref bean="org.sakaiproject.component.app.scheduler.AutowiringSpringBeanJobFactory"/>
         </property>
         <property name="initialJobSchedules">
             <list>

--- a/jobscheduler/scheduler-test-component-shared/pom.xml
+++ b/jobscheduler/scheduler-test-component-shared/pom.xml
@@ -44,6 +44,10 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jobscheduler/scheduler-test-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/AutowiredTestJob.java
+++ b/jobscheduler/scheduler-test-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/AutowiredTestJob.java
@@ -1,0 +1,35 @@
+package org.sakaiproject.component.app.scheduler.jobs;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.sakaiproject.id.api.IdManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * This is to test autowiring of Jobs.
+ */
+public class AutowiredTestJob implements Job {
+
+    private final Logger logger = LoggerFactory.getLogger(AutowiredTestJob.class);
+
+    @Inject
+    public void setIdManager(IdManager idManager) {
+        this.idManager = idManager;
+    }
+
+    private IdManager idManager;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        if (idManager != null) {
+            logger.info("Autowiring worked, generated ID {}", idManager.createUuid());
+        } else {
+            logger.info("IdManager was not autowired :-(");
+        }
+    }
+}

--- a/jobscheduler/scheduler-test-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-test-component/src/webapp/WEB-INF/components.xml
@@ -117,5 +117,59 @@
     </bean>
     <!-- sample bean job -->
 
+    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.schedulerdInvocationTest"
+          class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+          init-method="init">
+        <property name="beanId">
+            <value>org.sakaiproject.component.app.scheduler.ScheduledInvocationTestJob</value>
+        </property>
+        <property name="jobName">
+            <value>Scheduled Invocation Test Job</value>
+        </property>
+        <property name="schedulerManager">
+            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
+        </property>
+    </bean>
+
+    <bean id="org.sakaiproject.component.app.scheduler.ScheduledInvocationTestJob"
+          class="org.sakaiproject.component.app.scheduler.ScheduledInvocationTestJob">
+        <property name="timeService" ref="org.sakaiproject.time.api.TimeService"/>
+        <property name="sim" ref="org.sakaiproject.api.app.scheduler.ScheduledInvocationManager"/>
+    </bean>
+
+    <bean id="scheduledInvocationTestCommand"
+          class="org.sakaiproject.component.app.scheduler.ScheduledInvocationTestCommand"/>
+
+
+    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.longTestJob"
+          class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+          init-method="init">
+        <property name="beanId">
+            <value>org.sakaiproject.component.app.scheduler.jobs.LongTestJob</value>
+        </property>
+        <property name="jobName">
+            <value>Long Test Job</value>
+        </property>
+        <property name="schedulerManager">
+            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
+        </property>
+    </bean>
+
+    <bean id="org.sakaiproject.component.app.scheduler.jobs.LongTestJob"
+          class="org.sakaiproject.component.app.scheduler.jobs.LongTestJob">
+    </bean>
+
+
+    <bean class="org.sakaiproject.component.app.scheduler.JobBeanWrapperRegistrar" init-method="init">
+        <property name="schedulerManager">
+            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
+        </property>
+        <property name="jobBeans">
+            <bean class="org.sakaiproject.component.app.scheduler.AutowiredJobBeanWrapper">
+                <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.AutowiredTestJob"/>
+                <constructor-arg value="Test Autowired Job"/>
+            </bean>
+        </property>
+    </bean>
    
 </beans>

--- a/kernel/deploy/shared/pom.xml
+++ b/kernel/deploy/shared/pom.xml
@@ -100,6 +100,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <scope>compile</scope>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -574,6 +574,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>geronimo-spec</groupId>
         <artifactId>geronimo-spec-jms</artifactId>
         <version>1.1-rc4</version>


### PR DESCRIPTION
This means you can just register a class with the job scheduler and then quartz will create an instance when it needs to and have spring autowire any dependencies.