### PR TITLE
SAK-31941 Remove confusing Delete Topic button

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
@@ -138,11 +138,6 @@
 					<h:outputText value="#{msgs.cdfm_topic_settings}"/>
 				</h:commandLink>
 				
-				<h:commandLink action="#{ForumTool.processActionDeleteTopicConfirm}" id="delete_confirm" accesskey="d" rendered="#{!ForumTool.selectedTopic.markForDeletion && ForumTool.displayTopicDeleteOption}">
-				<f:param value="#{ForumTool.selectedTopic.topic.id}" name="topicId"/>
-				<h:outputText value="#{msgs.cdfm_button_bar_delete_topic}"/>
-				</h:commandLink>
-				
 				<h:outputLink id="print" value="javascript:printFriendly('#{ForumTool.printFriendlyUrl}');">
 					<h:graphicImage url="/../../library/image/silk/printer.png" alt="#{msgs.print_friendly}" title="#{msgs.print_friendly}" />
 				</h:outputLink>


### PR DESCRIPTION
The "Delete Topic" button on the Topic page in Forums has confused several users into deleting entire topics accidentally, and all of the conversations along with them.  This PR removes that button.  There are other, safer, clearer ways to delete topics already.