### PR TITLE
SAK-31736: Become User - Remind admins that 'logging out' returns them to the admin session they were in

### DIFF
--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -14,6 +14,7 @@ log.inputuserplaceholder = User
 log.inputpasswordplaceholder = Password
 
 sit_log   = Log Out
+sit_return = Return to
 sit_logout_warn = Are you sure you want to log out?
 sit_more  = All Sites
 sit_more_tab = My Active Sites

--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -14,7 +14,7 @@ log.inputuserplaceholder = User
 log.inputpasswordplaceholder = Password
 
 sit_log   = Log Out
-sit_return = Return to
+sit_return = Return to {0}
 sit_logout_warn = Are you sure you want to log out?
 sit_more  = All Sites
 sit_more_tab = My Active Sites

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -2358,20 +2358,22 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 	private String getImpersonatorDisplayId()
 	{
 		Session currentSession = SessionManager.getCurrentSession();
-		String currentUserId = currentSession.getUserId();
 		UsageSession originalSession = (UsageSession) currentSession.getAttribute(UsageSessionService.USAGE_SESSION_KEY);
-		String originalUserId = originalSession == null ? "" : originalSession.getUserId();
 		
-		if (originalSession != null && !originalUserId.equals(currentUserId))
+		if (originalSession != null)
 		{
-			try
+			String originalUserId = originalSession.getUserId();
+			if (!StringUtils.equals(currentSession.getUserId(), originalUserId))
 			{
-				User originalUser = UserDirectoryService.getUser(originalUserId);
-				return originalUser.getDisplayId();
-			}
-			catch (UserNotDefinedException e)
-			{
-				M_log.debug("Unable to retrieve user for id: " + originalUserId);
+				try
+				{
+					User originalUser = UserDirectoryService.getUser(originalUserId);
+					return originalUser.getDisplayId();
+				}
+				catch (UserNotDefinedException e)
+				{
+					M_log.debug("Unable to retrieve user for id: " + originalUserId);
+				}
 			}
 		}
 		

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1872,10 +1872,10 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				}
 				
 				// check if current user is being impersonated (by become user/sutool)
-				String impersonatorEid = getImpersonatorEid();
-				if (!impersonatorEid.isEmpty())
+				String impersonatorDisplayId = getImpersonatorDisplayId();
+				if (!impersonatorDisplayId.isEmpty())
 				{
-					message = rloader.getString("sit_return") + " " + impersonatorEid;
+					message = rloader.getString("sit_return") + " " + impersonatorDisplayId;
 				}
 
 				// check for a logout text override
@@ -2351,11 +2351,11 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 	}
 	
 	/**
-	 * Checks if current user is being impersonated (via become user/sutool) and returns userEId of
+	 * Checks if current user is being impersonated (via become user/sutool) and returns displayId of
 	 * the impersonator. Adapted from SkinnableLogin's isImpersonating()
-	 * @return userEid of impersonator, or empty string if not being impersonated
+	 * @return displayId of impersonator, or empty string if not being impersonated
 	 */
-	private String getImpersonatorEid()
+	private String getImpersonatorDisplayId()
 	{
 		Session currentSession = SessionManager.getCurrentSession();
 		String currentUserId = currentSession.getUserId();
@@ -2367,7 +2367,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 			try
 			{
 				User originalUser = UserDirectoryService.getUser(originalUserId);
-				return originalUser.getEid();
+				return originalUser.getDisplayId();
 			}
 			catch (UserNotDefinedException e)
 			{

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1875,7 +1875,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				String impersonatorDisplayId = getImpersonatorDisplayId();
 				if (!impersonatorDisplayId.isEmpty())
 				{
-					message = rloader.getString("sit_return") + " " + impersonatorDisplayId;
+					message = rloader.getFormattedMessage("sit_return", impersonatorDisplayId);
 				}
 
 				// check for a logout text override

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1881,7 +1881,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				// check for a logout text override
 				if (message == null)
 				{
-					message = StringUtils.defaultIfBlank(ServerConfigurationService.getString("logout.text"), rloader.getString("sit_log"));
+					message = ServerConfigurationService.getString("logout.text", rloader.getString("sit_log"));
 				}
 
 				// check for an image for the logout
@@ -2371,7 +2371,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 			}
 			catch (UserNotDefinedException e)
 			{
-				return "";
+				M_log.debug("Unable to retrieve user for id: " + originalUserId);
 			}
 		}
 		


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31736

Since SAK-27488, admins using the Become User feature are not logged out of Sakai when using the log out link, but are instead returned to their original admin session.

There is potential here for someone clicking log out once and forgetting to log out a second time, leaving an admin session open for anyone with access to their computer, particularly if they are accustomed to the old behaviour.

This patch will replace the "Log Out" text with "Return to <admin username>" to make it clear that they will not log out of Sakai but rather return to their prior admin session.