### PR TITLE
LSNBLDR-740 lessons read events for SimplePageItem objects utilizes the wrong ID

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -4668,9 +4668,9 @@ public class SimplePageBean {
 				entry.setComplete(complete);
 				entry.setPath(path);
 				entry.setToolId(toolId);
-				SimplePageItem i = findItem(itemId);
-				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/item/" + i.getSakaiId(), complete));
-				trackComplete(i, complete);
+				SimplePageItem item = findItem(itemId);
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/item/" + item.getId(), complete));
+				trackComplete(item, complete);
 				studentPageId = -1L;
 			}else if(path != null) {
 				entry.setPath(path);
@@ -4690,10 +4690,10 @@ public class SimplePageBean {
 				entry.setPath(path);
 				entry.setToolId(toolId);
 				entry.setDummy(false);
-				SimplePageItem i = findItem(itemId);
-				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/item/" + i.getSakaiId(), complete));
+				SimplePageItem item = findItem(itemId);
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.read", "/lessonbuilder/item/" + item.getId(), complete));
 				if (complete != wasComplete)
-				    trackComplete(i, complete);
+				    trackComplete(item, complete);
 				studentPageId = -1L;
 			}else if(path != null) {
 				entry.setComplete(true);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/LSNBLDR-740

When Lessons fires off a read event for SimplePageItem objects, it creates the event ref in the following format:

`/lessonbuilder/item/<ID>`

However, the ID it's sticking in there is retrieved via the getSakaiId() method. This method returns something other than the actual item ID.

In testing, I've found that typically it is an integer value of the actual ID minus 1. For example, if the item's ID is 401901, the value returned from getSakaiId() is 401900.

When searching through the code, it seems this field could also be used for storing an entity reference to some other object (maybe a quiz or an assignment).

However, for the purposes of events and resolving the event reference in question, we don't care about the entity reference that could be on the page/item. What we really want to resolve is the actual Lessons page/item. So the 'sakai ID' is irrelevant here; it should always be storing the actual item ID in the event ref string.
