### PR TITLE
SAK-32086 Change Cancel button to the right in the User Creation Form

### DIFF
--- a/user/user-tool/tool/src/webapp/vm/user/chef_users_edit.vm
+++ b/user/user-tool/tool/src/webapp/vm/user/chef_users_edit.vm
@@ -231,12 +231,13 @@ function removeOptionalAttributeBlock(elem) {
 #set ($paramNames = $user.Properties.PropertyNames)
 			
 			<div class="act">
-				<input type="submit" id="eventSubmit_doCancel" name="eventSubmit_doCancel" value="$tlang.getString("useedi.can")" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				#if($user)
 					<input type="submit" id="eventSubmit_doSave" class="active" name="eventSubmit_doSave" value="$tlang.getString("useedi.sav")" accesskey="s" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				#else
 					<input type="submit" id="eventSubmit_doSave" class="active" name="eventSubmit_doSave" value="$tlang.getString("useedi.sav2")" accesskey="s" onclick="SPNR.disableControlsAndSpin( this, null );" />
-				#end					
+				#end
+                <input type="submit" id="eventSubmit_doCancel" name="eventSubmit_doCancel" value="$tlang.getString("useedi.can")" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );" />
+
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 			<input type="hidden" name="alert_message" id="alert_message" value="$alertMessage" />


### PR DESCRIPTION
Simple change to have the Cancel button on the right of the buttons and save in the left, as it is usual in forms.