### PR TITLE
SAL-32391 Better warning when ID length exceeded.

### DIFF
--- a/content/content-bundles/resources/content.properties
+++ b/content/content-bundles/resources/content.properties
@@ -646,6 +646,8 @@ dragndrop.upload.error = There was an error uploading the file {0} to the server
 dragndrop.duplicated.error = The file {0} cannot be duplicated more than {1} times
 dragndrop.collection.error = There was an error attempting to store the file {1} in the folder {0}
 dragndrop.overload.error = There was an error uploading the file {0} to the server
+dragndrop.length.error = The total length of the path to the file {0} is longer than the limit of {1}, please use \
+  a shorter filename or a shorter folder name.
 
 # SAK-25709
 list.cols.columns=Display Columns

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -6460,13 +6460,10 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
             {
 	            addAlert(state, trb.getFormattedMessage("paste.error", new Object[]{name}));
             }
-            catch (IdLengthException e)
-            {
-				addAlert(state, trb.getFormattedMessage("alert.toolong", new String[]{e.getMessage()}));
-	            // TODO Auto-generated catch block
-	            logger.warn("IdLengthException " + e);
-            }
-			
+			catch (IdLengthException e)
+			{
+				addAlert(state, trb.getFormattedMessage("alert.toolong", e.getReference()));
+			}
 		}
 		else if("cancel".equals(user_action))
 		{

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -48,6 +48,7 @@ import java.io.PrintWriter;
 
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.lang.StringUtils;
+import org.sakaiproject.exception.IdLengthException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.cheftool.Context;
@@ -2161,12 +2162,14 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 		}
 		catch (OverQuotaException e) {
 			addAlert(state, rb.getString("alert.over-site-upload-quota"));
-			logger.warn("Drag and drop upload exceeded site quota: " + e, e);
 			return;
 		}
 		catch (ServerOverloadException e) {
 			addAlert(state,contentResourceBundle.getFormattedMessage("dragndrop.overload.error",new Object[]{uploadFileName}));
-			logger.warn("Drag and drop upload overloaded the server: " + e, e);
+			return;
+		}
+		catch (IdLengthException e) {
+			addAlert(state, contentResourceBundle.getFormattedMessage("dragndrop.length.error", e.getReference(), e.getLimit()));
 			return;
 		}
 		catch (Exception e) {

--- a/kernel/api/src/main/java/org/sakaiproject/exception/IdLengthException.java
+++ b/kernel/api/src/main/java/org/sakaiproject/exception/IdLengthException.java
@@ -29,8 +29,19 @@ package org.sakaiproject.exception;
 public class IdLengthException extends SakaiException
 {
 
-	public IdLengthException(String id)
+	private final int limit;
+
+	/**
+	 * @param id The resource for which the length is too long.
+	 * @param limit The limit that was hit.
+	 */
+	public IdLengthException(String id, int limit)
 	{
 		super(id);
+		this.limit = limit;
+	}
+
+	public int getLimit() {
+		return limit;
 	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -2185,7 +2185,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		String id = collectionId + name.trim();
 		if (id.length() > MAXIMUM_RESOURCE_ID_LENGTH)
 		{
-			throw new IdLengthException(id);
+			throw new IdLengthException(id, MAXIMUM_RESOURCE_ID_LENGTH);
 		}
 
 
@@ -3375,7 +3375,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		id = (String) fixTypeAndId(id, type).get("id");
 		if (id.length() > MAXIMUM_RESOURCE_ID_LENGTH)
 		{
-			throw new IdLengthException(id);
+			throw new IdLengthException(id, MAXIMUM_RESOURCE_ID_LENGTH);
 		}
 
 		ContentResourceEdit edit = null;
@@ -3473,7 +3473,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				String new_id = collectionId + base + "-" + attempts + ext;
 				if (new_id.length() > MAXIMUM_RESOURCE_ID_LENGTH)
 				{
-					throw new IdLengthException(new_id);
+					throw new IdLengthException(new_id, MAXIMUM_RESOURCE_ID_LENGTH);
 				}
 				if (!siblings.contains(new_id))
 				{
@@ -3561,7 +3561,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		String id = collectionId + name;
 		if(id.length() > ContentHostingService.MAXIMUM_RESOURCE_ID_LENGTH)
 		{
-			throw new IdLengthException(id);
+			throw new IdLengthException(id, MAXIMUM_RESOURCE_ID_LENGTH);
 		}
 
 		BaseResourceEdit edit = null;
@@ -3615,7 +3615,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 
 					if (id.length() > MAXIMUM_RESOURCE_ID_LENGTH)
 					{
-						throw new IdLengthException(id);
+						throw new IdLengthException(id, MAXIMUM_RESOURCE_ID_LENGTH);
 					}
 				}
 				while (siblings.contains(id));
@@ -3801,7 +3801,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		id = (String) fixTypeAndId(id, type).get("id");
 		if (id.length() > MAXIMUM_RESOURCE_ID_LENGTH)
 		{
-			throw new IdLengthException(id);
+			throw new IdLengthException(id, MAXIMUM_RESOURCE_ID_LENGTH);
 		}
 
 		ContentResourceEdit edit = null;
@@ -3898,7 +3898,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				String new_id = collectionId + base + "-" + attempts + ext;
 				if (new_id.length() > MAXIMUM_RESOURCE_ID_LENGTH)
 				{
-					throw new IdLengthException(new_id);
+					throw new IdLengthException(new_id, MAXIMUM_RESOURCE_ID_LENGTH);
 				}
 				if (!siblings.contains(new_id))
 				{
@@ -5039,7 +5039,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		String new_id = newName(id, folder_id);
 		if (new_id.length() >= MAXIMUM_RESOURCE_ID_LENGTH)
 		{
-			throw new IdLengthException(new_id);
+			throw new IdLengthException(new_id, MAXIMUM_RESOURCE_ID_LENGTH);
 		}
 
 		// Should use copyIntoFolder if possible
@@ -5515,7 +5515,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 	 *            if copied item is a collection and the new id is already in use or if the copied item is not a collection and a unique id cannot be found in some arbitrary number of attempts (@see MAXIMUM_ATTEMPTS_FOR_UNIQUENESS).
 	 * @exception ServerOverloadException
 	 *            if the server is configured to write the resource body to the filesystem and the save fails.
-	 * @see copyIntoFolder(String, String) method (preferred method for invocation from a tool).
+	 * @see #copyIntoFolder(String, String) method (preferred method for invocation from a tool).
 	 */
 	public String copy(String id, String new_id) throws PermissionException, IdUnusedException, TypeException, InUseException,
 	OverQuotaException, IdUsedException, ServerOverloadException


### PR DESCRIPTION
When uploading a file of creating a new file that will exceed the length of the ID column the error message generated wasn’t very good (just generic error, of null in message when creating text file).

Now we say what went wrong and when uploading a file specify what the actual limit is so the user has more of an idea how to fix it.