### PR TITLE
SAK-32184 Add back the import pack

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,6 +26,7 @@
     <module>archive-api</module>
     <module>archive-impl/impl2</module>
     <module>import-impl</module>
+    <module>import-pack</module>
     <module>import-handlers/content-handlers</module>
     <module>import-util</module>
     <module>import-parsers/common-cartridge</module>


### PR DESCRIPTION
We didn't squash down this one in the end but it wasn't part of the build any more. So add it back.