### PR TITLE
SAK-31811 Standardized the colour of the toolTitleNav links to fix colour contrast

### DIFF
--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -64,6 +64,8 @@ $tool-sub-menu-current-background-color: $background-color !default;
 $tool-sub-menu-current-hover-color: $tool-menu-color !default;
 $tool-sub-menu-current-hover-background-color: $background-color !default;
 
+$tool-nav-link-color: #666 !default;
+
 $main-content-background: $background-color !default;
 $top-header-background: $background-color-secondary !default;
 $sites-nav-background: $top-header-background !default;

--- a/reference/library/src/morpheus-master/sass/modules/tool/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/_base.scss
@@ -79,7 +79,7 @@
 		}
 	}
 	.#{$namespace}toolTitleNav__link{
-		//color: lighten( $text-color, 70% );
+		color: $tool-nav-link-color;
 		border: 1px solid #e0e0e0;
 		background: $tool-tab-background-color;
 		margin-right: 0.25em;
@@ -88,8 +88,8 @@
 		vertical-align: 0%;
 		&:hover{
 			background: $tool-background-color;
-			color: $primary-color;
-			box-shadow: 0 0 6px 0 rgba(0,0,0,.15);
+			color: $swapped-view-text-color;
+			text-decoration: none;
 		}
 		@media #{$tablet}{
 			background: $tool-background-color;
@@ -135,7 +135,7 @@
 			/*font-size: $default-font-size;*/
 			text-transform: uppercase;
 			font-size: 0.8em;
-			letter-spacing: 1.2px;
+			letter-spacing: 1px;
 			@media #{$tablet}{
 				display: none;
 			}

--- a/reference/library/src/morpheus-master/sass/modules/tool/_menu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/_menu.scss
@@ -23,7 +23,7 @@
 				border-top: 1px solid $tool-border-color;
 				border-left: 1px solid $tool-border-color;
 				border-right: 1px solid $tool-border-color;
-				color: #666;
+				color: $tool-nav-link-color;
 				display: block;
 				font-size: 0.8em;
 				margin: 2px 0.25em 0 0;
@@ -33,6 +33,12 @@
 				text-transform: uppercase;
 				@media #{$phone}{
 					@include sakai_button( $button-background-color, $button-border-color, $button-text-color, $button-background-secondary-color );
+				}
+				
+				&:hover
+				{
+					color: $swapped-view-text-color;
+					text-decoration: none;
 				}
 			}
 			&.current{


### PR DESCRIPTION
Standardized the colour of the toolTitleNav links to match the navIntraTool tabs and to address the accessibility of links' text colour contrast with their background colours; also removed link underlines from these tabs and buttons.

**Before:**
![01-before](https://cloud.githubusercontent.com/assets/12685096/18920562/c3a31998-856f-11e6-8df1-6cabaf48abb0.png)

**After:**
![02-after](https://cloud.githubusercontent.com/assets/12685096/18920572/cb441274-856f-11e6-943f-b6c02aaa1d31.png)

**Before (hover state on Student View):**
![03-before-hover](https://cloud.githubusercontent.com/assets/12685096/18920588/d55ca294-856f-11e6-845f-0c9968bd8407.png)

**After (hover state on Student View):**
![04-after-hover](https://cloud.githubusercontent.com/assets/12685096/18920602/ddfee10a-856f-11e6-895f-adc67527b583.png)

