### PR TITLE
SAK-21039 make wiki read events generated by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3896,8 +3896,8 @@
 # wiki.notification=false
 
 # Whether or not to track wiki page views in the event tracking table.
-# DEFAULT: false
-# wiki.trackreads=true
+# DEFAULT: true
+# wiki.trackreads=false
 
 # The name of the default wiki home page
 # DEFAULT: Home 

--- a/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/service/impl/RWikiObjectServiceImpl.java
+++ b/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/service/impl/RWikiObjectServiceImpl.java
@@ -150,7 +150,7 @@ public class RWikiObjectServiceImpl implements RWikiObjectService
 	
 	private int maxReferencesStringSize = 4000;
 
-	private boolean trackReads = ServerConfigurationService.getBoolean("wiki.trackreads", false);
+	private boolean trackReads = ServerConfigurationService.getBoolean("wiki.trackreads", true);
    
 	/**
 	 * Configuration: to run the ddl on init or not.

--- a/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/service/impl/CommandServiceImpl.java
+++ b/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/service/impl/CommandServiceImpl.java
@@ -138,7 +138,7 @@ public class CommandServiceImpl implements CommandService
 
 	public void init()
 	{
-        trackReads = ServerConfigurationService.getBoolean("wiki.trackreads", false);
+        trackReads = ServerConfigurationService.getBoolean("wiki.trackreads", true);
 
 		for (Iterator it = commandMap.keySet().iterator(); it.hasNext();)
 		{

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/commandComponents.xml
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/commandComponents.xml
@@ -16,7 +16,7 @@
     class="uk.ac.cam.caret.sakai.rwiki.tool.service.impl.CommandServiceImpl"
 	init-method="init" >
     <property name="eventTrackingService" ><ref bean="org.sakaiproject.event.api.EventTrackingService" /></property>
-    <property name="trackReads" ><value>false</value></property>
+    <property name="trackReads" ><value>true</value></property>
     <property name="commandMap">
       <map>
 	<entry key="save"><ref bean="saveCommand"/></entry>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-21039

"At the moment rwiki can generate read events, but these aren't turned on by default.

Can I suggest we turn them on by default so that everyone gets good wiki reporting in site stats. I believe content read events are on by default and the quantity of events generated there is far more than rwiki is likely to ever generate."