### PR TITLE
LSNBLDR-753 lessons does not generate events for creating or updating comments

### DIFF
--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -646,8 +646,8 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		 * 
 		 * Essentially, if any of those say that the edit is fine, it won't throw the error.
 		 */
-	    if(requiresEditPermission && !(o instanceof SimplePageItem && canEditPage(((SimplePageItem)o).getPageId()))
-	    			&& !(o instanceof SimplePage && canEditPage((SimplePage)o))
+		if(requiresEditPermission && !(o instanceof SimplePageItem && canEditPage(((SimplePageItem)o).getPageId()))
+				&& !(o instanceof SimplePage && canEditPage((SimplePage)o))
 				&& !(o instanceof SimplePageLogEntry || o instanceof SimplePageQuestionResponse)
 				&& !(o instanceof SimplePageGroup)) {
 			elist.add(nowriteerr);
@@ -655,30 +655,33 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		}
 
 		try {
-		    getHibernateTemplate().save(o);
-		    
-		    if (o instanceof SimplePageItem) {
-			SimplePageItem i = (SimplePageItem)o;
-			EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.create", "/lessonbuilder/item/" + i.getId(), true));
-		    } else if (o instanceof SimplePage) {
-			SimplePage i = (SimplePage)o;
-			EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.create", "/lessonbuilder/page/" + i.getPageId(), true));
-		    } 
+			getHibernateTemplate().save(o);
 
-		    if(o instanceof SimplePageItem || o instanceof SimplePage) {
-		    	updateStudentPage(o);
-		    }
-		    
-		    return true;
+			if (o instanceof SimplePageItem) {
+				SimplePageItem item = (SimplePageItem)o;
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.create", "/lessonbuilder/item/" + item.getId(), true));
+			} else if (o instanceof SimplePage) {
+				SimplePage page = (SimplePage)o;
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.create", "/lessonbuilder/page/" + page.getPageId(), true));
+			} else if (o instanceof SimplePageComment) {
+				SimplePageComment comment = (SimplePageComment)o;
+				EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.create", "/lessonbuilder/comment/" + comment.getId(), true));
+			}
+
+			if(o instanceof SimplePageItem || o instanceof SimplePage) {
+				updateStudentPage(o);
+			}
+
+			return true;
 		} catch (org.springframework.dao.DataIntegrityViolationException e) {
-		    getCause(e, elist);
-		    return false;
+			getCause(e, elist);
+			return false;
 		} catch (org.hibernate.exception.DataException e) {
-		    getCause(e, elist);
-		    return false;
+			getCause(e, elist);
+			return false;
 		} catch (DataAccessException e) {
-		    getCause(e, elist);
-		    return false;
+			getCause(e, elist);
+			return false;
 		}
 	}
 
@@ -820,18 +823,21 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		 */
 		if(requiresEditPermission && !(o instanceof SimplePageItem && canEditPage(((SimplePageItem)o).getPageId()))
 				&& !(o instanceof SimplePage && canEditPage((SimplePage)o))
-		   		&& !(o instanceof SimplePageLogEntry || o instanceof SimplePageQuestionResponse)
+				&& !(o instanceof SimplePageLogEntry || o instanceof SimplePageQuestionResponse)
 				&& !(o instanceof SimplePageGroup)) {
 			elist.add(nowriteerr);
 			return false;
 		}
 		
 		if (o instanceof SimplePageItem) {
-		    SimplePageItem i = (SimplePageItem)o;
-		    EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.update", "/lessonbuilder/item/" + i.getId(), true));
+			SimplePageItem item = (SimplePageItem)o;
+			EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.update", "/lessonbuilder/item/" + item.getId(), true));
 		} else if (o instanceof SimplePage) {
-		    SimplePage i = (SimplePage)o;
-		    EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.update", "/lessonbuilder/page/" + i.getPageId(), true));
+			SimplePage page = (SimplePage)o;
+			EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.update", "/lessonbuilder/page/" + page.getPageId(), true));
+		} else if (o instanceof SimplePageComment) {
+			SimplePageComment comment = (SimplePageComment)o;
+			EventTrackingService.post(EventTrackingService.newEvent("lessonbuilder.update", "/lessonbuilder/comment/" + comment.getId(), true));
 		}
 
 		try {
@@ -848,21 +854,21 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 					getHibernateTemplate().merge(o);
 				}
 			}
-		    
-		    if(o instanceof SimplePageItem || o instanceof SimplePage) {
-		    	updateStudentPage(o);
-		    }
-		    
-		    return true;
+
+			if(o instanceof SimplePageItem || o instanceof SimplePage) {
+				updateStudentPage(o);
+			}
+
+			return true;
 		} catch (org.springframework.dao.DataIntegrityViolationException e) {
-		    getCause(e, elist);
-		    return false;
+			getCause(e, elist);
+			return false;
 		} catch (org.hibernate.exception.DataException e) {
-		    getCause(e, elist);
-		    return false;
+			getCause(e, elist);
+			return false;
 		} catch (DataAccessException e) {
-		    getCause(e, elist);
-		    return false;
+			getCause(e, elist);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/LSNBLDR-753
Events are not generated when creating or updating comments. We get a create and update event on creation of a comments section, but these are actually 'item' event refs. There should be 'comment' event refs generated when any user submits a comment to any comment section.

When we create a comments section, we effectively get two events (lessonbuilder.create and lessonbuilder.update), with a ref as follows:

```/lessonbuilder/item/<itemID>```

Where the itemID is the ID of the comments section 'item'. When any user posts a comment to a comments section, there should be a lessonbuilder.create with an event ref like the following:

```/lessonbuilder/comment/<commentID>```

Which would allow interested parties to resolve the author, the time of posting the comment, the page hierarchy, etc. However, it seems the only time a comment event ref is generated is on deletion of a comment (lessonbuilder.delete).

This ticket will implement generation of create and update events for comments.