### PR TITLE
SAM-2997 - Additions to samigo xapi for score changes

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -43,6 +43,9 @@ public class SamigoConstants {
     public static final     String      EVENT_ASSESSMENT_SUBMITTED                          = "sam.assessmentSubmitted";
     public static final     String      EVENT_ASSESSMENT_AUTO_SUBMITTED                     = "sam.assessmentAutoSubmitted";
     public static final     String      EVENT_ASSESSMENT_TIMED_SUBMITTED                    = "sam.assessmentTimedSubmitted";
+    public static final     String      EVENT_ASSESSMENT_TOTAL_SCORE_UPDATE                 = "sam.total.score.update";
+    public static final     String      EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE               = "sam.student.score.update";
+
 
     /*
      * Notification Types

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/LinearAccessDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/LinearAccessDeliveryActionListener.java
@@ -39,8 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.event.api.Event;
-import org.sakaiproject.event.api.LearningResourceStoreService;
-import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.cover.NotificationService;
 import org.sakaiproject.tool.assessment.api.SamigoApiFactory;
 import org.sakaiproject.tool.assessment.data.dao.assessment.EventLogData;
@@ -57,6 +56,7 @@ import org.sakaiproject.tool.assessment.shared.api.assessment.SecureDeliveryServ
 import org.sakaiproject.tool.assessment.ui.bean.delivery.DeliveryBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.ui.web.session.SessionUtil;
+import org.sakaiproject.tool.assessment.util.SamigoLRSStatements;
 
 
 public class LinearAccessDeliveryActionListener extends DeliveryActionListener
@@ -64,7 +64,7 @@ public class LinearAccessDeliveryActionListener extends DeliveryActionListener
 {
   private static Logger log = LoggerFactory.getLogger(LinearAccessDeliveryActionListener.class);
   private static ResourceBundle eventLogMessages = ResourceBundle.getBundle("org.sakaiproject.tool.assessment.bundle.EventLogMessages");
-
+  private final EventTrackingService eventTrackingService= ComponentManager.get( EventTrackingService.class );
 
   /**
    * ACTION.
@@ -210,9 +210,8 @@ public class LinearAccessDeliveryActionListener extends DeliveryActionListener
     			  int timeRemaining = Integer.parseInt(delivery.getTimeLimit()) - Integer.parseInt(delivery.getTimeElapse());
     			  eventRef.append(timeRemaining);
     		  }
-    		  Event event = EventTrackingService.newEvent("sam.assessment.take", eventRef.toString(), true);
-    		  EventTrackingService.post(event);
-    		  registerIrss(delivery, event, false);
+    		  Event event = eventTrackingService.newEvent("sam.assessment.take", eventRef.toString(), site_id, true, NotificationService.NOTI_REQUIRED, SamigoLRSStatements.getStatementForTakeAssessment(delivery.getAssessmentTitle(),delivery.getPastDue(),false));
+    		  eventTrackingService.post(event);
     	  }
     	  else if (action == DeliveryBean.TAKE_ASSESSMENT_VIA_URL) {
     		  StringBuffer eventRef = new StringBuffer("publishedAssessmentId");
@@ -228,9 +227,8 @@ public class LinearAccessDeliveryActionListener extends DeliveryActionListener
     		  }
     		  PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
     		  String siteId = publishedAssessmentService.getPublishedAssessmentOwner(Long.valueOf(delivery.getAssessmentId()));
-    		  Event event = EventTrackingService.newEvent("sam.assessment.take", eventRef.toString(), siteId, true, NotificationService.NOTI_REQUIRED);
-    		  EventTrackingService.post(event);
-    		  registerIrss(delivery, event, true);
+    		  Event event = eventTrackingService.newEvent("sam.assessment.take", eventRef.toString(), siteId, true, NotificationService.NOTI_REQUIRED, SamigoLRSStatements.getStatementForTakeAssessment(delivery.getAssessmentTitle(),delivery.getPastDue(),false));
+    		  eventTrackingService.post(event);
     	  }    	  
       }
       else {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -54,7 +54,7 @@ import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Statement;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb.SAKAI_VERB;
 import org.sakaiproject.event.api.NotificationService;
-import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
@@ -75,6 +75,7 @@ import org.sakaiproject.tool.assessment.ui.bean.delivery.ItemContentsBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.SectionContentsBean;
 import org.sakaiproject.tool.assessment.ui.bean.shared.PersonBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.SamigoLRSStatements;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.user.api.PreferencesService;
@@ -94,6 +95,8 @@ import org.sakaiproject.user.api.UserDirectoryService;
 
 public class SubmitToGradingActionListener implements ActionListener {
 	private static final Logger log = LoggerFactory.getLogger(SubmitToGradingActionListener.class);
+    private final EventTrackingService eventTrackingService= ComponentManager.get( EventTrackingService.class );
+
 	
 	/**
 	 * The publishedAssesmentService
@@ -140,13 +143,8 @@ public class SubmitToGradingActionListener implements ActionListener {
 			// set AssessmentGrading in delivery
 			delivery.setAssessmentGrading(adata);
             if (adata.getForGrade()) {
-                Event event = EventTrackingService.newEvent("", adata.getPublishedAssessmentTitle(), true);
-                LearningResourceStoreService lrss = (LearningResourceStoreService) ComponentManager
-                    .get("org.sakaiproject.event.api.LearningResourceStoreService");
-                if (null != lrss && lrss.getEventActor(event) != null) {
-                    lrss.registerStatement(getStatementForGradedAssessment(adata, lrss.getEventActor(event), publishedAssessment),
-                        "sakai.samigo");
-                }
+                Event event = eventTrackingService.newEvent("", adata.getPublishedAssessmentTitle(), null, true, NotificationService.NOTI_OPTIONAL, SamigoLRSStatements.getStatementForGradedAssessment(adata, publishedAssessment));
+                eventTrackingService.post(event);
             }
 			// set url & confirmation after saving the record for grade
 			if (delivery.getForGrade())
@@ -1000,27 +998,4 @@ public class SubmitToGradingActionListener implements ActionListener {
 		else
 			return Boolean.FALSE;
 	}
-	
-    private LRS_Statement getStatementForGradedAssessment(AssessmentGradingData gradingData, LRS_Actor student,
-            PublishedAssessmentFacade publishedAssessment) {
-        LRS_Verb verb = new LRS_Verb(SAKAI_VERB.scored);
-        LRS_Object lrsObject = new LRS_Object(ServerConfigurationService.getPortalUrl() + "/assessment", "received-grade-assessment");
-        HashMap<String, String> nameMap = new HashMap<>();
-        nameMap.put("en-US", "User received a grade");
-        lrsObject.setActivityName(nameMap);
-        HashMap<String, String> descMap = new HashMap<>();
-        descMap.put("en-US", "User received a grade for their assessment: " + publishedAssessment.getTitle() + "; Submitted: "
-                + (gradingData.getIsLate() ? "late" : "on time"));
-        lrsObject.setDescription(descMap);
-        LRS_Context context = new LRS_Context("other", "assessment");
-        LRS_Statement statement = new LRS_Statement(student, verb, lrsObject, getLRS_Result(gradingData, publishedAssessment), context);
-        return statement;
-	}
-
-    private LRS_Result getLRS_Result(AssessmentGradingData gradingData, PublishedAssessmentFacade publishedAssessment) {
-        double score = gradingData.getFinalScore();
-        LRS_Result result = new LRS_Result(score, 0.0, publishedAssessment.getTotalScore(), null);
-        result.setCompletion(true);
-        return result;
-    }
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreUpdateListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreUpdateListener.java
@@ -40,7 +40,14 @@ import javax.faces.event.ActionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.commons.math3.util.Precision;
-import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Object;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Statement;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb.SAKAI_VERB;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingAttachment;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AttachmentIfc;
@@ -68,6 +75,8 @@ public class QuestionScoreUpdateListener
   implements ActionListener
 {
   private static Logger log = LoggerFactory.getLogger(QuestionScoreUpdateListener.class);
+  private final EventTrackingService eventTrackingService= ComponentManager.get( EventTrackingService.class );
+
   //private static EvaluationListenerUtil util;
   //private static BeanSort bs;
   //private static ContextUtil cu;
@@ -212,7 +221,7 @@ public class QuestionScoreUpdateListener
             data.setGradedDate(new Date());
             String targetString = "siteId=" + AgentFacade.getCurrentSiteId() + ", " + logString.toString();
             String safeString = targetString.length() > 255 ? targetString.substring(0, 255) : targetString;
-            EventTrackingService.post(EventTrackingService.newEvent("sam.question.score.update", safeString, true));
+            eventTrackingService.post(eventTrackingService.newEvent("sam.question.score.update", safeString, true));
             delegate.updateItemScore(data, newAutoScore-oldAutoScore, tbean.getPublishedAssessment());
           }
           
@@ -260,7 +269,7 @@ public class QuestionScoreUpdateListener
 	  GradingService gradingService = new GradingService();
 	  if (attachmentList.size() > 0) {
 			gradingService.saveOrUpdateAttachments(attachmentList);
-			EventTrackingService.post(EventTrackingService.newEvent("sam.student.score.update", 
+			eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, 
 					"siteId=" + AgentFacade.getCurrentSiteId() + ", Adding " + attachmentList.size() + " attachments for itemGradingData id = " + itemGradingData.getItemGradingId(), 
 					true));
 		}
@@ -271,7 +280,7 @@ public class QuestionScoreUpdateListener
 	  while (iter.hasNext()){
 		  Long attachmentId = (Long)iter.next();
 		  gradingService.removeItemGradingAttachment(attachmentId.toString());
-		  EventTrackingService.post(EventTrackingService.newEvent("sam.student.score.update", 
+		  eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, 
 				  "siteId=" + AgentFacade.getCurrentSiteId() + ", Removing attachmentId = " + attachmentId, true));
 	  }
 	  bean.setIsAnyItemGradingAttachmentListModified(true);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreUpdateListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreUpdateListener.java
@@ -40,7 +40,10 @@ import javax.faces.event.ActionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.commons.math3.util.Precision;
-import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingAttachment;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
@@ -53,6 +56,7 @@ import org.sakaiproject.tool.assessment.ui.bean.delivery.SectionContentsBean;
 import org.sakaiproject.tool.assessment.ui.bean.evaluation.StudentScoresBean;
 import org.sakaiproject.tool.assessment.ui.bean.evaluation.TotalScoresBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.SamigoLRSStatements;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 
 /**
@@ -70,6 +74,8 @@ public class StudentScoreUpdateListener
   implements ActionListener
 {
   private static Logger log = LoggerFactory.getLogger(StudentScoreUpdateListener.class);
+  private final EventTrackingService eventTrackingService= ComponentManager.get( EventTrackingService.class );
+
   private static ContextUtil cu;
 
   /**
@@ -220,7 +226,7 @@ public class StudentScoreUpdateListener
               data.setGradedDate(new Date());
               String targetString = "siteId=" + AgentFacade.getCurrentSiteId() + ", " + logString.toString();
               String safeString = targetString.length() > 255 ? targetString.substring(0, 255) : targetString;
-              EventTrackingService.post(EventTrackingService.newEvent("sam.student.score.update", safeString, true));
+              eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, safeString, true));
               log.debug("****4 itemGradingId="+data.getItemGradingId());
               log.debug("****5 set points = " + data.getAutoScore() + ", comments to " + data.getComments());
             }
@@ -269,7 +275,7 @@ public class StudentScoreUpdateListener
           logString.append(newComments);
           logString.append(", oldComments=");
           logString.append(oldComments);
-    	  EventTrackingService.post(EventTrackingService.newEvent("sam.student.score.update", logString.toString(), true));
+          eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, logString.toString(), AgentFacade.getCurrentSiteId(), true, NotificationService.NOTI_OPTIONAL, SamigoLRSStatements.getStatementForStudentScoreUpdate(adata, tbean.getPublishedAssessment())));
       }
 
       if (updateFlag) {
@@ -332,7 +338,7 @@ public class StudentScoreUpdateListener
     				GradingService gradingService = new GradingService();
     				if (attachmentList.size() > 0) {
     					gradingService.saveOrUpdateAttachments(attachmentList);
-    					EventTrackingService.post(EventTrackingService.newEvent("sam.student.score.update", 
+    					eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, 
     							"siteId=" + AgentFacade.getCurrentSiteId() + ", Adding " + attachmentList.size() + " attachments for itemGradingData id = " + itemGradingData.getItemGradingId(), 
     							true));
     				}
@@ -343,7 +349,7 @@ public class StudentScoreUpdateListener
     				while (iter4.hasNext()){
     					Long attachmentId = (Long)iter4.next();
     					gradingService.removeItemGradingAttachment(attachmentId.toString());
-    					EventTrackingService.post(EventTrackingService.newEvent("sam.student.score.update", 
+    					eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, 
     							"siteId=" + AgentFacade.getCurrentSiteId() + ", Removing attachmentId = " + attachmentId, true));
     				}
     			}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -55,6 +55,7 @@ import org.apache.commons.math3.util.Precision;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
 import org.sakaiproject.spring.SpringBeanLocator;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingAttachment;
@@ -261,7 +262,7 @@ public class GradingService
       for (int i=0; i<gdataList.size(); i++){
         AssessmentGradingData ag = (AssessmentGradingData)gdataList.get(i);
         saveOrUpdateAssessmentGrading(ag);
-        EventTrackingService.post(EventTrackingService.newEvent("sam.total.score.update", 
+        EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_TOTAL_SCORE_UPDATE, 
         		"siteId=" + AgentFacade.getCurrentSiteId() +
         		", gradedBy=" + AgentFacade.getAgentString() + 
         		", assessmentGradingId=" + ag.getAssessmentGradingId() + 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoLRSStatements.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoLRSStatements.java
@@ -1,0 +1,98 @@
+package org.sakaiproject.tool.assessment.util;
+
+import java.util.HashMap;
+
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Actor;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Context;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Object;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Result;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Statement;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb;
+import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb.SAKAI_VERB;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAssessmentData;
+import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
+import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
+
+/* 
+ * Class that holds custom code for generating LRS_Statements that contain special samigo Metadata
+ */
+public class SamigoLRSStatements {
+    private static final ServerConfigurationService serverConfigurationService = ComponentManager.get( ServerConfigurationService.class );
+
+    public static LRS_Statement getStatementForTakeAssessment(String assessmentTitle, boolean pastDue, boolean isViaURL) {
+    	StringBuffer lrssMetaInfo = new StringBuffer("Assesment: " + assessmentTitle);
+    	lrssMetaInfo.append(", Past Due?: " + pastDue);
+    	if (isViaURL) {
+    		lrssMetaInfo.append(", Assesment taken via URL.");
+    	}
+    	
+        String url = serverConfigurationService.getPortalUrl();
+        LRS_Verb verb = new LRS_Verb(SAKAI_VERB.attempted);
+        LRS_Object lrsObject = new LRS_Object(url + "/assessment", "attempted-assessment");
+        HashMap<String, String> nameMap = new HashMap<String, String>();
+        nameMap.put("en-US", "User attempted assessment");
+        lrsObject.setActivityName(nameMap);
+        HashMap<String, String> descMap = new HashMap<String, String>();
+        descMap.put("en-US", "User attempted assessment: " + lrssMetaInfo);
+        lrsObject.setDescription(descMap);
+        return new LRS_Statement(null, verb, lrsObject);
+    }
+    
+    public static LRS_Statement getStatementForGradedAssessment(AssessmentGradingData gradingData, PublishedAssessmentFacade publishedAssessment) {
+        LRS_Verb verb = new LRS_Verb(SAKAI_VERB.scored);
+        LRS_Object lrsObject = new LRS_Object(serverConfigurationService.getPortalUrl() + "/assessment", "received-grade-assessment");
+        HashMap<String, String> nameMap = new HashMap<>();
+        nameMap.put("en-US", "User received a grade");
+        lrsObject.setActivityName(nameMap);
+        HashMap<String, String> descMap = new HashMap<>();
+        descMap.put("en-US", "User received a grade for their assessment: " + publishedAssessment.getTitle() + "; Submitted: "
+                + (gradingData.getIsLate() ? "late" : "on time"));
+        lrsObject.setDescription(descMap);
+        LRS_Context context = new LRS_Context("other", "assessment");
+        LRS_Statement statement = new LRS_Statement(null, verb, lrsObject, getLRS_Result(gradingData, publishedAssessment), context);
+        return statement;
+	}
+
+    public static LRS_Statement getStatementForTotalScoreUpdate(AssessmentGradingData gradingData, PublishedAssessmentData publishedAssessment) {
+        LRS_Verb verb = new LRS_Verb(SAKAI_VERB.scored);
+        LRS_Object lrsObject = new LRS_Object(serverConfigurationService.getPortalUrl() + "/assessment", "total-score-update");
+        HashMap<String, String> nameMap = new HashMap<>();
+        nameMap.put("en-US", "Total score updated");
+        lrsObject.setActivityName(nameMap);
+        HashMap<String, String> descMap = new HashMap<>();
+        descMap.put("en-US", "Total score updated for: " + publishedAssessment.getTitle() + "; Submitted: "
+                + (gradingData.getIsLate() ? "late" : "on time"));
+        lrsObject.setDescription(descMap);
+        LRS_Context context = new LRS_Context("other", "assessment");
+        LRS_Statement statement = new LRS_Statement(null, verb, lrsObject, getLRS_Result(gradingData, publishedAssessment), context);
+        return statement;
+    }
+
+    public static LRS_Statement getStatementForStudentScoreUpdate(AssessmentGradingData gradingData, PublishedAssessmentData publishedAssessment) {
+        LRS_Verb verb = new LRS_Verb(SAKAI_VERB.scored);
+        LRS_Object lrsObject = new LRS_Object(serverConfigurationService.getPortalUrl() + "/assessment", "student-score-update");
+        HashMap<String, String> nameMap = new HashMap<>();
+        nameMap.put("en-US", "Student score updated");
+        lrsObject.setActivityName(nameMap);
+        HashMap<String, String> descMap = new HashMap<>();
+        descMap.put("en-US", "Student score updated for: " + publishedAssessment.getTitle() + "; Submitted: "
+                + (gradingData.getIsLate() ? "late" : "on time"));
+        lrsObject.setDescription(descMap);
+        LRS_Context context = new LRS_Context("other", "assessment");
+        LRS_Statement statement = new LRS_Statement(null, verb, lrsObject, getLRS_Result(gradingData, publishedAssessment), context);
+        return statement;
+    }
+
+    
+    private static LRS_Result getLRS_Result(AssessmentGradingData gradingData, PublishedAssessmentIfc publishedAssessment) {
+        double score = gradingData.getFinalScore();
+        LRS_Result result = new LRS_Result(score, 0.0, publishedAssessment.getTotalScore(), null);
+        result.setCompletion(true);
+        return result;
+    }
+    
+}


### PR DESCRIPTION
This also moved all of the LRS_Statement generation code into it's own util class because it seemed to make sense to me having it all together since it will make it easier to fix bugs there or add new detail.

The way this was updated, every Samigo code that wants to send to XAPI just needs to add this result generation onto the end of it's newEvent from the changes on https://jira.sakaiproject.org/browse/KNL-1451.

These events needs a lot more data than can be captured by the event alone (like various information about scoring) so it needs to generate it and send it along, rather than figuring it out afterward. 

Some of the other refactoring here changed the cover to the non-cover (because I didn't update the coverin KNL-1451) and this should be changed in all of Samigo, but seems like it would be better on a separate jira.