### PR TITLE
KNL-1477 dont compute potentially huge size of admin folders

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ListItem.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ListItem.java
@@ -138,7 +138,7 @@ public class ListItem
 	/** A long representing the number of milliseconds in one week.  Used for date calculations */
 	public static final long ONE_WEEK = 7L * ONE_DAY;
 	
-	public static final int EXPANDABLE_FOLDER_NAV_SIZE_LIMIT = ServerConfigurationService.getInt("sakai.content.resourceLimit", 0);  //SAK-21955
+	public static final int EXPANDABLE_FOLDER_NAV_SIZE_LIMIT = ServerConfigurationService.getInt("sakai.content.resourceLimit", 1000);  //SAK-21955
 
 	/**
 	 * Services
@@ -635,24 +635,29 @@ public class ListItem
 			{
 				shortSizeStr = typeDef.getSizeLabel(entity);
 			}
-        	int collection_size = collection.getMemberCount();
+			int collection_size = collection.getMemberCount();
 			if(shortSizeStr == null)
 			{
-	        	if(collection_size == 1)
-	        	{
-	        		shortSizeStr = rb.getString("size.item");
-	        	}
-	        	else
-	        	{
-		        	String[] args = { Integer.toString(collection_size) };
-		        	shortSizeStr = rb.getFormattedMessage("size.items", args);
-	        	}
+				if(collection_size == 1)
+				{
+					shortSizeStr = rb.getString("size.item");
+				}
+				else if(collection_size == -1)
+				{
+					shortSizeStr = "-";
+					setIsTooBig(true);
+				}
+				else
+				{
+					String[] args = { Integer.toString(collection_size) };
+					shortSizeStr = rb.getFormattedMessage("size.items", args);
+				}
 			}
 			else if(shortSizeStr.length() > ResourceType.MAX_LENGTH_SHORT_SIZE_LABEL)
 			{
 				shortSizeStr = shortSizeStr.substring(0, ResourceType.MAX_LENGTH_SHORT_SIZE_LABEL);
 			}
-			setIsEmpty(collection_size < 1);
+			setIsEmpty(collection_size == 0);
 			setSize(shortSizeStr);
 			String longSizeStr = null;
 			if(typeDef != null)
@@ -665,7 +670,6 @@ public class ListItem
 			}
 			else if(longSizeStr.length() > ResourceType.MAX_LENGTH_LONG_SIZE_LABEL)
 			{
-				
 				longSizeStr = longSizeStr.substring(0, ResourceType.MAX_LENGTH_LONG_SIZE_LABEL);
 			}
 			setSizzle(longSizeStr);
@@ -680,7 +684,8 @@ public class ListItem
 			//Prevent concurrent mode failures in admin Resource tool when clicking on resources that are too large.  Similar to 'isTooBig' but defined in properties
 			//To enable add the property sakai.content.resourceLimit=<int> to sakai.properties where int is the limit of an accessible resource folder
 			String siteId = getSiteContext(refstr);
-			if(this.EXPANDABLE_FOLDER_NAV_SIZE_LIMIT != 0 && siteId != null && ("!admin".equals(siteId) || SiteService.getUserSiteId("admin").contains(siteId)) && (collection_size > this.EXPANDABLE_FOLDER_NAV_SIZE_LIMIT))
+			if(this.EXPANDABLE_FOLDER_NAV_SIZE_LIMIT != 0 && siteId != null && 
+				("!admin".equals(siteId) || SiteService.getUserSiteId("admin").contains(siteId) || collection_size > this.EXPANDABLE_FOLDER_NAV_SIZE_LIMIT))
 			{
 				setIsTooBigNav(true);
 			}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.component.cover.ComponentManager;
@@ -149,6 +150,8 @@ public class DbContentService extends BaseContentService
      * The ID that is used in the content_resource table to test UTF8
      */
     private static final String UTF8TESTID = "UTF8TEST";
+
+    private static final String BASE_PUBLIC_ID = "/public/";
 
     private static final String[] BASE_COLLECTION_IDS = new String[]{
         "/","/attachment/","/group-user/","/group/","/private/","/public/","/user/"   
@@ -2569,6 +2572,11 @@ public class DbContentService extends BaseContentService
             if (collectionId == null || collectionId.trim().length() == 0)
             {
                 return 0;
+            }
+            // KNL-1477: Avoid querying CONTENT_COLLECTION and counting many thousands of rows
+            else if (ArrayUtils.contains(BASE_COLLECTION_IDS, collectionId) && !BASE_PUBLIC_ID.equals(collectionId))
+            {
+                return -1;
             }
             boolean goin = in();
             try


### PR DESCRIPTION
If you have 100k sites, then counting all /group/ or all /attachment/ will scan 100k rows and will not be fast.
