### PR TITLE
3049: hide the custom export dialog after invoking download

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -104,7 +104,7 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button wicket:id="downloadCustomGradebook" type="button" class="button_color pull-left">
+                        <button wicket:id="downloadCustomGradebook" type="button" class="button_color pull-left" data-dismiss="modal">
                             <wicket:message key="importExport.template.button.customGradebook"/>
                         </button>
                         <button type="button" class="pull-right" data-dismiss="modal">


### PR DESCRIPTION
Delivers #3049.

Hi @steveswinsburg,  as the `DownloadLink` isn't an ajax-link, I couldn't find a straight forward way to reset the form checkboxes.  I think we could refactor it to be an AjaxLink that invokes the download with JavaScript by setting the browser location (kinda like this https://cwiki.apache.org/confluence/display/WICKET/AJAX+update+and+file+download+in+one+blow). Any ideas?

I think it's ok to retain the form's state after clicking export, as it makes it clear to the user what they previously selected upon reopening it after a download .. 😵 