### PR TITLE
SAK-31857 dont load hidden sites from preferences when loading synoptic announcements

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -357,18 +357,18 @@ public class AnnouncementAction extends PagedResourceActionII
 	class EntryProvider extends MergedListEntryProviderBase
 	{
 		/** announcement channels from hidden sites */
-		private final List excludedSites = new ArrayList();
+		private final List<String> hiddenSites = new ArrayList<String>();
 
 		public EntryProvider() {
 			this(false);
 		}
 
-		public EntryProvider(boolean excludeHiddenSites) {
-			if (excludeHiddenSites) {
+		public EntryProvider(boolean includeHiddenSites) {
+			if (includeHiddenSites) {
 				List<String> excludedSiteIds = getExcludedSitesFromTabs();
 				if (excludedSiteIds != null) {
 					for (String siteId : excludedSiteIds) {
-						excludedSites.add(AnnouncementService.channelReference(siteId, SiteService.MAIN_CONTAINER));
+						hiddenSites.add(AnnouncementService.channelReference(siteId, SiteService.MAIN_CONTAINER));
 					}
 				}
 			}
@@ -413,7 +413,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			SecurityAdvisor advisor = getChannelAdvisor(ref);
 			try {
 				m_securityService.pushAdvisor(advisor);
-				return (!excludedSites.contains(ref) && AnnouncementService.allowGetChannel(ref));
+				return (!hiddenSites.contains(ref) && AnnouncementService.allowGetChannel(ref));
 			} finally {
 				m_securityService.popAdvisor(advisor);
 			}
@@ -1576,7 +1576,7 @@ public class AnnouncementAction extends PagedResourceActionII
 						}
 					}
 					mergedAnnouncementList.loadChannelsFromDelimitedString(isOnWorkspaceTab(), new MergedListEntryProviderFixedListWrapper(
-							new EntryProvider(true), state.getChannelId(), channelArrayFromConfigParameterValue,
+							new EntryProvider(false), state.getChannelId(), channelArrayFromConfigParameterValue,
 							new AnnouncementReferenceToChannelConverter()), StringUtil.trimToZero(SessionManager
 							.getCurrentSessionUserId()), channelArrayFromConfigParameterValue, m_securityService.isSuperUser(),
 							ToolManager.getCurrentPlacement().getContext());
@@ -4499,7 +4499,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			}
 
 			mergedAnnouncementList.loadChannelsFromDelimitedString(isOnWorkspaceTab(), new MergedListEntryProviderFixedListWrapper(
-					new EntryProvider(true), annState.getChannelId(), channelArrayFromConfigParameterValue,
+					new EntryProvider(false), annState.getChannelId(), channelArrayFromConfigParameterValue,
 					new AnnouncementReferenceToChannelConverter()),
 					StringUtil.trimToZero(SessionManager.getCurrentSessionUserId()), channelArrayFromConfigParameterValue,
 					m_securityService.isSuperUser(), ToolManager.getCurrentPlacement().getContext());


### PR DESCRIPTION
This is attempt to fix patch from Stanford here:

  https://jira.sakaiproject.org/browse/SAK-23316

The logic from that patch just seems wrong so I change variable name to try to be more clear. 

I found this while debugging performance and found an admin-user was loading 1300+ sites every time they logged in because of My Workspace -> Synoptic Announcements.

Reviews appreciated