### PR TITLE
SAK-26702 Make Gravatar protocol relative

### DIFF
--- a/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
@@ -124,7 +124,7 @@ public class ProfileConstants {
 	public static final String USER_PROPERTY_JPEG_PHOTO = "jpegPhoto";
 	
 	//gravatar base URL
-	public static final String GRAVATAR_BASE_URL = "http://www.gravatar.com/avatar/";
+	public static final String GRAVATAR_BASE_URL = "//www.gravatar.com/avatar/";
 
     // Defines the name of the blank image, the one a user gets when nothing else is available
     public static final String BLANK = "blank";


### PR DESCRIPTION
This works because HttpServletResponse.sendRedirect(String) accepts relative requests and makes them absolute. Browsers natively support protocol relative requests so it shouldn't be a problem there.