### PR TITLE
SAK-32603 Add support for monospaced inline text

### DIFF
--- a/rwiki/rwiki-tool/tool/src/bundle/uk/ac/cam/caret/sakai/rwiki/tool/bundle/PrepopulatePages.properties
+++ b/rwiki/rwiki-tool/tool/src/bundle/uk/ac/cam/caret/sakai/rwiki/tool/bundle/PrepopulatePages.properties
@@ -62,6 +62,7 @@ Type these codes| Displays as | Descriptions\n\
 \\_\\_bold\\_\\_ | __bold__ | simple bold text\n\
 \\~\\~italics\\~\\~ | ~~italics~~ | simple italic text\n\
 \\-\\-strike\\-\\- | --strike-- | strike through text\n\
+\\#\\#monospace\\#\\# | --monospace-- | monospaced text, useful for code examples\n\
 CH\\%\\%4\\%\\%|CH%%4%%| subscript (for more mathematical formatting, see below)\n\
 Ca\\^\\^2+\\^\\^| Ca^^2+^^| superscript \n\
 \\[my new page\\] | [my new page] | links to a new Wiki page with the name given in brackets\n\

--- a/rwiki/rwiki-util/radeox/src/bundle/META-INF/services/org.radeox.filter.Filter
+++ b/rwiki/rwiki-util/radeox/src/bundle/META-INF/services/org.radeox.filter.Filter
@@ -9,6 +9,7 @@ org.radeox.filter.StrikeThroughFilter
 org.radeox.filter.NewlineFilter
 org.radeox.filter.ParagraphFilter
 org.radeox.filter.BoldFilter
+org.radeox.filter.CodeFilter
 org.radeox.filter.ItalicFilter
 uk.ac.cam.caret.sakai.rwiki.component.filter.SuperscriptFilter
 uk.ac.cam.caret.sakai.rwiki.component.filter.SubscriptFilter

--- a/rwiki/rwiki-util/radeox/src/bundle/radeox_markup.properties
+++ b/rwiki/rwiki-util/radeox/src/bundle/radeox_markup.properties
@@ -27,6 +27,9 @@ macro.code.end=</pre></div>
 filter.bold.match=(?<!_)__(?!_)(.*?)(?<!_)__(?!_)
 filter.bold.print=<strong class=\"bold\">$1</strong>
 
+filter.code.match=(?<!#)##(?!#)(.*?)(?<!#)##(?!#)
+filter.code.print=<code>$1</code>
+
 # Notice the checks to ensure ~~~ doesn't match but \~~~ does.
 filter.italic.match=(?<!~)~~(?!~)(.*?)(?<!~)~~(?!~)
 filter.italic.print=<em class=\"italic\">$1</em>

--- a/rwiki/rwiki-util/radeox/src/java/org/radeox/filter/CodeFilter.java
+++ b/rwiki/rwiki-util/radeox/src/java/org/radeox/filter/CodeFilter.java
@@ -1,0 +1,35 @@
+/**********************************************************************************
+ *
+ * Copyright (c) 2017 The Sakai Foundation.
+ *
+ * Licensed under the Educational Community License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.opensource.org/licenses/ecl1.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.radeox.filter;
+
+/*
+ * CodeFilter replaces ##text## with code "text".
+ *
+ * @author Matthew Buckett
+ */
+
+import org.radeox.filter.regex.LocaleRegexReplaceFilter;
+
+public class CodeFilter extends LocaleRegexReplaceFilter implements CacheFilter
+{
+	protected String getLocaleKey()
+	{
+		return "filter.code";
+	}
+}


### PR DESCRIPTION
Add support to rwiki for monospaced inline text. This is useful for code snippets in a similar way to how backtracks are used in Markdown.