### PR TITLE
SAK-32484 add a valid outline for Firefox

### DIFF
--- a/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_tab-focus.scss
+++ b/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_tab-focus.scss
@@ -1,9 +1,8 @@
 // WebKit-style focus
 
 @mixin tab-focus() {
-  // WebKit-specific. Other browsers will keep their default outline style.
-  // (Initially tried to also force default via `outline: initial`,
-  // but that seems to erroneously remove the outline in Firefox altogether.)
+  // SAK-32484 Bootstrap 3 default for tab-focus totally ignores Firefox
+  outline: 5px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }


### PR DESCRIPTION
I don't like modifying Bootstrap SCSS files either, but I can't find a way to override a bootstrap mixin. Bootstrap v4 does things very differently so I don't think we will need to maintain this hack to make focus work in Firefox.

CC: @fostersdesign 