### PR TITLE
KNL-945 Fix BaseHibernateManager.updateAssignments throwing exception

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
@@ -230,7 +230,7 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
 		Long count = (Long) session.createCriteria(GradableObject.class)
                 .add(Restrictions.eq("name", assignment.getName()))
                 .add(Restrictions.eq("gradebook", assignment.getGradebook()))
-                .add(Restrictions.eq("id", assignment.getId()))
+                .add(Restrictions.ne("id", assignment.getId()))
                 .add(Restrictions.eq("removed", false))
                 .setProjection(Projections.rowCount())
                 .uniqueResult();


### PR DESCRIPTION
There's just a little bug in the KNL-945 hibernate refactor whereby `BaseHibernateManager.updateAssignments` always throws a `ConflictingAssignmentNameException`.  The patch ensure that the assignment being updated is not included in the name-uniqueness query.

Instead of creating a new JIRA for this little change, I've just reused the original JIRA in the commit message.  Hopefully that's ok.