### PR TITLE
SAM-2985 Assessment published with no due date and retract date has

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -280,7 +280,8 @@ averag_grading_single_submission="Average Grading" cannot be applied to assessme
 due_earlier_than_avaliable=The Due Date cannot be earlier than the Available Date.
 retract_earlier_than_avaliable=The Late Submission Date cannot be earlier than the Available Date or the Due Date.
 retract_earlier_than_due=The Late Submission Date cannot be earlier than the Available Date or the Due Date.
-retract_required_with_auto_submit=The late submission date must be set to force submission of saved student work after the due date. 
+retract_required_with_auto_submit=The late submission date must be set to force submission of saved student work after the due date.
+due_null_with_retract_date=You need to set a valid Due Date if the assessment has a Retract Date.
   
 # Secure delivery support
 require_secure_delivery = Require Locked Browser

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -170,6 +170,14 @@ public class ConfirmPublishAssessmentListener
 	    }
     }
     
+    // if due date is null we cannot have late submissions
+    if (assessmentSettings.getDueDate() == null && assessmentSettings.getLateHandling() != null && AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString().equals(assessmentSettings.getLateHandling()) &&
+        assessmentSettings.getRetractDate() !=null){
+        String noDueDate = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages","due_null_with_retract_date");
+        context.addMessage(null,new FacesMessage(FacesMessage.SEVERITY_WARN, noDueDate, null));
+        error=true;
+    }
+    
     // SAM-1088
     // if late submissions not allowed and late submission date is null, set late submission date to due date
     if (assessmentSettings.getLateHandling() != null && AssessmentAccessControlIfc.NOT_ACCEPT_LATE_SUBMISSION.toString().equals(assessmentSettings.getLateHandling()) &&

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -297,6 +297,15 @@ implements ActionListener
 		    }
 	    }
 
+        // if due date is null we cannot have late submissions
+        if (dueDate == null && assessmentSettings.getLateHandling() != null && AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString().equals(assessmentSettings.getLateHandling()) &&
+            retractDate !=null){
+            String noDueDate = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages","due_null_with_retract_date");
+            context.addMessage(null,new FacesMessage(FacesMessage.SEVERITY_WARN, noDueDate, null));
+            error=true;
+            
+        }
+
 	    // SAM-1088
 	    // if late submissions not allowed and late submission date is null, set late submission date to due date
 	    if (assessmentSettings.getLateHandling() != null && AssessmentAccessControlIfc.NOT_ACCEPT_LATE_SUBMISSION.equals(assessmentSettings.getLateHandling()) &&


### PR DESCRIPTION
"Active" status when it shouldn´t

Warning added if the user publish the assessment with Retract Date and no
Due Date