### PR TITLE
SAK-31649 disable file picker file type filters in Assignments for submissions

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -1472,7 +1472,11 @@ public class AssignmentAction extends PagedResourceActionII
 				if (!contentReviewService.allowAllContent() && assignmentSubmissionTypeTakesAttachments(assignment))
 				{
 					context.put("plagiarismFileTypes", rb.getFormattedMessage("gen.onlythefoll", getContentReviewAcceptedFileTypesMessage()));
-					context.put("content_review_acceptedMimeTypes", getContentReviewAcceptedMimeTypes());
+
+					// SAK-31649 commenting this out to remove file picker filters, as the results vary depending on OS and browser.
+					// If in the future browser support for the 'accept' attribute on a file picker becomes more robust and 
+					// ubiquitous across browsers, we can re-enable this feature.
+					//context.put("content_review_acceptedMimeTypes", getContentReviewAcceptedMimeTypes());
 				}
 			}
 			if (assignment.getContent().getTypeOfSubmission() == Assignment.NON_ELECTRONIC_ASSIGNMENT_SUBMISSION)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31649

The intention of these filters is to force the browser to only display file types that the Content Review Service accepts. Unfortunately, OS/browser support for the 'accept' attribute on a file picker is sporadic at best.

For instance, on Linux/Chromium, the default filter selected only shows .txt and .html files. Only after selecting the 'All Files' filter can you see the rest of the file types that the CRS accepts.

In Windows/IE, the default filter is "Custom Files", and only shows you *.odt, *.ps, *.htm, *.htm (yes it's repeated), *.pdf, *.ps (again, repeated), and *.txt. The other filter options are:
* "HTML", which shows you *.html and *.htm
* "Pictures", which shows you *.gif, *.jpg, *.jpeg and *.png (this filter is useless in terms of TII, and likely most other CR services)
* "All Files", .

This feature has proved quite problematic at our institution, and causes more confusion rather than being helpful.

Commenting out the single line of code that provides the 'accept' attribute on the file pickers effectively 'disables' this feature. By preserving the rest of the code, we can revisit this at a later time, when browser support becomes more robust.

No filters are provided in the file picker with this line commented out. There is still validation on the file types/mime types after the user selects the file, and an error message will be presented to the user at the top of the screen if they try to upload a file type which is not allowed by the CRS.