### PR TITLE
SAK-32200 Don't log rwiki warnings on clean db

### DIFF
--- a/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/model/impl/SQLScriptMigration.java
+++ b/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/model/impl/SQLScriptMigration.java
@@ -145,7 +145,7 @@ public class SQLScriptMigration extends HibernateDaoSupport implements DataMigra
 						log.debug("   Done {} rows in {} ms", l, (System.currentTimeMillis() - start));
 					} catch (HibernateException ex) {
 						if (newdb) {
-							log.warn("Unsuccessful data migration statement: {}", sql[i]);
+							log.debug("Unsuccessful data migration statement: {}", sql[i]);
 							log.debug("Cause: " + ex.getMessage());
 						} else {
 							log.warn("Unsuccessful data migration statement: {}", sql[i]);


### PR DESCRIPTION
Might be better to just remove all this code, but this is why we started getting lots of warnings on startup after the hibernate upgrade.