### PR TITLE
SAK-31711-2 Remove padding MarkAsRead Icon

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -148,8 +148,6 @@ a.markAsReadIcon{
 	cursor: pointer;
 	margin-left:.5em;
 	background: #fff url(../images/silk/email.png) 5px 5px no-repeat;
-	padding-bottom: 2px;
-	padding-top: 2px;
 }
 a.markAsReadIcon:hover{
 	background: #fff url(../images/silk/email_open.png) 5px 3px no-repeat


### PR DESCRIPTION
Removed the padding for the markAsRead icon as it causes the
button to be too small which makes it look odd in comparison to the other button.