### PR TITLE
SAK-30753 wiki table headings should be bold

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
+++ b/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
@@ -952,3 +952,7 @@ but render it for accessibility */
 div.rwikiRenderedContent table.listHier {
 	width: auto;
 }
+
+div.rwikiRenderedContent table.listHier th {
+	font-weight: bold;
+}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-30753

"the top row of a table should be rendered in bold on a grey background. The text isnt in bold"