### PR TITLE
3631 Improve link passthrough in GradebookNG

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -560,9 +560,8 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
   });
 
   // Clicks on the fixed column return you to the real column cell
-  self.$fixedColumns.find("td").on("mousedown", function(event) {
+  self.$fixedColumns.find("td,th").on("mousedown", function(event) {
     event.preventDefault();
-    self.$spreadsheet.scrollLeft(0);
     var cellIndex = $(this).index();
     var rowIndex = $(this).closest("tr").index();
     $targetCell = $($(self.$table.find("> tbody > tr").get(rowIndex)).find("> *").get(cellIndex));


### PR DESCRIPTION
Within the GradebookNG tool, there is a fixed column which appears only
once scrolled to the right. Clicks on elements within that column (i.e.
student name / the row itself) would not be passed through to the actual
element where the event is processed. This fixes that so that the
clicks are passed through correctly, for example: allowing one to
access the student overview panel when scrolled to the right.

This would resolve #3631 