### PR TITLE
LSNBLDR-711: Adding config for lessonbuilder.show.twitter.link

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4693,6 +4693,13 @@
 #  edit your widget (or create one if you don't have one), and the id (a long number) is the value of "data-widget-id"
 #  in the embed code bottom right.
 #lessonbuilder.twitter.widget.id=123456789012345678
+#
+# Set this to false to hide the 'Embed Twitter Timeline' link which
+# appears in the list when you click 'Add Content' in Lessons tool
+#
+# true/false Defaults to true (on)
+# ###############################################################
+#lessonbuilder.show.twitter.link=false
 
 #SAK-25438 - Zip Download in Resources
 #Option is not available unless the next properties are configured with a value (in bytes) greater than 0.

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4697,9 +4697,9 @@
 # Set this to false to hide the 'Embed Twitter Timeline' link which
 # appears in the list when you click 'Add Content' in Lessons tool
 #
-# true/false Defaults to true (on)
+# true/false Defaults to false (off)
 # ###############################################################
-#lessonbuilder.show.twitter.link=false
+#lessonbuilder.show.twitter.link=true
 
 #SAK-25438 - Zip Download in Resources
 #Option is not available unless the next properties are configured with a value (in bytes) greater than 0.

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -4092,10 +4092,13 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		    makeCsrf(form, "csrf26");
 		    UICommand.make(form, "add-student", "#{simplePageBean.addStudentContentSection}");
 
-			//Adding 'Embed twitter timeline' component
-			UIOutput.make(tofill, "twitter-li");
-			UILink twitterLink = UIInternalLink.makeURL(tofill, "add-twitter", "#");
-			twitterLink.decorate(new UITooltipDecorator(messageLocator.getMessage("simplepage.twitter-descrip")));
+			boolean showEmbedTwitterLink = ServerConfigurationService.getBoolean("lessonbuilder.show.twitter.link", true);
+			if (showEmbedTwitterLink){
+				//Adding 'Embed twitter timeline' component
+				UIOutput.make(tofill, "twitter-li");
+				UILink twitterLink = UIInternalLink.makeURL(tofill, "add-twitter", "#");
+				twitterLink.decorate(new UITooltipDecorator(messageLocator.getMessage("simplepage.twitter-descrip")));
+			}
 		    // in case we're on an old system without current BLTI
 		    if (bltiEntity != null && ((BltiInterface)bltiEntity).servicePresent()) {
 			Collection<BltiTool> bltiTools = simplePageBean.getBltiTools();

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -4092,7 +4092,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		    makeCsrf(form, "csrf26");
 		    UICommand.make(form, "add-student", "#{simplePageBean.addStudentContentSection}");
 
-			boolean showEmbedTwitterLink = ServerConfigurationService.getBoolean("lessonbuilder.show.twitter.link", true);
+			boolean showEmbedTwitterLink = ServerConfigurationService.getBoolean("lessonbuilder.show.twitter.link", false);
 			if (showEmbedTwitterLink){
 				//Adding 'Embed twitter timeline' component
 				UIOutput.make(tofill, "twitter-li");


### PR DESCRIPTION
This is adding some config to LSNBLDR-711 so that the feature can be turned on or off.

Default is on.

If this goes back to 11.x, then the property should be set to false and uncommented.