### PR TITLE
SAK-31949 Compilation content-review implementation

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -744,6 +744,27 @@
 						</div>
 						#end
 				<!-- End VeriCite custom options -->
+				#elseif($reviewServiceName.equals("Compilatio"))
+						#if ($content_review_note)
+							$content_review_note
+						#end
+						<h4>
+							$tlang.getString("review.originality.reports")
+						</h4>
+						<div class="radio">
+							#if($show_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT.contains($name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_IMMEDIATELY))
+								<label for="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_RADIO">
+									<input type="radio" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_RADIO" value="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_IMMEDIATELY" #if($value_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_RADIO.equals("$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_IMMEDIATELY"))checked#end/>$tlang.getString("review.originality.reports.immediately")<br/>
+								</label>
+								<br/>
+							#end
+							#if($show_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT.contains($name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_DUE))
+								<label for="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_RADIO">
+									<input type="radio" name="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_RADIO" value="$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_DUE" #if($value_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_RADIO.equals("$name_NEW_ASSIGNMENT_REVIEW_SERVICE_REPORT_DUE"))checked#end/>$tlang.getString("review.originality.reports.due")<br/>
+								</label>
+							#end
+						</div>
+				<!-- End Compilatio custom options -->
 				#end
 			</div>
 		#end

--- a/content-review/contentreview-federated/pack/src/webapp/WEB-INF/components.xml
+++ b/content-review/contentreview-federated/pack/src/webapp/WEB-INF/components.xml
@@ -19,6 +19,7 @@
         <util:list id="contentReviewProviders">
                 <!--ref bean="org.sakaiproject.contentreview.service.ContentReviewServiceTii"/>
                 <ref bean="org.sakaiproject.contentreview.service.ContentReviewServiceVeriCite"/>
+                <ref bean="org.sakaiproject.contentreview.service.ContentReviewServiceCompilatio"/>
                 -->
         </util:list>
         <!-- Override this list in sakai/sakai-configuration.xml (https://confluence.sakaiproject.org/display/REL/More+Flexible+Sakai+Configuration) like


### PR DESCRIPTION
This pull request is to help with the merge of compilatio content-review implementation in Sakai 11, it just adds to Assignments the compilatio options as other antiplagiarism solution does. Also adds the commented option in content-review base.