### PR TITLE
SAK-31653: missing return statement in EntityGroup.java

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/model/EntityGroup.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/model/EntityGroup.java
@@ -369,6 +369,7 @@ public class EntityGroup implements Group {
     public void addMember(String arg0, String arg1, boolean arg2, boolean arg3) {
         if (group != null) {
             group.addMember(arg0, arg1, arg2, arg3);
+            return;
         }
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
There's a missing return statement that will result in an exception being raised whenever addMember is called.
