### PR TITLE
SAK-31758: In Calendar tool, Manually entering date gives NaN/NaN/NaN

### DIFF
--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_new.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_new.vm
@@ -382,7 +382,8 @@ $(function() {
 					ashidden:{
 						month:"month",
 						day:"day",
-						year:"yearSelect"
+						year:"yearSelect",
+						iso8601: 'newCalendarDateISO8601'
 					}
 				});
 			</script>


### PR DESCRIPTION
There is a conflict with the event message editor (if the editor is removed, the problem dissapears) and a datepicker without indicate hh:mm:ss.
If hh:mm:ss is indicated with the input hidden ISO8601, problem also dissapears.