### PR TITLE
SAK-29738 Fix Worksite Setup search results paging

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -4676,7 +4676,7 @@ public class SiteAction extends PagedResourceActionII {
 		// read the search form field into the state object
 		String search = StringUtils.trimToNull(data.getParameters().getString(
 				FORM_SEARCH));
-
+		resetPaging(state);
 		// set the flag to go to the prev page on the next list
 		if (search == null) {
 			state.removeAttribute(STATE_SEARCH);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29738

Added resetPaging(state) to search method to for the results pages to start at page 1 instead of whatever results page the user had been on previously.  