### PR TITLE
SAK-32295 Don’t fail attachments in peer review mode.

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -17293,7 +17293,8 @@ public class AssignmentAction extends PagedResourceActionII
 		String mode = (String) state.getAttribute(STATE_MODE);
 		List attachments;
 
-		if(MODE_STUDENT_REVIEW_EDIT.equals(mode)) {
+		boolean inPeerReviewMode = MODE_STUDENT_REVIEW_EDIT.equals(mode);
+		if(inPeerReviewMode) {
 			// construct the state variable for peer attachment list
 			attachments = state.getAttribute(PEER_ATTACHMENTS) != null? (List) state.getAttribute(PEER_ATTACHMENTS) : entityManager.newReferenceList();
 		} else {
@@ -17374,7 +17375,7 @@ public class AssignmentAction extends PagedResourceActionII
 
 						// Check if the file is acceptable with the ContentReviewService
 						boolean blockedByCRS = false;
-						if (serverConfigurationService.getBoolean("assignment.useContentReview", false) && contentReviewService != null && contentReviewService.isSiteAcceptable(s))
+						if (!inPeerReviewMode && serverConfigurationService.getBoolean("assignment.useContentReview", false) && contentReviewService != null && contentReviewService.isSiteAcceptable(s))
 						{
 							String assignmentReference = (String) state.getAttribute(VIEW_SUBMISSION_ASSIGNMENT_REFERENCE);
 							Assignment a = getAssignment(assignmentReference, "doAttachUpload", state);
@@ -17410,7 +17411,7 @@ public class AssignmentAction extends PagedResourceActionII
 							}
 						}
 
-						if(MODE_STUDENT_REVIEW_EDIT.equals(mode)) {
+						if(inPeerReviewMode) {
 							state.setAttribute(PEER_ATTACHMENTS, attachments);
 						} else {
 							state.setAttribute(ATTACHMENTS, attachments);


### PR DESCRIPTION
When an assignment is in peer review student review mode there is an option for the student to provide attachments for their review, however we were attempting to check these with content-review which isn’t correct (and was failing). So this check has been disabled when in peer review mode.