### PR TITLE
SAK-31603 Correctly setup OAuth for upgrades.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4311,9 +4311,9 @@
 # #####
 # OAuth
 # #####
-# Enable OAuth support
-# DEFAULT: false
-# oauth.enabled=true
+# Disable OAuth support
+# DEFAULT: true
+# oauth.enabled=false
 
 # ######################################
 # SIGNUP TOOL added in Sakai 10

--- a/oauth/dao-hbm/pom.xml
+++ b/oauth/dao-hbm/pom.xml
@@ -58,6 +58,28 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>hibernate3-maven-plugin</artifactId>
+                <version>2.2</version>
+                <configuration>
+                    <components>
+                        <component>
+                            <name>hbm2ddl</name>
+                            <implementation>configuration</implementation>
+                        </component>
+                    </components>
+                    <componentProperties>
+                        <configurationfile>/src/ddl/hibernate.cfg.xml</configurationfile>
+                        <export>false</export>
+                        <update>false</update>
+                        <create>false</create>
+                        <outputfilename>siteassociation.sql</outputfilename>
+                    </componentProperties>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
     
 </project>

--- a/oauth/dao-hbm/src/ddl/hibernate.cfg.xml
+++ b/oauth/dao-hbm/src/ddl/hibernate.cfg.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+
+    <session-factory>
+
+        <property name="dialect">org.hibernate.dialect.MySQLInnoDBDialect</property>
+        <!--<property name="dialect">org.hibernate.dialect.Oracle10gDialect</property>-->
+
+        <mapping resource="org/sakaiproject/oauth/dao/Accessor.hbm.xml"/>
+        <mapping resource="org/sakaiproject/oauth/dao/Consumer.hbm.xml"/>
+
+
+    </session-factory>
+
+</hibernate-configuration>

--- a/reference/docs/conversion/sakai_11_0-11_1_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_0-11_1_mysql_conversion.sql
@@ -1,0 +1,7 @@
+-- SAK-23666/SAK-31603
+
+create table OAUTH_ACCESSORS (token varchar(255) not null, secret varchar(255), consumerId varchar(255), userId varchar(255), callbackUrl varchar(255), verifier varchar(255), creationDate datetime, expirationDate datetime, status integer, type integer, accessorSecret varchar(255), primary key (token));
+create table OAUTH_CONSUMERS (id varchar(255) not null, name varchar(255) not null, description varchar(255), url varchar(255), callbackUrl varchar(255), secret varchar(255) not null, accessorSecret varchar(255), recordModeEnabled bit, defaultValidity integer not null, primary key (id));
+create table OAUTH_RIGHTS (id varchar(255) not null, accessright varchar(255) not null, primary key (id, accessright));
+create index user_idx on OAUTH_ACCESSORS (userId);
+alter table OAUTH_RIGHTS add index FK5992789F74F42154 (id), add constraint FK5992789F74F42154 foreign key (id) references OAUTH_CONSUMERS (id);

--- a/reference/docs/conversion/sakai_11_0-11_1_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_11_0-11_1_oracle_conversion.sql
@@ -1,0 +1,7 @@
+-- SAK-23666/SAK-31603 
+
+create table OAUTH_ACCESSORS (token varchar2(255 char) not null, secret varchar2(255 char), consumerId varchar2(255 char), userId varchar2(255 char), callbackUrl varchar2(255 char), verifier varchar2(255 char), creationDate timestamp, expirationDate timestamp, status number(10,0), type number(10,0), accessorSecret varchar2(255 char), primary key (token));
+create table OAUTH_CONSUMERS (id varchar2(255 char) not null, name varchar2(255 char) not null, description varchar2(255 char), url varchar2(255 char), callbackUrl varchar2(255 char), secret varchar2(255 char) not null, accessorSecret varchar2(255 char), recordModeEnabled number(1,0), defaultValidity number(10,0) not null, primary key (id));
+create table OAUTH_RIGHTS (id varchar2(255 char) not null, accessright varchar2(255 char) not null, primary key (id, accessright));
+create index user_idx on OAUTH_ACCESSORS (userId);
+alter table OAUTH_RIGHTS add constraint FK5992789F74F42154 foreign key (id) references OAUTH_CONSUMERS;


### PR DESCRIPTION
On upgrade installations we weren’t creating the OAUTH_* tables, this meant that the oauth functionality would fail.
This uses the old hibernate3:hbm2ddl maven plugin to get the same DDL statements and needs editing to run on different schemas but this is just here as a reference as it shouldn't be needed again.