### PR TITLE
3210 ensure stored scores with more than 2 decimal places don't cause a concurrent edit error when in percentage mode

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -491,7 +491,7 @@ public class GradebookNgBusinessService {
 			// the passed in grades represents a percentage so the number needs to be adjusted back to points
 			final Double newGradePercentage = NumberUtils.toDouble(newGrade);
 			final Double newGradePointsFromPercentage = (newGradePercentage / 100) * maxPoints;
-			newGradeAdjusted = FormatHelper.formatDoubleToTwoDecimalPlaces(newGradePointsFromPercentage);
+			newGradeAdjusted = FormatHelper.formatDoubleToDecimal(newGradePointsFromPercentage);
 
 			// only convert if we had a previous value otherwise it will be out of sync
 			if (StringUtils.isNotBlank(oldGradeAdjusted)) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1,6 +1,7 @@
 package org.sakaiproject.gradebookng.business;
 
 import java.math.RoundingMode;
+import java.text.Format;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -498,21 +499,12 @@ public class GradebookNgBusinessService {
 				// is the latest saved score against score stored in the database. As the score
 				// is stored as points, we must convert this to a percentage. To be sure we're
 				// comparing apples with apples, we first determine the number of decimal places
-				// on the score, so the converted points-as-percentage is in the expected format. 
-				int numberOfDecimalPlaces = 0;
-				if (storedGradeAdjusted.indexOf(".") >= 0) {
-					numberOfDecimalPlaces = storedGradeAdjusted.split("\\.")[1].length();
-				}
+				// on the score, so the converted points-as-percentage is in the expected format.
 
 				final Double oldGradePercentage = NumberUtils.toDouble(oldGrade);
 				final Double oldGradePointsFromPercentage = (oldGradePercentage / 100) * maxPoints;
-				final NumberFormat df = NumberFormat.getInstance();
-				df.setMinimumFractionDigits(0);
-				df.setMaximumFractionDigits(numberOfDecimalPlaces);
-				df.setGroupingUsed(false);
-				df.setRoundingMode(RoundingMode.HALF_DOWN);
 
-				oldGradeAdjusted = df.format(oldGradePointsFromPercentage);
+				oldGradeAdjusted = FormatHelper.formatDoubleToMatch(oldGradePointsFromPercentage, storedGradeAdjusted);
 			}
 
 			// we dont need processing of the stored grade as the service does that when persisting.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -21,13 +21,43 @@ public class FormatHelper {
 	 * @return double to decimal places
 	 */
 	public static String formatDoubleToTwoDecimalPlaces(final Double score) {
+		return formatDoubleToNDecimalPlaces(score, 2);
+	}
+
+	/**
+	 * The value is a double (ie 12.34542) that needs to be formatted as a percentage with 'n' decimal places precision. And drop off any .0
+	 * if no decimal places.
+	 *
+	 * @param score as a double
+	 * @param n as an int
+	 * @return double to n decimal places
+	 */
+	private static String formatDoubleToNDecimalPlaces(final Double score, final int n) {
 		final NumberFormat df = NumberFormat.getInstance();
 		df.setMinimumFractionDigits(0);
-		df.setMaximumFractionDigits(2);
+		df.setMaximumFractionDigits(n);
 		df.setGroupingUsed(false);
 		df.setRoundingMode(RoundingMode.HALF_DOWN);
 
 		return formatGrade(df.format(score));
+	}
+
+	/**
+	 * Convert a double score to match the number of decimal places exhibited in the
+	 * toMatch string representation of a number
+	 *
+	 * @param score as a double
+	 * @param toMatch the number as a string
+	 * @return double to decimal places
+	 */
+	public static String formatDoubleToMatch(final Double score, final String toMatch) {
+		int numberOfDecimalPlaces = 0;
+
+		if (toMatch.indexOf(".") >= 0) {
+			numberOfDecimalPlaces = toMatch.split("\\.")[1].length();
+		}
+
+		return FormatHelper.formatDoubleToNDecimalPlaces(score, numberOfDecimalPlaces);
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -20,8 +20,8 @@ public class FormatHelper {
 	 * @param score as a double
 	 * @return double to decimal places
 	 */
-	public static String formatDoubleToTwoDecimalPlaces(final Double score) {
-		return formatDoubleToNDecimalPlaces(score, 2);
+	public static String formatDoubleToDecimal(final Double score) {
+		return formatDoubleToDecimal(score, 2);
 	}
 
 	/**
@@ -32,7 +32,7 @@ public class FormatHelper {
 	 * @param n as an int
 	 * @return double to n decimal places
 	 */
-	private static String formatDoubleToNDecimalPlaces(final Double score, final int n) {
+	private static String formatDoubleToDecimal(final Double score, final int n) {
 		final NumberFormat df = NumberFormat.getInstance();
 		df.setMinimumFractionDigits(0);
 		df.setMaximumFractionDigits(n);
@@ -57,7 +57,7 @@ public class FormatHelper {
 			numberOfDecimalPlaces = toMatch.split("\\.")[1].length();
 		}
 
-		return FormatHelper.formatDoubleToNDecimalPlaces(score, numberOfDecimalPlaces);
+		return FormatHelper.formatDoubleToDecimal(score, numberOfDecimalPlaces);
 	}
 
 	/**
@@ -68,7 +68,7 @@ public class FormatHelper {
 	 */
 	public static String formatDoubleAsPercentage(final Double score) {
 		// TODO does the % need to be internationalised?
-		return formatDoubleToTwoDecimalPlaces(score) + "%";
+		return formatDoubleToDecimal(score) + "%";
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeStatisticsPanel.java
@@ -208,7 +208,7 @@ public class GradeStatisticsPanel extends Panel {
 
 	private String constructAverageLabel(final List<Double> allGrades, final Assignment assignment) {
 		final double average = calculateAverage(allGrades);
-		final String averageFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(average));
+		final String averageFormatted = FormatHelper.formatDoubleToDecimal(Double.valueOf(average));
 
 		if (GbGradingType.PERCENTAGE.equals(gradingType)) {
 			return (new StringResourceModel("label.percentage.valued",
@@ -226,7 +226,7 @@ public class GradeStatisticsPanel extends Panel {
 
 	private String constructMedianLabel(final List<Double> allGrades, final Assignment assignment) {
 		final double median = calculateMedian(allGrades);
-		final String medianFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(median));
+		final String medianFormatted = FormatHelper.formatDoubleToDecimal(Double.valueOf(median));
 
 		if (GbGradingType.PERCENTAGE.equals(gradingType)) {
 			return (new StringResourceModel("label.percentage.valued",
@@ -244,7 +244,7 @@ public class GradeStatisticsPanel extends Panel {
 
 	private String constructLowestLabel(final List<Double> allGrades, final Assignment assignment) {
 		final double lowest = Collections.min(allGrades);
-		final String lowestFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(lowest));
+		final String lowestFormatted = FormatHelper.formatDoubleToDecimal(Double.valueOf(lowest));
 
 		if (GbGradingType.PERCENTAGE.equals(gradingType)) {
 			return (new StringResourceModel("label.percentage.valued",
@@ -262,7 +262,7 @@ public class GradeStatisticsPanel extends Panel {
 
 	private String constructHighestLabel(final List<Double> allGrades, final Assignment assignment) {
 		final double highest = Collections.max(allGrades);
-		final String highestFormatted = FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(highest));
+		final String highestFormatted = FormatHelper.formatDoubleToDecimal(Double.valueOf(highest));
 
 		if (GbGradingType.PERCENTAGE.equals(gradingType)) {
 			return (new StringResourceModel("label.percentage.valued",
@@ -281,7 +281,7 @@ public class GradeStatisticsPanel extends Panel {
 	private String constructStandardDeviationLabel(final List<Double> allGrades) {
 		final double deviation = calculateStandardDeviation(allGrades);
 
-		return FormatHelper.formatDoubleToTwoDecimalPlaces(Double.valueOf(deviation));
+		return FormatHelper.formatDoubleToDecimal(Double.valueOf(deviation));
 	}
 
 	private double calculateAverage(final List<Double> allGrades) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
@@ -672,7 +672,7 @@ public class SettingsCategoryPanel extends Panel {
 			// convert to percentage representation
 			final Double percentage = value * 100;
 
-			return FormatHelper.formatDoubleToTwoDecimalPlaces(percentage);
+			return FormatHelper.formatDoubleToDecimal(percentage);
 		}
 
 	}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -285,7 +285,7 @@ public class ExportPanel extends Panel {
 				final CourseGrade courseGrade = gbCourseGrade.getCourseGrade();
 
 				if (isCustomExport && this.includePoints) {
-					line.add(FormatHelper.formatDoubleToTwoDecimalPlaces(courseGrade.getPointsEarned()));
+					line.add(FormatHelper.formatDoubleToDecimal(courseGrade.getPointsEarned()));
 				}
 				if (isCustomExport && this.includeCalculatedGrade) {
 					line.add(courseGrade.getCalculatedGrade());


### PR DESCRIPTION
Delivers #3210.  Not sure if this is the best approach, but it was worky!  The goal was to put the score from the database and what we think is the database score in the same format so a fair comparison can be made.