### PR TITLE
SAK-31704 Use central cache in news tool.

### DIFF
--- a/simple-rss-portlet/pom.xml
+++ b/simple-rss-portlet/pom.xml
@@ -89,10 +89,12 @@
 		
 		<!-- ehcache, requires a slf4j impl-->
 		<dependency>
-			<groupId>net.sf.ehcache</groupId>
-			<artifactId>ehcache-core</artifactId>
-			<version>2.6.8</version>
-			<scope>compile</scope>
+			<groupId>org.sakaiproject.kernel</groupId>
+			<artifactId>sakai-component-manager</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.sakaiproject.kernel</groupId>
+			<artifactId>sakai-kernel-api</artifactId>
 		</dependency>
 
 		<!--  external shared dependencies -->


### PR DESCRIPTION
This allows multiple copies of the tool to startup inside the webapp, but also allows statistics about the cache to be seen in the Memory tool in the administration workspace.