### PR TITLE
SAK-32120 Remove explicit avalon dependency

### DIFF
--- a/calendar/calendar-impl/impl/pom.xml
+++ b/calendar/calendar-impl/impl/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>avalon-framework</groupId>
-            <artifactId>avalon-framework</artifactId>
-            <version>20020627</version>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>


### PR DESCRIPTION
The old avalon dependency is very outdated now and our newer version of apache fop pulls in a much newer version.