### PR TITLE
KNL-1507 HikariCP to 2.6.1

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1703,7 +1703,7 @@
       <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>2.6.0</version>
+        <version>2.6.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION

Changes in 2.6.1

 * issue 835 fix increased CPU consumption under heavy load caused by excessive
   spinning in the ConcurrentBag.requite() method.

 * issue 821 if a disconnection class exception is thrown during initial connection
   setup, do not set the flag that indicates that checkDriverSupport() is complete.

 * issue 817 updated behavior of new initializationFailTimeout, please see the
   official documentation for details.

 * issue 742 add direct MXBean accessor methods to HikariDataSource for users who do 
   not want run run JMX.