### PR TITLE
SAK-29126 Add a property to control JSF State in sakai.properties

### DIFF
--- a/calendar/calendar-summary-tool/tool/src/webapp/WEB-INF/web.xml
+++ b/calendar/calendar-summary-tool/tool/src/webapp/WEB-INF/web.xml
@@ -7,11 +7,6 @@
 	<description>Summary Calendar Tool</description>
 
 	<context-param>
-		<param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-		<param-value>client</param-value>
-	</context-param>
-
-	<context-param>
 		<!-- Changed ordering to meet DTD - PAFH 8/24/2006 -->
 		<description>
 			Set this flag to true if you want the JavaServer Faces

--- a/chat/chat-tool/tool/src/webapp/WEB-INF/web.xml
+++ b/chat/chat-tool/tool/src/webapp/WEB-INF/web.xml
@@ -67,10 +67,6 @@
     
 	<!-- the faces handling xml -->
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-    <context-param>
         <param-name>com.sun.faces.validateXml</param-name>
         <param-value>true</param-value>
     </context-param>

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1322,6 +1322,14 @@
 # DEFAULT: none (null) - code only responds if this is set to "websphere"
 # servlet.container=websphere
 
+# JSF Saving State Method
+# By default Sakai is using "client" as SAVING_STATE_METHOD in JSF tools
+# You can change this value to "server" in all jsf tools with default or in selected ones
+# jsf.state_saving_method=server
+# jsf.state_saving_method.{servlet-name}=server
+# Example: jsf.state_saving_method.sakai.samigo=server
+# Example: jsf.state_saving_method.sakai.summary.calendar=server
+
 
 # ########################################################################
 # EMAIL

--- a/gradebook/app/sakai-tool/src/webapp/WEB-INF/web.xml
+++ b/gradebook/app/sakai-tool/src/webapp/WEB-INF/web.xml
@@ -4,10 +4,6 @@
 	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 	<display-name>sakai-gradebook-tool</display-name>
 	<description>Sakai Gradebook Tool Integration</description>
-	<context-param>
-		<param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-		<param-value>client</param-value>
-	</context-param>
 	
 	<!-- the following context-param allows the gradebook to generate a random secret for 
 	MyFaces ViewState encryption. The encryption algorithm can be customized by 

--- a/help/help-tool/src/webapp/WEB-INF/web.xml
+++ b/help/help-tool/src/webapp/WEB-INF/web.xml
@@ -7,11 +7,6 @@
     <description>Sakai Help Tool</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
         <param-name>com.sun.faces.validateXml</param-name>
         <param-value>true</param-value>       
     </context-param>

--- a/jobscheduler/scheduler-tool/src/webapp/WEB-INF/web.xml
+++ b/jobscheduler/scheduler-tool/src/webapp/WEB-INF/web.xml
@@ -7,11 +7,6 @@
     <description>Scheduler Tool</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
         <param-name>com.sun.faces.validateXml</param-name>
         <param-value>true</param-value>       
     </context-param>

--- a/jsf/jsf-tool/pom.xml
+++ b/jsf/jsf-tool/pom.xml
@@ -24,8 +24,14 @@
             <artifactId>sakai-kernel-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-component-manager</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/jsf/jsf-tool/src/java/org/sakaiproject/jsf/util/JsfTool.java
+++ b/jsf/jsf-tool/src/java/org/sakaiproject/jsf/util/JsfTool.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -36,6 +37,8 @@ import org.sakaiproject.tool.api.ToolSession;
 import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.util.Web;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.component.api.ServerConfigurationService;
 
 /**
  * <p>
@@ -277,7 +280,15 @@ public class JsfTool extends HttpServlet
 	public void init(ServletConfig config) throws ServletException
 	{
 		super.init(config);
-
+		ServerConfigurationService scs = ComponentManager.get(ServerConfigurationService.class);
+		ServletContext context = config.getServletContext();
+		String customJsfState = scs.getString("jsf.state_saving_method."+config.getServletName(), null);
+		String defaultJsfState = scs.getString("jsf.state_saving_method", "client");
+		if (customJsfState != null) {
+			context.setInitParameter("javax.faces.STATE_SAVING_METHOD", customJsfState);
+		} else if (defaultJsfState != null) {
+			context.setInitParameter("javax.faces.STATE_SAVING_METHOD", defaultJsfState);
+		}
 		m_default = config.getInitParameter("default");
 		m_path = config.getInitParameter("path");
 		m_defaultToLastView = "true".equals(config.getInitParameter("default.last.view"));
@@ -288,7 +299,7 @@ public class JsfTool extends HttpServlet
 			m_path = m_path.substring(0, m_path.length() - 1);
 		}
 
-		M_log.info("init: default: " + m_default + " path: " + m_path);
+		M_log.info("init: "+config.getServletName()+"["+context.getInitParameter("javax.faces.STATE_SAVING_METHOD")+"]"+" default: " + m_default + " path: " + m_path);
 	}
 
 	/**

--- a/msgcntr/messageforums-app/src/webapp/WEB-INF/web.xml
+++ b/msgcntr/messageforums-app/src/webapp/WEB-INF/web.xml
@@ -8,10 +8,6 @@
     <display-name>messageforums</display-name>
     <description>Sakai Message Forums</description>
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-    <context-param>
     	<!-- Changed ordering - PAFH 8/24/2006 -->
         <description> Set this flag to true if you want the JavaServer 
                       Faces Reference Implementation to validate the

--- a/podcasts/podcasts-app/src/webapp/WEB-INF/web.xml
+++ b/podcasts/podcasts-app/src/webapp/WEB-INF/web.xml
@@ -6,11 +6,6 @@
     <description>Sakai Podcasts Tool</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
- 
-    <context-param>
         <param-name>contextConfigLocation</param-name>
         <param-value>/WEB-INF/local.xml</param-value>
     </context-param>

--- a/postem/postem-app/src/webapp/WEB-INF/web.xml
+++ b/postem/postem-app/src/webapp/WEB-INF/web.xml
@@ -5,11 +5,6 @@
     <display-name>sakai-postem</display-name>
     <description>Sakai Postem Gradebook Tool</description>
 
-    <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-    
 <!--sakai-->
     <!-- <context-param>
         <param-name>com.sun.faces.validateXml</param-name>

--- a/samigo/samigo-app/src/webapp/WEB-INF/web.xml
+++ b/samigo/samigo-app/src/webapp/WEB-INF/web.xml
@@ -10,11 +10,6 @@
 
   <!-- BEGIN SAMIGO JSF CONTEXT PARAM-->
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
         <description>
             Set this flag to true if you want the JavaServer Faces
             Reference Implementation to validate the XML in your

--- a/sections/sections-app/src/webapp/WEB-INF/web.xml
+++ b/sections/sections-app/src/webapp/WEB-INF/web.xml
@@ -10,10 +10,6 @@
     	<param-value>/WEB-INF/faces-application.xml,/WEB-INF/faces-beans.xml,/WEB-INF/faces-navigation.xml</param-value>
   	</context-param>
 	<context-param>
-		<param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-		<param-value>client</param-value>
-	</context-param>
-	<context-param>
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
             /WEB-INF/spring-services.xml

--- a/signup/tool/src/webapp/WEB-INF/web.xml
+++ b/signup/tool/src/webapp/WEB-INF/web.xml
@@ -13,11 +13,6 @@
 	<description>Sakai Sign-up</description>
 
 	<context-param>
-		<param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-		<param-value>client</param-value>
-	</context-param>
-
-	<context-param>
 		<param-name>com.sun.faces.validateXml</param-name>
 		<param-value>false</param-value>
 	</context-param>

--- a/site-manage/site-association-tool/tool/src/webapp/WEB-INF/web.xml
+++ b/site-manage/site-association-tool/tool/src/webapp/WEB-INF/web.xml
@@ -9,11 +9,6 @@
   <description>Site Association Tool</description>
 
   <context-param>
-    <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-    <param-value>client</param-value>
-  </context-param>
-
-  <context-param>
     <param-name>org.apache.myfaces.SERIALIZE_STATE_IN_SESSION</param-name>
     <param-value>false</param-value>
   </context-param>

--- a/syllabus/syllabus-app/src/webapp/WEB-INF/web.xml
+++ b/syllabus/syllabus-app/src/webapp/WEB-INF/web.xml
@@ -6,11 +6,6 @@
     <display-name>sakai-syllabus</display-name>
     <description>Sakai Syllabus Tool</description>
 
-    <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-    
 <!--sakai-->
     <context-param>
         <param-name>com.sun.faces.validateXml</param-name>

--- a/tool/tool-tool/su/src/webapp/WEB-INF/web.xml
+++ b/tool/tool-tool/su/src/webapp/WEB-INF/web.xml
@@ -6,11 +6,6 @@
     <description>tool-tool-su</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
         <param-name>com.sun.faces.validateXml</param-name>
         <param-value>true</param-value>
     </context-param>

--- a/user/user-tool-admin-prefs/admin-prefs/src/webapp/WEB-INF/web.xml
+++ b/user/user-tool-admin-prefs/admin-prefs/src/webapp/WEB-INF/web.xml
@@ -6,11 +6,6 @@
     <description>sakai-user-tool-admin-prefs</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
 	  <!-- Ordering changed to meet DTD - PAFH 8/30/2006 -->
         <description>
             Set this flag to true if you want the JavaServer Faces

--- a/user/user-tool-prefs/tool/src/webapp/WEB-INF/web.xml
+++ b/user/user-tool-prefs/tool/src/webapp/WEB-INF/web.xml
@@ -6,11 +6,6 @@
     <description>sakai-user-tool-prefs</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
 	  <!-- Ordering changed to meet DTD - PAFH 8/30/2006 -->
         <description>
             Set this flag to true if you want the JavaServer Faces

--- a/userauditservice/tool/src/webapp/WEB-INF/web.xml
+++ b/userauditservice/tool/src/webapp/WEB-INF/web.xml
@@ -9,11 +9,6 @@
   <description>Site User Audit Tool</description>
 
   <context-param>
-    <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-    <param-value>client</param-value>
-  </context-param>
-
-  <context-param>
     <param-name>org.apache.myfaces.SERIALIZE_STATE_IN_SESSION</param-name>
     <param-value>false</param-value>
   </context-param>

--- a/usermembership/tool/src/webapp/WEB-INF/web.xml
+++ b/usermembership/tool/src/webapp/WEB-INF/web.xml
@@ -6,11 +6,6 @@
     <description>User Membership Tool</description>
 
     <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
-    <context-param>
         <description>
             Set this flag to true if you want the JavaServer Faces
             Reference Implementation to validate the XML in your


### PR DESCRIPTION
We are experiencing problems with some users due to SAK-25677. Requests spend too much time to complete (ViewState size is really big). This change allow us to switch SAVING_STATE_METHOD in Samigo (or others) to "server", just with a new property in sakai.properties.