### PR TITLE
SAK-32475: duplicated too many decimal places error message

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -29,7 +29,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
@@ -148,7 +147,6 @@ import org.sakaiproject.scoringservice.api.ScoringService;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameException;
-import org.sakaiproject.service.gradebook.shared.ConflictingExternalIdException;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;
 import org.sakaiproject.service.gradebook.shared.GradebookNotFoundException;
 import org.sakaiproject.service.gradebook.shared.GradebookService;
@@ -177,7 +175,6 @@ import org.sakaiproject.util.FormattedText;
 import org.sakaiproject.util.ParameterParser;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.SortedIterator;
-import org.sakaiproject.util.StringUtil;
 import org.sakaiproject.util.Validator;
 
 /**
@@ -12205,7 +12202,7 @@ public class AssignmentAction extends PagedResourceActionII
 									int maxGrade = a.getContent().getMaxGradePoint();
 									try
 									{
-										if (Integer.parseInt(scalePointGrade(state, grade, factor)) > maxGrade)
+										if (state.getAttribute(STATE_MESSAGE) == null && Integer.parseInt(scalePointGrade(state, grade, factor)) > maxGrade)
 										{
 											if (state.getAttribute(GRADE_GREATER_THAN_MAX_ALERT) == null)
 											{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32475

In a very specific use case (steps to reproduce on the JIRA), the instructor will be presented with the following error message when providing a grade that uses too many decimal places:

> Alert: Please use only 2 decimal place(s) for the grade field. Please use only 2 decimal place(s) for the grade field. Please use a number for the grade field.

The decimal places warning message is repeated twice, and the 3rd message is just confusing.

The problem is that after calling validPointGrade, the STATE_MESSAGE is not checked for null before calling scalePointGrade, which then calls validPointGrade again and dumps the duplicated error message into STATE_MESSAGE. The solution is to simply check STATE_MESSAGE == null before calling scalePointGrade.