### PR TITLE
3369 allow date format to be set via gradebook I18n resources

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -1,5 +1,8 @@
 app.title = Gradebook
 
+format.date = MM/dd/yyyy
+format.datetime = MM/dd/yyyy HH:mm
+
 link.gradebook = Grades
 link.gradebook.tooltip = Grades
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -92,7 +92,8 @@ public class FormatHelper {
 	 * @return
 	 */
 	private static String formatDate(final Date date) {
-		final SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy"); // TODO needs to come from i18n
+		final String dateFormatString = MessageHelper.getString("format.date");
+		final SimpleDateFormat df = new SimpleDateFormat(dateFormatString);
 		return df.format(date);
 	}
 
@@ -118,7 +119,8 @@ public class FormatHelper {
 	 * @return
 	 */
 	public static String formatDateTime(final Date date) {
-		final SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy HH:mm"); // TODO needs to come from i18n
+		final String dateTimeFormatString = MessageHelper.getString("format.datetime");
+		final SimpleDateFormat df = new SimpleDateFormat(dateTimeFormatString);
 		return df.format(date);
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.html
@@ -36,7 +36,7 @@
 				</label>
 				<div class="col-xs-4">
                     <div class="input-group">
-                        <input wicket:id="duedate" type="text" class="form-control gb-datepicker" placeholder="mm/dd/yyyy" aria-describedby="duedate-help"/>
+                        <input wicket:id="duedate" type="text" class="form-control gb-datepicker" wicket:message="data-format:format.date,placeholder:format.date" aria-describedby="duedate-help"/>
                         <span class="input-group-btn">
                             <button class="btn btn-sm btn-default invoke-datepicker-btn" type="button"><span class="glyphicon glyphicon-calendar"></span></button>
                             <button class="btn btn-sm btn-default clear-datepicker-btn" type="button"><span class="glyphicon glyphicon-remove"></span></button>
@@ -51,9 +51,9 @@
                                     input: '#' + $datepicker.attr('id'),
                                     useTime: 0,
                                     icon: 0,
-                                    dateFormat: 'MM/DD/YYYY',
+                                    dateFormat: $datepicker.data("format"),
                                     timeFormat: '',
-                                    parseFormat: 'MM/DD/YYYY',
+                                    parseFormat: $datepicker.data("format"),
                                     ashidden: { iso8601: $datepicker.attr('id') + '_iso8601' }
                                 })
     

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
@@ -118,7 +118,7 @@ public class AddOrEditGradeItemPanelContent extends Panel {
 		// due date
 		// TODO date format needs to come from i18n
 		final DateTextField dueDate = new DateTextField("duedate", new PropertyModel<Date>(assignmentModel, "dueDate"),
-				"MM/dd/yyyy") {
+				getString("format.date")) {
 			private static final long serialVersionUID = 1L;
 
 			@Override


### PR DESCRIPTION
Delivers #3369, maybe? 

I've added `format.date` and `format.datetime` to the Gradebook I18n properties.  This gets pulled into the FormatHelper and date picker. 

The datepicker has its own ideas for date formats defined in `lang-datepicker.js`.  I assume we just duplicate that values for each language as required?

Things work as expected if I add a `GradebookNgApplication_fr_CA.properties` translation file with:
```
format.date = yyyy-MM-dd 
format.datetime = yyyy-MM-dd HH:mm
```
Is that the best we can do? 
