### PR TITLE
SAK-32349 Fix peer assessment and ScheduledInvocationManager

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/ScheduledInvocationManagerImpl.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/ScheduledInvocationManagerImpl.java
@@ -1,23 +1,36 @@
 package org.sakaiproject.component.app.scheduler;
 
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.ListenerManager;
+import org.quartz.ObjectAlreadyExistsException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SchedulerFactory;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.TriggerListener;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.quartz.listeners.TriggerListenerSupport;
+import org.sakaiproject.api.app.scheduler.DelayedInvocation;
+import org.sakaiproject.api.app.scheduler.ScheduledInvocationManager;
+import org.sakaiproject.component.app.scheduler.jobs.ScheduledInvocationJob;
+import org.sakaiproject.id.api.IdManager;
+import org.sakaiproject.time.api.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import org.hibernate.NonUniqueObjectException;
-import org.quartz.*;
-import org.quartz.impl.matchers.GroupMatcher;
-import org.quartz.listeners.TriggerListenerSupport;
-import org.sakaiproject.component.app.scheduler.jobs.ScheduledInvocationJob;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sakaiproject.api.app.scheduler.DelayedInvocation;
-import org.sakaiproject.api.app.scheduler.ScheduledInvocationManager;
-import org.sakaiproject.id.api.IdManager;
-import org.sakaiproject.time.api.Time;
-import org.springframework.transaction.annotation.Transactional;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 /**
  * componentId -> job key (name)
@@ -76,14 +89,14 @@ public class ScheduledInvocationManagerImpl implements ScheduledInvocationManage
 	}
 
 	@Override
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public String createDelayedInvocation(Time  time, String componentId, String opaqueContext) {
 		Instant instant = Instant.ofEpochMilli(time.getTime());
 		return createDelayedInvocation(instant, componentId, opaqueContext);
 	}
 
 	@Override
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public String createDelayedInvocation(Instant instant, String componentId, String opaqueContext) {
 		String uuid = m_idManager.createUuid();
 		createDelayedInvocation(instant, componentId, opaqueContext, uuid);
@@ -95,7 +108,7 @@ public class ScheduledInvocationManagerImpl implements ScheduledInvocationManage
 	 * and specify the UUID that should be used.
 	 * @see org.sakaiproject.component.app.scheduler.jobs.SchedulerMigrationJob
 	 */
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public void createDelayedInvocation(Instant instant, String componentId, String opaqueContext, String uuid) {
 		String oldUuid = dao.get(componentId, opaqueContext);
 		// Delete the existing one.
@@ -140,7 +153,7 @@ public class ScheduledInvocationManagerImpl implements ScheduledInvocationManage
 	/* (non-Javadoc)
 	 * @see org.sakaiproject.api.app.scheduler.ScheduledInvocationManager#deleteDelayedInvocation(java.lang.String)
 	 */
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public void deleteDelayedInvocation(String uuid) {
 
 		LOG.debug("Removing Delayed Invocation: " + uuid);
@@ -157,7 +170,7 @@ public class ScheduledInvocationManagerImpl implements ScheduledInvocationManage
 	/* (non-Javadoc)
 	 * @see org.sakaiproject.api.app.scheduler.ScheduledInvocationManager#deleteDelayedInvocation(java.lang.String, java.lang.String)
 	 */
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public void deleteDelayedInvocation(String componentId, String opaqueContext) {
 		LOG.debug("componentId=" + componentId + ", opaqueContext=" + opaqueContext);
 
@@ -170,7 +183,7 @@ public class ScheduledInvocationManagerImpl implements ScheduledInvocationManage
 	/* (non-Javadoc)
 	 * @see org.sakaiproject.api.app.scheduler.ScheduledInvocationManager#findDelayedInvocations(java.lang.String, java.lang.String)
 	 */
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public DelayedInvocation[] findDelayedInvocations(String componentId, String opaqueContext) {
 		LOG.debug("componentId=" + componentId + ", opaqueContext=" + opaqueContext);
 		Collection<String> uuids = dao.find(componentId, opaqueContext);

--- a/jobscheduler/scheduler-component-shared/src/test/java/org/sakaiproject/component/app/scheduler/ScheduledInvocationTest.java
+++ b/jobscheduler/scheduler-component-shared/src/test/java/org/sakaiproject/component/app/scheduler/ScheduledInvocationTest.java
@@ -105,4 +105,23 @@ public class ScheduledInvocationTest {
         Assert.assertNotEquals(first, second);
     }
 
+    @Test
+    public void testFindMissingTrigger() {
+        // Check that find still work when a trigger can't be found for a delayed invocation
+        // Here we have an entry in the dao, but there won't be a trigger.
+        Mockito.when(dao.find(COMPONENT_ID, CONTEXT)).thenReturn(Collections.singleton("uuid"));
+        DelayedInvocation[] delayedInvocations = manager.findDelayedInvocations(COMPONENT_ID, CONTEXT);
+        Assert.assertTrue(delayedInvocations.length == 0);
+    }
+
+    @Test
+    public void testCreateMissingTrigger() {
+        // Check that creating a delayed invokation still works.
+        // Here we have an entry in the dao, but there won't be a trigger.
+        Mockito.when(dao.find(COMPONENT_ID, CONTEXT)).thenReturn(Collections.singleton("uuid"));
+        Mockito.when(dao.get(COMPONENT_ID, CONTEXT)).thenReturn("uuid");
+        String uuid = manager.createDelayedInvocation(Instant.now(), COMPONENT_ID, CONTEXT);
+        Assert.assertNotNull(uuid);
+    }
+
 }

--- a/jobscheduler/scheduler-events-model/src/java/org/sakaiproject/scheduler/events/hibernate/ContextMapping.java
+++ b/jobscheduler/scheduler-events-model/src/java/org/sakaiproject/scheduler/events/hibernate/ContextMapping.java
@@ -51,7 +51,6 @@ public class ContextMapping {
 
         ContextMapping that = (ContextMapping) o;
 
-        if (!uuid.equals(that.uuid)) return false;
         if (!contextId.equals(that.contextId)) return false;
         return componentId.equals(that.componentId);
 
@@ -59,9 +58,17 @@ public class ContextMapping {
 
     @Override
     public int hashCode() {
-        int result = uuid.hashCode();
-        result = 31 * result + contextId.hashCode();
+        int result = contextId.hashCode();
         result = 31 * result + componentId.hashCode();
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ContextMapping{" +
+                "uuid='" + uuid + '\'' +
+                ", contextId='" + contextId + '\'' +
+                ", componentId='" + componentId + '\'' +
+                '}';
     }
 }

--- a/jobscheduler/scheduler-events-model/src/java/org/sakaiproject/scheduler/events/hibernate/ContextMapping.java
+++ b/jobscheduler/scheduler-events-model/src/java/org/sakaiproject/scheduler/events/hibernate/ContextMapping.java
@@ -1,74 +1,42 @@
 package org.sakaiproject.scheduler.events.hibernate;
 
-import javax.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 /**
  * Just maps a context ID, component ID to a quartz trigger UUID.
  */
 @Entity(name = "context_mapping")
 @Table(uniqueConstraints={@UniqueConstraint(columnNames = {"componentId", "contextId"})})
+@EqualsAndHashCode(exclude = {"uuid"})
+@ToString
 public class ContextMapping {
 
+    /**
+     *This is the ID of the quartz trigger
+     */
     @Id
-    // This is the ID of the quartz trigger
+    @Getter @Setter
     private String uuid;
 
-    // This is the context ID (opaque ID) passed when the job was created.
+    /**
+     * This is the context ID (opaque ID) passed when the job was created.
+     */
+    @Getter @Setter
     private String contextId;
 
-    // This is the component ID, we have this as a separate column so that overlapping context IDs (opaque IDs) aren't
-    // a problem.
+    /**
+     * This is the component ID, we have this as a separate column so that overlapping context IDs (opaque IDs) aren't
+     * a problem.
+     */
+    @Getter @Setter
     private String componentId;
 
-    public String getContextId() {
-        return contextId;
-    }
-
-    public void setContextId(String contextId) {
-        this.contextId = contextId;
-    }
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public String getComponentId() {
-        return componentId;
-    }
-
-    public void setComponentId(String componentId) {
-        this.componentId = componentId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ContextMapping that = (ContextMapping) o;
-
-        if (!contextId.equals(that.contextId)) return false;
-        return componentId.equals(that.componentId);
-
-    }
-
-    @Override
-    public int hashCode() {
-        int result = contextId.hashCode();
-        result = 31 * result + componentId.hashCode();
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "ContextMapping{" +
-                "uuid='" + uuid + '\'' +
-                ", contextId='" + contextId + '\'' +
-                ", componentId='" + componentId + '\'' +
-                '}';
-    }
 }


### PR DESCRIPTION
Another option might have been to have quartz use our central transactions, but that would have been a larger change with more risk.