### PR TITLE
SAK-25289 - Breadcrumbs trail incorrect when accessing forum topics

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -7218,10 +7218,6 @@ public class DiscussionForumTool
    */
   private void setSelectedForumForCurrentTopic(DiscussionTopic topic)
   {
-    if (selectedForum != null)
-    {
-      return;
-    }
     DiscussionForum forum = (DiscussionForum) topic.getBaseForum();
     if (forum == null)
     {


### PR DESCRIPTION
From what I can see the problem here is some old code from 2005 in setSelectedForumForCurrentTopic. It did a check if selectedforums != null and returned but in this case for some reason the selectedForum wasn't null but it was the wrong forum from a previous request. In the regular forums workflow selectedForum is ALWAYS null so I don't even see the point of this, and it seems to be not even always doing what you'd expect a setter to do. 

It seems to me like this is the best fix. An alternate might be to see why the selectedForum isn't reset. selectedTopic is always reset by this code in resetTopicById and I think it's expecting the forum to set along with the topic.