### PR TITLE
SAK-32486 - Custom scale definition doesn't work in Gradebook (components.xml default file needs update)

### DIFF
--- a/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
+++ b/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
@@ -208,7 +208,7 @@
 							<value>F</value>
 						</list>
 					</property>
-					<property name="defaultBottomPercents">
+					<property name="defaultBottomPercentsAsList">
 						<list>
 							<value>100.0</value>
 							<value>95.0</value>
@@ -238,7 +238,7 @@
 							<value>F</value>
 						</list>
 					</property>
-					<property name="defaultBottomPercents">
+					<property name="defaultBottomPercentsAsList">
 						<list>
 							<value>90.0</value>
 							<value>80.0</value>
@@ -295,7 +295,7 @@
 							<value>F!?</value>
 						</list>
 					</property>
-					<property name="defaultBottomPercents">
+					<property name="defaultBottomPercentsAsList">
 						<list>
 							<value>100.0</value>
 							<value>90.0</value>
@@ -321,7 +321,7 @@
 							<value>F</value>
 						</list>
 					</property>
-					<property name="defaultBottomPercents">
+					<property name="defaultBottomPercentsAsList">
 						<list>
 							<value>50.0</value>
 							<value>30.0</value>
@@ -341,7 +341,7 @@
 							<value>I</value>
 						</list>
 					</property>
-					<property name="defaultBottomPercents">
+					<property name="defaultBottomPercentsAsList">
 						<list>
 							<value>75.0</value>
 							<value>0.0</value>

--- a/gradebook/xdocs/add_custom_grade_mappings.txt
+++ b/gradebook/xdocs/add_custom_grade_mappings.txt
@@ -60,12 +60,13 @@ order.
 entered, should be put in the list after the worst (0%) percentage-mapped
 grades.
 
-* A GradingScaleDefinition should contain a list of "defaultBottomPercents".
+* A GradingScaleDefinition should contain a list of "defaultBottomPercentsAsList".
 These are percentages. They must be ordered to match the "grades" list.
-The bottom of the  "defaultBottomPercents" list must be "0" or "0.0".
+The bottom of the  "defaultBottomPercentsAsList" list must be "0" or "0.0".
 Since non-calculated grades have no percentage equivalent, they should
-not be given a place on the "defaultBottomPercents" list.
-
+not be given a place on the "defaultBottomPercentsAsList" list. 
+IMPORTANT: This property is also called "defaultBottomPercents" but must be defined as map instead of list, see
+the examples below.
 
 CONFIGURATION EXAMPLE: DEFAULT GRADING SCALES
 
@@ -105,7 +106,7 @@ by default if none are found in the database.
             <value>F</value>
           </list>
         </property>
-        <property name="defaultBottomPercents">
+        <property name="defaultBottomPercentsAsList">
           <list>
             <value>100.0</value>
             <value>95.0</value>
@@ -137,7 +138,7 @@ by default if none are found in the database.
             <value>F</value>
           </list>
         </property>
-        <property name="defaultBottomPercents">
+        <property name="defaultBottomPercentsAsList">
           <list>
             <value>90.0</value>
             <value>80.0</value>
@@ -158,7 +159,7 @@ by default if none are found in the database.
             <value>NP</value>
           </list>
         </property>
-        <property name="defaultBottomPercents">
+        <property name="defaultBottomPercentsAsList">
           <list>
             <value>75.0</value>
             <value>0.0</value>
@@ -215,7 +216,7 @@ This XML fragment would make five changes to the default grading scales:
             <value>F!?</value>
           </list>
         </property>
-        <property name="defaultBottomPercents">
+        <property name="defaultBottomPercentsAsList">
           <list>
             <value>100.0</value>
             <value>90.0</value>
@@ -245,7 +246,7 @@ This XML fragment would make five changes to the default grading scales:
             <value>NR</value>
           </list>
         </property>
-        <property name="defaultBottomPercents">
+        <property name="defaultBottomPercentsAsList">
           <list>
             <value>50.0</value>
             <value>30.0</value>
@@ -260,3 +261,24 @@ This XML fragment would make five changes to the default grading scales:
 
   <property name="defaultGradingScale" value="LetterGradeMapping"/>
 </bean>
+
+To define the property defaultBottomPercents instead of defaultBottomPercentsAsList, it must be defined as map.
+
+<property name="defaultBottomPercents">
+    <property name="grades">
+        <list>
+            <value>A</value>
+            <value>B</value>
+            <value>C</value>
+            <value>D</value>
+        </list>
+    </property>
+    <property name="defaultBottomPercents">
+        <map>
+            <entry key="A" value="90.0" />
+            <entry key="B" value="70.0" />
+            <entry key="C" value="50.0" />
+            <entry key="D" value="00.0" />
+        </map>
+    </property>
+</property>


### PR DESCRIPTION
Custom scale definition doesn't work in Gradebook (components.xml
default file needs update)