### PR TITLE
SAK-32360 Always pass site ID to LTI calls.

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -359,7 +359,7 @@ public interface LTIService {
     String getExportUrl(String siteId, String filterId, ExportType exportType);
 
 
-    List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteIf);
+    List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId);
 
     /**
      * Gets a list of the launchable tools in the site

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -39,41 +39,257 @@ import org.sakaiproject.site.api.Site;
  * </p>
  */
 public interface LTIService {
-	/** This string starts the references to resources in this service. */
-	static final String REFERENCE_ROOT = "/lti";
+    /**
+     * This string starts the references to resources in this service.
+     */
+    String REFERENCE_ROOT = "/lti";
 
-	/** Our indication that a secret is hidden */
-        public static final String SECRET_HIDDEN = "***************";
+    /**
+     * Our indication that a secret is hidden
+     */
+    String SECRET_HIDDEN = "***************";
 
-	static String WEB_PORTLET = "sakai.web.168";
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public boolean isAdmin();
+    String WEB_PORTLET = "sakai.web.168";
+    /**
+     * Model Descriptions for Foorm You should probably retrieve these through getters in
+     * case there is some filtering in the service based on role/permission
+     */
+    String[] CONTENT_MODEL = {
+            "id:key",
+            "tool_id:integer:hidden=true",
+            "SITE_ID:text:label=bl_content_site_id:required=true:maxlength=99:role=admin",
+            "title:text:label=bl_title:required=true:allowed=true:maxlength=1024",
+            "pagetitle:text:label=bl_pagetitle:required=true:allowed=true:maxlength=1024",
+            "fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
+            "frameheight:integer:label=bl_frameheight:allowed=true",
+            "newpage:checkbox:label=bl_newpage",
+            "debug:checkbox:label=bl_debug",
+            "custom:textarea:label=bl_custom:rows=5:cols=25:allowed=true:maxlength=16384",
+            "launch:url:label=bl_launch:maxlength=1024:allowed=true",
+            "consumerkey:text:label=bl_consumerkey:allowed=true:maxlength=1024",
+            "secret:text:label=bl_secret:allowed=true:maxlength=1024",
+            "resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin:only=lti2",
+            "xmlimport:text:hidden=true:maxlength=1M",
+            // LTI 2.x settings
+            "settings:text:hidden=true:maxlength=1M",
+            // Sakai LTI 1.x extension settings (see SAK-25621)
+            "settings_ext:text:hidden=true:maxlength=1M",
+            // LTI Content-Item (see SAK-29328)
+            "contentitem:text:label=bl_contentitem:rows=5:cols=25:maxlength=1M:hidden=true",
+            "placement:text:hidden=true:maxlength=256",
+            "placementsecret:text:hidden=true:maxlength=512",
+            "oldplacementsecret:text:hidden=true:maxlength=512",
+            "created_at:autodate",
+            "updated_at:autodate"};
+    String[] CONTENT_EXTRA_FIELDS = {
+            "SITE_TITLE:text:table=SAKAI_SITE:realname=TITLE",
+            "SITE_CONTACT_NAME:text:table=ssp1:realname=VALUE",
+            "SITE_CONTACT_EMAIL:text:table=ssp2:realname=VALUE",
+            "ATTRIBUTION:text:table=ssp3:realname=VALUE",
+            "URL:text:table=lti_tools:realname=launch",
+            "searchURL:text:table=NULL" //no realname and table is NULL for this, it just exists in the select
+    };
+    /**
+     *
+     */
+    String[] TOOL_MODEL = {
+            "id:key",
+            "version:radio:label=bl_version:choices=lti1,lti2:hidden=true",
+            "SITE_ID:text:maxlength=99:role=admin",
+            "title:text:label=bl_title:required=true:maxlength=1024",
+            "allowtitle:radio:label=bl_allowtitle:choices=disallow,allow",
+            "fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
+            "pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
+            "allowpagetitle:radio:label=bl_allowpagetitle:choices=disallow,allow",
+            "description:textarea:label=bl_description:maxlength=4096",
+            "status:radio:label=bl_status:choices=enable,disable",
+            "visible:radio:label=bl_visible:choices=visible,stealth:role=admin",
+            "resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin:only=lti2",
+            "deployment_id:integer:hidden=true",
+            "lti2_launch:header:fields=launch,consumerkey,secret:only=lti2",
+            "launch:url:label=bl_launch:maxlength=1024:required=true",
+            "allowlaunch:radio:label=bl_allowlaunch:choices=disallow,allow:only=lti1",
+            "consumerkey:text:label=bl_consumerkey:maxlength=1024",
+            "allowconsumerkey:radio:label=bl_allowconsumerkey:choices=disallow,allow:only=lti1",
+            "secret:text:label=bl_secret:maxlength=1024",
+            "allowsecret:radio:label=bl_allowsecret:choices=disallow,allow:only=lti1",
+            "frameheight:integer:label=bl_frameheight",
+            "allowframeheight:radio:label=bl_allowframeheight:choices=disallow,allow",
+            "privacy:header:fields=sendname,sendemailaddr",
+            "sendname:checkbox:label=bl_sendname",
+            "sendemailaddr:checkbox:label=bl_sendemailaddr",
+            "services:header:fields=allowoutcomes,allowroster,allowsettings",
+            "allowoutcomes:checkbox:label=bl_allowoutcomes",
+            "allowroster:checkbox:label=bl_allowroster",
+            "allowsettings:checkbox:label=bl_allowsettings",
+            // Hide these from end users until they are working in the various Sakai tools
+            "pl_header:header:fields=pl_launch,pl_linkselection,pl_importitem,pl_fileitem,pl_contenteditor,pl_assessmentselection",
+            "pl_launch:checkbox:label=bl_pl_launch",
+            "pl_linkselection:checkbox:label=bl_pl_linkselection",
+            "pl_importitem:checkbox:label=bl_pl_importitem:role=admin",
+            "pl_fileitem:checkbox:label=bl_pl_fileitem:role=admin",
+            "pl_contenteditor:checkbox:label=bl_pl_contenteditor:role=admin",
+            "pl_assessmentselection:checkbox:label=bl_pl_assessmentselection:role=admin",
+            "newpage:radio:label=bl_newpage:choices=off,on,content",
+            "debug:radio:label=bl_debug:choices=off,on,content",
+            // LTI 1.x user-entered custom
+            "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384",
+            // LTI 2.x settings from web services
+            "settings:text:hidden=true:maxlength=1M",
+            // LTI 2.x tool-registration time parameters
+            "parameter:textarea:label=bl_parameter:rows=5:cols=25:maxlength=16384:only=lti2",
+            "tool_proxy_binding:textarea:label=bl_tool_proxy_binding:maxlength=2M:only=lti2:hide=insert:role=admin",
+            "allowcustom:checkbox:label=bl_allowcustom",
+            "xmlimport:textarea:hidden=true:maxlength=1M",
+            "splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384",
+            "created_at:autodate",
+            "updated_at:autodate"};
+    /**
+     *
+     */
+    String[] DEPLOY_MODEL = {
+            "id:key",
+            "reg_state:radio:label=bl_reg_state:choices=lti2_ready,lti2_received,lti2_complete:hidden=true",
+            "title:text:label=bl_title:required=true:maxlength=1024",
+            "pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
+            "description:textarea:label=bl_description:maxlength=4096",
+            "lti2_status:header:fields=status,visible",
+            "status:radio:label=bl_status:choices=enable,disable",
+            "visible:radio:label=bl_visible:choices=visible,stealth:role=admin",
+            "privacy:header:fields=sendname,sendemailaddr",
+            "sendname:checkbox:label=bl_sendname",
+            "sendemailaddr:checkbox:label=bl_sendemailaddr",
+            "services:header:fields=allowoutcomes,allowroster,allowsettings",
+            "allowoutcomes:checkbox:label=bl_allowoutcomes",
+            "allowroster:checkbox:label=bl_allowroster",
+            "allowsettings:checkbox:label=bl_allowsettings",
+            "allowcontentitem:checkbox:label=bl_allowcontentitem",
+            "lti2_internal:header:fields=reg_launch,reg_key,reg_secret,reg_password,consumerkey,secret,reg_profile:hide=insert",
+            "reg_launch:url:label=bl_reg_launch:maxlength=1024:role=admin",
+            "reg_key:text:label=bl_reg_key:maxlength=1024:hide=insert:role=admin",
+            "reg_password:text:label=bl_reg_password:maxlength=1024:hide=insert:role=admin",
+            "reg_ack:text:label=bl_reg_ack:maxlength=4096:hide=insert:role=admin",
+            "consumerkey:text:label=bl_consumerkey:maxlength=1024:hide=insert",
+            "secret:text:label=bl_secret:maxlength=1024:hide=insert",
+            "new_secret:text:label=bl_secret:maxlength=1024:hide=insert",
+            "reg_profile:textarea:label=bl_reg_profile:maxlength=2M:hide=insert:role=admin",
+            "settings:text:hidden=true:maxlength=1M",   // This is "custom" in the JSON
+            "created_at:autodate",
+            "updated_at:autodate"};
+    // The model for the ToolProxy Binding (LTI 2.0)
+    String[] BINDING_MODEL = {
+            "id:key",
+            "tool_id:integer:hidden=true",
+            "SITE_ID:text:maxlength=99:role=admin",
+            "settings:text:hidden=true:maxlength=1M",
+            "created_at:autodate",
+            "updated_at:autodate"};
+    String[] MEMBERSHIPS_JOBS_MODEL = {
+            "SITE_ID:text:maxlength=99:required=true",
+            "memberships_id:text:maxlength=256:required=true",
+            "memberships_url:text:maxlength=4000:required=true",
+            "consumerkey:text:label=bl_consumerkey:allowed=true:maxlength=1024",
+            "lti_version:text:maxlength=32:required=true"};
+    /**
+     * Static constants for data fields
+     */
 
-	/**
-	 * 
-	 * @return
-	 */
-	public boolean isMaintain();
+    String LTI_ID = "id";
+    String LTI_SITE_ID = "SITE_ID";
+    String LTI_TOOL_ID = "tool_id";
+    String LTI_TITLE = "title";
+    String LTI_ALLOWTITLE = "allowtitle";
+    String LTI_PAGETITLE = "pagetitle";
+    String LTI_ALLOWPAGETITLE = "allowpagetitle";
+    String LTI_FA_ICON = "fa_icon";
+    String LTI_PLACEMENT = "placement";
+    String LTI_DESCRIPTION = "description";
+    String LTI_STATUS = "status";
+    String LTI_VISIBLE = "visible";
+    String LTI_LAUNCH = "launch";
+    String LTI_ALLOWLAUNCH = "allowlaunch";
+    String LTI_CONSUMERKEY = "consumerkey";
+    String LTI_ALLOWCONSUMERKEY = "allowconsumerkey";
+    String LTI_SECRET = "secret";
+    String LTI_NEW_SECRET = "new_secret";
+    String LTI_ALLOWSECRET = "allowsecret";
+    String LTI_SECRET_INCOMPLETE = "-----";
+    String LTI_FRAMEHEIGHT = "frameheight";
+    String LTI_ALLOWFRAMEHEIGHT = "allowframeheight";
+    String LTI_SENDNAME = "sendname";
+    String LTI_SENDEMAILADDR = "sendemailaddr";
+    String LTI_ALLOWOUTCOMES = "allowoutcomes";
+    String LTI_ALLOWROSTER = "allowroster";
+    String LTI_ALLOWSETTINGS = "allowsettings";
+    String LTI_ALLOWCONTENTITEM = "allowcontentitem";
+    String LTI_SETTINGS = "settings";
+    String LTI_SETTINGS_EXT = "settings_ext";
+    String LTI_CONTENTITEM = "contentitem";
+    String LTI_NEWPAGE = "newpage";
+    String LTI_DEBUG = "debug";
+    String LTI_CUSTOM = "custom";
+    String LTI_SPLASH = "splash";
+    String LTI_ALLOWCUSTOM = "allowcustom";
+    String LTI_XMLIMPORT = "xmlimport";
+    String LTI_CREATED_AT = "created_at";
+    String LTI_UPDATED_AT = "updated_at";
+    String LTI_MATCHPATTERN = "matchpattern";
+    String LTI_NOTE = "note";
+    String LTI_PLACEMENTSECRET = "placementsecret";
+    String LTI_OLDPLACEMENTSECRET = "oldplacementsecret";
+    String LTI_DEPLOYMENT_ID = "deployment_id";
+    // BLTI-230 - LTI 2.0
+    String LTI_VERSION = "version";
+    Long LTI_VERSION_1 = 0L;
+    Long LTI_VERSION_2 = new Long(1);
+    String LTI_RESOURCE_HANDLER = "resource_handler";
+    String LTI_REG_STATE = "reg_state";
+    String LTI_REG_STATE_REGISTERED = "1";
+    String LTI_REG_LAUNCH = "reg_launch";
+    String LTI_REG_KEY = "reg_key";
+    String LTI_REG_ACK = "reg_ack";
+    String LTI_REG_PASSWORD = "reg_password";
+    String LTI_PARAMETER = "parameter";
+    String LTI_REG_PROFILE = "reg_profile"; // A.k.a tool_proxy
+    // A subset of a tool_proxy with only a single resource_handler
+    String LTI_TOOL_PROXY_BINDING = "tool_proxy_binding";
+    // End of BLTI-230 - LTI 2.0
+    String LTI_PL_LAUNCH = "pl_launch";
+    String LTI_PL_LINKSELECTION = "pl_linkselection";
+    String LTI_PL_FILEITEM = "pl_fileitem";
+    String LTI_PL_IMPORTITEM = "pl_importitem";
+    String LTI_PL_CONTENTEDITOR = "pl_contenteditor";
+    String LTI_PL_ASSESSMENTSELECTION = "pl_assessmentselection";
+    String LTI_SEARCH_TOKEN_SEPARATOR_AND = "#&#";
+    String LTI_SEARCH_TOKEN_SEPARATOR_OR = "#|#";
+    String ESCAPED_LTI_SEARCH_TOKEN_SEPARATOR_AND = "\\#\\&\\#";
+    String ESCAPED_LTI_SEARCH_TOKEN_SEPARATOR_OR = "\\#\\|\\#";
+    String LTI_SEARCH_TOKEN_NULL = "#null#";
+    String LTI_SEARCH_TOKEN_DATE = "#date#";
+    String LTI_SEARCH_TOKEN_EXACT = "#exact#";
+    String LTI_SEARCH_INTERNAL_DATE_FORMAT = "dd/MM/yyyy H:mm:ss";
+    String LTI_SITE_ATTRIBUTION_PROPERTY_KEY = "basiclti.tool.site.attribution.key";
+    String LTI_SITE_ATTRIBUTION_PROPERTY_KEY_DEFAULT = "Department";
+    String LTI_SITE_ATTRIBUTION_PROPERTY_NAME = "basiclti.tool.site.attribution.name";
+    String LTI_SITE_ATTRIBUTION_PROPERTY_NAME_DEFAULT = "content.attribution";
+
+    // For Instructors, this model is filtered down dynamically based on
+    // Tool settings
+
+    boolean isMaintain(String siteId);
 
     /**
      * Adds a memberships job. Quartz uses these to sync memberships for LTI
      * sites
-     *
-     * @param newProps
-     * @return
      */
-    public Object insertMembershipsJob(String siteId, String membershipsId, String membershipsUrl, String consumerKey, String ltiVersion);
+    Object insertMembershipsJob(String siteId, String membershipsId, String membershipsUrl, String consumerKey, String ltiVersion);
 
     /**
      * Gets the memberships job for a site.
      *
      * @return A single row mapping, or null if none exists yet.
      */
-    public Map<String, Object> getMembershipsJob(String siteId);
+    Map<String, Object> getMembershipsJob(String siteId);
 
     /**
      * Gets all the memberships jobs. Quartz uses these to sync memberships for LTI
@@ -81,872 +297,212 @@ public interface LTIService {
      *
      * @return A list of row mappings
      */
-    public List<Map<String, Object>> getMembershipsJobs();
-
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getToolModel();
-
-	/**
-	 * 
-	 * @param newProps
-	 * @return
-	 */
-	public Object insertTool(Properties newProps);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @return
-	 */
-	public Object insertTool(Map<String,Object> newProps);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object insertToolDao(Properties newProps, String siteId);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @param siteId
-	 * @param isAdminRole
-	 * @param isMaintainRole
-	 * @return
-	 */
-        public Object insertToolDao(Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * insert lti tool content
-	 * @param id
-	 * @param toolId
-	 * @param reqProps
-	 * @return
-	 */
-	public Object insertToolContent(String id, String toolId, Properties reqProps);
-	
-	/**
-	 * insert lti tool content
-	 * @param id
-	 * @param toolId
-	 * @param reqProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object insertToolContent(String id, String toolId, Properties reqProps, String siteId);
-
-	/**
-	 * create an instance of lti tool within site
-	 * @param id
-	 * @param title
-	 * @return
-	 */
-	public Object insertToolSiteLink(String id, String title);
-	
-	/**
-	 * create an instance of lti tool within site
-	 * @param id
-	 * @param title
-	 * @param siteId
-	 * @return
-	 */
-	public Object insertToolSiteLink(String id, String title, String siteId);
-	
-	/**
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public Map<String, Object> getTool(Long key);
-
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @return
-	 */
-	public Map<String, Object> getToolDao(Long key, String siteId);
-
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @param isAdminRole
-	 * @return
-	 */
-        public abstract Map<String, Object> getToolDao(Long key, String siteId, boolean isAdminRole);
-
-	/**
-	 * 
-	 * @param resourceType
-	 * @return
-	 */
-	public Map<String, Object> getToolForResourceHandlerDao(String resourceType);
-
-	/**
-	 * 
-	 * @param url
-	 * @return
-	 */
-	public Map<String, Object> getTool(String url);
-
-	/**
-	 * 
-	 * @param tool
-	 * @param siteId
-	 * @return
-	 */
-	public String getToolLaunch(Map<String, Object> tool, String siteId);
-	
-	/**
-	 * 
-	 * @param siteId
-	 * @param filterId
-	 * @param exportType
-	 * @return
-	 */
-	public String getExportUrl(String siteId, String filterId, ExportType exportType);
-
-	/**
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public boolean deleteTool(Long key);
-
-	/**
-	 * 
-	 * @param key
-	 * @param isAdminRole
-	 * @param isMainRole
-	 * @param key
-	 * @return
-	 */
-        public boolean deleteToolDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateTool(Long key, Properties newProps);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateTool(Long key, Map<String, Object> newProps);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object updateToolDao(Long key, Map<String, Object> newProps, String siteId);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @param isMaintainRole
-	 * @return
-	 */
-	public Object updateToolDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @return
-	 */
-	public List<Map<String, Object>> getTools(String search, String order, int first, int last);
-
-	/**
-	 * Gets a list of the launchable tools in the site
-	 */
-	public List<Map<String, Object>> getToolsLaunch();
-
-	/**
-	 * Gets a list of tools that can configure themselves in the site
-	 */
-	public List<Map<String, Object>> getToolsLtiLink();
-
-	/**
-	 * Get a list of tools that can return a FileItem
-	 */
-	public List<Map<String, Object>> getToolsFileItem();
-
-	/**
-	 * Get a list of tools that can return an imported Common Cartridge
-	 */
-	public List<Map<String, Object>> getToolsImportItem();
-
-	/**
-	 * Get a list of tools that can return content for the editor
-	 */
-	public List<Map<String, Object>> getToolsContentEditor();
-
-	/**
-	 * Get a list of tools that can function as Assessments
-	 */
-	public List<Map<String, Object>> getToolsAssessmentSelection();
-
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @param siteId
-	 * @return
-	 */
-	public List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId);
-
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @param isAdmin
-	 * @return
-	 */
-	public List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId, boolean isAdmin);
-
-	/**
-	 * 
-	 * @param tool_id
-	 * @return
-	 */
-	public String[] getContentModel(Long tool_id);
-
-	/**
-	 * 
-	 * @param tool
-	 * @return
-	 */
-	public String[] getContentModel(Map<String,Object> tool);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @return
-	 */
-	public Object insertContent(Properties newProps);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object insertContentDao(Properties newProps, String siteId);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @param siteId
-	 * @param isAdminRole
-	 * @param isMaintainRole
-	 * @return
-	 */
-        public Object insertContentDao(Properties newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public Map<String, Object> getContent(Long key);
-	
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @return
-	 */
-	public Map<String, Object> getContent(Long key, String siteId);
-
-	/**
-	 * Absolutely no checking at all.
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public Map<String, Object> getContentDao(Long key);
-
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @return
-	 */
-	public Map<String, Object> getContentDao(Long key, String siteId);
-
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @param isAdminRole
-	 * @return
-	 */
-        public Map<String, Object> getContentDao(Long key, String siteId, boolean isAdminRole);
+    List<Map<String, Object>> getMembershipsJobs();
 
 
-	/**
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public boolean deleteContent(Long key);
+    // -- Models
 
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @param isAdminRole
-	 * @param isMaintainRole
-	 * @return
-	 */
-	public boolean deleteContentDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
-	
-	/**
-	 * remove the tool content site link
-	 * @param key
-	 * @return
-	 */
-	public String deleteContentLink(Long key);
+    String[] getToolModel(String siteId);
 
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateContent(Long key, Map<String, Object> newProps);
+    String[] getContentModel(Long tool_id, String siteId);
 
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateContent(Long key, Properties newProps);
-	
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object updateContent(Long key, Properties newProps, String siteId);
+    String[] getContentModel(Map<String, Object> tool, String siteId);
 
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object updateContentDao(Long key, Map<String, Object> newProps, String siteId);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @param isAdminRole
-	 * @param isMaintainRole
-	 * @return
-	 */
-	public Object updateContentDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @return
-	 */
-	public List<Map<String, Object>> getContents(String search, String order, int first, int last);
+    String[] getDeployModel();
 
 
-	/**
-	 * This finds a set of LTI Contents objects.
-	 * @param search The SQL search string to limit the results
-	 * @param order The SQL order by string.
-	 * @param first The first item that should be returned.
-	 * @param last The last item that should be returned.
-	 * @param siteId The site ID or null to search as admin.
-	 * @return A List of LTI Contents objects.
-	 */
-	public List<Map<String, Object>> getContentsDao(String search, String order, int first, int last, String siteId);
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @param siteId
-	 * @param isAdminRole
-	 * @return
-	 */
-        public  List<Map<String, Object>> getContentsDao(String search, String order, int first, int last, String siteId, boolean isAdminRole);
-    
+    // ---Tool
+
+    Object insertTool(Properties newProps, String siteId);
+
+    Object insertTool(Map<String, Object> newProps, String siteId);
+
+    Object insertToolDao(Properties newProps, String siteId);
+
+    Object insertToolDao(Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+    boolean deleteTool(Long key, String siteId);
+
+    boolean deleteToolDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+    Map<String, Object> getTool(String url);
+
+    Map<String, Object> getTool(Long key, String siteId);
+
+    Map<String, Object> getToolDao(Long key, String siteId);
+
+    Map<String, Object> getToolDao(Long key, String siteId, boolean isAdminRole);
+
+
+    Object updateTool(Long key, Properties newProps, String siteId);
+
+    Object updateTool(Long key, Map<String, Object> newProps, String siteId);
+
+    Object updateToolDao(Long key, Map<String, Object> newProps, String siteId);
+
+    Object updateToolDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+
+
+
+    // -- Tool Content
+    Object insertToolContent(String id, String toolId, Properties reqProps, String siteId);
+
+    Object insertToolSiteLink(String id, String title, String siteId);
+
+
+
+    Map<String, Object> getToolForResourceHandlerDao(String resourceType);
+
+
+
+    String getToolLaunch(Map<String, Object> tool, String siteId);
+
+    String getExportUrl(String siteId, String filterId, ExportType exportType);
+
+
+    List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteIf);
+
     /**
-	 * 
-	 * @param search
-	 * @return
-	 */
-    public int countContents(String search);
-    
+     * Gets a list of the launchable tools in the site
+     * @param siteId
+     */
+    List<Map<String, Object>> getToolsLaunch(String siteId);
+
     /**
-	 * 
-	 * @param search
-	 * @param siteId
-	 * @param isAdminRole
-	 * @return
-	 */
-    public int countContentsDao(String search, String siteId, boolean isAdminRole);
+     * Gets a list of tools that can configure themselves in the site
+     * @param siteId
+     */
+    List<Map<String, Object>> getToolsLtiLink(String siteId);
 
-	/**
-	 * 
-	 * @param content
-	 * @return
-	 */
-	public String getContentLaunch(Map<String, Object> content);
+    /**
+     * Get a list of tools that can return a FileItem
+     * @param siteId
+     */
+    List<Map<String, Object>> getToolsFileItem(String siteId);
 
-	/**
-	 * 
-	 * @param content
-	 * @param tool
-	 */
-	public void filterContent(Map<String, Object> content, Map<String, Object> tool);
+    /**
+     * Get a list of tools that can return an imported Common Cartridge
+     * @param siteId
+     */
+    List<Map<String, Object>> getToolsImportItem(String siteId);
 
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getDeployModel();
+    /**
+     * Get a list of tools that can return content for the editor
+     * @param siteId
+     */
+    List<Map<String, Object>> getToolsContentEditor(String siteId);
 
-	/**
-	 * 
-	 * @param newProps
-	 * @return
-	 */
-	public Object insertDeployDao(Properties newProps);
+    /**
+     * Get a list of tools that can function as Assessments
+     * @param siteId
+     */
+    List<Map<String, Object>> getToolsAssessmentSelection(String siteId);
 
-	/**
-	 * 
-	 * @param newProps
-	 * @param siteId
-	 * @param isMaintainRole
-	 * @param isAdminRole
-	 * @return
-	 */
-        public Object insertDeployDao(Properties newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
+    List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId);
 
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateDeployDao(Long key, Object newProps);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @param isMaintainRole
-	 * @param isAdminRole
-	 * @return
-	 */
-        public Object updateDeployDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public boolean deleteDeployDao(Long key);
-
-	/**
-	 * 
-	 * @param key
-	 * @param siteId
-	 * @param isMaintainRole
-	 * @param isAdminRole
-	 * @return
-	 */
-        public boolean deleteDeployDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
-
-	/**
-	 * Absolutely no checking at all.
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public Map<String, Object> getDeployDao(Long key);
-
-	/**
-	 * Absolutely no checking at all.
-	 * 
-	 * @param key
-	 * @param isMaintainRole
-	 * @param isAdminRole
-	 * @return
-	 */
-        public  Map<String, Object> getDeployDao(Long key, String siteId, boolean isAdminRole);
-
-	/**
-	 * Absolutely no checking at all.
-	 * 
-	 * @param consumerKey
-	 * @return
-	 */
-	public Map<String, Object> getDeployForConsumerKeyDao(String consumerKey);
-
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @param siteId
-	 * @return
-	 */
-	public List<Map<String, Object>> getDeploysDao(String search, String order, int first, int last);
-
-	/**
-	 * 
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @param siteId
-	 * @param isAdminRole
-	 * @return
-	 */
-        public List<Map<String, Object>> getDeploysDao(String search, String order, int first, int last, String siteId, boolean isAdminRole);
-
-	/**
-	 * 
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
-	public Object insertProxyBindingDao(Properties newProps);
-
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateProxyBindingDao(Long key, Object newProps);
-
-	/**
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public boolean deleteProxyBindingDao(Long key);
-
-	/**
-	 * Absolutely no checking at all.
-	 * 
-	 * @param key
-	 * @return
-	 */
-	public Map<String, Object> getProxyBindingDao(Long key);
-
-	/**
-	 * Absolutely no checking at all.
-	 * 
-	 * @param tool_id
-	 * @param siteId
-	 * @return
-	 */
-	public Map<String, Object> getProxyBindingDao(Long tool_id, String siteId);
+    List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId, boolean isAdmin);
 
 
-	/**
-	 * 
-	 * @param row
-	 * @param fieldInfo
-	 * @return
-	 */
-	public String formOutput(Object row, String fieldInfo);
+    // --- Content
 
-	/**
-	 * 
-	 * @param row
-	 * @param fieldInfo
-	 * @return
-	 */
-	public String formOutput(Object row, String[] fieldInfo);
+    Object insertContent(Properties newProps, String siteId);
 
-	/**
-	 * 
-	 * @param row
-	 * @param fieldInfo
-	 * @return
-	 */
-	public String formInput(Object row, String fieldInfo);
+    Object insertContentDao(Properties newProps, String siteId);
 
-	/**
-	 * 
-	 * @param row
-	 * @param fieldInfo
-	 * @return
-	 */
-	public String formInput(Object row, String[] fieldInfo);
+    Object insertContentDao(Properties newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
 
-	// For Instructors, this model is filtered down dynamically based on
-	// Tool settings
-	/**
-	 * Model Descriptions for Foorm You should probably retrieve these through getters in
-	 * case there is some filtering in the service based on role/permission
-	 */
-	static String[] CONTENT_MODEL = { 
-		"id:key", 
-		"tool_id:integer:hidden=true",
-		"SITE_ID:text:label=bl_content_site_id:required=true:maxlength=99:role=admin",
-		"title:text:label=bl_title:required=true:allowed=true:maxlength=1024",
-		"pagetitle:text:label=bl_pagetitle:required=true:allowed=true:maxlength=1024",
-		"fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
-		"frameheight:integer:label=bl_frameheight:allowed=true",
-		"newpage:checkbox:label=bl_newpage",
-		"debug:checkbox:label=bl_debug",
-		"custom:textarea:label=bl_custom:rows=5:cols=25:allowed=true:maxlength=16384",
-		"launch:url:label=bl_launch:maxlength=1024:allowed=true",
-		"consumerkey:text:label=bl_consumerkey:allowed=true:maxlength=1024",
-		"secret:text:label=bl_secret:allowed=true:maxlength=1024",
-		"resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin:only=lti2",
-		"xmlimport:text:hidden=true:maxlength=1M",
-		// LTI 2.x settings
-		"settings:text:hidden=true:maxlength=1M",
-		// Sakai LTI 1.x extension settings (see SAK-25621)
-		"settings_ext:text:hidden=true:maxlength=1M",
-		// LTI Content-Item (see SAK-29328)
-		"contentitem:text:label=bl_contentitem:rows=5:cols=25:maxlength=1M:hidden=true",
-		"placement:text:hidden=true:maxlength=256", 
-		"placementsecret:text:hidden=true:maxlength=512",
-		"oldplacementsecret:text:hidden=true:maxlength=512",
-		"created_at:autodate",
-		"updated_at:autodate" };
-	
-    public static final String[] CONTENT_EXTRA_FIELDS = { 
-    	"SITE_TITLE:text:table=SAKAI_SITE:realname=TITLE", 
-    	"SITE_CONTACT_NAME:text:table=ssp1:realname=VALUE", 
-    	"SITE_CONTACT_EMAIL:text:table=ssp2:realname=VALUE", 
-    	"ATTRIBUTION:text:table=ssp3:realname=VALUE",
-    	"URL:text:table=lti_tools:realname=launch",
-    	"searchURL:text:table=NULL" //no realname and table is NULL for this, it just exists in the select
-    };
+    Map<String, Object> getContent(Long key, String siteId);
 
-	/**
-	 * 
-	 */
-	static String[] TOOL_MODEL = { 
-		"id:key",
-		"version:radio:label=bl_version:choices=lti1,lti2:hidden=true",
-		"SITE_ID:text:maxlength=99:role=admin",
-		"title:text:label=bl_title:required=true:maxlength=1024",
-		"allowtitle:radio:label=bl_allowtitle:choices=disallow,allow",
-		"fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
-		"pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
-		"allowpagetitle:radio:label=bl_allowpagetitle:choices=disallow,allow",
-		"description:textarea:label=bl_description:maxlength=4096",
-		"status:radio:label=bl_status:choices=enable,disable",
-		"visible:radio:label=bl_visible:choices=visible,stealth:role=admin",
-		"resource_handler:text:label=bl_resource_handler:maxlength=1024:role=admin:only=lti2",
-		"deployment_id:integer:hidden=true",
-		"lti2_launch:header:fields=launch,consumerkey,secret:only=lti2",
-		"launch:url:label=bl_launch:maxlength=1024:required=true",
-		"allowlaunch:radio:label=bl_allowlaunch:choices=disallow,allow:only=lti1",
-		"consumerkey:text:label=bl_consumerkey:maxlength=1024",
-		"allowconsumerkey:radio:label=bl_allowconsumerkey:choices=disallow,allow:only=lti1",
-		"secret:text:label=bl_secret:maxlength=1024",
-		"allowsecret:radio:label=bl_allowsecret:choices=disallow,allow:only=lti1",
-		"frameheight:integer:label=bl_frameheight",
-		"allowframeheight:radio:label=bl_allowframeheight:choices=disallow,allow",
-		"privacy:header:fields=sendname,sendemailaddr",
-		"sendname:checkbox:label=bl_sendname",
-		"sendemailaddr:checkbox:label=bl_sendemailaddr",
-		"services:header:fields=allowoutcomes,allowroster,allowsettings",
-		"allowoutcomes:checkbox:label=bl_allowoutcomes",
-		"allowroster:checkbox:label=bl_allowroster",
-		"allowsettings:checkbox:label=bl_allowsettings",
-		// Hide these from end users until they are working in the various Sakai tools
-		"pl_header:header:fields=pl_launch,pl_linkselection,pl_importitem,pl_fileitem,pl_contenteditor,pl_assessmentselection",
-		"pl_launch:checkbox:label=bl_pl_launch",
-		"pl_linkselection:checkbox:label=bl_pl_linkselection",
-		"pl_importitem:checkbox:label=bl_pl_importitem:role=admin",
-		"pl_fileitem:checkbox:label=bl_pl_fileitem:role=admin",
-		"pl_contenteditor:checkbox:label=bl_pl_contenteditor:role=admin",
-		"pl_assessmentselection:checkbox:label=bl_pl_assessmentselection:role=admin",
-		"newpage:radio:label=bl_newpage:choices=off,on,content",
-		"debug:radio:label=bl_debug:choices=off,on,content",
-		// LTI 1.x user-entered custom
-		"custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384",
-		// LTI 2.x settings from web services
-		"settings:text:hidden=true:maxlength=1M",
-		// LTI 2.x tool-registration time parameters
-		"parameter:textarea:label=bl_parameter:rows=5:cols=25:maxlength=16384:only=lti2",
-		"tool_proxy_binding:textarea:label=bl_tool_proxy_binding:maxlength=2M:only=lti2:hide=insert:role=admin",
-		"allowcustom:checkbox:label=bl_allowcustom",
-		"xmlimport:textarea:hidden=true:maxlength=1M",
-		"splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384",
-		"created_at:autodate", 
-		"updated_at:autodate" };
+    Map<String, Object> getContentDao(Long key);
 
-	/**
-	 * 
-	 */
-	static String[] DEPLOY_MODEL = { 
-		"id:key",
-		"reg_state:radio:label=bl_reg_state:choices=lti2_ready,lti2_received,lti2_complete:hidden=true",
-		"title:text:label=bl_title:required=true:maxlength=1024",
-		"pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
-		"description:textarea:label=bl_description:maxlength=4096",
-		"lti2_status:header:fields=status,visible",
-		"status:radio:label=bl_status:choices=enable,disable",
-		"visible:radio:label=bl_visible:choices=visible,stealth:role=admin",
-		"privacy:header:fields=sendname,sendemailaddr",
-		"sendname:checkbox:label=bl_sendname",
-		"sendemailaddr:checkbox:label=bl_sendemailaddr",
-		"services:header:fields=allowoutcomes,allowroster,allowsettings",
-		"allowoutcomes:checkbox:label=bl_allowoutcomes",
-		"allowroster:checkbox:label=bl_allowroster",
-		"allowsettings:checkbox:label=bl_allowsettings",
-		"allowcontentitem:checkbox:label=bl_allowcontentitem",
-		"lti2_internal:header:fields=reg_launch,reg_key,reg_secret,reg_password,consumerkey,secret,reg_profile:hide=insert",
-		"reg_launch:url:label=bl_reg_launch:maxlength=1024:role=admin",
-		"reg_key:text:label=bl_reg_key:maxlength=1024:hide=insert:role=admin",
-		"reg_password:text:label=bl_reg_password:maxlength=1024:hide=insert:role=admin",
-		"reg_ack:text:label=bl_reg_ack:maxlength=4096:hide=insert:role=admin",
-		"consumerkey:text:label=bl_consumerkey:maxlength=1024:hide=insert",
-		"secret:text:label=bl_secret:maxlength=1024:hide=insert",
-		"new_secret:text:label=bl_secret:maxlength=1024:hide=insert",
-		"reg_profile:textarea:label=bl_reg_profile:maxlength=2M:hide=insert:role=admin",
-		"settings:text:hidden=true:maxlength=1M",   // This is "custom" in the JSON
-		"created_at:autodate", 
-		"updated_at:autodate" };
+    Map<String, Object> getContentDao(Long key, String siteId);
 
-	// The model for the ToolProxy Binding (LTI 2.0)
-	static String[] BINDING_MODEL = { 
-		"id:key", 
-		"tool_id:integer:hidden=true",
-		"SITE_ID:text:maxlength=99:role=admin",
-		"settings:text:hidden=true:maxlength=1M",
-		"created_at:autodate",
-		"updated_at:autodate" };
+    Map<String, Object> getContentDao(Long key, String siteId, boolean isAdminRole);
 
-	static String[] MEMBERSHIPS_JOBS_MODEL = { 
-		"SITE_ID:text:maxlength=99:required=true",
-		"memberships_id:text:maxlength=256:required=true",
-		"memberships_url:text:maxlength=4000:required=true",
-		"consumerkey:text:label=bl_consumerkey:allowed=true:maxlength=1024",
-		"lti_version:text:maxlength=32:required=true"};
+    boolean deleteContent(Long key, String siteId);
 
-	/** Static constants for data fields */
+    boolean deleteContentDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
 
-	static final String LTI_ID =    	"id";
-	static final String LTI_SITE_ID =     "SITE_ID";
-	static final String LTI_TOOL_ID =     "tool_id";
-	static final String LTI_TITLE =    	"title";
-	static final String LTI_ALLOWTITLE =	"allowtitle";
-	static final String LTI_PAGETITLE =    	"pagetitle";
-	static final String LTI_ALLOWPAGETITLE =	"allowpagetitle";
-	static final String LTI_FA_ICON =       "fa_icon";
-	static final String LTI_PLACEMENT =    "placement";
-	static final String LTI_DESCRIPTION = "description";
-	static final String LTI_STATUS = 	"status";
-	static final String LTI_VISIBLE = 	"visible";
-	static final String LTI_LAUNCH = 	"launch";
-	static final String LTI_ALLOWLAUNCH = 	"allowlaunch";
-	static final String LTI_CONSUMERKEY= 	"consumerkey";
-	static final String LTI_ALLOWCONSUMERKEY= 	"allowconsumerkey";
-	static final String LTI_SECRET =   	"secret";
-	static final String LTI_NEW_SECRET =   	"new_secret";
-	static final String LTI_ALLOWSECRET =   	"allowsecret";
-	static final String LTI_SECRET_INCOMPLETE = "-----";
-	static final String LTI_FRAMEHEIGHT = "frameheight";
-	static final String LTI_ALLOWFRAMEHEIGHT = "allowframeheight";
-	static final String LTI_SENDNAME =	"sendname";
-	static final String LTI_SENDEMAILADDR = "sendemailaddr";
-	static final String LTI_ALLOWOUTCOMES = "allowoutcomes";
-	static final String LTI_ALLOWROSTER = "allowroster";
-	static final String LTI_ALLOWSETTINGS = "allowsettings";
-	static final String LTI_ALLOWCONTENTITEM = "allowcontentitem";
-	static final String LTI_SETTINGS = "settings";
-	static final String LTI_SETTINGS_EXT = "settings_ext";
-	static final String LTI_CONTENTITEM = "contentitem";
-	static final String LTI_NEWPAGE =	"newpage";
-	static final String LTI_DEBUG =	"debug";
-	static final String LTI_CUSTOM = 	"custom";
-	static final String LTI_SPLASH = 	"splash";
-	static final String LTI_ALLOWCUSTOM = "allowcustom";
-	static final String LTI_XMLIMPORT = 	"xmlimport";
-	static final String LTI_CREATED_AT =  "created_at"; 
-	static final String LTI_UPDATED_AT = 	"updated_at";
-	static final String LTI_MATCHPATTERN = "matchpattern";
-	static final String LTI_NOTE = 	"note";
-	static final String LTI_PLACEMENTSECRET = 	"placementsecret";
-	static final String LTI_OLDPLACEMENTSECRET = 	"oldplacementsecret";
-	static final String LTI_DEPLOYMENT_ID = 	"deployment_id";
-	// BLTI-230 - LTI 2.0
-	static final String LTI_VERSION = "version";
-	static final Long LTI_VERSION_1 = new Long(0);
-	static final Long LTI_VERSION_2 = new Long(1);
-	static final String LTI_RESOURCE_HANDLER = "resource_handler";
-	static final String LTI_REG_STATE = "reg_state";
-	static final String LTI_REG_STATE_REGISTERED = "1";
-	static final String LTI_REG_LAUNCH = "reg_launch";
-	static final String LTI_REG_KEY = "reg_key";
-	static final String LTI_REG_ACK = "reg_ack";
-	static final String LTI_REG_PASSWORD = "reg_password";
-	static final String LTI_PARAMETER = "parameter";
-	static final String LTI_REG_PROFILE = "reg_profile"; // A.k.a tool_proxy
-	// A subset of a tool_proxy with only a single resource_handler
-	static final String LTI_TOOL_PROXY_BINDING = "tool_proxy_binding";
-	// End of BLTI-230 - LTI 2.0
-	static final String LTI_PL_LAUNCH = "pl_launch";
-	static final String LTI_PL_LINKSELECTION = "pl_linkselection";
-	static final String LTI_PL_FILEITEM = "pl_fileitem";
-	static final String LTI_PL_IMPORTITEM = "pl_importitem";
-	static final String LTI_PL_CONTENTEDITOR = "pl_contenteditor";
-	static final String LTI_PL_ASSESSMENTSELECTION = "pl_assessmentselection";
-	
-	public static final String LTI_SEARCH_TOKEN_SEPARATOR_AND = "#&#";
-	public static final String LTI_SEARCH_TOKEN_SEPARATOR_OR = "#|#";
-	public static final String ESCAPED_LTI_SEARCH_TOKEN_SEPARATOR_AND = "\\#\\&\\#";
-	public static final String ESCAPED_LTI_SEARCH_TOKEN_SEPARATOR_OR = "\\#\\|\\#";
-	public static final String LTI_SEARCH_TOKEN_NULL = "#null#";
-	public static final String LTI_SEARCH_TOKEN_DATE = "#date#";
-	public static final String LTI_SEARCH_TOKEN_EXACT = "#exact#";
-	public static final String LTI_SEARCH_INTERNAL_DATE_FORMAT = "dd/MM/yyyy H:mm:ss";
-	public static final String LTI_SITE_ATTRIBUTION_PROPERTY_KEY = "basiclti.tool.site.attribution.key";
-	public static final String LTI_SITE_ATTRIBUTION_PROPERTY_KEY_DEFAULT = "Department";
-	public static final String LTI_SITE_ATTRIBUTION_PROPERTY_NAME = "basiclti.tool.site.attribution.name";
-	public static final String LTI_SITE_ATTRIBUTION_PROPERTY_NAME_DEFAULT = "content.attribution";
 
+
+    Object updateContent(Long key, Map<String, Object> newProps, String siteId);
+
+    Object updateContent(Long key, Properties newProps, String siteId);
+
+    Object updateContentDao(Long key, Map<String, Object> newProps, String siteId);
+
+    Object updateContentDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+    List<Map<String, Object>> getContents(String search, String order, int first, int last, String siteId);
+
+    /**
+     * This finds a set of LTI Contents objects.
+     *
+     * @param search The SQL search string to limit the results
+     * @param order  The SQL order by string.
+     * @param first  The first item that should be returned.
+     * @param last   The last item that should be returned.
+     * @param siteId The site ID or null to search as admin.
+     * @return A List of LTI Contents objects.
+     */
+    List<Map<String, Object>> getContentsDao(String search, String order, int first, int last, String siteId);
+
+    List<Map<String, Object>> getContentsDao(String search, String order, int first, int last, String siteId, boolean isAdminRole);
+
+    int countContents(String search, String siteId);
+
+    int countContentsDao(String search, String siteId, boolean isAdminRole);
+
+    String deleteContentLink(Long key, String siteId);
+
+    String getContentLaunch(Map<String, Object> content);
+
+    void filterContent(Map<String, Object> content, Map<String, Object> tool);
+
+
+    // --- Deploy
+    Object insertDeployDao(Properties newProps);
+
+    Object insertDeployDao(Properties newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+    Object updateDeployDao(Long key, Object newProps);
+
+    Object updateDeployDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+    boolean deleteDeployDao(Long key);
+
+    boolean deleteDeployDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
+
+    Map<String, Object> getDeployDao(Long key);
+
+    Map<String, Object> getDeployDao(Long key, String siteId, boolean isAdminRole);
+
+    Map<String, Object> getDeployForConsumerKeyDao(String consumerKey);
+
+    List<Map<String, Object>> getDeploysDao(String search, String order, int first, int last);
+
+    List<Map<String, Object>> getDeploysDao(String search, String order, int first, int last, String siteId, boolean isAdminRole);
+
+    // -- Proxy binding
+    boolean deleteProxyBindingDao(Long key);
+
+    Object insertProxyBindingDao(Properties newProps);
+
+    Object updateProxyBindingDao(Long key, Object newProps);
+
+    Map<String, Object> getProxyBindingDao(Long tool_id, String siteId);
+
+
+    // These can be static and moved to the tool, or at least split off into a Foorm UI
+
+    String formOutput(Object row, String fieldInfo);
+
+    String formOutput(Object row, String[] fieldInfo);
+
+    String formInput(Object row, String fieldInfo);
+
+    String formInput(Object row, String[] fieldInfo);
+
+    boolean isAdmin(String siteId);
 }

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -325,8 +325,6 @@ public interface LTIService {
 
     boolean deleteToolDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole);
 
-    Map<String, Object> getTool(String url);
-
     Map<String, Object> getTool(Long key, String siteId);
 
     Map<String, Object> getToolDao(Long key, String siteId);

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -446,15 +446,6 @@ public abstract class BaseLTIService implements LTIService {
 	}
 
 	@Override
-	public Map<String, Object> getTool(String url) {
-		throw new java.lang.RuntimeException("getTool(String url) not implemented");
-	}
-
-	private boolean getTool(Object urlorkey, Map<String, Object> retval) {
-		throw new java.lang.RuntimeException("getTool(String url) not implemented");
-	}
-
-	@Override
 	public Map<String, Object> getTool(Long key, String siteId) {
 		return getToolDao(key, siteId, isAdmin(siteId));
 	}

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -41,7 +41,6 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.tool.api.SessionManager;
-import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.foorm.SakaiFoorm;
@@ -132,7 +131,6 @@ public abstract class BaseLTIService implements LTIService {
 	/**
 	 * 
 	 */
-	protected ToolManager toolManager = null;
 
 	/**
 	 * 
@@ -144,17 +142,11 @@ public abstract class BaseLTIService implements LTIService {
 	 */
 	protected void getServices() {
 		if (securityService == null)
-			securityService = (SecurityService) ComponentManager
-				.get("org.sakaiproject.authz.api.SecurityService");
+			securityService = ComponentManager.get(SecurityService.class);
 		if (siteService == null)
-			siteService = (SiteService) ComponentManager
-				.get("org.sakaiproject.site.api.SiteService");
-		if (toolManager == null)
-			toolManager = (ToolManager) ComponentManager
-				.get("org.sakaiproject.tool.api.ToolManager");
+			siteService = ComponentManager.get(SiteService.class);
 		if (serverConfigurationService == null)
-            serverConfigurationService = (ServerConfigurationService) ComponentManager
-                .get("org.sakaiproject.component.api.ServerConfigurationService");
+			serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
 	}
 
 	/**********************************************************************************************************************************************************************************************************************************************************
@@ -203,8 +195,9 @@ public abstract class BaseLTIService implements LTIService {
 	 *********************************************************************************************************************************************************************************************************************************************************/
 
 	/* Tool Model */
-	public String[] getToolModel() {
-		return getToolModelDao(isAdmin());
+	@Override
+	public String[] getToolModel(String siteId) {
+		return getToolModelDao(isAdmin(siteId));
 	}
 
 	public String[] getToolModelDao() {
@@ -218,25 +211,20 @@ public abstract class BaseLTIService implements LTIService {
 
 
 	/* Content Model */
-	public String[] getContentModel(Long tool_id) {
-		Map<String, Object> tool = getToolDao(tool_id, getContext(), isAdmin());
-		return getContentModelDao(tool, isAdmin());
+	public String[] getContentModel(Long tool_id, String siteId) {
+		Map<String, Object> tool = getToolDao(tool_id, siteId, isAdmin(siteId));
+		return getContentModelDao(tool, isAdmin(siteId));
 	}
 
-	public String[] getContentModel(Map<String, Object> tool) {
-		return getContentModelDao(tool, isAdmin());
+	@Override
+	public String[] getContentModel(Map<String, Object> tool, String siteId) {
+		return getContentModelDao(tool, isAdmin(siteId));
 	}
 
 	// Note that there is no
 	//   public String[] getContentModelDao(Long tool_id, String siteId) 
 	// on purpose - if code is doing Dao style it can retrieve its own tool
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getContentModelDao(Map<String, Object>, java.lang.String, boolean)
-	 */
 	protected String[] getContentModelDao(Map<String, Object> tool, boolean isAdminRole) {
 		if ( tool == null ) return null;
 		String[] retval = foorm.filterForm(tool, CONTENT_MODEL);
@@ -244,25 +232,7 @@ public abstract class BaseLTIService implements LTIService {
 		return retval;
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
-	protected String getContext() {
-		String retval = toolManager.getCurrentPlacement().getContext();
-		// Don't continue - this will be a security hole in isAdmin()
-		if ( retval == null ) {
-			throw new java.lang.RuntimeException("getContext() required non-null context");
-		}
-		return retval;
-	}
-
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getContentLaunch(java.util.Map)
-	 */
+	@Override
 	public String getContentLaunch(Map<String, Object> content) {
 		if ( content == null ) return null;
 		int key = getInt(content.get(LTIService.LTI_ID));
@@ -272,12 +242,7 @@ public abstract class BaseLTIService implements LTIService {
 		return LAUNCH_PREFIX + siteId + "/content:" + key;
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getToolLaunch(java.util.Map)
-	 */
+	@Override
 	public String getToolLaunch(Map<String, Object> tool, String siteId) {
 		if ( tool == null ) return null;
 		int key = getInt(tool.get(LTIService.LTI_ID));
@@ -286,74 +251,36 @@ public abstract class BaseLTIService implements LTIService {
 		return LAUNCH_PREFIX + siteId + "/tool:" + key;
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getExportUrl(java.lang.String, java.lang.String, org.sakaiproject.lti.api.LTIExportService.ExportType)
-	 */
+	@Override
 	public String getExportUrl(String siteId, String filterId, ExportType exportType) {
-        if (siteId == null) {
-            return null;
-        }
-        return "/access/basiclti/site/" + siteId + "/export:" + exportType + ((filterId != null && !"".equals(filterId)) ? (":" + filterId) : "");
-    }
+		if (siteId == null) {
+			return null;
+		}
+		return "/access/basiclti/site/" + siteId + "/export:" + exportType + ((filterId != null && !"".equals(filterId)) ? (":" + filterId) : "");
+	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#formOutput(java.lang.Object,
-	 *      java.lang.String)
-	 */
+	@Override
 	public String formOutput(Object row, String fieldInfo) {
 		return foorm.formOutput(row, fieldInfo, rb);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#formOutput(java.lang.Object,
-	 *      java.lang.String[])
-	 */
+	@Override
 	public String formOutput(Object row, String[] fieldInfo) {
 		return foorm.formOutput(row, fieldInfo, rb);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#formInput(java.lang.Object,
-	 *      java.lang.String)
-	 */
+	@Override
 	public String formInput(Object row, String fieldInfo) {
 		return foorm.formInput(row, fieldInfo, rb);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#formInput(java.lang.Object,
-	 *      java.lang.String[])
-	 */
+	@Override
 	public String formInput(Object row, String[] fieldInfo) {
 		return foorm.formInput(row, fieldInfo, rb);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#isAdmin()
-	 */
-	public boolean isAdmin() {
-		return isAdmin(getContext());
-	}
-
-	protected boolean isAdmin(String siteId) {
+	@Override
+	public boolean isAdmin(String siteId) {
 		if ( siteId == null ) {
 			throw new java.lang.RuntimeException("isAdmin() requires non-null siteId");
 		}
@@ -361,125 +288,63 @@ public abstract class BaseLTIService implements LTIService {
 		return isMaintain(siteId);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#isMaintain()
-	 */
-	public boolean isMaintain() {
-		return isMaintain(getContext());
-	}
-
-	protected boolean isMaintain(String siteId) {
+	@Override
+	public boolean isMaintain(String siteId) {
 		return siteService.allowUpdateSite(siteId);
 	}
 
 	/**
 	 * Simple API signature for the update series of methods
 	 */
-	public Object updateTool(Long key, Map<String, Object> newProps) {
-		return updateTool(key, (Object) newProps);
+	@Override
+	public Object updateTool(Long key, Map<String, Object> newProps, String siteId) {
+		return updateTool(key, (Object) newProps, siteId);
 	}
 
 	/**
 	 * Simple API signature for the update series of methods
 	 */
-	public Object updateTool(Long key, Properties newProps) {
-		return updateTool(key, (Object) newProps);
+	@Override
+	public Object updateTool(Long key, Properties newProps, String siteId) {
+		return updateTool(key, (Object) newProps, siteId);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.impl.BaseLTIService#updateTool(java.lang.Long,
-	 *	  java.lang.Object)
-	 */
-	protected Object updateTool(Long key, Object newProps) {
-		return updateToolDao(key, newProps, getContext(), isAdmin(), isMaintain());
-	}
-
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.impl.BaseLTIService#updateToolDao(java.lang.Long,
-	 *	  java.lang.Object, java.lang.String)
-	 */
+	@Override
 	public Object updateToolDao(Long key, Map<String, Object> newProps, String siteId) {
-		return updateToolDao(key, (Object) newProps, siteId, true, true);
+		return updateToolDao(key, newProps, siteId, true, true);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#updateContent(java.lang.Long, java.util.Map)
-	 */
-	public Object updateContent(Long key, Map<String, Object> newProps) {
-		return updateContent(key, (Object) newProps);
+	private Object updateTool(Long key, Object newProps, String siteId) {
+		return updateToolDao(key, newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#updateContent(java.lang.Long,
-	 *      java.util.Properties)
-	 */
-	public Object updateContent(Long key, Properties newProps) {
-		return updateContent(key, (Object) newProps);
-	}
-	
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
+	@Override
 	public Object updateContent(Long key, Properties newProps, String siteId)
 	{
 		return updateContentDao(key, newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @return
-	 */
-	public Object updateContent(Long key, Object newProps)
+	@Override
+	public Object updateContent(Long key, Map<String, Object> map, String siteId)
 	{
-		return updateContentDao(key, newProps, getContext(), isAdmin(), isMaintain());
+		return updateContentDao(key, map, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	/**
-	 * 
-	 * @param key
-	 * @param newProps
-	 * @param siteId
-	 * @return
-	 */
+	@Override
 	public Object updateContentDao(Long key, Map<String, Object> newProps, String siteId)
 	{
 		return updateContentDao(key, (Object) newProps, siteId, true, true);
 	}
 
-	public boolean deleteContent(Long key) {
-		return deleteContentDao(key, getContext(), isAdmin(), isMaintain());
+	@Override
+	public boolean deleteContent(Long key, String siteId) {
+		return deleteContentDao(key, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	/**
-	 * 
-	 * @param o
-	 * @return
-	 */
 	public static int getInt(Object o) {
 		if (o instanceof String) {
 			try {
-				return (new Integer((String) o)).intValue();
+				return new Integer((String) o);
 			} catch (Exception e) {
 				return -1;
 			}
@@ -489,10 +354,10 @@ public abstract class BaseLTIService implements LTIService {
 		return -1;
 	}
 
-	// Adjust the content object based on the settings in the tool object
 	/**
-	 * 
+	 * Adjust the content object based on the settings in the tool object
 	 */
+	@Override
 	public void filterContent(Map<String, Object> content, Map<String, Object> tool) {
 		if (content == null || tool == null)
 			return;
@@ -515,13 +380,6 @@ public abstract class BaseLTIService implements LTIService {
 		content.put(LTIService.LTI_NEWPAGE, newpage+"");
 	}
 
-	/**
-	 * 
-	 * @param propName
-	 * @param content
-	 * @param tool
-	 * @return
-	 */
 	public static Integer getCorrectProperty(String propName, Map<String, Object> content,
 			Map<String, Object> tool) {
 		int toolProp = getInt(tool.get(propName));
@@ -549,11 +407,11 @@ public abstract class BaseLTIService implements LTIService {
 		return null;
 	}
 
-    protected abstract Object insertMembershipsJobDao(String siteId, String membershipsId, String membershipsUrl, String consumerKey, String ltiVersion);
+	protected abstract Object insertMembershipsJobDao(String siteId, String membershipsId, String membershipsUrl, String consumerKey, String ltiVersion);
 
-    public Object insertMembershipsJob(String siteId, String membershipsId, String membershipsUrl, String consumerKey, String ltiVersion) {
-        return insertMembershipsJobDao(siteId, membershipsId, membershipsUrl, consumerKey, ltiVersion);
-    }
+	public Object insertMembershipsJob(String siteId, String membershipsId, String membershipsUrl, String consumerKey, String ltiVersion) {
+		return insertMembershipsJobDao(siteId, membershipsId, membershipsUrl, consumerKey, ltiVersion);
+	}
 
 	protected abstract Map<String, Object> getMembershipsJobDao(String siteId);
 
@@ -567,146 +425,137 @@ public abstract class BaseLTIService implements LTIService {
 		return getMembershipsJobsDao();
 	}
 
-	public Object insertTool(Properties newProps) {
-		return insertToolDao(newProps, getContext(), isAdmin(), isMaintain());
+	@Override
+	public Object insertTool(Properties newProps, String siteId) {
+		return insertToolDao(newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	public Object insertTool(Map<String,Object> newProps) {
-		return insertToolDao(newProps, getContext(), isAdmin(), isMaintain());
+	@Override
+	public Object insertTool(Map<String, Object> newProps, String siteId) {
+		return insertToolDao(newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
+	@Override
 	public Object insertToolDao(Properties newProps, String siteId) {
 		return insertToolDao(newProps, siteId, true, true);
 	}
 
-	public boolean deleteTool(Long key) {
-		return deleteToolDao(key, getContext(), isAdmin(), isMaintain());
+	@Override
+	public boolean deleteTool(Long key, String siteId) {
+		return deleteToolDao(key, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	public boolean deleteToolDao(Long key, String siteId) {
-		return deleteToolDao(key, siteId, true, true);
-	}
-
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getTool(java.lang.String)
-	 */
+	@Override
 	public Map<String, Object> getTool(String url) {
 		throw new java.lang.RuntimeException("getTool(String url) not implemented");
 	}
 
-	/**
-	 * 
-	 * @param urlorkey
-	 * @param retval
-	 * @return
-	 */
 	private boolean getTool(Object urlorkey, Map<String, Object> retval) {
 		throw new java.lang.RuntimeException("getTool(String url) not implemented");
 	}
 
-	public Map<String, Object> getTool(Long key) {
-		return getToolDao(key, getContext(), isAdmin());
+	@Override
+	public Map<String, Object> getTool(Long key, String siteId) {
+		return getToolDao(key, siteId, isAdmin(siteId));
 	}
 
+	@Override
 	public Map<String, Object> getToolDao(Long key, String siteId)
 	{
 		return getToolDao(key, siteId, true);
 	}
 
-	public List<Map<String, Object>> getTools(String search, String order, int first, int last) {
-		return getToolsDao(search, order, first, last, getContext(), isAdmin());
+	@Override
+	public List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId) {
+		return getToolsDao(search, order, first, last, siteId, isAdmin(siteId));
 	}
 
-        public List<Map<String, Object>> getToolsLaunch() {
+	@Override
+    public List<Map<String, Object>> getToolsLaunch(String siteId) {
 		return getTools( "lti_tools."+LTIService.LTI_PL_LAUNCH+" = 1 OR ( " +
 			"( lti_tools."+LTIService.LTI_PL_LINKSELECTION+" IS NULL OR lti_tools."+LTIService.LTI_PL_LINKSELECTION+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_FILEITEM+" IS NULL OR lti_tools."+LTIService.LTI_PL_FILEITEM+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_IMPORTITEM+" IS NULL OR lti_tools."+LTIService.LTI_PL_IMPORTITEM+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_CONTENTEDITOR+" IS NULL OR lti_tools."+LTIService.LTI_PL_CONTENTEDITOR+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_ASSESSMENTSELECTION+" IS NULL OR lti_tools."+LTIService.LTI_PL_ASSESSMENTSELECTION+" = 0 ) " +
-			" ) ", null, 0, 0);
+			" ) ", null, 0, 0, siteId);
 	}
 
-        public List<Map<String, Object>> getToolsLtiLink() {
-		return getTools("lti_tools."+LTIService.LTI_PL_LINKSELECTION+" = 1",null,0,0);
+	@Override
+    public List<Map<String, Object>> getToolsLtiLink(String siteId) {
+		return getTools("lti_tools."+LTIService.LTI_PL_LINKSELECTION+" = 1",null,0,0, siteId);
 	}
 
-        public List<Map<String, Object>> getToolsFileItem() {
-		return getTools("lti_tools."+LTIService.LTI_PL_FILEITEM+" = 1",null,0,0);
+	@Override
+    public List<Map<String, Object>> getToolsFileItem(String siteId) {
+		return getTools("lti_tools."+LTIService.LTI_PL_FILEITEM+" = 1",null,0,0, siteId);
 	}
 
-        public List<Map<String, Object>> getToolsImportItem() {
-		return getTools("lti_tools."+LTIService.LTI_PL_IMPORTITEM+" = 1",null,0,0);
+	@Override
+    public List<Map<String, Object>> getToolsImportItem(String siteId) {
+		return getTools("lti_tools."+LTIService.LTI_PL_IMPORTITEM+" = 1",null,0,0, siteId);
 	}
 
-
-        public List<Map<String, Object>> getToolsContentEditor() {
-		return getTools("lti_tools."+LTIService.LTI_PL_CONTENTEDITOR+" = 1",null,0,0);
+	@Override
+    public List<Map<String, Object>> getToolsContentEditor(String siteId) {
+		return getTools("lti_tools."+LTIService.LTI_PL_CONTENTEDITOR+" = 1",null,0,0, siteId);
 	}
 
-        public List<Map<String, Object>> getToolsAssessmentSelection() {
-		return getTools("lti_tools."+LTIService.LTI_PL_ASSESSMENTSELECTION+" = 1",null,0,0);
+	@Override
+    public List<Map<String, Object>> getToolsAssessmentSelection(String siteId) {
+		return getTools("lti_tools."+LTIService.LTI_PL_ASSESSMENTSELECTION+" = 1",null,0,0, siteId);
 	}
 
+	@Override
 	public List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId) {
 		return getToolsDao(search, order, first, last, siteId, true);
 	}
 
-	public Object insertContent(Properties newProps) {
-		return insertContentDao(newProps, getContext(), isAdmin(), isMaintain());
+	@Override
+	public Object insertContent(Properties newProps, String siteId) {
+		return insertContentDao(newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	public Object insertContentDao(Properties newProps, String siteId)
-	{
+	@Override
+	public Object insertContentDao(Properties newProps, String siteId) {
 		return insertContentDao(newProps, siteId, true, true);
 	}
 
-	public Map<String, Object> getContent(Long key) {
-		return getContentDao(key, getContext(), isAdmin());
+	@Override
+	public Map<String, Object> getContent(Long key, String siteId) {
+		return getContentDao(key, siteId, isAdmin(siteId));
 	}
 
-	public Map<String, Object> getContent(Long key, String siteId) {
-		return getContentDao(key, siteId, isAdmin());
-	}
-	
 	// This is with absolutely no site checking...
+	@Override
 	public Map<String, Object> getContentDao(Long key) {
 		return getContentDao(key, null, true);
 	}
 
+	@Override
 	public Map<String, Object> getContentDao(Long key, String siteId) {
 		return getContentDao(key, siteId, true);
 	}
 
-	public List<Map<String, Object>> getContents(String search, String order, int first, int last) 
+	@Override
+	public List<Map<String, Object>> getContents(String search, String order, int first, int last, String siteId)
 	{
-		return getContentsDao(search, order, first, last, getContext(), isAdmin());
+		return getContentsDao(search, order, first, last, siteId, isAdmin(siteId));
 	}
 
+	@Override
 	public List<Map<String, Object>> getContentsDao(String search, String order, int first, int last, String siteId) {
 		return getContentsDao(search, order, first, last, siteId, true);
 	}
 
-	public int countContents(final String search) {
-		return countContentsDao(search, getContext(), isAdmin());
+	@Override
+	public int countContents(final String search, String siteId) {
+		return countContentsDao(search, siteId, isAdmin(siteId));
 	}
 
-	public Object insertToolContent(String id, String toolId, Properties reqProps)
-	{
-		return insertToolContentDao(id, toolId, reqProps, getContext(), isAdmin(), isMaintain());
-	}
-	
-	// TODO: Review the site-manage use cases for this method signature
+	@Override
 	public Object insertToolContent(String id, String toolId, Properties reqProps, String siteId)
 	{
-		if ( isAdmin() || siteId.equals(getContext()) ) {
-			// Is OK
-		} else {
-			M_log.warn("insertToolContent siteId="+siteId+" context="+getContext()+" isAdmin="+isAdmin());
-		}
 		return insertToolContentDao(id, toolId, reqProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 	
@@ -759,22 +608,13 @@ public abstract class BaseLTIService implements LTIService {
 		}
 		return retval;
 	}
-	
-	public Object insertToolSiteLink(String id, String button_text)
-	{
-		return insertToolSiteLink(id, button_text, getContext());
-	}
-	
+
+	@Override
 	public Object insertToolSiteLink(String id, String button_text, String siteId)
 	{
 		return insertToolSiteLinkDao(id, button_text, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
-/*
-	public Object insertToolSiteLinkDao(String id, String button_text, String siteId)
-	{
-		return insertToolSiteLinkDao(id, button_text, siteId, true, true);
-	}
-*/
+
 	protected Object insertToolSiteLinkDao(String id, String button_text, String siteId, boolean isAdminRole, boolean isMaintainRole)
 	{
 		Object retval = null;
@@ -837,17 +677,13 @@ public abstract class BaseLTIService implements LTIService {
 				
 		return retval;
 	}
-	
-	public String deleteContentLink(Long key)
+
+	@Override
+	public String deleteContentLink(Long key, String siteId)
 	{
-		return deleteContentLinkDao(key, getContext(), isAdmin(), isMaintain() );
+		return deleteContentLinkDao(key, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 
-	public String deleteContentLinkDao(Long key, String siteId)
-	{
-		return deleteContentLinkDao(key, siteId, true, true);
-	}
-	
 	protected String deleteContentLinkDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole)
 	{
 		if ( ! isMaintainRole ) {

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
@@ -189,45 +189,19 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return insertThingDao("lti_tools", LTIService.TOOL_MODEL, null, newProps, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getToolDao(java.lang.Long, java.lang.String, boolean)
-	 */
-	public Map<String, Object> getToolDao(Long key, String siteId, boolean isAdminRole) 
+	public Map<String, Object> getToolDao(Long key, String siteId, boolean isAdminRole)
 	{
 		return getThingDao("lti_tools", LTIService.TOOL_MODEL, key, siteId, isAdminRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#deleteToolDao(java.lang.Long, java.lang.String, boolean)
-	 */
 	public boolean deleteToolDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole) {
 		return deleteThingDao("lti_tools", LTIService.TOOL_MODEL, key, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.impl.BaseLTIService#updateToolDao(java.lang.Long,
-	 *      java.lang.Object, java.lang.String, boolean)
-	 */
 	public Object updateToolDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole) {
 		return updateThingDao("lti_tools", LTIService.TOOL_MODEL, null, key, (Object) newProps, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getToolsDao(java.lang.String, java.lang.String,
-	 *      int, int, java.lang.String, boolean)
-	 */
 	public List<Map<String, Object>> getToolsDao(String search, String order, int first,
 			int last, String siteId, boolean isAdminRole) {
 
@@ -381,26 +355,13 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return retval;
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#deleteContent(java.lang.Long, java.lang.String, boolean)
-	 */
 	public boolean deleteContentDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole) {
 		deleteContentLinkDao(key, siteId, isAdminRole, isMaintainRole);
 		return deleteThingDao("lti_content", LTIService.CONTENT_MODEL, key, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.impl.BaseLTIService#updateContentDao(java.lang.Long, 
-	 *      java.lang.Object, java.lang.String, boolean)
-	 */
-	public Object updateContentDao(Long key, Object newProps, String siteId, 
-		boolean isAdminRole, boolean isMaintainRole) 
+	public Object updateContentDao(Long key, Object newProps, String siteId,
+		boolean isAdminRole, boolean isMaintainRole)
 	{
 		if ( key == null || newProps == null ) {
 			throw new IllegalArgumentException(
@@ -454,13 +415,6 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 			key, newProps, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#getContentsDao(java.lang.String,
-	 *      java.lang.String, int, int)
-	 */
 	public List<Map<String, Object>> getContentsDao(String search, String order, int first,
 			int last, String siteId, boolean isAdminRole) {
 
@@ -522,24 +476,11 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return insertThingDao("lti_deploy", LTIService.DEPLOY_MODEL, null, newProps, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.api.LTIService#deleteDeployDao(java.lang.Long, java.lang.String, boolean)
-	 */
 	public boolean deleteDeployDao(Long key, String siteId, boolean isAdminRole, boolean isMaintainRole) {
 		if ( ! isAdminRole ) throw new IllegalArgumentException("Currently we support admins/Dao access");
 		return deleteThingDao("lti_deploy", LTIService.DEPLOY_MODEL, key, siteId, isAdminRole, isMaintainRole);
 	}
 
-	/**
-	 * 
-	 * {@inheritDoc}
-	 * 
-	 * @see org.sakaiproject.lti.impl.BaseLTIService#updateDeployDao(java.lang.Long,
-	 *      java.lang.Object, java.lang.String, boolean)
-	 */
 	public Object updateDeployDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole) {
 		if ( ! isAdminRole ) throw new IllegalArgumentException("Currently we support admins/Dao access");
 		return updateThingDao("lti_deploy", LTIService.DEPLOY_MODEL, null, key, newProps, siteId, isAdminRole, isMaintainRole);
@@ -747,15 +688,6 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return retval;
 	}
 
-	/**
-	 * 
-	 * @param table
-	 * @param model
-	 * @param key
-	 * @param siteId - This is allowed to be null
-	 * @param isMaintainRole
-	 * @return
-	 */
 	private Map<String, Object> getThingDao(String table, String[] model, Long key,
 			String siteId, boolean isAdminRole)
 	{
@@ -793,19 +725,7 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return null;
 	}
 
-	/**
-	 * 
-	 * @param table
-	 * @param model
-	 * @param search
-	 * @param order
-	 * @param first
-	 * @param last
-	 * @param siteId
-	 * @param isMaintainRole
-	 * @return
-	 */
-	public List<Map<String, Object>> getThingsDao(String table, String[] model, 
+	public List<Map<String, Object>> getThingsDao(String table, String[] model,
 		String extraSelect, String joinClause, String search, String groupBy, String order, 
 		int first, int last, String siteId, boolean isAdminRole) 
 	{
@@ -879,18 +799,7 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return getResultSet(statement, ((fields.size() > 0) ? fields.toArray() : null), columns);
 	}
 
-	/**
-	 * 
-	 * @param table
-	 * @param model
-	 * @param joinClause
-	 * @param search
-	 * @param groupBy
-	 * @param siteId
-	 * @param isMaintainRole
-	 * @return
-	 */
-	public int countThingsDao(String table, String[] model, String joinClause, String search, String groupBy, String siteId, boolean isAdminRole) 
+	public int countThingsDao(String table, String[] model, String joinClause, String search, String groupBy, String siteId, boolean isAdminRole)
 	{
 		if (table == null || model == null ) {
 			throw new IllegalArgumentException("table and model must be non-null");

--- a/basiclti/basiclti-tool/src/webapp/vm/lti_content_delete.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_content_delete.vm
@@ -18,7 +18,7 @@
         <p class="shorttext">
         	$tlang.getString("bl_launch"):
         	#set($tool=false)
-			#set($tool=$ltiService.getTool($content.get("tool_id_long"), $content.get("SITE_ID")))
+			#set($tool=$ltiService.getTool($tool_id_long, $content.get("SITE_ID")))
 			#if ($!tool)
 				$tool.get("launch")
 			#end

--- a/basiclti/basiclti-tool/src/webapp/vm/lti_content_delete.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_content_delete.vm
@@ -18,7 +18,7 @@
         <p class="shorttext">
         	$tlang.getString("bl_launch"):
         	#set($tool=false)
-			#set($tool=$ltiService.getTool($content.get("tool_id_long")))
+			#set($tool=$ltiService.getTool($content.get("tool_id_long"), $content.get("SITE_ID")))
 			#if ($!tool)
 				$tool.get("launch")
 			#end

--- a/basiclti/basiclti-tool/src/webapp/vm/lti_tool_site.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_tool_site.vm
@@ -196,7 +196,7 @@ ${includeLatestJQuery}
 					 #set($launch = $validator.escapeHtml($content.get("launch")))
 				#else
 					#set($tool=false)
-					#set($tool=$ltiService.getTool($content.get("tool_id_long")))
+					#set($tool=$ltiService.getTool($content.get("tool_id_long"), $content.get("SITE_ID")))
 					#if ($!tool)
 						#set($launch = $validator.escapeHtml($tool.get("launch")))
 					#end

--- a/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -21,17 +21,11 @@
 
 package org.sakaiproject.portlets;
 
-import java.lang.Integer;
-
 import java.io.PrintWriter;
 import java.io.IOException;
-import java.io.InputStream;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.ResourceBundle;
-import java.util.List;
 import java.util.Enumeration;
 
 import org.slf4j.Logger;
@@ -42,37 +36,23 @@ import javax.portlet.RenderRequest;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.RenderResponse;
-import javax.portlet.PortletRequest;
 import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
-import javax.portlet.PortletPreferences;
 import javax.portlet.PortletContext;
 import javax.portlet.PortletConfig;
-import javax.portlet.WindowState;
 import javax.portlet.PortletMode;
 import javax.portlet.PortletSession;
-import javax.portlet.ReadOnlyException;
-
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.sakaiproject.portlet.util.VelocityHelper;
 import org.sakaiproject.portlet.util.JSPHelper;
 import org.sakaiproject.util.FormattedText;
 import org.sakaiproject.util.ResourceLoader;
 
-import org.sakaiproject.tool.api.Session;
-import org.sakaiproject.tool.cover.SessionManager;
-
-import org.sakaiproject.site.api.Site;
-import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.tool.api.Placement;
 import org.sakaiproject.tool.cover.ToolManager;
-import org.sakaiproject.tool.api.ToolSession;
 
 import javax.servlet.ServletRequest;
 import org.sakaiproject.thread_local.cover.ThreadLocalManager;
@@ -211,12 +191,12 @@ public class SakaiIFrame extends GenericPortlet {
 				return;
 			}
 			try {
-				content = m_ltiService.getContent(key);
+				content = m_ltiService.getContent(key, placement.getContext());
 				Long tool_id = getLongNull(content.get("tool_id"));
 				// If we are supposed to popup (per the content), do so and optionally
 				// copy the calue into the placement to communicate with the portal
 				if (tool_id != null) {
-					tool = m_ltiService.getTool(tool_id);
+					tool = m_ltiService.getTool(tool_id, placement.getContext());
 					m_ltiService.filterContent(content, tool);
 				}
 				Object popupValue = content.get("newpage");
@@ -288,7 +268,7 @@ public class SakaiIFrame extends GenericPortlet {
 				return;
 			}
 
-			Map<String, Object> content = m_ltiService.getContent(key);
+			Map<String, Object> content = m_ltiService.getContent(key, placement.getContext());
 			if ( content == null ) {
 				out.println(rb.getString("get.info.notconfig"));
 				M_log.warn("Cannot find content item placement="+placement.getId()+" key="+key);
@@ -297,14 +277,14 @@ public class SakaiIFrame extends GenericPortlet {
 
 			// attach the ltiToolId to each model attribute, so that we could have the tool configuration page for multiple tools
 			String foundLtiToolId = content.get(m_ltiService.LTI_TOOL_ID).toString();
-			Map<String, Object> tool = m_ltiService.getTool(Long.valueOf(foundLtiToolId));
+			Map<String, Object> tool = m_ltiService.getTool(Long.valueOf(foundLtiToolId), placement.getContext());
 			if ( tool == null ) {
 				out.println(rb.getString("get.info.notconfig"));
 				M_log.warn("Cannot find tool placement="+placement.getId()+" key="+foundLtiToolId);
 				return;
 			}
 
-			String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(foundLtiToolId));
+			String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(foundLtiToolId), placement.getContext());
 			String formInput=m_ltiService.formInput(content, contentToolModel);
 			context.put("formInput", formInput);
 			
@@ -376,7 +356,7 @@ public class SakaiIFrame extends GenericPortlet {
 				String name = (String) names.nextElement();
 				reqProps.setProperty(name, request.getParameter(name));
 			}
-			Object retval = m_ltiService.updateContent(Long.parseLong(id), reqProps);
+			Object retval = m_ltiService.updateContent(Long.parseLong(id), reqProps, placement.getContext());
 			String fa_icon = (String)request.getParameter(LTIService.LTI_FA_ICON);
 			if ( fa_icon != null && fa_icon.length() > 0 ) {
 				placement.getPlacementConfig().setProperty("imsti.fa_icon",fa_icon);

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/BltiExport.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/BltiExport.java
@@ -53,7 +53,7 @@ public class BltiExport {
 	    return ret;
 	List<Map<String,Object>> contents = null;
 	try {
-	    contents = ltiService.getContents(null, null, 0, 0);
+	    contents = ltiService.getContents(null, null, 0, 0, siteId);
 	} catch (Exception e) {
 	    // this should never happen, but we saw it once
 	    return null;
@@ -61,7 +61,7 @@ public class BltiExport {
 		
 	for (Map<String,Object> content : contents) {
 	    Long id = getLong(content.get(LTIService.LTI_ID));
-	    if (id.longValue() != -1L && entityReal(id)) {
+	    if (id.longValue() != -1L && entityReal(id, siteId)) {
 		ret.add("blti/" + id);
 	    }
 	}
@@ -69,14 +69,14 @@ public class BltiExport {
     }
 
     // we saw a weird site where this wasn't true. Admin had changed accessibility of tool
-    public boolean entityReal(Long bkey) {
-	Map content = ltiService.getContent(bkey);
+    public boolean entityReal(Long bkey, String siteId) {
+	Map content = ltiService.getContent(bkey, siteId);
 	if (content == null)
 	    return false;
 	Long toolKey = getLongNull(content.get(LTIService.LTI_TOOL_ID));
 	if (toolKey == null)
 	    return false;
-	Map tool = ltiService.getTool(toolKey);
+	Map tool = ltiService.getTool(toolKey, siteId);
 	if (tool == null)
 	    return false;
 	return true;
@@ -87,13 +87,13 @@ public class BltiExport {
 	String id = bltiRef.substring(i + 1);
 
 	Long bkey = getLong(id);
-	Map content = ltiService.getContent(bkey);
+	Map content = ltiService.getContent(bkey, bean.siteId);
 	if (content == null)
 	    return false;
 	Long toolKey = getLongNull(content.get(LTIService.LTI_TOOL_ID));
 	if (toolKey == null)
 	    return false;
-	Map tool = ltiService.getTool(toolKey);
+	Map tool = ltiService.getTool(toolKey, bean.siteId);
 	if (tool == null)
 	    return false;
 	

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
@@ -230,7 +230,7 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	String search = null;
 	if (bltiToolId != null)
 	    search = "tool_id=" + bltiToolId;
-	List<Map<String,Object>> contents = ltiService.getContents(search,null,0,0, getSiteId());
+	List<Map<String,Object>> contents = ltiService.getContents(search,null,0,0, bean.getCurrentSiteId());
 	for (Map<String, Object> content : contents ) {
 	    Long id = getLong(content.get(LTIService.LTI_ID));
 	    if ( id == -1 ) continue;
@@ -271,10 +271,10 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	if ( id == null ) return; // Likely a failure
 	if ( ltiService == null) return;  // not basiclti or old
 	Long key = getLong(id);
-	content = ltiService.getContent(key, getSiteId());
+	content = ltiService.getContent(key, ToolManager.getCurrentPlacement().getContext());
 	if ( content == null ) return;
 	Long toolKey = getLongNull(content.get("tool_id"));
-	if (toolKey != null ) tool = ltiService.getTool(toolKey, getSiteId());
+	if (toolKey != null ) tool = ltiService.getTool(toolKey, ToolManager.getCurrentPlacement().getContext());
     }	
 
     // properties of entities

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
@@ -25,16 +25,10 @@ package org.sakaiproject.lessonbuildertool.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.Map;
-import java.util.Iterator;
 import java.util.Properties;
 
 import java.net.URLEncoder;
@@ -42,13 +36,10 @@ import java.net.URLEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.sakaiproject.lessonbuildertool.service.LessonSubmission;
 import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean;
 import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.UrlItem;
 
-import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.cover.ToolManager;
-import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
@@ -57,7 +48,6 @@ import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 
 import org.sakaiproject.memory.api.Cache;
-import org.sakaiproject.memory.api.CacheRefresher;
 import org.sakaiproject.memory.api.MemoryService;
 
 import uk.org.ponder.messageutil.MessageLocator;
@@ -240,7 +230,7 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	String search = null;
 	if (bltiToolId != null)
 	    search = "tool_id=" + bltiToolId;
-	List<Map<String,Object>> contents = ltiService.getContents(search,null,0,0);
+	List<Map<String,Object>> contents = ltiService.getContents(search,null,0,0, getSiteId());
 	for (Map<String, Object> content : contents ) {
 	    Long id = getLong(content.get(LTIService.LTI_ID));
 	    if ( id == -1 ) continue;
@@ -281,10 +271,10 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	if ( id == null ) return; // Likely a failure
 	if ( ltiService == null) return;  // not basiclti or old
 	Long key = getLong(id);
-	content = ltiService.getContent(key);
+	content = ltiService.getContent(key, getSiteId());
 	if ( content == null ) return;
 	Long toolKey = getLongNull(content.get("tool_id"));
-	if (toolKey != null ) tool = ltiService.getTool(toolKey);
+	if (toolKey != null ) tool = ltiService.getTool(toolKey, getSiteId());
     }	
 
     // properties of entities
@@ -304,7 +294,7 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	// If I return null here, it appears that I cause an NPE in LB
 	if ( content == null ) return getErrorUrl();
 	String ret = (String) content.get("launch_url");
-	if ( ltiService != null && tool != null && ltiService.isMaintain()
+	if ( ltiService != null && tool != null && ltiService.isMaintain(getSiteId())
 	    	&& LTIService.LTI_SECRET_INCOMPLETE.equals((String) tool.get(LTIService.LTI_SECRET)) 
 		&& LTIService.LTI_SECRET_INCOMPLETE.equals((String) tool.get(LTIService.LTI_CONSUMERKEY)) ) {
 		String toolId = getCurrentTool("sakai.siteinfo");
@@ -371,7 +361,7 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	String search = null;
 	if (bltiToolId != null)
 	    search = "lti_tools.id=" + bltiToolId;
-	List<Map<String,Object>> tools = ltiService.getTools(search,null,0,0);
+	List<Map<String,Object>> tools = ltiService.getTools(search,null,0,0, bean.getCurrentSiteId());
 	for ( Map<String,Object> tool : tools ) {
 		String url = ServerConfigurationService.getToolUrl() + "/" + toolId + "/sakai.basiclti.admin.helper.helper?panel=ContentConfig&tool_id=" 
 			+ tool.get(LTIService.LTI_ID) + "&returnUrl=" + URLEncoder.encode(returnUrl);
@@ -469,7 +459,7 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 	//
 	Map<String,Object> theTool = null;
 	Map<String,Object> theBaseTool = null;
-	List<Map<String,Object>> tools = ltiService.getTools(null,null,0,0);
+	List<Map<String,Object>> tools = ltiService.getTools(null,null,0,0, simplePageBean.getCurrentSiteId());
 	for ( Map<String,Object> tool : tools ) {
 		String toolLaunch = (String) tool.get(LTIService.LTI_LAUNCH);
 		if ( toolLaunch.equals(launchUrl) ) {
@@ -504,11 +494,11 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 		props.setProperty(LTIService.LTI_XMLIMPORT,strXml);
 		if (custom != null)
 		    props.setProperty(LTIService.LTI_CUSTOM, custom);
-		Object result = ltiService.insertTool(props);
+		Object result = ltiService.insertTool(props, simplePageBean.getCurrentSiteId());
 		if ( result instanceof String ) {
 			log.info("Could not insert tool - "+result);
 		}
-		if ( result instanceof Long ) theTool = ltiService.getTool((Long) result);
+		if ( result instanceof Long ) theTool = ltiService.getTool((Long) result, simplePageBean.getCurrentSiteId());
 	}
 
 	Map<String,Object> theContent = null;
@@ -521,11 +511,11 @@ public class BltiEntity implements LessonEntity, BltiInterface {
 		props.setProperty(LTIService.LTI_LAUNCH,launchUrl);
 		props.setProperty(LTIService.LTI_XMLIMPORT,strXml);
 		if ( custom != null ) props.setProperty(LTIService.LTI_CUSTOM,custom);
-		Object result = ltiService.insertContent(props);
+		Object result = ltiService.insertContent(props, getSiteId());
 		if ( result instanceof String ) {
 			log.info("Could not insert content - "+result);
 		}
-		if ( result instanceof Long ) theContent = ltiService.getContent((Long) result);
+		if ( result instanceof Long ) theContent = ltiService.getContent((Long) result, getSiteId());
 	}
 
 	String sakaiId = null;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -25,7 +25,6 @@
 package org.sakaiproject.lessonbuildertool.tool.beans;
 
 import java.text.SimpleDateFormat;
-import java.text.Format;
 import java.math.BigDecimal;
 
 import org.apache.commons.lang.StringUtils;
@@ -65,7 +64,6 @@ import org.sakaiproject.lessonbuildertool.tool.producers.PagePickerProducer;
 import org.sakaiproject.lessonbuildertool.tool.view.GeneralViewParameters;
 import org.sakaiproject.memory.api.Cache;
 import org.sakaiproject.memory.api.MemoryService;
-import org.sakaiproject.memory.api.SimpleConfiguration;
 import org.sakaiproject.site.api.*;
 import org.sakaiproject.time.cover.TimeService;
 import org.sakaiproject.tool.api.Placement;
@@ -89,7 +87,6 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URI;
 import java.net.URLConnection;
-import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -6422,7 +6419,7 @@ public class SimplePageBean {
 	}
 
 	public List<Map<String, Object>> getToolsImportItem() {
-		return ltiService.getToolsImportItem();
+		return ltiService.getToolsImportItem(getCurrentSiteId());
 	}
 
 	public void handleImportItem() {
@@ -6439,7 +6436,7 @@ public class SimplePageBean {
                         return;
                 }
 
-                Map<String, Object> tool = ltiService.getTool(toolKey);
+                Map<String, Object> tool = ltiService.getTool(toolKey, getCurrentSiteId());
                 if ( tool == null ) {
 			setErrKey("simplepage.lti-import-error-id", toolId);
                         return;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/LtiImportItemProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/LtiImportItemProducer.java
@@ -30,21 +30,13 @@ import java.util.Properties;
 
 import java.net.URLEncoder;
 
-import org.sakaiproject.lessonbuildertool.service.LessonEntity;
 import org.sakaiproject.tool.cover.SessionManager;
 
-import org.sakaiproject.lessonbuildertool.SimplePage;
-import org.sakaiproject.lessonbuildertool.SimplePageItem;
 import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean;
-import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.UrlItem;
-import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.BltiTool;
 import org.sakaiproject.lessonbuildertool.tool.view.GeneralViewParameters;
-import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.ToolSession;
-import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
 import org.sakaiproject.component.cover.ServerConfigurationService;
-import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.lti.api.LTIService;
 import org.tsugi.lti2.ContentItem;
 import org.slf4j.Logger;
@@ -53,21 +45,15 @@ import org.sakaiproject.basiclti.util.SakaiBLTIUtil;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.tool.api.Placement;
 
-import org.sakaiproject.lessonbuildertool.service.BltiEntity;
-
 import uk.org.ponder.messageutil.MessageLocator;
 import uk.org.ponder.localeutil.LocaleGetter;										  
 import uk.org.ponder.rsf.components.UIBranchContainer;
 import uk.org.ponder.rsf.components.UICommand;
 import uk.org.ponder.rsf.components.UIContainer;
-import uk.org.ponder.rsf.components.UIVerbatim;
 import uk.org.ponder.rsf.components.UIForm;
 import uk.org.ponder.rsf.components.UILink;
 import uk.org.ponder.rsf.components.UIOutput;
 import uk.org.ponder.rsf.components.UIInput;
-import uk.org.ponder.rsf.components.UISelect;
-import uk.org.ponder.rsf.components.UISelectChoice;
-import uk.org.ponder.rsf.components.UIInternalLink;
 import uk.org.ponder.rsf.components.decorators.UIFreeAttributeDecorator;
 import uk.org.ponder.rsf.flow.jsfnav.NavigationCase;
 import uk.org.ponder.rsf.flow.jsfnav.NavigationCaseReporter;
@@ -161,7 +147,7 @@ public class LtiImportItemProducer implements ViewComponentProducer, NavigationC
 		}
 
 		// We are not in the pop-up iframe, create a list of  tools registered as importers
-		List<Map<String, Object>> toolsImportItem = ltiService.getToolsImportItem();
+		List<Map<String, Object>> toolsImportItem = ltiService.getToolsImportItem(toolManager.getCurrentPlacement().getContext());
 		if ( toolsImportItem.size() < 1 ) {
 			UIOutput.make(tofill, "error-div");
 			UIBranchContainer er = UIBranchContainer.make(tofill, "errors:");

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -48,6 +48,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.Vector;
 
 import javax.servlet.ServletContext;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2900,7 +2900,7 @@ public class SiteAction extends PagedResourceActionII {
 					 String toolId = entry.getKey();
 					// get the proper html for tool input
 					String ltiToolId = toolMap.get("id").toString();
-					String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), site.getId());
+					String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), UUID.randomUUID().toString());
 					// attach the ltiToolId to each model attribute, so that we could have the tool configuration page for multiple tools
 					for(int k=0; k<contentToolModel.length;k++)
 					{
@@ -3943,7 +3943,7 @@ public class SiteAction extends PagedResourceActionII {
 			SessionState state, Site site, boolean updateToolRegistration) {
 		List<Map<String, Object>> visibleTools, allTools;
 		// get the visible and all (including stealthed) list of lti tools
-		visibleTools = m_ltiService.getTools(null,null,0,0, site.getId());
+		visibleTools = m_ltiService.getTools(null,null,0,0, UUID.randomUUID().toString());
 		if (site == null) {
 			allTools = visibleTools;
 		} else {
@@ -6461,7 +6461,8 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		List<Map<String, Object>> allTools;
 		String siteId = "";
 		if ( site == null )
-			allTools = m_ltiService.getTools(null,null,0,0, site.getId());
+			// We dont' have a site yet so just ask for all the available ones.
+			allTools = m_ltiService.getTools(null,null,0,0, UUID.randomUUID().toString());
 		else
 		{
 			siteId = Objects.toString(site.getId(), "");


### PR DESCRIPTION
The LTIService now always wants the site ID passed into all it’s calls as assuming that the context is correct doesn’t work when the tool is in helper mode in My Workspace or the Administration Workspace.

As lots of the method signatures were changing I also did a cleanup, removing lots of useless JavaDoc and adding @Override to the appropriate methods.