### PR TITLE
SAK-31920 Don't export anonymous users in spreadsheet

### DIFF
--- a/assignment/assignment-api/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/assignment-api/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -689,7 +689,7 @@ public interface AssignmentService extends EntityProducer
 	 *        Describes the portlet context - generated with DefaultId.getChannel().
 	 * @return List All the Assignments will be listed
 	 */
-	public List getListAssignmentsForContext(String context);
+	public List<Assignment> getListAssignmentsForContext(String context);
 
 	/**
 	 * Retrieve a map of Assignments to a list of User IDs of those who

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -27,15 +27,10 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.poi.ss.usermodel.Cell;
-import org.sakaiproject.assignment.impl.sort.AssignmentComparator;
 import org.sakaiproject.assignment.impl.sort.AssignmentSubmissionComparator;
 import org.sakaiproject.assignment.impl.sort.UserComparator;
-import org.sakaiproject.assignment.impl.sort.UserIdComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.poi.hssf.usermodel.*;
-import org.apache.poi.ss.util.WorkbookUtil;
 import org.sakaiproject.announcement.api.AnnouncementChannel;
 import org.sakaiproject.announcement.api.AnnouncementService;
 import org.sakaiproject.assignment.api.*;
@@ -185,6 +180,12 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 	private AuthzGroupService authzGroupService;
 	public void setAuthzGroupService (AuthzGroupService authzGroupService) {
 		this.authzGroupService = authzGroupService;
+	}
+
+	private GradeSheetExporter gradeSheetExporter;
+
+	public void setGradeSheetExporter(GradeSheetExporter gradeSheetExporter) {
+		this.gradeSheetExporter = gradeSheetExporter;
 	}
 
 	String newline = "<br />\n";
@@ -4362,343 +4363,14 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 	public byte[] getGradesSpreadsheet(String ref) throws IdUnusedException, PermissionException
 	{
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		if (getGradesSpreadsheet(out, ref)) {
+		if (gradeSheetExporter.getGradesSpreadsheet(out, ref)) {
 			return out.toByteArray();
 		}
+
 		return null;
 	}
 
-	/**
-	 * Access and output the grades spreadsheet for the reference, either for an assignment or all assignments in a context.
-	 *
-	 * @param out
-	 *        The outputStream to stream the grades spreadsheet into.
-	 * @param ref
-	 *        The reference, either to a specific assignment, or just to an assignment context.
-	 * @return Whether the grades spreadsheet is successfully output.
-	 * @throws IdUnusedException
-	 *         if there is no object with this id.
-	 * @throws PermissionException
-	 *         if the current user is not allowed to access this.
-	 */
-	public boolean getGradesSpreadsheet(final OutputStream out, final String ref)
-			throws IdUnusedException, PermissionException {
-		boolean retVal = false;
-		String typeGradesString = REF_TYPE_GRADES + Entity.SEPARATOR;
-		String [] parts = ref.substring(ref.indexOf(typeGradesString) + typeGradesString.length()).split(Entity.SEPARATOR);
-		String idSite = (parts.length>1) ? parts[1] : parts[0];
-		String context = (parts.length>1) ? SiteService.siteGroupReference(idSite, parts[3]) : SiteService.siteReference(idSite);
 
-		// get site title for display purpose
-		String siteTitle = "";
-		String sheetName = "";
-		try
-		{
-			Site site = SiteService.getSite(idSite);
-			siteTitle = (parts.length>1)? site.getTitle()+" - "+ site.getGroup(parts[3]).getTitle(): site.getTitle();
-			sheetName = (parts.length>1)? site.getGroup(parts[3]).getTitle(): site.getTitle();
-		}
-		catch (Exception e)
-		{
-			// ignore exception
-			M_log.debug(this + ":getGradesSpreadsheet cannot get site context=" + idSite + e.getMessage());
-		}
-		
-		// does current user allowed to grade any assignment?
-		boolean allowGradeAny = false;
-		boolean hasAtLeastOneAnonAssignment = false;
-		List<Assignment> assignmentsList = getListAssignmentsForContext(idSite);
-		for (Assignment assignment: assignmentsList)
-		{
-			if (allowGradeSubmission(assignment.getReference()))
-			{
-				allowGradeAny = true;
-			}
-
-			if (assignmentUsesAnonymousGrading(assignment))
-			{
-				hasAtLeastOneAnonAssignment = true;
-			}
-		}
-		
-		if (!allowGradeAny)
-		{
-			// not permitted to download the spreadsheet
-			return false;
-		}
-		else
-		{
-			int rowNum = 0;
-			HSSFWorkbook wb = new HSSFWorkbook();
-			
-			HSSFSheet sheet = wb.createSheet(WorkbookUtil.createSafeSheetName(sheetName));
-	
-			// Create a row and put some cells in it. Rows are 0 based.
-			HSSFRow row = sheet.createRow(rowNum++);
-	
-			row.createCell(0).setCellValue(rb.getString("download.spreadsheet.title"));
-	
-			// empty line
-			row = sheet.createRow(rowNum++);
-			row.createCell(0).setCellValue("");
-	
-			// site title
-			row = sheet.createRow(rowNum++);
-			row.createCell(0).setCellValue(rb.getString("download.spreadsheet.site") + siteTitle);
-	
-			// download time
-			row = sheet.createRow(rowNum++);
-			row.createCell(0).setCellValue(
-					rb.getString("download.spreadsheet.date") + TimeService.newTime().toStringLocalFull());
-	
-			// empty line
-			row = sheet.createRow(rowNum++);
-			row.createCell(0).setCellValue("");
-	
-			HSSFCellStyle style = wb.createCellStyle();
-	
-			// this is the header row number
-			int headerRowNumber = rowNum;
-			// set up the header cells
-			row = sheet.createRow(rowNum++);
-			int cellColumnNum = 0;
-			
-			// user enterprise id column
-			HSSFCell cell = row.createCell(cellColumnNum++);
-			cell.setCellStyle(style);
-			cell.setCellValue(rb.getString("download.spreadsheet.column.name"));
-	
-			// user name column
-			cell = row.createCell(cellColumnNum++);
-			cell.setCellStyle(style);
-			cell.setCellValue(rb.getString("download.spreadsheet.column.userid"));
-			
-			// starting from this row, going to input user data
-			Iterator assignments = new SortedIterator(assignmentsList.iterator(), new AssignmentComparator());
-
-			// site members excluding those who can add assignments
-			// hashmap which stores the Excel row number for particular user
-			HashMap<String, Integer> user_row = new HashMap<>();
-			
-			List<String> allowAddAnySubmissionUsers = allowAddAnySubmissionUsers(context);
-			List<User> members = UserDirectoryService.getUsers(allowAddAnySubmissionUsers);
-            members.sort(new UserComparator());
-			for (User user: members)
-			{
-				// create the column for user first
-				row = sheet.createRow(rowNum);
-				// update user_row Hashtable
-				user_row.put(user.getId(), rowNum);
-				rowNum++;
-				// increase row
-				// put user displayid and sortname in the first two cells
-				row.createCell(0).setCellValue(user.getSortName());
-				row.createCell(1).setCellValue(user.getDisplayId());
-			}
-			rowNum++;
-
-			int index = 0;
-			// the grade data portion starts from the third column, since the first two are used for user's display id and sort name
-			while (assignments.hasNext())
-			{
-				Assignment a = (Assignment) assignments.next();
-
-				int assignmentType = a.getContent().getTypeOfGrade();
-
-				// for column header, check allow grade permission based on each assignment
-				if(!a.getDraft() && allowGradeSubmission(a.getReference()))
-				{
-					// put in assignment title as the column header
-					rowNum = headerRowNumber;
-					row = sheet.getRow(rowNum++);
-					cellColumnNum = (index + 2);
-					cell = row.createCell(cellColumnNum); // since the first two column is taken by student id and name
-					cell.setCellStyle(style);
-					cell.setCellValue(a.getTitle());
-
-					for (int loopNum = 0; loopNum < members.size(); loopNum++)
-					{
-						// prepopulate the column with the "no submission" string
-						row = sheet.getRow(rowNum++);
-						cell = row.createCell(cellColumnNum);
-						cell.setCellType(Cell.CELL_TYPE_STRING);
-						cell.setCellValue(rb.getString("listsub.nosub"));
-					}
-
-					// begin to populate the column for this assignment, iterating through student list
-					for (Iterator sIterator=getSubmissions(a).iterator(); sIterator.hasNext();)
-					{
-						AssignmentSubmission submission = (AssignmentSubmission) sIterator.next();
-
-						String userId = submission.getSubmitterId();
-
-						if (a.isGroup()) {
-
-							User[] _users = submission.getSubmitters();
-							for (int i=0; _users != null && i < _users.length; i++) {
-
-								userId = _users[i].getId();
-
-								if (user_row.containsKey(userId))
-								{
-									// find right row
-									row = sheet.getRow(user_row.get(userId));
-
-									if (submission.getGraded() && submission.getGrade() != null)
-									{
-										// graded and released
-										if (assignmentType == 3)
-										{
-											try
-											{
-												// numeric cell type?
-												String grade = (StringUtils.trimToNull(a.getProperties().getProperty(AssignmentService.PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT))!=null)?
-														submission.getGradeForUserInGradeBook(userId)!=null?
-																submission.getGradeForUserInGradeBook(userId):submission.getGradeForUser(userId):submission.getGradeForUser(userId);
-												if(grade == null)
-												{
-													grade=submission.getGradeDisplay();
-												}
-												int factor = submission.getAssignment().getContent().getFactor();
-												int dec = (int)Math.log10(factor);
-
-												//We get float number no matter the locale it was managed with.
-												NumberFormat nbFormat = FormattedText.getNumberFormat(dec,dec,null);
-												float f = nbFormat.parse(grade).floatValue();
-
-												// remove the String-based cell first
-												cell = row.getCell(cellColumnNum);
-												row.removeCell(cell);
-												// add number based cell
-												cell=row.createCell(cellColumnNum);
-												cell.setCellType(Cell.CELL_TYPE_NUMERIC);
-												cell.setCellValue(f);
-
-												style = wb.createCellStyle();
-												String format ="#,##0.";
-												for (int j=0; j<dec; j++) {
-													format = format.concat("0");
-												}
-												style.setDataFormat(wb.createDataFormat().getFormat(format));
-												cell.setCellStyle(style);
-											}
-											catch (Exception e)
-											{
-												// if the grade is not numeric, let's make it as String type
-												// No need to remove the cell and create a new one, as the existing one is String type.
-												cell = row.getCell(cellColumnNum);
-												cell.setCellType(Cell.CELL_TYPE_STRING);
-												cell.setCellValue(submission.getGradeForUser(userId) == null ? submission.getGradeDisplay():
-														submission.getGradeForUser(userId));
-											}
-										}
-										else
-										{
-											// String cell type
-											cell = row.getCell(cellColumnNum);
-											cell.setCellValue(submission.getGradeForUser(userId) == null ? submission.getGradeDisplay():
-													submission.getGradeForUser(userId));
-										}
-									}
-									else if (submission.getSubmitted() && submission.getTimeSubmitted() != null)
-									{
-										// submitted, but no grade available yet
-										cell = row.getCell(cellColumnNum);
-										cell.setCellValue(rb.getString("gen.nograd"));
-									}
-								} // if
-							}
-
-						}
-						else
-						{
-
-							if (user_row.containsKey(userId))
-							{
-								// find right row
-								row = sheet.getRow(user_row.get(userId));
-
-								if (submission.getGraded() && submission.getGrade() != null)
-								{
-									// graded and released
-									if (assignmentType == 3)
-									{
-										try
-										{
-											// numeric cell type?
-											String grade = submission.getGradeDisplay();
-											int factor = submission.getAssignment().getContent().getFactor();
-											int dec = (int)Math.log10(factor);
-
-											//We get float number no matter the locale it was managed with.
-											NumberFormat nbFormat = FormattedText.getNumberFormat(dec,dec,null);
-											float f = nbFormat.parse(grade).floatValue();
-
-											// remove the String-based cell first
-											cell = row.getCell(cellColumnNum);
-											row.removeCell(cell);
-											// add number based cell
-											cell=row.createCell(cellColumnNum);
-											cell.setCellType(Cell.CELL_TYPE_NUMERIC);
-											cell.setCellValue(f);
-
-											style = wb.createCellStyle();
-											String format ="#,##0.";
-											for (int j=0; j<dec; j++) {
-												format = format.concat("0");
-											}
-											style.setDataFormat(wb.createDataFormat().getFormat(format));
-											cell.setCellStyle(style);
-										}
-										catch (Exception e)
-										{
-											// if the grade is not numeric, let's make it as String type
-											// No need to remove the cell and create a new one, as the existing one is String type.
-											cell = row.getCell(cellColumnNum);
-											cell.setCellType(Cell.CELL_TYPE_STRING);
-											// Setting grade display instead grade.
-											cell.setCellValue(submission.getGradeDisplay());
-										}
-									}
-									else
-									{
-										// String cell type
-										cell = row.getCell(cellColumnNum);
-										cell.setCellValue(submission.getGradeDisplay());
-									}
-								}
-								else if (submission.getSubmitted() && submission.getTimeSubmitted() != null)
-								{
-									// submitted, but no grade available yet
-									cell = row.getCell(cellColumnNum);
-									cell.setCellValue(rb.getString("gen.nograd"));
-								}
-							} // if
-
-						}
-					}
-				}
-
-				index++;
-
-			}
-			
-			// output
-			try
-			{
-				wb.write(out);
-				retVal = true;
-			}
-			catch (IOException e)
-			{
-				M_log.warn(" getGradesSpreadsheet Can not output the grade spread sheet for reference= " + ref);
-			}
-			
-			return retVal;
-		}
-
-	} // getGradesSpreadsheet
-	
 	@SuppressWarnings("deprecation")
 	public Collection<Group> getSubmitterGroupList(String searchFilterOnly, String allOrOneGroup, String searchString, String aRef, String contextString) {
 	    Collection<Group> rv = new ArrayList<Group>();
@@ -4723,7 +4395,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		                    rv.add(_gg);
 		                    //}
 		                }
-		            } 
+		            }
 		            else
 		            {
 		                Collection<String> groupRefs = a.getGroups();
@@ -4784,7 +4456,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 
                         			commitEdit(s);
                         			// clear the permission
-                        		} 
+                        		}
                         		catch (Exception e)
                         		{
                         			M_log.warn("getSubmitterGroupList: exception thrown while creating empty submission for group who has not submitted: " + e.getMessage());
@@ -6164,7 +5836,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 								try
 								{
 									out = res.getOutputStream();
-									getGradesSpreadsheet(out, ref.getReference());
+									gradeSheetExporter.getGradesSpreadsheet(out, ref.getReference());
 									out.flush();
 									out.close();
 								}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.poi.ss.usermodel.Cell;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.poi.hssf.usermodel.*;
@@ -4392,8 +4393,9 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 		String sheetName = "";
 		try
 		{
-			siteTitle = (parts.length>1)?SiteService.getSite(idSite).getTitle()+" - "+SiteService.getSite(idSite).getGroup((String)parts[3]).getTitle():SiteService.getSite(idSite).getTitle();
-			sheetName = (parts.length>1)?SiteService.getSite(idSite).getGroup((String)parts[3]).getTitle():SiteService.getSite(idSite).getTitle();
+			Site site = SiteService.getSite(idSite);
+			siteTitle = (parts.length>1)? site.getTitle()+" - "+ site.getGroup(parts[3]).getTitle(): site.getTitle();
+			sheetName = (parts.length>1)? site.getGroup(parts[3]).getTitle(): site.getTitle();
 		}
 		catch (Exception e)
 		{
@@ -4521,7 +4523,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 						// prepopulate the column with the "no submission" string
 						row = sheet.getRow(rowNum++);
 						cell = row.createCell(cellNum);
-						cell.setCellType(1);
+						cell.setCellType(Cell.CELL_TYPE_STRING);
 						cell.setCellValue(rb.getString("listsub.nosub"));
 					}
 
@@ -4571,7 +4573,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 										row.removeCell(cell);
 										// add number based cell
 										cell=row.createCell(cellNum);
-										cell.setCellType(0);
+										cell.setCellType(Cell.CELL_TYPE_NUMERIC);
 										cell.setCellValue(f);
 			
 										style = wb.createCellStyle();
@@ -4587,7 +4589,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 										// if the grade is not numeric, let's make it as String type
 										// No need to remove the cell and create a new one, as the existing one is String type.
 										cell = row.getCell(cellNum);
-										cell.setCellType(1);
+										cell.setCellType(Cell.CELL_TYPE_STRING);
 										cell.setCellValue(submission.getGradeForUser(userId) == null ? submission.getGradeDisplay():
                                                                                     submission.getGradeForUser(userId));
 									}
@@ -4639,7 +4641,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 										row.removeCell(cell);
 										// add number based cell
 										cell=row.createCell(cellNum);
-										cell.setCellType(0);
+										cell.setCellType(Cell.CELL_TYPE_NUMERIC);
 										cell.setCellValue(f);
 			
 										style = wb.createCellStyle();
@@ -4655,7 +4657,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 										// if the grade is not numeric, let's make it as String type
 										// No need to remove the cell and create a new one, as the existing one is String type. 
 										cell = row.getCell(cellNum);
-										cell.setCellType(1);
+										cell.setCellType(Cell.CELL_TYPE_STRING);
 										// Setting grade display instead grade.
 										cell.setCellValue(submission.getGradeDisplay());
 									}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
@@ -425,7 +425,13 @@ public class GradeSheetExporter {
         public int compareTo(Submitter o) {
             int value = Boolean.compare(this.anonymous, o.anonymous);
             if (value == 0) {
-               value = this.id.compareTo(o.id);
+                if (anonymous) {
+                    // Sort by ID for anonymous ones
+                    value = this.id.compareTo(o.id);
+                } else {
+                    // Sort by sortName for normal ones.
+                    value = this.sortName.compareTo(o.sortName);
+                }
             }
             return value;
         }

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
@@ -1,0 +1,381 @@
+package org.sakaiproject.assignment.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.poi.hssf.usermodel.*;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.util.WorkbookUtil;
+import org.sakaiproject.assignment.api.Assignment;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.AssignmentSubmission;
+import org.sakaiproject.assignment.impl.sort.AssignmentComparator;
+import org.sakaiproject.assignment.impl.sort.UserComparator;
+import org.sakaiproject.entity.api.Entity;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.cover.SiteService;
+import org.sakaiproject.time.cover.TimeService;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.cover.UserDirectoryService;
+import org.sakaiproject.util.FormattedText;
+import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.SortedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Exporter for the assignments grades spreadsheet. This encapsulates all the Apache POI code.
+ */
+public class GradeSheetExporter {
+
+    public final Logger log = LoggerFactory.getLogger(GradeSheetExporter.class);
+
+    /** the resource bundle */
+    private ResourceLoader rb = new ResourceLoader("assignment");
+
+    private AssignmentService assignmentService;
+
+    public void setAssignmentService(AssignmentService assignmentService) {
+        this.assignmentService = assignmentService;
+    }
+
+    /**
+     * Access and output the grades spreadsheet for the reference, either for an assignment or all assignments in a context.
+     *
+     * @param out
+     *        The outputStream to stream the grades spreadsheet into.
+     * @param ref
+     *        The reference, either to a specific assignment, or just to an assignment context.
+     * @return Whether the grades spreadsheet is successfully output.
+     * @throws IdUnusedException
+     *         if there is no object with this id.
+     * @throws PermissionException
+     *         if the current user is not allowed to access this.
+     */
+    public boolean getGradesSpreadsheet(final OutputStream out, final String ref)
+            throws IdUnusedException, PermissionException {
+        boolean retVal = false;
+        String typeGradesString = AssignmentService.REF_TYPE_GRADES + Entity.SEPARATOR;
+        String [] parts = ref.substring(ref.indexOf(typeGradesString) + typeGradesString.length()).split(Entity.SEPARATOR);
+        String idSite = (parts.length>1) ? parts[1] : parts[0];
+        String context = (parts.length>1) ? SiteService.siteGroupReference(idSite, parts[3]) : SiteService.siteReference(idSite);
+
+        // get site title for display purpose
+        String siteTitle = "";
+        String sheetName = "";
+        try
+        {
+            Site site = SiteService.getSite(idSite);
+            siteTitle = (parts.length>1)? site.getTitle()+" - "+ site.getGroup(parts[3]).getTitle(): site.getTitle();
+            sheetName = (parts.length>1)? site.getGroup(parts[3]).getTitle(): site.getTitle();
+        }
+        catch (Exception e)
+        {
+            // ignore exception
+            log.debug(this + ":getGradesSpreadsheet cannot get site context=" + idSite + e.getMessage());
+        }
+
+        // does current user allowed to grade any assignment?
+        boolean allowGradeAny = false;
+        List<Assignment> assignmentsList = assignmentService.getListAssignmentsForContext(idSite);
+        for (Assignment assignment: assignmentsList)
+        {
+            if (assignmentService.allowGradeSubmission(assignment.getReference()))
+            {
+                allowGradeAny = true;
+            }
+        }
+
+        if (!allowGradeAny)
+        {
+            // not permitted to download the spreadsheet
+            return false;
+        }
+        else
+        {
+            int rowNum = 0;
+
+            HSSFWorkbook wb = new HSSFWorkbook();
+
+            HSSFSheet sheet = wb.createSheet(WorkbookUtil.createSafeSheetName(sheetName));
+
+            // Create a row and put some cells in it. Rows are 0 based.
+            HSSFRow row = sheet.createRow(rowNum++);
+
+            row.createCell(0).setCellValue(rb.getString("download.spreadsheet.title"));
+
+            // empty line
+            row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue("");
+
+            // site title
+            row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(rb.getString("download.spreadsheet.site") + siteTitle);
+
+            // download time
+            row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(
+                    rb.getString("download.spreadsheet.date") + TimeService.newTime().toStringLocalFull());
+
+            // empty line
+            row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue("");
+
+            HSSFCellStyle style = wb.createCellStyle();
+            HSSFCell cell;
+
+            // this is the header row number
+            int headerRowNumber = rowNum;
+            // set up the header cells
+            row = sheet.createRow(rowNum++);
+            int cellColumnNum = 0;
+
+            // user enterprise id column
+            cell = row.createCell(cellColumnNum++);
+            cell.setCellStyle(style);
+            cell.setCellValue(rb.getString("download.spreadsheet.column.name"));
+
+            // user name column
+            cell = row.createCell(cellColumnNum++);
+            cell.setCellStyle(style);
+            cell.setCellValue(rb.getString("download.spreadsheet.column.userid"));
+
+            // starting from this row, going to input user data
+            Iterator assignments = new SortedIterator(assignmentsList.iterator(), new AssignmentComparator());
+
+            // site members excluding those who can add assignments
+            // hashmap which stores the Excel row number for particular user
+            HashMap<String, Integer> user_row = new HashMap<>();
+
+            List<String> allowAddAnySubmissionUsers = assignmentService.allowAddAnySubmissionUsers(context);
+            List<User> members = UserDirectoryService.getUsers(allowAddAnySubmissionUsers);
+            members.sort(new UserComparator());
+            for (User user: members)
+            {
+                // create the column for user first
+                row = sheet.createRow(rowNum);
+                // update user_row Hashtable
+                user_row.put(user.getId(), rowNum);
+                rowNum++;
+                // increase row
+                // put user displayid and sortname in the first two cells
+                row.createCell(0).setCellValue(user.getSortName());
+                row.createCell(1).setCellValue(user.getDisplayId());
+
+            }
+            rowNum++;
+
+            int index = 0;
+            // the grade data portion starts from the third column, since the first two are used for user's display id and sort name
+            while (assignments.hasNext())
+            {
+                Assignment a = (Assignment) assignments.next();
+
+                int assignmentType = a.getContent().getTypeOfGrade();
+
+                // for column header, check allow grade permission based on each assignment
+                if (assignmentService.assignmentUsesAnonymousGrading(a)) {
+                    // Skip anonymous ones as we don't want to leak grades
+                }
+                else if(!a.getDraft() && assignmentService.allowGradeSubmission(a.getReference()))
+                {
+                    // put in assignment title as the column header
+                    rowNum = headerRowNumber;
+                    row = sheet.getRow(rowNum++);
+                    cellColumnNum = (index + 2);
+                    cell = row.createCell(cellColumnNum); // since the first two column is taken by student id and name
+                    cell.setCellStyle(style);
+                    cell.setCellValue(a.getTitle());
+
+                    for (int loopNum = 0; loopNum < members.size(); loopNum++)
+                    {
+                        // prepopulate the column with the "no submission" string
+                        row = sheet.getRow(rowNum++);
+                        cell = row.createCell(cellColumnNum);
+                        cell.setCellType(Cell.CELL_TYPE_STRING);
+                        cell.setCellValue(rb.getString("listsub.nosub"));
+                    }
+
+                    // begin to populate the column for this assignment, iterating through student list
+                    for (Iterator sIterator=assignmentService.getSubmissions(a).iterator(); sIterator.hasNext();)
+                    {
+                        AssignmentSubmission submission = (AssignmentSubmission) sIterator.next();
+
+                        String userId = submission.getSubmitterId();
+
+                        if (a.isGroup()) {
+
+                            User[] _users = submission.getSubmitters();
+                            for (int i=0; _users != null && i < _users.length; i++) {
+
+                                userId = _users[i].getId();
+
+                                if (user_row.containsKey(userId))
+                                {
+                                    // find right row
+                                    row = sheet.getRow(user_row.get(userId));
+
+                                    if (submission.getGraded() && submission.getGrade() != null)
+                                    {
+                                        // graded and released
+                                        if (assignmentType == 3)
+                                        {
+                                            try
+                                            {
+                                                // numeric cell type?
+                                                String grade = (StringUtils.trimToNull(a.getProperties().getProperty(AssignmentService.PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT))!=null)?
+                                                        submission.getGradeForUserInGradeBook(userId)!=null?
+                                                                submission.getGradeForUserInGradeBook(userId):submission.getGradeForUser(userId):submission.getGradeForUser(userId);
+                                                if(grade == null)
+                                                {
+                                                    grade=submission.getGradeDisplay();
+                                                }
+                                                int factor = submission.getAssignment().getContent().getFactor();
+                                                int dec = (int)Math.log10(factor);
+
+                                                //We get float number no matter the locale it was managed with.
+                                                NumberFormat nbFormat = FormattedText.getNumberFormat(dec,dec,null);
+                                                float f = nbFormat.parse(grade).floatValue();
+
+                                                // remove the String-based cell first
+                                                cell = row.getCell(cellColumnNum);
+                                                row.removeCell(cell);
+                                                // add number based cell
+                                                cell=row.createCell(cellColumnNum);
+                                                cell.setCellType(Cell.CELL_TYPE_NUMERIC);
+                                                cell.setCellValue(f);
+
+                                                style = wb.createCellStyle();
+                                                String format ="#,##0.";
+                                                for (int j=0; j<dec; j++) {
+                                                    format = format.concat("0");
+                                                }
+                                                style.setDataFormat(wb.createDataFormat().getFormat(format));
+                                                cell.setCellStyle(style);
+                                            }
+                                            catch (Exception e)
+                                            {
+                                                // if the grade is not numeric, let's make it as String type
+                                                // No need to remove the cell and create a new one, as the existing one is String type.
+                                                cell = row.getCell(cellColumnNum);
+                                                cell.setCellType(Cell.CELL_TYPE_STRING);
+                                                cell.setCellValue(submission.getGradeForUser(userId) == null ? submission.getGradeDisplay():
+                                                        submission.getGradeForUser(userId));
+                                            }
+                                        }
+                                        else
+                                        {
+                                            // String cell type
+                                            cell = row.getCell(cellColumnNum);
+                                            cell.setCellValue(submission.getGradeForUser(userId) == null ? submission.getGradeDisplay():
+                                                    submission.getGradeForUser(userId));
+                                        }
+                                    }
+                                    else if (submission.getSubmitted() && submission.getTimeSubmitted() != null)
+                                    {
+                                        // submitted, but no grade available yet
+                                        cell = row.getCell(cellColumnNum);
+                                        cell.setCellValue(rb.getString("gen.nograd"));
+                                    }
+                                } // if
+                            }
+
+                        }
+                        else
+                        {
+
+                            if (user_row.containsKey(userId))
+                            {
+                                // find right row
+                                row = sheet.getRow(user_row.get(userId));
+
+                                if (submission.getGraded() && submission.getGrade() != null)
+                                {
+                                    // graded and released
+                                    if (assignmentType == 3)
+                                    {
+                                        try
+                                        {
+                                            // numeric cell type?
+                                            String grade = submission.getGradeDisplay();
+                                            int factor = submission.getAssignment().getContent().getFactor();
+                                            int dec = (int)Math.log10(factor);
+
+                                            //We get float number no matter the locale it was managed with.
+                                            NumberFormat nbFormat = FormattedText.getNumberFormat(dec,dec,null);
+                                            float f = nbFormat.parse(grade).floatValue();
+
+                                            // remove the String-based cell first
+                                            cell = row.getCell(cellColumnNum);
+                                            row.removeCell(cell);
+                                            // add number based cell
+                                            cell=row.createCell(cellColumnNum);
+                                            cell.setCellType(Cell.CELL_TYPE_NUMERIC);
+                                            cell.setCellValue(f);
+
+                                            style = wb.createCellStyle();
+                                            String format ="#,##0.";
+                                            for (int j=0; j<dec; j++) {
+                                                format = format.concat("0");
+                                            }
+                                            style.setDataFormat(wb.createDataFormat().getFormat(format));
+                                            cell.setCellStyle(style);
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            // if the grade is not numeric, let's make it as String type
+                                            // No need to remove the cell and create a new one, as the existing one is String type.
+                                            cell = row.getCell(cellColumnNum);
+                                            cell.setCellType(Cell.CELL_TYPE_STRING);
+                                            // Setting grade display instead grade.
+                                            cell.setCellValue(submission.getGradeDisplay());
+                                        }
+                                    }
+                                    else
+                                    {
+                                        // String cell type
+                                        cell = row.getCell(cellColumnNum);
+                                        cell.setCellValue(submission.getGradeDisplay());
+                                    }
+                                }
+                                else if (submission.getSubmitted() && submission.getTimeSubmitted() != null)
+                                {
+                                    // submitted, but no grade available yet
+                                    cell = row.getCell(cellColumnNum);
+                                    cell.setCellValue(rb.getString("gen.nograd"));
+                                }
+                            } // if
+
+                        }
+                    }
+                }
+
+                index++;
+
+            }
+
+            // output
+            try
+            {
+                wb.write(out);
+                retVal = true;
+            }
+            catch (IOException e)
+            {
+                log.warn(" getGradesSpreadsheet Can not output the grade spread sheet for reference= " + ref);
+            }
+
+            return retVal;
+        }
+
+    } // getGradesSpreadsheet
+
+
+}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentComparator.java
@@ -1,0 +1,39 @@
+package org.sakaiproject.assignment.impl.sort;
+
+import org.sakaiproject.assignment.api.Assignment;
+import org.sakaiproject.time.api.Time;
+
+import java.util.Comparator;
+
+/**
+ * The AssignmentComparator class that sorts by the due date of the assignment.
+ */
+public class AssignmentComparator implements Comparator<Assignment> {
+    /**
+     * implementing the compare function
+     *
+     * @param o1 The first object
+     * @param o2 The second object
+     * @return The compare result. 1 is o1 < o2; -1 otherwise
+     */
+    public int compare(Assignment o1, Assignment o2) {
+        int result = -1;
+
+        // sorted by the assignment due date
+        Time t1 = o1.getDueTime();
+        Time t2 = o2.getDueTime();
+
+        if (t1 == null) {
+            result = -1;
+        } else if (t2 == null) {
+            result = 1;
+        } else if (t1.before(t2)) {
+            result = -1;
+        } else {
+            result = 1;
+        }
+        return result;
+    }
+
+
+}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
@@ -13,7 +13,7 @@ import java.text.RuleBasedCollator;
 import java.util.Comparator;
 
 /**
- * Created by buckett on 04/11/2016.
+ * Sorts assignment submissions by the submitter's sort name.
  */
 public class AssignmentSubmissionComparator implements Comparator<AssignmentSubmission> {
 
@@ -57,9 +57,6 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
 
     /**
      * get the submitter sortname String for the AssignmentSubmission object
-     *
-     * @param o2
-     * @return
      */
     private String getSubmitterSortname(Object o2) {
         String rv = "";

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
@@ -1,0 +1,90 @@
+package org.sakaiproject.assignment.impl.sort;
+
+import org.sakaiproject.assignment.api.AssignmentSubmission;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.cover.SiteService;
+import org.sakaiproject.user.api.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
+import java.util.Comparator;
+
+/**
+ * Created by buckett on 04/11/2016.
+ */
+public class AssignmentSubmissionComparator implements Comparator<AssignmentSubmission> {
+
+    private static Logger M_log = LoggerFactory.getLogger(AssignmentSubmissionComparator.class);
+
+    private Collator collator;
+
+    public AssignmentSubmissionComparator() {
+        try {
+            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
+        } catch (ParseException e) {
+            // error with init RuleBasedCollator with rules
+            // use the default Collator
+            collator = Collator.getInstance();
+            M_log.warn(this + " AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead. " + e);
+        }
+    }
+
+    @Override
+    public int compare(AssignmentSubmission a1, AssignmentSubmission a2) {
+        int result;
+        String name1 = getSubmitterSortname(a1);
+        String name2 = getSubmitterSortname(a2);
+        result = compareString(name1, name2);
+        return result;
+    }
+
+    private int compareString(String s1, String s2) {
+        int result;
+        if (s1 == null && s2 == null) {
+            result = 0;
+        } else if (s2 == null) {
+            result = 1;
+        } else if (s1 == null) {
+            result = -1;
+        } else {
+            result = collator.compare(s1.toLowerCase(), s2.toLowerCase());
+        }
+        return result;
+    }
+
+    /**
+     * get the submitter sortname String for the AssignmentSubmission object
+     *
+     * @param o2
+     * @return
+     */
+    private String getSubmitterSortname(Object o2) {
+        String rv = "";
+        if (o2 instanceof AssignmentSubmission) {
+            // get Assignment
+            AssignmentSubmission _submission = (AssignmentSubmission) o2;
+            if (_submission.getAssignment().isGroup()) {
+                // get the Group
+                try {
+                    Site _site = SiteService.getSite(_submission.getAssignment().getContext());
+                    rv = _site.getGroup(_submission.getSubmitterId()).getTitle();
+                } catch (Throwable _dfd) {
+                }
+            } else {
+                User[] users2 = ((AssignmentSubmission) o2).getSubmitters();
+                if (users2 != null) {
+                    StringBuffer users2Buffer = new StringBuffer();
+                    for (int i = 0; i < users2.length; i++) {
+                        users2Buffer.append(users2[i].getSortName() + " ");
+                    }
+                    rv = users2Buffer.toString();
+                }
+            }
+        }
+        return rv;
+    }
+
+}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserComparator.java
@@ -1,0 +1,14 @@
+package org.sakaiproject.assignment.impl.sort;
+
+import org.sakaiproject.user.api.User;
+
+import java.util.Comparator;
+
+/**
+ * This sorts users.
+ */
+public class UserComparator implements Comparator<User> {
+    public int compare(User u1, User u2) {
+        return u1.compareTo(u2);
+    }
+}

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserComparator.java
@@ -1,14 +1,40 @@
 package org.sakaiproject.assignment.impl.sort;
 
 import org.sakaiproject.user.api.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
 import java.util.Comparator;
 
 /**
  * This sorts users.
  */
 public class UserComparator implements Comparator<User> {
+
+    private static Logger M_log = LoggerFactory.getLogger(UserComparator.class);
+
+    private Collator collator;
+
+    public UserComparator() {
+        // TODO this should be in a service and should repect the current user's locale
+        try {
+            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
+        } catch (ParseException e) {
+            // error with init RuleBasedCollator with rules
+            // use the default Collator
+            collator = Collator.getInstance();
+            M_log.warn(this + " UserIdComparator cannot init RuleBasedCollator. Will use the default Collator instead. " + e);
+        }
+        // This is to ignore case of the values
+        collator.setStrength(Collator.SECONDARY);
+    }
+
     public int compare(User u1, User u2) {
-        return u1.compareTo(u2);
+        String name1 = u1.getSortName();
+        String name2 = u2.getDisplayName();
+        return collator.compare(name1, name2);
     }
 }

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserComparator.java
@@ -34,7 +34,7 @@ public class UserComparator implements Comparator<User> {
 
     public int compare(User u1, User u2) {
         String name1 = u1.getSortName();
-        String name2 = u2.getDisplayName();
+        String name2 = u2.getSortName();
         return collator.compare(name1, name2);
     }
 }

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserIdComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/UserIdComparator.java
@@ -1,0 +1,76 @@
+package org.sakaiproject.assignment.impl.sort;
+
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.cover.UserDirectoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
+import java.util.Comparator;
+
+/**
+ * Sorts a collection of User IDs by their sortnames.
+ */
+public class UserIdComparator implements Comparator<String> {
+
+    private static Logger M_log = LoggerFactory.getLogger(UserIdComparator.class);
+
+    private Collator collator;
+
+    public UserIdComparator() {
+        // TODO this should be in a service and should repect the current user's locale
+        try {
+            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
+        } catch (ParseException e) {
+            // error with init RuleBasedCollator with rules
+            // use the default Collator
+            collator = Collator.getInstance();
+            M_log.warn(this + " UserIdComparator cannot init RuleBasedCollator. Will use the default Collator instead. " + e);
+        }
+        // This is to ignore case of the values
+        collator.setStrength(Collator.SECONDARY);
+    }
+
+    @Override
+    public int compare(String id1, String id2) {
+        // sorted by the user's display name
+        String s1 = null;
+        if (id1 != null) {
+            try {
+                User u1 = UserDirectoryService.getUser(id1);
+                s1 = u1 != null ? u1.getSortName() : null;
+            } catch (Exception e) {
+                M_log.warn(" AssignmentComparator.compare " + e.getMessage() + " id=" + id1);
+            }
+        }
+
+        String s2 = null;
+        if (id2 != null) {
+            try {
+                User u2 = UserDirectoryService.getUser(id2);
+                s2 = u2 != null ? u2.getSortName() : null;
+            } catch (Exception e) {
+                M_log.warn(" AssignmentComparator.compare " + e.getMessage() + " id=" + id2);
+            }
+        }
+
+        return compareNullSafeString(s1, s2);
+    }
+
+
+    private int compareNullSafeString(String s1, String s2) {
+        int result;
+        if (s1 == null && s2 == null) {
+            result = 0;
+        } else if (s2 == null) {
+            result = 1;
+        } else if (s1 == null) {
+            result = -1;
+        } else {
+            result = collator.compare(s1, s2);
+        }
+        return result;
+    }
+}

--- a/assignment/assignment-impl/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
+++ b/assignment/assignment-impl/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
@@ -24,33 +24,35 @@ package org.sakaiproject.assignment.impl;
 import junit.framework.TestCase;
 
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.mockito.Mockito;
 import org.sakaiproject.assignment.api.Assignment;
 import org.sakaiproject.assignment.api.AssignmentSubmission;
+import org.sakaiproject.assignment.impl.sort.AssignmentSubmissionComparator;
+import org.sakaiproject.assignment.impl.sort.UserIdComparator;
 import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.user.api.User;
 
+import java.util.Comparator;
+
+
+@SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(UserDirectoryService.class)
 public class AssignmentComparatorTest extends TestCase {
 
-	private static final Logger log = LoggerFactory.getLogger(AssignmentComparatorTest.class);
-	
-	private BaseAssignmentService.AssignmentComparator sortNameComparator;
-	private BaseAssignmentService.AssignmentComparator submitterNameComparator;
+	private Comparator<String> sortNameComparator;
+	private Comparator<AssignmentSubmission> submitterNameComparator;
 	private AssignmentSubmission assignmentSubmission1, assignmentSubmission2, assignmentSubmission3, assignmentSubmission4;
 	
 	protected void setUp() throws Exception {
 		// Mock Static Cover
 		PowerMockito.mockStatic(UserDirectoryService.class);
 
-		sortNameComparator = new BaseAssignmentService.AssignmentComparator("sortname", "true");
-		submitterNameComparator = new BaseAssignmentService.AssignmentComparator("submitterName", "true");
+		sortNameComparator = new UserIdComparator();
+		submitterNameComparator = new AssignmentSubmissionComparator();
 
 		Assignment asm = Mockito.mock(Assignment.class);
 		Mockito.when(asm.isGroup()).thenReturn(false);
@@ -58,42 +60,36 @@ public class AssignmentComparatorTest extends TestCase {
 		User user1 = Mockito.mock(User.class);
 		Mockito.when(user1.getSortName()).thenReturn("Muñoz");
 
-		assignmentSubmission1 = (AssignmentSubmission) Mockito.mock(AssignmentSubmission.class);
+		assignmentSubmission1 = Mockito.mock(AssignmentSubmission.class);
 		Mockito.when(assignmentSubmission1.getAssignment()).thenReturn(asm);
 		Mockito.when(assignmentSubmission1.getSubmitters()).thenReturn(new User[]{user1});
 
 		User user2 = Mockito.mock(User.class);
 		Mockito.when(user2.getSortName()).thenReturn("Muñiz");
 
-		assignmentSubmission2 = (AssignmentSubmission) Mockito.mock(AssignmentSubmission.class);
+		assignmentSubmission2 = Mockito.mock(AssignmentSubmission.class);
 		Mockito.when(assignmentSubmission2.getAssignment()).thenReturn(asm);
 		Mockito.when(assignmentSubmission2.getSubmitters()).thenReturn(new User[]{user2});
 		
 		User user3 = Mockito.mock(User.class);
 		Mockito.when(user3.getSortName()).thenReturn("Smith");
 
-		assignmentSubmission3 = (AssignmentSubmission) Mockito.mock(AssignmentSubmission.class);
+		assignmentSubmission3 = Mockito.mock(AssignmentSubmission.class);
 		Mockito.when(assignmentSubmission3.getAssignment()).thenReturn(asm);
 		Mockito.when(assignmentSubmission3.getSubmitters()).thenReturn(new User[]{user3});
 
 		User user4 = Mockito.mock(User.class);
 		Mockito.when(user4.getSortName()).thenReturn("Adam");
 
-		assignmentSubmission4 = (AssignmentSubmission) Mockito.mock(AssignmentSubmission.class);
+		assignmentSubmission4 = Mockito.mock(AssignmentSubmission.class);
 		Mockito.when(assignmentSubmission4.getAssignment()).thenReturn(asm);
 		Mockito.when(assignmentSubmission4.getSubmitters()).thenReturn(new User[]{user4});
 
-		try {
-			Mockito.when(UserDirectoryService.getUser("user1")).thenReturn(user1);
-			Mockito.when(UserDirectoryService.getUser("user2")).thenReturn(user2);
-			Mockito.when(UserDirectoryService.getUser("user3")).thenReturn(user3);
-			Mockito.when(UserDirectoryService.getUser("user4")).thenReturn(user4);
-			Mockito.when(UserDirectoryService.getUser("usernull")).thenReturn(null);
-		} catch (Exception e) {
-			// TODO: handle exception
-			log.error(e.getMessage());
-		}
-		
+        Mockito.when(UserDirectoryService.getUser("user1")).thenReturn(user1);
+        Mockito.when(UserDirectoryService.getUser("user2")).thenReturn(user2);
+        Mockito.when(UserDirectoryService.getUser("user3")).thenReturn(user3);
+        Mockito.when(UserDirectoryService.getUser("user4")).thenReturn(user4);
+        Mockito.when(UserDirectoryService.getUser("usernull")).thenReturn(null);
 	}
 	
 	public void testSortNameEQComparator() {

--- a/assignment/assignment-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/assignment/assignment-impl/pack/src/webapp/WEB-INF/components.xml
@@ -40,6 +40,9 @@
 
 	<bean id="org.sakaiproject.assignment.impl.GradeSheetExporter" class="org.sakaiproject.assignment.impl.GradeSheetExporter">
 		<property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService"/>
+		<property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+		<property name="timeService" ref="org.sakaiproject.time.api.TimeService"/>
+		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
 	</bean>
 
 	<bean id="org.sakaiproject.assignment.taggable.api.AssignmentActivityProducer"

--- a/assignment/assignment-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/assignment/assignment-impl/pack/src/webapp/WEB-INF/components.xml
@@ -27,6 +27,7 @@
  		<property name="securityService"><ref bean="org.sakaiproject.authz.api.SecurityService"/></property>
  		<property name="developerHelperService"><ref bean="org.sakaiproject.entitybroker.DeveloperHelperService"/></property>
 		<property name="authzGroupService"><ref bean="org.sakaiproject.authz.api.AuthzGroupService"/></property>
+		<property name="gradeSheetExporter"><ref bean="org.sakaiproject.assignment.impl.GradeSheetExporter"/></property>
  		
  		<!--use to allow group awareness option in assignments. 
  			By default this is true.-->
@@ -35,6 +36,10 @@
  		<!--use to hide or show the Assignments 'Add to Gradebook' option for group particular assignments.
  			By default this is false -->
  		<property name="allowGroupAssignmentsInGradebook"><value>true</value></property>
+	</bean>
+
+	<bean id="org.sakaiproject.assignment.impl.GradeSheetExporter" class="org.sakaiproject.assignment.impl.GradeSheetExporter">
+		<property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService"/>
 	</bean>
 
 	<bean id="org.sakaiproject.assignment.taggable.api.AssignmentActivityProducer"

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/User.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/User.java
@@ -84,7 +84,7 @@ public interface User extends Entity, Comparable
 	/**
 	 * Access the user's name for sorting purposes.
 	 * 
-	 * @return The user's name for sorting purposes.
+	 * @return The user's name for sorting purposes, never <code>null</code>
 	 */
 	String getSortName();
 


### PR DESCRIPTION
When exporting a spreadsheet from the assignments tool anonymous users were displayed without their anonymous ID. This changes it so they are still exported but the user appears multiple times in the spreadsheet, once with their full name and once for each assignment submitted under an anonymous ID.

The comparators were also extracted out into type safe classes as there was one comparator that dealt with multiple types. This could be improved but needs more refactoring outside just assignments.

The results are also sorted by ID for the anonymous ones so that you can't see who an anonymous user is by comparing the lists of anonymous and non anonymous users.

When reading through code I also added generics and constants where I was updating it.

I extracted the code out into another class as it's self contained and should never have been in the main assignments service class in the first place.