### PR TITLE
SAK-32163 Add commons-collection4 to tomcat/lib

### DIFF
--- a/kernel/deploy/shared/pom.xml
+++ b/kernel/deploy/shared/pom.xml
@@ -131,6 +131,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
             <scope>compile</scope>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -506,6 +506,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.1</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
         <version>1.10</version>


### PR DESCRIPTION
The upgrade of ical4j to version 2 depends on commons-collection4 so we also need that in the shared classloader. It can co-exist with older commons-collections as all it’s classes are in a different package.