### PR TITLE
KNL-1451 - Add metadata to event tracking service

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/event/api/Event.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/api/Event.java
@@ -45,6 +45,13 @@ public interface Event extends Serializable
 	 */
 	String getResource();
 
+    /**
+	 * Access the resource metadata.
+	 * 
+	 * @return The metadata string.
+	 */
+	String getMetadata();
+
 	/**
 	 * Access the event context
 	 * 

--- a/kernel/api/src/main/java/org/sakaiproject/event/api/EventTrackingService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/api/EventTrackingService.java
@@ -84,6 +84,25 @@ public interface EventTrackingService
 	 */
 	Event newEvent(String event, String resource, String context, boolean modify, int priority);
 
+/**
+	 * Construct a Event object.
+	 * 
+	 * @param event
+	 *        The Event id.
+	 * @param resource
+	 *        The resource reference.
+	 * @param context
+	 *        The Event's context (may be null).
+	 * @param modify
+	 *        Set to true if this event caused a resource modification, false if it was just an access.
+	 * @param priority
+	 *        The Event's notification priority. Use NotificationService.NOTI_OPTIONAL as default.
+	 * @param metadata
+	 *        Additional, optional currently unpersisted metadata (null is the default)
+	 * @return A new Event object that can be used with this service.
+	 */
+	Event newEvent(String event, String resource, String context, boolean modify, int priority, String metadata);
+
 	/**
 	 * Post an event
 	 * 

--- a/kernel/api/src/main/java/org/sakaiproject/event/api/SimpleEvent.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/api/SimpleEvent.java
@@ -57,6 +57,7 @@ public class SimpleEvent implements Event {
         setPriority(event.getPriority());
         setEventTime(event.getEventTime());
         setServerId(serverId);
+        setMetadata(event.getMetadata());
     }
 
     /** The Event's sequence number. */
@@ -67,6 +68,9 @@ public class SimpleEvent implements Event {
 
     /** The Event's resource reference string. */
     protected String resource = "";
+
+    /** The Event's metadata reference string */
+    protected String metadata = null;
 
     /** The Event's context. May be null. */
     protected String context = null;
@@ -125,6 +129,25 @@ public class SimpleEvent implements Event {
      */
     public void setResource(String id) {
         resource = (id != null) ? id : "";
+    }
+    
+    /**
+     * Access the resource metadata.
+     * 
+     * @return The resource metadata string.
+     */
+    public String getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Set the resource id.
+     * 
+     * @param id
+     *        The resource id string.
+     */
+    public void setMetadata(String id) {
+        metadata = (id != null) ? id : "";
     }
 
     /**

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/BaseEventTrackingService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/BaseEventTrackingService.java
@@ -187,7 +187,7 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 	 */
 	public Event newEvent(String event, String resource, boolean modify)
 	{
-		return new BaseEvent(event, resource, modify, NotificationService.NOTI_OPTIONAL);
+		return new BaseEvent(event, resource, modify, NotificationService.NOTI_OPTIONAL, null);
 	}
 
 	/**
@@ -205,7 +205,7 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 	 */
 	public Event newEvent(String event, String resource, boolean modify, int priority)
 	{
-		return new BaseEvent(event, resource, modify, priority);
+		return new BaseEvent(event, resource, modify, priority, null);
 	}
 
 	/**
@@ -225,8 +225,29 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 	 */
 	public Event newEvent(String event, String resource, String context, boolean modify, int priority)
 	{
-		return new BaseEvent(event, resource, context, modify, priority);
+		return new BaseEvent(event, resource, context, modify, priority, null);
 	}
+
+	/**
+	 * Construct a Event object.
+	 *
+	 * @param event
+	 *        The Event id.
+	 * @param resource
+	 *        The resource reference.
+	 * @param context
+	 *        The Event's context.
+	 * @param modify
+	 *        Set to true if this event caused a resource modification, false if it was just an access.
+	 * @param priority
+	 *        The Event's notification priority.
+	 * @return A new Event object that can be used with this service.
+	 */
+	public Event newEvent(String event, String resource, String context, boolean modify, int priority, String metadata)
+	{
+		return new BaseEvent(event, resource, context, modify, priority, metadata);
+	}
+
 
 	/**
 	 * Post an event
@@ -377,7 +398,7 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 		}
 		else
 		{
-			event = new BaseEvent(e.getEvent(), e.getResource(), e.getModify(), e.getPriority());
+			event = new BaseEvent(e.getEvent(), e.getResource(), e.getModify(), e.getPriority(),null);
 			event.setSessionId(e.getSessionId());
 			event.setUserId(e.getUserId());
 		}
@@ -522,6 +543,9 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 		/** Event creation time. */
 		protected Date m_time = null;
 
+		/** Event metadata */
+		protected String m_metadata = null;
+
 		/**
 		 * Construct
 		 *
@@ -534,10 +558,11 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 		 * @param priority
 		 *        The Event's notification priority.
 		 */
-		public BaseEvent(String event, String resource, boolean modify, int priority)
+		public BaseEvent(String event, String resource, boolean modify, int priority, String metadata)
 		{
 			setEvent(event);
 			setResource(resource);
+			m_metadata = metadata;
 			m_modify = modify;
 			m_priority = priority;
 
@@ -582,22 +607,31 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 		 * @param priority
 		 *        The Event's notification priority.
 		 */
+		public BaseEvent(String event, String resource, String context, boolean modify, int priority, String metadata)
+		{
+			this(event,resource,modify,priority,metadata);
+			m_context = context;
+		}
+		
+		/**
+		 * Construct
+		 *
+		 * @param seq
+		 *        The event sequence number.
+		 * @param event
+		 *        The Event id.
+		 * @param resource
+		 *        The resource id.
+		 * @param modify
+		 *        If the event caused a modify, true, if it was just an access, false.
+		 * @param priority
+		 *        The Event's notification priority.
+		 */
 		public BaseEvent(String event, String resource, String context, boolean modify, int priority)
 		{
-			setEvent(event);
-			setResource(resource);
-			m_modify = modify;
-			m_priority = priority;
-			m_context = context;
-
-			// KNL-997
-			String uId = sessionManager().getCurrentSessionUserId();
-			if (uId == null)
-			{
-				uId = "?";
-			}
-			setUserId(uId);
+			this(event, resource, context, modify, priority,null);
 		}
+
 
 		/**
 		 * Construct
@@ -692,7 +726,17 @@ public abstract class BaseEventTrackingService implements EventTrackingService
 		{
 			return m_context;
 		}
-		
+
+		/**
+		 * Access the resource metadata.
+		 *
+		 * @return The resource metadata string.
+		 */
+		public String getMetadata()
+		{
+			return m_metadata;
+		}
+
 		/**
 		 * Access the UsageSession id. If null, check for a User id.
 		 *

--- a/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockEventTrackingService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockEventTrackingService.java
@@ -101,6 +101,16 @@ public class MockEventTrackingService implements EventTrackingService
 	}
 
 	/* (non-Javadoc)
+	 * @see org.sakaiproject.event.api.EventTrackingService#newEvent(java.lang.String, java.lang.String, java.lang.String, boolean, int)
+	 */
+	public Event newEvent(String event, String resource, String context, boolean modify, int priority, String metadata)
+	{
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	/* (non-Javadoc)
 	 * @see org.sakaiproject.event.api.EventTrackingService#post(org.sakaiproject.event.api.Event)
 	 */
 	public void post(Event event)

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/conditions/impl/TestConditionService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/conditions/impl/TestConditionService.java
@@ -69,6 +69,10 @@ public class TestConditionService {
 			public String getResource() {
 				return "69";
 			}
+			
+			public String getMetadata() {
+				return null; 
+			}
 
 			public String getSessionId() {
 				// TODO Auto-generated method stub
@@ -112,6 +116,10 @@ public class TestConditionService {
 
 			public String getResource() {
 				return "zt10";
+			}
+			
+			public String getMetadata() {
+				return null;
 			}
 
 			public String getSessionId() {


### PR DESCRIPTION
Here's the thought on this, I think it *might* be useful to persist additional data on events to the database. But what I *really* want it for is for additional data to be available on an event for the BaseLearningRecordStoreService.update method. I'm thinking I can clean up Samigo, adding a few more events and having the existing 2 calls to registerStatement that are hardcoded into samigo just use the regular event mechanism, passing along additional data that isn't persisted in Sakai but can be persisted in an LRS. 

I believe this is a dependent on SAM-2997 unless or else that code is going to be a lot more duplication.