### PR TITLE
SAK-31779 Correct typo in Basic LTI admin tool.

### DIFF
--- a/basiclti/basiclti-tool/src/webapp/vm/lti_tool_system.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_tool_system.vm
@@ -125,7 +125,7 @@ ${includeLatestJQuery}
 			<img src="/basiclti-admin-tool/addons/pager/icons/next.png" class="next" alt="Next" />
 			<img src="/basiclti-admin-tool/addons/pager/icons/last.png" class="last" alt="Last" />
 			<select class="pagesize">
-				<option value="10">10/option>
+				<option value="10">10</option>
 				<option selected="selected" value="50">50</option>
 				<option value="100">100</option>
 				<option value="200">200</option>


### PR DESCRIPTION
The 10 option in the list of tools installed in the system had a typo in it.