### PR TITLE
LSNBLDR-708; make save of topic work consistently

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
@@ -1011,7 +1011,9 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
           //sak-5146 saveDiscussionForum(discussionForum, parentForumDraftStatus);
             
         } else {
-            getHibernateTemplate().saveOrUpdate(topic);
+	    // LSNBLDR-708 we've checked that it's existing, so it's always an update. Need merge or Lessons sometimes fails to save
+	    getHibernateTemplate().merge(topic);	    
+	    // getHibernateTemplate().saveOrUpdate(topic);
         }
         //now schedule any jobs that are needed for the open/close dates
         //this will require having the ID of the topic (if its a new one)


### PR DESCRIPTION
This should at least for considered for 11.1. It's needed for Lessons access control to work reliably for forums.

It replaced a hibernate saveOrUpdate with merge. It's in a conditional that verifies that the object already exists, so only the update is needed. Merge works like update, but handles the situation where there's another object with the same ID. I've been unable to find a way to fix that error any other way. The change should be harmless.
