### PR TITLE
LSNBLDR-633: Fix for 'non-static method cannot be referenced'

### DIFF
--- a/lessonbuilder/tool/src/webapp/removePage.jsp
+++ b/lessonbuilder/tool/src/webapp/removePage.jsp
@@ -79,7 +79,7 @@
 	return;
     }
 
-    if(SimplePageBean.isStudentPage(simplePage)) {
+    if(simplePage.getOwner()!=null && !simplePage.isOwned()) {
 	out.println("Can't remove student pages this way");
 	return;
     }


### PR DESCRIPTION
This is a fix for Sean Horner's comment (at the bottom of https://jira.sakaiproject.org/browse/LSNBLDR-633) where removePage.jsp is trying to reference a non-static method from a static context.  
It doesn't seem to stop Sakai building or starting up successfully.