### PR TITLE
SAK-32302 Correctly allows lookups by AID.

### DIFF
--- a/entitybroker/core-providers/src/test/org/sakaiproject/entitybroker/providers/UserEntityProviderFindAndCheckUserId.java
+++ b/entitybroker/core-providers/src/test/org/sakaiproject/entitybroker/providers/UserEntityProviderFindAndCheckUserId.java
@@ -1,0 +1,121 @@
+package org.sakaiproject.entitybroker.providers;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sakaiproject.entitybroker.DeveloperHelperService;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.user.api.UserNotDefinedException;
+
+/**
+ * Tests the various ways of finding users in different configurations.
+ */
+public class UserEntityProviderFindAndCheckUserId {
+
+    private UserEntityProvider provider;
+    private UserDirectoryService uds;
+    private DeveloperHelperService dhs;
+    private User user;
+
+    @Before
+    public void setUp() throws UserNotDefinedException {
+        provider = new UserEntityProvider();
+        uds = Mockito.mock(UserDirectoryService.class);
+        dhs = Mockito.mock(DeveloperHelperService.class);
+        user = Mockito.mock(User.class);
+
+        // Set the default for these methods, need to use Yoda syntax when mocking other invocations of these methods.
+        Mockito.when(uds.getUserId(Mockito.anyString())).thenThrow(UserNotDefinedException.class);
+        Mockito.when(uds.getUserByEid(Mockito.anyString())).thenThrow(UserNotDefinedException.class);
+        Mockito.when(uds.getUserByAid(Mockito.anyString())).thenThrow(UserNotDefinedException.class);
+        Mockito.when(uds.getUserEid(Mockito.anyString())).thenThrow(UserNotDefinedException.class);
+
+        provider.setUserDirectoryService(uds);
+        provider.setDeveloperHelperService(dhs);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNull() {
+        provider.findAndCheckUserId(null, null);
+    }
+
+    @Test
+    public void testNoExplicitSeparateId() throws UserNotDefinedException {
+        Mockito.when(dhs.getConfigurationSetting("separateIdEid@org.sakaiproject.user.api.UserDirectoryService", null)).thenReturn("true");
+        Mockito.when(dhs.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(false);
+        Mockito.doReturn("eid").when(uds).getUserEid("id");
+        Mockito.doReturn(user).when(uds).getUserByAid("eid");
+        Mockito.when(user.getId()).thenReturn("id");
+        Assert.assertEquals("id", provider.findAndCheckUserId("id", null));
+        Assert.assertEquals("id", provider.findAndCheckUserId("/user/id", null));
+        Assert.assertEquals("id", provider.findAndCheckUserId("eid", null));
+        Assert.assertEquals("id", provider.findAndCheckUserId("/user/eid", null));
+        Assert.assertNull(provider.findAndCheckUserId("missing", null));
+    }
+
+    @Test
+    public void testNoExplicitSeparateEid() throws UserNotDefinedException {
+        Mockito.when(dhs.getConfigurationSetting("separateIdEid@org.sakaiproject.user.api.UserDirectoryService", null)).thenReturn("true");
+        Mockito.when(dhs.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(false);
+        Mockito.doReturn("eid").when(uds).getUserEid("eid");
+        Assert.assertEquals("eid", provider.findAndCheckUserId(null, "eid"));
+        Assert.assertEquals("eid", provider.findAndCheckUserId(null, "/user/eid"));
+        Assert.assertNull(provider.findAndCheckUserId(null, "missing"));
+    }
+
+    @Test
+    public void testExplicitSeparateId() throws UserNotDefinedException {
+        Mockito.when(dhs.getConfigurationSetting("separateIdEid@org.sakaiproject.user.api.UserDirectoryService", null)).thenReturn("true");
+        Mockito.when(dhs.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(true);
+        Mockito.doReturn("eid").when(uds).getUserEid("id");
+
+        Assert.assertEquals("id", provider.findAndCheckUserId("id", null));
+        Assert.assertEquals("id", provider.findAndCheckUserId("/user/id", null));
+        Assert.assertNull(provider.findAndCheckUserId("missing", null));
+        Assert.assertEquals("id", provider.findAndCheckUserId("id=id", null));
+        Assert.assertNull(provider.findAndCheckUserId("id=missing", null));
+
+    }
+
+    @Test
+    public void testExplicitSeparateEid() throws UserNotDefinedException {
+        Mockito.when(dhs.getConfigurationSetting("separateIdEid@org.sakaiproject.user.api.UserDirectoryService", null)).thenReturn("true");
+        Mockito.when(dhs.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(true);
+        Mockito.doReturn("eid").when(uds).getUserEid("id");
+        Mockito.doReturn(user).when(uds).getUserByAid("eid");
+        Mockito.when(user.getId()).thenReturn("id");
+        Assert.assertEquals("id", provider.findAndCheckUserId(null, "id"));
+        Assert.assertEquals("id", provider.findAndCheckUserId(null, "/user/id"));
+        // I would expect this to work, but it doesn't
+        // Assert.assertEquals("id", provider.findAndCheckUserId(null, "eid"));
+        Assert.assertNull(provider.findAndCheckUserId(null, "missing"));
+        // This looks wrong as we are returning a different ID to the one supplied, unlike all the other calls.
+        Assert.assertEquals("id", provider.findAndCheckUserId(null, "id=eid"));
+        Assert.assertNull(provider.findAndCheckUserId(null, "id=missing"));
+    }
+
+    @Test
+    public void testNoExplicitNoSeparateId() throws UserNotDefinedException {
+        Mockito.when(dhs.getConfigurationSetting("separateIdEid@org.sakaiproject.user.api.UserDirectoryService", null)).thenReturn("false");
+        Mockito.when(dhs.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(false);
+        Mockito.doReturn(user).when(uds).getUserByAid("id");
+        Mockito.when(user.getId()).thenReturn("id");
+        Assert.assertEquals("id", provider.findAndCheckUserId("id", null));
+        Assert.assertEquals("id", provider.findAndCheckUserId("/user/id", null));
+        Assert.assertNull(provider.findAndCheckUserId("missing", null));
+    }
+
+
+    @Test
+    public void testNoExplicitNoSeparateEid() throws UserNotDefinedException {
+        Mockito.when(dhs.getConfigurationSetting("separateIdEid@org.sakaiproject.user.api.UserDirectoryService", null)).thenReturn("false");
+        Mockito.when(dhs.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(false);
+        Mockito.doReturn(user).when(uds).getUserByAid("id");
+        Mockito.when(user.getId()).thenReturn("id");
+        Assert.assertEquals("id", provider.findAndCheckUserId(null, "id"));
+        Assert.assertEquals("id", provider.findAndCheckUserId(null, "/user/id"));
+        Assert.assertNull(provider.findAndCheckUserId(null, "missing"));
+    }
+}


### PR DESCRIPTION
The original patch didn’t work correctly as entitybroker wants to check the ID before it actually looks it up and in configurations when we weren’t passing through to getUserByIdEid() this wasn’t working.