### PR TITLE
SAK-31690 dont throw an error if user does not exist

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
@@ -638,9 +638,6 @@ public class UserEntityProvider extends AbstractEntityProvider implements CoreEn
                     //log.warn(msg);
                 }
             }
-            if (user == null) {
-                throw new IllegalArgumentException("Could not find user with eid="+userEid+" or id="+userId);
-            }
         }
         return user;
     }

--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
@@ -623,9 +623,6 @@ public class UserEntityProvider extends AbstractEntityProvider implements CoreEn
                         //msg += " (attempting check using user id="+userId+")";
                         doCheckForId = true;
                     }
-                    // SAK-22690 removed this log warning
-                    //msg += " :: " + e.getMessage();
-                    //log.warn(msg);
                 }
             }
             if (doCheckForId) {
@@ -633,9 +630,6 @@ public class UserEntityProvider extends AbstractEntityProvider implements CoreEn
                     user = userDirectoryService.getUser(userId);
                 } catch (UserNotDefinedException e) {
                     user = null;
-                    // SAK-22690 removed this log warning
-                    //String msg = "Could not find user with id="+userId+" :: " + e.getMessage();
-                    //log.warn(msg);
                 }
             }
         }


### PR DESCRIPTION
For example, ask for the membership of a site with one orphaned user (user that no longer exists in LDAP):

https://sakai.example.edu/direct/membership/site/c7788b6d-e30b-4aae-b87e-1433d104e5dd.json

This will bomb with 

HTTP Status 400 - Cannot execute custom action (site): Illegal arguments: Could not find user with eid=id=660de1f0-297c-4306-a945-484de8d2a4da or id=660de1f0-297c-4306-a945-484de8d2a4da (rethrown)