### PR TITLE
Allows items to be imported with no points specified

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -453,4 +453,6 @@ error.addeditgradeitem.titlecharacters = Gradebook item names cannot start with 
 importExport.error.grade = An error occurred importing a grade. Please check the file.
 importExport.error.comment = An error occurred importing a comment. Please check the file.
 importExport.commentname = + comments
-importExport.error.badfile = The file you uploaded was not formatted correctly
+importExport.error.incorrecttype = The file you uploaded was not recognised as a CSV or Excel file.
+importExport.error.incorrectformat = The file you uploaded was not formatted correctly
+importExport.error.empty = The file you uploaded was empty

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportColumn.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportColumn.java
@@ -3,27 +3,35 @@ package org.sakaiproject.gradebookng.business.model;
 import java.io.Serializable;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
- * Created by chmaurer on 1/27/15.
+ * Describes the type of column imported
  */
-@Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ImportColumn implements Serializable {
 
-	public static final int TYPE_REGULAR = 0;
-	public static final int TYPE_ITEM_WITH_POINTS = 1;
-	public static final int TYPE_ITEM_WITH_COMMENTS = 2;
+	private static final long serialVersionUID = 1L;
 
+	@Getter
+	@Setter
 	private String columnTitle;
-	private String points;
-	private int type = TYPE_REGULAR;
 
-	// public ImportColumn(String columnTitle, String points, int type) {
-	//
-	// }
+	@Getter
+	@Setter
+	private String points;
+
+	@Getter
+	@Setter
+	private Type type = Type.REGULAR;
+
+	public enum Type {
+		GBITEM_WITH_POINTS,
+		GBITEM_WITH_COMMENTS,
+		REGULAR;
+	}
 
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedGradeWrapper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedGradeWrapper.java
@@ -4,15 +4,21 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * Created by chmaurer on 1/23/15.
+ * Wraps an imported file
  */
-@Data
 public class ImportedGradeWrapper implements Serializable {
 
-	// private List<ProcessedGradeItem> processedGradeItems;
+	private static final long serialVersionUID = 1L;
+
+	@Getter
+	@Setter
 	private List<ImportedGrade> importedGrades;
+
+	@Getter
+	@Setter
 	private Collection<ImportColumn> columns;
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItemStatus.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItemStatus.java
@@ -2,13 +2,17 @@ package org.sakaiproject.gradebookng.business.model;
 
 import java.io.Serializable;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * Created by chmaurer on 3/16/15.
+ * Status of an imported item
+ * TODO these values should be an enum rather than an ints
  */
-@Data
 public class ProcessedGradeItemStatus implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
 
 	public static final int STATUS_UPDATE = 0;
 	public static final int STATUS_NEW = 1;
@@ -16,7 +20,12 @@ public class ProcessedGradeItemStatus implements Serializable {
 	public static final int STATUS_UNKNOWN = 3;
 	public static final int STATUS_EXTERNAL = 4;
 
+	@Getter
+	@Setter
 	private int statusCode;
+
+	@Getter
+	@Setter
 	private String statusValue;
 
 	public ProcessedGradeItemStatus(final int statusCode) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -42,7 +42,6 @@ public class ImportGradesHelper {
 	// column names we know about
 	final static String IMPORT_USER_ID = "Student ID";
 	final static String IMPORT_USER_NAME = "Student Name";
-	final static String IMPORT_COURSE_GRADE = "Course Grade";
 
 	// patterns for detecting column headers and their types
 	final static Pattern ASSIGNMENT_WITH_POINTS_PATTERN = Pattern.compile("([\\w ]+ \\[[0-9]+(\\.[0-9][0-9]?)?\\])");
@@ -168,17 +167,8 @@ public class ImportGradesHelper {
 			} else if (StringUtils.equals(importColumn.getColumnTitle(), IMPORT_USER_NAME)) {
 				grade.setStudentName(lineVal);
 
-			// process cours egrade column
-			} else if (StringUtils.equals(importColumn.getColumnTitle(), IMPORT_COURSE_GRADE)) {
-				ImportedGradeItem courseGradeItem = grade.getGradeItemMap().get(IMPORT_COURSE_GRADE);
-				if (courseGradeItem == null) {
-					courseGradeItem = new ImportedGradeItem(IMPORT_COURSE_GRADE);
-				}
-				courseGradeItem.setGradeItemScore(lineVal);
-				grade.getGradeItemMap().put(IMPORT_COURSE_GRADE, courseGradeItem);
-
 			//process item with points column
-			} else if (ImportColumn.TYPE_ITEM_WITH_POINTS == importColumn.getType()) {
+			} else if (importColumn.getType() == ImportColumn.Type.GBITEM_WITH_POINTS) {
 				final String assignmentName = importColumn.getColumnTitle();
 				ImportedGradeItem importedGradeItem = grade.getGradeItemMap().get(assignmentName);
 				if (importedGradeItem == null) {
@@ -188,7 +178,7 @@ public class ImportGradesHelper {
 				grade.getGradeItemMap().put(assignmentName, importedGradeItem);
 
 			//process comments
-			} else if (ImportColumn.TYPE_ITEM_WITH_COMMENTS == importColumn.getType()) {
+			} else if (importColumn.getType() == ImportColumn.Type.GBITEM_WITH_COMMENTS) {
 				final String assignmentName = importColumn.getColumnTitle();
 				ImportedGradeItem importedGradeItem = grade.getGradeItemMap().get(assignmentName);
 				if (importedGradeItem == null) {
@@ -197,8 +187,14 @@ public class ImportGradesHelper {
 				importedGradeItem.setGradeItemComment(lineVal);
 				grade.getGradeItemMap().put(assignmentName, importedGradeItem);
 
-			} else {
-
+			// process any left overs. These will be gb items without points
+			} else if (importColumn.getType() == ImportColumn.Type.REGULAR) {
+				final String assignmentName = importColumn.getColumnTitle();
+				ImportedGradeItem importedGradeItem = grade.getGradeItemMap().get(assignmentName);
+				if (importedGradeItem == null) {
+					importedGradeItem = new ImportedGradeItem(assignmentName);
+				}
+				grade.getGradeItemMap().put(assignmentName, importedGradeItem);
 			}
 		}
 
@@ -231,18 +227,26 @@ public class ImportGradesHelper {
 			final Assignment assignment = assignmentNameMap.get(assignmentName);
 			final ProcessedGradeItemStatus status = determineStatus(column, assignment, importedGradeWrapper, transformedGradeMap);
 
-			if (column.getType() == ImportColumn.TYPE_ITEM_WITH_POINTS) {
+			// skip the student columns
+			if(StringUtils.equals(column.getColumnTitle(), IMPORT_USER_ID) ||
+					StringUtils.equals(column.getColumnTitle(), IMPORT_USER_NAME)) {
+				continue;
+			}
+
+			if (column.getType() == ImportColumn.Type.GBITEM_WITH_POINTS) {
 				processedGradeItem.setItemTitle(assignmentName);
 				processedGradeItem.setItemPointValue(column.getPoints());
 				processedGradeItem.setStatus(status);
-			} else if (column.getType() == ImportColumn.TYPE_ITEM_WITH_COMMENTS) {
-
-				// internal only, no longer displayed, but used to link up the columns as it is unique
+			} else if (column.getType() == ImportColumn.Type.GBITEM_WITH_COMMENTS) {
 				processedGradeItem.setCommentLabel(assignmentName + " Comments");
 				processedGradeItem.setCommentStatus(status);
+			} else if (column.getType() == ImportColumn.Type.REGULAR) {
+				log.debug("Title: " + assignmentName + ", status: " + status.getStatusCode());
+				processedGradeItem.setItemTitle(assignmentName);
+				processedGradeItem.setStatus(status);
 			} else {
 				// Just get out
-				log.warn("Bad column type - " + column.getType() + ".  Skipping.");
+				log.warn("Bad column. Type: " + column.getType() + ", header: " + assignmentName + ".  Skipping.");
 				continue;
 			}
 
@@ -275,9 +279,18 @@ public class ImportGradesHelper {
 
 	}
 
+	/**
+	 * Determine the status of a column
+	 * @param column
+	 * @param assignment
+	 * @param importedGradeWrapper
+	 * @param transformedGradeMap
+	 * @return
+	 */
 	private static ProcessedGradeItemStatus determineStatus(final ImportColumn column, final Assignment assignment,
 			final ImportedGradeWrapper importedGradeWrapper,
 			final Map<Long, AssignmentStudentGradeInfo> transformedGradeMap) {
+
 		ProcessedGradeItemStatus status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_UNKNOWN);
 		if (assignment == null) {
 			status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_NEW);
@@ -307,19 +320,23 @@ public class ImportGradesHelper {
 					importedComment = importedGradeItem.getGradeItemComment();
 				}
 
-				if (column.getType() == ImportColumn.TYPE_ITEM_WITH_POINTS) {
+				if (column.getType() == ImportColumn.Type.GBITEM_WITH_POINTS) {
 					final String trimmedImportedScore = StringUtils.removeEnd(importedScore, ".0");
 					final String trimmedActualScore = StringUtils.removeEnd(actualScore, ".0");
 					if (trimmedImportedScore != null && !trimmedImportedScore.equals(trimmedActualScore)) {
 						status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_UPDATE);
 						break;
 					}
-				} else if (column.getType() == ImportColumn.TYPE_ITEM_WITH_COMMENTS) {
+				} else if (column.getType() == ImportColumn.Type.GBITEM_WITH_COMMENTS) {
 					if (importedComment != null && !importedComment.equals(actualComment)) {
 						status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_UPDATE);
 						break;
 					}
+				} else if (column.getType() == ImportColumn.Type.REGULAR) {
+					status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_UPDATE);
+					break;
 				}
+
 			}
 			// If we get here, must not have been any changes
 			if (status.getStatusCode() == ProcessedGradeItemStatus.STATUS_UNKNOWN) {
@@ -382,8 +399,6 @@ public class ImportGradesHelper {
 	private static ImportColumn parseHeaderForImportColumn(final String headerValue) throws GbImportExportException {
 		final ImportColumn importColumn = new ImportColumn();
 
-		System.out.println("headerValue: " + headerValue + "%%%");
-
 		// assignment with points header
 		final Matcher m1 = ASSIGNMENT_WITH_POINTS_PATTERN.matcher(headerValue);
 		if (m1.matches()) {
@@ -399,7 +414,7 @@ public class ImportGradesHelper {
 				importColumn.setPoints(pointsMatcher.group());
 			}
 
-			importColumn.setType(ImportColumn.TYPE_ITEM_WITH_POINTS);
+			importColumn.setType(ImportColumn.Type.GBITEM_WITH_POINTS);
 
 			return importColumn;
 		}
@@ -413,7 +428,7 @@ public class ImportGradesHelper {
 			if (titleMatcher.find()) {
 				importColumn.setColumnTitle(trim(titleMatcher.group()));
 			}
-			importColumn.setType(ImportColumn.TYPE_ITEM_WITH_COMMENTS);
+			importColumn.setType(ImportColumn.Type.GBITEM_WITH_COMMENTS);
 
 			return importColumn;
 		}
@@ -422,7 +437,7 @@ public class ImportGradesHelper {
 		if (m3.matches()) {
 
 			importColumn.setColumnTitle(headerValue);
-			importColumn.setType(ImportColumn.TYPE_REGULAR);
+			importColumn.setType(ImportColumn.Type.REGULAR);
 
 			return importColumn;
 		}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -48,7 +48,7 @@ public class ImportGradesHelper {
 	final static Pattern ASSIGNMENT_COMMENT_PATTERN = Pattern.compile("(\\* [\\w ]+)");
 	final static Pattern STANDARD_HEADER_PATTERN = Pattern.compile("([\\w ]+)");
 	final static Pattern POINTS_PATTERN = Pattern.compile("(\\d+)(?=]$)");
-	final static Pattern IGNORE_PATTERN = Pattern.compile("(\\#[\\w ]+)");
+	final static Pattern IGNORE_PATTERN = Pattern.compile("(\\#.+)");
 
 	/**
 	 * Parse a CSV into a list of ImportedGrade objects. Returns list if ok, or null if error
@@ -333,7 +333,8 @@ public class ImportGradesHelper {
 						break;
 					}
 				} else if (column.getType() == ImportColumn.Type.REGULAR) {
-					status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_UPDATE);
+					//must be NA if it isn't new
+					status = new ProcessedGradeItemStatus(ProcessedGradeItemStatus.STATUS_NA);
 					break;
 				}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
@@ -14,6 +14,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
+import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.gradebookng.tool.panels.AddOrEditGradeItemPanelContent;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
@@ -51,7 +52,9 @@ public class CreateGradeItemStep extends Panel {
         // setup new assignment for populating
         final Assignment assignment = new Assignment();
         assignment.setName(StringUtils.trim(processedGradeItem.getItemTitle()));
-        assignment.setPoints(Double.parseDouble(processedGradeItem.getItemPointValue()));
+        if(StringUtils.isNotBlank(processedGradeItem.getItemPointValue())) {
+        	assignment.setPoints(Double.parseDouble(processedGradeItem.getItemPointValue()));
+        }
 
         final Model<Assignment> assignmentModel = new Model<>(assignment);
 
@@ -89,6 +92,10 @@ public class CreateGradeItemStep extends Panel {
                     newPanel = new GradeImportConfirmationStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
                 }
 
+                // clear any previous errors
+				final ImportExportPage page = (ImportExportPage) getPage();
+				page.clearFeedback();
+
                 newPanel.setOutputMarkupId(true);
                 CreateGradeItemStep.this.replaceWith(newPanel);
 
@@ -101,7 +108,11 @@ public class CreateGradeItemStep extends Panel {
 
 			@Override
             public void onSubmit() {
-                log.debug("Clicking back button...");
+
+				// clear any previous errors
+				final ImportExportPage page = (ImportExportPage) getPage();
+				page.clearFeedback();
+
                 Component newPanel = null;
                 if (step > 1) {
                     importWizardModel.setStep(step-1);
@@ -110,10 +121,9 @@ public class CreateGradeItemStep extends Panel {
                 else {
                     newPanel = new GradeItemImportSelectionStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
                 }
+
                 newPanel.setOutputMarkupId(true);
                 CreateGradeItemStep.this.replaceWith(newPanel);
-
-
             }
         };
         backButton.setDefaultFormProcessing(false);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -25,6 +25,7 @@ import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItemDetail;
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
 import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameException;
@@ -167,16 +168,20 @@ public class GradeImportConfirmationStep extends Panel {
 
 			@Override
 			public void onSubmit() {
-				log.debug("Clicking back button...");
+
+				// clear any previous errors
+				final ImportExportPage page = (ImportExportPage) getPage();
+				page.clearFeedback();
+
 				Component newPanel = null;
 				if (assignmentsToCreate.size() > 0) {
 					newPanel = new CreateGradeItemStep(GradeImportConfirmationStep.this.panelId, Model.of(importWizardModel));
 				} else {
 					newPanel = new GradeItemImportSelectionStep(GradeImportConfirmationStep.this.panelId, Model.of(importWizardModel));
 				}
+
 				newPanel.setOutputMarkupId(true);
 				GradeImportConfirmationStep.this.replaceWith(newPanel);
-
 			}
 		};
 		backButton.setDefaultFormProcessing(false);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -37,9 +37,8 @@ public class GradeImportUploadStep extends Panel {
 	private static final long serialVersionUID = 1L;
 
 	// list of mimetypes for each category. Must be compatible with the parser
-	private static final String[] XLS_MIME_TYPES = { "application/vnd.ms-excel",
-			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" };
-	private static final String[] CSV_MIME_TYPES = { "text/csv" };
+	private static final String[] XLS_MIME_TYPES = { "application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" };
+	private static final String[] CSV_MIME_TYPES = { "text/csv", "text/plain", "text/comma-separated-values", "application/csv" };
 
 	private final String panelId;
 
@@ -103,9 +102,9 @@ public class GradeImportUploadStep extends Panel {
 					final ImportedGradeWrapper importedGradeWrapper = parseImportedGradeFile(upload.getInputStream(),
 							upload.getContentType(), userMap);
 
-					// couldn't parse
+					// incorrect file type?
 					if(importedGradeWrapper == null) {
-						error(getString("importExport.error.badfile"));
+						error(getString("importExport.error.incorrecttype"));
 						return;
 					}
 
@@ -118,8 +117,10 @@ public class GradeImportUploadStep extends Panel {
 
 					// if null, the file was of the incorrect type
 					// if empty there are no users
-					if (processedGradeItems == null || processedGradeItems.isEmpty()) {
-						error(getString("importExport.error.badfile"));
+					if (processedGradeItems == null) {
+						error(getString("importExport.error.incorrectformat"));
+					} else if (processedGradeItems.isEmpty()) {
+						error(getString("importExport.error.empty"));
 					} else {
 						// GO TO NEXT PAGE
 						log.debug(processedGradeItems.size());

--- a/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/helpers/TestImportGradesHelper.java
+++ b/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/helpers/TestImportGradesHelper.java
@@ -91,7 +91,7 @@ public class TestImportGradesHelper {
 
 		Assert.assertNotNull(processedGradeItems);
 
-		Assert.assertEquals("wrong number of results", 4, processedGradeItems.size());
+		Assert.assertEquals("Wrong number of columns", 4, processedGradeItems.size());
 
 		// assignment 1
 		Assert.assertEquals("wrong status", ProcessedGradeItemStatus.STATUS_NA, processedGradeItems.get(0).getStatus().getStatusCode());
@@ -117,7 +117,7 @@ public class TestImportGradesHelper {
 
 	/**
 	 * Mock up some assignment data
-	 * 
+	 *
 	 * @return List of mocked assignments
 	 */
 	private List<Assignment> mockAssignments() {
@@ -147,7 +147,7 @@ public class TestImportGradesHelper {
 
 	/**
 	 * Mock up some student grade data
-	 * 
+	 *
 	 * @return
 	 */
 	private List<GbStudentGradeInfo> mockStudentGrades() {
@@ -193,15 +193,18 @@ public class TestImportGradesHelper {
 	private ImportedGradeWrapper mockImportedGrades() {
 		final ImportedGradeWrapper importedGradeWrapper = new ImportedGradeWrapper();
 		final List<ImportColumn> columns = new ArrayList<ImportColumn>();
-		columns.add(new ImportColumn("Student ID", null, ImportColumn.TYPE_REGULAR));
-		columns.add(new ImportColumn("Student Name", null, ImportColumn.TYPE_REGULAR));
-		columns.add(new ImportColumn("Assignment 1", "10.0", ImportColumn.TYPE_ITEM_WITH_POINTS));
-		columns.add(new ImportColumn("Assignment 1", "N/A", ImportColumn.TYPE_ITEM_WITH_COMMENTS));
-		columns.add(new ImportColumn("Assignment 2", "10.0", ImportColumn.TYPE_ITEM_WITH_POINTS));
-		columns.add(new ImportColumn("Assignment 2", "N/A", ImportColumn.TYPE_ITEM_WITH_COMMENTS));
-		columns.add(new ImportColumn("Assignment 3", "100.0", ImportColumn.TYPE_ITEM_WITH_POINTS));
-		columns.add(new ImportColumn("Assignment 3", "N/A", ImportColumn.TYPE_ITEM_WITH_COMMENTS));
-		columns.add(new ImportColumn("Assignment Ext", "1000.0", ImportColumn.TYPE_ITEM_WITH_POINTS));
+
+
+		// only list actual columns to be turned into the import here
+		columns.add(new ImportColumn("Student ID", null, ImportColumn.Type.REGULAR));
+		columns.add(new ImportColumn("Student Name", null, ImportColumn.Type.REGULAR));
+		columns.add(new ImportColumn("Assignment 1", "10.0", ImportColumn.Type.GBITEM_WITH_POINTS));
+		columns.add(new ImportColumn("Assignment 1", "N/A", ImportColumn.Type.GBITEM_WITH_COMMENTS));
+		columns.add(new ImportColumn("Assignment 2", "10.0", ImportColumn.Type.GBITEM_WITH_POINTS));
+		columns.add(new ImportColumn("Assignment 2", "N/A", ImportColumn.Type.GBITEM_WITH_COMMENTS));
+		columns.add(new ImportColumn("Assignment 3", "100.0", ImportColumn.Type.GBITEM_WITH_POINTS));
+		columns.add(new ImportColumn("Assignment 3", "N/A", ImportColumn.Type.GBITEM_WITH_COMMENTS));
+		columns.add(new ImportColumn("Assignment Ext", "1000.0", ImportColumn.Type.GBITEM_WITH_POINTS));
 
 		importedGradeWrapper.setColumns(columns);
 
@@ -256,4 +259,6 @@ public class TestImportGradesHelper {
 
 		return importedGradeWrapper;
 	}
+
+
 }


### PR DESCRIPTION
This delivers a few fixes.

1.  Part of #1396 - allow import of gradebook items without points.
2. Fixes #3100, error message box should now be cleared between steps.
3. Fixes #2796, any type of column should be ignored if it starts with a #. Also the error messages are more granular.
