### PR TITLE
KNL-1499 upgrade HikariCP to 2.6.0

### DIFF
--- a/help/help-component/pom.xml
+++ b/help/help-component/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>2.5.1</version>
+      <version>2.6.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/help/help-component/pom.xml
+++ b/help/help-component/pom.xml
@@ -108,8 +108,6 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>2.6.0</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1735,7 +1735,7 @@
       <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>2.5.1</version>
+        <version>2.6.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION

Changes in 2.6.0

 * Redesign of the contention code path resulting in doubling contended throughput; now
   contended pool access retains 98% of the uncontended throughput.
 
 * issue 793 add new HikariConfig method, setScheduledExecutor(ScheduledExecutorService),
   and deprecate method setScheduledExecutorService(ScheduledThreadPoolExecutor). It is
   unfortunate that the deprecated method has the more accurate name, but its signature
   cannot be changed without breaking binary compatibility.

 * issue 770 add a new property initializationFailTimeout, and deprecate configuration
   property initializationFailFast.

 * issue 774 significantly improve spike load handling.

 * issues 518/769 add new metric for tracking how long physical connection acquisition is
   taking.  DropWizard histogram name "ConnectionCreation", and Prometheus summary name
   "hikaricp_connection_creation_millis".

 * issue 741 cancel HouseKeeper task on pool shutdown. If the ScheduledExecutor being used
   did not belong to HikariCP, this task would remain scheduled after shutdown, causing a
   memory leak.

 * issue 781 more technically accurate wording of pool startup and shutdown log messages.
