### PR TITLE
SAM-3191 Fix scoring of all-or-nothing mult choice mult correct

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -1151,7 +1151,7 @@ public class GradingService
       // that means the user didn't answer all of the correct answers only.  
       // We need to set their score to 0 for all ItemGrading items
       for(Entry<Long, Double[]> entry : mcmcAllOrNothingCheck.entrySet()){
-    	  if(Double.compare(entry.getValue()[0], entry.getValue()[1]) != 0){    		  
+    	  if(!Precision.equalsIncludingNaN(entry.getValue()[0], entry.getValue()[1], 0.001d)) {	  
     		  //reset all scores to 0 since the user didn't get all correct answers
     		  iter = itemGradingSet.iterator();
     		  while(iter.hasNext()){


### PR DESCRIPTION
Fix precision issue when scoring multiple-choice multiple-correct
questions when the all-or-nothing option is on.