### PR TITLE
SAK-31662 Fix docs on Backfill Tool Quart job.

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/backfilltool/Messages.properties
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/backfilltool/Messages.properties
@@ -9,4 +9,4 @@ overwrite.description=If true then replace existing role definitions.
 tool=Tool
 tool.description=The tool ID of the tool to add.
 skip.user.sites=Skip User Sites
-skip.user.sites.description=If true then the tool will also be added to user sites.
+skip.user.sites.description=If false then the tool will also be added to user sites.


### PR DESCRIPTION
The documentation said to set it to true to include user sites in the list when it should have been false.