### PR TITLE
SAK-32151 Be explicit about dependency with scope

### DIFF
--- a/rubrics/pom.xml
+++ b/rubrics/pom.xml
@@ -58,7 +58,8 @@
             <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
-                <scope>provided</scope>
+		<version>${sakai.commons.lang.version}</version>
+		<scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>commons-configuration</groupId>


### PR DESCRIPTION
With older Maven versions you have to specify a version when you specify
a scope even if the version is defined in a parent POM. Later maven
versions cope with this. Maven 3.2.3 which is used on the nightly server
fails. Maven 3.2.5+ seem to work.