### PR TITLE
SAK-31823 Update Master POM Tomcat version to reflect current supported

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -115,7 +115,7 @@
     <sakai.spring.test.artifactId>spring-test</sakai.spring.test.artifactId>
     <sakai.spring.test.version>4.1.9.RELEASE</sakai.spring.test.version>
     <sakai.tika.version>1.12</sakai.tika.version>
-    <sakai.tomcat.version>8.0.20</sakai.tomcat.version>
+    <sakai.tomcat.version>8.0.32</sakai.tomcat.version>
     <sakai.velocity.version>1.6.4</sakai.velocity.version>
     <sakai.xerces.impl.version>2.6.2</sakai.xerces.impl.version>
     <sakai.xerces.api.version>2.6.2</sakai.xerces.api.version>


### PR DESCRIPTION
Our QA testing for Sakai 11 and so far for Sakai 12 (currently master) has been on 8.0.32 but the pom.xml has 8.0.20 .  