### PR TITLE
SAM-2996 user data is lost when violating rules in a matrix of choices question

### DIFF
--- a/samigo/samigo-app/src/webapp/js/samigo-global.js
+++ b/samigo/samigo-app/src/webapp/js/samigo-global.js
@@ -61,6 +61,7 @@ $( document ).ready(function() {
 function whichradio(el) {
 	var parentTable = $(el).closest('table');
 	var forcedRanking;
+	var allowChange = true;
 	// resolve the property for this instance
 	$(parentTable).siblings('input[type=hidden]').each(
 			function() {
@@ -86,8 +87,11 @@ function whichradio(el) {
 		$('input[type=radio]',parentTable).not(el).each(function(){
 			var id = $(this).prop('id');
 			if(id.indexOf(colId) !== -1 && $(this).is(':checked')) {
-				$(this).prop('checked',false);
+				alert("You are only allowed one selection per column, please try again.");
+				allowChange = false;
 			}
 		});
 	}
+
+	return allowChange;
 }

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMatrixChoicesSurvey.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMatrixChoicesSurvey.jsp
@@ -72,7 +72,7 @@ should be included in file importing DeliveryMessages
        			value="#{matrixBean.responseId}"
        			disabled="#{delivery.actionString=='reviewAssessment'|| delivery.actionString=='gradeAssessment'}"
        			itemValue="#{matrixBean.answerSid[colIndex]}"
-       			onClick="javascript:whichradio(this);" />
+       			onClick="if( whichradio(this) !== true ) {return false;}" />
          </t:columns>
          </t:dataTable>
      <f:verbatim><br /></f:verbatim>      


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2996

When answering a matrix of choices question using forced ranking, if you fill in all the columns and then try to change one, you get a pop-up alert telling you this is not allowed (in 10.x). However, it clears the user's previous (valid) selection for the column in question in this scenario, and the user may not notice this. This can result in the user submitting the question without realizing one of their answers/selections had been cleared out.

In 10.x, this bug clears out the user's previous choice in the given row. In 11.x+, this has actually gotten worse. You are no longer even given the message stating that this is not allowed (regression), and the JavaScript code not only clears the user's choice for the given row, but also their previously selected radio button for the column in question. So the user effectively loses two of their valid selections, and is not presented with any message indicating what happened.

The linked PR reintroduces the message that is presented to the user, and preserves all previous valid input for the radio buttons.