### PR TITLE
SAK-32323 Remove redundant maven sections.

### DIFF
--- a/announcement/pom.xml
+++ b/announcement/pom.xml
@@ -19,15 +19,6 @@
     <module>announcement-tool/tool</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/announcement/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/assignment/pom.xml
+++ b/assignment/pom.xml
@@ -20,15 +20,6 @@
     <module>assignment-tool/tool</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/assignment/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/calendar/pom.xml
+++ b/calendar/pom.xml
@@ -24,15 +24,6 @@
         <module>calendar-util/util</module>
     </modules>
     
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/calendar/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -36,15 +36,6 @@
     <module>import-parsers/blackboard_6/impl</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/common/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/courier/pom.xml
+++ b/courier/pom.xml
@@ -21,15 +21,6 @@
         <module>courier-util/util</module>
     </modules>
     
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/courier/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/edu-services/pom.xml
+++ b/edu-services/pom.xml
@@ -20,15 +20,6 @@
     <module>scoring-service</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/edu-services/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <!--internal dependencies -->

--- a/emailtemplateservice/pom.xml
+++ b/emailtemplateservice/pom.xml
@@ -27,15 +27,6 @@
     <module>tool</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/emailtemplateservice/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/endorsed/pom.xml
+++ b/endorsed/pom.xml
@@ -16,14 +16,6 @@
     <version>12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <licenses>
-        <license>
-            <name>Educational Community License, Version 2.0</name>
-            <url>http://www.opensource.org/licenses/ECL-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/entitybroker/pom.xml
+++ b/entitybroker/pom.xml
@@ -69,14 +69,6 @@
       <timezone>0</timezone>
     </developer>
   </developers>
-  <licenses>
-    <license>
-      <name>Educational Community License, Version 2.0</name>
-      <url>http://www.opensource.org/licenses/ecl2.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <!-- define source code repository location -->
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/external-calendaring-service/pom.xml
+++ b/external-calendaring-service/pom.xml
@@ -64,14 +64,4 @@
 		</dependencies>
 	</dependencyManagement>	
 	
-	<!--  this is only currently setup for snapshot releases, no stable releases -->
-	<distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/external-calendaring-service/${project.version}</url>
-        </site>
-    </distributionManagement>
-    
-    <build/>
 </project>

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -37,12 +37,6 @@
 		</pluginRepository>
     </pluginRepositories>
 
-	<issueManagement>
-        <system>JIRA</system>
-        <url>https://jira.oucs.ox.ac.uk/jira/browse/WL-3179</url>
-    </issueManagement>
-
-
   	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/jobscheduler/pom.xml
+++ b/jobscheduler/pom.xml
@@ -23,12 +23,4 @@
     <module>scheduler-test-component-shared</module>
   </modules>
 
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/scheduler/${project.version}</url>
-    </site>
-  </distributionManagement>
-
 </project>

--- a/jsf/pom.xml
+++ b/jsf/pom.xml
@@ -28,15 +28,6 @@
         <module>myfaces-widgets-depend</module>
     </modules>
 
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/jsf/${project.version}</url>
-        </site>
-    </distributionManagement>
-    
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/lessonbuilder/pom.xml
+++ b/lessonbuilder/pom.xml
@@ -256,14 +256,6 @@
     </profiles>
 
 
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/lessonbuilder/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <pluginRepositories>
         <pluginRepository>
             <id>maven2-central-repo</id>

--- a/mailarchive/pom.xml
+++ b/mailarchive/pom.xml
@@ -21,15 +21,6 @@
         <module>mailarchive-tool/tool</module>
     </modules>
     
-      
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/mailarchive/${project.version}</url>
-        </site>
-    </distributionManagement>
-      
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/mailsender/pom.xml
+++ b/mailsender/pom.xml
@@ -70,15 +70,6 @@
     </profile>
   </profiles>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/mailsender/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -25,7 +25,7 @@
   </developers>
   <issueManagement>
     <system>jira</system>
-    <url>http://bugs.sakaiproject.org/jira/browse/SAK</url>
+    <url>http://jira.sakaiproject.org/browse/SAK</url>
   </issueManagement>
   <ciManagement>
     <system>continuum</system>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -21,15 +21,6 @@
         <module>search-adapters/impl</module>
     </modules>
     
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/message/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/msgcntr/pom.xml
+++ b/msgcntr/pom.xml
@@ -20,15 +20,6 @@
     <module>messageforums-hbm</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/msgcntr/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -21,13 +21,6 @@
         <url>http://www.sakaiproject.org/sakai-foundation</url>
     </organization>
     <inceptionYear>2009</inceptionYear>
-    <licenses>
-        <license>
-            <name>ECL-2.0</name>
-            <url>http://opensource.org/licenses/ECL-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <developers>
         <developer>

--- a/pack/pack-bin/pom.xml
+++ b/pack/pack-bin/pom.xml
@@ -19,11 +19,6 @@
         <url>http://sakaiproject.org/</url>
     </organization>
 
-    <issueManagement>
-        <system>jira</system>
-        <url>http://jira.sakaiproject.org/browse/SAK</url>
-    </issueManagement>
-
     <prerequisites>
         <maven>${maven.prereq.version}</maven>
     </prerequisites>

--- a/pack/pack-demo/pom.xml
+++ b/pack/pack-demo/pom.xml
@@ -19,11 +19,6 @@
         <url>http://sakaiproject.org/</url>
     </organization>
 
-    <issueManagement>
-        <system>jira</system>
-        <url>http://jira.sakaiproject.org/browse/SAK</url>
-    </issueManagement>
-
     <prerequisites>
         <maven>${maven.prereq.version}</maven>
     </prerequisites>

--- a/pack/pack-src/pom.xml
+++ b/pack/pack-src/pom.xml
@@ -19,11 +19,6 @@
         <url>http://sakaiproject.org/</url>
     </organization>
 
-    <issueManagement>
-        <system>jira</system>
-        <url>http://jira.sakaiproject.org/browse/SAK</url>
-    </issueManagement>
-
     <prerequisites>
         <maven>${maven.prereq.version}</maven>
     </prerequisites>

--- a/pack/pom.xml
+++ b/pack/pom.xml
@@ -30,11 +30,6 @@
         <module>pack-src</module>
     </modules>
     
-    <issueManagement>
-        <system>jira</system>
-        <url>http://jira.sakaiproject.org/browse/SAK</url>
-    </issueManagement>
-
     <prerequisites>
         <maven>${maven.prereq.version}</maven>
     </prerequisites>

--- a/polls/pom.xml
+++ b/polls/pom.xml
@@ -14,30 +14,12 @@
     <artifactId>polls</artifactId>
     <packaging>pom</packaging>
 
-    <licenses>
-        <license>
-            <name>ECL-2.0</name>
-            <url>http://www.opensource.org/licenses/ecl2.txt</url>
-            <distribution>repo</distribution>
-            <comments>Copyright 2003-2010 Sakai Foundation</comments>
-        </license>
-    </licenses>
-
     <modules>
         <module>api</module>
         <module>impl</module>
         <module>tool</module>
     </modules>
-    
 
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/polls/${project.version}</url>
-        </site>
-    </distributionManagement>
-    
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -28,15 +28,6 @@
         <module>portal-util/util</module>
     </modules>
 
-
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/portal/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/presence/pom.xml
+++ b/presence/pom.xml
@@ -21,15 +21,6 @@
         <module>presence-util/util</module>
     </modules>
 
-
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/presence/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/profile2/pom.xml
+++ b/profile2/pom.xml
@@ -28,13 +28,6 @@
 		<module>tool</module>
 		<module>bundle</module>
 	</modules>
-	<distributionManagement>
-		<site>
-			<id>sakai-site</id>
-			<name>Sakai release Site</name>
-			<url>scpexe://source.sakaiproject.org/var/www/html/release/profile2/${project.version}</url>
-		</site>
-	</distributionManagement>
 	<dependencyManagement>
 		<dependencies>
 			<!-- internal -->
@@ -95,8 +88,4 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-	<issueManagement>
-		<system>JIRA</system>
-		<url>http://jira.sakaiproject.org/browse/SAK</url>
-	</issueManagement>
 </project>

--- a/reset-pass/pom.xml
+++ b/reset-pass/pom.xml
@@ -20,15 +20,6 @@
     <module>account-validator-tool</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/reset-pass/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/samigo/pom.xml
+++ b/samigo/pom.xml
@@ -31,15 +31,6 @@
 		<module>samlite-impl</module>
 	</modules>
 	
-
-	<distributionManagement>
-		<site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/samigo/${project.version}</url>
-        </site>
-	</distributionManagement>
-
 	<dependencyManagement>
         <dependencies>
             <dependency>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -47,12 +47,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/search/${project.version}</url>
-    </site>
-  </distributionManagement>
-
 </project>

--- a/shortenedurl/pom.xml
+++ b/shortenedurl/pom.xml
@@ -28,34 +28,12 @@
 		</developer>
 	</developers>
 
-	<licenses>
-        <license>
-            <name>Educational Community License, Version 2.0</name>
-            <url>http://www.opensource.org/licenses/ecl2.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    
-    <issueManagement>
-        <system>JIRA</system>
-        <url>http://jira.sakaiproject.org/jira/browse/TINYURL</url>
-    </issueManagement>
-    
     <modules>
         <module>api</module>
         <module>impl</module>
         <module>tool</module>
     </modules>
 
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/shortenedurl/${project.version}</url>
-        </site>
-    </distributionManagement>
-    
 	<dependencyManagement>
 		<dependencies>
 			

--- a/signup/pom.xml
+++ b/signup/pom.xml
@@ -50,14 +50,6 @@
 		<module>tool</module>
 	</modules>
 
-	<distributionManagement>
-		<site>
-			<id>sakai-site</id>
-			<name>Sakai release Site</name>
-			<url>scpexe://source.sakaiproject.org/var/www/html/release/signup/${project.version}</url>
-		</site>
-	</distributionManagement>
-
 	<dependencyManagement>
 		<dependencies>
 			<!-- project dependencies -->

--- a/site-manage/pom.xml
+++ b/site-manage/pom.xml
@@ -60,15 +60,6 @@
         </profile>
     </profiles>
 
-
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/site-manage/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -19,13 +19,4 @@
     <module>mergedlist-util/util</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scp://source.sakaiproject.org/var/www/html/release/site/${project.version}</url>
-    </site>
-  </distributionManagement>
-
 </project>

--- a/sitestats/pom.xml
+++ b/sitestats/pom.xml
@@ -59,23 +59,6 @@
     </profile>
   </profiles>
 
-  <!-- Source code repository location -->
-
-  <!-- Distribution Management -->
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/sitestats/${project.version}</url>
-    </site>
-  </distributionManagement>
-
-  <!-- JIRA -->
-  <issueManagement>
-    <system>JIRA</system>
-    <url>http://jira.sakaiproject.org/jira/browse/STAT</url>
-  </issueManagement>
-
   <!-- Project related dependencies -->
   <dependencyManagement>
     <dependencies>

--- a/taggable/pom.xml
+++ b/taggable/pom.xml
@@ -20,15 +20,6 @@
         <module>taggable-impl/impl</module>
     </modules>
 
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/taggable/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/userauditservice/pom.xml
+++ b/userauditservice/pom.xml
@@ -29,15 +29,6 @@
     <module>util</module>
   </modules>
 
-
-  <distributionManagement>
-    <site>
-      <id>sakai-site</id>
-      <name>Sakai release Site</name>
-      <url>scpexe://source.sakaiproject.org/var/www/html/release/userauditservice/${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -19,13 +19,4 @@
         <module>tool-api</module>
         <module>util</module>
     </modules>
-    
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/velocity/${project.version}</url>
-        </site>
-    </distributionManagement>
 </project>

--- a/webservices/pom.xml
+++ b/webservices/pom.xml
@@ -21,19 +21,6 @@
   	
   	<inceptionYear>2005</inceptionYear>
   	
-	<licenses>
-        <license>
-            <name>Educational Community License, Version 2.0</name>
-            <url>http://www.opensource.org/licenses/ecl2.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    
-    <issueManagement>
-        <system>JIRA</system>
-        <url>http://jira.sakaiproject.org/jira/browse/SAK</url>
-    </issueManagement>
-    
     <developers>
         <developer>
             <name>Steve Swinsburg</name>
@@ -45,14 +32,5 @@
     <modules>
         <module>cxf</module>
     </modules>
-    
-    
-    <distributionManagement>
-        <site>
-            <id>sakai-site</id>
-            <name>Sakai release Site</name>
-            <url>scpexe://source.sakaiproject.org/var/www/html/release/webservices/${project.version}</url>
-        </site>
-    </distributionManagement>
-    
+
 </project>


### PR DESCRIPTION
As all modules in the build inherit from the master pom.xml and this defines most sections all modules in most cases shouldn’t redefine things like the license and issue tracker as it’s redundant.

Also corrected Jira URL in master.