### PR TITLE
SAK-32124 Run the seed sites and users job automatically

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4655,3 +4655,6 @@
 # DEFAULT: false
 #gradebook.enable.finalgrade=false
 
+# Run the seed sites automatically on startup, this is mainly for the demo setup
+# DEFAULT: false
+#quartz.seedsites.autorun=true

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/demo.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/demo.sakai.properties
@@ -47,3 +47,6 @@ portal.quicklink.url.2=https://www.apereo.org/
 portal.quicklink.title.2=Apereo Website
 portal.quicklink.name.2=Apereo
 portal.quicklink.icon.2=cl fa fa-globe
+
+# Run the seed sites job at startup.
+quartz.seedsites.autorun=true

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutoRun.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutoRun.java
@@ -1,0 +1,88 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ **********************************************************************************
+ *
+ * Copyright (c) 2017 The Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+package org.sakaiproject.component.app.scheduler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.quartz.*;
+import org.sakaiproject.api.app.scheduler.JobBeanWrapper;
+import org.sakaiproject.api.app.scheduler.SchedulerManager;
+import org.sakaiproject.component.api.ServerConfigurationService;
+
+import java.util.List;
+
+/**
+ * This class runs some quartz jobs automatically at startup.
+ */
+public class AutoRun {
+
+    private static final Log log = LogFactory.getLog(AutoRun.class);
+
+    private SchedulerManager schedulerManager;
+    private ServerConfigurationService serverConfigurationService;
+    private List<JobBeanWrapper> startup;
+    private String config;
+
+    public void setSchedulerManager(SchedulerManager schedulerManager) {
+        this.schedulerManager = schedulerManager;
+    }
+
+    public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    public void setStartup(List<JobBeanWrapper> startup) {
+        this.startup = startup;
+    }
+
+    public void setConfig(String config) {
+        this.config = config;
+    }
+
+    public void init() {
+        if (serverConfigurationService.getBoolean(config, false)) {
+            log.info("AutoRun running");
+            Scheduler scheduler = schedulerManager.getScheduler();
+
+            for (JobBeanWrapper job : startup) {
+                try {
+                    JobDataMap jobData = new JobDataMap();
+                    jobData.put(JobBeanWrapper.SPRING_BEAN_NAME, job.getBeanId());
+                    jobData.put(JobBeanWrapper.JOB_TYPE, job.getJobType());
+
+                    JobDetail jobDetail = JobBuilder.newJob(job.getJobClass())
+                            .withIdentity(job.getJobType(), null)
+                            .setJobData(jobData)
+                            .build();
+
+                    // Non durable job that will get removed
+                    scheduler.addJob(jobDetail, true, true);
+                    scheduler.triggerJob(jobDetail.getKey());
+                    log.info("Triggered job: " + job.getJobType());
+                } catch (SchedulerException se) {
+                    log.warn("Failed to run job: " + startup, se);
+                }
+
+            }
+        }
+    }
+
+}

--- a/site-manage/site-manage-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/site-manage/site-manage-impl/pack/src/webapp/WEB-INF/components.xml
@@ -122,4 +122,17 @@
             <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
         </property>
     </bean>
+	<!-- This is mainly used for demo so that some content is created automatically -->
+	<bean class="org.sakaiproject.component.app.scheduler.AutoRun" init-method="init">
+		<property name="schedulerManager" ref="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+		<property name="startup">
+			<list>
+				<ref bean="org.sakaiproject.api.app.scheduler.JobBeanWrapper.SeedSitesAndUsers"/>
+			</list>
+		</property>
+		<property name="config">
+			<value>quartz.seedsites.autorun</value>
+		</property>
+	</bean>
 </beans>


### PR DESCRIPTION
This allows us to have the demo mode have some random sites and content created automatically at startup when in demo mode. Normal startups don’t run this job, but if you want to have it run at startup you can just set the property:

   quartz.seedsites.autorun=true