### PR TITLE
SAK-32387 sites containing iframes jump back to top after site finish…

### DIFF
--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -327,9 +327,6 @@ function setMainFrameHeightNow(id, maxHeight)
 	
 	if (frame)
 	{
-		// reset the scroll
-		parent.window.scrollTo(0,0);
-
 		var objToResize = (frame.style) ? frame.style : frame;
   
     // SAK-11014 revert           if ( false ) {


### PR DESCRIPTION
…ed loading

more on [Jira](https://jira.sakaiproject.org/browse/SAK-32387)

I'm not actually sure what this (11 year old) line was for. But removing it worked for us.