### PR TITLE
SAK-31898 sitestats -> preferences -> cancel button behaviour unintuitive

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/PreferencesPage.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/PreferencesPage.java
@@ -177,7 +177,7 @@ public class PreferencesPage extends BasePage {
 			@Override
 			public void onSubmit() {
 				prefsdata = null;
-				super.onSubmit();
+				setResponsePage(OverviewPage.class);
 			}
 		};
 		cancel.setDefaultFormProcessing(false);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31898

In Sitestats, go to Preferences, then click cancel. Nothing happens; it just clears out changes made to the form. The button should abort changes and redirect you back to the Overview page.