### PR TITLE
SAM-3167 Increase chance that tests pass.

### DIFF
--- a/samigo/samigo-services/src/test/org/sakaiproject/spring/SpringBeanLocatorTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/spring/SpringBeanLocatorTest.java
@@ -23,9 +23,12 @@ public class SpringBeanLocatorTest {
         get1.start();
         get2.start();
 
+        // Increase the chances that the other threads will have run
+        Thread.yield();
+
         SpringBeanLocator.setApplicationContext(context);
-        get1.join(1000);
-        get2.join(1000);
+        get1.join(10000);
+        get2.join(10000);
         // Cross thread assertions
         Assert.assertTrue(get1.good);
         Assert.assertTrue(get2.good);


### PR DESCRIPTION
Travis CI had a test failure on this. Probably because the box was heavily loaded and the other threads didn't have a chance to run. This increases the timeout and attempts to break things more by yielding in the current thread.