### PR TITLE
LSNBLDR-780 Don’t fail to parse bad mneme references.

### DIFF
--- a/lessonbuilder/tool/opt-src/java/org/sakaiproject/lessonbuildertool/service/MnemeEntity.java
+++ b/lessonbuilder/tool/opt-src/java/org/sakaiproject/lessonbuildertool/service/MnemeEntity.java
@@ -248,6 +248,10 @@ public class MnemeEntity implements LessonEntity, QuizEntity {
 
     public LessonEntity getEntity(String ref) {
 	int i = ref.indexOf("/",1);
+	if (i < 1 && i < ref.length()) {
+		// We didn't find it.
+		return null;
+	}
 	String typeString = ref.substring(1, i);
 	String id = ref.substring(i+1);
 

--- a/lessonbuilder/tool/opt-src/test/org/sakaiproject/lessonbuildertool/service/MnemeEntityTest.java
+++ b/lessonbuilder/tool/opt-src/test/org/sakaiproject/lessonbuildertool/service/MnemeEntityTest.java
@@ -1,0 +1,53 @@
+package org.sakaiproject.lessonbuildertool.service;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MnemeEntityTest {
+
+    private MnemeEntity mnemeEntity;
+
+    @Before
+    public void setUp() {
+        mnemeEntity = new MnemeEntity();
+    }
+
+    @Test
+    public void testGetEntityGood() {
+        // Expected format of entity
+        LessonEntity entity = mnemeEntity.getEntity("/mneme/id");
+        assertEquals("sakai.mneme", entity.getToolId());
+        assertEquals("/mneme/id", entity.getReference());
+    }
+
+    @Test
+    public void testGetEntityDummy() {
+        // Some entries in the DB have a dummy reference.
+        LessonEntity entity = mnemeEntity.getEntity("/dummy");
+        assertNull(entity);
+    }
+
+    @Test
+    public void testGetEntitySlash() {
+        // Attempt to break parsing
+        LessonEntity entity = mnemeEntity.getEntity("/");
+        assertNull(entity);
+    }
+
+    @Test
+    public void testGetEntityEmpty() {
+        // Attempt to break parsing
+        LessonEntity entity = mnemeEntity.getEntity("");
+        assertNull(entity);
+    }
+
+    @Test
+    public void testGetEntityJunk() {
+        // Attempt to break parsing
+        LessonEntity entity = mnemeEntity.getEntity("junkjunkjunk");
+        assertNull(entity);
+    }
+}

--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -240,6 +240,20 @@
                 </configuration>
               </execution>
               <execution>
+                  <id>add-test-source</id>
+                  <phase>generate-sources</phase>
+                  <goals>
+                      <goal>add-test-source</goal>
+                  </goals>
+                  <configuration>
+                      <sources>
+                          <source>${src1}/test</source>
+                          <source>${src2}/test</source>
+                          <source>${src3}/test</source>
+                      </sources>
+                  </configuration>
+              </execution>
+              <execution>
                 <id>add-resource</id>
                 <phase>generate-resources</phase>
                 <goals>


### PR DESCRIPTION
In the database we have mneme references of /dummy which are causing the page to blow up. We should stop the /dummy references from appearing but it should also not be the case that these cause the page to blow up.