### PR TITLE
SAK-31319 - Use default value for content review options when not shown to instructor

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2674,7 +2674,7 @@ public class AssignmentAction extends PagedResourceActionII
 		boolean defaultStoreInstIndex = serverConfigurationService.getBoolean("contentreview.option.store_inst_index.default", showStoreInstIndex);
 		context.put("value_NEW_ASSIGNMENT_REVIEW_SERVICE_STORE_INST_INDEX", (state.getAttribute(NEW_ASSIGNMENT_REVIEW_SERVICE_STORE_INST_INDEX) == null) ? Boolean.toString(defaultStoreInstIndex) : state.getAttribute(NEW_ASSIGNMENT_REVIEW_SERVICE_STORE_INST_INDEX));
 		
-		//exclude quoted materials
+		//exclude small matches
 		boolean displayExcludeType = serverConfigurationService.getBoolean("turnitin.option.exclude_smallmatches", true);
 		context.put("show_NEW_ASSIGNMENT_REVIEW_SERVICE_EXCLUDE_SMALL_MATCHES", displayExcludeType);
 		if(displayExcludeType){
@@ -9768,16 +9768,26 @@ public class AssignmentAction extends PagedResourceActionII
         //Rely on the deprecated "turnitin.option.exclude_quoted" setting if set, otherwise use "contentreview.option.exclude_quoted"
         boolean showExcludeQuoted = serverConfigurationService.getBoolean("turnitin.option.exclude_quoted", serverConfigurationService.getBoolean("contentreview.option.exclude_quoted", Boolean.TRUE));
 		if(showExcludeQuoted){
-			//we don't want to pass parameters if the user didn't get an option to set it
 			opts.put("exclude_quoted", assign.isExcludeQuoted() ? "1" : "0");
+		} else {
+			Boolean defaultExcludeQuoted = serverConfigurationService.getBoolean("contentreview.option.exclude_quoted.default", true);
+			opts.put("exclude_quoted", defaultExcludeQuoted ? "1" : "0");
 		}
+
+		//exclude self plag
 		if(serverConfigurationService.getBoolean("contentreview.option.exclude_self_plag", true)){
-			//we don't want to pass parameters if the user didn't get an option to set it
 			opts.put("exclude_self_plag", assign.isExcludeSelfPlag() ? "1" : "0");
+		} else {
+			Boolean defaultExcludeSelfPlag = serverConfigurationService.getBoolean("contentreview.option.exclude_self_plag.default", true);
+			opts.put("exclude_self_plag", defaultExcludeSelfPlag ? "1" : "0");
 		}
+
+		//Store institutional Index
 		if(serverConfigurationService.getBoolean("contentreview.option.store_inst_index", true)){
-			//we don't want to pass parameters if the user didn't get an option to set it
 			opts.put("store_inst_index", assign.isStoreInstIndex() ? "1" : "0");
+		} else {
+			Boolean defaultStoreInstIndex = serverConfigurationService.getBoolean("contentreview.option.store_inst_index.default", true);
+			opts.put("store_inst_index", defaultStoreInstIndex ? "1" : "0");
 		}
         
         if((assign.getExcludeType() == 1 || assign.getExcludeType() == 2) 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32319

Content Review has options to hide settings from the being shown to the instructor while creating an assignment, but it didn't allow for the global setting to be settable from the config. When the setting was hidden from appearing to the admin, it became unset as opposed to using the default.

These are the existing configs.
- contentreview.option.exclude_quoted  == To show field to instructor
- contentreview.option.exclude_quoted.default == default value
- contentreview.option.exclude_self_plag == To show field to instructor
- contentreview.option.exclude_self_plag.default == default value
- contentreview.option.store_inst_index == To show field to instructor
- contentreview.option.store_inst_index.default == default value