### PR TITLE
KNL-1523 Include portal.include.extrahead on site display

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -2311,6 +2311,8 @@ public abstract class BaseSiteService implements SiteService, Observer
 							+ "/tool_base.css\" type=\"text/css\" rel=\"stylesheet\" media=\"all\" />");
 					out.println("<link href=\"" + skinRepo + "/" + skin
 							+ "/tool.css\" type=\"text/css\" rel=\"stylesheet\" media=\"all\" />");
+					out.println(serverConfigurationService().getString("portal.include.extrahead", ""));
+
 					out.println("<title>");
 					out.println(site.getTitle());
 					out.println("</title>");


### PR DESCRIPTION
When displaying the site entity include the portal.include.extrahead property as well. This means that this property is now displayed on HTML pages from resources, in the portal and on Site entities.