### PR TITLE
SAK-31922 - /direct/login no longer works

### DIFF
--- a/entitybroker/utils/src/java/org/sakaiproject/entitybroker/util/servlet/DirectServlet.java
+++ b/entitybroker/utils/src/java/org/sakaiproject/entitybroker/util/servlet/DirectServlet.java
@@ -153,7 +153,7 @@ public abstract class DirectServlet extends HttpServlet {
         String uri = req.getRequestURI();
         if ( uri != null ) {
             String[] parts = uri.split("/");
-            if ((parts.length == 2) && ((parts[1].equals("login")))) {
+            if ((parts.length > 0) && ("login".equals(parts[parts.length-1]))) {
                 handleUserLogin(req, res, null);
             } else {
                 dispatch(req, res);


### PR DESCRIPTION
This broke because parts[2] now contained the login (and parts.length ==3)

I just changed it to always look at the last value which should be /login (or well something not /login)

I think if you have an eb direct and it ends in /login this is isn't a case to worry about like nobody is going to have /direct/announcement/login. I guess it could be changed to be exactly 2 or 3?