### PR TITLE
SAK-30756 fix tooltips in wiki

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
+++ b/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
@@ -317,11 +317,12 @@ a.rwiki_help_popup_link span{ padding: 0 }
 	margin-bottom: 4px;
 	padding: 5px 5px 5px 5px;
 	width:100%;
-    width: 27em;
+	width: 27em;
 	color: inherit;
 	border: 1px solid #09c;
 	background-color: #cef;
 	line-height: 100%;
+	z-index: 1;
 }
 .rwiki_help_popup textarea{
 	width:98%


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30756

Tool tips were displaying but the underlying text would bleed through, making the tool tip's text unreadable. Solution was to add z-index to tool tip container. Screen shots in the JIRA ticket.