### PR TITLE
SAK-31606 Button text is hard to see on hidden folders

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -197,11 +197,11 @@
 		padding-left:10px;
 	}
 	.inactive button {
-		color: #000 !important;
+		color: #fff !important;
 		border:1px solid #ccc !important;
 	}
 	.inactive button span {
-		color: #000 !important;
+		color: #fff !important;
 	}
 	.inactive .dropdown-menu a {
 		color:#000 !important;


### PR DESCRIPTION
The Actions menu is just as active as on a non-hidden folder - unlike the folder (or file) it is not different from any other Actions menu