### PR TITLE
SAK-30700 - Selecting an option causes table alignment to shift

### DIFF
--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/ShoppingEditPage.html
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/ShoppingEditPage.html
@@ -63,6 +63,8 @@
 		
 		div.wicket-tree-table div.row-selected{
 			background-color: #FFF !important;
+			margin-left: -15px;
+			margin-right: -15px;
 		}
 		
 		div.wicket-tree-table div.row-selected a.node-link span{

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserEditPage.html
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserEditPage.html
@@ -52,6 +52,8 @@
 		}
 		div.wicket-tree-table div.row-selected{
 			background-color: #FFF !important;
+			margin-left: -15px;
+			margin-right: -15px;
 		}
 		div.wicket-tree-table div.row-selected a.node-link span{
 			font-weight: normal !important;


### PR DESCRIPTION
Selecting an option causes table alignment to shift.

This only affects 11.x because Master uses Wicket 6.x and is not affected by this issue.