### PR TITLE
SAK-29928 Switch to java internal zip and Files.copy methods

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -32,6 +32,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.text.Collator;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
@@ -57,6 +59,7 @@ import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.*;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -66,8 +69,6 @@ import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
-import org.apache.tools.zip.ZipEntry;
-import org.apache.tools.zip.ZipFile;
 import org.sakaiproject.announcement.api.AnnouncementChannel;
 import org.sakaiproject.announcement.api.AnnouncementMessage;
 import org.sakaiproject.announcement.api.AnnouncementMessageEdit;
@@ -15911,13 +15912,11 @@ public class AssignmentAction extends PagedResourceActionII
 		{
 			tempFile = File.createTempFile(String.valueOf(System.currentTimeMillis()),"");
 			
-			tmpFileOut = new FileOutputStream(tempFile);
-			writeToStream(fileContentStream, tmpFileOut);
-			tmpFileOut.flush();
-			tmpFileOut.close();
+			final Path destination = Paths.get(tempFile.getCanonicalPath());
+			Files.copy(fileContentStream, destination, StandardCopyOption.REPLACE_EXISTING);
 
-			ZipFile zipFile = new ZipFile(tempFile, "UTF-8");
-			Enumeration<ZipEntry> zipEntries = zipFile.getEntries();
+			ZipFile zipFile = new ZipFile(tempFile, StandardCharsets.UTF_8);
+			Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
 			ZipEntry entry;
 			while (zipEntries.hasMoreElements() && validZipFormat)
 			{
@@ -17360,29 +17359,6 @@ public class AssignmentAction extends PagedResourceActionII
 	}
 
 
-	/**
-	 * Simply take as much as possible out of 'in', and write it to 'out'. Don't
-	 * close the streams, just transfer the data.
-	 * 
-	 * @param in
-	 * 		The data provider
-	 * @param out
-	 * 		The data output
-	 * @throws IOException
-	 * 		Thrown if there is an IOException transfering the data
-	 */
-	private void writeToStream(InputStream in, OutputStream out) throws IOException {
-		byte[] buffer = new byte[INPUT_BUFFER_SIZE];
-		
-		try {
-			while (in.read(buffer) > 0) {
-				out.write(buffer);
-			}
-		} catch (IOException e) {
-			throw e;
-		}
-	}
-    
     /**
      * Categories are represented as Integers. Right now this feature only will
      * be active for new assignments, so we'll just always return 0 for the 


### PR DESCRIPTION
Particular zip files created on certain Ubuntu distributions did not upload correctly into Assignments Upload All feature.

This switches to java.util.Zip and also removes custom code for copying the input stream in favour of  Files.copy. This change has been run in production at UCT for a while in Sakai 10.x.
