### PR TITLE
SAK-32577 Set OAuth Admin Application Icon

### DIFF
--- a/library/src/morpheus-master/sass/base/_icons.scss
+++ b/library/src/morpheus-master/sass/base/_icons.scss
@@ -50,6 +50,7 @@
     sakai-motd : ( extend : fa-list-ul ),
     sakai-news : ( extend : fa-rss ),
     sakai-oauth : ( extend : fa-key ),
+    sakai-oauth-admin : ( extend : fa-key ),
     sakai-online : ( extend : fa-server ),
     sakai-pasystem : ( extend : fa-bell ),
     sakai-podcasts : ( extend : fa-microphone ),


### PR DESCRIPTION
This didn’t have an icon set and this is the same as the end user tool icon.