### PR TITLE
SAK-30646 Fix download links in Site Export

### DIFF
--- a/archive/archive-tool/tool/src/webapp/vm/archive/chef_archive-download.vm
+++ b/archive/archive-tool/tool/src/webapp/vm/archive/chef_archive-download.vm
@@ -1,45 +1,3 @@
-
-<script type="text/javascript" src="/library/js/jquery/1.4.2/jquery-1.4.2.min.js"></script>
-
-<script type="text/javascript">
-
-	/**
-	 * main
-	 */
-    jQuery(function(){
-    	
-    	/**
-    	 * Dispatch a request to the download servlet. 
-		 * Constructs and submits a form in the success response.
-    	 */
-        jQuery(".downloadLink").click(function(){
-            var filename=jQuery(this).attr("rel");
-    		        			
-			jQuery.ajax({
-                type: "POST",
-                url: '/sakai-archive-tool/download',
-                data: 'archive='+filename,
-                success: function(response, status, request) {
-                    var disp = request.getResponseHeader('Content-Disposition');
-                    if (disp && disp.search('attachment') != -1) {
-						var form = jQuery('<form method="POST" action="/sakai-archive-tool/download">');
-                        form.append(jQuery('<input type="hidden" name="archive" value="' + filename + '">'));
-                        jQuery('body').append(form);
-                        form.submit();
-                    }
-                },
-				error: function (request, status, error) {
-        			alert('An error occurred downloading the file. Please check the logs.');
-      			}
-            });
-			
-        });
-    	
-    });
-
-</script>
-
-
 <div class="portletBody">
 	
 	<h3>
@@ -70,7 +28,7 @@
     	#foreach($archive in $archives)
     		<tr>
     			<td>
-					<a href="javascript:void(0);" rel="$!archive.filename" class="downloadLink">
+					<a href="/sakai-archive-tool/download/?archive=$!archive.filename" class="downloadLink">
         				#if ($archive.siteTitle)
         					$!archive.siteTitle <span class="smalltext">($!archive.siteId)</span>
         				#else 

--- a/archive/archive-tool/tool/src/webapp/vm/archive/chef_archive-download.vm
+++ b/archive/archive-tool/tool/src/webapp/vm/archive/chef_archive-download.vm
@@ -28,11 +28,11 @@
     	#foreach($archive in $archives)
     		<tr>
     			<td>
-					<a href="/sakai-archive-tool/download/?archive=$!archive.filename" class="downloadLink">
+					<a href="/sakai-archive-tool/download/?archive=#chef_html($!archive.filename)" class="downloadLink">
         				#if ($archive.siteTitle)
-        					$!archive.siteTitle <span class="smalltext">($!archive.siteId)</span>
+        					#chef_html($!archive.siteTitle) <small>(#chef_html($!archive.siteId))</small>
         				#else 
-        					$!archive.siteId
+        					#chef_html($!archive.siteId)
 						#end
 					</a>
     			<td>


### PR DESCRIPTION
The download links were POST requests, this switches them to GETs and drops the broken jQuery. Also added some handling of errors.