### PR TITLE
SAK-31705 Added 'Search Users' facility to site-info.

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1151,6 +1151,7 @@ sitegen.roledescription.TeachingAssistant =  Can read, add, and revise most cont
 ##Additional site info
 sitegen.siteinfolist.modify = Modification date
 sitegen.siteinfolist.usermodify = Modified by
+sitegen.siteinfolist.searchUser=Search
 
 useOfficialDescription=Use Official Description
 

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -110,8 +110,20 @@
 				utils.resizeFrame();
 			}
 		});
+		//catch enter key press for search box
+		$('#$form_search').keyup(function(event){
+			if(event.keyCode === 13){
+				$("#searchUser").click();
+			}
+		});
 	  });
 	  
+	//method called to do search for the participant
+	function doSearch(url){
+		var searchText = $('#$form_search' ).val();
+		location = url + "&search=" + searchText;
+		return true;
+	}
 	
 </script>
 
@@ -555,6 +567,14 @@
 								#end 
 							#end 
 						</a>
+						<span class="site-searchbox">
+							<label for="$form_search" class="skip">$tlang.getString('list.search')</label>
+							<input size="10"  value="$validator.escapeHtml($!userSearch)" name="$form_search" id="$form_search" type="text" class="searchField"  />
+							<input type="button" id="searchUser" value="$tlang.getString('sitegen.siteinfolist.searchUser')" onclick="doSearch('#toolLink($action "doUser_search")');" />
+							#if (($!userSearch) && (!$userSearch.equals("")))
+								<input type="button" class="button" value="$tlang.getString("list.cls")" onclick="location = '#toolLink($action "doUser_search_clear")';return false;" />
+							#end
+						</span>
 					</th>
 					#if ($hasProviderSet)
 						<th id="coursename" scope="col">


### PR DESCRIPTION
Added Search input and clear search in the chef_site-siteInfo-list.vm.
If search word is in session state then Participant List is filtered for
the search term in each Participant's displayName and displayId.
Corrected the position of search box in the participant's table.

Have added new variable to STATE_SITE_PARTICIPANT_LIST in SiteAction class
to save the original site members list. Search is case insensitive.