### PR TITLE
SAK-32427 Fix for user email/AID lookups.

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -1638,8 +1638,8 @@ public class SiteManageGroupSectionRoleHandler {
     	        group.setTitle(importedGroup.getGroupTitle());
 			}
 			
-			//add all of the imported members to the group
-    		for(String userId: importedGroup.getUserIds()){
+    		// add all of the imported members to the group
+    		for(String userId : importedGroup.getUserIds()) {
     			this.addUserToGroup(userId, group);
     		}
 

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -1638,18 +1638,12 @@ public class SiteManageGroupSectionRoleHandler {
     	        group.setTitle(importedGroup.getGroupTitle());
 			}
 			
-		// Add all of the imported members to the group
-		for( String userId : importedGroup.getUserIds()) {
-			try {
-				String internalUserId = userDirectoryService.getUserId(userId);
-				this.addUserToGroup(internalUserId, group);
-			} catch (UserNotDefinedException e) {
-				M_log.error("Could not find user with id = {}", userId);
-			}
-		}
+			//add all of the imported members to the group
+    		for(String userId: importedGroup.getUserIds()){
+    			this.addUserToGroup(userId, group);
+    		}
 
     		try {
-    			siteService.saveGroupMembership(site);
     			siteService.save(site);
     		} catch (IdUnusedException | PermissionException e) {
             	M_log.error("processImportedGroups failed for site: " + site.getId(), e);

--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupImportStep2Producer.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/rsf/GroupImportStep2Producer.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -96,6 +98,7 @@ public class GroupImportStep2Producer implements ViewComponentProducer, Navigati
             }
             
             //print each user
+            SortedSet<String> foundUserIds = new TreeSet<>();
             for(String userId: importedGroup.getUserIds()) {
             	
             	UIOutput output = UIOutput.make(branch,"member:",userId);
@@ -109,7 +112,9 @@ public class GroupImportStep2Producer implements ViewComponentProducer, Navigati
             			Map<String,String> cssMap = new HashMap<String,String>();
                 		cssMap.put("color","grey");
                 		output.decorate(new UICSSDecorator(cssMap));
-            		}
+            		} else {
+            		    foundUserIds.add(foundUserId);
+                    }
             		
             	} else {
             		badData = true;
@@ -119,6 +124,7 @@ public class GroupImportStep2Producer implements ViewComponentProducer, Navigati
             		output.decorate(new UICSSDecorator(cssMap));
             	}
             }
+            importedGroup.setUserIds(foundUserIds);
         }
         
         UIForm createForm = UIForm.make(content, "form");


### PR DESCRIPTION
It also fixes a problem with non-id members not being correctly added to the group. If you attempt to add a user with an email address or AID then they get looked up in the earlier part of the wizard, but then not added to the group in the last step.

Also the saveGroupMembership call is redundant and can be removed as saving the site will save any changes to the group membership.