### PR TITLE
Don't cache artifacts from our own build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ sudo: false
 cache:
  directories:
  - $HOME/.m2
+
+# We don't want to cache our own artifacts, just the externally downloaded ones.
+# This makes the cache smaller and helps highlight problems with a clean build
+before_cache:
+ - find $HOME/.m2/repository/org/sakaiproject -name \*-SNAPSHOT.\*  -delete


### PR DESCRIPTION
Artifacts that are part of our own build shouldn't be cached. This should make the travis caches small but also help us detect build issues that would fail against a clean repository.