### PR TITLE
3580 fix javascript error in GradebookNG

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -189,7 +189,7 @@ public class BasePage extends WebPage {
 		// Shared JavaScript and stylesheets
 		// Bootstrap (lock in a version we've tested with and pair it with Wicket's jQuery)
 		response.render(JavaScriptHeaderItem
-			.forUrl(String.format("/library/webjars/bootstrap/3.3.6/js/bootstrap.min.js?version=%s", version)));
+			.forUrl(String.format("/library/webjars/bootstrap/3.3.7/js/bootstrap.min.js?version=%s", version)));
 		// Some global gradebookng styles
 		response.render(CssHeaderItem
 			.forUrl(String.format("/gradebookng-tool/styles/gradebook-shared.css?version=%s", version)));


### PR DESCRIPTION
Caused by the change to the bootstrap version.  We need to pull in bootstrap ahead of the portal, so update the bootstrap import to v3.3.7 so it's all worky.

Delivers #3580.