### PR TITLE
3006 show both "readonly" and "extra credit" icons when applicable

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPopoverPanel.html
@@ -5,6 +5,9 @@
 <wicket:panel>
     <a wicket:id="closePopoverLink"  href="javascript:void(0);" class="gb-popover-close"></a>
     <ul class="gb-popover-notifications">
+        <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
+        <li wicket:id="isReadOnlyNotification" class="gb-popover-notification-is-readonly text-info"><span wicket:id="message"></span></li>
+
         <li wicket:id="saveErrorNotification" class="gb-popover-notification-error text-danger"><span wicket:id="message"></span></li>
         <li wicket:id="isInvalidNotification" class="gb-popover-notification-invalid text-warning">
             <span wicket:id="message"></span>
@@ -22,8 +25,6 @@
             <p wicket:id="editCommentContainer"><a href="javascript:void(0);" class="gb-popover-link"><wicket:message key="comment.option.edit" /></a></p>
             <p wicket:id="externalComment">Editable in [Tool Name] Tool</p>
         </li>
-        <li wicket:id="isExternalNotification" class="gb-popover-notification-is-external text-info"><span wicket:id="message"></span></li>
-        <li wicket:id="isReadOnlyNotification" class="gb-popover-notification-is-readonly text-info"><span wicket:id="message"></span></li>
     </ul>
 
 </wicket:panel>

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -715,6 +715,11 @@
   font-family: "gradebook-icons";
   content: '\f040';
 }
+.gb-popover-notification-is-external:before,
+.gb-popover-notification-is-readonly {
+  font-family: "gradebook-icons";
+  content: '\f023';
+}
 .gb-popover-notifications .gb-popover-link {
   float: right;
   font-size: 0.9em;
@@ -869,6 +874,16 @@ div.wicket-modal div.w_right > div {
 .gb-external-item-cell .gb-cell-notification-warning:before {
   color: #CCC;
   content: '\f023';
+}
+.gb-readonly-item-cell.grade-save-over-limit .gb-cell-notification-warning:after,
+.gb-external-item-cell.grade-save-over-limit .gb-cell-notification-warning:after {
+  font-family: "gradebook-icons";
+  content: '\f0fe';
+  color: rgb(200,144,0);
+  font-size: 10px;
+  left: 12px;
+  position: absolute;
+  top: 6px;
 }
 .gb-readonly-item-cell:focus .gb-cell-notification-warning,
 .gb-readonly-item-cell .gb-cell-notification-warning:focus,


### PR DESCRIPTION
Including a slight refactor of the setting of the cell's CSS classes.  Now we specify a 'base' CSS class which will allow the doubling up of classes e.g. an external score that is also extra credit.  Then style these doubled-up scores accordingly, with both icons.

Delivers #3006.