### PR TITLE
KNL-1498 Reduce memory usage when handling cache invalidation arising…

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
@@ -433,7 +433,7 @@ public abstract class SakaiSecurity implements SecurityService, Observer
                     HashSet<String> permKeysToInvalidate = new HashSet<>();
                     for (Member member : members) {
                         if (member != null && member.isActive() && member.getUserId() != null) {
-		            boolean canSwap = (member.getRole().isAllowed(SiteService.SITE_ROLE_SWAP));
+		            boolean canSwap = member.getRole().isAllowed(SiteService.SITE_ROLE_SWAP);
                             permKeysToInvalidate.add(makeCacheKey(member.getUserId(), null, perm, azgRef, false));
 			    // Only invalidate swapped roles if the user can swap
 			    // This is an approximation. If a user is swapped and their permission to swap is removed

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
@@ -417,6 +417,9 @@ public abstract class SakaiSecurity implements SecurityService, Observer
                 }
             }
         }
+
+        m_callCache.removeAll(keysToInvalidate);
+
         // now handle all the real users
 	// clear both normal and swapped users
 	// start with a set of all roles to which one can swap
@@ -425,29 +428,30 @@ public abstract class SakaiSecurity implements SecurityService, Observer
 
         Set<Member> members = azg.getMembers();
         if (members != null && !members.isEmpty()) {
-            for (Member member : members) {
+            for (String perm : permissions) {
+              HashSet<String> permKeysToInvalidate = new HashSet<String>();
+              for (Member member : members) {
                 if (member != null && member.isActive() && member.getUserId() != null) {
 		    boolean canSwap = (member.getRole().isAllowed(SiteService.SITE_ROLE_SWAP));
-                    for (String perm : permissions) {
-                        if (perm != null) {
-                            keysToInvalidate.add(makeCacheKey(member.getUserId(), null, perm, azgRef, false));
+                    if (perm != null) {
+                            permKeysToInvalidate.add(makeCacheKey(member.getUserId(), null, perm, azgRef, false));
 			    // Only invalidate swapped roles if the user can swap
 			    // This is an approximation. If a user is swapped and their permission to swap is removed
 			    // or the role they are swapped to has been removed from the site
 			    // we will not invalidate their data. Their info may wait until the expiration time to sync up
 			    if (canSwap) {
 				for (String invRole: svRolesFinal) {
-				    keysToInvalidate.add(makeCacheKey(member.getUserId(), invRole, perm, azgRef, false));
+				    permKeysToInvalidate.add(makeCacheKey(member.getUserId(), invRole, perm, azgRef, false));
 				}
-			    }
-                        }
-                    }
-                }
+		            }
+                      }
+                  }
+              }
+              // invalidate all keys (do this as a batch)
+              if (cacheDebug) M_log.info("SScache:changed "+azgRef+":keys="+keysToInvalidate);
+              m_callCache.removeAll(permKeysToInvalidate);
             }
         }
-        // invalidate all keys (do this as a batch)
-        if (cacheDebug) M_log.info("SScache:changed "+azgRef+":keys="+keysToInvalidate);
-        m_callCache.removeAll(keysToInvalidate);
         if (cacheDebug) logCacheState("cacheRealmPermsChanged("+realmRef+", roles="+roles+", perms="+permissions+")");
     }
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
@@ -429,11 +429,11 @@ public abstract class SakaiSecurity implements SecurityService, Observer
         Set<Member> members = azg.getMembers();
         if (members != null && !members.isEmpty()) {
             for (String perm : permissions) {
-              HashSet<String> permKeysToInvalidate = new HashSet<String>();
-              for (Member member : members) {
-                if (member != null && member.isActive() && member.getUserId() != null) {
-		    boolean canSwap = (member.getRole().isAllowed(SiteService.SITE_ROLE_SWAP));
-                    if (perm != null) {
+                if (perm != null) {
+                    HashSet<String> permKeysToInvalidate = new HashSet<>();
+                    for (Member member : members) {
+                        if (member != null && member.isActive() && member.getUserId() != null) {
+		            boolean canSwap = (member.getRole().isAllowed(SiteService.SITE_ROLE_SWAP));
                             permKeysToInvalidate.add(makeCacheKey(member.getUserId(), null, perm, azgRef, false));
 			    // Only invalidate swapped roles if the user can swap
 			    // This is an approximation. If a user is swapped and their permission to swap is removed
@@ -444,12 +444,12 @@ public abstract class SakaiSecurity implements SecurityService, Observer
 				    permKeysToInvalidate.add(makeCacheKey(member.getUserId(), invRole, perm, azgRef, false));
 				}
 		            }
-                      }
-                  }
-              }
-              // invalidate all keys (do this as a batch)
-              if (cacheDebug) M_log.info("SScache:changed "+azgRef+":keys="+keysToInvalidate);
-              m_callCache.removeAll(permKeysToInvalidate);
+                        }
+                    }
+                    // invalidate all keys (do this as a batch)
+                    if (cacheDebug) M_log.info("SScache:changed "+azgRef+":keys="+keysToInvalidate);
+                    m_callCache.removeAll(permKeysToInvalidate);
+                }
             }
         }
         if (cacheDebug) logCacheState("cacheRealmPermsChanged("+realmRef+", roles="+roles+", perms="+permissions+")");


### PR DESCRIPTION
… from a realm update

This is a compromise between creating a single large map of keys to invalidate, and calling
cache.remove() for each entry. In many cases (sites above 25 users or so), the set of potential
keys to invalidate will exceed the size of the cache. For large sites (for example 20K site members,
200 permissions), this iterates through the permissions first and does a set of cache invalidations
per permission, so the invalidation map size will be 20K. This still gains some efficiency by
allowing removeAll() to iterate through the smaller collection (the cache size).