### PR TITLE
SAK-25750 Upgrade to a newer version of castor.

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -838,9 +838,9 @@
       </dependency>
       <!-- shared/lib -->
       <dependency>
-        <groupId>castor</groupId>
+        <groupId>org.codehaus.castor</groupId>
         <artifactId>castor</artifactId>
-        <version>1.0</version>
+        <version>1.1.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/portal/portal-service-impl/impl/pom.xml
+++ b/portal/portal-service-impl/impl/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>sakai-portal-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>castor</groupId>
-            <artifactId>castor</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.portlet</groupId>
             <artifactId>portlet-api</artifactId>
         </dependency>

--- a/portal/portal-shared-deploy/pom.xml
+++ b/portal/portal-shared-deploy/pom.xml
@@ -20,7 +20,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>castor</groupId>
+            <groupId>org.codehaus.castor</groupId>
             <artifactId>castor</artifactId>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
This means we’re keeping castor in sync with the version pluto depends on. The dependency isn’t needed in the service as it’s pulled in transitively.

This also fixes the startup warning that were being seen with newer versions of Tomcat as the newer castor JAR doesn’t have a META-INF/MANIFEST.MF that contains a Class-Path attribute.