### PR TITLE
SAK-31839 Fix alpha ordering on Manage Tools page

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -651,14 +651,14 @@ var setupCategTools = function(){
         var mylist = $('#toolSelectionList ul');
         var listitems = mylist.children('li').get();
         listitems.sort(function(a, b){
-            return $(a).text().toUpperCase().localeCompare($(b).text().toUpperCase());
+            return $(a).text().trim().toUpperCase().localeCompare($(b).text().trim().toUpperCase());
         });
         $.each(listitems, function(idx, itm){
             mylist.append(itm);
         });
         if ($('#toolSelectionList ul li').length > 1) {
-            if ($('#toolSelectionList ul').find('li#selected_sakai_home').length) {
-             $('#toolSelectionList ul').find('li#selected_sakai_home').insertBefore($('#toolSelectionList ul li:first-child'));
+            if ($('#toolSelectionList ul').find('li#sakai_home').length) {
+             $('#toolSelectionList ul').find('li#sakai_home').insertBefore($('#toolSelectionList ul li:first-child'));
             }
             // SAK-22384
             var listHeader = document.getElementById("#toolSelectionListHeader");


### PR DESCRIPTION
… in the Selected Tools panel after a tool is selected.  Tool link items have a different number of preceding whitespace, so `trim()` the `text()` to be sure we're sorting on letters.  Also patch reordering of the Home item to the top (The id seemed to have changed).

Delivers https://jira.sakaiproject.org/browse/SAK-31839