### PR TITLE
SAM-3002 unexpected behaviour with matrix of choices after saving which results in user data loss

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -868,22 +868,21 @@ public class SubmitToGradingActionListener implements ActionListener {
 			if (answerModified) {
 				for (int m = 0; m < grading.size(); m++) {
 					ItemGradingData itemgrading = grading.get(m);
+
+					// Remove all previous answers
 					if (itemgrading !=null && itemgrading.getItemGradingId() != null && itemgrading.getItemGradingId().intValue() > 0) {
-						// remove all old answer
 						removes.add(itemgrading);
-					} else {
-						// add new answer
-						if (itemgrading !=null && (itemgrading.getPublishedAnswerId() != null
-							|| itemgrading.getAnswerText() != null
-							|| (itemgrading.getRationale() != null 
-							&& StringUtils.isNotBlank(itemgrading.getRationale())))) { 
-							itemgrading.setAgentId(AgentFacade.getAgentString());
-							itemgrading.setSubmittedDate(new Date());
-							if (itemgrading.getRationale() != null && itemgrading.getRationale().length() > 0) {
-								itemgrading.setRationale(TextFormat.convertPlaintextToFormattedTextNoHighUnicode(log, itemgrading.getRationale()));
-							}
-							adds.add(itemgrading);
+					}
+
+					// Add all provided answers, regardless if they're new or not
+					if (itemgrading !=null && (itemgrading.getPublishedAnswerId() != null || itemgrading.getAnswerText() != null
+							|| (itemgrading.getRationale() != null && StringUtils.isNotBlank(itemgrading.getRationale())))) { 
+						itemgrading.setAgentId(AgentFacade.getAgentString());
+						itemgrading.setSubmittedDate(new Date());
+						if (itemgrading.getRationale() != null && itemgrading.getRationale().length() > 0) {
+							itemgrading.setRationale(TextFormat.convertPlaintextToFormattedTextNoHighUnicode(log, itemgrading.getRationale()));
 						}
+						adds.add(itemgrading);
 					}
 				}
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3002

When answering a matrix of choices question, if you partially fill out your answers, click 'Save' (or 'Next' or 'Previous'), then fill out more answers and 'Save' again, your original answers will be lost and only the 'new' answers will be preserved.

The same behaviour can be seen using the next and previous buttons. Anything you saved (or was inherently saved when using next and previous), will be lost the next time you save (or do next or previous). This process can be repeated infinitely, until or unless you press the 'Reset Selection' link.

The end result is user data loss which the user may not be aware of. This can be catastrophic in the case of a final exam or such.

The problem here is that the code is removing all old answers, and only adding new ones. So the simple solution is to remove all previous answers, and always add all provided answers (regardless if they're new or not).