### PR TITLE
SAK-24332 Error message when a user/role/group id contains a space or period (mailsender)

### DIFF
--- a/mailsender/tool/src/java/org/sakaiproject/mailsender/tool/producers/fragments/UsersProducer.java
+++ b/mailsender/tool/src/java/org/sakaiproject/mailsender/tool/producers/fragments/UsersProducer.java
@@ -25,6 +25,7 @@ import org.sakaiproject.mailsender.logic.ComposeLogic;
 import org.sakaiproject.mailsender.tool.params.UsersViewParameters;
 import org.sakaiproject.user.api.User;
 
+import uk.org.ponder.beanutil.PathUtil;
 import uk.org.ponder.messageutil.TargettedMessage;
 import uk.org.ponder.messageutil.TargettedMessageList;
 import uk.org.ponder.rsf.components.UIBoundBoolean;
@@ -112,8 +113,9 @@ public class UsersProducer implements ViewComponentProducer, ViewParamsReporter
 							viewParams.id + "-" + Integer.toString(i));
 					String displayName = user.getLastName() + ", " + user.getFirstName() + " ("
 							+ user.getDisplayId() + ")";
-					UIBoundBoolean input = UIBoundBoolean.make(cell, "mailsender-user",
-							"emailBean.newEmail.userIds." + user.getId());
+					String path = PathUtil.buildPath(new String []{
+							"emailBean","newEmail","userIds",user.getId()});
+					UIBoundBoolean input = UIBoundBoolean.make(cell, "mailsender-user", path);
 					UIVerbatim label = UIVerbatim.make(cell, "mailsender-userLabel",
 							displayName);
 					


### PR DESCRIPTION
The mailsender tool doesn't escape a recipient's internal user ID before using it in an EL path expression.

This results in an Exception and emails not being sent when e.g the user ID is an email address (== a String containing at least one dot, which will then be interpreted if not escaped)

This patch uses RSF's [PathUtil.buildPath(String[])](https://source.sakaiproject.org/release/rsf/ponderUtil/uk/org/ponder/beanutil/PathUtil.html#buildPath%28java.lang.String[]) method instead of String concatenation to escape the user ID.

[https://jira.sakaiproject.org/browse/SAK-24332?filter=15819](https://jira.sakaiproject.org/browse/SAK-24332?filter=15819)