### PR TITLE
SAK-31680 fix for two issues in Sakai 11 mysql conversion script

### DIFF
--- a/reference/docs/conversion/sakai_11_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_mysql_conversion.sql
@@ -387,7 +387,7 @@ drop index MFR_MESSAGE_DELETED_I on MFR_MESSAGE_T;
 -- END SAK-29571 MFR_MESSAGE_DELETD_I causes bad performance
 
 -- LSNBLDR-646
-drop index if exists lesson_builder_qr_questionId on lesson_builder_q_responses;
+drop index lesson_builder_qr_questionId on lesson_builder_q_responses;
 -- END LSNBLDR-646
 
 -- SAK-29546 Add site visit totals per user

--- a/reference/docs/conversion/sakai_11_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_mysql_conversion.sql
@@ -387,7 +387,7 @@ drop index MFR_MESSAGE_DELETED_I on MFR_MESSAGE_T;
 -- END SAK-29571 MFR_MESSAGE_DELETD_I causes bad performance
 
 -- LSNBLDR-646
-drop index lesson_builder_qr_questionId on lesson_builder_q_responses;
+drop index if exists lesson_builder_qr_questionId on lesson_builder_q_responses;
 -- END LSNBLDR-646
 
 -- SAK-29546 Add site visit totals per user
@@ -765,7 +765,7 @@ ALTER TABLE lti_content MODIFY title VARCHAR(1024);
 ALTER TABLE lti_content MODIFY pagetitle VARCHAR(1024);
 ALTER TABLE lti_content MODIFY consumerkey VARCHAR(1024);
 ALTER TABLE lti_content MODIFY secret VARCHAR(1024);
-alter table lti_content modify custom varchar(65536);
+ALTER TABLE lti_content MODIFY custom MEDIUMTEXT;
 ALTER TABLE lti_content MODIFY xmlimport MEDIUMTEXT;
 ALTER TABLE lti_content MODIFY settings MEDIUMTEXT;
 ALTER TABLE lti_content MODIFY settings_ext MEDIUMTEXT;
@@ -774,7 +774,7 @@ ALTER TABLE lti_tools MODIFY title VARCHAR(1024);
 ALTER TABLE lti_tools MODIFY pagetitle VARCHAR(1024);
 ALTER TABLE lti_tools MODIFY consumerkey VARCHAR(1024);
 ALTER TABLE lti_tools MODIFY secret VARCHAR(1024);
-alter table lti_tools modify custom varchar(65536);
+ALTER TABLE lti_tools MODIFY custom MEDIUMTEXT;
 
 ALTER TABLE lti_deploy MODIFY reg_profile MEDIUMTEXT;
 ALTER TABLE lti_deploy MODIFY settings MEDIUMTEXT;


### PR DESCRIPTION
changed type of two cols from illegal varchar size to mediumtext; 
added 'if exists' to a 'drop index' which didn't exist in our 10.5 DB

( https://jira.sakaiproject.org/browse/SAK-31680 )
