### PR TITLE
SAK-32376: Ensure multiple places are obeying the option to display roster title rather than site title

### DIFF
--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SiteTitleAdvisorCMS.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SiteTitleAdvisorCMS.java
@@ -21,8 +21,10 @@
 
 package org.sakaiproject.coursemanagement.impl;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.collections.CollectionUtils;
@@ -80,7 +82,7 @@ public class SiteTitleAdvisorCMS implements SiteTitleAdvisor
     /**
      * {@inheritDoc}
      */
-    public String getUserSpecificSiteTitle( Site site, String userID )
+    public String getUserSpecificSiteTitle( Site site, String userID, List<String> siteProviders )
     {
         // Short circuit - only continue if sakai.property set to true
         if( portalUseSectionTitle )
@@ -108,8 +110,14 @@ public class SiteTitleAdvisorCMS implements SiteTitleAdvisor
             // Short circuit - only continue if user is not null and user does not have the site.upd permission in the given site
             if( currentUser != null && !ss.unlock( currentUser, SITE_UPDATE_PERMISSION, site.getReference() ) )
             {
+                Collection<String> providerIDs = siteProviders;
+                if( providerIDs == null )
+                {
+                    String realmID = site.getReference();
+                    providerIDs = azgs.getProviderIDsForRealms( ((List<String>) Arrays.asList( new String[] {realmID} )) ).get( realmID );
+                }
+
                 // Short circuit - only continue if there are more than one provider ID (cross listed site)
-                Set<String> providerIDs = azgs.getProviderIds( site.getReference() );
                 if( CollectionUtils.isNotEmpty( providerIDs ) )
                 {
                     // Get the current user's section membership/role map

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/AuthzGroupService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/AuthzGroupService.java
@@ -79,6 +79,14 @@ public interface AuthzGroupService extends EntityProducer
 	static final String AUTH_ROLE = ".auth";
 
 	/**
+	 * Get all provider IDs for the realms given.
+	 *
+	 * @param realmIDs a List of the realms you want the provider IDs for.
+	 * @return a Map, where the key is the realm ID, and the value is a List of Strings of provider IDs for that realm
+	 */
+	public Map<String, List<String>> getProviderIDsForRealms(List<String> realmIDs);
+
+	/**
 	 * Access a list of AuthzGroups that meet specified criteria, naturally sorted.
 	 * NOTE: The group objects returned will not have the associated roles loaded.
 	 * if you need to save the realm retrieve it with {@link #getAuthzGroup(String)}

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -1257,4 +1257,12 @@ public interface SiteService extends EntityProducer
 	 * @return the site or section title
 	 */
 	public String getUserSpecificSiteTitle( Site site, String userID );
-} 
+
+	/**
+	 * Similar to getUserSpecificSiteTitle(Site site, String userId), but consumes the specified siteProviders (for performance savings)
+	 *
+	 * @see getUserSpecificSiteTitle(Site site, String userId)
+	 * @param siteProviders the site providers corresponding to the specified site; if null, they will be looked up
+	 */
+	public String getUserSpecificSiteTitle(Site site, String userID, List<String> siteProviders);
+}

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteTitleAdvisor.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteTitleAdvisor.java
@@ -21,6 +21,8 @@
 
 package org.sakaiproject.site.api;
 
+import java.util.List;
+
 /**
  * SAK-29138 - Portal, user and site-manage tools will optionally (if an implementation is
  * present) use this to conditionally display the site or section title in the UI.
@@ -29,7 +31,7 @@ package org.sakaiproject.site.api;
  */
 public interface SiteTitleAdvisor
 {
-    /**
+	/**
 	 * Given a site and a user ID, return the appropriate site or section title for the user.
 	 * 
 	 * SAK-29138 - Takes into account 'portal.use.sectionTitle' sakai.property; 
@@ -39,7 +41,8 @@ public interface SiteTitleAdvisor
 	 * 
 	 * @param site the site in question
 	 * @param userID the ID of the current user
+	 * @param siteProviders the providerIDs associated with this site; they will be queried if this parameter is null
 	 * @return the site or section title
 	 */
-	public String getUserSpecificSiteTitle( Site site, String userID );
+	public String getUserSpecificSiteTitle( Site site, String userID, List<String> siteProviders );
 }

--- a/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
@@ -571,4 +571,18 @@ public class SiteService
 
 		return service.getUserSpecificSiteTitle( site, userID );
 	}
+
+	/**
+	 * Similar to getUserSpecificSiteTitle(Site site, String userId), but consumes the specified siteProviders (for performance savings)
+	 *
+	 * @see getUserspecificSiteTitle(Site site, String userId)
+	 * @param siteProviders the site providers corresponding to the specified site; if null, they will be looked up
+	 */
+	public static String getUserSpecificSiteTitle(Site site, String userId, List<String> siteProviders)
+	{
+		org.sakaiproject.site.api.SiteService service = getInstance();
+		if (service == null) return null;
+
+		return service.getUserSpecificSiteTitle(site, userId, siteProviders);
+	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroupService.java
@@ -331,6 +331,14 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 	/**
 	 * {@inheritDoc}
 	 */
+	public Map<String, List<String>> getProviderIDsForRealms(List<String> realmIDs)
+	{
+		return m_storage.getProviderIDsForRealms(realmIDs);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public List getAuthzGroups(String criteria, PagingPosition page)
 	{
 		return m_storage.getAuthzGroups(criteria, page);
@@ -1364,6 +1372,14 @@ public abstract class BaseAuthzGroupService implements AuthzGroupService
 		 *        The azGroup to remove.
 		 */
 		void remove(AuthzGroup azGroup);
+
+		/**
+		 * Get all provider IDs for the realms given.
+		 *
+		 * @param realmIDs a List of the realms you want the provider IDs for.
+		 * @return a Map, where the key is the realm ID, and the value is a List of Strings of provider IDs for that realm
+		 */
+		public Map<String, List<String>> getProviderIDsForRealms(List<String> realmIDs);
 
 		/**
 		 * Access a list of AuthzGroups that meet specified criteria, naturally sorted.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -1121,6 +1121,54 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 		/**
 		 * {@inheritDoc}
 		 */
+		public Map<String, List<String>> getProviderIDsForRealms(List<String> realmIDs)
+		{
+			Map<String, List<String>> realmProviderMap = new HashMap<>();
+			if (realmIDs != null && realmIDs.size() > 0)
+			{
+				// Custom reader to get only realm_id and provider_id
+				SqlReader reader = (result)-> {
+					try
+					{
+						String realmID = result.getString(1);
+						String providerIDs = result.getString(2);
+						List<String> retVal = new ArrayList<>();
+						retVal.add(realmID);
+						retVal.add(providerIDs);
+						return retVal;
+					}
+					catch (SQLException ex)
+					{
+						// Avoid nulls by returning an empty Colleciton<String>
+						M_log.warn("getProviderIDsForRealms.readSqlResultRecord: " + ex);
+						return Collections.<String>emptyList();
+					}
+				};
+
+				// Execute the SQL statement
+				String sql = dbAuthzGroupSql.getSelectRealmsProviderIDsSql(orInClause(realmIDs.size(), "r.realm_id"));
+				Object[] fields = realmIDs.toArray();
+				List<List<String>> results = (List<List<String>>) m_sql.dbRead(sql, fields, reader);
+
+				// Build the realm-provider map
+				for (List<String> list : results)
+				{
+					String realmID = list.get(0);
+					String providerIDs = list.get(1);
+
+					if (StringUtils.isNotBlank(realmID) && StringUtils.isNotBlank(providerIDs))
+					{
+						realmProviderMap.put(realmID, Arrays.asList(providerIDs.split("\\+")));
+					}
+				}
+			}
+
+			return realmProviderMap;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
 		public Set getAuthzGroupIds(String providerId)
 		{
 			String statement = dbAuthzGroupSql.getSelectRealmIdSql();

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSql.java
@@ -115,6 +115,8 @@ public interface DbAuthzGroupSql
 
 	String getSelectRealmProviderId2Sql();
 
+	String getSelectRealmsProviderIDsSql(String inClause);
+
 	String getSelectRealmProviderSql(String inClause);
 
 	String getSelectRealmRoleDescriptionSql();

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlDefault.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupSqlDefault.java
@@ -362,6 +362,11 @@ public class DbAuthzGroupSqlDefault implements DbAuthzGroupSql
 		return sqlBuilder.toString();
 	}
 
+	public String getSelectRealmsProviderIDsSql(String inClause)
+	{
+		return "SELECT r.realm_id, r.provider_id FROM sakai_realm r WHERE " + inClause;
+	}
+
 	public String getSelectRealmProvider2Sql()
 	{
 		return "SELECT RR.ROLE_NAME, RRD.DESCRIPTION, RRD.PROVIDER_ONLY FROM SAKAI_REALM_ROLE_DESC RRD"

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -3557,11 +3557,19 @@ public abstract class BaseSiteService implements SiteService, Observer
 	/**
 	 * {@inheritDoc}
 	 */
-	public String getUserSpecificSiteTitle( Site site, String userID )
+	public String getUserSpecificSiteTitle(Site site, String userID)
+	{
+		return getUserSpecificSiteTitle(site, userID, null);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getUserSpecificSiteTitle(Site site, String userID, List<String> siteProviders)
 	{
 		if( m_siteTitleAdvisor != null )
 		{
-			return m_siteTitleAdvisor.getUserSpecificSiteTitle( site, userID );
+			return m_siteTitleAdvisor.getUserSpecificSiteTitle( site, userID, siteProviders );
 		}
 		else
 		{

--- a/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockAuthzGroupService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockAuthzGroupService.java
@@ -25,6 +25,10 @@ import org.w3c.dom.Element;
 
 public class MockAuthzGroupService implements AuthzGroupService {
 
+	public Map<String, List<String>> getProviderIDsForRealms(List<String> realmIDs) {
+		return null;
+	}
+
 	public AuthzGroup addAuthzGroup(String id) throws GroupIdInvalidException,
 			GroupAlreadyDefinedException, AuthzPermissionException {
 		// TODO Auto-generated method stub

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalSiteHelper.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalSiteHelper.java
@@ -21,6 +21,7 @@
 
 package org.sakaiproject.portal.api;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -98,7 +99,7 @@ public interface PortalSiteHelper
 	Map convertSiteToMap(HttpServletRequest req, Site s, String prefix,
 			String currentSiteId, String myWorkspaceSiteId, boolean includeSummary,
 			boolean expandSite, boolean resetTools, boolean doPages,
-			String toolContextPath, boolean loggedIn);
+			String toolContextPath, boolean loggedIn, List<String> siteProviders);
 
 	/**
 	 * SAK-29138 - Get the site or section title for the current user for the current site.
@@ -112,6 +113,23 @@ public interface PortalSiteHelper
 	 * @return the site or section title
 	 */
 	String getUserSpecificSiteTitle( Site site, boolean escaped );
+
+	/**
+	 * Similar to getUserSpecificSiteTitle(Site site, boolean escaped), but also takes truncated parameter
+	 *
+	 * @see getUserSpecificSiteTitle(Site site, String userId)
+	 * @param truncated true if you want long titles to be truncated with an ellipses
+	 */
+	String getUserSpecificSiteTitle(Site site, boolean truncated, boolean escaped);
+
+	/**
+	 * Similar to getUserSpecificSiteTitle(Site site, boolean escaped), but consumes the specified siteProviders (for performance savings)
+	 *
+	 * @see getUserSpecificSiteTitle(Site site, String userId)
+	 * @param truncated true if you want long titles to be truncated with an ellipses
+	 * @param siteProviders the site providers corresponding to the specified site; if null, they will be looked up
+	 */
+	String getUserSpecificSiteTitle(Site site, boolean truncated, boolean escaped, List<String> siteProviders);
 
 	/**
 	 * Generates a SiteView object from the current request and location

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/JoinHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/JoinHandler.java
@@ -1,6 +1,7 @@
 package org.sakaiproject.portal.charon.handlers;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -11,6 +12,7 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.portal.api.PortalRenderContext;
+import org.sakaiproject.portal.charon.site.PortalSiteHelperImpl;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.tool.api.Session;
@@ -133,11 +135,12 @@ public class JoinHandler extends BasePortalHandler
 					String serviceName = ServerConfigurationService.getString("ui.service", "Sakai");
 					
 					// SAK-29138
-					String title = serviceName + " : "+ portal.getSiteHelper().getUserSpecificSiteTitle( site, false );
+					List<String> siteProviders = (List<String>) PortalSiteHelperImpl.getProviderIDsForSite(site);
+					String title = serviceName + " : " + portal.getSiteHelper().getUserSpecificSiteTitle(site, true, false, siteProviders);
 					
 					String skin = site.getSkin();
 					PortalRenderContext context = portal.startPageContext(siteType, title, skin, req);
-					context.put("currentSite", portal.getSiteHelper().convertSiteToMap(req, site, null, site.getId(), null, false, false, false, false, null, true));
+					context.put("currentSite", portal.getSiteHelper().convertSiteToMap(req, site, null, site.getId(), null, false, false, false, false, null, true, siteProviders));
 					context.put("uiService", serviceName);
 					
 					boolean restrictedByAccountType = !SiteService.getInstance().isAllowedToJoin(siteId);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -23,18 +23,17 @@ package org.sakaiproject.portal.charon.handlers;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Enumeration;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.Cookie;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -57,6 +56,7 @@ import org.sakaiproject.portal.api.PortalRenderContext;
 import org.sakaiproject.portal.api.SiteView;
 import org.sakaiproject.portal.api.StoredState;
 import org.sakaiproject.portal.charon.site.AllSitesViewImpl;
+import org.sakaiproject.portal.charon.site.PortalSiteHelperImpl;
 import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.tool.api.ToolSession;
 import org.sakaiproject.tool.api.ToolManager;
@@ -406,8 +406,9 @@ public class SiteHandler extends WorksiteHandler
 		session.removeAttribute(Portal.ATTR_SITE_PAGE + siteId);
 
 		// SAK-29138 - form a context sensitive title
+		List<String> providers = PortalSiteHelperImpl.getProviderIDsForSites(((List<Site>) Arrays.asList(new Site[] { site }))).get(site.getReference());
 		String title = ServerConfigurationService.getString("ui.service","Sakai") + " : "
-				+ portal.getSiteHelper().getUserSpecificSiteTitle( site, false );
+				+ portal.getSiteHelper().getUserSpecificSiteTitle(site, false, false, providers);
 
 		// Lookup the page in the site - enforcing access control
 		// business rules
@@ -535,8 +536,8 @@ public class SiteHandler extends WorksiteHandler
 			rcontext.put("siteTitle", rb.getString("sit_mywor") );
 			rcontext.put("siteTitleTruncated", rb.getString("sit_mywor") );
 		}else{
-			rcontext.put("siteTitle", Web.escapeHtml(site.getTitle()));
-			rcontext.put("siteTitleTruncated", portal.getSiteHelper().getUserSpecificSiteTitle( site, false ) );
+			rcontext.put("siteTitle", portal.getSiteHelper().getUserSpecificSiteTitle(site, false, true, providers));
+			rcontext.put("siteTitleTruncated", portal.getSiteHelper().getUserSpecificSiteTitle(site, true, false, providers));
 		}
 		
 		addLocale(rcontext, site, session.getUserId());

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/CurrentSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/CurrentSiteViewImpl.java
@@ -21,6 +21,7 @@
 
 package org.sakaiproject.portal.charon.site;
 
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import org.sakaiproject.component.api.ServerConfigurationService;
@@ -95,11 +96,12 @@ public class CurrentSiteViewImpl implements SiteView
 		try
 		{
 			Site site = siteHelper.getSiteVisit(currentSiteId);
+			List<String> siteProviders = (List<String>) PortalSiteHelperImpl.getProviderIDsForSite(site);
 			siteMap = siteHelper
 					.convertSiteToMap(request, site, prefix, currentSiteId,
 							myWorkspaceSiteId, includeSummary,
 							/* expandSite */true, resetTools, doPages, toolContextPath,
-							loggedIn);
+							loggedIn, siteProviders);
 		}
 		catch (IdUnusedException e)
 		{

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.alias.api.Alias;
 import org.sakaiproject.alias.api.AliasService;
+import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
@@ -122,6 +123,10 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			toolManager = (ToolManager) ComponentManager.get(ToolManager.class.getName());
 		}
 		return toolManager;
+	}
+
+	private static AuthzGroupService getAuthzGroupService() {
+		return (AuthzGroupService) ComponentManager.get(AuthzGroupService.class.getName());
 	}
 
 	public void setToolManager(ToolManager toolManager) {
@@ -289,6 +294,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
                 }
 
 		// Determine the depths of the child sites if needed
+		Map<String, List<String>> realmProviderMap = getProviderIDsForSites(mySites);
 		for (Iterator i = mySites.iterator(); i.hasNext();)
 		{
 			Site s = (Site) i.next();
@@ -317,7 +323,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 
 			Map m = convertSiteToMap(req, s, prefix, currentSiteId, myWorkspaceSiteId,
 					includeSummary, expandSite, resetTools, doPages, toolContextPath,
-					loggedIn);
+					loggedIn, realmProviderMap.get(s.getReference()));
 
 			// Add the Depth of the site
 			m.put("depth", cDepth);
@@ -344,16 +350,64 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 	}
 
 	/**
+	 * Get all provider IDs for the given site.
+	 *
+	 * @author bjones86 - OWL-1551
+	 *
+	 * @param site the site to retrieve all provider IDs
+	 * @return a List of Strings of provider IDs for the given site
+	 */
+	public static List<String> getProviderIDsForSite(Site site)
+	{
+		List<String> providers = new ArrayList<>();
+		if (site != null)
+		{
+			providers.addAll(getAuthzGroupService().getProviderIds(site.getReference()));
+		}
+
+		return providers;
+	}
+
+	/**
+	 * Get all provider IDs for all sites given.
+	 * @author bjones86 - OWL-1551
+	 *
+	 * @param sites the list of sites to retrieve all provider IDs
+	 * @return a Map, where the key is the realm ID, and the value is a list of provider IDs for that site
+	 */
+	public static Map<String, List<String>> getProviderIDsForSites(List<Site> sites)
+	{
+		Map<String, List<String>> realmProviderMap = new HashMap<>();
+		if (!sites.isEmpty())
+		{
+			List<String> realmIDs = new ArrayList<>();
+			for (Site site : sites)
+			{
+				realmIDs.add(site.getReference());
+			}
+
+			realmProviderMap = getAuthzGroupService().getProviderIDsForRealms(realmIDs);
+		}
+
+		return realmProviderMap;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public String getUserSpecificSiteTitle( Site site, boolean escaped )
 	{
-		return getUserSpecificSiteTitle( site, true, escaped );
+		return getUserSpecificSiteTitle( site, true, escaped, null );
 	}
 
 	public String getUserSpecificSiteTitle( Site site, boolean truncated, boolean escaped )
 	{
-		String retVal = SiteService.getUserSpecificSiteTitle( site, UserDirectoryService.getCurrentUser().getId() );
+		return getUserSpecificSiteTitle(site, truncated, escaped, null);
+	}
+
+	public String getUserSpecificSiteTitle(Site site, boolean truncated, boolean escaped, List<String> siteProviders)
+	{
+		String retVal = SiteService.getUserSpecificSiteTitle( site, UserDirectoryService.getCurrentUser().getId(), siteProviders );
 		if( truncated )
 		{
 			retVal = FormattedText.makeShortenedText( retVal, null, null, null );
@@ -373,12 +427,12 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 	 * @see org.sakaiproject.portal.api.PortalSiteHelper#convertSiteToMap(javax.servlet.http.HttpServletRequest,
 	 *      org.sakaiproject.site.api.Site, java.lang.String, java.lang.String,
 	 *      java.lang.String, boolean, boolean, boolean, boolean,
-	 *      java.lang.String, boolean)
+	 *      java.lang.String, boolean, java.util.List<java.lang.String>)
 	 */
 	public Map convertSiteToMap(HttpServletRequest req, Site s, String prefix,
 			String currentSiteId, String myWorkspaceSiteId, boolean includeSummary,
 			boolean expandSite, boolean resetTools, boolean doPages,
-			String toolContextPath, boolean loggedIn)
+			String toolContextPath, boolean loggedIn, List<String> siteProviders)
 	{
 		if (s == null) return null;
 		Map<String, Object> m = new HashMap<>();
@@ -394,12 +448,9 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				&& (s.getId().equals(myWorkspaceSiteId) || effectiveSite
 						.equals(myWorkspaceSiteId))));
 		
-		// SAK-29138
-		String siteTitleTruncated = getUserSpecificSiteTitle( s, true, true );
-		String siteTitleNotTruncated = getUserSpecificSiteTitle( s, false, true );
-		m.put( "siteTitleNotTruncated", siteTitleNotTruncated );
-		m.put( "siteTitle", siteTitleTruncated );
-		m.put( "fullTitle", siteTitleNotTruncated );
+		String siteTitle = getUserSpecificSiteTitle(s, false, true, siteProviders);
+		m.put("siteTitle", siteTitle);
+		m.put("fullTitle", siteTitle);
 		
 		m.put("siteDescription", s.getHtmlDescription());
 
@@ -440,12 +491,8 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					// System.out.println("PWD["+i+"]="+site.getId()+"
 					// "+site.getTitle());
 					Map<String, Object> pm = new HashMap<>();
-					String siteTitleTruncatedBreadCrumb = getUserSpecificSiteTitle( site, true, true );
-					String siteTitleNotTruncatedBreadCrumb = getUserSpecificSiteTitle( site, false, true );
-					
-					pm.put("siteTitleNotTruncated", siteTitleNotTruncatedBreadCrumb );
-					pm.put("siteTitle", siteTitleTruncatedBreadCrumb );
-					pm.put("fullTitle", siteTitleNotTruncatedBreadCrumb );
+					List<String> providers = getProviderIDsForSite(site);
+					pm.put("siteTitle", getUserSpecificSiteTitle(site, false, true, providers));
 					pm.put("siteUrl", siteUrl + Web.escapeUrl(getSiteEffectiveId(site)));
 
 					l.add(pm);

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MembershipAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MembershipAction.java
@@ -243,7 +243,11 @@ public class MembershipAction extends PagedResourceActionII
 		else
 		{
 			// process all the sites the user has access to so can unjoin
-			List unjoinableSites = prepPage(state);
+			List<Site> unjoinableSites = prepPage(state);
+			for (Site site : unjoinableSites)
+			{
+				site.setTitle(SITE_SERV.getUserSpecificSiteTitle(site, userDirectoryService.getCurrentUser().getId()));
+			}
 			pagingInfoToContext(state, context);
 			context.put("unjoinableSites", unjoinableSites);
 			context.put("tlang", RB);
@@ -428,7 +432,11 @@ public class MembershipAction extends PagedResourceActionII
 		}
 		context.put(SEARCH_TERM, state.getAttribute(SEARCH_TERM));
 
-		List openSites = prepPage(state);
+		List<Site> openSites = prepPage(state);
+		for (Site site : openSites)
+		{
+			site.setTitle(SITE_SERV.getUserSpecificSiteTitle(site, userDirectoryService.getCurrentUser().getId()));
+		}
 		context.put("openSites", openSites);
 
 		pagingInfoToContext(state, context);

--- a/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/tool/UserPrefsTool.java
+++ b/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/tool/UserPrefsTool.java
@@ -34,7 +34,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.Vector;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
@@ -2253,7 +2252,7 @@ public class UserPrefsTool
 			
 			try {
 				Site site = SiteService.getSite(siteId);
-				this.siteTitle =site.getTitle();
+				this.siteTitle = getUserSpecificSiteTitle(site);
 			} catch (IdUnusedException e) {
 				LOG.warn("Unable to get Site object for id: " + siteId, e);
 			}
@@ -2308,7 +2307,7 @@ public class UserPrefsTool
 			this.defaultOpen = defaultOpen;
 			
 			for (DecoratedSiteBean dsb : sites) {
-				sitesAsSelects.add(new SelectItem(dsb.getSite().getId(), dsb.getSite().getTitle()));
+				sitesAsSelects.add(new SelectItem(dsb.getSite().getId(), getUserSpecificSiteTitle(dsb.getSite())));
 			}			
 		}
 		
@@ -2567,6 +2566,7 @@ public class UserPrefsTool
 					termsToSites.put(term, new ArrayList<Site>(1));
 				}
 
+				site.setTitle(getUserSpecificSiteTitle(site));
 				termsToSites.get(term).add(site);
 			}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32376

A commit from SAK-30334 (21c0baf) broke Preferences obeying the sakai.property to display roster title rather than site title, which was introduced in SAK-29138.

This PR reimplements this aspect of the feature, as well as making the breadcrumbs,  browser/tab title and Membership tool obey the sakai.property. It also contains some performance improvements we've had in production for over a year.