### PR TITLE
SAK-31613 Changed primary blue used in Morpheus meet WCAG colour contrast requirements

### DIFF
--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -34,7 +34,7 @@ $header-font-weight: 700 !default;										// 400 or 700 as you wish
 $background-color: 			 #FFFFFF !default;
 $background-color-secondary: #444444 !default;
 
-$primary-color:    			 #2a94c0 !default;
+$primary-color:    			 #247fa6 !default;
 $primary-color-shadow:			 #2A87C0 !default;
 $secondary-color:  			 #F00 !default;
 $alt-colour: 				 #d36f00 !default;


### PR DESCRIPTION
I have changed the primary blue used throughout Morpheus to meet WCAG Level A requirements. 

The former colour code for the primary blue in Sakai was #2a94c0, but was not high enough contrast on white. I changed this to a slightly darker blue (#247fa6), which passes the contrast ratio with white of 4.51:1. 

~~I also removed the primary-color-shadow variable and its one use case to avoid confusion.~~

*Before:*

![01-before](https://cloud.githubusercontent.com/assets/12685096/18915301/8ecdc558-855e-11e6-977d-8295a1010f79.png)

*After:*

![02-after](https://cloud.githubusercontent.com/assets/12685096/18915311/949efff6-855e-11e6-98f6-cd10f3d0c490.png)
