### PR TITLE
SAK-11486 Basic support for recurring events

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
@@ -105,64 +105,64 @@ public class IcalendarReader extends Reader
 				Component component = (Component) i.next();
 
 	
-                                if ( component.getProperty("SUMMARY") == null )
-                                {
-                                    M_log.warn("IcalendarReader: SUMMARY is required; event not imported");
-                                    continue;
-                                }
-                                DateTime from = new DateTime(Date.from(ZonedDateTime.now().minusMonths(6).toInstant()));
-                                DateTime to = new DateTime(Date.from(ZonedDateTime.now().plusMonths(12).toInstant()));
-                                Period range = new Period(from, to);
-                                
+				if ( component.getProperty("SUMMARY") == null )
+				{
+					M_log.warn("IcalendarReader: SUMMARY is required; event not imported");
+					continue;
+				}
+				DateTime from = new DateTime(Date.from(ZonedDateTime.now().minusMonths(6).toInstant()));
+				DateTime to = new DateTime(Date.from(ZonedDateTime.now().plusMonths(12).toInstant()));
+				Period range = new Period(from, to);
+
 				PeriodList list = component.calculateRecurrenceSet(range);
 				for (Iterator j = list.iterator(); j.hasNext();) 
-                                {
-                                    Period period = (Period) j.next();
-                                    Dur duration = period.getDuration();
-                                    int durationminutes = duration.getMinutes();
-                                    int durationhours = duration.getHours();
-                                    //todo investiage ical4j's handling of 'days'
-                                    
-                                    if (durationminutes < 10)
-                                    {
+				{
+					Period period = (Period) j.next();
+					Dur duration = period.getDuration();
+					int durationminutes = duration.getMinutes();
+					int durationhours = duration.getHours();
+					//todo investiage ical4j's handling of 'days'
+
+					if (durationminutes < 10)
+					{
 					durationformat = "0"+durationminutes;
-                                    }
-                                    else
-                                    {
+					}
+					else
+					{
 					durationformat = ""+durationminutes;
-                                    }
+					}
 
-                                    if (durationhours != 0)
-                                    {
-					durationformat = durationhours+":"+durationformat;
-                                    }
-                                    String description = "";
-                                    if ( component.getProperty("DESCRIPTION") != null ) {
-                                            description = component.getProperty("DESCRIPTION").getValue();
-                                    }
-                                    String location = "";
-                                    if (component.getProperty("LOCATION") != null) {
-                                        location = component.getProperty("LOCATION").getValue();
-                                    }
-                                    String columns[]	= 
-                                                    {component.getProperty("SUMMARY").getValue(),
-                                                     description,
-                                                     DateFormat.getDateInstance(DateFormat.SHORT, rb.getLocale()).format(period.getStart()),
-                                                     DateFormat.getTimeInstance(DateFormat.SHORT, rb.getLocale()).format(period.getStart()),
-                                                     durationformat,
-                                                     location};
+					if (durationhours != 0)
+					{
+						durationformat = durationhours+":"+durationformat;
+					}
+					String description = "";
+					if ( component.getProperty("DESCRIPTION") != null) {
+						description = component.getProperty("DESCRIPTION").getValue();
+					}
+					String location = "";
+					if (component.getProperty("LOCATION") != null) {
+						location = component.getProperty("LOCATION").getValue();
+					}
+					String columns[]	= 
+							{component.getProperty("SUMMARY").getValue(),
+							 description,
+							 DateFormat.getDateInstance(DateFormat.SHORT, rb.getLocale()).format(period.getStart()),
+							 DateFormat.getTimeInstance(DateFormat.SHORT, rb.getLocale()).format(period.getStart()),
+							 durationformat,
+							 location};
 
-                                    // Remove trailing/leading quotes from all columns.
-                                    //trimLeadingTrailingQuotes(columns);
+					// Remove trailing/leading quotes from all columns.
+					//trimLeadingTrailingQuotes(columns);
 
-                                    handler.handleRow(
-                                            processLine(
-                                                    columnDescriptionArray,
-                                                    lineNumber,
-                                                    columns));
+					handler.handleRow(
+						processLine(
+							columnDescriptionArray,
+							lineNumber,
+							columns));
 
-                                    lineNumber++;
-                                }
+					lineNumber++;
+				}
 			} // end for
 		
 		}
@@ -248,8 +248,8 @@ public class IcalendarReader extends Reader
 			// a good place to set it: startCal.setTimeZone()
 			GregorianCalendar startCal = new GregorianCalendar();
 			if ( startDate != null ) {
-                            startCal.setTimeInMillis( startDate.getTime() );
-                        }
+				startCal.setTimeInMillis( startDate.getTime() );
+			}
 			startTimeBreakdown.setYear( startCal.get(Calendar.YEAR) );
 			startTimeBreakdown.setMonth( startCal.get(Calendar.MONTH)+1 );
 			startTimeBreakdown.setDay( startCal.get(Calendar.DAY_OF_MONTH) );

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
@@ -137,13 +137,13 @@ public class IcalendarReader extends Reader
 					durationformat = durationhours+":"+durationformat;
                                     }
                                     String description = "";
-                                    if ( component.getProperty("DESCRIPTION") != null )
+                                    if ( component.getProperty("DESCRIPTION") != null ) {
                                             description = component.getProperty("DESCRIPTION").getValue();
-
+                                    }
                                     String location = "";
-                                    if (component.getProperty("LOCATION") != null)
-                                    location = component.getProperty("LOCATION").getValue();
-
+                                    if (component.getProperty("LOCATION") != null) {
+                                        location = component.getProperty("LOCATION").getValue();
+                                    }
                                     String columns[]	= 
                                                     {component.getProperty("SUMMARY").getValue(),
                                                      description,
@@ -247,9 +247,9 @@ public class IcalendarReader extends Reader
 			// if the source time zone were known, this would be
 			// a good place to set it: startCal.setTimeZone()
 			GregorianCalendar startCal = new GregorianCalendar();
-			if ( startDate != null )
-				startCal.setTimeInMillis( startDate.getTime() );
-				
+			if ( startDate != null ) {
+                            startCal.setTimeInMillis( startDate.getTime() );
+                        }
 			startTimeBreakdown.setYear( startCal.get(Calendar.YEAR) );
 			startTimeBreakdown.setMonth( startCal.get(Calendar.MONTH)+1 );
 			startTimeBreakdown.setDay( startCal.get(Calendar.DAY_OF_MONTH) );

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
@@ -23,6 +23,7 @@ package org.sakaiproject.calendar.impl.readers;
 
 import java.io.InputStream;
 import java.text.DateFormat;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -33,8 +34,10 @@ import java.util.Map;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.model.Component;
-import net.fortuna.ical4j.model.component.VEvent;
-import net.fortuna.ical4j.model.property.DateProperty;
+import net.fortuna.ical4j.model.Dur;
+import net.fortuna.ical4j.model.DateTime;
+import net.fortuna.ical4j.model.Period;
+import net.fortuna.ical4j.model.PeriodList;
 import net.fortuna.ical4j.util.CompatibilityHints;
 
 import org.slf4j.Logger;
@@ -100,83 +103,66 @@ public class IcalendarReader extends Reader
 			for (Iterator i = calendar.getComponents("VEVENT").iterator(); i.hasNext();)
 			{
 				Component component = (Component) i.next();
-	
-				// Find event duration
-				DateProperty dtstartdate;
-				DateProperty dtenddate;
-				if(component instanceof VEvent){
-					VEvent vEvent = (VEvent) component;
-					dtstartdate = vEvent.getStartDate();
-					dtenddate = vEvent.getEndDate(true);
-				}else{
-					dtstartdate = (DateProperty) component.getProperty("DTSTART");
-					dtenddate =  (DateProperty) component.getProperty("DTEND");
-				}
-            
-            if ( component.getProperty("SUMMARY") == null )
-            {
-					M_log.warn("IcalendarReader: SUMMARY is required; event not imported");
-               continue;
-            }
-            String summary = component.getProperty("SUMMARY").getValue();
-            
-            if ( component.getProperty("RRULE") != null )
-            {
-					M_log.warn("IcalendarReader: Re-occurring events not supported: " + summary );
-					continue;
-            }
-            else if (dtstartdate == null || dtenddate == null )
-            {
-					M_log.warn("IcalendarReader: DTSTART/DTEND required: " + summary );
-					continue;
-            }
-			
-				int durationsecs = (int) ((dtenddate.getDate().getTime() - dtstartdate.getDate().getTime()) / 1000);
-				int durationminutes = (durationsecs/60) % 60;
-				int durationhours = (durationsecs/(60*60)) % 24;
-			
-				// Put duration in proper format (hh:mm or mm) if less than 1 hour
-				if (durationminutes < 10)
-				{
-					durationformat = "0"+durationminutes;
-				}
-				else
-				{
-					durationformat = ""+durationminutes;
-				}
 
-				if (durationhours != 0)
-				{
+	
+                                if ( component.getProperty("SUMMARY") == null )
+                                {
+                                    M_log.warn("IcalendarReader: SUMMARY is required; event not imported");
+                                    continue;
+                                }
+                                DateTime from = new DateTime(Date.from(ZonedDateTime.now().minusMonths(6).toInstant()));
+                                DateTime to = new DateTime(Date.from(ZonedDateTime.now().plusMonths(12).toInstant()));
+                                Period range = new Period(from, to);
+                                
+				PeriodList list = component.calculateRecurrenceSet(range);
+				for (Iterator j = list.iterator(); j.hasNext();) 
+                                {
+                                    Period period = (Period) j.next();
+                                    Dur duration = period.getDuration();
+                                    int durationminutes = duration.getMinutes();
+                                    int durationhours = duration.getHours();
+                                    //todo investiage ical4j's handling of 'days'
+                                    
+                                    if (durationminutes < 10)
+                                    {
+					durationformat = "0"+durationminutes;
+                                    }
+                                    else
+                                    {
+					durationformat = ""+durationminutes;
+                                    }
+
+                                    if (durationhours != 0)
+                                    {
 					durationformat = durationhours+":"+durationformat;
-				}
-				
-				String description = "";
-				if ( component.getProperty("DESCRIPTION") != null )
-					description = component.getProperty("DESCRIPTION").getValue();
-               
-            String location = "";
-				if (component.getProperty("LOCATION") != null)
-               location = component.getProperty("LOCATION").getValue();
-               
-				String columns[]	= 
-						{component.getProperty("SUMMARY").getValue(),
-						 description,
-						 DateFormat.getDateInstance(DateFormat.SHORT, rb.getLocale()).format(dtstartdate.getDate()),
-						 DateFormat.getTimeInstance(DateFormat.SHORT, rb.getLocale()).format(dtstartdate.getDate()),
-						 durationformat,
-						 location};
-				
-				// Remove trailing/leading quotes from all columns.
-				//trimLeadingTrailingQuotes(columns);
-			
-				handler.handleRow(
-					processLine(
-						columnDescriptionArray,
-						lineNumber,
-						columns));
-					
-				lineNumber++;
-			
+                                    }
+                                    String description = "";
+                                    if ( component.getProperty("DESCRIPTION") != null )
+                                            description = component.getProperty("DESCRIPTION").getValue();
+
+                                    String location = "";
+                                    if (component.getProperty("LOCATION") != null)
+                                    location = component.getProperty("LOCATION").getValue();
+
+                                    String columns[]	= 
+                                                    {component.getProperty("SUMMARY").getValue(),
+                                                     description,
+                                                     DateFormat.getDateInstance(DateFormat.SHORT, rb.getLocale()).format(period.getStart()),
+                                                     DateFormat.getTimeInstance(DateFormat.SHORT, rb.getLocale()).format(period.getStart()),
+                                                     durationformat,
+                                                     location};
+
+                                    // Remove trailing/leading quotes from all columns.
+                                    //trimLeadingTrailingQuotes(columns);
+
+                                    handler.handleRow(
+                                            processLine(
+                                                    columnDescriptionArray,
+                                                    lineNumber,
+                                                    columns));
+
+                                    lineNumber++;
+                                }
 			} // end for
 		
 		}


### PR DESCRIPTION
This PR uses ical4j’s recurring event support to create individual events for recurring events.  

This currently has some caveats, but any support for recurring events may be better than none, and perhaps it's a starting point for better support.  Known caveats:

1. It creates individual events on the Sakai calendar, it does not attempt to translate ical recurring patterns (and corresponding exceptions) to Sakai's recurring event models.
2. Ical4j's recurring event method requires a time range, so right now it arbitrarily only considers events six months in the past and 12 months in the future.
3. Ical4j seems to handle exceptions to recurrence well with one known exception.  If an individual occurrence has its summary and/or description changed, but not the time, it will be duplicated on the calendar: one event with the "default" event summary, and one with the modified summary.  This is a limitation of the ical4j library.

I have tested a few .ical calendars from a few different sources such as Outlook, Google Calendar, and (Mac) Calendar.  More sources and more recurrence patterns ought to be tested, obviously.
