### PR TITLE
KNL-1508 Don’t lose title changes on save.

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SitePage.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SitePage.java
@@ -45,7 +45,8 @@ public interface SitePage extends Edit, Serializable
 
 	/** flag custom page title (excluded from localization) */
 	public static final String PAGE_CUSTOM_TITLE_PROP = "sitePage.customTitle";
-	
+
+	/** String that contains a list of tools IDs on the home page that have custom titles. */
 	public static final String PAGE_HOME_TOOLS_CUSTOM_TITLE_PROP = "sitePage.homeToolsCustomTitle";
    
 	/** boolean page property for site home page **/

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseToolConfiguration.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseToolConfiguration.java
@@ -580,6 +580,13 @@ public class BaseToolConfiguration extends org.sakaiproject.util.Placement imple
 		return rv;
 	}
 
+	public void setTitle(String title)
+	{
+		// This is needed so that on save we don't lose the title attribute.
+		m_custom_title = title != null;
+		super.setTitle(title);
+	}
+
 	/**
 	 * Replace tool title with its localized value
 	 * 


### PR DESCRIPTION
When saving the placement the SQL code calls getTitle() which checks if the placement has a custom title and unless it does just returns the default title for the tool.

This change means that when we changes the title the flag indicating that it has a custom title is also updated and so the save works.