### PR TITLE
3580 fix Bootstrap popovers and dropdown menus in GradebookNG tool

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -186,9 +186,13 @@ public class BasePage extends WebPage {
 		response.render(StringHeaderItem
 				.forString("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />"));
 
-		// Shared stylesheets
+		// Shared JavaScript and stylesheets
+		// Bootstrap (lock in a version we've tested with and pair it with Wicket's jQuery)
+		response.render(JavaScriptHeaderItem
+			.forUrl(String.format("/library/webjars/bootstrap/3.3.6/js/bootstrap.min.js?version=%s", version)));
+		// Some global gradebookng styles
 		response.render(CssHeaderItem
-				.forUrl(String.format("/gradebookng-tool/styles/gradebook-shared.css?version=%s", version)));
+			.forUrl(String.format("/gradebookng-tool/styles/gradebook-shared.css?version=%s", version)));
 
 	}
 
@@ -215,7 +219,7 @@ public class BasePage extends WebPage {
 		flagWithPopover.add(new AttributeModifier("data-html", "true"));
 		flagWithPopover.add(new AttributeModifier("data-container", "#gradebookGrades"));
 		flagWithPopover.add(new AttributeModifier("data-template",
-				"'<div class=\"gb-popover popover\" role=\"tooltip\"><div class=\"arrow\"></div><div class=\"popover-content\"></div></div>'"));
+				"<div class=\"gb-popover popover\" role=\"tooltip\"><div class=\"arrow\"></div><div class=\"popover-content\"></div></div>"));
 		flagWithPopover.add(new AttributeModifier("data-content", generatePopoverContent(message)));
 		flagWithPopover.add(new AttributeModifier("tabindex", "0"));
 

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -111,6 +111,7 @@ GradebookSpreadsheet.prototype.setupGradeItemCellModels = function() {
     tooltip = tooltip.replace("{0}", self.getCellModel($cell).getRow().find(".gb-student-cell:first").attr("abbr"));
     tooltip = tooltip.replace("{1}", self.getCellModel($cell).header.$cell.attr("abbr"));
     $dropdown.attr("title", tooltip);
+    $dropdown.dropdown();
 
     $cell.data("has-dropdown", true);
   };
@@ -1420,12 +1421,13 @@ GradebookSpreadsheet.prototype.setupMenusAndPopovers = function() {
         mouseDownEvent.stopPropagation();
         $(mouseDownEvent.target).focus();
       }
-    })
+      return true;
+    });
 
     $btnGroup.find("ul.dropdown-menu li a").on("mousedown", function(mouseDownEvent) {
       mouseDownEvent.stopPropagation();
       $(mouseDownEvent.target).focus();
-    })
+    });
 
     $btnGroup.find(".btn.dropdown-toggle, ul.dropdown-menu li a").on("blur", handleDropdownItemBlur);
 
@@ -1433,6 +1435,9 @@ GradebookSpreadsheet.prototype.setupMenusAndPopovers = function() {
       $btnGroup.find(".btn.dropdown-toggle, ul.dropdown-menu li a").off("blur", handleDropdownItemBlur);
     });
   });
+
+  // initialize all dropdown menus
+  self.$spreadsheet.find('.dropdown-toggle').dropdown();
 };
 
 


### PR DESCRIPTION
Delivers #3580.  The Wicket jQuery loads in the <head> but $PBJQ and Bootstrap is loaded at the end of the page. We need Bootstrap to be loaded and integrated with the jQuery that Wicket (and our custom JavaScript) uses, so pull in Bootstrap at the top of the page.