### PR TITLE
3842 Force gradebookng to use sakai's preferred version of jQuery and Bootstrap

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
@@ -6,6 +6,7 @@ import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.cycle.AbstractRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.settings.IExceptionSettings;
 import org.apache.wicket.settings.IRequestCycleSettings.RenderStrategy;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
@@ -67,6 +68,9 @@ public class GradebookNgApplication extends WebApplication {
 				return new RenderPageRequestHandler(new PageProvider(new ErrorPage(e)));
 			}
 		});
+
+		// Disable Wicket's loading of jQuery - we load Sakai's preferred version in BasePage.java
+		getJavaScriptLibrarySettings().setJQueryReference(new PackageResourceReference(GradebookNgApplication.class,"empty.js"));
 
 		// cleanup the HTML
 		getMarkupSettings().setStripWicketTags(true);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/empty.js
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/empty.js
@@ -1,0 +1,1 @@
+/* Empty javascript file to replace Wicket's jQuery - see BasePage.java for the jQuery version we include */ 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -187,9 +187,16 @@ public class BasePage extends WebPage {
 				.forString("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />"));
 
 		// Shared JavaScript and stylesheets
-		// Bootstrap (lock in a version we've tested with and pair it with Wicket's jQuery)
-		response.render(JavaScriptHeaderItem
-			.forUrl(String.format("/library/webjars/bootstrap/3.3.7/js/bootstrap.min.js?version=%s", version)));
+		// Force Wicket to use Sakai's version of jQuery
+		response.render(
+			new PriorityHeaderItem(
+				JavaScriptHeaderItem
+					.forUrl(String.format("/library/webjars/jquery/1.11.3/jquery.min.js?version=%s", version))));
+		// And pair this instance of jQuery with a Bootstrap version we've tested with
+		response.render(
+			new PriorityHeaderItem(
+				JavaScriptHeaderItem
+					.forUrl(String.format("/library/webjars/bootstrap/3.3.7/js/bootstrap.min.js?version=%s", version))));
 		// Some global gradebookng styles
 		response.render(CssHeaderItem
 			.forUrl(String.format("/gradebookng-tool/styles/gradebook-shared.css?version=%s", version)));


### PR DESCRIPTION
Delivers #3842.

This ensure that:
1) one version jQuery is loaded into any GradebookNG page
2) the bootstrap widgets are paired with the version of jQuery that Wicket also relies on
3) bootstrap is no longer loaded twice on GradebookNG pages (widgets were sometimes initialized twice)