### PR TITLE
Fix maven build warning in webjars.

### DIFF
--- a/reference/webjars/ckeditor-autosave/pom.xml
+++ b/reference/webjars/ckeditor-autosave/pom.xml
@@ -68,6 +68,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>

--- a/reference/webjars/ckeditor-wordcount/pom.xml
+++ b/reference/webjars/ckeditor-wordcount/pom.xml
@@ -69,6 +69,7 @@
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <extensions>true</extensions>
+                <version>1.6.7</version>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>


### PR DESCRIPTION
This locks down the maven plugin version that would generate errors
like:

    [WARNING] Some problems were encountered while building the effective model for org.sakaiproject.webjars:ckeditor-wordcount:jar:4897cb23a9f2ca7fb6b792add4350fb9e2a1722c
    [WARNING] 'version' contains an expression but should be a constant.  @ org.sakaiproject.webjars:ckeditor-wordcount:${ckeditor.wordcount.version}, /home/travis/build/sakaiproject/sakai/reference/webjars/ckeditor-wordcount/pom.xml, line 15, column 14
    [WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ org.sakaiproject.webjars:ckeditor-wordcount:${ckeditor.wordcount.version}, /home/travis/build/sakaiproject/sakai/reference/webjars/ckeditor-wordcount/pom.xml, line 68, column 21