### PR TITLE
SAK-32470: membership -> 'clear selections' button no longer works

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership.vm
@@ -119,7 +119,7 @@
 
 		<form action="#toolForm("$action")" method="post">
 			<div class="table-responsive">
-				<table id="membership" class="table table-bordered table-hover table-striped" summary ="$tlang.getString('joinable.list.summary')" id="currentSites">
+				<table class="table table-bordered table-hover table-striped" summary ="$tlang.getString('joinable.list.summary')" id="currentSites">
 					<tr>
 						<th id="checkbox" scope="col" class="screenOnly attach">
 							<input title="$tlang.getString("mb.selectalltitle")" type="checkbox" name="selunselall" id="selunselallid"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32470

Duplicate id attribute on the table broke the jQuery selectors in the JavaScript function.
