### PR TITLE
SAK-32264 Fix for MIME detection with path has dots

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -9211,7 +9211,15 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		extType.put("id", id);
 		if (type == null) type = "";
 		extType.put("type", type);
-		String extension = Validator.getFileExtension(id);
+		
+		// SAK-32264 note - this will not catch the case where the last segment ends up being the site id and the site id has '.' chars
+		String[] idSegments;
+		String idLastSegment = id;
+		if (id != null) {
+			idSegments = id.split("/");
+			idLastSegment = idSegments.length > 0 ? idSegments[idSegments.length - 1]:id;
+		}
+		String extension = Validator.getFileExtension(idLastSegment);
 
 		if (extension.length() != 0)
 		{

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -9212,14 +9212,10 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		if (type == null) type = "";
 		extType.put("type", type);
 		
-		// SAK-32264 note - this will not catch the case where the last segment ends up being the site id and the site id has '.' chars
 		String[] idSegments;
-		String idLastSegment = id;
-		if (id != null) {
-			idSegments = id.split("/");
-			idLastSegment = idSegments.length > 0 ? idSegments[idSegments.length - 1]:id;
-		}
-		String extension = Validator.getFileExtension(idLastSegment);
+		idSegments = id.split("/");
+		String filename = idSegments.length > 0 ? idSegments[idSegments.length - 1]:id;
+		String extension = Validator.getFileExtension(filename);
 
 		if (extension.length() != 0)
 		{

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/BaseContentServiceFixTypeAndIdTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/BaseContentServiceFixTypeAndIdTest.java
@@ -20,174 +20,206 @@
  **********************************************************************************/
 package org.sakaiproject.content.impl;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.Map;
 
-import junit.extensions.TestSetup;
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-import static org.mockito.Mockito.*;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import static org.junit.Assert.assertEquals;
-
-import org.sakaiproject.content.api.ContentResource;
-import org.sakaiproject.content.api.ContentTypeImageService;
-import org.sakaiproject.content.api.ContentHostingService;
-import org.sakaiproject.content.impl.BaseContentService;
-import org.sakaiproject.test.SakaiKernelTestBase;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
- * @author austin48@hawaii.edu
+ * Simple tests for fixTypeAndId in BaseContentService
  */
-public class BaseContentServiceTest extends SakaiKernelTestBase {
-	
-    private static final Log log = LogFactory.getLog(BaseContentServiceTest.class);
-    
-	public static Test suite()
-	{
-		TestSetup setup = new TestSetup(new TestSuite(BaseContentServiceTest.class))
-		{
-			protected void setUp() throws Exception 
-			{
-				log.debug("starting oneTimeSetup");
-				oneTimeSetup(null);
-				log.debug("finished oneTimeSetup");
-			}
-			protected void tearDown() throws Exception 
-			{
-				log.debug("starting tearDown");
-				oneTimeTearDown();
-				log.debug("finished tearDown");
-			}
-		};
-		return setup;
-	}
-    
-    public void testFixTypeAndId() throws Exception {
+public class BaseContentServiceFixTypeAndIdTest {
 
-        ContentHostingService contentHostingService = getService(ContentHostingService.class);
-        BaseContentService baseContentService = (BaseContentService)contentHostingService;
-        
+    private BaseContentService contentHostingService;
+    private String id;
+    private String type;
+    private Map extType;
+
+    @Before
+    public void setUp() {
+
+        contentHostingService = new DbContentService();
         BasicContentTypeImageService mockBasicContentTypeImageService = mock(BasicContentTypeImageService.class);
-        baseContentService.setContentTypeImageService(mockBasicContentTypeImageService);            
-                        
-        Map extType = null;       
-        String site_id;
-        String id;
-        String type;
-        
+        contentHostingService.setContentTypeImageService(mockBasicContentTypeImageService);
+
         when(mockBasicContentTypeImageService.getContentTypeExtension("audio/wav")).thenReturn("wav");
         when(mockBasicContentTypeImageService.getContentTypeExtension("image/png")).thenReturn("png");
-        
-        //
-        // no extension in id
-        //    
+    }
+
+    @Test
+    public void testAttachmentNoExtensionSimpleId() throws Exception {
         id = "/attachment/foobarbaz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".wav", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
+    }
 
+    @Test
+    public void testAttachmentNoExtensionDashId() throws Exception {
         id = "/attachment/foo-bar-baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".wav", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testAttachmentNoExtensionUnderscore() throws Exception {
         id = "/attachment/foo_bar_baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".wav", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
-        
+
+    }
+
+    @Test
+    public void testAttachmentNoExtensionDots() {
         id = "/attachment/foo.bar.baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".wav", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
+    }
 
-        //
-        // no extension in id
-        //
+    @Test
+    public void testGroupNoExtensionSimpleId() {
         id = "/group/foobarbaz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".png", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
+    }
 
+    @Test
+    public void testGroupNoExtensionDashId() throws Exception {
         id = "/group/foo-bar-baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".png", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testGroupNoExtensionUnderscore() {
         id = "/group/foo_bar_baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".png", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testGroupNoExtensionDots() {
         id = "/group/foo.bar.baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id + ".png", extType.get("id"));        // append extension
         assertEquals(type, extType.get("type"));
-                
-        //
-        // inlcude .wav extension in id
-        //
+    }
+
+    @Test
+    public void testAttachmentSimpleId() {
         id = "/attachment/foobarbaz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
+    }
 
+    @Test
+    public void testAttachmentDashId() {
         id = "/attachment/foo-bar-baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testAttachmentUnderscore() {
         id = "/attachment/foo_bar_baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testAttachmentDots() {
         id = "/attachment/foo.bar.baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
         type = "audio/wav";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
-        
-        //
-        // inlcude .png extension in id
-        //
+    }
+
+    @Test
+    public void testGroupSimpleId() {
         id = "/group/foobarbaz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
+    }
 
+    @Test
+    public void testGroupDashId() {
         id = "/group/foo-bar-baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testGroupUnderscore() {
         id = "/group/foo_bar_baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
+        extType = contentHostingService.fixTypeAndId(id, type);
         assertEquals(id, extType.get("id"));        // don't append extension to id
         assertEquals(type, extType.get("type"));
-        
+    }
+
+    @Test
+    public void testGroupDots() {
         id = "/group/foo.bar.baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
         type = "image/png";
-        extType = baseContentService.fixTypeAndId(id, type);
-        assertEquals(id, extType.get("id"));        // don't append extension to id
+        extType = contentHostingService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));
+        assertEquals(type, extType.get("type"));
+    }
+
+    @Test
+    public void testUnknownType() {
+        id = "/group/siteId/file.unknown";
+        type = "";
+        extType = contentHostingService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));
+        assertNull(extType.get("type"));
+    }
+
+    @Test
+    public void testPathWithDots() {
+        id = "/group/siteId/folder.with.dots/filename.wav";
+        type = "audio/wav";
+        extType = contentHostingService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));
+        assertEquals(type, extType.get("type"));
+    }
+
+    @Test
+    public void testFilenameWithDots() {
+        id = "/group/siteId/filename.with.dots.wav";
+        type = "audio/wav";
+        extType = contentHostingService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));
         assertEquals(type, extType.get("type"));
     }
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/BaseContentServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/BaseContentServiceTest.java
@@ -1,0 +1,193 @@
+/**********************************************************************************
+ * $URL: $
+ * $Id: $
+ ***********************************************************************************
+ *
+ * Copyright (c) 2010, 2011, 2012, 2013, 2014 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+package org.sakaiproject.content.impl;
+
+import java.util.Map;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import static org.mockito.Mockito.*;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import static org.junit.Assert.assertEquals;
+
+import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.content.api.ContentTypeImageService;
+import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.content.impl.BaseContentService;
+import org.sakaiproject.test.SakaiKernelTestBase;
+
+/**
+ * @author austin48@hawaii.edu
+ */
+public class BaseContentServiceTest extends SakaiKernelTestBase {
+	
+    private static final Log log = LogFactory.getLog(BaseContentServiceTest.class);
+    
+	public static Test suite()
+	{
+		TestSetup setup = new TestSetup(new TestSuite(BaseContentServiceTest.class))
+		{
+			protected void setUp() throws Exception 
+			{
+				log.debug("starting oneTimeSetup");
+				oneTimeSetup(null);
+				log.debug("finished oneTimeSetup");
+			}
+			protected void tearDown() throws Exception 
+			{
+				log.debug("starting tearDown");
+				oneTimeTearDown();
+				log.debug("finished tearDown");
+			}
+		};
+		return setup;
+	}
+    
+    public void testFixTypeAndId() throws Exception {
+
+        ContentHostingService contentHostingService = getService(ContentHostingService.class);
+        BaseContentService baseContentService = (BaseContentService)contentHostingService;
+        
+        BasicContentTypeImageService mockBasicContentTypeImageService = mock(BasicContentTypeImageService.class);
+        baseContentService.setContentTypeImageService(mockBasicContentTypeImageService);            
+                        
+        Map extType = null;       
+        String site_id;
+        String id;
+        String type;
+        
+        when(mockBasicContentTypeImageService.getContentTypeExtension("audio/wav")).thenReturn("wav");
+        when(mockBasicContentTypeImageService.getContentTypeExtension("image/png")).thenReturn("png");
+        
+        //
+        // no extension in id
+        //    
+        id = "/attachment/foobarbaz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".wav", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+
+        id = "/attachment/foo-bar-baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".wav", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+        
+        id = "/attachment/foo_bar_baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".wav", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+        
+        id = "/attachment/foo.bar.baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".wav", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+
+        //
+        // no extension in id
+        //
+        id = "/group/foobarbaz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".png", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+
+        id = "/group/foo-bar-baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".png", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+        
+        id = "/group/foo_bar_baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".png", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+        
+        id = "/group/foo.bar.baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id + ".png", extType.get("id"));        // append extension
+        assertEquals(type, extType.get("type"));
+                
+        //
+        // inlcude .wav extension in id
+        //
+        id = "/attachment/foobarbaz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+
+        id = "/attachment/foo-bar-baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+        
+        id = "/attachment/foo_bar_baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+        
+        id = "/attachment/foo.bar.baz/fckeditor/e3ec10b2-62de-4492-bb39-c582249269e0/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.wav";
+        type = "audio/wav";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+        
+        //
+        // inlcude .png extension in id
+        //
+        id = "/group/foobarbaz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+
+        id = "/group/foo-bar-baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+        
+        id = "/group/foo_bar_baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+        
+        id = "/group/foo.bar.baz/9dcf51f8-8889-4ad3-b430-f8ddaaaea461.png";
+        type = "image/png";
+        extType = baseContentService.fixTypeAndId(id, type);
+        assertEquals(id, extType.get("id"));        // don't append extension to id
+        assertEquals(type, extType.get("type"));
+    }
+}


### PR DESCRIPTION
Although this affects the audio recorder in CKEditor it looks to be a general problem with the code that attempts to guess at the MIME type. It doesn't appear to get the filename but instead passes the whole path.