### PR TITLE
SAK-32364 implement Hans suggestions to improve iOS Voiceover experience

### DIFF
--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -204,12 +204,6 @@ body.is-logged-out{
 	}
 }
 
-#totoolmenu{
-	@media #{$phone}{
-		display:none !important;
-	}
-}
-
 .#{$namespace}toolsNav__title--current-site{
 	display: none;
 	@media #{$phone}{

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
@@ -38,7 +38,7 @@
 						#set( $breadToolName  = $page.pageTitle )
 	
 						<li class="Mrphs-toolsNav__menuitem is-current">
-							<a class="Mrphs-toolsNav__menuitem--link #if(${page.hidden})is-invisible#end" href="${page.pageResetUrl}" title="${page.pageTitle}" role="presentation">
+							<a class="Mrphs-toolsNav__menuitem--link #if(${page.hidden})is-invisible#end" href="${page.pageResetUrl}" title="${page.pageTitle}">
 								<span class="Mrphs-toolsNav__menuitem--icon ${page.menuClass} $!{page.menuClassOverride} icon-active"></span>
 								<span class="Mrphs-toolsNav__menuitem--title">${page.pageTitle}</span>
 							</a>
@@ -93,7 +93,7 @@
 					#if (${page.current})
 	
 						<li class="Mrphs-toolsNav__menuitem is-current">
-							<a class="Mrphs-toolsNav__menuitem--link #if(${page.hidden})is-invisible#end" href="${page.pageResetUrl}" title="${page.pageTitle}" role="presentation">
+							<a class="Mrphs-toolsNav__menuitem--link #if(${page.hidden})is-invisible#end" href="${page.pageResetUrl}" title="${page.pageTitle}">
 								<span class="Mrphs-toolsNav__menuitem--icon ${page.menuClass} $!{page.menuClassOverride} icon-active"></span>
 								<span class="Mrphs-toolsNav__menuitem--title">${page.pageTitle}</span>
 							</a>
@@ -182,12 +182,12 @@
 		#if ( $subSites )
 	
 			<nav id="subSites" #if ($showSubsitesAsFlyout) class="is-hidden"#end>
-					<ul role="menu">
+					<ul>
 	
 						#foreach ( $site in $subSites )
 	
 							<li>
-								<a class="Mrphs-toolsNav__menuitem--link #if(!${site.isPublished})is-invisible#end" href="${site.siteUrl}" title="${rloader.subsite} ${site.fullTitle}" role="menuitem">
+								<a class="Mrphs-toolsNav__menuitem--link #if(!${site.isPublished})is-invisible#end" href="${site.siteUrl}" title="${rloader.subsite} ${site.fullTitle}">
 									<span class="Mrphs-toolsNav__menuitem--icon ${sitePages.subsiteClass}"></span>
 									<span class="Mrphs-toolsNav__menuitem--title">${rloader.subsite} ${site.siteTitle}</span>
 								</a>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
@@ -2,14 +2,14 @@
     <h1 class="skip" tabindex="-1" id="sitetabs">${rloader.sit_worksiteshead}</h1>
     <div id="show-all-sites" tabindex="-1"><i class="fa fa-angle-double-left" aria-hidden="true"></i><span>${rloader.sit_more}</span></div>
     <div id="topnav_container">
-        <ul class="Mrphs-sitesNav__menu" id="topnav" role="menubar" aria-label="${rloader.sit_worksiteshead}">
+        <ul class="Mrphs-sitesNav__menu" id="topnav" aria-label="${rloader.sit_worksiteshead}">
 
             #foreach ( $site in $tabsSites.tabsSites )
 
-        		 #if (${site.isMyWorkspace})
+                #if (${site.isMyWorkspace})
                     <li class="Mrphs-sitesNav__menuitem Mrphs-sitesNav__menuitem--myworkspace #if (${site.isCurrentSite}) is-selected #end">
-                        <a class="link-container" href="${site.siteUrl}" title="${rloader.sit_mywor}" role="menuitem">
-                            <i class="fa fa-home" aria-hidden="true"></i>
+                        <a class="link-container" href="${site.siteUrl}" title="${rloader.sit_mywor}">
+                            <span class="fa fa-home" aria-hidden="true"></span>
                             <span class="Mrphs-sitesNav__menuitem--myworkspace-label">${rloader.sit_mywor}</span>
                             <span class="Mrphs-sitesNav__drop" tabindex="-1" data-site-id="${site.siteId}"></span>
                         </a>
@@ -19,7 +19,7 @@
                 ## Only show other sites if they're the current site, a favorite of the current user, or if there *is* no current user and we're showing Gateway sites.
                 #if (!${site.isMyWorkspace} && (${site.favorite} == "true" || ${site.isCurrentSite} || !${userIsLoggedIn}))
                     <li class="Mrphs-sitesNav__menuitem #if (${site.isCurrentSite}) is-selected #end">
-                        <a class="link-container" href="${site.siteUrl}" title="${site.fullTitle}" role="menuitem" aria-haspopup="true">
+                        <a class="link-container" href="${site.siteUrl}" title="${site.fullTitle}">
                             <span>#if ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )${site.shortDescription}#else${site.siteTitle}#end</span>
                         </a>
                         <a class="Mrphs-sitesNav__dropdown" href="#" data-site-id="${site.siteId}" role="separator"></a>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/loginImage-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/loginImage-snippet.vm
@@ -1,14 +1,14 @@
-<div id="loginLinksImage" class="Mrphs-loginUser" role="menu" tabindex="999">
+<div id="loginLinksImage" class="Mrphs-loginUser" tabindex="999">
 
     #if (${loginHasImage1})
 
-        <p role="menuitem" class="Mrphs-loginUser__menuitem">
+        <p class="Mrphs-loginUser__menuitem">
             <a href="${loginLogInOutUrl}" title="${loginMessage}" id="loginLink1" class="Mrphs-loginUser__image" data-warning="${logoutWarningMessage}"><img src="${loginImage1}" alt="${loginMessage}"></a>
         </p>
 
     #else
 
-        <p role="menuitem" class="Mrphs-loginUser__menuitem">
+        <p class="Mrphs-loginUser__menuitem">
             <a href="${loginLogInOutUrl}" title="${loginMessage}" id="loginLink1" class="Mrphs-loginUser__message" data-warning="${logoutWarningMessage}">
                 <i class="login-Icon"></i>
                 <span class="Mrphs-login-Message">${loginMessage}</span>
@@ -21,13 +21,13 @@
 
         #if (${loginHasImage2})
 
-            <p role="menuitem" class="Mrphs-loginUser__menuitem Mrphs-loginUser__menuitem--alt">
+            <p class="Mrphs-loginUser__menuitem Mrphs-loginUser__menuitem--alt">
                 <a href="${loginLogInOutUrl2}" title="${loginMessage2}" id="loginLink2" class="Mrphs-loginUser__image"><img src="${loginImage2}" alt="${loginMessage2}"></a>
             </p>
 
         #else
 
-            <p role="menuitem" class="Mrphs-loginUser__menuitem Mrphs-loginUser__menuitemk--alt">
+            <p class="Mrphs-loginUser__menuitem Mrphs-loginUser__menuitemk--alt">
                 <a href="${loginLogInOutUrl2}" title="${loginMessage2}" id="loginLink2" class="Mrphs-loginUser__message">
                     <i class="login-Icon"></i>
                     <span class="Mrphs-login-Message">${loginMessage2}</span>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
@@ -1,27 +1,27 @@
 <nav id="skipNav" class="Mrphs-skipNav">
-    <ul role="menu" class="Mrphs-skipNav__menu">
+    <ul class="Mrphs-skipNav__menu">
 
         #if ($siteNavHasAccessibilityURL)
-            <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--accessibility">
+            <li class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--accessibility">
                 <a href="$siteNavAccessibilityURL" class="Mrphs-skipNav__link" title="${rloader.sit_accessibility}" accesskey="0">
                     ${rloader.sit_accessibility}
                     <span class="accesibility_key">[0]</span>
                 </a>
             </li>
         #end ## END of IF ($siteNavHasAccessibilityURL)
-        <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--content">
+        <li class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--content">
             <a href="#tocontent" class="Mrphs-skipNav__link" title="${rloader.sit_jumpcontent}" accesskey="c">
                 ${rloader.sit_jumpcontent}
                 <span class="accesibility_key">[c]</span>
             </a>
         </li>
-        <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--worksite">
+        <li class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--worksite">
             <a href="#sitetabs" id="more-sites-menu" class="Mrphs-skipNav__link js-toggle-sites-nav" title="${rloader.sit_jumpworksite}" accesskey="w">
                 <i class="fa fa-th all-sites-icon" aria-hidden="true"></i> ${rloader.sit_worksites}
                 <span class="accesibility_key">[w]</span>
             </a>
         </li>
-        <li role="menuitem" class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--tools">
+        <li class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--tools">
             <a href="#totoolmenu" class="Mrphs-skipNav__link js-toggle-tools-nav" title="${rloader.sit_jumptools}" accesskey="l">
                 <i class="fa fa-bars tools-icon" aria-hidden="true"></i>
                 ${rloader.sit_menutools}


### PR DESCRIPTION
> 1. The reason the “Tools begins here” H1 isn’t read in responsive layout is because it’s hidden with display:none:
> 2. The reason that VoiceOver doesn't announce the text content of the "Tools" and "Sites" links is that the links are wrapped inside "menuitem" roles. Menu item roles can't contain links. The "menu" and "menuitem" roles need to be removed here, as these roles are only applicable for desktop application style menubars and dropdown menus.
> 3. The links in the Tools list are incorrectly marked up with role="presentation"