### PR TITLE
SAK-32321 Fix intermittent sitestats test failures.

### DIFF
--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/ReportManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/ReportManagerTest.java
@@ -169,6 +169,9 @@ public class ReportManagerTest extends AbstractTransactionalJUnit4SpringContextT
 		((ReportManagerImpl)M_rm).setResourceLoader(msgs);
 		((StatsUpdateManagerImpl)M_sum).setSiteService(M_ss);
 		((StatsUpdateManagerImpl)M_sum).setStatsManager(M_sm);
+		// This is needed to make the tests deterministic, otherwise on occasion the collect thread will run
+		// and break the tests.
+		M_sum.setCollectThreadEnabled(false);
 	}
 
 	// ---- SAMPLE DATA ----

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
@@ -185,7 +185,10 @@ public class StatsManagerTest extends AbstractTransactionalJUnit4SpringContextTe
 		((StatsManagerImpl)M_sm).setCountFilesUsingCHS(false);
 		((StatsUpdateManagerImpl)M_sum).setSiteService(M_ss);
 		((StatsUpdateManagerImpl)M_sum).setStatsManager(M_sm);
-		
+		// This is needed to make the tests deterministic, otherwise on occasion the collect thread will run
+		// and break the tests.
+		M_sum.setCollectThreadEnabled(false);
+
 		M_ers.setStatsManager(M_sm);
 	}
 


### PR DESCRIPTION
Some of the other tests inside site stats still had the collect thread enabled which would cause errors on some test runs. Disabling the collect thread should fix these and the tests still pass without it running.