### PR TITLE
SAK-31740 Don’t specify http methods, apply to all.

### DIFF
--- a/dav/dav/src/webapp/WEB-INF/web.xml
+++ b/dav/dav/src/webapp/WEB-INF/web.xml
@@ -57,19 +57,6 @@
 		<web-resource-collection>
 			<web-resource-name>The Sakai DAV Access Point</web-resource-name>
 			<url-pattern>/*</url-pattern>
-			<http-method>GET</http-method>
-			<http-method>HEAD</http-method>
-			<http-method>OPTIONS</http-method>
-			<http-method>PROPFIND</http-method>
-			<http-method>PROPPATCH</http-method>
-			<http-method>DELETE</http-method>
-			<http-method>POST</http-method>
-			<http-method>PUT</http-method>
-			<http-method>LOCK</http-method>
-			<http-method>UNLOCK</http-method>
-			<http-method>MKCOL</http-method>
-			<http-method>MOVE</http-method>
-			<http-method>COPY</http-method>
 		</web-resource-collection>
 		<auth-constraint>
 			<role-name>tomcat</role-name>


### PR DESCRIPTION
If you specify a limited number of http-methods then tomcat warns on startup that unlisted methods will be allowed through without any security constrains applied to them.

All the methods in DavServlet were in the list so applying the security constraint to all methods won’t change the behaviour.

The error that would appear in the logs was: 

    For security constraints with URL pattern [/*] only the HTTP methods [HEAD MKCOL POST PROPFIND LOCK COPY OPTIONS PUT DELETE MOVE GET PROPPATCH UNLOCK] are covered. All other methods are uncovered.