### PR TITLE
SAK-31801 Signup muddles usernames and user ids.

### DIFF
--- a/signup/api/src/java/org/sakaiproject/signup/logic/SakaiFacade.java
+++ b/signup/api/src/java/org/sakaiproject/signup/logic/SakaiFacade.java
@@ -475,4 +475,13 @@ public interface SakaiFacade {
 	
 	// Returns Google calendar if the calendar has been created in Google
 	public Calendar getAdditionalCalendar(String siteId) throws PermissionException;
+
+	/**
+	 * Get a user by displayId. Only use this if you are certain that there is only one user that matches,
+	 * as it will only return the first user if there are multiples.
+	 *
+	 * @param displayId  string display id (e.g. Oxford username)
+	 * @return           a User or <code>null</code> if no match
+	 */
+	public User getUserByDisplayId(String displayId);
 }

--- a/signup/impl/src/java/org/sakaiproject/signup/logic/SakaiFacadeImpl.java
+++ b/signup/impl/src/java/org/sakaiproject/signup/logic/SakaiFacadeImpl.java
@@ -1464,4 +1464,17 @@ public class SakaiFacadeImpl implements SakaiFacade {
 		securityService.popAdvisor(securityAdvisor);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public User getUserByDisplayId(String displayId) {
+		User user = null;
+		try {
+			user = userDirectoryService.getUserByAid(displayId);
+		} catch (UserNotDefinedException e) {
+			// that's fine just return null
+		}
+		return user;
+	}
+
 }

--- a/signup/tool/src/bundle/messages.properties
+++ b/signup/tool/src/bundle/messages.properties
@@ -556,7 +556,7 @@ events_organizer_download_instruction = Select the meetings and then click the E
 
 events_organizer_instruction = Click 'Add' to create a new meeting, or click a meeting title to modify or copy it.
 
-exception.multiple.eids = {0} Matches multiple users. Please select from the following usernames: {1}
+exception.multiple.displayIds = {0} Matches multiple users. Please select from the following usernames: {1}
 exception.no.such.user  = No user was found for user ID:&nbsp;
 
 expand_all_recur_events = &nbsp;Expand all recurring meetings.

--- a/signup/tool/src/bundle/messages_en_AU.properties
+++ b/signup/tool/src/bundle/messages_en_AU.properties
@@ -534,7 +534,7 @@ events_organizer_download_instruction = Select the meetings and then click the E
 
 events_organizer_instruction = Click 'Add' to create a new meeting, or click a meeting title to modify or copy it.
 
-exception.multiple.eids = {0} Matches multiple users. Please select from the following usernames: {1}
+exception.multiple.displayIds = {0} Matches multiple users. Please select from the following usernames: {1}
 exception.no.such.user  = No user was found for user ID:&nbsp;
 
 expand_all_recur_events = &nbsp;Expand all recurring meetings.

--- a/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/NewSignupMeetingBean.java
+++ b/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/NewSignupMeetingBean.java
@@ -991,14 +991,15 @@ public class NewSignupMeetingBean implements MeetingTypes, SignupMessageTypes, S
 		if(attendeeEidOrEmail ==null || attendeeEidOrEmail.length() <1)
 			return PRE_ASSIGN_ATTENDEE_PAGE_URL;
 		
-		//check if there are multiple email addresses associated with input
-		List<String> associatedEids = getEidsForEmail(attendeeEidOrEmail.trim());
-		if(associatedEids.size() > 1) {
-			Utilities.addErrorMessage(MessageFormat.format(Utilities.rb.getString("exception.multiple.eids"), new Object[] {attendeeEidOrEmail, StringUtils.join(associatedEids, ", ")}));
+		//check if there are many users associated with the input email address
+		List<String> associatedDisplayIds = getEidsForEmail(attendeeEidOrEmail.trim());
+		if(associatedDisplayIds.size() > 1) {
+			Object[] ids = {attendeeEidOrEmail, StringUtils.join(associatedDisplayIds, ", ")};
+			Utilities.addErrorMessage(MessageFormat.format(Utilities.rb.getString("exception.multiple.displayIds"), ids));
 			return PRE_ASSIGN_ATTENDEE_PAGE_URL;
 		}
 
-		String attendeeUserId = getUserIdForEidOrEmail(attendeeEidOrEmail.trim());
+		String attendeeUserId = getUserIdForDisplayIdOrEidOrEmail(attendeeEidOrEmail.trim());
 		if(StringUtils.isBlank(attendeeEidOrEmail)){
 			Utilities.addErrorMessage(Utilities.rb.getString("exception.no.such.user") + attendeeEidOrEmail);
 			return PRE_ASSIGN_ATTENDEE_PAGE_URL;
@@ -1019,6 +1020,19 @@ public class NewSignupMeetingBean implements MeetingTypes, SignupMessageTypes, S
 		}
 
 		return PRE_ASSIGN_ATTENDEE_PAGE_URL;
+	}
+
+
+	/**
+	 * Gets the userId for a user, given a displayId or an Eid or an email.
+	 * We check for users with the values in this order.
+	 *
+	 * @param value  the string to lookup
+	 * @return       the userId or <code>null</code> if User cannot be found
+	 */
+	public String getUserIdForDisplayIdOrEidOrEmail(String value) {
+		User user = sakaiFacade.getUserByDisplayId(value);
+		return (user == null) ? getUserIdForEidOrEmail(value) : user.getId();
 	}
 
 	/**

--- a/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/SignupUIBaseBean.java
+++ b/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/SignupUIBaseBean.java
@@ -975,4 +975,32 @@ abstract public class SignupUIBaseBean implements SignupBeanConstants, SignupMes
 		this.customCategory = customCategory;
 	}
 
+	/**
+	 * Gets the userId for a user, given a displayId or an Eid or an email.
+	 * We check for users with the values in this order.
+	 *
+	 * @param value  the string to lookup
+	 * @return       the userId or <code>null</code> if User cannot be found
+	 */
+	public String getUserIdForDisplayIdOrEidOrEmail(String value) {
+		User user = sakaiFacade.getUserByDisplayId(value);
+		return (user == null) ? getUserIdForEidOrEmail(value) : user.getId();
+	}
+
+	/**
+	 * Get the display ids associated with an email address since there may be many users with an email address.
+	 * We prefer to use this in the UI over the enterprise ID because it is more meaningful.
+	 *
+	 * @param email  The email address.
+	 * @return       A list of display id strings.
+	 */
+	public List<String> getDisplayIdsForEmail(String email) {
+		List<User> users = sakaiFacade.getUsersByEmail(email);
+		List<String> displayIds = new ArrayList<String>();
+		for (User user : users) {
+			displayIds.add(user.getDisplayId());
+		}
+		return displayIds;
+	}
+
 }

--- a/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/organizer/OrganizerSignupMBean.java
+++ b/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/organizer/OrganizerSignupMBean.java
@@ -407,13 +407,14 @@ public class OrganizerSignupMBean extends SignupUIBaseBean {
 			userEidOrEmail = (String) replacedAttendeeEidOrEmail.getValue();
 		}
 		
-		//check if there are multiple email addresses associated with input
-		List<String> associatedEids = getEidsForEmail(userEidOrEmail.trim());
-		if(associatedEids.size() > 1) {
-			throw new SignupUserActionException(MessageFormat.format(Utilities.rb.getString("exception.multiple.eids"), new Object[] {userEidOrEmail, StringUtils.join(associatedEids, ", ")}));
+		//check if there are many users associated with the input email address
+		List<String> associatedDisplayIds = getEidsForEmail(userEidOrEmail.trim());
+		if(associatedDisplayIds.size() > 1) {
+			Object[] ids = {userEidOrEmail, StringUtils.join(associatedDisplayIds, ", ")};
+			throw new SignupUserActionException(MessageFormat.format(Utilities.rb.getString("exception.multiple.displayIds"), ids));
 		}
-		
-		String replacerUserId = getUserIdForEidOrEmail(userEidOrEmail);
+
+		String replacerUserId = getUserIdForDisplayIdOrEidOrEmail(userEidOrEmail);
 		SignupUser replSignUser = getSakaiFacade().getSignupUser(getMeetingWrapper().getMeeting(), replacerUserId);
 		if(replSignUser ==null){
 			throw new SignupUserActionException(MessageFormat.format(Utilities.rb.getString("user.has.no.permission.attend"), new Object[] {userEidOrEmail}));
@@ -624,14 +625,15 @@ public class OrganizerSignupMBean extends SignupUIBaseBean {
 			return ORGANIZER_MEETING_PAGE_URL;
 		}
 		
-		//check if there are multiple email addresses associated with input
-		List<String> associatedEids = getEidsForEmail(newAttendeeEidOrEmail.trim());
-		if(associatedEids.size() > 1) {
-			Utilities.addErrorMessage(MessageFormat.format(Utilities.rb.getString("exception.multiple.eids"), new Object[] {newAttendeeEidOrEmail, StringUtils.join(associatedEids, ", ")}));
+		//check if there are many users associated with the input email address
+		List<String> associatedDisplayIds = getDisplayIdsForEmail(newAttendeeEidOrEmail.trim());
+		if(associatedDisplayIds.size() > 1) {
+			Object[] ids = {newAttendeeEidOrEmail, StringUtils.join(associatedDisplayIds, ", ")};
+			Utilities.addErrorMessage(MessageFormat.format(Utilities.rb.getString("exception.multiple.displayIds"), ids));
 			return ORGANIZER_MEETING_PAGE_URL;
 		}
 
-		String newUserId = getUserIdForEidOrEmail(newAttendeeEidOrEmail.trim());
+		String newUserId = getUserIdForDisplayIdOrEidOrEmail(newAttendeeEidOrEmail.trim());
 		if(StringUtils.isBlank(newUserId)){
 			Utilities.addErrorMessage(Utilities.rb.getString("exception.no.such.user") + newAttendeeEidOrEmail);
 			return ORGANIZER_MEETING_PAGE_URL;
@@ -758,14 +760,15 @@ public class OrganizerSignupMBean extends SignupUIBaseBean {
 			return ORGANIZER_MEETING_PAGE_URL;
 		}
 		
-		//check if there are multiple email addresses associated with input
-		List<String> associatedEids = getEidsForEmail(newWaiterEidOrEmail.trim());
-		if(associatedEids.size() > 1) {
-			Utilities.addErrorMessage(MessageFormat.format(Utilities.rb.getString("exception.multiple.eids"), new Object[] {newWaiterEidOrEmail, StringUtils.join(associatedEids, ", ")}));
+		//check if there are many users associated with the input email address
+		List<String> associatedDisplayIds = getEidsForEmail(newWaiterEidOrEmail.trim());
+		if(associatedDisplayIds.size() > 1) {
+			Object[] ids = {newWaiterEidOrEmail, StringUtils.join(associatedDisplayIds, ", ")};
+			Utilities.addErrorMessage(MessageFormat.format(Utilities.rb.getString("exception.multiple.displayIds"), ids));
 			return ORGANIZER_MEETING_PAGE_URL;
 		}
-		
-		String waiterUserId = getUserIdForEidOrEmail(newWaiterEidOrEmail.trim());
+
+		String waiterUserId = getUserIdForDisplayIdOrEidOrEmail(newWaiterEidOrEmail.trim());
 		if(StringUtils.isBlank(waiterUserId)){
 			Utilities.addErrorMessage(Utilities.rb.getString("exception.no.such.user") + newWaiterEidOrEmail);
 			return ORGANIZER_MEETING_PAGE_URL;


### PR DESCRIPTION
This fixes some of the confusing behaviour in the sign up tool where the ui
refers to user IDs but this corresponds to the enterprise ID as opposed to
the display ids.
