### PR TITLE
2655: Add gradebook grades table caption and target to screen readers

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -264,6 +264,8 @@ message.addcoursegradeoverride.invalid = The course grade entered is invalid acc
 
 message.updateungradeditems.success=The ungraded items were updated.
 
+gradespage.caption = Rows of student names. Columns of gradebook items. Press enter key in a cell to add or edit a grade. Two tabs to move through each cell. Filter list with accesskey F.
+
 grade.option.viewlog = Grade Log
 grade.log.entry = {0} - Score set to <b>{1}</b> by {2}
 grade.log.none = No grades have been entered for this cell.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -492,6 +492,11 @@ public class GradebookPage extends BasePage {
 					}
 				};
 			}
+
+			@Override
+			protected IModel<String> getCaptionModel() {
+				return Model.of(getString("gradespage.caption"));
+			}
 		};
 		table.addBottomToolbar(new NavigationToolbar(table) {
 			@Override

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -428,6 +428,7 @@ GradebookSpreadsheet.prototype.setupFixedTableHeader = function(reset) {
                         attr("class", self.$table.attr("class")).
                         addClass("gb-fixed-header-table").
                         attr("role", "presentation").
+                        attr("aria-hidden", "true").
                         hide();
 
   var $fixedHeaderHead = $("<thead>");
@@ -493,11 +494,13 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
   self.$fixedColumnsHeader = $("<table>").attr("class", self.$table.attr("class")).
                                           addClass("gb-fixed-column-headers-table").
                                           attr("role", "presentation").
+                                          attr("aria-hidden", "true").
                                           hide();
 
   self.$fixedColumns = $("<table>").attr("class", self.$table.attr("class")).
                                     addClass("gb-fixed-columns-table").
                                     attr("role", "presentation").
+                                    attr("aria-hidden", "true").
                                     hide();
 
   var $headers = self.$table.find("> thead > tr.gb-headers > th").slice(0,3);

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -220,6 +220,17 @@
 #gradebookGrades .btn.dropdown-toggle:focus {
   border: 1px solid #DDD;
 }
+#gradebookGrades #gradebookGradesTable caption {
+  /* hide the caption from users, but retain for screen readers */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
 #gradebookGrades #gradebookGradesTable tfoot .gb-cell-inner {
   /* ensure there's enough room at the bottom of the scrollable div
      so that the bottom-most menus display without being cropped */


### PR DESCRIPTION
Also use aria-hidden on presentation tables, as text in table still read by screenreader  when role='presentation' alone.

Delivers #2655.