### PR TITLE
KNL-1475 remove the unnecessary sub-select from getUsersIsAllowed

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
@@ -949,7 +949,7 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 	/**
 	 * {@inheritDoc}
 	 */
-	public Set getUsersIsAllowed(String function, Collection azGroups)
+	public Set<String> getUsersIsAllowed(String function, Collection<String> azGroups)
 	{
 		return m_storage.getUsersIsAllowed(function, azGroups);
 	}
@@ -1463,7 +1463,7 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 		 *        A collection of the ids of AuthzGroups to consult.
 		 * @return the Set (String) of user ids of users who are allowed to perform the function in the named AuthzGroups.
 		 */
-		Set getUsersIsAllowed(String function, Collection azGroups);
+		Set<String> getUsersIsAllowed(String function, Collection<String> azGroups);
 
 		/**
 		 * Get the set of user ids per group of users who are allowed to perform the function in the named AuthzGroups.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -2170,9 +2170,8 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 			Object[] fields = new Object[1 + realms.size()];
 			int pos = 0;
 			fields[pos++] = lock;
-			for (Iterator<String> i = realms.iterator(); i.hasNext();)
+			for (String roleRealm : realms)
 			{
-				String roleRealm = i.next();
 				fields[pos++] = roleRealm;
 			}
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -2162,31 +2162,25 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 		/**
 		 * {@inheritDoc}
 		 */
-		public Set getUsersIsAllowed(String lock, Collection realms)
+		public Set<String> getUsersIsAllowed(String lock, Collection<String> realms)
 		{
-			if ((lock == null) || (realms == null) || (realms.isEmpty())) return new HashSet();
+			if ((lock == null) || (realms == null) || (realms.isEmpty())) return new HashSet<String>();
 
-			String sql = dbAuthzGroupSql.getSelectRealmRoleGroupUserIdSql(orInClause(realms.size(), "SR.REALM_ID"), orInClause(realms.size(),
-					"SR1.REALM_ID"));
-			Object[] fields = new Object[1 + (2 * realms.size())];
+			String sql = dbAuthzGroupSql.getSelectRealmRoleUserIdSql(orInClause(realms.size(), "SR.REALM_ID"));
+			Object[] fields = new Object[1 + realms.size()];
 			int pos = 0;
-			for (Iterator i = realms.iterator(); i.hasNext();)
-			{
-				String roleRealm = (String) i.next();
-				fields[pos++] = roleRealm;
-			}
 			fields[pos++] = lock;
-			for (Iterator i = realms.iterator(); i.hasNext();)
+			for (Iterator<String> i = realms.iterator(); i.hasNext();)
 			{
-				String roleRealm = (String) i.next();
+				String roleRealm = i.next();
 				fields[pos++] = roleRealm;
 			}
 
 			// read the strings
-			List results = m_sql.dbRead(sql, fields, null);
+			List<String> results = m_sql.dbRead(sql, fields, null);
 
 			// prepare the return
-			Set rv = new HashSet();
+			Set<String> rv = new HashSet<String>();
 			rv.addAll(results);
 			return rv;
 		}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
@@ -129,7 +129,7 @@ public interface DbAuthzGroupSql
 
 	String getSelectRealmUserGroupSql( String inClause );
 
-	String getSelectRealmRoleGroupUserIdSql(String inClause1, String inClause2);
+	String getSelectRealmRoleUserIdSql(String inClause);
 
 	String getSelectRealmRoleGroupUserIdSql(String inClause);
 	

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlDefault.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlDefault.java
@@ -441,22 +441,15 @@ public class DbAuthzGroupSqlDefault implements DbAuthzGroupSql
 		return sqlBuf.toString();
 	}
 	
-	public String getSelectRealmRoleGroupUserIdSql(String inClause1, String inClause2)
+	public String getSelectRealmRoleUserIdSql(String inClause)
 	{
 		StringBuilder sqlBuf = new StringBuilder();
 
-		sqlBuf.append("select SRRG.USER_ID ");
-		sqlBuf.append("from SAKAI_REALM_RL_GR SRRG ");
-		sqlBuf.append("inner join SAKAI_REALM SR ON SRRG.REALM_KEY = SR.REALM_KEY ");
-		sqlBuf.append("where " + inClause1 + " ");
-		sqlBuf.append("and SRRG.ACTIVE = '1' ");
-		sqlBuf.append("and SRRG.ROLE_KEY in ");
-		sqlBuf.append("(select SRRF.ROLE_KEY ");
-		sqlBuf.append("from SAKAI_REALM_RL_FN SRRF ");
-		sqlBuf.append("inner join SAKAI_REALM_FUNCTION SRF ON SRRF.FUNCTION_KEY = SRF.FUNCTION_KEY ");
-		sqlBuf.append("inner join SAKAI_REALM SR1 ON SRRF.REALM_KEY = SR1.REALM_KEY ");
-		sqlBuf.append("where SRF.FUNCTION_NAME = ? ");
-		sqlBuf.append("and " + inClause2 + ")");
+		sqlBuf.append("SELECT USER_ID ");
+		sqlBuf.append("FROM SAKAI_REALM SR INNER JOIN SAKAI_REALM_RL_GR SRRG ON SR.REALM_KEY = SRRG.REALM_KEY ");
+		sqlBuf.append("INNER JOIN SAKAI_REALM_RL_FN SRRF ON SRRF.ROLE_KEY = SRRG.ROLE_KEY AND SRRF.REALM_KEY = SR.REALM_KEY ");
+		sqlBuf.append("INNER JOIN SAKAI_REALM_FUNCTION SRF ON SRRF.FUNCTION_KEY = SRF.FUNCTION_KEY ");
+		sqlBuf.append("WHERE FUNCTION_NAME = ? and SRRG.ACTIVE = '1' and " + inClause + " ");
 
 		return sqlBuf.toString();
 	}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlMySql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlMySql.java
@@ -102,26 +102,6 @@ public class DbAuthzGroupSqlMySql extends DbAuthzGroupSqlDefault
 				+ "(AK_SAKAI_REALM_ID) where SAKAI_REALM_RL_FN.REALM_KEY = SAKAI_REALM.REALM_KEY " + "and " + inClause
 				+ getCountRealmRoleFunctionEndSql(roleIds, inClause);
 	}
-
-	@Override
-	public String getSelectRealmRoleGroupUserIdSql(String inClause1, String inClause2)
-	{
-		StringBuilder sqlBuf = new StringBuilder();
-
-		sqlBuf.append("select SRRG.USER_ID ");
-		sqlBuf.append("from SAKAI_REALM_RL_GR SRRG ");
-		sqlBuf.append("inner join SAKAI_REALM SR force index (AK_SAKAI_REALM_ID) ON SRRG.REALM_KEY = SR.REALM_KEY ");
-		sqlBuf.append("where " + inClause1 + " ");
-		sqlBuf.append("and SRRG.ACTIVE = '1' ");
-		sqlBuf.append("and SRRG.ROLE_KEY in ");
-		sqlBuf.append("(select SRRF.ROLE_KEY ");
-		sqlBuf.append("from SAKAI_REALM_RL_FN SRRF ");
-		sqlBuf.append("inner join SAKAI_REALM_FUNCTION SRF ON SRRF.FUNCTION_KEY = SRF.FUNCTION_KEY ");
-		sqlBuf.append("inner join SAKAI_REALM SR1 force index (AK_SAKAI_REALM_ID) ON SRRF.REALM_KEY = SR1.REALM_KEY ");
-		sqlBuf.append("where SRF.FUNCTION_NAME = ? ");
-		sqlBuf.append("and " + inClause2 + ")");
-		return sqlBuf.toString();
-	}
 	
 	@Override
 	public String getDeleteRealmRoleGroup4Sql()

--- a/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockAuthzGroupService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockAuthzGroupService.java
@@ -124,7 +124,7 @@ public class MockAuthzGroupService implements AuthzGroupService {
 		return null;
 	}
 	
-	public Set getUsersIsAllowed(String function, Collection azGroups) {
+	public Set<String> getUsersIsAllowed(String function, Collection<String> azGroups) {
 		// TODO Auto-generated method stub
 		return null;
 	}


### PR DESCRIPTION
that can cause terrible MySQL query performance in sites with 150+ groups.

Primary change is towards bottom of PR look for getSelectRealmRoleUserIdSql. I remove the sub-select as it's unnecessary, can cause bad performance, requires 1+ temporary tables, and is confusing.