### PR TITLE
SAK-31894 .gitignore has garbage in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,4 @@ sakai-demo.zip
 .metadata
 .DS_Store
 *nb-configuration.xml
-<<<<<<< HEAD
-=======
 velocity.log
->>>>>>> f62f37e... SAK-31805 Remove velocity.log (#3446)


### PR DESCRIPTION
The .gitignore file contains stuff from an unresolved conflict. This should be removed.