### PR TITLE
SAK-27494 prevent samigo from creating duplicate gradebook items (same name)

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
@@ -160,7 +160,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
      */
     public static final String UPDATE_SAME_SCORE_PROP = "gradebook.externalAssessments.updateSameScore";
 
-	public void addExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl,
+	public synchronized void addExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl,
 			final String title, final double points, final Date dueDate, final String externalServiceDescription)
             throws ConflictingAssignmentNameException, ConflictingExternalIdException, GradebookNotFoundException {
 
@@ -684,7 +684,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 		addExternalAssessment(gradebookUid, externalId, externalUrl, title, points, dueDate, externalServiceDescription, ungraded, null);
 	}
 	
-	public void addExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl, final String title, final Double points, 
+	public synchronized void addExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl, final String title, final Double points,
 		final Date dueDate, final String externalServiceDescription, final Boolean ungraded, final Long categoryId) 
 		throws GradebookNotFoundException, ConflictingAssignmentNameException, ConflictingExternalIdException, AssignmentHasIllegalPointsException
 	{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-27494

This has been sitting around in JIRA with a patch for over 2 years now.