### PR TITLE
SAK-31776 Don’t fail to log when no cause for quartz.

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/NavigableEventLogListener.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/NavigableEventLogListener.java
@@ -124,8 +124,11 @@ public class NavigableEventLogListener implements TriggerListener, JobListener
 
                 if (exception != null)
                 {
-                    sb.append (", exception: ").append(exception.getMessage())
-                      .append(", exception cause: ").append(exception.getCause().getClass().getName());
+                    sb.append (", exception: ").append(exception.getMessage());
+                    if (exception.getCause() != null)
+                    {
+                      sb.append(", exception cause: ").append(exception.getCause().getClass().getName());
+                    }
                 }
                 sb.append("]");
 


### PR DESCRIPTION
When logging a job execution that had an exception with it, if there isn’t a cause the listener would fail to run completely. The simple fix is to just check before attempting to use look at the cause.