### PR TITLE
SAK-32117 - Content review is disabled for all options after selecting NON-ELECTRONIC submissions

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -66,7 +66,7 @@
 				reviewSwitchNe1.style.display='none';
 				lblReviewService.className='';
 				reviewSwitchNe2.style.display='none';
-				ASNseReview.disabled=false;
+				useReview.disabled=false;
 			#end
 			## SAK-26640
 			document.getElementById('tempAllowRes').style.display = 'block';
@@ -88,7 +88,7 @@
 				}
 				useReview.checked=false;
 				useReview.disabled=true;
-				lblUseReview.className='instruction';
+				lblUseReview.className='';
 				reviewSwitchNe1.style.removeProperty('display');
 			#end
 			## SAK-26640


### PR DESCRIPTION
Content review is disabled for all options after selecting NON-ELECTRONIC submissions.

This was fixed in master, for some reason wasn't merged in 11.x