### PR TITLE
3651 In GradebookNG prevent erroneous row added

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -506,8 +506,10 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
 
   var $headers = self.$table.find("> thead > tr.gb-headers > th").slice(0,3);
   var $thead = $("<thead>");
-  // append a dummy header row for when categorised
-  $thead.append($("<tr>").addClass("gb-categories-row").append($("<th>").attr("colspan", $headers.length)));
+  if(self.isGroupedByCategory()) {
+    // append a dummy header row for when categorised
+    $thead.append($("<tr>").addClass("gb-categories-row").append($("<th>").attr("colspan", $headers.length)));
+  }
 
  // add the row for all cloned cells
   $thead.append($("<tr>").addClass("gb-clone-row").addClass("gb-headers"));


### PR DESCRIPTION
Within the GradebookNG tool if one where to turn "Group by Category" on
(when categories where enabled) and then to turn off Categories, if the
user where to scroll right then the fixed header would have an
extraneous row on it. This change causes the row to only be added when
group by category is enabled.

Resolves #3651 