### PR TITLE
SAK-31752 - wrong error message appears to students for non-electronic submissions

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5411,7 +5411,7 @@ public class AssignmentAction extends PagedResourceActionII
 				String userId = u == null ? "" : u.getId();
 				addAlert(state, rb.getFormattedMessage("cannotfin_submission_1", new String[]{assignmentReference, userId}));
 			}
-			if (submission != null)
+			if (submission != null && a.getContent().getTypeOfSubmission() != Assignment.NON_ELECTRONIC_ASSIGNMENT_SUBMISSION)
 			{
 				String submissionReference = submission.getReference();
 				prepareStudentViewGrade(state, submissionReference);


### PR DESCRIPTION
1. As instructor create a non-electronic assignment whose Open Date is in the past, and the Due Date / Accept Until are both in the future
2. Go to the assignment's "View submissions" link
3. As a student view the assignment
Symptom: Student sees alert message is "The close date of the assignment has passed. You can no longer submit to this assignment."
Note: Step 2 creates dummy submission objects for the instructor to grade; if you skip step 2, you'll get the appropriate message:
"This assignment does not accept online submissions. Contact your instructor for additional instructions."