### PR TITLE
SAK-31756 use FA for visual indicator of non-normal assignments

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/css/assignment.css
+++ b/assignment/assignment-tool/tool/src/webapp/css/assignment.css
@@ -50,21 +50,6 @@ a.toggleAnchor > h4 {
 .highLightBlock{
     background:#eee;
 }
-.group_icon {
-            padding: 0 16px 0 6px;
-            white-space: nowrap;
-            background: url(/library/image/silk/group.png) center no-repeat;
-}
-.user_icon {
-            padding: 0 16px 0 6px;
-            white-space: nowrap;
-            background: url(/library/image/silk/user.png) center no-repeat;
-}
-.section_icon {
-            padding: 0 16px 0 6px;
-            white-space: nowrap;
-            background: url(/library/image/silk/group_key.png) center no-repeat;
-}
 
 .popupMessage{
     background-color: #ffffcb !important;

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -22,15 +22,13 @@
 
 #macro( assignmentTitleIcon $assignment )
     #if ($!assignment.isGroup() )
-        <span class="group_icon" title="$tlang.getString('gen.groupassignment')" alt="$tlang.getString('gen.groupassignment')"></span>
-    #else
-        <span class="user_icon" title="$tlang.getString('gen.userassignment')" alt="$tlang.getString('gen.userassignment')"></span>
+        <i class="fa fa-users" aria-hidden="true" title="$tlang.getString('gen.groupassignment')"></i>
     #end
 #end
 
 #macro( sectionIcon $group )
     #if ($!group.getProperties().get("sections_category"))
-        <span class="section_icon" title="$tlang.getString('gen.section.info')" alt="$tlang.getString('gen.section.info')"></span> 
+        <i class="fa fa-users" aria-hidden="true" title="$tlang.getString('gen.section.info')"></i>
     #end
 #end
 

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -41,9 +41,7 @@
 		$validator.escapeHtml($assignment.getTitle()) 
 		<small>
 		#if ($!assignment.isGroup() )
-			<span class="group_icon" title="$tlang.getString('gen.groupassignment')" alt="$tlang.getString('gen.groupassignment')"></span>
-		#else
-			<span class="user_icon" title="$tlang.getString('gen.userassignment')" alt="$tlang.getString('gen.userassignment')"></span>
+			<i class="fa fa-users" aria-hidden="true" title="$tlang.getString('gen.groupassignment')"></i>
 		#end
 		  - $tlang.getString('gen.subm2')
 		</small>

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_group_error.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_group_error.vm
@@ -7,9 +7,7 @@
 					</th>
 					<td>
                                         #if ($!assignment.isGroup() )
-                                           <span class="group_icon" title="$tlang.getString('gen.groupassignment')" alt="$tlang.getString('gen.groupassignment')"></span>
-                                        #else
-                                           <span class="user_icon" title="$tlang.getString('gen.userassignment')" alt="$tlang.getString('gen.userassignment')"></span>
+                                           <i class="fa fa-users" aria-hidden="true" title="$tlang.getString('gen.groupassignment')"></i>
                                         #end
 						$validator.escapeHtml($assignment.getTitle())
 						#set ($deleted = false)


### PR DESCRIPTION
Implement Kyle suggestions for assignment icons.

This removes the icon for normal assignments. Icon now only used to indicate group submissions.

I use aria-hidden on the fontawesome icon.

CC: @kyleblythe 