### PR TITLE
3315 fix cells not being editable after a score is changed

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -1818,7 +1818,11 @@ GradebookEditableCell.prototype.handleSaveComplete = function(cellId) {
   this.handleWicketCellReplacement(cellId);
   // ensure fixed headers are aligned correctly after save, as vertical scroll
   // may change as messages are added/removed from above the grade table
-  $(document).trigger("scroll");
+  setTimeout(function() {
+    // take this off the critical path as we don't want any errors on
+    // the document scroll to stop the spreadsheet working
+    $(document).trigger("scroll");
+  });
 };
 
 


### PR DESCRIPTION
When triggering a document scroll, ensure this is off the critical path as any errors will stop the cell from being initialised.

Delivers #3315.