### PR TITLE
SAK-32316 Allow email/AID for group CSV imports.

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/bundle/org/sakaiproject/site/tool/managegroupsectionrole/bundle/Messages.properties
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/bundle/org/sakaiproject/site/tool/managegroupsectionrole/bundle/Messages.properties
@@ -110,14 +110,14 @@ group.importinstruction = Import groups from a spreadsheet or csv file
 
 import1.title = Upload a file containing the groups you wish to create
 import1.instr.req.header = File requirements
-import1.instr.req.1 = The CSV file should contain the group details in the columns: group title, username. 
+import1.instr.req.1 = The CSV file should contain the group details in the columns: group title, username/email address. 
 import1.instr.req.2 = Columns must be in the order above, but <b>do not include a row of column headers</b>.
 import1.instr.req.3 = Fields must be comma separated, contain no spaces between fields and each field surrounded with double quotes if it is to contain a space.
 import1.error = The file you uploaded was not readable. Please check the file is of the correct format, and try again.
 import1.continue = Continue
 
 import2.check = Verify the imported data
-import2.error = The data you supplied contained invalid users or the users are not part of the site (highlighted in red). You need to correct these issues and start again.
+import2.error = The data you supplied contained invalid users, matched multiple users or users who are not part of the site (highlighted in red). You need to correct these issues and start again.
 import2.okay = The following data was found in the uploaded file. If this is correct, click 'Continue'.
 import2.grouptitle = Group Title
 import2.userid = User ID

--- a/site-manage/site-manage-group-section-role-helper/tool/src/bundle/org/sakaiproject/site/tool/managegroupsectionrole/bundle/Messages_en_GB.properties
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/bundle/org/sakaiproject/site/tool/managegroupsectionrole/bundle/Messages_en_GB.properties
@@ -64,20 +64,3 @@ site_group_title_length_limit=Title length cannot exceed {0} characters. Please 
 
 group.import = Import from file
 group.importinstruction = Import groups from a spreadsheet or csv file
-
-import1.title = Upload a file containing the groups you wish to create
-import1.instr.req.header = File requirements
-import1.instr.req.1 = The CSV file should contain the group details in the columns: group title, username. 
-import1.instr.req.2 = Columns must be in the order above, but <b>do not include a row of column headers</b>.
-import1.instr.req.3 = Fields must be comma separated, contain no spaces between fields and each field surrounded with double quotes if it is to contain a space.
-import1.error = The file you uploaded was not readable. Please check the file is of the correct format, and try again.
-import1.continue = Continue
-
-import2.check = Verify the imported data
-import2.error = The data you supplied contained invalid users or the users are not part of the site (highlighted in red). You need to correct these issues and start again.
-import2.okay = The following data was found in the uploaded file. If this is correct, click 'Continue'.
-import2.grouptitle = Group Title
-import2.userid = User ID
-import2.continue = Import groups
-import2.couldntimportgroups = An error occurred importing the groups. Please contact an administrator.
-import2.groupexists = This group already exists, the membership will be merged. The existing users are noted in grey.

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupImportStep2Producer.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupImportStep2Producer.java
@@ -89,19 +89,20 @@ public class GroupImportStep2Producer implements ViewComponentProducer, Navigati
             //if group already exists, get the users that are already in the group,
             //merge so we get one list, then display the new or merged ones appropriately.
             Set<String> userIds = importedGroup.getUserIds();
-            List<String> existingUserIds = new ArrayList<String>();
+            List<String> existingUserIds = new ArrayList<>();
             if(groupExists) {
-            	existingUserIds = handler.getGroupUserIds(existingGroup);
-            	userIds.addAll(existingUserIds);
-        	}
+                existingUserIds = handler.getGroupUserIds(existingGroup);
+                userIds.addAll(existingUserIds);
+            }
             
             //print each user
             for(String userId: importedGroup.getUserIds()) {
             	
             	UIOutput output = UIOutput.make(branch,"member:",userId);
             	
-            	//check user is valid
-            	if(handler.isValidSiteUser(userId)){
+                //check user is valid
+                String foundUserId = handler.lookupUser(userId);
+                if(foundUserId != null && handler.isValidSiteUser(foundUserId)){
             		//is user existing?
             		if(existingUserIds.contains(userId)) {
             			//highlight grey


### PR DESCRIPTION
When importing a group into a site using a CSV file as well as searching for a user by EID it can be helpful to also search by AID and email address.

We are also more flexible and ignore rows that have empty values in them.
Also delete en_GB properties todo with importing that are identical to en.