### PR TITLE
SAK-31824 Fix issue with hover over titles with collapsed menu.

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -294,7 +294,6 @@ nav#subSites{
 						vertical-align: middle;
 					} @else {
 						display: block;
-						max-width: 100%;
 						width: 100%;
 					}
 					text-overflow: ellipsis;


### PR DESCRIPTION
See this for the problem: 
![menucollapsedhovertitletrunc](https://cloud.githubusercontent.com/assets/17832659/22659013/06b189fa-ec94-11e6-822b-a73c5ffb30ce.JPG)

After fix:
![menucollapsedhoverovertitlefix](https://cloud.githubusercontent.com/assets/17832659/22659021/0f4526d0-ec94-11e6-9c3e-843f72681c27.JPG)

For more info and images following tests see the Jira.

