### PR TITLE
SAK-31948 Don't order anonymous assignments by sortname.

### DIFF
--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.sakaiproject.assignment.impl.sort.AnonymousSubmissionComparator;
 import org.sakaiproject.assignment.impl.sort.AssignmentSubmissionComparator;
 import org.sakaiproject.assignment.impl.sort.UserComparator;
 import org.slf4j.Logger;
@@ -4966,8 +4967,15 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 				if (allowGradeSubmission(aRef))
 				{
 					AssignmentContent content = a.getContent();
-					zipSubmissions(aRef, a.getTitle(), content.getTypeOfGradeString(), content.getTypeOfSubmission(), 
-							new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator()), out, exceptionMessage, withStudentSubmissionText, withStudentSubmissionAttachment, withGradeFile, withFeedbackText, withFeedbackComment, withFeedbackAttachment, withoutFolders,gradeFileFormat, includeNotSubmitted);
+					SortedIterator sortedIterator;
+					if (assignmentUsesAnonymousGrading(a))
+					{
+						sortedIterator = new SortedIterator(submissions.iterator(), new AnonymousSubmissionComparator());
+					} else {
+						sortedIterator = new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator());
+					}
+					zipSubmissions(aRef, a.getTitle(), content.getTypeOfGradeString(), content.getTypeOfSubmission(),
+							sortedIterator, out, exceptionMessage, withStudentSubmissionText, withStudentSubmissionAttachment, withGradeFile, withFeedbackText, withFeedbackComment, withFeedbackAttachment, withoutFolders,gradeFileFormat, includeNotSubmitted);
 	
 					if (exceptionMessage.length() > 0)
 					{

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AnonymousSubmissionComparator.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/sort/AnonymousSubmissionComparator.java
@@ -1,0 +1,44 @@
+package org.sakaiproject.assignment.impl.sort;
+
+import org.sakaiproject.assignment.api.AssignmentSubmission;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.cover.SiteService;
+import org.sakaiproject.user.api.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
+import java.util.Comparator;
+
+/**
+ * Sorts assignment submissions by the submission's anonymous ID.
+ */
+public class AnonymousSubmissionComparator implements Comparator<AssignmentSubmission> {
+
+    private static Logger M_log = LoggerFactory.getLogger(AnonymousSubmissionComparator.class);
+
+    private Collator collator;
+
+    public AnonymousSubmissionComparator() {
+        try {
+            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
+        } catch (ParseException e) {
+            // error with init RuleBasedCollator with rules
+            // use the default Collator
+            collator = Collator.getInstance();
+            M_log.warn(this + " AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead. " + e);
+        }
+    }
+
+    @Override
+    public int compare(AssignmentSubmission a1, AssignmentSubmission a2) {
+        int result;
+        String name1 = a1.getAnonymousSubmissionId();
+        String name2 = a2.getAnonymousSubmissionId();
+        result = collator.compare(name1, name2);
+        return result;
+    }
+
+}

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11124,6 +11124,7 @@ public class AssignmentAction extends PagedResourceActionII
 
 		state.setAttribute(STATE_MODE, MODE_INSTRUCTOR_REPORT_SUBMISSIONS);
 		state.setAttribute(SORTED_BY, SORTED_SUBMISSION_BY_LASTNAME);
+		state.setAttribute(SORTED_SUBMISSION_BY, SORTED_GRADE_SUBMISSION_BY_LASTNAME);
 		state.setAttribute(SORTED_ASC, Boolean.TRUE.toString());
 
 	} // doReport_submissions
@@ -14270,6 +14271,7 @@ public class AssignmentAction extends PagedResourceActionII
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
 		// all the resources for paging
 		List returnResources = new ArrayList();
+		boolean hasOneAnon = false;
 
 		boolean allowAddAssignment = AssignmentService.allowAddAssignment(contextString);
 		if (MODE_LIST_ASSIGNMENTS.equals(mode))
@@ -14369,6 +14371,8 @@ public class AssignmentAction extends PagedResourceActionII
 					    _dupUsers = usersInMultipleGroups(a, true);
 						}
 					}
+					// Have we found an anonymous assignment in the list.
+					hasOneAnon = hasOneAnon || AssignmentService.getInstance().assignmentUsesAnonymousGrading(a);
 					//get the list of users which are allowed to grade this assignment
 					List allowGradeAssignmentUsers = AssignmentService.allowGradeAssignmentUsers(a.getReference());
 					String deleted = a.getProperties().getProperty(ResourceProperties.PROP_ASSIGNMENT_DELETED);
@@ -14588,6 +14592,10 @@ public class AssignmentAction extends PagedResourceActionII
 				{
 					// ignore, continue with default sort
 				}
+			}
+			else if (hasOneAnon)
+			{
+				ac.setAnon(true);
 			}
 			
 			try


### PR DESCRIPTION
When displaying lists of submitters involving anonymous assignments we have to make sure we sort by the anonymous ID and not the user's sortname so we don't leak information about who has what result.

Ideally we would clean up all the comparators here, but that's lots of work and won't be easy to merge back to 11.x