### PR TITLE
SAK-32144 bootstrap 3 applies a nowrap to table cell content 

### DIFF
--- a/reference/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss
+++ b/reference/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss
@@ -182,6 +182,18 @@ table {
     // Tighten up spacing
     > .table {
       margin-bottom: 0;
+
+      // Ensure the content doesn't wrap
+      > thead,
+      > tbody,
+      > tfoot {
+        > tr {
+          > th,
+          > td {
+            white-space: nowrap;
+          }
+        }
+      }
     }
 
     // Special overrides for the bordered tables

--- a/reference/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss
+++ b/reference/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_tables.scss
@@ -182,18 +182,6 @@ table {
     // Tighten up spacing
     > .table {
       margin-bottom: 0;
-
-      // Ensure the content doesn't wrap
-      > thead,
-      > tbody,
-      > tfoot {
-        > tr {
-          > th,
-          > td {
-            white-space: nowrap;
-          }
-        }
-      }
     }
 
     // Special overrides for the bordered tables

--- a/reference/library/src/morpheus-master/sass/base/_bootstrap-defaults.scss
+++ b/reference/library/src/morpheus-master/sass/base/_bootstrap-defaults.scss
@@ -147,7 +147,7 @@ $icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../" + $skin-na
 
 // SAK-32144 override the nowrap behavior of table-responsive
 .table-responsive {
-  @media screen and (max-width: 480px) {
+  @media #{$phone} {
     > .table {
       // Ensure the Sakai table content does wrap
       > thead,

--- a/reference/library/src/morpheus-master/sass/base/_bootstrap-defaults.scss
+++ b/reference/library/src/morpheus-master/sass/base/_bootstrap-defaults.scss
@@ -145,6 +145,25 @@ $icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../" + $skin-na
 //** Border color for table and cell borders.
 // $table-border-color:            #ddd
 
+// SAK-32144 override the nowrap behavior of table-responsive
+.table-responsive {
+  @media screen and (max-width: 480px) {
+    > .table {
+      // Ensure the Sakai table content does wrap
+      > thead,
+      > tbody,
+      > tfoot {
+        > tr {
+          > th,
+          > td {
+            white-space: normal !important;
+          }
+        }
+      }
+    }
+  }
+}
+
 
 //== Buttons
 //


### PR DESCRIPTION
And this… makes tools like announcements and assignments look terrible. Before and After 

![nowrap](https://cloud.githubusercontent.com/assets/810505/22571925/e9982eea-e96f-11e6-860e-ce9001708129.PNG)

![nowrap-removed](https://cloud.githubusercontent.com/assets/810505/22571927/eb907f86-e96f-11e6-9a0e-c315be5042f9.PNG)
