### PR TITLE
SAK-32263 Preserve Forum Topic Order on Dupe

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
@@ -29,6 +29,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.SortedSet;
 
 import org.hibernate.Query;
 import org.hibernate.collection.internal.PersistentSet;
@@ -58,6 +60,7 @@ import org.sakaiproject.component.app.messageforums.dao.hibernate.PrivateForumIm
 import org.sakaiproject.component.app.messageforums.dao.hibernate.PrivateTopicImpl;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.Util;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.util.comparator.ForumBySortIndexAscAndCreatedDateDesc;
+import org.sakaiproject.component.app.messageforums.dao.hibernate.util.comparator.TopicBySortIndexAscAndCreatedDateDesc;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.id.api.IdManager;
@@ -271,7 +274,7 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
       };
 
     Topic tempTopic = null;
-    Set resultSet = new HashSet();      
+    SortedSet resultSet = new TreeSet(new TopicBySortIndexAscAndCreatedDateDesc());
     List temp = (ArrayList) getHibernateTemplate().execute(hcb);
     for (Iterator i = temp.iterator(); i.hasNext();)
     {


### PR DESCRIPTION
When a forum was being duplicated via transferCopyEntitiesRefMigrator
the topic List was retrieved in an unsorted order. As such, it was
possible for a topic with a sortOrder > 1 to be selected first and
imported into the new forum. Then when the forum was saved in
    MessageForumsForumManagerImpl#saveDiscussionForum
      (org.sakaiproject.api.app.messageforums.DiscussionForum, boolean,
        boolean, java.lang.String)
the topics would be retrieved using BaseForumImpl#getTopics. This
method would first check to see if the topicSet was sorted by going
through the topics and checking their sort order, starting at 1.

With the topic list being retrieved in an unsorted order, you could
have the first topic inserted to have a sort order > 1. Then when
getTopics was ran, with only one topic in the set (whose sortOrder
is > 1), it would "correct" the sortOrder of this topic.

This change causes the topics to be retireved in a sorted order, thus
the first topic inserted would have a sortOrder of 1 and getTopics would
not rewrite the sortOrder.