### PR TITLE
SAK-31799 make favorites clickable on mobile

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/site.vm
@@ -82,6 +82,9 @@
             document.write('\x3Cscript src="${pageWebjarsPath}bootstrap/3.3.7/js/bootstrap.min.js$!{portalCDNQuery}">'+'\x3C/script>')
             document.write('\x3Cscript src="${pageWebjarsPath}jquery-ui/1.11.3/jquery-ui.min.js$!{portalCDNQuery}">'+'\x3C/script>')
             document.write('\x3Clink rel="stylesheet" href="${pageWebjarsPath}jquery-ui/1.11.3/jquery-ui.min.css$!{portalCDNQuery}"/>')
+            if (Modernizr.touch) {
+              document.write('\x3Cscript type="text/javascript" src="${pageWebjarsPath}jquery-ui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js$!{portalCDNQuery}">'+'\x3C/script>')
+            }
             window.console && console.log('Portal scripts loaded JQ+MI+BS+UI');
         } else {
             if (typeof jQuery.migrateWarnings == 'undefined') {

--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -525,17 +525,13 @@ $PBJQ(document).ready(function($){
         var favoriteItem = itemsBySiteId[siteid].clone(false);
 
         favoriteItem.addClass('organize-favorite-item').data('site-id', siteid);
-        var dragHandle = $PBJQ('<i class="fa fa-bars fav-drag-handle"></i>');
+        var dragHandle = $PBJQ('<a href="javascript:void(0);" class="fav-drag-handle"><i class="fa fa-bars"></i></a>');
 
         // Hide the tool dropdown
         $PBJQ('.toolMenus', favoriteItem).remove();
 
         // Show a drag handle
         favoriteItem.append(dragHandle);
-
-        // And disable the link to site so we don't accidentally hit it while
-        // dragging
-        $PBJQ(favoriteItem).find('.fav-title a').attr('href', null);
 
         list.append(favoriteItem);
 
@@ -544,6 +540,7 @@ $PBJQ(document).ready(function($){
       });
 
       list.sortable({
+        handle: ".fav-drag-handle",
         stop: function () {
           // Update our ordering based on the new selection
           favoritesList = list.find('.organize-favorite-item').map(function () {

--- a/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -389,16 +389,13 @@ ul.favoriteSiteList{
 	.fav-drag-handle{
 		display: inline-block;
 		position: relative;
-		right: -4px;
+		right: 2px;
+		padding: 0 6px;
 		color: $tool-border-color;
 		cursor: move; /* fallback if grab cursor is unsupported */
 		cursor: grab;
 		cursor: -moz-grab;
 		cursor: -webkit-grab;
-
-		@media #{$phone}{
-			display: none;
-		}
 	}
 	.fav-drag-handle:active{
 		cursor: grabbing;


### PR DESCRIPTION
Delivers https://jira.sakaiproject.org/browse/SAK-31799.

Now that links are clickable, I've had to change it so drag is initiated from the drag handle (instead of dragging from anywhere inside the favorite container).  

I've also fixed a bug whereby sortable wasn't working for touch devices on some pages.  `jquery-ui-touch-punch` is required for sortable to work on any touch device, so I've ensured that this is loaded as required.