### PR TITLE
SAK-32445 Fix Assignments Grading with ".X" Grades

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -15063,8 +15063,16 @@ public class AssignmentAction extends PagedResourceActionII
 				{
 					if (index == 0)
 					{
+						int trailingData = point.substring(1).length();
 						// if the point is the first char, add a 0 for the integer part
 						point = "0".concat(point.substring(1));
+						// ensure that the point value has the correct # of decimals
+						// by padding with zeros
+						if(trailingData < dec) {
+							for(int i = trailingData; i < dec; i++) {
+								point = point + "0";
+							}
+						}
 					}
 					else if (index < point.length() - 1)
 					{


### PR DESCRIPTION
When an assignment was saved with a grade such as ".7" with less
than the number of allowed decimal places (2 is default), the grade was
saved as "0.07"). This changes causes it to be saved as "0.70" by
padding entered scores with trailing 0s as appropriate.

[JIRA](https://jira.sakaiproject.org/browse/SAK-32445)