### PR TITLE
SAK-32075 Add a11y checker plugin to ckeditor.

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -16,8 +16,6 @@
 		<bootstrap-version>3.3.7</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<!-- Empty defaults -->
-		<ckeditor-plugins></ckeditor-plugins>
-		<ckeditor-toolbar-full></ckeditor-toolbar-full>
 		<ckeditor-extra-plugins></ckeditor-extra-plugins>
 	</properties>
 	<dependencies>
@@ -373,17 +371,15 @@
 			</build>
 		</profile>
 		<profile>
-			<id>ckeditor-a11ychecker</id>
+			<!-- These plugins can't be part of the standard build -->
+			<id>ckeditor-extras</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
+				<property>
+					<name>ckeditor-extras</name>
+				</property>
 			</activation>
 			<properties>
-				<ckeditor-plugins>
-					// Accessibility checker has a dependency on balloonpanel
-					CKEDITOR.plugins.addExternal('balloonpanel',webJars+'balloonpanel/4.6.2/', 'plugin.js');
-					CKEDITOR.plugins.addExternal('a11ychecker',webJars+'a11ychecker/1.1.0/', 'plugin.js');
-				</ckeditor-plugins>
-				<ckeditor-toolbar-full> ,['A11ychecker'] </ckeditor-toolbar-full>
 				<ckeditor-extra-plugins>,a11ychecker</ckeditor-extra-plugins>
 			</properties>
 			<dependencies>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -15,6 +15,10 @@
 	<properties>
 		<bootstrap-version>3.3.7</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
+		<!-- Empty defaults -->
+		<ckeditor-plugins></ckeditor-plugins>
+		<ckeditor-toolbar-full></ckeditor-toolbar-full>
+		<ckeditor-extra-plugins></ckeditor-extra-plugins>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -61,6 +65,7 @@
 			<version>${ckeditor.wordcount.version}</version>
 			<scope>runtime</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>dropzone</artifactId>
@@ -363,8 +368,38 @@
 							</execution>
 						</executions>
 					</plugin>
+
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>ckeditor-a11ychecker</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<ckeditor-plugins>
+					// Accessibility checker has a dependency on balloonpanel
+					CKEDITOR.plugins.addExternal('balloonpanel',webJars+'balloonpanel/4.6.2/', 'plugin.js');
+					CKEDITOR.plugins.addExternal('a11ychecker',webJars+'a11ychecker/1.1.0/', 'plugin.js');
+				</ckeditor-plugins>
+				<ckeditor-toolbar-full> ,['A11ychecker'] </ckeditor-toolbar-full>
+				<ckeditor-extra-plugins>,a11ychecker</ckeditor-extra-plugins>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.sakaiproject.webjars</groupId>
+					<artifactId>ckeditor-a11ychecker</artifactId>
+					<version>${ckeditor.a11ychecker.version}</version>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.sakaiproject.webjars</groupId>
+					<artifactId>ckeditor-balloonpanel</artifactId>
+					<version>${ckeditor.balloonpanel.version}</version>
+					<scope>runtime</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 	<build>
@@ -383,6 +418,18 @@
 						<phase>generate-resources</phase>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<webResources>
+						<resource>
+							<directory>src/webapp-filtered</directory>
+							<filtering>true</filtering>
+						</resource>
+					</webResources>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -16,7 +16,7 @@
 		<bootstrap-version>3.3.7</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<!-- Empty defaults -->
-		<ckeditor-extra-plugins></ckeditor-extra-plugins>
+		<ckeditor-a11y-extra-plugins></ckeditor-a11y-extra-plugins>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -380,7 +380,7 @@
 				</property>
 			</activation>
 			<properties>
-				<ckeditor-extra-plugins>,a11ychecker</ckeditor-extra-plugins>
+				<ckeditor-a11y-extra-plugins>,a11ychecker</ckeditor-a11y-extra-plugins>
 			</properties>
 			<dependencies>
 				<dependency>

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -235,7 +235,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             //ckconfig.extraPlugins+="atd-ckeditor,";
             //ckconfig.contentsCss = [basePath+'atd-ckeditor/atd.css'];
 
-            ckconfig.extraPlugins+="image2,audiorecorder,movieplayer,wordcount,fmath_formula,autosave,fontawesome,notification${ckeditor-extra-plugins}";
+            ckconfig.extraPlugins+="image2,audiorecorder,movieplayer,wordcount,fmath_formula,autosave,fontawesome,notification${ckeditor-a11y-extra-plugins}";
 
             //SAK-29648
             ckconfig.contentsCss = [basePath+'/fontawesome/font-awesome/css/font-awesome.min.css'];

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -162,6 +162,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             ['Styles','Format','Font','FontSize'],
             ['TextColor','BGColor'],
             ['Maximize', 'ShowBlocks']
+            ${ckeditor-toolbar-full}
         ],
         toolbar: 'Full',
         resize_dir: 'both',
@@ -215,6 +216,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             CKEDITOR.plugins.addExternal('wordcount',webJars+'wordcount/4897cb23a9f2ca7fb6b792add4350fb9e2a1722c/', 'plugin.js');
             CKEDITOR.plugins.addExternal('notification',basePath+'notification/', 'plugin.js');
             CKEDITOR.plugins.addExternal('fontawesome',basePath+'fontawesome/', 'plugin.js');
+            ${ckeditor-plugins}
             /*
                To enable after the deadline uncomment these two lines and add atd-ckeditor to toolbar
                and to extraPlugins. This also needs extra stylesheets.
@@ -231,7 +233,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             //ckconfig.extraPlugins+="atd-ckeditor,";
             //ckconfig.contentsCss = [basePath+'atd-ckeditor/atd.css'];
 
-            ckconfig.extraPlugins+="image2,audiorecorder,movieplayer,wordcount,fmath_formula,autosave,fontawesome,notification";
+            ckconfig.extraPlugins+="image2,audiorecorder,movieplayer,wordcount,fmath_formula,autosave,fontawesome,notification${ckeditor-extra-plugins}";
 
             //SAK-29648
             ckconfig.contentsCss = [basePath+'/fontawesome/font-awesome/css/font-awesome.min.css'];

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -162,7 +162,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             ['Styles','Format','Font','FontSize'],
             ['TextColor','BGColor'],
             ['Maximize', 'ShowBlocks']
-            ${ckeditor-toolbar-full}
+            ,['A11ychecker']
         ],
         toolbar: 'Full',
         resize_dir: 'both',
@@ -216,7 +216,9 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             CKEDITOR.plugins.addExternal('wordcount',webJars+'wordcount/4897cb23a9f2ca7fb6b792add4350fb9e2a1722c/', 'plugin.js');
             CKEDITOR.plugins.addExternal('notification',basePath+'notification/', 'plugin.js');
             CKEDITOR.plugins.addExternal('fontawesome',basePath+'fontawesome/', 'plugin.js');
-            ${ckeditor-plugins}
+            // Accessibility checker has a dependency on balloonpanel
+            CKEDITOR.plugins.addExternal('balloonpanel',webJars+'balloonpanel/4.6.2/', 'plugin.js');
+            CKEDITOR.plugins.addExternal('a11ychecker',webJars+'a11ychecker/1.1.0/', 'plugin.js');
             /*
                To enable after the deadline uncomment these two lines and add atd-ckeditor to toolbar
                and to extraPlugins. This also needs extra stylesheets.

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -146,6 +146,8 @@
     <ckeditor.autosave.version>8541f541d9985cfd0859c7d8eb6be404afe95a2d</ckeditor.autosave.version>
     <!-- Source at https://github.com/w8tcha/CKEditor-WordCount-Plugin -->
     <ckeditor.wordcount.version>4897cb23a9f2ca7fb6b792add4350fb9e2a1722c</ckeditor.wordcount.version>
+    <ckeditor.a11ychecker.version>1.1.0</ckeditor.a11ychecker.version>
+    <ckeditor.balloonpanel.version>4.6.2</ckeditor.balloonpanel.version>
   </properties>
   <distributionManagement>
     <snapshotRepository>

--- a/webjars/ckeditor-a11ychecker/README.md
+++ b/webjars/ckeditor-a11ychecker/README.md
@@ -1,0 +1,3 @@
+WebJar for CKEditor autosave
+
+More info: http://webjars.org

--- a/webjars/ckeditor-a11ychecker/pom.xml
+++ b/webjars/ckeditor-a11ychecker/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>webjars</artifactId>
+        <groupId>org.sakaiproject.webjars</groupId>
+        <version>12-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+    <groupId>org.sakaiproject.webjars</groupId>
+    <artifactId>ckeditor-a11ychecker</artifactId>
+    <version>${ckeditor.a11ychecker.version}</version>
+    <name>CKEditor-a11ychecker-webjar</name>
+    <description>WebJar for CKEditor-a11ychecker</description>
+    <url>http://webjars.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <upstream.version>${ckeditor.a11ychecker.version}</upstream.version>
+        <upstream.url>http://download.ckeditor.com/a11ychecker/releases/a11ychecker</upstream.url>
+        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/a11ychecker/${upstream.version}</destDir>
+        <requirejs>
+            {
+                "paths": {
+                    "a11ychecker": "a11ychecker",
+                }
+            }
+        </requirejs>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${destDir}" />
+                                <get src="${upstream.url}_${upstream.version}.zip" dest="${project.build.directory}/${project.artifactId}.zip" />
+                                <echo message="unzip archives" />
+                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}">
+                                    <cutdirsmapper dirs="1"/>
+                                </unzip>
+                                    
+                                <echo message="moving resources" />
+                                <move todir="${destDir}">
+                    <fileset dir="${project.build.directory}" excludes="tests/" />
+                                </move>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/webjars/ckeditor-balloonpanel/README.md
+++ b/webjars/ckeditor-balloonpanel/README.md
@@ -1,0 +1,3 @@
+WebJar for CKEditor autosave
+
+More info: http://webjars.org

--- a/webjars/ckeditor-balloonpanel/pom.xml
+++ b/webjars/ckeditor-balloonpanel/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>webjars</artifactId>
+        <groupId>org.sakaiproject.webjars</groupId>
+        <version>12-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+    <groupId>org.sakaiproject.webjars</groupId>
+    <artifactId>ckeditor-balloonpanel</artifactId>
+    <version>${ckeditor.balloonpanel.version}</version>
+    <name>CKEditor-balloonpanel-webjar</name>
+    <description>WebJar for CKEditor-balloonpanel</description>
+    <url>http://webjars.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <upstream.version>${ckeditor.balloonpanel.version}</upstream.version>
+	<upstream.url>http://download.ckeditor.com/balloonpanel/releases/balloonpanel</upstream.url>
+        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/balloonpanel/${upstream.version}</destDir>
+        <requirejs>
+            {
+                "paths": {
+                    "balloonpanel": "balloonpanel",
+                }
+            }
+        </requirejs>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${destDir}" />
+                                <get src="${upstream.url}_${upstream.version}.zip" dest="${project.build.directory}/${project.artifactId}.zip" />
+                                <echo message="unzip archives" />
+                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}">
+                                    <cutdirsmapper dirs="1"/>
+                                </unzip>
+                                    
+                                <echo message="moving resources" />
+                                <move todir="${destDir}">
+					<fileset dir="${project.build.directory}"/>
+                                </move>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/webjars/pom.xml
+++ b/webjars/pom.xml
@@ -26,5 +26,15 @@
               <module>ckeditor-wordcount</module>
           </modules>
       </profile>
+      <profile>
+          <id>ckeditor-a11ychecker</id>
+          <activation>
+              <activeByDefault>false</activeByDefault>
+          </activation>
+          <modules>
+              <module>ckeditor-balloonpanel</module>
+              <module>ckeditor-a11ychecker</module>
+          </modules>
+      </profile>
   </profiles>
 </project>

--- a/webjars/pom.xml
+++ b/webjars/pom.xml
@@ -27,9 +27,12 @@
           </modules>
       </profile>
       <profile>
-          <id>ckeditor-a11ychecker</id>
+          <id>ckeditor-extras</id>
           <activation>
               <activeByDefault>false</activeByDefault>
+              <property>
+                  <name>ckeditor-extras</name>
+              </property>
           </activation>
           <modules>
               <module>ckeditor-balloonpanel</module>


### PR DESCRIPTION
This plugin is disabled by default, to enable it you need to build with the maven profile:

    mvn -Pckeditor-a11ychecker install

This is because it’s license isn’t compatible with the ECL.