### PR TITLE
SAK-32252 Update to central mockito version.

### DIFF
--- a/assignment/assignment-impl/impl/pom.xml
+++ b/assignment/assignment-impl/impl/pom.xml
@@ -121,12 +121,11 @@
     	    <groupId>commons-io</groupId>
     	    <artifactId>commons-io</artifactId>
         </dependency>
-    	<dependency>
-    	    <groupId>org.mockito</groupId>
-    	    <artifactId>mockito-all</artifactId>
-    	    <version>1.10.19</version>
-    	    <scope>test</scope>
-    	</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/calendar/calendar-util/util/pom.xml
+++ b/calendar/calendar-util/util/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dashboard/impl/pom.xml
+++ b/dashboard/impl/pom.xml
@@ -166,12 +166,11 @@
 			<artifactId>commons-dbcp</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.2.9</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/entitybroker/core-providers/pom.xml
+++ b/entitybroker/core-providers/pom.xml
@@ -59,8 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/external-calendaring-service/impl/pom.xml
+++ b/external-calendaring-service/impl/pom.xml
@@ -78,8 +78,7 @@
     	</dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gradebookng/tool/pom.xml
+++ b/gradebookng/tool/pom.xml
@@ -95,8 +95,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/jobscheduler/scheduler-component-shared/pom.xml
+++ b/jobscheduler/scheduler-component-shared/pom.xml
@@ -132,8 +132,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jobscheduler/scheduler-component-shared/src/test/java/org/sakaiproject/component/app/scheduler/ScheduledInvocationTest.java
+++ b/jobscheduler/scheduler-component-shared/src/test/java/org/sakaiproject/component/app/scheduler/ScheduledInvocationTest.java
@@ -81,7 +81,6 @@ public class ScheduledInvocationTest {
     public void testCreateAndDeleteBySearch() {
         Time time = Mockito.mock(Time.class);
         Mockito.when(time.getTime()).thenReturn(0L);
-        Mockito.when(dao.get(COMPONENT_ID, CONTEXT)).thenReturn("uuid");
         String uuid = manager.createDelayedInvocation(time, COMPONENT_ID, CONTEXT);
         manager.deleteDelayedInvocation(COMPONENT_ID, CONTEXT);
         DelayedInvocation[] empty = manager.findDelayedInvocations(ALL, ALL);

--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <deploy.target>shared</deploy.target>
     <kernel.basedir>${basedir}/..</kernel.basedir>
-    <powermock.version>1.6.2</powermock.version>
+    <powermock.version>1.6.6</powermock.version>
   </properties>
   <dependencies>
     <dependency>

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -304,8 +304,7 @@
     </dependency>
    <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
    </dependency>
    <dependency>

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/WrappedContentResourceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/WrappedContentResourceTest.java
@@ -47,7 +47,6 @@ public class WrappedContentResourceTest {
 	@Test
 	public void testWrapping() throws Exception {
 		// Check the header and footer get correctly appended.
-		when(resource.getContent()).thenReturn("body".getBytes());
 		when(resource.streamContent()).then(new Answer<Object>() {
 			@Override
 			public Object answer(InvocationOnMock invocationOnMock) throws Throwable {

--- a/kernel/kernel-util/pom.xml
+++ b/kernel/kernel-util/pom.xml
@@ -74,10 +74,9 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.8.5</version>
-        <scope>test</scope>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/login/login-tool/tool/pom.xml
+++ b/login/login-tool/tool/pom.xml
@@ -53,11 +53,9 @@
         <scope>provided</scope>
     </dependency>
     <dependency>
-    	<groupId>org.mockito</groupId>
-    	<artifactId>mockito-all</artifactId>
-    	<version>1.8.5</version>
-    	<type>jar</type>
-    	<scope>test</scope>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 	<dependency>
 	    <groupId>org.springframework.security.extensions</groupId>

--- a/mailarchive/mailarchive-subetha/pom.xml
+++ b/mailarchive/mailarchive-subetha/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
+++ b/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
@@ -138,7 +138,6 @@ public class SakaiMessageHandlerTest {
     @Test()
     public void testIgnorePostmaster() throws Exception {
         when(aliasService.getTarget("postmaster")).thenThrow(IdUnusedException.class);
-        when(rb.getString("err_addr_unknown")).thenReturn("err_addr_unknown");
         SmartClient client = createClient();
         client.from("sender@example.com");
         client.to("postmaster@sakai.example.com");

--- a/mailsender/api/pom.xml
+++ b/mailsender/api/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/mailsender/impl/src/test/org/sakaiproject/mailsender/logic/impl/ComposeLogicImplTest.java
+++ b/mailsender/impl/src/test/org/sakaiproject/mailsender/logic/impl/ComposeLogicImplTest.java
@@ -33,6 +33,7 @@ import org.sakaiproject.user.api.UserDirectoryService;
 @RunWith(MockitoJUnitRunner.class)
 public class ComposeLogicImplTest {
 	static final String REALM_ID = "composeLogicTest";
+	static final String SITE_ID = "testSiteId";
 
 	@Mock SiteService siteService;
 	@Mock Site site;
@@ -70,6 +71,7 @@ public class ComposeLogicImplTest {
 		when(toolManager.getCurrentPlacement().getPlacementConfig()).thenReturn(props);
 
 		// setup site service
+		when(externalLogic.getSiteID()).thenReturn(SITE_ID);
 		when(siteService.getSite(anyString())).thenReturn(site);
 
 		// setup site

--- a/mailsender/impl/src/test/org/sakaiproject/mailsender/logic/impl/ExternalLogicImplTest.java
+++ b/mailsender/impl/src/test/org/sakaiproject/mailsender/logic/impl/ExternalLogicImplTest.java
@@ -308,8 +308,6 @@ public class ExternalLogicImplTest {
 
 	@Test
 	public void emailArchiveIsNotAddedToSite() throws Exception {
-		when(site.getTools("sakai.mailbox")).thenReturn(Collections.EMPTY_SET);
-
 		MailArchiveChannel channel = mock(MailArchiveChannel.class);
 		MailArchiveMessageEdit msg = mock(MailArchiveMessageEdit.class);
 		MailArchiveMessageHeaderEdit header = mock(MailArchiveMessageHeaderEdit.class);
@@ -356,7 +354,7 @@ public class ExternalLogicImplTest {
 
 		when(contentHostingService.newResourceProperties()).thenReturn(attachmentProperties);
 		when(contentHostingService.addAttachmentResource(
-				anyString(), anyString(), anyString(), anyString(), any(InputStream.class), any(ResourceProperties.class)
+				anyString(), anyString(), eq(null), anyString(), any(InputStream.class), any(ResourceProperties.class)
 		)).thenReturn(resource);
 		when(resource.getReference()).thenReturn("attachmentReference");
 

--- a/mailsender/pom.xml
+++ b/mailsender/pom.xml
@@ -92,13 +92,6 @@
         <artifactId>mailsender-impl</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <!-- TESTING -->
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>1.8.5</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -116,6 +116,7 @@
     <sakai.log4j.version>1.2.17</sakai.log4j.version>
     <sakai.slf4j.version>1.7.21</sakai.slf4j.version>
     <sakai.poi.version>3.14</sakai.poi.version>
+    <sakai.mockito.version>2.2.16</sakai.mockito.version>
     <sakai.okiosid.version>2.0</sakai.okiosid.version>
     <joda.time.version>2.9.7</joda.time.version>
     <sakai.genericdao.version>0.11.0</sakai.genericdao.version>
@@ -1648,6 +1649,18 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.11</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${sakai.mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${sakai.mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/polls/impl/pom.xml
+++ b/polls/impl/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -77,12 +77,6 @@
                 <artifactId>velocity</artifactId>
                 <version>${sakai.velocity.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -113,11 +113,12 @@
             <artifactId>xom</artifactId>
             <version>1.1</version>
         </dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>

--- a/providers/cm-authz-provider/pom.xml
+++ b/providers/cm-authz-provider/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/search/elasticsearch/impl/src/test/org/sakaiproject/search/elasticsearch/ElasticSearchTest.java
+++ b/search/elasticsearch/impl/src/test/org/sakaiproject/search/elasticsearch/ElasticSearchTest.java
@@ -7,8 +7,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-
-
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
@@ -17,7 +15,6 @@ import org.sakaiproject.search.api.EntityContentProducer;
 import org.sakaiproject.search.api.InvalidSearchQueryException;
 import org.sakaiproject.search.api.SearchList;
 import org.sakaiproject.search.api.SearchResult;
-import org.sakaiproject.search.elasticsearch.filter.SearchItemFilter;
 import org.sakaiproject.search.elasticsearch.filter.impl.SearchSecurityFilter;
 import org.sakaiproject.search.model.SearchBuilderItem;
 import org.sakaiproject.site.api.Site;
@@ -28,7 +25,6 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -134,8 +130,6 @@ public class ElasticSearchTest {
             resources.put(name, resource1);
             events.add(newEvent);
             when(newEvent.getResource()).thenReturn(resource1.getName());
-            when(newEvent.getContext()).thenReturn(siteId);
-            when(entityContentProducer.matches(name)).thenReturn(true);
             when(entityContentProducer.matches(newEvent)).thenReturn(true);
             when(entityContentProducer.getSiteId(name)).thenReturn(resource1.getSiteId());
             when(entityContentProducer.getAction(newEvent)).thenReturn(SearchBuilderItem.ACTION_ADD);
@@ -167,8 +161,6 @@ public class ElasticSearchTest {
         when(serverConfigurationService.getConfigData().getItems()).thenReturn(new ArrayList());
         when(serverConfigurationService.getServerId()).thenReturn("server1");
         when(serverConfigurationService.getServerName()).thenReturn("clusterName");
-        when(serverConfigurationService.getString("elasticsearch.index.number_of_shards")).thenReturn("1");
-        when(serverConfigurationService.getString("elasticsearch.index.number_of_replicas")).thenReturn("0");
 
         when(serverConfigurationService.getSakaiHomePath()).thenReturn(System.getProperty("java.io.tmpdir") + "/" + new Date().getTime());
         when(notificationService.addTransientNotification()).thenReturn(notificationEdit);
@@ -303,10 +295,8 @@ public class ElasticSearchTest {
         Resource resource = new Resource(null, "xyz", "resource_with_no_content");
 
         when(event.getResource()).thenReturn(resource.getName());
-        when(entityContentProducer.matches("resource_with_no_content")).thenReturn(false);
         List resourceList = new ArrayList();
         resourceList.add(resource);
-        when(entityContentProducer.getSiteContentIterator("xyz")).thenReturn(resourceList.iterator());
 
         elasticSearchIndexBuilder.addResource(notification, event);
 
@@ -480,7 +470,6 @@ public class ElasticSearchTest {
         when(newEvent.getResource()).thenReturn(resource.getName());
         events.add(newEvent);
         when(entityContentProducer.matches(newEvent)).thenReturn(true);
-        when(entityContentProducer.matches(resourceName)).thenReturn(true);
 
         when(entityContentProducer.getSiteId(resourceName)).thenReturn(siteId);
         when(entityContentProducer.getAction(newEvent)).thenReturn(SearchBuilderItem.ACTION_ADD);

--- a/search/elasticsearch/pom.xml
+++ b/search/elasticsearch/pom.xml
@@ -40,12 +40,6 @@
                 <artifactId>guava</artifactId>
                 <version>11.0.2</version>
             </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>1.9.5</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/signup/impl/pom.xml
+++ b/signup/impl/pom.xml
@@ -117,7 +117,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/signup/tool/pom.xml
+++ b/signup/tool/pom.xml
@@ -157,7 +157,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/site-manage/site-manage-tool/tool/pom.xml
+++ b/site-manage/site-manage-tool/tool/pom.xml
@@ -154,7 +154,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
 

--- a/sitestats/sitestats-impl/pom.xml
+++ b/sitestats/sitestats-impl/pom.xml
@@ -207,8 +207,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/textarea/elfinder-sakai/pom.xml
+++ b/textarea/elfinder-sakai/pom.xml
@@ -59,7 +59,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/textarea/elfinder-sakai/src/test/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactoryTest.java
+++ b/textarea/elfinder-sakai/src/test/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactoryTest.java
@@ -47,8 +47,6 @@ public class ContentSiteVolumeFactoryTest {
 
         Mockito.when(contentHostingService.getSiteCollection("siteId")).thenReturn("/group/siteId");
         Mockito.when(contentHostingService.getContainingCollectionId("/group/siteId/example")).thenReturn("/group/siteId");
-        Mockito.when(contentHostingService.getContainingCollectionId("/group/siteId")).thenReturn("/group");
-        Mockito.when(contentHostingService.getContainingCollectionId("/group")).thenReturn("");
         Mockito.when(service.getSiteVolume("siteId")).thenReturn(siteVolume);
         Mockito.when(siteVolume.getRoot()).thenReturn(siteItem);
 
@@ -69,8 +67,6 @@ public class ContentSiteVolumeFactoryTest {
     public void testParentCrossSite() {
 
         Mockito.when(contentHostingService.getSiteCollection("siteId")).thenReturn("/group/siteId");
-        Mockito.when(contentHostingService.getContainingCollectionId("/group/otherId/example")).thenReturn("/group/otherId");
-        Mockito.when(contentHostingService.getContainingCollectionId("/group/otherId")).thenReturn("/group");
         Mockito.when(service.getSiteVolume("siteId")).thenReturn(siteVolume);
         Mockito.when(siteVolume.getRoot()).thenReturn(siteItem);
 

--- a/webservices/cxf/pom.xml
+++ b/webservices/cxf/pom.xml
@@ -170,7 +170,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.0.31-beta</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This defines mockito centrally and has all projects use that version, this reduces the number of versions of mockito we need to download.