### PR TITLE
SAK-31656 Override defaults first in SCSS skin.

### DIFF
--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -1,20 +1,22 @@
 /* Global namespace */
 
-$namespace : "Mrphs-";
-$skin-name : "morpheus-default"; // This is used for bootstrap font behaviour.
+@import "customization"; //it is copied from the user supplied file by maven
 
-$break-small-end: 	800px;
-$break-medium-end: 	1030px;
+$namespace : "Mrphs-" !default;
+$skin-name : "morpheus-default" !default; // This is used for bootstrap font behaviour.
 
-$phone  :       "only screen and (max-width : #{ $break-small-end })";
-$tablet :       "only screen and (max-width : #{ $break-medium-end })";
-$desktop:       "only screen and (min-width : #{ $break-medium-end + 1 })";
-$nonPhone:      "only screen and (min-width : #{ $break-small-end + 1 })";
+$break-small-end: 	800px !default;
+$break-medium-end: 	1030px !default;
+
+$phone  :       "only screen and (max-width : #{$break-small-end})" !default;
+$tablet :       "only screen and (max-width : #{$break-medium-end})" !default;
+$desktop:       "only screen and (min-width : #{$break-medium-end + 1})" !default;
+$nonPhone:      "only screen and (min-width : #{$break-small-end + 1})" !default;
 
 // For the "More Sites" drawer, just use one column if there's not
 // enough room to show two side-by-side.
-$break-more-sites-single-column: 1200px;
-$more-sites-single-column: "only screen and (max-width : #{ $break-more-sites-single-column })";
+$break-more-sites-single-column: 1200px !default;
+$more-sites-single-column: "only screen and (max-width : #{$break-more-sites-single-column})" !default;
 
 /* Typography*/
 
@@ -144,7 +146,7 @@ $sites-nav-submenu-item-selected-border:    none !default;
 $tool-menu-width: 7.5em !default;
 
 /* Navigation Hierarchy */
-$hierarchy-size: 3.5em;
+$hierarchy-size: 3.5em !default;
 
 /* Golden Ratio width for 16px font http://www.pearsonified.com/typography/ */
 $measure: 960px !default;
@@ -161,7 +163,5 @@ $icon-size: 20px !default;
 /* Footer */
 $footer-background: transparent !default;
 $footer-color: $background-color-secondary !default;
-
-@import "customization"; //it is created on-the-fly by maven.
 
 @import url(#{$font-family-url});

--- a/reference/library/src/morpheus-master/sass/examples/_customization_example_reversed.scss
+++ b/reference/library/src/morpheus-master/sass/examples/_customization_example_reversed.scss
@@ -1,0 +1,3 @@
+// Reverse the colors just for testing.
+$text-color: 			 #FFFFFF;
+$background-color:				 #212121;


### PR DESCRIPTION
Locally at Oxford we've got our own changes to the Sakai default skin and these are in a customisations file. By default this customisation file in pulled in at the end of the _defaults.css file so you can override any of the variables in _defaults.css. As an example in _defaults.scss there is a primary colour defined as:

    $primary-color: #2a94c0 !default;

we then in our customizations file re-define the primary colour to be:

    $primary-color: #002147;

the problem is that if this primary colour is referenced anywhere else in _defaults.scss our re-define doesn't work because the value is already copied into the new variables, as an example:

    $tool-menu-current-color: $primary-color !default;

here the tool menu current color will be the standard Sakai one, rather than our Oxford one. The !default on the end of the line says to only assign a value if one isn't already present so it seems that the sensible option is to import the customisations at the start of the defaults file rather than the end so that re-definitions take effect in all locations in the file.