### PR TITLE
SAK-32295 Just escape the attributes we need to.

### DIFF
--- a/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/macros/ImageMacro.java
+++ b/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/macros/ImageMacro.java
@@ -117,10 +117,10 @@ public class ImageMacro extends BaseMacro
 			{
 				link = context.convertLink(link);
 
-				writer.write("<a href=\"" + link + "\""); //$NON-NLS-1$ //$NON-NLS-2$
+				writer.write("<a href=\"" + Encoder.escape(link) + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 				if (target != null)
 				{
-					writer.write("target=\"" + target + "\""); //$NON-NLS-1$ //$NON-NLS-2$
+					writer.write("target=\"" + Encoder.escape(target) + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 				writer.write(">"); //$NON-NLS-1$
 			}
@@ -138,12 +138,12 @@ public class ImageMacro extends BaseMacro
 
 			imageName = context.convertLink(imageName);
 			writer.write("<img src=\""); //$NON-NLS-1$
-			writer.write(imageName);
+			writer.write(Encoder.escape(imageName));
 			writer.write("\" "); //$NON-NLS-1$
 			if (cssclass != null)
 			{
 				writer.write("class=\""); //$NON-NLS-1$
-				writer.write(cssclass);
+				writer.write(Encoder.escape(cssclass));
 				writer.write("\" "); //$NON-NLS-1$
 			}
 			if (alt != null)

--- a/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/service/impl/RWikiObjectServiceImpl.java
+++ b/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/service/impl/RWikiObjectServiceImpl.java
@@ -64,7 +64,6 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.orm.hibernate4.HibernateOptimisticLockingFailureException;
 import org.hibernate.HibernateException;
-import org.sakaiproject.util.api.FormattedText;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -142,8 +141,6 @@ public class RWikiObjectServiceImpl implements RWikiObjectService
 
 	private SecurityService securityService;
 
-	private FormattedText formattedTextService;
-
 	/** Configuration: to run the ddl on init or not. */
 	protected boolean autoDdl = false;
 
@@ -192,7 +189,6 @@ public class RWikiObjectServiceImpl implements RWikiObjectService
 		renderService = (RenderService) load(cm, RenderService.class.getName());
 		preferenceService = (PreferenceService) load(cm,
 				PreferenceService.class.getName());
-		formattedTextService = (FormattedText) load(cm, FormattedText.class.getName());
 		userDirectoryService = (UserDirectoryService) load(cm,UserDirectoryService.class.getName());
 		entityManager.registerEntityProducer(this,
 				RWikiObjectService.REFERENCE_ROOT);
@@ -591,11 +587,8 @@ public class RWikiObjectServiceImpl implements RWikiObjectService
 			// create a history instance
 			RWikiHistoryObject rwho = hdao.createRWikiHistoryObject(rwo);
 
-			// sanitize the content
-			String formattedContent = formattedTextService.escapeHtmlFormattedTextarea(content);
-
 			// set the content and increment the revision
-			rwo.setContent(formattedContent.replaceAll("\r\n?", "\n")); //$NON-NLS-1$ //$NON-NLS-2$
+			rwo.setContent(content.replaceAll("\r\n?", "\n")); //$NON-NLS-1$ //$NON-NLS-2$
 			rwo.setRevision(Integer.valueOf(rwo.getRevision().intValue() + 1));
 
 			// render to get a list of links


### PR DESCRIPTION
Rather than escaping everything in the wiki tool we just escape the output of the image tag so that we don’t accidentally escape content in the tool.