### PR TITLE
SAK-31859 avoid gradebook percentage calcs divide by zero

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
@@ -1327,6 +1327,11 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
     	BigDecimal pointsEarned = new BigDecimal(doublePointsEarned.toString());
     	BigDecimal pointsPossible = new BigDecimal(doublePointsPossible.toString());
 
+    	// Avoid dividing by zero
+    	if (pointsEarned.compareTo(BigDecimal.ZERO) == 0 || pointsPossible.compareTo(BigDecimal.ZERO) == 0) {
+    		return new Double(0);
+    	}
+
     	BigDecimal equivPercent = pointsEarned.divide(pointsPossible, GradebookService.MATH_CONTEXT).multiply(new BigDecimal("100"));
     	return Double.valueOf(equivPercent.doubleValue());
     	


### PR DESCRIPTION
I found this in GBNG using Settings -> Percentages

CC: @steveswinsburg @payten 