### PR TITLE
SAK-31670 When aliases disabled don’t query DB.

### DIFF
--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/SiteNeighbourhoodServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/SiteNeighbourhoodServiceImpl.java
@@ -545,11 +545,11 @@ public class SiteNeighbourhoodServiceImpl implements SiteNeighbourhoodService
 				return (String)originalId;
 			}
 		}
-		List<Alias> aliases = aliasService.getAliases(id);
 		if (!useSiteAliases)
 		{
 			return null;
 		}
+		List<Alias> aliases = aliasService.getAliases(id);
 		if (aliases.size() > 0)
 		{
 			if (aliases.size() > 1 && log.isInfoEnabled())


### PR DESCRIPTION
If aliases are disabled we would still look in the DB for any aliases. This is wrong and we should only be looking when aliases are enabled.