### PR TITLE
KNL-1455 - Change default log level of org.springframework to INFO

### DIFF
--- a/kernel/kernel-common/src/main/config/log4j.properties
+++ b/kernel/kernel-common/src/main/config/log4j.properties
@@ -25,6 +25,10 @@ log4j.appender.Sakai.Encoding=UTF-8
 
 # Application logging options
 log4j.logger.org.apache=INFO
+# We want more info from spring framework but beans are mostly redundant and web is mostly timing information
+log4j.logger.org.springframework=INFO
+log4j.logger.org.springframework.beans=WARN
+log4j.logger.org.springframework.web=WARN
 log4j.logger.org.sakaiproject=INFO
 log4j.logger.uk.ac.cam.caret.rwiki=INFO
 log4j.logger.org.theospi=INFO
@@ -33,6 +37,7 @@ log4j.logger.MySQL=INFO
 #log4j.logger.org.springframework=DEBUG
 
 # Ignore erroneous MyFaces warnings
+log4j.logger.org.apache.myfaces=WARN
 log4j.logger.org.apache.myfaces.el.VariableResolverImpl=ERROR
 log4j.logger.org.apache.myfaces.shared_impl.webapp.webxml.WebXmlParser=ERROR
 log4j.logger.org.apache.myfaces.shared_tomahawk.webapp.webxml.WebXmlParser=ERROR


### PR DESCRIPTION
Any thoughts? I guess we could go more specific if some things should stay warn, but most things seem pretty nice.

Maybe the stuff in org.springframework.beans is a little noisy and redundant? I feel like it's all useful for helping to identify problems though.