### PR TITLE
SAK-31936 site creation notification email update conversion script fails on case sensitive MySQL instances

### DIFF
--- a/reference/docs/conversion/sakai_11_mysql_conversion.sql
+++ b/reference/docs/conversion/sakai_11_mysql_conversion.sql
@@ -443,7 +443,7 @@ ALTER TABLE CITATION_COLLECTION_ORDER MODIFY COLUMN CITATION_ID VARCHAR(36) NULL
 -- End SAK-29974
 
 --  SAK-30000 Site creation notification email template updates
-UPDATE email_template_item
+UPDATE EMAIL_TEMPLATE_ITEM
 SET message = '
 From Worksite Setup to ${serviceName} support:
 
@@ -453,7 +453,7 @@ From Worksite Setup to ${serviceName} support:
 ${sections}
 '
 WHERE template_key = 'sitemanage.notifySiteCreation' AND template_locale = 'default';
-UPDATE email_template_item
+UPDATE EMAIL_TEMPLATE_ITEM
 SET subject = 'Site "${siteTitle}" was successfully created by ${currentUserDisplayName}', message = '
 Hi, ${currentUserDisplayName}:
 

--- a/reference/docs/conversion/sakai_11_oracle_conversion.sql
+++ b/reference/docs/conversion/sakai_11_oracle_conversion.sql
@@ -463,7 +463,7 @@ UPDATE SAKAI_SITE_TOOL SET TITLE='Calendar' WHERE REGISTRATION = 'sakai.schedule
 UPDATE SAKAI_SITE_PAGE SET TITLE='Calendar' WHERE TITLE = 'Schedule';
 
 -- SAK-30000 Site creation notification email template updates
-UPDATE email_template_item
+UPDATE EMAIL_TEMPLATE_ITEM
 SET message = '
 From Worksite Setup to ${serviceName} support:
 
@@ -473,7 +473,7 @@ From Worksite Setup to ${serviceName} support:
 ${sections}
 '
 WHERE template_key = 'sitemanage.notifySiteCreation' AND template_locale = 'default';
-UPDATE email_template_item
+UPDATE EMAIL_TEMPLATE_ITEM
 SET subject = 'Site "${siteTitle}" was successfully created by ${currentUserDisplayName}', message = '
 Hi, ${currentUserDisplayName}:
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-31936

The conversion script fails to update the template on case sensitive MySQL instances because the table name is not in upper case. The convention is to use the case in which the table was originally created.

Thanks to @smarquard for identifying this issue.