### PR TITLE
SAK-32136 Change web links text in Resources actions menu and Add Web…

### DIFF
--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -195,7 +195,7 @@ Copyright: It is your personal responsibility to verify that you have permission
 to upload the file(s) to this website. Text, graphics and other media files may all be subject to copyright control \
 even if your site is restricted to site members.
 instr.url			 = Copy-and-paste or type in the web address (URL) and then click 'Continue' at the bottom.
-instr.urls		 	= Press the 'Add Web Links Now' button when you have finished.
+instr.urls		 	= Add both the address and name for a web link (URL). Click the 'Add Web Link Now' button when you have finished.
 instr.ezproxy   = If linking to a library database that you would like to make available off-campus, enter the URL and click 'Make Library Link Available Off-Campus.'
 label.addfile		 = Add Another File
 label.addFolder		 = Add Another Folder
@@ -225,7 +225,7 @@ label.update		 = Update
 label.upl		 = Upload New Version Now
 label.upload		 = File To Upload
 label.url			 = URL
-label.urlnow		 = Add Web Links Now
+label.urlnow		 = Add Web Link Now
 label.urls		 = Web Address (URL)
 label.ezproxy  = Make Library Link Available Off-Campus
 label.version		 = Upload a new version

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourceTypeLabeler.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourceTypeLabeler.java
@@ -51,7 +51,7 @@ public class ResourceTypeLabeler
 					label = ResourcesAction.trb.getString("create.folder");
 					break;
 				case NEW_URLS:
-					label = ResourcesAction.trb.getString("create.urls");
+					label = ResourcesAction.trb.getString("create.url");
 					break;
 				case CREATE:
 					ResourceTypeRegistry registry = (ResourceTypeRegistry) ComponentManager.get("org.sakaiproject.content.api.ResourceTypeRegistry");

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -1,7 +1,7 @@
 <!-- resources/sakai_create_uploads.vm, use with org.sakaiproject.tool.content.ResourcesHelperAction.java -->
 <div class="portletBody specialLink">
 	<h3>
-		$tlang.getString("create.urls")
+		$tlang.getString("create.url")
 	</h3>
 	#if ($itemAlertMessage)
 		<div class="alertMessage">$tlang.getString("label.alert") $validator.escapeHtml($itemAlertMessage)</div>

--- a/content/content-types/src/java/org/sakaiproject/content/types/UrlResourceType.java
+++ b/content/content-types/src/java/org/sakaiproject/content/types/UrlResourceType.java
@@ -82,7 +82,7 @@ public class UrlResourceType extends BaseResourceType
 	
 	public UrlResourceType()
 	{		
-		actions.put(CREATE, new BaseInteractionAction(CREATE, ActionType.NEW_URLS, typeId, helperId, localizer("create.urls")));
+		actions.put(CREATE, new BaseInteractionAction(CREATE, ActionType.NEW_URLS, typeId, helperId, localizer("create.url")));
 		actions.put(REVISE_CONTENT, new BaseInteractionAction(REVISE_CONTENT, ActionType.REVISE_CONTENT, typeId, helperId, localizer("action.revise")));
 		actions.put(ACCESS_PROPERTIES, new BaseServiceLevelAction(ACCESS_PROPERTIES, ActionType.VIEW_METADATA, typeId, false, localizer("action.access")));
 		actions.put(REVISE_METADATA, new BaseServiceLevelAction(REVISE_METADATA, ActionType.REVISE_METADATA, typeId, false, localizer("action.props")));

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ResourceToolAction.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ResourceToolAction.java
@@ -64,7 +64,7 @@ public interface ResourceToolAction
 		NEW_FOLDER,
 		
 		/**
-		 * Create URLs -- Handled by Resources tool.  Can create multiple URLs at once.  
+		 * Create a URL -- Handled by Resources tool.  Can create one link to a URL at a time (previously was multiple links).  
 		 * 		No content; requires metadata only.  Requires content.new permission in parent 
 		 * 		folder.
 		 */


### PR DESCRIPTION
… Link page.

I have left the ResourceToolAction enum constant as NEW_URLS (and added a comment) as from the linked Jira (SAK-31809) it looks like we may go back to wanting the ability to add multiple links.

![postfixactionsmenu](https://cloud.githubusercontent.com/assets/17832659/25232247/8da0b00e-25d2-11e7-8a7c-d29b0bb9a6a6.JPG)
![postfixweblinkspage](https://cloud.githubusercontent.com/assets/17832659/25232256/9109e878-25d2-11e7-8a9f-da265f753827.JPG)
