### PR TITLE
SAK-31953 Pointer arrow now showing for mobile tools menu.

### DIFF
--- a/reference/library/src/morpheus-master/sass/base/_responsive.scss
+++ b/reference/library/src/morpheus-master/sass/base/_responsive.scss
@@ -8,8 +8,22 @@ body{
 				top: 6.3em;
 				left: 0px;
 				box-shadow: 0px 0em 1em rgba(0,0,0,0.5);
-				overflow-y:auto;
 				height:95%;
+				&:after {
+					bottom: 100%;
+					left: 25%;
+					border: solid transparent;
+					content: " ";
+					height: 0;
+					width: 0;
+					position: absolute;
+					pointer-events: none;
+					border-color: rgba(255, 255, 255, 0);
+					border-bottom-color: $tool-menu-background-color;
+					border-width: 7px;
+					margin-left: -7px;
+					outline: 0;
+				}
 				.Mrphs-toolsNav__menuitem--title{
 					display: inline-block;
 					letter-spacing: 0px;
@@ -31,24 +45,10 @@ body{
 					margin: 0;
 					border-bottom:  1px solid darken( $tool-menu-background-color, 5% );
 					position: relative;
-					&:after {
-						bottom: 100%;
-						left: 25%;
-						border: solid transparent;
-						content: " ";
-						height: 0;
-						width: 0;
-						position: absolute;
-						pointer-events: none;
-						border-color: rgba(255, 255, 255, 0);
-						border-bottom-color: #FFF;
-						border-width: 7px;
-						margin-left: -7px;
-						outline: 0;
-					}
 				}
 			}
 			#toolMenu, #subSites{
+				overflow: auto;
 				ul{
 					list-style: none;
 					padding: 0 0 0 0;


### PR DESCRIPTION
Move the :after pseudo class so that the arrow pointing at the tool menu is displayed for a mobile sized screen.  Add an overflow property so that the arrow is actually shown.