### PR TITLE
SAK-32068 Add BATV test with SMTP.

### DIFF
--- a/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
+++ b/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
@@ -168,6 +168,31 @@ public class SakaiMessageHandlerTest {
         verify(channel, times(1)).addMailArchiveMessage(anyString(), eq("sender@example.com"), any(), any(), any(), any());
     }
 
+    @Test
+    // Check that the BATV parsing is working correctly
+    public void testSiteIdAcceptBatv() throws Exception {
+        User sender = mock(User.class);
+        when(userDirectoryService.findUsersByEmail("sender@example.com")).thenReturn(Collections.singleton(sender));
+
+        MailArchiveChannel channel = mock(MailArchiveChannel.class);
+        when(channel.getEnabled()).thenReturn(true);
+        when(channel.getOpen()).thenReturn(false);
+        when(channel.allowAddMessage(sender)).thenReturn(true);
+        when(channel.getId()).thenReturn("channelId");
+        when(channel.getContext()).thenReturn("siteId");
+
+        when(mailArchiveService.channelReference("siteId", SiteService.MAIN_CONTAINER)).thenReturn("/site/siteId");
+        when(mailArchiveService.getMailArchiveChannel("/site/siteId")).thenReturn(channel);
+
+        SmartClient client = createClient();
+        client.from("prvs=2987A7B7C7=sender@example.com");
+        client.to("siteId@sakai.example.com");
+        // BATV is only in the envelope so the mail message should be the same.
+        writeData(client, "/simple-email.txt");
+
+        verify(channel, times(1)).addMailArchiveMessage(anyString(), eq("sender@example.com"), any(), any(), any(), any());
+    }
+
     // Check that sending to multiple addressess at the same time works.
     @Test
     public void testMultipleSiteIdAccept() throws Exception {


### PR DESCRIPTION
This tests BATV from addresses in a full SMTP transaction.