### PR TITLE
SAK-32440 Allow hiding LTI config in Site Info -> Manage Tools

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -523,4 +523,14 @@ public interface LTIService {
 	 * @return <code>true</code> if the user has to provide some more configuration.
 	 */
 	boolean needsConfig(Map<String, Object> tool, String[] contentToolModel);
+
+    /**
+     * This returns the default properties that an instance of the tool should have.
+     * This is useful when you want to create an instance of the tool, but don't want to prompt the user to confirm
+     * any of the configuration.
+     * @param ltiTool The LTI tool.
+     * @param contentToolModel The model for the tool.
+     * @return The default required values.
+     */
+    Properties defaultConfig(Map<String, Object> ltiTool, String[] contentToolModel);
 }

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -99,6 +99,7 @@ public interface LTIService {
             "title:text:label=bl_title:required=true:maxlength=1024",
             "allowtitle:radio:label=bl_allowtitle:choices=disallow,allow",
             "fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
+            "allowfa_icon:radio:label=bl_allowfa_icon:choices=disallow,allow",
             "pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
             "allowpagetitle:radio:label=bl_allowpagetitle:choices=disallow,allow",
             "description:textarea:label=bl_description:maxlength=4096",

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -460,6 +460,7 @@ public interface LTIService {
     void filterContent(Map<String, Object> content, Map<String, Object> tool);
 
 
+
     // --- Deploy
     Object insertDeployDao(Properties newProps);
 
@@ -504,4 +505,12 @@ public interface LTIService {
     String formInput(Object row, String[] fieldInfo);
 
     boolean isAdmin(String siteId);
+
+	/**
+	 * This checks if a tool has to be configured to work in the site or if we should just skip the configuration.
+	 * @param tool The LTI tool.
+	 * @param contentToolModel The model for the tool.
+	 * @return <code>true</code> if the user has to provide some more configuration.
+	 */
+	boolean needsConfig(Map<String, Object> tool, String[] contentToolModel);
 }

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -142,6 +142,8 @@ public interface LTIService {
             "tool_proxy_binding:textarea:label=bl_tool_proxy_binding:maxlength=2M:only=lti2:hide=insert:role=admin",
             "allowcustom:checkbox:label=bl_allowcustom",
             "xmlimport:textarea:hidden=true:maxlength=1M",
+            // Should we hide the more advanced config options when allowing people to add this tool?
+            "hideconfig:checkbox:label=bl_hideconfig",
             "splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384",
             "created_at:autodate",
             "updated_at:autodate"};
@@ -503,6 +505,14 @@ public interface LTIService {
     String formInput(Object row, String fieldInfo);
 
     String formInput(Object row, String[] fieldInfo);
+
+    /**
+     * Should the user be presented with config options when adding tool?
+     * @param tool The tool being added.
+     * @param contentToolModel The content model for the tool..
+     * @return <code>true</code> If we should skip config options when adding this tool.
+     */
+    boolean hideConfig(Map<String, Object> tool, String[] contentToolModel);
 
     boolean isAdmin(String siteId);
 

--- a/basiclti/basiclti-impl/src/bundle/ltiservice.properties
+++ b/basiclti/basiclti-impl/src/bundle/ltiservice.properties
@@ -87,6 +87,7 @@ bl_resource_handler=Resource Handler
 bl_parameter=Launch Parameters
 bl_enabled_capability=Enabled Capabilities
 bl_contentitem=Enabled Capabilities
+bl_hideconfig=Hide options when adding tool
 
 bl_version=LTI Version
 bl_version_lti1=LTI 1.x Tool

--- a/basiclti/basiclti-impl/src/bundle/ltiservice.properties
+++ b/basiclti/basiclti-impl/src/bundle/ltiservice.properties
@@ -78,6 +78,9 @@ bl_allowcustom=Allow additional custom parameters
 bl_custom=Custom Parameters (key=value on separate lines)
 bl_splash=Splash Screen (If this is non-blank it is shown before the tool is launched)
 bl_fa_icon=Choose a custom icon (leave empty to use the default icon)
+bl_allowfa_icon=Allow icon to be changed
+bl_allowfa_icon_disallow=Do no allow
+bl_allowfa_icon_allow=Allow
 bl_matchpattern=Launch URL Pattern to Match
 bl_launchurl=Actual Launch Url
 bl_resource_handler=Resource Handler

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -296,6 +296,12 @@ public abstract class BaseLTIService implements LTIService {
 	}
 
 	@Override
+	public boolean hideConfig(Map<String, Object> tool, String[] contentToolModel) {
+		Object hideconfig = tool.get("hideconfig");
+		return hideconfig instanceof Integer && hideconfig.equals(1);
+	}
+
+	@Override
 	public boolean isAdmin(String siteId) {
 		if ( siteId == null ) {
 			throw new java.lang.RuntimeException("isAdmin() requires non-null siteId");

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -280,6 +280,22 @@ public abstract class BaseLTIService implements LTIService {
 	}
 
 	@Override
+	public boolean needsConfig(Map<String, Object> tool, String[] fieldInfos) {
+		for (String fieldInfo: fieldInfos) {
+			Properties info = foorm.parseFormString(fieldInfo);
+			// Field is hidden no matter it's type
+			boolean isHidden = "true".equals(info.getProperty("hidden", null));
+			String type = info.getProperty("type", null);
+			// Is rendered as a hidden input or empty so user can't change
+			boolean isInvisible = "hidden".equals(type) || "key".equals(type) || "autodate".equals(type);
+			if (!isHidden && !isInvisible) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
 	public boolean isAdmin(String siteId) {
 		if ( siteId == null ) {
 			throw new java.lang.RuntimeException("isAdmin() requires non-null siteId");
@@ -570,6 +586,7 @@ public abstract class BaseLTIService implements LTIService {
 		{
 			reqProps.setProperty(LTIService.LTI_PLACEMENTSECRET, UUID.randomUUID().toString());
 			// insertContentDao checks to make sure that the TOOL_ID in reqProps is suitable
+			reqProps.setProperty(LTIService.LTI_TOOL_ID, toolId);
 			retval = insertContentDao(reqProps, siteId, isAdminRole, isMaintainRole);
 		} else {
 			contentKey = new Long(id);
@@ -626,7 +643,7 @@ public abstract class BaseLTIService implements LTIService {
 			retval = new String("1" + rb.getString("error.content.not.found"));
 			return retval;
 		}
-	
+		Map<String, Object> tool = getToolDao(new Long(content.get(LTI_TOOL_ID).toString()), siteId);
 		String contentSite = (String) content.get(LTI_SITE_ID);
 		try
 		{
@@ -636,13 +653,16 @@ public abstract class BaseLTIService implements LTIService {
 			{
 				SitePage sitePage = site.addPage();
 		
-				ToolConfiguration tool = sitePage.addTool(WEB_PORTLET);
+				ToolConfiguration toolConfiguration = sitePage.addTool(WEB_PORTLET);
 				String fa_icon = (String)content.get(LTI_FA_ICON);
+				if (fa_icon == null || fa_icon.isEmpty()) {
+					fa_icon = (String)tool.get(LTI_FA_ICON);
+				};
 				if ( fa_icon != null && fa_icon.length() > 0 ) {
-					tool.getPlacementConfig().setProperty("imsti.fa_icon",fa_icon);
+					toolConfiguration.getPlacementConfig().setProperty("imsti.fa_icon",fa_icon);
 				}
-				tool.getPlacementConfig().setProperty("source",(String)content.get("launch_url"));
-				tool.setTitle((String) content.get(LTI_TITLE));
+				toolConfiguration.getPlacementConfig().setProperty("source",(String)content.get("launch_url"));
+				toolConfiguration.setTitle((String) content.get(LTI_TITLE));
 				
 				sitePage.setTitle(button_text);
 				sitePage.setTitleCustom(true);
@@ -650,7 +670,7 @@ public abstract class BaseLTIService implements LTIService {
 		
 				// Record the new placement in the content item
 				Properties newProps = new Properties();
-				newProps.setProperty(LTI_PLACEMENT, tool.getId());
+				newProps.setProperty(LTI_PLACEMENT, toolConfiguration.getId());
 				retval = updateContentDao(key, newProps, siteId, isAdminRole, isMaintainRole);
 			}
 			catch (PermissionException ee)

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -295,6 +295,18 @@ public abstract class BaseLTIService implements LTIService {
 		return false;
 	}
 
+	public Properties defaultConfig(Map<String, Object> tool, String[] fieldInfos) {
+		Properties props = new Properties();
+		for (String fieldInfo: fieldInfos) {
+			Properties info = foorm.parseFormString(fieldInfo);
+			if ("true".equals(info.getProperty("required", null))) {
+				String field = info.getProperty("field");
+				props.put(field, tool.get(field));
+			}
+		}
+		return props;
+	}
+
 	@Override
 	public boolean hideConfig(Map<String, Object> tool, String[] contentToolModel) {
 		Object hideconfig = tool.get("hideconfig");

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2903,7 +2903,7 @@ public class SiteAction extends PagedResourceActionII {
 					String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), site.getId());
 					Map<String, Object> ltiTool = m_ltiService.getTool(Long.valueOf(ltiToolId), site.getId());
 
-					if (m_ltiService.needsConfig(ltiTool, contentToolModel)) {
+					if (!m_ltiService.hideConfig(ltiTool, contentToolModel) && m_ltiService.needsConfig(ltiTool, contentToolModel)) {
 						// attach the ltiToolId to each model attribute, so that we could have the tool configuration page for multiple tools
 						for (int k = 0; k < contentToolModel.length; k++) {
 							contentToolModel[k] = ltiToolId + "_" + contentToolModel[k];
@@ -11687,14 +11687,14 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 					// whether there is any lti tool been selected
 					if (existingLtiIds == null)
 					{
-						needsLtiConfig |= m_ltiService.needsConfig(tool, contentToolModel);
+						needsLtiConfig |= !m_ltiService.hideConfig(tool, contentToolModel) && m_ltiService.needsConfig(tool, contentToolModel);
 					}
 					else
 					{
 						if (!existingLtiIds.keySet().contains(ltiToolId))
 						{
 							// there are some new lti tool(s) selected
-							needsLtiConfig |= m_ltiService.needsConfig(tool, contentToolModel);
+							needsLtiConfig |= !m_ltiService.hideConfig(tool, contentToolModel) && m_ltiService.needsConfig(tool, contentToolModel);
 						}
 					}
 						

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -11415,9 +11415,14 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				if (!oldLtiTools.containsKey(ltiToolId))
 				{
 					Map<String, Object> toolValues = ltiTool.getValue();
-					Properties reqProperties = (Properties) toolValues.get("reqProperties");
-					if (reqProperties==null) {
-						reqProperties = new Properties();
+					// Need to copy in default required.
+					String[] contentModel = m_ltiService.getContentModel(new Long(ltiToolId), site.getId());
+					Properties reqProperties = m_ltiService.defaultConfig(ltiTool.getValue(), contentModel);
+					// This holds any properties that have come back from the form if shown
+					Properties editedProperties = (Properties) toolValues.get("reqProperties");
+					if (editedProperties!=null) {
+						// Overwrite with anything that's come back from the form
+						reqProperties.putAll(editedProperties);
 					}
 					Object retval = m_ltiService.insertToolContent(null, ltiToolId, reqProperties, site.getId());
 					if (retval instanceof String)

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2872,6 +2872,7 @@ public class SiteAction extends PagedResourceActionII {
 			 */
 			site_type = (String) state.getAttribute(STATE_SITE_TYPE);
 			boolean existingSite = site != null ? true : false;
+			String siteId = site != null ? site.getId() : UUID.randomUUID().toString();
 			if (existingSite) {
 				// revising a existing site's tool
 				context.put("existingSite", Boolean.TRUE);
@@ -2900,8 +2901,8 @@ public class SiteAction extends PagedResourceActionII {
 				for (Map.Entry<String, Map<String, Object>> entry : currentLtiTools.entrySet() ) {
 					Map<String, Object> toolMap = entry.getValue();
 					String ltiToolId = toolMap.get("id").toString();
-					String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), site.getId());
-					Map<String, Object> ltiTool = m_ltiService.getTool(Long.valueOf(ltiToolId), site.getId());
+					String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), siteId);
+					Map<String, Object> ltiTool = m_ltiService.getTool(Long.valueOf(ltiToolId), siteId);
 
 					if (!m_ltiService.hideConfig(ltiTool, contentToolModel) && m_ltiService.needsConfig(ltiTool, contentToolModel)) {
 						// attach the ltiToolId to each model attribute, so that we could have the tool configuration page for multiple tools
@@ -12963,6 +12964,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		if (state.getAttribute(STATE_LTITOOL_SELECTED_LIST) != null)
 		{
 			Site site = getStateSite(state);
+			String siteId = site != null? site.getId(): UUID.randomUUID().toString();
 			Properties reqProps = params.getProperties();
 			// remember the reqProps may contain multiple lti inputs, so we need to differentiate those inputs and store one tool specific input into the map
 			HashMap<String, Map<String, Object>> ltiTools = (HashMap<String, Map<String, Object>>) state.getAttribute(STATE_LTITOOL_SELECTED_LIST);
@@ -12970,7 +12972,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			{
 				String ltiToolId = ltiToolEntry.getKey();
 				Map<String, Object> ltiToolAttributes = ltiToolEntry.getValue();
-				String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), site.getId());
+				String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(ltiToolId), siteId);
 				Properties reqForCurrentTool = new Properties();
 				// the input page contains attributes prefixed with lti tool id, need to look for those attribute inut values
 				for (int k=0; k< contentToolModel.length;k++)

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -11668,6 +11668,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		boolean homeSelected = false;
 		// lti tool selection
 		boolean needsLtiConfig = false;
+		String siteId = getStateSite(state) == null? UUID.randomUUID().toString(): getStateSite(state).getId();
 
 		// Add new pages and tools, if any
 		if (params.getStrings("selectedTools") == null && params.getStrings("selectedLtiTools") == null) {
@@ -11687,8 +11688,8 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				else if (toolId.startsWith(LTITOOL_ID_PREFIX))
 				{
 					String ltiToolId = toolId.substring(LTITOOL_ID_PREFIX.length());
-					Map<String, Object> tool = m_ltiService.getTool(Long.valueOf(ltiToolId), UUID.randomUUID().toString());
-					String[] contentToolModel = m_ltiService.getContentModel(Long.valueOf(ltiToolId), UUID.randomUUID().toString());
+					Map<String, Object> tool = m_ltiService.getTool(Long.valueOf(ltiToolId), siteId);
+					String[] contentToolModel = m_ltiService.getContentModel(Long.valueOf(ltiToolId), siteId);
 					// whether there is any lti tool been selected
 					if (existingLtiIds == null)
 					{


### PR DESCRIPTION
When adding a LTI tool this allows the config to be hidden in Site Info so that you only see it if you use the external tools tab. This is so that advanced users can customise the tool but normal users don't get confused by the advanced options.

This also changes the adding of LTI tools so that if there's nothing to configure it doesn't needlessly ask you for LTI config. Also it allows you to prevent people from changing the tool icon.