### PR TITLE
SAK-32248 External login page now has configurable message.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -200,9 +200,6 @@
 # DEFAULT: false (disabled)
 #xlogin.enabled=true
 
-# Text to display for the extra login (no effect if xlogin is not enabled)
-# DEFAULT: Guest Login
-#xlogin.text=Guest Login
 
 # Use xlogin page to re-login (use when enabling container login e.g. CAS)
 # DEFAULT: true
@@ -213,9 +210,19 @@
 #container.login.choice.icon=http://url/to/cas.jpg
 #container.login.choice.text=Container login Users
 #login.text.title=Login for container users
+
+# Text to display for the extra login (no effect if xlogin is not enabled)
+# If a message is required to indicate the type of login populate xlogin.choice
+# and login.text.title
 #xlogin.choice.icon=http://url/to/sakai.jpg
+#xlogin.choice=This page is for external user accounts. If you have an institution Single Sign On Account please use the
 #xlogin.choice.text = Guest Users
 #xlogin.text.title=Login for guest users
+#xlogin.text=Guest Login
+
+# Support for linking off the external login page to the container login page
+# only for when container.login=true and xlogin.enabled=true  
+#login.container.url=/portal/login  
 
 # Should logins be allowed through HTTP basic authentication?
 # DEFAULT: false

--- a/library/src/morpheus-master/sass/modules/access/_base.scss
+++ b/library/src/morpheus-master/sass/modules/access/_base.scss
@@ -109,6 +109,10 @@
 		text-align: center;
 	}
 }
+#Mrphs-xlogin .xloginMessage{
+	padding: 0.9em;
+	text-align: center;
+}
 
 #loginPortalMask{
 	background: rgba(0,0,0,0.5);

--- a/login/login-render-engine-impl/impl/src/webapp/vm/defaultskin/xlogin.vm
+++ b/login/login-render-engine-impl/impl/src/webapp/vm/defaultskin/xlogin.vm
@@ -11,7 +11,10 @@
     	<form id="Mrphs-xlogin" method="post" action="${action}" #if (${notify}) class="with-errors" #end>
             <h1>${loginRequired}</h1>
             <aside class="logo"></aside>
-        	#if (${notify})
+            #if (${xloginChoice})
+                <div class="xloginMessage">${xloginChoice}&nbsp;<a href="${loginContainerUrl}">${containerText}</a></div>
+            #end
+            #if (${notify})
         		<div class="alertMessage" role="alert">${notify}</div>
         	#end
     		<fieldset>	

--- a/login/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
+++ b/login/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
@@ -450,6 +450,10 @@ public class SkinnableLogin extends HttpServlet implements Login {
 		String uiService = serverConfigurationService.getString("ui.service", "Sakai");
 		String passwordResetUrl = getPasswordResetUrl();
 
+		String xloginChoice = serverConfigurationService.getString("xlogin.choice", null);
+		String containerText = serverConfigurationService.getString("login.text.title", "Container Login");
+		String loginContainerUrl = serverConfigurationService.getString("login.container.url");
+
 		String eidWording = rb.getString("userid");
 		String pwWording = rb.getString("log.pass");
 		String loginRequired = rb.getString("log.logreq");
@@ -470,6 +474,9 @@ public class SkinnableLogin extends HttpServlet implements Login {
 		rcontext.put("cancelWording", cancelWording);
 		rcontext.put("passwordResetUrl", passwordResetUrl);
 		rcontext.put("passwordResetWording", passwordResetWording);
+		rcontext.put("xloginChoice", xloginChoice);
+		rcontext.put("containerText", containerText);
+		rcontext.put("loginContainerUrl", loginContainerUrl);
 
 		String eid = StringEscapeUtils.escapeHtml(request.getParameter("eid"));
 		String pw = StringEscapeUtils.escapeHtml(request.getParameter("pw"));


### PR DESCRIPTION
Before change:
![prechange](https://cloud.githubusercontent.com/assets/17832659/23619465/a03a3fec-028b-11e7-8c05-fd41ef4d5e60.JPG)
After change:
![postchange](https://cloud.githubusercontent.com/assets/17832659/23619475/a5f94536-028b-11e7-8094-9a72d021e009.JPG)

Note that properties need to be set before one can see this external login page - please see the Jira.
