### PR TITLE
SAK-32155 Include MariaDB driver property in default.sakai.properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -392,6 +392,7 @@
 ## MySQL settings
 # vendor@org.sakaiproject.db.api.SqlService=mysql
 # driverClassName@javax.sql.BaseDataSource=com.mysql.jdbc.Driver
+# driverClassName@javax.sql.BaseDataSource=org.mariadb.jdbc.Driver
 # hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 # url@javax.sql.BaseDataSource=jdbc:mysql://127.0.0.1:3306/sakai?useUnicode=true&characterEncoding=UTF-8
 # validationQuery@javax.sql.BaseDataSource=select 1 from DUAL


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32155

Since the MariaDB driver is used for MySQL connections by default now, we should include the driver configuration in default.sakai.properties.

I've added this line to the MySQL database configuration section:

`driverClassName@javax.sql.BaseDataSource=org.mariadb.jdbc.Driver`

Should we remove the MySQL driver line? Or just leave it in there commented out?
