### PR TITLE
SAM-3126 Improve the Honor Pledge formatting

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -1276,3 +1276,12 @@ input[type='reset'].linearButton {
 {
 	margin-top: 10px;
 }
+
+.honor-container {
+	display: table-row;
+}
+
+.honor-container label {
+	display: table-cell;
+	padding-left: .5em;
+}

--- a/samigo/samigo-app/src/webapp/jsf/delivery/beginTakingAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/beginTakingAssessment.jsp
@@ -191,8 +191,8 @@
  <h:panelGroup layout="block" styleClass="honor-container" rendered="#{delivery.honorPledge && delivery.firstTimeTaking}">
 	<h:selectBooleanCheckbox id="honor_pledge" />
 	<h:outputLabel for="honor_pledge" value="#{deliveryMessages.honor_pledge_detail}"/>
-	<h:outputText id="honorPledgeRequired" value="#{deliveryMessages.honor_required}" styleClass="alertMessage" style="display:none"/>
 </h:panelGroup>
+    <h:outputText id="honorPledgeRequired" value="#{deliveryMessages.honor_required}" styleClass="alertMessage" style="display:none"/>
 
 
 <p class="act">


### PR DESCRIPTION
Make sure the honor pledge is better formatted when the pledge
is long and wraps to multiple lines by ensuring the checkbox is
always to the left and the text is to the right of that checkbox.