### PR TITLE
SAM-3167 Fix for samigo attempting to work early.

### DIFF
--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -243,7 +243,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
         	<groupId>joda-time</groupId>

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/IntegrationContextFactory.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/context/IntegrationContextFactory.java
@@ -60,7 +60,7 @@ public abstract class IntegrationContextFactory
       }
       catch (Exception ex)
       {
-        log.error("Unable to read integration context: " + ex);
+        log.error("Unable to read integration context", ex);
       }
     }
     log.debug("instance="+instance);

--- a/samigo/samigo-services/src/test/org/sakaiproject/spring/SpringBeanLocatorTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/spring/SpringBeanLocatorTest.java
@@ -1,0 +1,48 @@
+package org.sakaiproject.spring;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+/**
+ * This tests the concurrence of SpringBeanLocator.
+ */
+public class SpringBeanLocatorTest {
+
+    @Test
+    public void testWait() throws InterruptedException {
+        ConfigurableApplicationContext context = new GenericApplicationContext();
+        ConfigurableListableBeanFactory factory = context.getBeanFactory();
+        Object bean = new Object();
+        factory.registerSingleton("test", bean);
+        context.refresh();
+        Locator get1 = new Locator(SpringBeanLocator.getInstance());
+        Locator get2 = new Locator(SpringBeanLocator.getInstance());
+        get1.start();
+        get2.start();
+
+        SpringBeanLocator.setApplicationContext(context);
+        get1.join(1000);
+        get2.join(1000);
+        // Cross thread assertions
+        Assert.assertTrue(get1.good);
+        Assert.assertTrue(get2.good);
+    }
+
+    class Locator extends Thread {
+
+        final SpringBeanLocator locator;
+        boolean good = false;
+
+        Locator(SpringBeanLocator locator) {
+            this.locator = locator;
+        }
+
+        @Override
+        public void run() {
+            good = locator.getBean("test") != null;
+        }
+    }
+}


### PR DESCRIPTION
The importing job was attempting to read archives containing samigo assessments early in the startup and this showed that the fix to block samigo code until the webapp has been started up wasn’t working correctly.

This correctly uses the `waitLock.wait()` inside the synchronized block, before we were getting an java.lang.IllegalMonitorStateException when attempting to `wait()`;

Also simplified the code as we don’t need to have 2 contexts as we can just actually have one and use more generic interfaces.