### PR TITLE
Very noisy INFO: EntityEncodingManager: No entities to format (json) …

### DIFF
--- a/entitybroker/rest/src/java/org/sakaiproject/entitybroker/rest/EntityEncodingManager.java
+++ b/entitybroker/rest/src/java/org/sakaiproject/entitybroker/rest/EntityEncodingManager.java
@@ -436,7 +436,7 @@ public class EntityEncodingManager {
         }
         if (entities.isEmpty()) {
             // just log this for now
-            log.info("EntityEncodingManager: No entities to format ("+format+") and output for ref (" + ref + ")");
+            log.debug("EntityEncodingManager: No entities to format ("+format+") and output for ref (" + ref + ")");
         }
 
         // SAK-22738 - do not show form editing when batch processing is disabled


### PR DESCRIPTION
Seeing this log message thousands of times per day on a large PROD Sakai 11 instance 

INFO: EntityEncodingManager: No entities to format (json) and output for ref (/gbng)