### PR TITLE
SAK-31515 Don’t display Resources when tool missing

### DIFF
--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/content/ContentSiteVolumeFactory.java
@@ -2,6 +2,7 @@ package org.sakaiproject.elfinder.sakai.content;
 
 import cn.bluejoe.elfinder.controller.ErrorException;
 import cn.bluejoe.elfinder.service.FsItem;
+import org.sakaiproject.exception.TypeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.content.api.*;
@@ -291,7 +292,14 @@ public class ContentSiteVolumeFactory implements SiteVolumeFactory {
 
         public FsItem getRoot() {
             String id = contentHostingService.getSiteCollection(siteId);
-            return fromPath(id);
+            try {
+                contentHostingService.getCollection(id);
+                return fromPath(id);
+            } catch (IdUnusedException | PermissionException ignored) {
+            } catch (TypeException e) {
+                LOG.warn("Unexpected error getting root.", e);
+            }
+            return null;
         }
 
         public long getSize(FsItem fsi) {

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/site/SiteFsVolume.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/site/SiteFsVolume.java
@@ -130,7 +130,10 @@ public class SiteFsVolume extends ReadOnlyFsVolume {
             for (Map.Entry<String, SiteVolumeFactory> factory : service.getToolVolume().entrySet()) {
                 // Check that the tool is present in the site.
                 if (site.getToolForCommonId(factory.getValue().getToolId()) != null) {
-                    children.add(factory.getValue().getVolume(service, siteId).getRoot());
+                    FsItem root = factory.getValue().getVolume(service, siteId).getRoot();
+                    if (root != null) {
+                        children.add(root);
+                    }
                 }
             }
         } catch (PermissionException pe) {


### PR DESCRIPTION
In elfinder even if the Resources tool was missing from the site the Resources tool would be opened when using elfinder as a file picker. This stops that and prevents the Resources folder form being displayed even when it’s set as the initial folder.

It was always the case that when browsing an alternative site that if the Resources tool wasn’t present you wouldn’t see that folder present in elfinder.

If the resources tool is added, some files added and then removed you will still see the Resources folder when browsing the current site.