### PR TITLE
SAK-32495 create an accessible toggle/switch for auto-favorites using aria-clicked and role=switch

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -776,7 +776,7 @@ $PBJQ(document).ready(function($){
 
       list.disableSelection();
 
-      $('#autoFavoritesEnabled').attr('aria-checked', autoFavoritesEnabled)
+      $('#autoFavoritesEnabled').attr('aria-checked', autoFavoritesEnabled);
       $('#organizeFavorites .onoffswitch').show();
     }
   });

--- a/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -776,7 +776,7 @@ $PBJQ(document).ready(function($){
 
       list.disableSelection();
 
-      $('#autoFavoritesEnabled').prop('checked', autoFavoritesEnabled)
+      $('#autoFavoritesEnabled').attr('aria-checked', autoFavoritesEnabled)
       $('#organizeFavorites .onoffswitch').show();
     }
   });
@@ -842,12 +842,20 @@ $PBJQ(document).ready(function($){
 
   });
 
+  $PBJQ("#autoFavoritesEnabled").click(function() {
+	$(this).attr('aria-checked', function(index, clicked) {
+		var pressed = (clicked === 'true');
+		return String(!pressed);
+	});
+	$(this).trigger('change');
+  });
+
   $PBJQ('#autoFavoritesEnabled').on('change', function () {
-    autoFavoritesEnabled = this.checked;
+    autoFavoritesEnabled = $(this).attr('aria-checked') === 'true';
 
     $('.favorites-help-text').hide();
 
-    if (this.checked) {
+    if (autoFavoritesEnabled) {
       $('.favorites-help-text.autofavorite-enabled').show();
     } else {
       $('.favorites-help-text.autofavorite-disabled').show();

--- a/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -815,7 +815,7 @@ li.organizeFavorites:not(.active) .favoriteCountAndWarning.maxFavoritesReached {
 		}
 
 		span {
-			padding: 0.4em 0.8em;
+			padding: 0.2em 0.6em;
 			border-radius: $button-radius;
 		}
 	}

--- a/library/src/morpheus-master/sass/modules/more-sites/_base.scss
+++ b/library/src/morpheus-master/sass/modules/more-sites/_base.scss
@@ -802,53 +802,23 @@ li.organizeFavorites:not(.active) .favoriteCountAndWarning.maxFavoritesReached {
 	width: 28%;
 	padding-left: 1em;
 
-	/* Switch generator CSS from https://proto.io/freebies/onoff/ */
-	.onoffswitch {
-		position: relative; width: 66px;
-		-webkit-user-select:none; -moz-user-select:none; -ms-user-select: none;
+	button {
+		color: $text-color !important;
+		background: $background-color;
+		border-color: $button-primary-border-color;
+		border-radius: $button-radius;
+		padding: 0.6em;
+
+		&[aria-checked="true"] :first-child, &[aria-checked="false"] :last-child {
+			background-color: $button-primary-hover-background-color;
+			color: $button-primary-text-color;
+		}
+
+		span {
+			padding: 0.4em 0.8em;
+			border-radius: $button-radius;
+		}
 	}
-	.onoffswitch-checkbox {
-		display: none;
-	}
-	.onoffswitch-label {
-		display: block; overflow: hidden; cursor: pointer;
-		border: 2px solid #999999; border-radius: 20px;
-	}
-	.onoffswitch-inner {
-		display: block; width: 200%; margin-left: -100%;
-		transition: margin 0.3s ease-in 0s;
-	}
-	.onoffswitch-inner:before, .onoffswitch-inner:after {
-		display: block; float: left; width: 50%; height: 23px; padding: 0; line-height: 23px;
-		font-size: 14px; color: white; font-family: Trebuchet, Arial, sans-serif; font-weight: bold;
-		box-sizing: border-box;
-	}
-	.onoffswitch-inner:before {
-		content: "ON";
-		padding-left: 10px;
-		background-color: #4ACC5F; color: #FFFFFF;
-	}
-	.onoffswitch-inner:after {
-		content: "OFF";
-		padding-right: 10px;
-		background-color: #EEEEEE; color: #999999;
-		text-align: right;
-	}
-	.onoffswitch-switch {
-		display: block; width: 16px; margin: 3.5px;
-		background: #FFFFFF;
-		position: absolute; top: 0; bottom: 0;
-		right: 39px;
-		border: 2px solid #999999; border-radius: 20px;
-		transition: all 0.3s ease-in 0s; 
-	}
-	.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-inner {
-		margin-left: 0;
-	}
-	.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-switch {
-		right: 0px;
-	}
-	/* End switch generator CSS from https://proto.io/freebies/onoff/ */
 }
 
 @media #{$phone} {

--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -91,6 +91,8 @@ moresite_organize_favorites = Organize Favorites
 moresite_favorites = Favorites
 moresite_add_to_favorites = Add to favorites
 moresite_remove_from_favorites = Remove from favorites
+moresite_favorites_on = On
+moresite_favorites_off = Off
 
 timeout_dialog_title = Timeout Alert
 timeout_dialog_warning_message = Your session will timeout in <span>{0}</span> minutes.

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -158,14 +158,13 @@
                     </div>
 
                     <div id="favorite-settings-pane">
-                        <p>${rloader.sit_autofav_description}</p>
+                        <div id="autofav-description">${rloader.sit_autofav_description}</div>
 
                         <div class="onoffswitch" style="display: none">
-                            <input type="checkbox" name="autoFavoritesEnabled" class="onoffswitch-checkbox" id="autoFavoritesEnabled">
-                            <label class="onoffswitch-label" for="autoFavoritesEnabled">
-                                <span class="onoffswitch-inner"></span>
-                                <span class="onoffswitch-switch"></span>
-                            </label>
+                            <button role="switch" aria-checked="true" aria-labelledby="autofav-description" class="btn btn-lg" id="autoFavoritesEnabled">
+                                <span class="onoffswitch-inner">${rloader.moresite_favorites_on}</span>
+                                <span class="onoffswitch-switch">${rloader.moresite_favorites_off}</span>
+                            </button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Heavily based on the ideas here: https://inclusive-components.design/toggle-button/

* aria-clicked gets toggled on every user click
* On and Off are visible and simple spans. The two choices are plain and not swapped out or hidden
  * "As a rule of thumb, you should never change pressed state and label together. If the label changes, the button has already changed state in a sense, just not via explicit WAI-ARIA state management."
* role="switch" is nice for screen-readers
* SCSS rewritten to use button colors
* simple space or enter or click on the button will change the state
* the button is tabbable with a keyboard

<img width="1020" alt="screen shot 2017-06-07 at 6 14 21 pm" src="https://user-images.githubusercontent.com/810505/26903937-9f0b5852-4bad-11e7-8e70-3a6d62e1bc75.png">

CC: @kyleblythe is NYU interested in the styling of this on/off button in master?