### PR TITLE
SAK-32502: grade report group filter not reflecting selection after page refresh

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -25,15 +25,15 @@
 				<span class="skip">$tlang.getString("newassig.selectmessage")</span>
 
 				<div class="spinnerBesideContainer">
-					<select id="view" name="viewgroup" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null ); return false;">nchange="ASN.disableControls(); ASN.disableLink( 'downloadAll' ); ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
+					<select id="view" name="viewgroup" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null ); return false;">
 
 					#if (!$showSubmissionByFilterSearchOnly)
-						<option value="all" #if($!view.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
+						<option value="all" #if($!viewString.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
 					#else
 						<option value="" >$tlang.getString('please_select_group')</option>
 					#end
 					#foreach($aGroup in $groups)
-						<option value="$!aGroup.Reference" #if($!view.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
+						<option value="$!aGroup.Reference" #if($!viewString.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
 					#end
 					</select>
 				</div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32502

The variable being checked in the Velocity template is not the correct one that contains the group ID of the group the user selected. Changing the variable to the correct one solves the problem.

There was also some garbage HTML introduced in SAK-30067 that is useless and just clutters things in the DOM. Not sure how I didn't see that in SAK-30067... It doesn't affect functionality but it shouldn't be there.