### PR TITLE
SAK-32185 Circular dependencies check later in build

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -2006,6 +2006,8 @@
               <goals>
                   <goal>enforce</goal>
               </goals>
+              <!-- Against a clean repository you can't run `mvn validate` with enforcer enabled -->
+              <phase>install</phase>
               <configuration>
                   <rules>
                       <banCircularDependencies/>


### PR DESCRIPTION
If you attempt todo `mvn validate` against an empty repository it will fail because inter project dependencies aren't yet installed in the local repository and so can't be found. Moving the circular dependencies check to later in the builds means we can keep doing it but not break the validate phase.