### PR TITLE
SAK-31655 Respect $logo-width when wider than tools

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -23,7 +23,7 @@ body.is-logged-out{
 		overflow: hidden;
 		padding: 0 1em;
 		text-align: center;
-		width: $tool-menu-width;
+		min-width: $tool-menu-width;
 		@include flex-shrink( 0 );
 		@include transition( width 0.5s linear 0s );
 		.#{$namespace}headerLogo--institution{


### PR DESCRIPTION
If the $logo-width is larger than $tool-menu-width then the logo gets trimmed off and $logo-width isn’t respected.