### PR TITLE
SAK-31678 Fixed reload message when starring sites so it appears on one line

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -479,7 +479,9 @@ ul.favoriteSiteList{
 	border-radius: 3px;
 	text-decoration: none;
 
-	a{
+	a
+	{
+		display: inline-block; // to override flex on login links
 		color: $primary-color;
 	}
 


### PR DESCRIPTION
Simple fix to make the text of the reload message appear on one line:

Before:
![01-before](https://cloud.githubusercontent.com/assets/12685096/18608389/cb00b67c-7cb5-11e6-84ac-4a1e4b272a2c.png)

After:
![02-after](https://cloud.githubusercontent.com/assets/12685096/18608393/cfbd1fb6-7cb5-11e6-84b8-d1207053c1cf.png)

