### PR TITLE
SAK-31792 Require Maven 3.1.1 minimum

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1983,7 +1983,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.0.5</version>
+                  <version>3.1.1</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>${sakai.jdk.version}</version>


### PR DESCRIPTION
One of our plugins requires Maven 3.1.1 and having the requirement for the whole project makes the build fail earlier.