### PR TITLE
SAK-32386: force 'overview' tool to the top of the tool menu via sakai.property

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -912,6 +912,11 @@
 # DEFAULT: 0
 # portal.cdn.expire=0
 
+# Allows forcing the 'Overview' tool to the top of tool list LHS menu system wide.
+# See SAK-32386.
+# DEFAULT: false
+# portal.forceOverviewToTop=true
+
 # ########################################################################
 # SECURITY
 # ########################################################################


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32386

There was a need at our institution to force the 'Overview' tool (formerly 'Home') to the top of the tool list in every site. We've implemented this behind a sakai.property (portal.forceOverviewToTop) which defaults to false to preserve OOTB functionality .