### PR TITLE
SAK-32215 Prevent deadlock at startup due to quartz misfire handler

### DIFF
--- a/kernel/component-manager/src/main/java/org/sakaiproject/component/impl/SpringCompMgr.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/component/impl/SpringCompMgr.java
@@ -95,6 +95,8 @@ public class SpringCompMgr implements ComponentManager {
 	/** Records that close has been called. */
 	protected boolean m_hasBeenClosed = false;
 
+	protected boolean lateRefresh = false;
+
 	/**
 	 * Initialize.
 	 * 
@@ -122,6 +124,8 @@ public class SpringCompMgr implements ComponentManager {
 	public void init(boolean lateRefresh) {
 		if (m_ac != null)
 			return;
+
+		this.lateRefresh = lateRefresh;
 
 		// Make sure a "sakai.home" system property is set.
 		ensureSakaiHome();
@@ -159,6 +163,7 @@ public class SpringCompMgr implements ComponentManager {
 			try {
 				// get the singletons loaded
 				m_ac.refresh();
+				m_ac.start();
 				m_ac.publishEvent(new SakaiComponentEvent(this, SakaiComponentEvent.Type.STARTED));
 			} catch (Exception e) {
 				if (Boolean.valueOf(System.getProperty(SHUTDOWN_ON_ERROR, "false"))) {
@@ -297,6 +302,9 @@ public class SpringCompMgr implements ComponentManager {
 	 */
 	public void close() {
 		m_hasBeenClosed = true;
+		if (!lateRefresh) {
+			m_ac.stop();
+		}
 		if(m_ac.isActive()) {
 			m_ac.publishEvent(new SakaiComponentEvent(this, SakaiComponentEvent.Type.STOPPING));
 		}

--- a/kernel/component-manager/src/test/java/org/sakaiproject/util/ComponentsLoaderTest.java
+++ b/kernel/component-manager/src/test/java/org/sakaiproject/util/ComponentsLoaderTest.java
@@ -42,7 +42,6 @@ public class ComponentsLoaderTest {
 	@After
 	public void tearDown() throws Exception {
 		builder.tearDown();
-		componentMgr.close();
 	}
 	
 	/**


### PR DESCRIPTION
If quartz tried to run some misfired jobs while the component manager was still starting up it would deadlock the startup of Sakai.

This introduces the Spring lifecycle to our application context and uses it to start the quartz scheduler once the application context has been refreshed.
