### PR TITLE
SAK-32260 Modify tool menu default settings.

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -146,8 +146,8 @@ $sites-nav-submenu-item-selected-color:     $sites-nav-menu-item-selected-color 
 $sites-nav-submenu-item-selected-border:    none !default;
 
 /* Tool Menu */
-$tool-menu-width: 7.5em !default;
-$tool-menu-width-collapsed: $tool-menu-width / 2 !default;
+$tool-menu-width: 14.2em !default;
+$tool-menu-width-collapsed: 3.75em !default;
 
 /* Navigation Hierarchy */
 $hierarchy-size: 3.5em !default;
@@ -163,7 +163,7 @@ $logo-width: 50px !default;
 /* Tool icons */
 $skin-with-icons: true !default;
 $icon-size: 20px !default;
-$tool-menu-icon-on-left: false !default;
+$tool-menu-icon-on-left: true !default;
 
 /* Footer */
 $footer-background: transparent !default;


### PR DESCRIPTION
Set the icons to be on the left hand side not above the tool title.
Also increase the tool menu width because of this change.

Post config change:
![postfixdesktop](https://cloud.githubusercontent.com/assets/17832659/23507307/5b11315e-ff44-11e6-98f3-ba35dd61d17c.JPG)
