### PR TITLE
SAK-32085 xlogin screen still uses 'login' instead of 'log in'

### DIFF
--- a/login/login-tool/tool/src/bundle/auth.properties
+++ b/login/login-tool/tool/src/bundle/auth.properties
@@ -10,10 +10,10 @@ invalid = Invalid
 
 log.log    = Log in
 log.cancel = Cancel
-log.login  = Login
+log.login  = Log in
 log.logreq = Login Required
 log.pass   = password
-log.ple    = Please Login
+log.ple    = Please log in
 
 orpass = or password
 
@@ -33,6 +33,3 @@ log.disabled.user=Your account has been disabled.
 log.tryagain = Unable to process that login, please try again.
 log.password.reset = Forgot your password?
 log.choicereq = Select your authentication source
-
-
-

--- a/login/login-tool/tool/src/bundle/auth_en_GB.properties
+++ b/login/login-tool/tool/src/bundle/auth_en_GB.properties
@@ -10,10 +10,10 @@ invalid = Invalid
 
 log.log    = Log in
 log.cancel = Cancel
-log.login  = Login
+log.login  = Log in
 log.logreq = Login Required
 log.pass   = password
-log.ple    = Please Login
+log.ple    = Please log in
 
 orpass = or password
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32085

The xlogin screen (when you type your password wrong) still says "Login required" and "Invalid login", and the button is still "Login". See SAK-29728 for reasoning behind the switch from "login" to "log in".

https://jira.sakaiproject.org/browse/SAK-29728