### PR TITLE
SAM-2949 : Student View: Return to Assessment List link is not aligne…

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -64,8 +64,13 @@
 		padding: 0 1em 0 1em;
 	}
 	
-	.feedBackCheck, .feedBackCross{
+	.feedBackCheck, .feedBackCross, .feedBackNone{
+		min-width: 20px;
 		margin-right: 0.2em;
+	}
+	
+	.feedBackNone{
+		visibility: hidden;
 	}
 	
 	.feedBackCheck{
@@ -226,6 +231,10 @@
 		.extendedTime-mins {
 			min-width: 70px;
 		}
+	}
+	
+	.navIntraTool {
+		margin: 0px !important;
 	}
 
 }

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMultipleChoiceSingleCorrect.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMultipleChoiceSingleCorrect.jsp
@@ -60,6 +60,10 @@ should be included in file importing DeliveryMessages
         rendered="#{((question.itemData.partialCreditFlag && (selection.answer.partialCredit le 0 || selection.answer.partialCredit == null)) || (selection.answer.isCorrect != null && !selection.answer.isCorrect)) && selection.response}"
         styleClass="icon-sakai--delete feedBackCross" >
       </h:panelGroup>
+      <h:panelGroup id="noimage"
+        rendered="#{!selection.response}"
+        styleClass="icon-sakai--check feedBackNone">
+      </h:panelGroup>
     </h:panelGroup>
     <div class="mcscFixUpTarget"></div>
 	<h:panelGroup> 	 


### PR DESCRIPTION
…d & highlight colors

- Solved alignment issues. Change the background color for "Return to
assessment list" tab is not viable, because it's difficult to see it.
- This PR reverts in some way "SAM-2721 : use bootstrap classes and grid
for Samigo HTML" (https://github.com/sakaiproject/sakai/commit/87d4bc58e900101191011b1249ed14ed7b17a3ae) from
@ottenhoff committed on 8 Mar 2016. So which component is preferable :
h:dataTable, t:dataList or t:dataTable?