### PR TITLE
SAK-31944 Fix Calendar tool Month display name

### DIFF
--- a/calendar/calendar-util/util/pom.xml
+++ b/calendar/calendar-util/util/pom.xml
@@ -53,5 +53,11 @@
         	<artifactId>joda-time</artifactId>
         	<version>${joda.time.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.2.16</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
+++ b/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
@@ -23,6 +23,10 @@ package org.sakaiproject.util;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Clock;
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -115,46 +119,40 @@ public class CalendarUtil
 	  dateFriday = calendarFriday.getTime();
 	  dateSaturday = calendarSaturday.getTime();
 
-	  Calendar calendarJanuary = Calendar.getInstance();
-	  Calendar calendarFebruary = Calendar.getInstance();
-	  Calendar calendarMarch = Calendar.getInstance();
-	  Calendar calendarApril = Calendar.getInstance();
-	  Calendar calendarMay = Calendar.getInstance();
-	  Calendar calendarJune = Calendar.getInstance();
-	  Calendar calendarJuly = Calendar.getInstance();
-	  Calendar calendarAugust = Calendar.getInstance();
-	  Calendar calendarSeptember = Calendar.getInstance();
-	  Calendar calendarOctober = Calendar.getInstance();
-	  Calendar calendarNovember = Calendar.getInstance();
-	  Calendar calendarDecember = Calendar.getInstance();
+	  // Previously Calendar was used, but it had problems getting the month right
+	  // when the current day of the month was 31.
+	  YearMonth currentYearMonth = YearMonth.now();
+	  YearMonth jan = currentYearMonth.with(Month.JANUARY);
+	  YearMonth feb = currentYearMonth.with(Month.FEBRUARY);
+	  YearMonth mar = currentYearMonth.with(Month.MARCH);
+	  YearMonth apr = currentYearMonth.with(Month.APRIL);
+	  YearMonth may = currentYearMonth.with(Month.MAY);
+	  YearMonth jun = currentYearMonth.with(Month.JUNE);
+	  YearMonth jul = currentYearMonth.with(Month.JULY);
+	  YearMonth aug = currentYearMonth.with(Month.AUGUST);
+	  YearMonth sep = currentYearMonth.with(Month.SEPTEMBER);
+	  YearMonth oct = currentYearMonth.with(Month.OCTOBER);
+	  YearMonth nov = currentYearMonth.with(Month.NOVEMBER);
+	  YearMonth dec = currentYearMonth.with(Month.DECEMBER);
 
-	  calendarJanuary.set(Calendar.MONTH, Calendar.JANUARY); 
-	  calendarFebruary.set(Calendar.MONTH, Calendar.FEBRUARY); 
-	  calendarMarch.set(Calendar.MONTH, Calendar.MARCH); 
-	  calendarApril.set(Calendar.MONTH, Calendar.APRIL); 
-	  calendarMay.set(Calendar.MONTH, Calendar.MAY); 
-	  calendarJune.set(Calendar.MONTH, Calendar.JUNE); 
-	  calendarJuly.set(Calendar.MONTH, Calendar.JULY); 
-	  calendarAugust.set(Calendar.MONTH, Calendar.AUGUST); 
-	  calendarSeptember.set(Calendar.MONTH, Calendar.SEPTEMBER); 
-	  calendarOctober.set(Calendar.MONTH, Calendar.OCTOBER); 
-	  calendarNovember.set(Calendar.MONTH, Calendar.NOVEMBER); 
-	  calendarDecember.set(Calendar.MONTH, Calendar.DECEMBER); 
-
-	  dateJanuary = calendarJanuary.getTime();
-	  dateFebruary = calendarFebruary.getTime();
-	  dateMarch = calendarMarch.getTime();
-	  dateApril = calendarApril.getTime();
-	  dateMay = calendarMay.getTime();
-	  dateJune = calendarJune.getTime();
-	  dateJuly = calendarJuly.getTime();
-	  dateAugust = calendarAugust.getTime();
-	  dateSeptember = calendarSeptember.getTime();
-	  dateOctober = calendarOctober.getTime();
-	  dateNovember = calendarNovember.getTime();
-	  dateDecember = calendarDecember.getTime();
+	  dateJanuary = getDateFromYearMonth(jan);
+	  dateFebruary = getDateFromYearMonth(feb);
+	  dateMarch = getDateFromYearMonth(mar);
+	  dateApril = getDateFromYearMonth(apr);
+	  dateMay = getDateFromYearMonth(may);
+	  dateJune = getDateFromYearMonth(jun);
+	  dateJuly = getDateFromYearMonth(jul);
+	  dateAugust = getDateFromYearMonth(aug);
+	  dateSeptember = getDateFromYearMonth(sep);
+	  dateOctober = getDateFromYearMonth(oct);
+	  dateNovember = getDateFromYearMonth(nov);
+	  dateDecember = getDateFromYearMonth(dec);
 
 	}
+
+	private Date getDateFromYearMonth(YearMonth ym) {
+        return Date.from(ym.atDay(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+    }
 
 	/**
 	* Access the current user.
@@ -219,8 +217,7 @@ public class CalendarUtil
 	}	// getNextMonth
 
 	/**
-	* Set the calendar to the next year, and return this.
-	* @return the next year.
+	* Set the calendar to the next year
 	*/
 	public void setNextYear()
 	{
@@ -242,8 +239,7 @@ public class CalendarUtil
 	}	// getPrevMonth	
 
 	/**
-	* Set the calendar to the prev year, and return this.
-	* @return the prev year.
+	* Set the calendar to the prev year.
 	*/
 	public void setPrevYear()
 	{
@@ -274,8 +270,7 @@ public class CalendarUtil
 	}	// getDay_Of_Week
 
 	/**
-	* Set the calendar to the next week, and return this.
-	* @return the next week.
+	* Set the calendar to the next week
 	*/
 	public void setNextWeek()
 	{
@@ -284,8 +279,7 @@ public class CalendarUtil
 	}	// setNextWeek
 
 	/**
-	* Set the calendar to the prev week, and return this.
-	* @return the prev week.
+	* Set the calendar to the prev week
 	*/
 	public void setPrevWeek()
 	{
@@ -332,8 +326,7 @@ public class CalendarUtil
 	*/
 	public int getDayOfMonth() 
 	{
-		int dayofmonth = m_calendar.get(Calendar.DAY_OF_MONTH);
-		return dayofmonth;
+		return m_calendar.get(Calendar.DAY_OF_MONTH);
 
 	}	// getDayOfMonth
 	
@@ -410,7 +403,7 @@ public class CalendarUtil
 	public String[] getCalendarMonthNames(boolean longNames) {
 
 		Locale currentLocale = rb.getLocale();
-		String[] months = null; 
+		String[] months;
 		
 		if (longNames) {
 
@@ -492,7 +485,7 @@ public class CalendarUtil
 		SimpleDateFormat longDay = new SimpleDateFormat("EEEE", currentLocale);
 		SimpleDateFormat shortDay = new SimpleDateFormat("EEE", currentLocale);
 		
-		String[] weekDays = null; 
+		String[] weekDays;
 		String[] longWeekDays = new String[] 
 		{
 			longDay.format(dateSunday),

--- a/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
+++ b/calendar/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
@@ -44,11 +44,13 @@ public class CalendarUtil
 {	
 	/** Our logger. */
 	private static Logger M_log = LoggerFactory.getLogger(CalendarUtil.class);
+
+	private Clock clock = Clock.systemDefaultZone();
 	
 	/** The calendar object this is based upon. */
 	Calendar m_calendar = null;
 	DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.SHORT);
-	ResourceLoader rb = new ResourceLoader("calendar");
+	ResourceLoader rb;
 
 	Date dateSunday = null;
 	Date dateMonday = null;
@@ -76,12 +78,13 @@ public class CalendarUtil
 	/**
 	* Construct.
 	*/
-	public CalendarUtil() 
+	public CalendarUtil()
 	{
+		rb = new ResourceLoader("calendar");
 		Locale locale = rb.getLocale();
 		m_calendar = Calendar.getInstance(locale);
 		initDates();
-		
+
 	}	// CalendarUtil
 	
 	/**
@@ -89,19 +92,42 @@ public class CalendarUtil
 	*/
 	public CalendarUtil(Calendar calendar) 
 	{
+		rb = new ResourceLoader("calendar");
 		m_calendar = calendar;
 		initDates();
 		
 	}	// CalendarUtil
 
+	/**
+	 * Constructor for testing.
+	 * @param clock the clock to use for the current time.
+	 */
+	public CalendarUtil(Clock clock, ResourceLoader rb)
+	{
+		this.clock = clock;
+		this.rb = rb;
+		m_calendar = getCalendarInstance();
+		initDates();
+	}
+
+	/**
+	 * This creates a calendar based on the clock. This is to allow testing of the class.
+	 * @return A calendar.
+	 */
+	private Calendar getCalendarInstance() {
+		Calendar instance = Calendar.getInstance();
+		instance.setTime(Date.from(clock.instant()));
+		return instance;
+	}
+
 	void initDates() {
-	  Calendar calendarSunday = Calendar.getInstance();
-	  Calendar calendarMonday = Calendar.getInstance();
-	  Calendar calendarTuesday = Calendar.getInstance();
-	  Calendar calendarWednesday = Calendar.getInstance();
-	  Calendar calendarThursday = Calendar.getInstance();
-	  Calendar calendarFriday = Calendar.getInstance();
-	  Calendar calendarSaturday = Calendar.getInstance();
+	  Calendar calendarSunday = getCalendarInstance();
+	  Calendar calendarMonday = getCalendarInstance();
+	  Calendar calendarTuesday = getCalendarInstance();
+	  Calendar calendarWednesday = getCalendarInstance();
+	  Calendar calendarThursday = getCalendarInstance();
+	  Calendar calendarFriday = getCalendarInstance();
+	  Calendar calendarSaturday = getCalendarInstance();
 
 	  calendarSunday.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
 	  calendarMonday.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
@@ -121,7 +147,7 @@ public class CalendarUtil
 
 	  // Previously Calendar was used, but it had problems getting the month right
 	  // when the current day of the month was 31.
-	  YearMonth currentYearMonth = YearMonth.now();
+	  YearMonth currentYearMonth = YearMonth.now(clock);
 	  YearMonth jan = currentYearMonth.with(Month.JANUARY);
 	  YearMonth feb = currentYearMonth.with(Month.FEBRUARY);
 	  YearMonth mar = currentYearMonth.with(Month.MARCH);

--- a/calendar/calendar-util/util/src/test/org/sakaiproject/util/CalendarUtilTest.java
+++ b/calendar/calendar-util/util/src/test/org/sakaiproject/util/CalendarUtilTest.java
@@ -2,9 +2,16 @@ package org.sakaiproject.util;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -46,6 +53,18 @@ public class CalendarUtilTest {
         // This a day that the clocks go forward in London
         DateTime dateTime = new DateTime(2015, 3, 29, 0, 0, zone);
         assertEquals("PM", CalendarUtil.getLocalPMString(dateTime));
+    }
+
+    @Test
+    public void testDayOfMonthAtEnd() {
+        // This tests a problem with how Sakai was calculating the month when it was the last day of the month.
+        ResourceLoader rb = Mockito.mock(ResourceLoader.class);
+        Mockito.when(rb.getLocale()).thenReturn(Locale.ENGLISH);
+        Instant instant = Instant.parse("2007-08-31T09:30:00Z");
+        CalendarUtil util = new CalendarUtil(Clock.fixed(instant, ZoneOffset.ofHours(0)),rb);
+        String[] calendarMonthNames = util.getCalendarMonthNames(false);
+        String[] expected = new String[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+        Assert.assertArrayEquals(expected, calendarMonthNames);
     }
 
 


### PR DESCRIPTION
Previously in the Calendar tool, the month name would be displayed
incorrectly when it was the 31 day of a month. This was resolved
by using the new Java 8 YearMonth object.