### PR TITLE
SAK-32084 Styled the no-JS message for Morpheus

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/_main.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_main.scss
@@ -89,3 +89,19 @@
 		}
 	}
 }
+
+.#{$namespace}noJs.js-warn-no-js
+{
+	position: fixed;
+	bottom: 0;
+	left: 10%;
+	width: 80%;
+	padding: 1em;
+	z-index: 200;
+	border-top-left-radius: 5px;
+	border-top-right-radius: 5px;
+	background-color: #c00;
+	font-size: 1.143em;
+	text-align: center;
+	color: #fff;
+}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32084

The message that appears when JavaScript isn't enabled for Sakai isn't styled in Morpheus.

I have recreated the fixed red box that floats at the bottom of the browser window similar to how it did in Sakai 10. Works in the narrow mobile view too.

See the before and after screenshots for details.

**Before:**
![01-before-nojs](https://cloud.githubusercontent.com/assets/12685096/21867123/cde17b9a-d81a-11e6-8d13-809fc5955522.png)

**After:**
![02-after-nojs](https://cloud.githubusercontent.com/assets/12685096/21867136/d81f4c54-d81a-11e6-9375-030b21feba88.png)

![03-after-nojs-mobile](https://cloud.githubusercontent.com/assets/12685096/21867141/db193564-d81a-11e6-8cda-ac87f91b7026.png)



