### PR TITLE
SAK-32477: copy drop down selectedIndex attribute to cloned element

### DIFF
--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -215,6 +215,7 @@ SPNR.disableSelects = function( escapeList )
             newSelect.size = select.size;
             newSelect.className = select.className;
             newSelect.innerHTML = select.innerHTML;
+            newSelect.selectedIndex = select.selectedIndex;
 
             // Add the clone to the DOM where the original was
             var parent = select.parentNode;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32477

Drop down selections appear to change when submitting forms that utilize the modern clone/disable & spin JavaScript routine. The submitted value is the user's selection, but it can cause confusion if the user sees the drop down flip selections.

Simple solution: copy over the selectedIndex attribute from the original to the cloned element.