### PR TITLE
SAK-31684 Give good error when converting favourites.

### DIFF
--- a/user/user-util/src/java/org/sakaiproject/user/util/ConvertUserFavoriteSitesSakai11.java
+++ b/user/user-util/src/java/org/sakaiproject/user/util/ConvertUserFavoriteSitesSakai11.java
@@ -116,7 +116,9 @@ class ConvertUserFavoriteSitesSakai11 {
 
                 migrateFavoriteSites(db);
             } finally  {
-                db.close();
+                if (db != null) {
+                    db.close();
+                }
             }
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
When the favourites conversion fails if there isn’t a DB connection, rather that getting a message about not being able to connect to the database you will get a NullPointerException, this fixes it and keeps the underlying error.