### PR TITLE
SAM-3007 Samigo, return to the published tab

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex_content.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex_content.jsp
@@ -87,7 +87,7 @@ $(document).ready(function() {
 	var selectedTab = 0;
 	<h:outputText rendered="#{author.justPublishedAnAssessment}" value="selectedTab = 1;" />
 
-	$("#tabs").tabs({ selected: selectedTab });
+	$("#tabs").tabs({ active: selectedTab });
 
 	// SET THE HEIGHT ON TABS CONTAINER IF PUBLISHED IS LARGER THAN WORKING COPIES
 	if ($('#tabs-2').height() > $('#tabs-1').height()) {


### PR DESCRIPTION
This change makes it so that when you are on the Published
Copies tab and edit an assessment, you are brought back to that
tab.