### PR TITLE
SAK-32276 Cope with no CandidateDetailsProvider

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -17873,25 +17873,29 @@ public class AssignmentAction extends PagedResourceActionII
 
 		try {
 			Site st = siteService.getSite((String) state.getAttribute(STATE_CONTEXT_STRING));
-			Map<String, List<String>> notesMap = new HashMap<String, List<String>>();
-			if(o instanceof List) {
-				List l = (List)o;
-				for(Object obj : l){
-					User u = null;
-					if(obj instanceof SubmitterSubmission) {
-						u = ((SubmitterSubmission)obj).getUser();
-					}
-					if(u != null) {
-						if(notesMap.get(u.getId()) == null) {
-							notesMap.put(u.getId(), candidateDetailProvider.getAdditionalNotes(u, st).orElse(new ArrayList<String>()));
+			boolean notesEnabled = candidateDetailProvider != null && candidateDetailProvider.isAdditionalNotesEnabled(st);
+			context.put("isAdditionalNotesEnabled", notesEnabled);
+			Map<String, List<String>> notesMap = new HashMap<>();
+			if (notesEnabled) {
+				if (o instanceof List) {
+					List l = (List) o;
+					for (Object obj : l) {
+						User u = null;
+						if (obj instanceof SubmitterSubmission) {
+							u = ((SubmitterSubmission) obj).getUser();
+						}
+						if (u != null) {
+							if (notesMap.get(u.getId()) == null) {
+								List<String> notes = candidateDetailProvider.getAdditionalNotes(u, st).orElse(new ArrayList<>());
+								notesMap.put(u.getId(), notes);
+							}
 						}
 					}
+				} else if (o instanceof User) {
+					User u = (User) o;
+					notesMap.put(u.getId(), candidateDetailProvider.getAdditionalNotes(u, st).orElse(new ArrayList<>()));
 				}
-			} else if(o instanceof User) {
-				User u = (User)o;
-				notesMap.put(u.getId(), candidateDetailProvider.getAdditionalNotes(u, st).orElse(new ArrayList<String>()));
 			}
-			context.put("isAdditionalNotesEnabled", candidateDetailProvider != null && candidateDetailProvider.isAdditionalNotesEnabled(st));
 			context.put("notesMap", notesMap);
 		} catch (IdUnusedException iue) {
 			M_log.warn(this + ":addAdditionalNotesToContext: Site not found!" + iue.getMessage());


### PR DESCRIPTION
Assignments was failing (NPE) when viewing submissions when there wasn’t a candidate details provider set. Now when there’s no provider we don’t ask it for any notes.