### PR TITLE
3616-Uncategorized GB Items should not be counted

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3185,7 +3185,10 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			Assignment assignment = gradeRecord.getAssignment();
 						
 			// remove if not for this category (rule 1)
-			if(assignment.getCategory() != null && categoryId.longValue() != assignment.getCategory().getId().longValue()){
+			if(assignment.getCategory() == null){
+				return true;
+			}
+			if(categoryId.longValue() != assignment.getCategory().getId().longValue()){
 				return true;
 			}
 			


### PR DESCRIPTION
This causes any assignment which is uncategorized (that is a null
category) to not be included in the category grade calculation.

This resolves #3616 .