### PR TITLE
SAK-21985 wiki tables should not be 100% width at all times

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
+++ b/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
@@ -947,3 +947,7 @@ but render it for accessibility */
 	height:1px;
 	overflow:hidden;
 }
+
+div.rwikiRenderedContent table.listHier {
+	width: auto;
+}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-21985

"Not sure whether this is officially classified as a 'feature' but in my mind it's a bug. Wiki tables now span the whole width of the page which makes them look pretty awful. see screenshot"