### PR TITLE
SAK-31723 - Subsites position is not in right position

### DIFF
--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
@@ -45,8 +45,10 @@ $PBJQ(document).ready(function(){
 	initialOffset = $PBJQ("#toolMenu").offset().top - $window.scrollTop();
 	$PBJQ(window).scroll(function(){
 		var follow = ($window.height()- padding) > $tools.height();
-		var _subHeight = (-1 * ( $PBJQ('#toolMenu').height() - $PBJQ("#toggleSubsitesLink").position().top ) );
-		var _top   = ( $PBJQ("#toggleSubsitesLink").length > 0 )?_subHeight:0;
+		var _top   = 0;
+		if( $PBJQ("#toggleSubsitesLink").length > 0 ){
+			_top = (-1 * ( $PBJQ('#toolMenu').height() - $PBJQ("#toggleSubsitesLink").position().top ) );
+		}
 		if( $PBJQ("#toolMenuWrap").css('position') !== 'fixed' && follow ) {
 			if($window.scrollTop() > offset.top ) {
 				$PBJQ("#toolMenu").stop().animate({


### PR DESCRIPTION
Maven making the compressed JS has done a wrong optimization. We had before `_subHeight` (it was failing too) this code

`var _top   = ( $PBJQ("#toggleSubsitesLink").length > 0 )?(-1 * ( $PBJQ('#toolMenu').height() - $PBJQ("#toggleSubsitesLink").position().top ) ):0;`

And maven compress it to this failing code:
`var c=(-1*($PBJQ("#toolMenu").height()-$PBJQ("#toggleSubsitesLink").position().top));`
`var b=($PBJQ("#toggleSubsitesLink").length>0)?c:0;`

We need to check `toggleSubsitesLink` exists before figure out its position