### PR TITLE
SAK-32131 Fix issue with lowercase growing string.

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.8.5</version>
+                <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -118,10 +118,23 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
+
     </dependencies>
 
     <build>

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/BasePortalHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/BasePortalHandler.java
@@ -56,7 +56,7 @@ public abstract class BasePortalHandler implements PortalHandler
 	public BasePortalHandler()
 	{
 		urlFragment = "none";
-		timeService = (TimeService) ComponentManager.get(TimeService.class);
+		timeService = ComponentManager.get(TimeService.class);
 	}
 
 	private TimeService timeService;

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -1068,8 +1068,8 @@ public class SiteHandler extends WorksiteHandler
 			Map<String, String> m = new HashMap<>();
 			m.put("responseHead", pp.head);
 			m.put("responseBody", pp.body);
-			log.debug("responseHead "+pp.head.length()+
-					" bytes, responseBody "+pp.body.length()+" bytes");
+			log.debug("responseHead {} bytes, responseBody {} bytes",
+					pp.head.length(), pp.body.length());
 			return m;
 		}
 		log.debug("bufferContent could not find head/body content");

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Cookie;
 
 import org.apache.commons.collections.CollectionUtils;
-
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.authz.api.Role;
@@ -1044,73 +1044,95 @@ public class SiteHandler extends WorksiteHandler
 				Matcher mc = p.matcher(contentType.toLowerCase());
 				if ( mc.find() ) return bufferedResponse;
 			}
-		} catch (ToolException e) {
-			e.printStackTrace();
-			return Boolean.FALSE;
-		} catch (IOException e) {
-			e.printStackTrace();
+		} catch (ToolException | IOException e) {
+			log.warn("Failed to buffer content.", e);
 			return Boolean.FALSE;
 		}
+		String tidAllow = ServerConfigurationService.getString(LEGACY_IFRAME_SUPPRESS_PROP, IFRAME_SUPPRESS_DEFAULT);
+		tidAllow = ServerConfigurationService.getString(IFRAME_SUPPRESS_PROP, tidAllow);
+		boolean debug = tidAllow.contains(":debug:");
 
 		String responseStr = bufferedResponse.getInternalBuffer();
 		if (responseStr == null || responseStr.length() < 1) return Boolean.FALSE;
 
-		String responseStrLower = responseStr.toLowerCase();
-		int headStart = responseStrLower.indexOf("<head");
-		headStart = findEndOfTag(responseStrLower, headStart);
-		int headEnd = responseStrLower.indexOf("</head");
-		int bodyStart = responseStrLower.indexOf("<body");
-		bodyStart = findEndOfTag(responseStrLower, bodyStart);
+		PageParts pp = parseHtmlParts(responseStr, debug);
+		if (pp != null)
+		{
+			if (debug)
+			{
+				log.info(" ---- Head --- ");
+				log.info(pp.head);
+				log.info(" ---- Body --- ");
+				log.info(pp.body);
+			}
+			Map<String, String> m = new HashMap<>();
+			m.put("responseHead", pp.head);
+			m.put("responseBody", pp.body);
+			log.debug("responseHead "+pp.head.length()+
+					" bytes, responseBody "+pp.body.length()+" bytes");
+			return m;
+		}
+		log.debug("bufferContent could not find head/body content");
+		return bufferedResponse;
+	}
 
-		// Some tools (Blogger for example) have multiple 
+	/**
+	 * Simple tuple so a method can return both a head and body.
+	 */
+	static class PageParts {
+		String head;
+		String body;
+	}
+
+	/**
+	 * Attempts to find the HTML head and body in the document and return them back.
+	 * @param responseStr The HTML to be parse
+	 * @param debug If <code>true</code> then log where we found the head and body.
+	 *
+	 * @return <code>null</code> if we failed to parse the page or a PageParts object.
+	 */
+	PageParts parseHtmlParts(String responseStr, boolean debug) {
+		// We can't lowercase the string and search in it as then the offsets don't match when a character is a
+		// different length in upper and lower case
+		int headStart = StringUtils.indexOfIgnoreCase(responseStr, "<head");
+		headStart = findEndOfTag(responseStr, headStart);
+		int headEnd = StringUtils.indexOfIgnoreCase(responseStr, "</head");
+		int bodyStart = StringUtils.indexOfIgnoreCase(responseStr, "<body");
+		bodyStart = findEndOfTag(responseStr, bodyStart);
+
+		// Some tools (Blogger for example) have multiple
 		// head-body pairs - browsers seem to not care much about
 		// this so we will do the same - so that we can be
 		// somewhat clean - we search for the "last" end
 		// body tag - for the normal case there will only be one
-		int bodyEnd = responseStrLower.lastIndexOf("</body");
-		// If there is no body end at all or it is before the body 
+		int bodyEnd = StringUtils.indexOfIgnoreCase(responseStr, "</body");
+		// If there is no body end at all or it is before the body
 		// start tag we simply - take the rest of the response
-		if ( bodyEnd < bodyStart ) bodyEnd = responseStrLower.length() - 1;
+		if ( bodyEnd < bodyStart ) bodyEnd = responseStr.length() - 1;
 
-		String tidAllow = ServerConfigurationService.getString(LEGACY_IFRAME_SUPPRESS_PROP, IFRAME_SUPPRESS_DEFAULT);
-		tidAllow = ServerConfigurationService.getString(IFRAME_SUPPRESS_PROP, tidAllow);
-		if( tidAllow.indexOf(":debug:") >= 0 )
+		if(debug)
 			log.info("Frameless HS="+headStart+" HE="+headEnd+" BS="+bodyStart+" BE="+bodyEnd);
 
 		if (bodyEnd > bodyStart && bodyStart > headEnd && headEnd > headStart
-				&& headStart > 1)
-		{
-			Map m = new HashMap<String,String> ();
-			String headString = responseStr.substring(headStart + 1, headEnd);
-			
-			// SAK-29908 
+				&& headStart > 1) {
+			PageParts pp = new PageParts();
+			pp.head = responseStr.substring(headStart + 1, headEnd);
+
+			// SAK-29908
 			// Titles come twice to view and tool title overwrites main title because
 			// it is printed before.
 
-			int titleStart = headString.indexOf("<title");
-			int titleEnd = headString.indexOf("</title");
-			titleEnd = findEndOfTag(headString, titleEnd);
-			
-			headString = (titleStart != -1 && titleEnd != -1)?headString.substring(0, titleStart) + headString.substring(titleEnd + 1):headString;
+			int titleStart = pp.head.indexOf("<title");
+			int titleEnd = pp.head.indexOf("</title");
+			titleEnd = findEndOfTag(pp.head, titleEnd);
+
+			pp.head = (titleStart != -1 && titleEnd != -1) ? pp.head.substring(0, titleStart) + pp.head.substring(titleEnd + 1) : pp.head;
 			// End SAK-29908
-			
-			String bodyString = responseStr.substring(bodyStart + 1, bodyEnd);
-			if (tidAllow.indexOf(":debug:") >= 0)
-			{
-				log.info(" ---- Head --- ");
-				log.info(headString);
-				log.info(" ---- Body --- ");
-				log.info(bodyString);
-			}
-			m.put("responseHead", headString);
-			m.put("responseBody", bodyString);
-			log.debug("responseHead "+headString.length()+
-					" bytes, responseBody "+bodyString.length()+" bytes");
-			return m;
+
+			pp.body = responseStr.substring(bodyStart + 1, bodyEnd);
+			return pp;
 		}
-		log.debug("bufferContent could not find head/body content");
-		// log.debug(responseStr);
-		return bufferedResponse;
+		return null;
 	}
 
 	private int findEndOfTag(String string, int startPos)

--- a/portal/portal-impl/impl/src/test/org/sakaiproject/portal/charon/handlers/SiteHandlerTest.java
+++ b/portal/portal-impl/impl/src/test/org/sakaiproject/portal/charon/handlers/SiteHandlerTest.java
@@ -1,0 +1,75 @@
+package org.sakaiproject.portal.charon.handlers;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.time.api.TimeService;
+
+import static org.sakaiproject.portal.charon.handlers.SiteHandler.*;
+
+/**
+ * Tests for SiteHandler
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ComponentManager.class)
+public class SiteHandlerTest {
+
+    private SiteHandler siteHandler;
+    private boolean debug;
+
+    @Before
+    public void setUp() {
+        debug = false;
+        PowerMockito.mockStatic(ComponentManager.class);
+        TimeService timeService = Mockito.mock(TimeService.class);
+        Mockito.when(ComponentManager.get(TimeService.class)).thenReturn(timeService);
+
+        siteHandler = new SiteHandler();
+    }
+
+    @Test
+    public void testParseHtmlSimple() {
+        PageParts pp = siteHandler.parseHtmlParts("<html><head><title>Hello</title></head><body><h1>Hello World</h1></body></html>", debug);
+        Assert.assertNotNull(pp);
+        Assert.assertEquals("", pp.head);
+        Assert.assertEquals("<h1>Hello World</h1>", pp.body);
+    }
+
+    @Test
+    public void testParseHtmlStyle() {
+        PageParts pp = siteHandler.parseHtmlParts("<html><head><style>h1 { font: larger; }</style><title>Hello</title></head><body><h1>Hello World</h1></body></html>", debug);
+        Assert.assertNotNull(pp);
+        Assert.assertEquals("<style>h1 { font: larger; }</style>", pp.head);
+        Assert.assertEquals("<h1>Hello World</h1>", pp.body);
+    }
+
+    @Test
+    public void testParseHtmlNoHead() {
+        PageParts pp = siteHandler.parseHtmlParts("<html><body><h1>Hello World</h1></body></html>", debug);
+        Assert.assertNull(pp);
+    }
+
+    @Test
+    public void testParseHtmlNoBody() {
+        PageParts pp = siteHandler.parseHtmlParts("<html><head><title>Hello</title></head></html>", debug);
+        Assert.assertNull(pp);
+    }
+
+    @Test
+    public void testParseHtmlLowercaseUnicode() {
+        // When this HTML fragment is lowercased it becomes longer (more bytes in the string) so the offsets can
+        // become incorrect causing a stack trace (stack overflow). The test has enough extra bytes to overflow
+        // past the end of the string.
+        PageParts pp = siteHandler.parseHtmlParts("<html><head></head><body>İİİİİİİİİİİİİİİİ</body></html>", debug);
+        Assert.assertNotNull(pp);
+        Assert.assertEquals("", pp.head);
+        Assert.assertEquals("İİİİİİİİİİİİİİİİ", pp.body);
+    }
+}
+


### PR DESCRIPTION
Some characters get longer when they become lowercased and this was causing the portal code to incorrectly inline the tool. In severe cases this would cause an out of bounds exception.

In other cases the returned page would contain multiple closing body tags.
The refactor here makes it possible to write a unit test for the code without having to mock large parts of the request.