### PR TITLE
3116 fixes Firefox form POST issues

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
@@ -11,6 +11,9 @@ import org.apache.wicket.settings.IRequestCycleSettings.RenderStrategy;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 import org.sakaiproject.gradebookng.tool.pages.ErrorPage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
+import org.sakaiproject.gradebookng.tool.pages.PermissionsPage;
+import org.sakaiproject.gradebookng.tool.pages.SettingsPage;
 
 /**
  * Main application class
@@ -25,11 +28,10 @@ public class GradebookNgApplication extends WebApplication {
 		super.init();
 
 		// page mounting for bookmarkable URLs
-		// not really compatible with the ONE_PASS_RENDER as the mountpoints are always one previous to current page
-		// mountPage("/grades", GradebookPage.class);
-		// mountPage("/settings", SettingsPage.class);
-		// mountPage("/importexport", ImportExportPage.class);
-		// mountPage("/permissions", PermissionsPage.class);
+		mountPage("/", GradebookPage.class);
+		mountPage("/settings", SettingsPage.class);
+		mountPage("/importexport", ImportExportPage.class);
+		mountPage("/permissions", PermissionsPage.class);
 
 		// remove the version number from the URL so that browser refreshes re-render the page
 		getRequestCycleSettings().setRenderStrategy(RenderStrategy.ONE_PASS_RENDER);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -84,7 +84,7 @@ public class BasePage extends WebPage {
 
 			@Override
 			public void onClick() {
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 			@Override
@@ -102,7 +102,7 @@ public class BasePage extends WebPage {
 
 			@Override
 			public void onClick() {
-				setResponsePage(new ImportExportPage());
+				setResponsePage(ImportExportPage.class);
 			}
 
 			@Override
@@ -119,7 +119,7 @@ public class BasePage extends WebPage {
 
 			@Override
 			public void onClick() {
-				setResponsePage(new PermissionsPage());
+				setResponsePage(PermissionsPage.class);
 			}
 
 			@Override
@@ -136,7 +136,7 @@ public class BasePage extends WebPage {
 
 			@Override
 			public void onClick() {
-				setResponsePage(new SettingsPage());
+				setResponsePage(SettingsPage.class);
 			}
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -556,7 +556,7 @@ public class GradebookPage extends BasePage {
 				setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 			@Override
@@ -634,7 +634,7 @@ public class GradebookPage extends BasePage {
 				setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 		});

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -173,7 +173,7 @@ public class SettingsPage extends BasePage {
 
 			@Override
 			public void onSubmit() {
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 		};
 		cancel.setDefaultFormProcessing(false);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AssignmentColumnHeaderPanel.java
@@ -96,7 +96,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 				gradebookPage.setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 		};
@@ -241,7 +241,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 					AssignmentColumnHeaderPanel.this.businessService.updateAssignmentOrder(assignmentId.longValue(), (order - 1));
 				}
 
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 			@Override
@@ -280,7 +280,7 @@ public class AssignmentColumnHeaderPanel extends Panel {
 					AssignmentColumnHeaderPanel.this.businessService.updateAssignmentOrder(assignmentId.longValue(), (order + 1));
 				}
 
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CategoryColumnHeaderPanel.java
@@ -65,7 +65,7 @@ public class CategoryColumnHeaderPanel extends Panel {
 				gradebookPage.setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 		};

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeColumnHeaderPanel.java
@@ -68,7 +68,7 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 				gradebookPage.setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 		};
@@ -145,7 +145,7 @@ public class CourseGradeColumnHeaderPanel extends Panel {
 				gradebookPage.setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/DeleteItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/DeleteItemPanel.java
@@ -49,7 +49,7 @@ public class DeleteItemPanel extends Panel {
 				DeleteItemPanel.this.businessService.removeAssignment(assignmentIdToDelete);
 
 				getSession().success(MessageFormat.format(getString("delete.success"), assignmentTitle));
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 
 		};

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/HeaderFlagPopoverPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/HeaderFlagPopoverPanel.java
@@ -69,7 +69,7 @@ public class HeaderFlagPopoverPanel extends Panel {
 				final Link link = new Link("link") {
 					@Override
 					public void onClick() {
-						setResponsePage(new SettingsPage());
+						setResponsePage(SettingsPage.class);
 					}
 				};
 				link.add(new Label("linkText", getString("label.coursegrade.editsettings")));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNameColumnHeaderPanel.java
@@ -68,7 +68,7 @@ public class StudentNameColumnHeaderPanel extends Panel {
 				gradebookPage.setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 		};
 
@@ -103,7 +103,7 @@ public class StudentNameColumnHeaderPanel extends Panel {
 				gradebookPage.setUiSettings(settings);
 
 				// refresh
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 
 			}
 		};

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -104,7 +104,7 @@ public class UpdateUngradedItemsPanel extends Panel {
 
 					if (success) {
 						UpdateUngradedItemsPanel.this.window.close(target);
-						setResponsePage(new GradebookPage());
+						setResponsePage(GradebookPage.class);
 					} else {
 						// InvalidGradeException
 						error(getString("grade.notifications.invalid"));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ZeroUngradedItemsPanel.java
@@ -52,7 +52,7 @@ public class ZeroUngradedItemsPanel extends Panel {
 				}
 
 				ZeroUngradedItemsPanel.this.window.close(target);
-				setResponsePage(new GradebookPage());
+				setResponsePage(GradebookPage.class);
 			}
 		};
 		add(submit);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -155,7 +155,7 @@ public class GradeImportConfirmationStep extends Panel {
 
 				if (!this.errors) {
 					getSession().success(getString("importExport.confirmation.success"));
-					setResponsePage(new GradebookPage());
+					setResponsePage(GradebookPage.class);
 				}
 				//auto refresh will render the errors
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -81,7 +81,7 @@ public class GradeImportUploadStep extends Panel {
 			final Button cancel = new Button("cancelbutton") {
 				@Override
 				public void onSubmit() {
-					setResponsePage(new GradebookPage());
+					setResponsePage(GradebookPage.class);
 				}
 			};
 			cancel.setDefaultFormProcessing(false);


### PR DESCRIPTION
Delivers #3116.

This fixes a Firefox bug, whereby navigating the GradebookNG tool and returning to the Grades sepreadsheet causes all subsequent POST requests to fail with a 302 redirect.

To fix, set mount points for the 4 GradebookNG pages, so the base page is always consistent.  Secondly, use the class variant of setResponsePage to navigate to those mount points.

I haven't set a milestone yet.. 11.2 so we can get some reasonable testing in?