### PR TITLE
LSNBLDR-805 - Problem importing more than 1 item on a page

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/cc/PrintHandler.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/cc/PrintHandler.java
@@ -400,7 +400,7 @@ public class PrintHandler extends DefaultHandler implements AssessmentHandler, D
 			I think the ideal here would be that this only updates resources that are in the manifest, but really any
 			relative resources are going to be incorrect pulled out of a package and need an update.
 		   */
-		  org.jsoup.nodes.Document doc = Jsoup.parse(htmlString);
+		  org.jsoup.nodes.Document doc = Jsoup.parseBodyFragment(htmlString);
 		  org.jsoup.select.Elements hrefs = doc.select("[href]");
 		  org.jsoup.select.Elements srcs = doc.select("[src]");
 
@@ -434,7 +434,7 @@ public class PrintHandler extends DefaultHandler implements AssessmentHandler, D
 				  }
 			  }
 		  }
-		  htmlString = doc.toString();
+		  htmlString = doc.body().html();
 	  }
 	  
 	  return htmlString;


### PR DESCRIPTION
Problem was parsing a fragment as HTML inserted the full HTML into lessons which caused the page problems. I think this might be a bigger issue for lessons that some tags need to be stripped but this at least keeps it from messing up import fragments.