### PR TITLE
SAK-32258 - Page order helper no longer working

### DIFF
--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
@@ -45,6 +45,8 @@ public class SitePageEditHandler {
     public String state;
     public String title = "";
     public boolean update;
+    //This nil is needed for RSF Producers do not remove!
+    public String nil = null;
     
     private final String TOOL_CFG_FUNCTIONS = "functions.require";
     private final String PORTAL_VISIBLE = "sakai-portal:visible";


### PR DESCRIPTION
RSF does some reflection to look for properties in the classes. When this was removed it broke because the producers used it. I feel like RSF MethodAnalyser maybe could be a little more lenient when this fails rather than throwing a "UniversalRuntimeException". Maybe it can return Optional type now!