### PR TITLE
LSNBLDR-633: Restrict editing of Lessons pages and subpages to one person

### DIFF
--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -909,7 +909,11 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	}
 
 	public List<SimplePage> getSitePages(String siteId) {
-	    DetachedCriteria d = DetachedCriteria.forClass(SimplePage.class).add(Restrictions.eq("siteId", siteId)).add(Restrictions.isNull("owner"));
+	    DetachedCriteria d = DetachedCriteria.forClass(SimplePage.class).add(Restrictions.eq("siteId", siteId))
+		    .add(Restrictions.disjunction()
+				    .add(Restrictions.isNull("owner"))
+				    .add(Restrictions.eq("owned", true))
+		    );
 
 		List<SimplePage> l = (List<SimplePage>) getHibernateTemplate().findByCriteria(d);
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -7045,7 +7045,7 @@ public class SimplePageBean {
 		if (!checkCsrf())
 		    return;
 
-		if(getCurrentPage().getOwner() == null) {
+		if(canEditPage()) {
 			SimplePageItem item = appendItem("", messageLocator.getMessage("simplepage.student-content"), SimplePageItem.STUDENT_CONTENT);
 			item.setDescription(messageLocator.getMessage("simplepage.student-content"));
 			saveItem(item);


### PR DESCRIPTION
This is fix for 2 bugs:

1. Shared page not showing up: Add 2 Lessons Tools (L1 & L2). On first tool, add text to the top page and give the page an owner, then add sub page (SP1) and add text to that sub page. On second lessons tool do 'Add Sub Page' and elect to select an existing page.
On the 'Pick a Page' screen: SP1 page should be listed under L1

2. An owned page cannot have a student page added to it: New Lessons tool -> give it an owner -> -> Click Add Student Content -> 'You do not have the required permissions to do that.'