### PR TITLE
3602 fix js errors on GradebookNG settings tab 

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -217,6 +217,10 @@ public class SettingsPage extends BasePage {
 
 		final String version = ServerConfigurationService.getString("portal.cdn.version", "");
 
+		// Drag and Drop (requires jQueryUI)
+		response.render(JavaScriptHeaderItem
+			.forUrl(String.format("/library/webjars/jquery-ui/1.11.3/jquery-ui.min.js?version=%s", version)));
+
 		response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/styles/gradebook-settings.css?version=%s", version)));
 		response.render(
 				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/scripts/gradebook-settings.js?version=%s", version)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
@@ -276,12 +276,15 @@ public class SettingsCategoryPanel extends Panel {
 
 				// if categories and weighting, disable course grade points
 				final AjaxCheckBox points = settingsPage.getSettingsGradeReleasePanel().getPointsCheckBox();
-				if (type == GbCategoryType.WEIGHTED_CATEGORY) {
-					points.setEnabled(false);
-				} else {
-					points.setEnabled(true);
+				// only do this if course grade is released and the points checkbox is visible
+				if (SettingsCategoryPanel.this.model.getObject().getGradebookInformation().isCourseGradeDisplayed()) {
+					if (type == GbCategoryType.WEIGHTED_CATEGORY) {
+						points.setEnabled(false);
+					} else {
+						points.setEnabled(true);
+					}
+					target.add(points);
 				}
-				target.add(points);
 
 				// reinitialize any custom behaviour
 				target.appendJavaScript("sakai.gradebookng.settings.categories = new GradebookCategorySettings($('#settingsCategories'));");

--- a/gradebookng/tool/src/webapp/scripts/gradebook-settings.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-settings.js
@@ -19,8 +19,11 @@ function GradebookCategorySettings($container) {
   this.$container = $container;
   this.$table = this.$container.find("table");
 
-  this.setupSortableCategories();
-  this.setupKeyboardSupport();
+  // only if categories are enabled
+  if (this.$table.length > 0) {
+    this.setupSortableCategories();
+    this.setupKeyboardSupport();
+  }
 }
 
 
@@ -58,10 +61,6 @@ GradebookCategorySettings.prototype.setupKeyboardSupport = function() {
 
 
 GradebookCategorySettings.prototype.focusLastRow = function() {
-  console.log("focusLastRow");
-  console.log(this.$table);
-  console.log(this.$table.find(".gb-category-row:last :text:first"));
-  console.log(this.$table.find(".gb-category-row:last :text:first").is(":visible"));
   // get the first input#text in the last row of the table
   var $input = this.$table.find(".gb-category-row:last :text:first");
   // attempt to set focus


### PR DESCRIPTION
The reported js error was due to jQueryUI sortable not being attached to Wicket's jQuery.  Plus also fixed an error if the course grade had not been released and the categories enabled changes.

Delivers #3602.