### PR TITLE
Fix for lesson breadcrumb links that are the same color as their back…

### DIFF
--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -971,6 +971,7 @@ ul#toolbar li em {
 
 }
 .lessons-siteHierarchy-title {
+   color: white;
    font-weight: bold;
    margin-left: 0.5em;
 }


### PR DESCRIPTION
…ground; change their color to white.

Essentially, in lessons, when viewing subpages, the final title in the breadcrumb trail is always hidden from view because its font color is the same as the background color. All this change does is change the color of that final title to white so that it is visible over the dark background.
