### PR TITLE
SAK-32182 Remove redundant ToolListeners

### DIFF
--- a/portal/portal-charon/charon/src/webapp/WEB-INF/web.xml
+++ b/portal/portal-charon/charon/src/webapp/WEB-INF/web.xml
@@ -5,11 +5,6 @@
 	<display-name>portal</display-name>
 	<description>port</description>
 
-	<!-- the tool listener is to register portlets -->
-	<listener>
-		<listener-class>org.sakaiproject.util.ToolListener</listener-class>
-	</listener>
-
 	<filter>
 		<filter-name>sakai.request</filter-name>
 		<filter-class>org.sakaiproject.util.RequestFilter</filter-class>

--- a/webservices/cxf/src/webapp/WEB-INF/web.xml
+++ b/webservices/cxf/src/webapp/WEB-INF/web.xml
@@ -72,11 +72,6 @@
         <param-value>classpath*:applicationContext*.xml</param-value>
     </context-param>
 
-    <!-- Listeners -->
-    <listener>
-        <listener-class>org.sakaiproject.util.ToolListener</listener-class>
-    </listener>
-
     <listener>
 		<listener-class>org.sakaiproject.util.SakaiContextLoaderListener</listener-class>
 	</listener>


### PR DESCRIPTION
Having a tools listener (to register Sakai tools) without any tool registration results in needless warnings in the logs.