### PR TITLE
SAK-31520 - In Resources add another web link doesn't work

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -1217,10 +1217,6 @@
 			}
 			$( frame ).height( clientH );
 		} 
-		else 
-		{
-			throw( "resizeFrame did not get the frame (using name=" + window.name + ")" );
-		}
 	}
 	function handleAccessNotGroup(evt)
 	{


### PR DESCRIPTION
Because there are no frames anymore for most tools this won't find the frame. I believe the error that was thrown was causing other problems on the page and doesn't seem necessary.