### PR TITLE
SAK-32303 Allow stopping of some jobs

### DIFF
--- a/jobscheduler/scheduler-component-shared/README.beanjobs.md
+++ b/jobscheduler/scheduler-component-shared/README.beanjobs.md
@@ -3,9 +3,15 @@ Autowiring Quartz Jobs
 
 To implement a quartz job now all you need todo is create a class that
 implements the org.quartz.Job interface and register this class with the
-scheuduler manager. The class doesn't need to be a spring bean as it
+scheduler manager. The class doesn't need to be a spring bean as it
 can be autowired with any services it needs. The data from the job map
 is also available to the autowiring.
+
+If you are migrating an old job that was wrapped by a SpringJobBeanWrapper
+instance you can ask the scheduler to migrate old copies of the job to the
+new version at startup. Todo this add a mapping to the migration property.
+The key is the old bean ID and the value is the class of the quartz job that
+replaces it.
 
 See: org.springframework.scheduling.quartz.SpringBeanJobFactory
 See: org.sakaiproject.component.app.scheduler.jobs.AutowiredTestJob

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/backfill-tool.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/backfill-tool.xml
@@ -3,23 +3,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <!-- Job to backfill tool into a site -->
-    <bean id="org.sakaiproject.component.app.scheduler.jobs.backfilltool.BackFillToolJob"
-          class="org.sakaiproject.component.app.scheduler.jobs.backfilltool.BackFillToolJob">
-        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
-        <property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager"/>
-        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
-    </bean>
-
-    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.BackFillToolJob"
-          class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobBeanWrapper"
-          init-method="init">
-        <property name="beanId">
-            <value>org.sakaiproject.component.app.scheduler.jobs.backfilltool.BackFillToolJob</value>
-        </property>
-        <property name="jobName">
-            <value>Backfill tool into sites</value>
-        </property>
+    <bean id="org.sakaiproject.api.app.scheduler.BackFillToolJob"
+          class="org.sakaiproject.component.app.scheduler.ConfigurableAutowiredJobBeanWrapper">
+        <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.backfilltool.BackFillToolJob"/>
+        <constructor-arg value="Backfill tools to sites"/>
         <property name="resourceBundleBase"
                   value="org.sakaiproject.component.app.scheduler.jobs.backfilltool.Messages"/>
         <property name="configurableJobProperties">
@@ -55,9 +42,6 @@
                     <property name="defaultValue" value="true"/>
                 </bean>
             </set>
-        </property>
-        <property name="schedulerManager">
-            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
         </property>
     </bean>
 </beans>

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -274,23 +274,10 @@
 		</property>
 	</bean>
 
-    <!-- Job to backfill roles into a site from a template -->
-    <bean id="org.sakaiproject.component.app.scheduler.jobs.backfillrole.BackFillRoleJob"
-          class="org.sakaiproject.component.app.scheduler.jobs.backfillrole.BackFillRoleJob">
-        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
-        <property name="authzService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
-        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
-    </bean>
-
-    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.BackFillRoleJob"
-          class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobBeanWrapper"
-          init-method="init">
-        <property name="beanId">
-            <value>org.sakaiproject.component.app.scheduler.jobs.backfillrole.BackFillRoleJob</value>
-        </property>
-        <property name="jobName">
-            <value>Backfill roles from templates</value>
-        </property>
+    <bean id="org.sakaiproject.api.app.scheduler.BackFillRoleJob"
+          class="org.sakaiproject.component.app.scheduler.ConfigurableAutowiredJobBeanWrapper">
+        <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.backfillrole.BackFillRoleJob"/>
+        <constructor-arg value="Backfill roles from templates"/>
         <property name="resourceBundleBase" value="org.sakaiproject.component.app.scheduler.jobs.backfillrole.Messages"/>
         <property name="configurableJobProperties">
             <set>
@@ -318,11 +305,7 @@
                     <property name="descriptionResourceKey" value="role.description"/>
                     <property name="defaultValue" value=""/>
                 </bean>
-
             </set>
-        </property>
-        <property name="schedulerManager">
-            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
         </property>
     </bean>
 
@@ -404,6 +387,8 @@
                     <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync"/>
                     <constructor-arg value="Sync the provided groups in authz"/>
                 </bean>
+                <ref bean="org.sakaiproject.api.app.scheduler.BackFillRoleJob"/>
+                <ref bean="org.sakaiproject.api.app.scheduler.BackFillToolJob"/>
             </list>
         </property>
     </bean>

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -236,32 +236,6 @@
         </property>
     </bean>
 
-    <!-- Job for syncing authz provided groups this iterates over all the authz groups
-         with a provider ID set and updates them. -->
-    <bean id="org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync"
-          class="org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync">
-        <property name="authzGroupService">
-            <ref bean="org.sakaiproject.authz.api.AuthzGroupService"/>
-        </property>
-        <property name="sessionManager">
-            <ref bean="org.sakaiproject.tool.api.SessionManager"/>
-        </property>
-    </bean>
-
-    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.AuthzGroupProviderSync"
-          class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
-          init-method="init">
-        <property name="beanId">
-            <value>org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync</value>
-        </property>
-        <property name="jobName">
-            <value>Sync the provided groups in authz</value>
-        </property>
-        <property name="schedulerManager">
-            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
-        </property>
-    </bean>
-
 	   <!-- this is the helper that will register the above bean with the job scheduler -->
 	   <!--
 	   <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.DatetimeEventJob"
@@ -420,10 +394,17 @@
             <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
         </property>
         <property name="jobBeans">
-            <bean class="org.sakaiproject.component.app.scheduler.AutowiredJobBeanWrapper">
-                <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.ValidateScheduledInvocations"/>
-                <constructor-arg value="Scheduled Invocation Validation"/>
-            </bean>
+            <list>
+                <bean class="org.sakaiproject.component.app.scheduler.AutowiredJobBeanWrapper">
+                    <constructor-arg
+                            value="org.sakaiproject.component.app.scheduler.jobs.ValidateScheduledInvocations"/>
+                    <constructor-arg value="Scheduled Invocation Validation"/>
+                </bean>
+                <bean class="org.sakaiproject.component.app.scheduler.AutowiredJobBeanWrapper">
+                    <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync"/>
+                    <constructor-arg value="Sync the provided groups in authz"/>
+                </bean>
+            </list>
         </property>
     </bean>
 

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -3,13 +3,16 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/tx
         http://www.springframework.org/schema/tx/spring-tx.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
     <tx:annotation-driven transaction-manager="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager"/>
 
@@ -58,6 +61,18 @@
             <set>
             </set>
         </property>
+        <property name="migration">
+            <util:map>
+                <!-- The spring bean to class name mappings, key and value can be different -->
+                <entry key="org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync"
+                    value="org.sakaiproject.component.app.scheduler.jobs.AuthzGroupProviderSync"/>
+                <entry key="org.sakaiproject.component.app.scheduler.jobs.backfillrole.BackFillRoleJob"
+                       value="org.sakaiproject.component.app.scheduler.jobs.backfillrole.BackFillRoleJob"/>
+                <entry key="org.sakaiproject.component.app.scheduler.jobs.backfilltool.BackFillToolJob"
+                       value="org.sakaiproject.component.app.scheduler.jobs.backfilltool.BackFillToolJob"/>
+            </util:map>
+        </property>
+
         <property name="qrtzPropFile" value="quartz.properties"/>
         <property name="qrtzPropFileSakai" value="sakai.quartz.properties"/>
         <property name="globalTriggerListener">


### PR DESCRIPTION
Don't allow concurrent execution of the AuthzGroupProviderSync job as it doesn't make sense. Locally we've back an issue where multiple copies of this job were running concurrently and killing system performance. Also allow jobs to be stopped from the administration interface for some of the long running jobs.

We need to switch to spring injected jobs to allow stopping as you need a different instance of the jobs for each run to be able to cancel the correct one.