### PR TITLE
SAK-32398 Remove Apache Commons FileItem#get() use

### DIFF
--- a/access/access-impl/impl/src/java/org/sakaiproject/access/tool/WebServlet.java
+++ b/access/access-impl/impl/src/java/org/sakaiproject/access/tool/WebServlet.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.access.tool;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Enumeration;
 
 import javax.servlet.ServletConfig;
@@ -196,14 +197,18 @@ public class WebServlet extends AccessServlet
 			if (o != null && o instanceof FileItem)
 			{
 				FileItem fi = (FileItem) o;
-				// System.out.println("found file " + fi.getName());
-				if (!writeFile(fi.getName(), fi.getContentType(), fi.get(), path, req, res, true)) return;
+				try (InputStream inputStream = fi.getInputStream())
+				{
+					if (!writeFile(fi.getName(), fi.getContentType(), inputStream, path, req, res, true)) return;
+				} catch (IOException ioe) {
+					M_log.warn("Problem getting InputStream", ioe);
+				}
 			}
 		}
 	}
 
-	protected boolean writeFile(String name, String type, byte[] data, String dir, HttpServletRequest req,
-			HttpServletResponse resp, boolean mkdir)
+	protected boolean writeFile(String name, String type, InputStream inputStream, String dir, HttpServletRequest req,
+								HttpServletResponse resp, boolean mkdir)
 	{
 		try
 		{
@@ -283,7 +288,7 @@ public class WebServlet extends AccessServlet
 				resourceProperties.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
 
 				// System.out.println("Trying Add " + path);
-				ContentResource resource = contentHostingService.addResource(path, type, data, resourceProperties,
+				ContentResource resource = contentHostingService.addResource(path, type, inputStream, resourceProperties,
 						NotificationService.NOTI_NONE);
 
 			}
@@ -295,7 +300,7 @@ public class WebServlet extends AccessServlet
 					try
 					{
 						ContentCollection collection = contentHostingService.addCollection(dir, resourceProperties);
-						return writeFile(name, type, data, dir, req, resp, false);
+						return writeFile(name, type, inputStream, dir, req, resp, false);
 					}
 					catch (Throwable ee)
 					{

--- a/feedback/src/java/org/sakaiproject/feedback/util/FileItemDataSource.java
+++ b/feedback/src/java/org/sakaiproject/feedback/util/FileItemDataSource.java
@@ -1,0 +1,45 @@
+package org.sakaiproject.feedback.util;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.io.FilenameUtils;
+
+import javax.activation.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Proxy to allow FileItems to be used as DataSources for attachments.
+ */
+public class FileItemDataSource implements DataSource {
+
+    private FileItem fileItem;
+
+    public FileItemDataSource(FileItem fileItem) {
+        this.fileItem = fileItem;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return fileItem.getInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        throw new IOException("getOutputStream() isn't supported");
+    }
+
+    @Override
+    public String getContentType() {
+        return fileItem.getContentType();
+    }
+
+    @Override
+    public String getName() {
+        String fileName = fileItem.getName();
+        if (fileName != null) {
+            fileName = FilenameUtils.getName(fileName);
+        }
+        return fileName;
+    }
+}

--- a/feedback/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
+++ b/feedback/src/java/org/sakaiproject/feedback/util/SakaiProxy.java
@@ -177,15 +177,7 @@ public class SakaiProxy {
 
 		if (fileItems.size() > 0) {
 			for (FileItem fileItem : fileItems) {
-				String name = fileItem.getName();
-
-				if (name.contains("/")) {
-					name = name.substring(name.lastIndexOf("/") + 1);
-                } else if (name.contains("\\")) {
-					name = name.substring(name.lastIndexOf("\\") + 1);
-                }
-
-				attachments.add(new Attachment(new ByteArrayDataSource(fileItem.get(), fileItem.getContentType()), name));
+				attachments.add(new Attachment(new FileItemDataSource(fileItem)));
 			}
 		}
 


### PR DESCRIPTION
This returns the file upload as a byte array which if you are allowing large uploads would all get read onto the heap. Instead it uses an input stream.

Opening this as another PR as #4181 has been looked over and I didn't want to confuse people who are reviewing what code is old and what is new.