### PR TITLE
SAK-31825 Don’t request the same attribute twice.

### DIFF
--- a/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapAttributeMapper.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapAttributeMapper.java
@@ -505,11 +505,9 @@ public class SimpleLdapAttributeMapper implements LdapAttributeMapper {
 			physicalAttrNames = new String[0];
 			return;
 		}
-		physicalAttrNames = new String[attributeMappings.size()];
-		int k = 0;
-		for ( String name : attributeMappings.values() ) {
-			physicalAttrNames[k++] = name;
-		}
+
+		// filter out any duplicate values so we don't request them twice
+		physicalAttrNames = attributeMappings.values().stream().distinct().toArray(String[]::new);
 	}
     
     /**


### PR DESCRIPTION
We have multiple attributes mapped to the same key in LDAP which results in Sakai requesting them twice, although this shouldn’t result in any problems this tidies it up so we just request it once.