### PR TITLE
SAK-31612 Fixed link colour contrast in User menu

### DIFF
--- a/reference/library/src/morpheus-master/sass/_defaults.scss
+++ b/reference/library/src/morpheus-master/sass/_defaults.scss
@@ -35,6 +35,7 @@ $background-color: 			 #FFFFFF !default;
 $background-color-secondary: #444444 !default;
 
 $primary-color:    			 #247fa6 !default;
+$primary-color-highContrast: darken( $primary-color, 4% ) !default;	// for use of primary on non-white light backgrounds, such as greys
 $primary-color-shadow:			 #2A87C0 !default;
 $secondary-color:  			 #F00 !default;
 $alt-colour: 				 #d36f00 !default;

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -120,9 +120,11 @@ body.is-logged-out{
 			display: block;
 			padding: 0.5em 0.65em;
 			text-decoration: none;
-			&:hover, &:active
+			color: $primary-color-highContrast;
+			&:focus, &:hover, &:active
 			{
 				text-decoration: underline;
+    			color: $primary-color-highContrast;
 			}
 			.toolMenuIcon{
 				@extend .fa-fw;


### PR DESCRIPTION
Introduced a darker alternative blue to appear on grey and satisfy colour contrast requirements to fix the link colour contrast in the User menu for WCAG and accessibility. 

The links are now a slightly darker blue that can be used elsewhere in Sakai when the blue appears on grey.

**Before:**
![01-before](https://cloud.githubusercontent.com/assets/12685096/18931491/7386ff08-859a-11e6-96d8-ad23508f8be7.png)

**After:**
![02-after](https://cloud.githubusercontent.com/assets/12685096/18931494/78f4959a-859a-11e6-98e1-3316eea10bae.png)
