### PR TITLE
SAK-31905 Use the GroupProvider when packing/unpacking.

### DIFF
--- a/reference/docs/conversion/sakai_11_1-11_2_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_1-11_2_mysql_conversion.sql
@@ -23,4 +23,8 @@ DROP INDEX SST_EVENTS_USER_ID_IX ON SST_EVENTS;
 -- If you're using a custom implementation you need to check what separator is used between provider IDs and if you
 -- are using anything other than "," this uncomment this and update to use your separator
 -- UPDATE SAKAI_REALM SET PROVIDER_ID = REPLACE(PROVIDER_ID, ',', '+') where PROVIDER_ID like '%,%';
+
+-- You do want to run this part of it which fixes any older role IDs to use the correct separator.
+UPDATE SAKAI_SITE_GROUP_PROPERTY SET value = REPLACE(value, '+', ',')
+  WHERE name = 'group_prop_role_providerid' AND value LIKE '%+%';
 -- END SAK-31905

--- a/reference/docs/conversion/sakai_11_1-11_2_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_1-11_2_mysql_conversion.sql
@@ -18,3 +18,9 @@ DROP INDEX SST_PRESENCE_SITE_ID_IX ON SST_PRESENCES;
 DROP INDEX SST_EVENTS_USER_ID_IX ON SST_EVENTS;
 -- END SAK-31276
 
+-- SAK-31905
+-- Uncomment this if you're using a standard Sakai GroupProvider/CourseManagement
+-- If you're using a custom implementation you need to check what separator is used between provider IDs and if you
+-- are using anything other than "," this uncomment this and update to use your separator
+-- UPDATE SAKAI_REALM SET PROVIDER_ID = REPLACE(PROVIDER_ID, ',', '+') where PROVIDER_ID like '%,%';
+-- END SAK-31905

--- a/reference/docs/conversion/sakai_11_1-11_2_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_11_1-11_2_oracle_conversion.sql
@@ -21,3 +21,9 @@ DROP INDEX SST_PRESENCE_SITE_ID_IX ON SST_PRESENCES;
 DROP INDEX SST_EVENTS_USER_ID_IX ON SST_EVENTS;
 -- END SAK-31276
 
+-- SAK-31905
+-- Uncomment this if you're using a standard Sakai GroupProvider/CourseManagement
+-- If you're using a custom implementation you need to check what separator is used between provider IDs and if you
+-- are using anything other than "," this uncomment this and update to use your separator
+-- UPDATE SAKAI_REALM SET PROVIDER_ID = REPLACE(PROVIDER_ID, ',', '+') where PROVIDER_ID like '%,%';
+-- END SAK-31905

--- a/reference/docs/conversion/sakai_11_1-11_2_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_11_1-11_2_oracle_conversion.sql
@@ -26,4 +26,8 @@ DROP INDEX SST_EVENTS_USER_ID_IX ON SST_EVENTS;
 -- If you're using a custom implementation you need to check what separator is used between provider IDs and if you
 -- are using anything other than "," this uncomment this and update to use your separator
 -- UPDATE SAKAI_REALM SET PROVIDER_ID = REPLACE(PROVIDER_ID, ',', '+') where PROVIDER_ID like '%,%';
+
+-- You do want to run this part of it which fixes any older role IDs to use the correct separator.
+UPDATE SAKAI_SITE_GROUP_PROPERTY SET value = REPLACE(value, '+', ',')
+  WHERE name = 'group_prop_role_providerid' AND value LIKE '%+%';
 -- END SAK-31905

--- a/site-manage/site-manage-group-section-role-helper/pack/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/RoleGroupEventWatcher.java
+++ b/site-manage/site-manage-group-section-role-helper/pack/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/RoleGroupEventWatcher.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.authz.api.AuthzGroup;
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.Member;
@@ -224,10 +223,10 @@ public class RoleGroupEventWatcher implements Observer
 						// whether saving site is needed because some groups need updates
 						boolean needSave = false;
 						
-						for (Object g : site.getGroups())
+						for (Group g : site.getGroups())
 						{
-							ResourceProperties properties = ((Group) g).getProperties();
-							if (properties.getProperty(((Group) g).GROUP_PROP_WSETUP_CREATED) != null && properties.getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID) != null)
+							ResourceProperties properties = g.getProperties();
+							if (properties.getProperty(Group.GROUP_PROP_WSETUP_CREATED) != null && properties.getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID) != null)
 							{
 								needSave = true;
 								
@@ -236,7 +235,7 @@ public class RoleGroupEventWatcher implements Observer
 								
 								if (roleString != null && roleString.length() > 0)
 								{
-									Set<Member> members = ((Group) g).getMembers();
+									Set<Member> members = g.getMembers();
 									
 									Collection<String> roles = SiteGroupHelper.unpack(roleString);
 									for (String role : roles)
@@ -246,17 +245,17 @@ public class RoleGroupEventWatcher implements Observer
 										{
 											if (m.getRole().getId().equals(role))
 											{
-												((Group) g).removeMember(m.getUserId());
+												g.removeMember(m.getUserId());
 											}
 										}
 										
 										// update the group member with current realm users
-										Set roleUserSet = r.getUsersHasRole(role.trim());
+										Set<String> roleUserSet = r.getUsersHasRole(role.trim());
 										if (roleUserSet != null && !roleUserSet.isEmpty())
 										{
-											for(Object userId:roleUserSet)
+											for(String userId:roleUserSet)
 											{
-												((Group) g).addMember((String) userId, role.trim(), true, false);
+												g.addMember(userId, role.trim(), true, false);
 											}
 										}
 									}

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupEditProducer.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupEditProducer.java
@@ -2,6 +2,7 @@ package org.sakaiproject.site.tool.helper.managegroupsectionrole.rsf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -9,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.commons.lang.StringUtils;
 
 import org.slf4j.Logger;
@@ -97,7 +99,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
     	// group provider id
     	String groupProviderId = null;
     	// list of group role provider ids
-    	List<String> groupRoleProviderRoles = null;
+    	Collection<String> groupRoleProviderRoles = null;
     	
     	UIForm groupForm = UIForm.make(arg0, "groups-form");
 
@@ -267,7 +269,7 @@ public class GroupEditProducer implements ViewComponentProducer, ActionResultInt
 
 	     /********************** for the group members list **************************/
 	     List<String> groupRosters = handler.getGroupRosters(g);
-	     List<String> groupProviderRoles = handler.getGroupProviderRoles(g);
+	     Collection<String> groupProviderRoles = handler.getGroupProviderRoles(g);
 	     List<Member> groupMembersCopy = new ArrayList<>();
 	     groupMembersCopy.addAll(groupMembers);
 	     for( Member p : groupMembersCopy )

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteConstants.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteConstants.java
@@ -34,7 +34,10 @@ public class SiteConstants {
 	public static final String SORTED_BY_GROUP_TITLE = "group_title";
 	
 	public static final String SORTED_BY_GROUP_SIZE = "group_size";
-	
+
+	/**
+	 * This stores the list of roles that a group should have as participants from the containing sites.
+	 */
 	public static final String GROUP_PROP_ROLE_PROVIDERID = "group_prop_role_providerid";
 	
 	public static final int SITE_GROUP_TITLE_LIMIT = 99;

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
@@ -2,11 +2,13 @@ package org.sakaiproject.site.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.regex.Pattern;
 
 /**
- * Helper for managing groups in a site.
+ * Helper for managing groups in a site, this is used to pack role IDs into the
+ * {@link SiteConstants#GROUP_PROP_ROLE_PROVIDERID} property on a group. This is different
+ * from when the provider IDs are packed into a provider ID.
  *
+ * @see SiteConstants#GROUP_PROP_ROLE_PROVIDERID
  * @author Matthew Buckett
  */
 public class SiteGroupHelper {


### PR DESCRIPTION
Use the provider for packing/unpacking of the provider IDs. The main change for this fix is in SiteManageGroupSectionRoleHandler where we use the GroupProvider rather than the SiteGroupHelper for packing the IDs.

Added generics to RoleGroupEventWatcher as I was looking at what the code was doing, not other changes in that file.

I inlined the `getProviderString(List<String>)` call as it’s only used once and wanted to make it clearer which call should be used in which place.

The packing (and unpacking) that should be used is

`GroupProvider.packId()` for `Group.setProviderGroupId()`
`SiteGroupHelper.pack()` fot `SiteContants.GROUP_PROP_ROLE_PROVIDERID`