### PR TITLE
LSNBLDR-736 lessons event ref for event type lessonbuilder.read is ambiguous

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -4667,7 +4667,7 @@ public class SimplePageBean {
 				entry.setPath(path);
 				entry.setToolId(toolId);
 				SimplePageItem i = findItem(itemId);
-				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/page/" + i.getSakaiId(), complete));
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/item/" + i.getSakaiId(), complete));
 				trackComplete(i, complete);
 				studentPageId = -1L;
 			}else if(path != null) {
@@ -4689,7 +4689,7 @@ public class SimplePageBean {
 				entry.setToolId(toolId);
 				entry.setDummy(false);
 				SimplePageItem i = findItem(itemId);
-				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/page/" + i.getSakaiId(), complete));
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/item/" + i.getSakaiId(), complete));
 				if (complete != wasComplete)
 				    trackComplete(i, complete);
 				studentPageId = -1L;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/LSNBLDR-736

All lessons event refs are in the following format:

"/lessonbuilder/[page|item|comment]/ID"

The middle chunk of the ref determines what type of object the event is referring to; either a SimplePage, SimplePageItem, or SimplePageComment.

However, there is a problem in the code for the "lessonbuilder.read" events. These events can refer to either a SimplePage or a SimplePageItem, however the code always builds the event ref with the "/page/" identifier.

Due to the way IDs are used in Lessons, it becomes impossible to determine if this event refers to a SimplePage or a SimplePageItem, because the IDs for both are just incrementing integers. So you could very well have both a SimplePage and a SimplePageItem with the same ID.

There is code already in Lessons to determine the correct object the event refers to, but when building the event ref it always just sticks the "/page/" part in there regardless. This is a bug. It should be using the "/page/" OR "/item/" part depending on what object is being operated on. The solution is very simple, it's just two lines.