### PR TITLE
SAK-32005 make stats aware of wiki.read events OOTB

### DIFF
--- a/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
+++ b/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
@@ -495,12 +495,7 @@
 		toolId="sakai.rwiki"
 		selected="true">
 		<event eventId="wiki.new" selected="true"/>
-		<!--
-			"wiki.read" requires the following on sakai.properties:
-				wiki.trackReads = true
-			IMPORTANT: please see SAK-11214 before enabling this event.
-		 -->
-		<!--<event eventId="wiki.read" selected="true"/>-->
+		<event eventId="wiki.read" selected="true"/>
 		<event eventId="wiki.revise" selected="true"/>
 		<eventParserTip for="contextId" separator="/" index="3"/>
 	</tool>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32005

Prior to SAK-21039 you had to flip a sakai.property to make the system generate wiki.read events. As a result, statistics was never made aware of the event, and even if you turn generation of that event on, statistics won't include it in reports because it doesn't know the event type exists.

Make statistics recognize the wiki.read event, as it's now generated by default OOTB.