### PR TITLE
SAK-20077 users without rwiki.update permission can't comment, but still see links to generate new and edit existing comments

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
@@ -281,10 +281,12 @@ ${util.formatDateTime($date,$request)}
 				<h5 class="commentsTitle specialLink" >
 					<a href="#" id="commentsToggle" class="toggleOpen">${rlb.jsp_hide_comments}</a>
 					<span id="totalComments" class="textPanelFooter"></span>
-					<span class="commentsToolBar">
-						<a href="#" id="createCommentLink" onclick="ajaxRefPopup(this,'${util.escapeHtml(${renderBean.newCommentURL})}',0); return false;" >${rlb.jsp_addcomment}</a>
-					</span>								
-				</h5>								
+					#if (${renderBean.canEdit})
+						<span class="commentsToolBar">
+							<a href="#" id="createCommentLink" onclick="ajaxRefPopup(this,'${util.escapeHtml(${renderBean.newCommentURL})}',0); return false;" >${rlb.jsp_addcomment}</a>
+						</span>
+					#end
+				</h5>
 			</li>
 		</ul>	
 		<ul class="rwiki_comments specialLink" id ="commentsList">	
@@ -295,10 +297,12 @@ ${util.formatDateTime($date,$request)}
 				<li class="rwikicommentbody_${comment.commentLevel} commentList">
 					<div class="commentHeader"><span class="commentAuthor">#formatDisplayName(${comment.rwikiObject.user})</span><span class="textPanelFooter">(${comment.rwikiObject.version})</span>
 							<ul class="actionItem itemAction">
-								<li><span>
-									<a href="#" onclick="ajaxRefPopup(this,'${util.escapeHtml(${comment.newCommentURL})}',0); return false;" >${rlb.jsp_comment}</a>
-								</span></li>
-								#if (${comment.canEdit})
+								#if (${renderBean.canEdit})
+									<li><span>
+										<a href="#" onclick="ajaxRefPopup(this,'${util.escapeHtml(${comment.newCommentURL})}',0); return false;" >${rlb.jsp_comment}</a>
+									</span></li>
+								#end
+								#if (${comment.canEdit} && ${renderBean.canEdit})
 									<li><span>
 										<a href="#" onclick="ajaxRefPopup(this,'${util.escapeHtml(${comment.editCommentURL})}',0); return false;" >${rlb.jsp_edit}</a>
 									</span></li>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-20077

If the user doesn't have the permission to comment, why show them the links? This action is controlled by the rwiki.update permission.