### PR TITLE
Remove settings.xml so it doesn't interfere with builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - echo "MAVEN_OPTS='-Xms168m -Xmx1536m -XX:NewSize=64m -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.defaultLogLevel=warn'" > ~/.mavenrc
   # https://github.com/travis-ci/travis-ci/issues/4629
   # This stops lots of warning about the broken nexus.codehaus.org repository
-  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+  - rm ~/.m2/settings.xml
   
 language: java
 jdk:


### PR DESCRIPTION
Because settings.xml defines a bunch of repos that aren't updated, we should just remove it before the build starts