### PR TITLE
SAK-31641 Switch to VARCHAR rather than INTs for enum.

### DIFF
--- a/oauth/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Accessor.hbm.xml
+++ b/oauth/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Accessor.hbm.xml
@@ -37,11 +37,13 @@
         <property name="status">
             <type name="org.hibernate.type.EnumType">
                 <param name="enumClass">org.sakaiproject.oauth.domain.Accessor$Status</param>
+                <param name="type">12</param><!-- Make it a string -->
             </type>
         </property>
         <property name="type">
             <type name="org.hibernate.type.EnumType">
                 <param name="enumClass">org.sakaiproject.oauth.domain.Accessor$Type</param>
+                <param name="type">12</param><!-- Make it a string -->
             </type>
         </property>
         <property name="accessorSecret"/>

--- a/reference/docs/conversion/sakai_12_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_12_mysql_conversion.sql
@@ -126,3 +126,24 @@ create unique index dash_lock_ts_idx on dash_task_lock (task, server_id);
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-99', '!user', 'Dashboard', '0', 0, '0' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-999', '!user-99', '!user', 'sakai.dashboard', 1, 'Dashboard', NULL );
 
+-- 
+-- SAK-31641 Switch from INTs to VARCHARs in Oauth
+-- 
+ALTER TABLE OAUTH_ACCESSORS
+CHANGE
+  status status VARCHAR(255),
+  CHANGE type type VARCHAR(255)
+;
+
+UPDATE OAUTH_ACCESSORS SET status = CASE
+  WHEN status = 0 THEN "VALID"
+  WHEN status = 1 THEN "REVOKED"
+  WHEN status = 2 THEN "EXPIRED"
+END;
+
+UPDATE OAUTH_ACCESSORS SET type = CASE
+  WHEN type = 0 THEN "REQUEST"
+  WHEN type = 1 THEN "REQUEST_AUTHORISING"
+  WHEN type = 2 THEN "REQUEST_AUTHORISED"
+  WHEN type = 3 THEN "ACCESS"
+END;

--- a/reference/docs/conversion/sakai_12_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_12_oracle_conversion.sql
@@ -139,3 +139,24 @@ create unique index dash_lock_ts_idx on dash_task_lock (task, server_id);
 INSERT INTO SAKAI_SITE_PAGE VALUES('!user-99', '!user', 'Dashboard', '0', 0, '0' );
 INSERT INTO SAKAI_SITE_TOOL VALUES('!user-999', '!user-99', '!user', 'sakai.dashboard', 1, 'Dashboard', NULL );
 
+--
+-- SAK-31641 Switch from INTs to VARCHARs in Oauth
+--
+ALTER TABLE oauth_accessors
+MODIFY (
+  status VARCHAR2(255)
+, type VARCHAR2(255)
+);
+
+UPDATE oauth_accessors SET status = CASE
+  WHEN status = 0 THEN 'VALID'
+  WHEN status = 1 THEN 'REVOKED'
+  WHEN status = 2 THEN 'EXPIRED'
+END;
+
+UPDATE oauth_accessors SET type = CASE
+  WHEN type = 0 THEN 'REQUEST'
+  WHEN type = 1 THEN 'REQUEST_AUTHORISING'
+  WHEN type = 2 THEN 'REQUEST_AUTHORISED'
+  WHEN type = 3 THEN 'ACCESS'
+END;


### PR DESCRIPTION
This makes the oauth code use VARCHARs rather than INTs for it’s enums as it makes the database more readable and helps to prevent problems when enums are changed.

This is also needed as we currently have this setup from our 10.x OAuth deployment and migrating to INTs seems like a backwards step.