### PR TITLE
SAK-31682 autocomplete suggestions for hosts (PA Tool).

### DIFF
--- a/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/PASystemServlet.java
+++ b/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/PASystemServlet.java
@@ -42,7 +42,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.sakaiproject.authz.cover.SecurityService;
+import org.sakaiproject.cluster.api.ClusterService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.pasystem.api.I18n;
@@ -72,11 +74,13 @@ public class PASystemServlet extends HttpServlet {
     private static final Logger LOG = LoggerFactory.getLogger(PASystemServlet.class);
 
     private PASystem paSystem;
+    private ClusterService clusterService;
 
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
 
-        paSystem = (PASystem) ComponentManager.get(PASystem.class);
+        paSystem = ComponentManager.get(PASystem.class);
+        clusterService = ComponentManager.get(ClusterService.class);
     }
 
     private Handler handlerForRequest(HttpServletRequest request) {
@@ -89,7 +93,7 @@ public class PASystemServlet extends HttpServlet {
         if (path.contains("/popups/")) {
             return new PopupsHandler(paSystem);
         } else if (path.contains("/banners/")) {
-            return new BannersHandler(paSystem);
+            return new BannersHandler(paSystem, clusterService);
         } else {
             return new IndexHandler(paSystem);
         }

--- a/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/handlers/BannersHandler.java
+++ b/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/handlers/BannersHandler.java
@@ -24,9 +24,13 @@
 
 package org.sakaiproject.pasystem.tool.handlers;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+
+import org.sakaiproject.cluster.api.ClusterService;
 import org.sakaiproject.pasystem.api.Banner;
 import org.sakaiproject.pasystem.api.PASystem;
 import org.sakaiproject.pasystem.tool.forms.BannerForm;
@@ -40,9 +44,11 @@ public class BannersHandler extends CrudHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(BannersHandler.class);
     private final PASystem paSystem;
+    private  final ClusterService clusterService;
 
-    public BannersHandler(PASystem pasystem) {
+    public BannersHandler(PASystem pasystem, ClusterService clusterService) {
         this.paSystem = pasystem;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -58,6 +64,7 @@ public class BannersHandler extends CrudHandler {
     protected void handleEdit(HttpServletRequest request, Map<String, Object> context) {
         String uuid = extractId(request);
         context.put("subpage", "banner_form");
+        context.put("hosts", clusterService.getServers().stream().sorted().collect(Collectors.toList()));
 
         Optional<Banner> banner = paSystem.getBanners().getForId(uuid);
 
@@ -73,6 +80,7 @@ public class BannersHandler extends CrudHandler {
     protected void showNewForm(Map<String, Object> context) {
         context.put("subpage", "banner_form");
         context.put("mode", "new");
+        context.put("hosts", clusterService.getServers().stream().sorted().collect(Collectors.toList()));
     }
 
     @Override

--- a/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/views/banner_form.hbs
+++ b/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/views/banner_form.hbs
@@ -52,7 +52,12 @@
   <div class="form-group">
     <label  class="col-sm-2 control-label" for="message">{{{t this "Hosts"}}}</label>
     <div class="col-sm-10">
-      <input class="form-control" type="text" name="hosts" id="hosts" value="{{banner.hosts}}" />
+      <input class="form-control" type="text" name="hosts" id="hosts" list="hosts-list" multiple="true" value="{{banner.hosts}}" />
+      <datalist id="hosts-list">
+      {{#each hosts}}
+        <option value="{{{this}}}"/>
+      {{/each}}
+      </datalist>
     </div>
   </div>
 


### PR DESCRIPTION
Output the known list of hosts so that they can autocompleted by browsers that support them, This doesn’t stop people from typing in hosts that don’t exist in the dropdown but helps prevent mistypes of existing hosts. The in browser autocomplete doesn't work after the first hostname has been entered but it's a simple solution for the most common case of a message for a specific host.

The <datalist> element is supported in most popular browser on the desktop apart from Safari. When it isn't supported it's just ignored so it doesn't break anything.

http://caniuse.com/#feat=datalist