### PR TITLE
SAK-31931 Make URLs relative in Overview (Site Information Display)

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -27,6 +27,11 @@
 # DEFAULT: localhost
 # serverName=localhost
 
+# aliases the server may have. If the server sees a URL with this it can assume that the same content would be
+# accessed if the serverName was put in it's place.
+# DEFAULT: (EMPTY)
+# serverNameAliases=www.sakai.inst.edu,other.sakai.inst.edu
+
 ## Fill-ins for the css/vm ui (Worksite Setup, Digest Service, Email notification, Worksite Setup, Contact Support, Portal)
 # Name of the institution running the app 
 # DEFAULT: "" (empty string)

--- a/kernel/component-manager/src/main/java/org/sakaiproject/component/api/ServerConfigurationService.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/component/api/ServerConfigurationService.java
@@ -21,6 +21,7 @@
 
 package org.sakaiproject.component.api;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -70,6 +71,14 @@ public interface ServerConfigurationService
 	 * @return The server DNS name.
 	 */
 	String getServerName();
+
+	/**
+	 * Access alternative names
+	 *
+	 * @return The server alternative names (doesn't contain the server name)
+	 *         or an empty collection if there is no alternative name
+	 */
+	Collection<String> getServerNameAliases();
 
 	/**
 	 * Access the URL to the root of the server - append any additional path to the end.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/BasicConfigurationService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/BasicConfigurationService.java
@@ -23,19 +23,11 @@ package org.sakaiproject.component.impl;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.Arrays;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -288,6 +280,14 @@ public class BasicConfigurationService implements ServerConfigurationService, Ap
     public String getServerName()
     {
         return getConfig("serverName", "localhost"); //(String) properties.get("serverName");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<String> getServerNameAliases(){
+        String[] names = getStrings("serverNameAliases");
+        return (names == null) ? Collections.<String>emptyList() : Arrays.asList(names);
     }
 
     /**

--- a/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockServerConfigurationService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockServerConfigurationService.java
@@ -1,5 +1,6 @@
 package org.sakai.memory.impl.test;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -75,6 +76,11 @@ public class MockServerConfigurationService implements
 	}
 
 	public String getServerName() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	public Collection<String> getServerNameAliases() {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/mocks/FakeServerConfigurationService.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/mocks/FakeServerConfigurationService.java
@@ -117,6 +117,11 @@ public class FakeServerConfigurationService implements ServerConfigurationServic
 		return null;
 	}
 
+	@Override
+	public Collection<String> getServerNameAliases() {
+		return Collections.emptyList();
+	}
+
 	public String getServerUrl() {
 		return "http://localhost:8080";
 	}

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/mocks/FakeServerConfigurationService.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/mocks/FakeServerConfigurationService.java
@@ -18,10 +18,12 @@
  */
 package org.sakaiproject.sitestats.test.mocks;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Locale;
+import java.util.Map;
 
 import org.sakaiproject.component.api.ServerConfigurationService;
 

--- a/web/web-portlet/src/java/org/sakaiproject/portlets/PortletIFrame.java
+++ b/web/web-portlet/src/java/org/sakaiproject/portlets/PortletIFrame.java
@@ -591,15 +591,20 @@ public class PortletIFrame extends GenericPortlet {
 					    Site s = SiteService.getSite(ToolManager.getCurrentPlacement().getContext());
 					    String siteId = s.getId();
 
-					    String infoUrl = StringUtils.trimToNull(s.getInfoUrl());
-					    if (infoUrl != null)
-					    {
-                                            //Check if infoUrl is relative? and prepend the server url
-                                            if(infoUrl.startsWith("/") && !infoUrl.contains("://")){
-                                                infoUrl = ServerConfigurationService.getServerUrl() + infoUrl;
-                                            }
-						    context.put("info_url", FormattedText.escapeHtmlFormattedTextarea(infoUrl));
-					    }
+						String infoUrl = StringUtils.trimToNull(s.getInfoUrl());
+						if (infoUrl != null)
+						{
+							//Check if infoUrl is relative? and prepend the server url
+							if(infoUrl.startsWith("/") && !infoUrl.contains("://")){
+								infoUrl = ServerConfigurationService.getServerUrl() + infoUrl;
+							}
+							//Check if infoUrl is relative? and prepend the server url
+							String serverUrl = ServerConfigurationService.getServerUrl();
+							if(infoUrl.startsWith("/") && infoUrl.indexOf("://") == -1){
+								infoUrl = serverUrl + infoUrl;
+							}
+							context.put("info_url", FormattedText.escapeHtmlFormattedTextarea(infoUrl));
+						}
 
 					    String description = StringUtils.trimToNull(s.getDescription());
 					    if (description != null)
@@ -872,12 +877,17 @@ public class PortletIFrame extends GenericPortlet {
             if (SPECIAL_WORKSITE.equals(special))
             {
                 //Check info-url for null and empty
-                if(StringUtils.isNotBlank(infoUrl)){
+                if(StringUtils.isNotBlank(infoUrl)) {
                     // If the site info url has server url then make it a relative link.
-                    String serverName = new URL(ServerConfigurationService.getServerUrl()).getHost();
-                    // if the supplied url starts with protocol//serverName:port/
-                    Pattern serverUrlPattern = Pattern.compile(String.format("^(https?:)?//%s:?\\d*/", serverName));
-                    infoUrl = serverUrlPattern.matcher(infoUrl).replaceFirst("/");
+                    Collection<String> serverNames = new ArrayList<String>();
+                    //get the server name
+                    serverNames.add(new URL(ServerConfigurationService.getServerUrl()).getHost());
+                    serverNames.addAll(ServerConfigurationService.getInstance().getServerNameAliases());
+                    for (String serverName : serverNames) {
+                        // if the supplied url starts with protocol//serverName:port/
+                        Pattern serverUrlPattern = Pattern.compile(String.format("^(https?:)?//%s:?\\d*/", serverName));
+                        infoUrl = serverUrlPattern.matcher(infoUrl).replaceFirst("/");
+                    }
                 }
                 String description = StringUtils.trimToNull(request.getParameter("description"));
                 //Need to save this processed


### PR DESCRIPTION
When editing the Site URL in Site Information Display the URL is made relative if it's pointing to the current host. This change also adds support for a set of aliases that the current service is know as.

Having host relative URLs makes is much easier to move the content to a test server and have all the links work.