### PR TITLE
SAK-32242: Portal loads tool.css and print.css twice for inlined tools

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1380,7 +1380,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		retval.setProperty("sakai.html.head.css", headCss);
 		retval.setProperty("sakai.html.head.lang", rloader.getLocale().getLanguage());
 		retval.setProperty("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(skin,ToolUtils.isInlineRequest(req)));
-		retval.setProperty("sakai.html.head.css.skin", CSSUtils.getCssToolSkinLink(skin));
+		retval.setProperty("sakai.html.head.css.skin", ToolUtils.isInlineRequest(req) ? "" : CSSUtils.getCssToolSkinLink(skin));
 		retval.setProperty("sakai.html.head.js", headJs.toString());
 
 		return retval;

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1284,7 +1284,8 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 	{
 		Properties retval = new Properties();
 
-		String headCss = CSSUtils.getCssHead(skin,ToolUtils.isInlineRequest(req));
+		boolean isInlineReq = ToolUtils.isInlineRequest(req);
+		String headCss = CSSUtils.getCssHead(skin, isInlineReq);
 		
 		Editor editor = portalService.getActiveEditor(placement);
 		String preloadScript = editor.getPreloadScript() == null ? ""
@@ -1379,8 +1380,8 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		retval.setProperty("sakai.html.head", head);
 		retval.setProperty("sakai.html.head.css", headCss);
 		retval.setProperty("sakai.html.head.lang", rloader.getLocale().getLanguage());
-		retval.setProperty("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(skin,ToolUtils.isInlineRequest(req)));
-		retval.setProperty("sakai.html.head.css.skin", ToolUtils.isInlineRequest(req) ? "" : CSSUtils.getCssToolSkinLink(skin));
+		retval.setProperty("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(skin, isInlineReq));
+		retval.setProperty("sakai.html.head.css.skin", CSSUtils.getCssToolSkinLink(skin, isInlineReq));
 		retval.setProperty("sakai.html.head.js", headJs.toString());
 
 		return retval;

--- a/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
+++ b/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
@@ -283,9 +283,10 @@ public class ToolPortal extends HttpServlet
 	protected void setupForward(HttpServletRequest req, HttpServletResponse res,
 			Placement p, String skin) throws ToolException
 	{
+		boolean isInlineReq = ToolUtils.isInlineRequest(req);
 		// setup html information that the tool might need (skin, body on load,
 		// js includes, etc).
-		String headCss = CSSUtils.getCssHead(skin, ToolUtils.isInlineRequest(req));
+		String headCss = CSSUtils.getCssHead(skin, isInlineReq);
 		String headJs = "<script type=\"text/javascript\" src=\"/library/js/headscripts.js\"></script>\n";
         
         Site site=null;
@@ -338,8 +339,8 @@ public class ToolPortal extends HttpServlet
 
 		req.setAttribute("sakai.html.head", head);
 		req.setAttribute("sakai.html.head.css", headCss);
-		req.setAttribute("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(CSSUtils.getSkinFromSite(site),ToolUtils.isInlineRequest(req)));
-		req.setAttribute("sakai.html.head.css.skin", ToolUtils.isInlineRequest(req) ? "" : CSSUtils.getCssToolSkinLink(CSSUtils.getSkinFromSite(site)));
+		req.setAttribute("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(CSSUtils.getSkinFromSite(site), isInlineReq));
+		req.setAttribute("sakai.html.head.css.skin", CSSUtils.getCssToolSkinLink(CSSUtils.getSkinFromSite(site), isInlineReq));
 		req.setAttribute("sakai.html.head.js", headJs);
 		req.setAttribute("sakai.html.body.onload", bodyonload.toString());
 	}

--- a/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
+++ b/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
@@ -339,7 +339,7 @@ public class ToolPortal extends HttpServlet
 		req.setAttribute("sakai.html.head", head);
 		req.setAttribute("sakai.html.head.css", headCss);
 		req.setAttribute("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(CSSUtils.getSkinFromSite(site),ToolUtils.isInlineRequest(req)));
-		req.setAttribute("sakai.html.head.css.skin", CSSUtils.getCssToolSkinLink(CSSUtils.getSkinFromSite(site)));
+		req.setAttribute("sakai.html.head.css.skin", ToolUtils.isInlineRequest(req) ? "" : CSSUtils.getCssToolSkinLink(CSSUtils.getSkinFromSite(site)));
 		req.setAttribute("sakai.html.head.js", headJs);
 		req.setAttribute("sakai.html.body.onload", bodyonload.toString());
 	}

--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/CSSUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/CSSUtils.java
@@ -21,7 +21,6 @@
 
 package org.sakaiproject.portal.util;
 
-import org.sakaiproject.portal.util.PortalUtils;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 
@@ -211,7 +210,13 @@ public class CSSUtils
 
 	}
 	
-	public static String getCssToolSkinLink(String skin) {
+	public static String getCssToolSkinLink(String skin, boolean isInlineRequest) {
+
+		if (isInlineRequest)
+		{
+			return "";
+		}
+
 		String headCssToolSkin = "<link href=\"" 
 				+ getCssToolSkinCDN(skin)
 				+ "\" type=\"text/css\" rel=\"stylesheet\" media=\"screen, tty, tv, handheld, projection\" />\n";
@@ -229,7 +234,7 @@ public class CSSUtils
 		String headCss = getCssToolBaseLink(skin,isInlineRequest);
 		if (!isInlineRequest)
 		{
-			headCss += getCssToolSkinLink(skin);
+			headCss += getCssToolSkinLink(skin, isInlineRequest);
 		}
 		return headCss;
 	}

--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/CSSUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/CSSUtils.java
@@ -196,15 +196,15 @@ public class CSSUtils
 	 * @return headCssToolBse
 	 */
 	public static String getCssToolBaseLink(String skin,boolean isInlineRequest) {
-		String headCssPortalSkin = "<link href=\"" 
-				+ getCssPortalSkinCDN(skin)
-				+ "\" type=\"text/css\" rel=\"stylesheet\" media=\"screen, tty, tv, handheld, projection\" />\n";
 
 		String headCssToolBase = "<link href=\""
 				+ getCssToolBaseCDN()
 				+ "\" type=\"text/css\" rel=\"stylesheet\" media=\"screen, tty, tv, handheld, projection\" />\n";
 
 		if ( ! isInlineRequest ) {
+			String headCssPortalSkin = "<link href=\"" 
+				+ getCssPortalSkinCDN(skin)
+				+ "\" type=\"text/css\" rel=\"stylesheet\" media=\"screen, tty, tv, handheld, projection\" />\n";
 			headCssToolBase = headCssPortalSkin + headCssToolBase;
 		}
 		return headCssToolBase;
@@ -226,9 +226,12 @@ public class CSSUtils
 	public static String getCssHead(String skin, boolean isInlineRequest) {
 		// setup html information that the tool might need (skin, body on load,
 		// js includes, etc).
-		String headCssToolBase = getCssToolBaseLink(skin,isInlineRequest);
-		String headCssToolSkin = getCssToolSkinLink(skin); 
-		return headCssToolBase + headCssToolSkin;
+		String headCss = getCssToolBaseLink(skin,isInlineRequest);
+		if (!isInlineRequest)
+		{
+			headCss += getCssToolSkinLink(skin);
+		}
+		return headCss;
 	}
 
 }

--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ToolUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ToolUtils.java
@@ -64,16 +64,6 @@ public class ToolUtils
 	public static final boolean PORTAL_INLINE_EXPERIMENTAL_DEFAULT = true;
 
 	/**
-	 * Determine if this is an inline request (only use in tool code)
-	 *
-	 * @return True if this is a request where a tool will be inlined.
-	 */
-	public static boolean isInlineRequest()
-	{
-		return (isInlineRequest());
-	}
-
-	/**
 	 * Determine if this is an inline request.
 	 *
 	 * @param <code>req</code>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32242

For tool content that is inlined into portal, adds a reference to
tool.css and print.css, even though these will already be included on
the page. This results in the styles being loaded and parsed twice by
the browser, which slows down page render time and causes issues when
trying to debug CSS live on a page.

The issue occurs because of the two #parse directives at the top of
includeStandardHead.vm. The first one adds the content of the tool's
header (which portal also contributes to) when the tool is inlined. The
second one just always adds tool.css and print.css.

This patch will address the issue by having portal only add the
tool.css/print.css references to the tool's header if it is not being
inlined.