### PR TITLE
SAK-32608: Extend CandidateDetailProvider to provide institutional numeric ids (student numbers) for use in Gradebook

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -567,6 +567,12 @@ public interface GradebookService {
 	public boolean currentUserHasViewOwnGradesPerm(String gradebookUid);
 	
 	/**
+	 * @param gradebookUid
+	 * @return true if the current user has the gradebook.viewStudentNumbers permission 
+	 */
+	public boolean currentUserHasViewStudentNumbersPerm(String gradebookUid);
+	
+	/**
 	 * Get the grade records for the given list of students and the given assignment.
 	 * This can only be called by an instructor or TA that has access, not student.
 	 * 

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/tool/gradebook/facades/Authz.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/tool/gradebook/facades/Authz.java
@@ -35,6 +35,7 @@ public interface Authz {
 	public boolean isUserAbleToGradeAll(String gradebookUid, String userUid);
 	public boolean isUserAbleToEditAssessments(String gradebookUid);
 	public boolean isUserAbleToViewOwnGrades(String gradebookUid);
+	public boolean isUserAbleToViewStudentNumbers(String gradebookUid);
 	public boolean isUserHasGraderPermissions(String gradebookUid);
 	public boolean isUserHasGraderPermissions(Long gradebookId);
 	public boolean isUserHasGraderPermissions(Long gradebookId, String userUid);

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -1721,6 +1721,12 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
   }
   
   @Override
+  public boolean currentUserHasViewStudentNumbersPerm(String gradebookUid)
+  {
+	  return authz.isUserAbleToViewStudentNumbers(gradebookUid);
+  }
+  
+  @Override
   public List<GradeDefinition> getGradesForStudentsForItem(final String gradebookUid, final Long gradableObjectId, List<String> studentIds) {
 	  if (gradableObjectId == null) {
 		  throw new IllegalArgumentException("null gradableObjectId passed to getGradesForStudentsForItem");

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/AuthzSakai2Impl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sakai2impl/AuthzSakai2Impl.java
@@ -53,7 +53,8 @@ public class AuthzSakai2Impl extends AuthzSectionsImpl implements Authz {
     	PERMISSION_GRADE_ALL = "gradebook.gradeAll",
     	PERMISSION_GRADE_SECTION = "gradebook.gradeSection",
     	PERMISSION_EDIT_ASSIGNMENTS = "gradebook.editAssignments",
-    	PERMISSION_VIEW_OWN_GRADES = "gradebook.viewOwnGrades";
+    	PERMISSION_VIEW_OWN_GRADES = "gradebook.viewOwnGrades",
+        PERMISSION_VIEW_STUDENT_NUMBERS = "gradebook.viewStudentNumbers";
 
     /**
      * Perform authorization-specific framework initializations for the Gradebook.
@@ -74,6 +75,10 @@ public class AuthzSakai2Impl extends AuthzSectionsImpl implements Authz {
 
         if(!registered.contains(PERMISSION_VIEW_OWN_GRADES)) {
             FunctionManager.registerFunction(PERMISSION_VIEW_OWN_GRADES);
+        }
+
+        if(!registered.contains(PERMISSION_VIEW_STUDENT_NUMBERS)) {
+            FunctionManager.registerFunction(PERMISSION_VIEW_STUDENT_NUMBERS);
         }
     }
 
@@ -122,6 +127,11 @@ public class AuthzSakai2Impl extends AuthzSectionsImpl implements Authz {
 
 	public boolean isUserAbleToViewOwnGrades(String gradebookUid) {
 		return hasPermission(gradebookUid, PERMISSION_VIEW_OWN_GRADES);
+	}
+	
+	public boolean isUserAbleToViewStudentNumbers(String gradebookUid)
+	{
+		return hasPermission(gradebookUid, PERMISSION_VIEW_STUDENT_NUMBERS);
 	}
 
 	private boolean hasPermission(String gradebookUid, String permission) {

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sections/AuthzSectionsImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sections/AuthzSectionsImpl.java
@@ -116,6 +116,12 @@ public class AuthzSectionsImpl implements Authz {
 		return getSectionAwareness().isSiteMemberInRole(gradebookUid, userUid, Role.STUDENT);
 	}
 	
+	public boolean isUserAbleToViewStudentNumbers(String gradebookUid)
+	{
+		String userUid = authn.getUserUid();
+		return getSectionAwareness().isSiteMemberInRole(gradebookUid, userUid, Role.INSTRUCTOR);
+	}
+	
 	public String getGradeViewFunctionForUserForStudentForItem(String gradebookUid, Long itemId, String studentUid) {
 		if (itemId == null || studentUid == null || gradebookUid == null) {
 			throw new IllegalArgumentException("Null parameter(s) in AuthzSectionsServiceImpl.isUserAbleToGradeItemForStudent");

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -70,6 +70,7 @@ error.concurrentedit=Concurrent edits have been detected. Refresh the tool to se
 
 column.header.section = Section
 column.header.students = Students
+column.header.studentNumber = Student Number
 column.header.coursegrade = Course Grade
 
 filter.students = Filter students
@@ -246,6 +247,7 @@ importExport.export.advancedOption.description = Select from the options below t
 importExport.export.advancedOption.warning = Customized exports can only be imported back into the system if Student ID and Student Name are retained in the first and second columns and all other formatting conventions are followed.
 importExport.export.advancedOption.exportFormat = Export File Format
 importExport.export.advancedOption.includeStudentName = Student Name
+importExport.export.advancedOption.includeStudentNumber = Student Number
 importExport.export.advancedOption.includePoints = Total Points
 importExport.export.advancedOption.includeLastLogDate = Last Log Date
 importExport.export.advancedOption.includeCourseGrade = Course Grade
@@ -256,6 +258,7 @@ importExport.export.advancedOption.includeGradeItemScores = Gradebook Item Score
 importExport.export.advancedOption.includeGradeItemComments = Gradebook Item Comments
 importExport.export.csv.headers.studentId = Student ID
 importExport.export.csv.headers.studentName = Student Name
+importExport.export.csv.headers.studentNumber = Student Number
 importExport.export.csv.headers.points = Total Points
 importExport.export.csv.headers.courseGrade = Course Grade
 importExport.export.csv.headers.calculatedGrade = Calculated Grade

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/StudentNumberComparator.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/StudentNumberComparator.java
@@ -1,0 +1,26 @@
+package org.sakaiproject.gradebookng.business;
+
+import java.util.Comparator;
+import lombok.RequiredArgsConstructor;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.user.api.CandidateDetailProvider;
+import org.sakaiproject.user.api.User;
+
+/**
+ * Comparator class for sorting a list of users by student number
+ * @author plukasew
+ */
+@RequiredArgsConstructor
+public class StudentNumberComparator implements Comparator<User>
+{
+	private final CandidateDetailProvider provider;
+	private final Site site;
+	
+	@Override
+	public int compare(final User u1, final User u2)
+	{
+		String stunum1 = provider.getInstitutionalNumericId(u1, site).orElse("");
+		String stunum2 = provider.getInstitutionalNumericId(u2, site).orElse("");
+		return stunum1.compareTo(stunum2);
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbStudentGradeInfo.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbStudentGradeInfo.java
@@ -32,6 +32,9 @@ public class GbStudentGradeInfo implements Serializable {
 
 	@Getter
 	private String studentEid;
+	
+	@Getter
+	private String studentNumber;
 
 	@Getter
 	@Setter
@@ -46,12 +49,17 @@ public class GbStudentGradeInfo implements Serializable {
 	public GbStudentGradeInfo() {
 	}
 
-	public GbStudentGradeInfo(final User u) {
+	public GbStudentGradeInfo(final User u)
+	{
+		this(u, "");
+	}
+	public GbStudentGradeInfo(final User u, final String studentNumber) {
 		this.studentUuid = u.getId();
 		this.studentEid = u.getEid();
 		this.studentFirstName = u.getFirstName();
 		this.studentLastName = u.getLastName();
 		this.studentDisplayName = u.getDisplayName();
+		this.studentNumber = studentNumber;
 		this.grades = new HashMap<Long, GbGradeInfo>();
 		this.categoryAverages = new HashMap<Long, Double>();
 	}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbHeadersToolbar.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbHeadersToolbar.html
@@ -1,6 +1,6 @@
 <wicket:panel xmlns:wicket="http://wicket.apache.org">
 	<tr wicket:id="categoriesRow" class="gb-categories-row" role="row">
-		<th colspan="3"><!-- empty --></th>
+		<th wicket:id="empty"><!-- empty --></th>
 		<th wicket:id="categories" scope="col" role="columnheader">
 			<span class="gb-category-label">
 				<span wicket:id="extraCreditCategoryFlag" class="gb-category-extra-credit"></span>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbHeadersToolbar.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbHeadersToolbar.java
@@ -15,6 +15,7 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
@@ -44,6 +45,10 @@ public class GbHeadersToolbar extends HeadersToolbar {
 
 		if (categoriesEnabled && settings.isCategoriesEnabled()) {
 			final WebMarkupContainer categoriesRow = new WebMarkupContainer("categoriesRow");
+			
+			final Label emptyCat = new Label("empty", Model.of(""));
+			emptyCat.add(new AttributeModifier("colspan", (Integer) modelData.get("fixedColCount")));
+			categoriesRow.add(emptyCat);
 
 			final List<Assignment> assignments = (List<Assignment>) modelData.get("assignments");
 			List<CategoryDefinition> categories = (List<CategoryDefinition>) modelData.get("categories");

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -68,6 +68,12 @@ public class GradebookUiSettings implements Serializable {
 	 */
 	@Getter
 	private SortDirection studentSortOrder;
+	
+	/**
+	 * The direction to sort the student number column
+	 */
+	@Getter
+	private SortDirection studentNumberSortOrder;
 
 	/**
 	 * For sorting based on coursegrade
@@ -187,12 +193,19 @@ public class GradebookUiSettings implements Serializable {
 		resetSortOrder();
 		this.studentSortOrder = sortOrder;
 	}
+	
+	public void setStudentNumberSortOrder(SortDirection sortOrder)
+	{
+		resetSortOrder();
+		studentNumberSortOrder = sortOrder;
+	}
 
 	private void resetSortOrder() {
 		this.courseGradeSortOrder = null;
 		this.categorySortOrder = null;
 		this.assignmentSortOrder = null;
 		this.studentSortOrder = null;
+		studentNumberSortOrder = null;
 	}
 
 	@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -59,6 +59,7 @@ import org.sakaiproject.gradebookng.tool.panels.CourseGradeItemCellPanel;
 import org.sakaiproject.gradebookng.tool.panels.GradeItemCellPanel;
 import org.sakaiproject.gradebookng.tool.panels.StudentNameCellPanel;
 import org.sakaiproject.gradebookng.tool.panels.StudentNameColumnHeaderPanel;
+import org.sakaiproject.gradebookng.tool.panels.StudentNumberColumnHeaderPanel;
 import org.sakaiproject.gradebookng.tool.panels.ToggleGradeItemsToolbarPanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
@@ -279,6 +280,39 @@ public class GradebookPage extends BasePage {
 
 		};
 		cols.add(studentNameColumn);
+		
+		// student number column (if enabled)
+		if (businessService.isStudentNumberVisible())
+		{
+			final AbstractColumn studentNumberColumn = new AbstractColumn(new Model(""))
+			{
+				@Override
+				public Component getHeader(final String componentId)
+				{
+					return new StudentNumberColumnHeaderPanel(componentId);
+				}
+
+				@Override
+				public void populateItem(final Item cellItem, final String componentId, final IModel rowModel)
+				{
+					final GbStudentGradeInfo studentGradeInfo = (GbStudentGradeInfo) rowModel.getObject();
+
+					final String studentNumber = StringUtils.defaultIfBlank(studentGradeInfo.getStudentNumber(), "-");
+
+					cellItem.add(new Label(componentId, studentNumber));
+					cellItem.add(new AttributeModifier("data-studentUuid", studentGradeInfo.getStudentUuid()));
+					cellItem.add(new AttributeModifier("abbr", studentNumber));
+					cellItem.add(new AttributeModifier("aria-label", studentNumber));
+				}
+
+				@Override
+				public String getCssClass()
+				{
+					return "gb-student-number-cell";
+				}
+			};
+			cols.add(studentNumberColumn);
+		}
 
 		// course grade column
 		final boolean courseGradeVisible = this.businessService.isCourseGradeVisible(this.currentUserUuid);
@@ -510,6 +544,7 @@ public class GradebookPage extends BasePage {
 		modelData.put("categories", categories);
 		modelData.put("categoryType", this.businessService.getGradebookCategoryType());
 		modelData.put("categoriesEnabled", categoriesEnabled);
+		modelData.put("fixedColCount", (businessService.isStudentNumberVisible()) ? 4 : 3);
 
 		table.addTopToolbar(new GbHeadersToolbar(table, null, Model.ofMap(modelData)));
 		table.add(new AttributeModifier("data-siteid", this.businessService.getCurrentSiteId()));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -423,7 +423,7 @@ public class GradebookPage extends BasePage {
 		// lookup in there)
 
 		List<CategoryDefinition> categories = new ArrayList<>();
-
+		int fixedColCount = businessService.isStudentNumberVisible() ? 4 : 3;
 		if (categoriesEnabled) {
 
 			// only work with categories if enabled
@@ -434,8 +434,7 @@ public class GradebookPage extends BasePage {
 
 			Collections.sort(categories, CategoryDefinition.orderComparator);
 
-			int currentColumnIndex = 3; // take into account first three header
-										// columns
+			int currentColumnIndex = fixedColCount; // take into account the fixed columns
 
 			for (final CategoryDefinition category : categories) {
 
@@ -544,7 +543,7 @@ public class GradebookPage extends BasePage {
 		modelData.put("categories", categories);
 		modelData.put("categoryType", this.businessService.getGradebookCategoryType());
 		modelData.put("categoriesEnabled", categoriesEnabled);
-		modelData.put("fixedColCount", (businessService.isStudentNumberVisible()) ? 4 : 3);
+		modelData.put("fixedColCount", fixedColCount);
 
 		table.addTopToolbar(new GbHeadersToolbar(table, null, Model.ofMap(modelData)));
 		table.add(new AttributeModifier("data-siteid", this.businessService.getCurrentSiteId()));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNumberColumnHeaderPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNumberColumnHeaderPanel.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<body>
+<wicket:panel>
+	
+	<div class="gb-title">
+		<a wicket:id="title"><wicket:container wicket:id="label" /></a>
+	</div>
+	
+</wicket:panel>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNumberColumnHeaderPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentNumberColumnHeaderPanel.java
@@ -1,0 +1,72 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
+import org.sakaiproject.gradebookng.business.SortDirection;
+import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
+import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+
+/**
+ *
+ * @author plukasew
+ */
+public class StudentNumberColumnHeaderPanel extends Panel
+{	
+	public StudentNumberColumnHeaderPanel(final String id)
+	{
+		super(id);
+	}
+	
+	@Override
+	public void onInitialize()
+	{
+		super.onInitialize();
+		
+		final GradebookPage gradebookPage = (GradebookPage) getPage();
+		
+		// title
+		final Link<String> title = new Link<String>("title")
+		{
+			@Override
+			public void onClick()
+			{
+				// toggle the sort direction on each click
+				final GradebookUiSettings settings = gradebookPage.getUiSettings();
+
+				// if null, set a default sort, otherwise toggle, save, refresh.
+				if (settings.getStudentNumberSortOrder() == null) {
+					settings.setStudentNumberSortOrder(SortDirection.getDefault());
+				} else {
+					final SortDirection sortOrder = settings.getStudentNumberSortOrder();
+					settings.setStudentNumberSortOrder(sortOrder.toggle());
+				}
+
+				// save settings
+				gradebookPage.setUiSettings(settings);
+
+				// refresh
+				setResponsePage(GradebookPage.class);
+			}
+		};
+		
+		title.add(new AttributeModifier("title", new ResourceModel("column.header.studentNumber")));
+		title.add(new Label("label", new ResourceModel("column.header.studentNumber")));
+		final GradebookUiSettings settings = gradebookPage.getUiSettings();
+		SortDirection sort = settings.getStudentNumberSortOrder();
+		if (sort != null)
+		{
+			title.add(new AttributeModifier("class", "gb-sort-" + sort.toString().toLowerCase()));
+		}
+		
+		add(title);
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -52,6 +52,14 @@
                                         <wicket:message key="importExport.export.advancedOption.includeStudentName"/>
                                     </label>
                                 </div>
+                                <wicket:enclosure child="includeStudentNumber">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" wicket:id="includeStudentNumber">
+                                            <wicket:message key="importExport.export.advancedOption.includeStudentNumber"/>
+                                        </label>
+                                    </div>
+                                </wicket:enclosure>
                                 <wicket:enclosure child="includePoints">
                                     <div class="checkbox">
                                         <label>
@@ -60,12 +68,6 @@
                                         </label>
                                     </div>
                                 </wicket:enclosure>
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" wicket:id="includeCourseGrade">
-                                        <wicket:message key="importExport.export.advancedOption.includeCourseGrade"/>
-                                    </label>
-                                </div>
                                 <div class="checkbox">
                                     <label>
                                         <input type="checkbox" wicket:id="includeLastLogDate">
@@ -84,6 +86,12 @@
                                     <label>
                                         <input type="checkbox" wicket:id="includeGradeItemComments">
                                         <wicket:message key="importExport.export.advancedOption.includeGradeItemComments"/>
+                                    </label>
+                                </div>
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" wicket:id="includeCourseGrade">
+                                        <wicket:message key="importExport.export.advancedOption.includeCourseGrade"/>
                                     </label>
                                 </div>
                                 <div class="checkbox">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -39,6 +39,7 @@ public class ExportPanel extends BasePanel {
 	ExportFormat exportFormat = ExportFormat.CSV;
 	boolean includeStudentName = true;
 	boolean includeStudentId = true;
+	boolean includeStudentNumber = false;
 	boolean includeGradeItemScores = true;
 	boolean includeGradeItemComments = true;
 	boolean includeCourseGrade = false;
@@ -74,6 +75,19 @@ public class ExportPanel extends BasePanel {
 				setDefaultModelObject(ExportPanel.this.includeStudentName);
 			}
 		});
+		
+		if (businessService.isStudentNumberVisible())
+		{
+			add(new AjaxCheckBox("includeStudentNumber", Model.of(this.includeStudentNumber)) {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				protected void onUpdate(final AjaxRequestTarget ajaxRequestTarget) {
+					ExportPanel.this.includeStudentNumber = !ExportPanel.this.includeStudentNumber;
+					setDefaultModelObject(ExportPanel.this.includeStudentNumber);
+				}
+			});
+		}
 
 		add(new AjaxCheckBox("includeGradeItemScores", Model.of(this.includeGradeItemScores)) {
 			private static final long serialVersionUID = 1L;
@@ -184,6 +198,11 @@ public class ExportPanel extends BasePanel {
 				header.add(getString("importExport.export.csv.headers.studentName"));
 			}
 
+			if (isCustomExport && this.includeStudentNumber)
+			{
+				header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.studentNumber")));
+			}
+
 			// get list of assignments. this allows us to build the columns and then fetch the grades for each student for each assignment from the map
 			final List<Assignment> assignments = this.businessService.getGradebookAssignments();
 
@@ -240,6 +259,10 @@ public class ExportPanel extends BasePanel {
 				}
 				if (!isCustomExport ||this.includeStudentName) {
 					line.add(studentGradeInfo.getStudentLastName() + ", " + studentGradeInfo.getStudentFirstName());
+				}
+				if (isCustomExport && this.includeStudentNumber)
+				{
+					line.add(studentGradeInfo.getStudentNumber());
 				}
 				if (!isCustomExport || this.includeGradeItemScores || this.includeGradeItemComments) {
 					assignments.forEach(assignment -> {

--- a/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -21,7 +21,7 @@
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 		<property name="gradebookExternalAssessmentService" ref="org.sakaiproject.service.gradebook.GradebookExternalAssessmentService"/>
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
-		
+		<property name="candidateDetailProvider" ref="org.sakaiproject.user.api.CandidateDetailProvider" />
 		
 	</bean>
 

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grades.js
@@ -504,7 +504,18 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
                                     attr("aria-hidden", "true").
                                     hide();
 
-  var $headers = self.$table.find("> thead > tr.gb-headers > th").slice(0,3);
+  //var $headers = self.$table.find("> thead > tr.gb-headers > th").slice(0,3);
+  var $headers = self.$table.find("> thead > tr.gb-headers > th");
+  var courseGradeIndex = 2;
+  $headers.each(function(index, origCell)
+  {
+      if ($(origCell).hasClass("gb-course-grade"))
+      {
+          courseGradeIndex = index;
+          return false;
+      }
+  });
+  $headers = $headers.slice(0, courseGradeIndex + 1);
   var $thead = $("<thead>");
   if(self.isGroupedByCategory()) {
     // append a dummy header row for when categorised
@@ -527,7 +538,8 @@ GradebookSpreadsheet.prototype.setupFixedColumns = function() {
   var $tbody = $("<tbody>");
   self.$table.find("> tbody > tr").each(function(i, origRow) {
     var $tr = $("<tr>");
-    self._cloneCells($(origRow).find(" > :lt(3)")).appendTo($tr);
+    //self._cloneCells($(origRow).find(" > :lt(3)")).appendTo($tr);
+    self._cloneCells($(origRow)).children().slice(0, courseGradeIndex + 1).appendTo($tr);
     $tbody.append($tr);
   });
   self.$fixedColumns.append($tbody);

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -236,11 +236,6 @@
      so that the bottom-most menus display without being cropped */
   min-height: 40px;
 }
-/* Distinguish Headers and Fixed Columns */
-#gradebookGrades table thead tr > *:nth-child(3),
-#gradebookGrades table tbody tr > *:nth-child(3) {
-  border-right: 1px solid #BBB !important;
-}
 #gradebookGrades table tr.gb-headers th {
   border-bottom-color: #BBB;
 }
@@ -353,10 +348,13 @@
 }
 #gradebookGrades .gb-course-grade {
   text-align: center;
+  /* Distinguish Headers and Fixed Columns */
+  border-right: 1px solid #BBB !important;
 }
 #gradebookGrades .gb-grade-item-cell > div,
 #gradebookGrades .gb-course-grade > div,
-#gradebookGrades .gb-category-item-column-cell > div {
+#gradebookGrades .gb-category-item-column-cell > div,
+#gradebookGrades .gb-student-number-cell > div {
   line-height: 2.6em;
 }
 #gradebookGrades .gb-course-grade.points > div > span {
@@ -1198,4 +1196,17 @@ and (max-device-width : 736px) {
   overflow-y: scroll;
   overflow-x: hidden;
   max-height:100px;
+}
+
+#gradebookGrades .gb-student-number-cell
+{
+  width: 180px;
+  max-width: 180px;
+  min-width: 180px;
+  text-align: center;
+}
+
+#gradebookGrades .gb-student-number-cell .gb-title
+{
+  text-align: left;
 }

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/CandidateDetailProvider.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/CandidateDetailProvider.java
@@ -41,4 +41,20 @@ public interface CandidateDetailProvider {
      * @return If <code>true</code> then show the additional details for this site.
      */
      boolean isAdditionalNotesEnabled(Site site);
+
+    /**
+     * Gets the student number (institutional numeric id) for the given user.
+     * 
+     * @param user the user to retrieve the student number for
+     * @param site the site in which the lookup is happening
+     * @return the user's student number, or empty if cannot be found
+     */
+    public Optional<String> getInstitutionalNumericId(User user, Site site);
+
+    /**
+     * Should the student number (institutional numeric id) be used for this site.
+     * @param site The site in which the lookup is happening
+     * @return true if the property is enabled at the site or system level
+     */
+    boolean isInstitutionalNumericIdEnabled(Site site);
 }

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/CandidateDetailProvider.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/CandidateDetailProvider.java
@@ -52,6 +52,17 @@ public interface CandidateDetailProvider {
     public Optional<String> getInstitutionalNumericId(User user, Site site);
 
     /**
+     * Gets the student number (institutional numeric id) for the given user, ignoring their student
+     * number visibility permission. This method is intended for use only when there is a business case
+     * requiring full access to student numbers. It is not intended for use when displaying student numbers
+     * to end users.
+     * @param candidate the user to retrieve the student number for
+     * @param site the site in which the lookup is happening
+     * @return the user's student number, or empty if cannot be found
+     */
+    public Optional<String> getInstitutionalNumericIdIgnoringCandidatePermissions(User candidate, Site site);
+
+    /**
      * Should the student number (institutional numeric id) be used for this site.
      * @param site The site in which the lookup is happening
      * @return true if the property is enabled at the site or system level

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -566,6 +566,8 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 			functionManager().registerFunction(SECURE_UPDATE_USER_OWN_PASSWORD);
 			functionManager().registerFunction(SECURE_UPDATE_USER_OWN_TYPE);
 			functionManager().registerFunction(SECURE_UPDATE_USER_ANY);
+			functionManager().registerFunction("user.studentnumber.visible");
+			
 
 			// if no provider was set, see if we can find one
 			if ((m_provider == null) && (m_providerName != null))

--- a/providers/component/src/webapp/WEB-INF/candidate-details.xml
+++ b/providers/component/src/webapp/WEB-INF/candidate-details.xml
@@ -24,6 +24,8 @@
                         <bean class="org.sakaiproject.user.detail.CandidateDetailProviderImpl" init-method="init">
                             <property name="siteService"
                                       ref="org.sakaiproject.site.api.SiteService"/>
+							<property name="securityService"
+                                      ref="org.sakaiproject.authz.api.SecurityService"/>
                             <property name="serverConfigurationService"
                                       ref="org.sakaiproject.component.api.ServerConfigurationService"/>
                             <property name="toolManager"

--- a/providers/component/src/webapp/WEB-INF/candidate-details.xml
+++ b/providers/component/src/webapp/WEB-INF/candidate-details.xml
@@ -24,7 +24,7 @@
                         <bean class="org.sakaiproject.user.detail.CandidateDetailProviderImpl" init-method="init">
                             <property name="siteService"
                                       ref="org.sakaiproject.site.api.SiteService"/>
-							<property name="securityService"
+                            <property name="securityService"
                                       ref="org.sakaiproject.authz.api.SecurityService"/>
                             <property name="serverConfigurationService"
                                       ref="org.sakaiproject.component.api.ServerConfigurationService"/>

--- a/providers/jldap/src/java/edu/amc/sakai/user/AttributeMappingConstants.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/AttributeMappingConstants.java
@@ -73,6 +73,7 @@ public abstract class AttributeMappingConstants {
 	
 	public static final String CANDIDATE_ID_ATTR_MAPPING_KEY = "candidateID";
 	public static final String ADDITIONAL_INFO_ATTR_MAPPING_KEY = "additionalInfo";
+	public static final String STUDENT_NUMBER_ATTR_MAPPING_KEY = "studentNumber";
 	
 	/** Default value in {@link #DEFAULT_ATTR_MAPPINGS} representing
 	 * the physical name of a user entry's login (aka Sakai "EID") attribute
@@ -111,6 +112,9 @@ public abstract class AttributeMappingConstants {
 	
 	public static final String DEFAULT_CANDIDATE_ID_ATTR = "employeeNumber";
 	public static final String DEFAULT_ADDITIONAL_INFO_ATTR = "description";
+	public static final String DEFAULT_STUDENT_NUMBER_ID_ATTR = "employeeNumber";
+	
+	public final static String SYSTEM_PROP_ENCRYPT_NUMERIC_ID = "encryptInstitutionalNumericID";
 	
 	/**
 	 * Default set of user entry attribute mappings. Keys are
@@ -139,6 +143,7 @@ public abstract class AttributeMappingConstants {
 		CANDIDATE_ATTR_MAPPINGS.putAll(DEFAULT_ATTR_MAPPINGS);
 		CANDIDATE_ATTR_MAPPINGS.put(CANDIDATE_ID_ATTR_MAPPING_KEY, DEFAULT_CANDIDATE_ID_ATTR);
 		CANDIDATE_ATTR_MAPPINGS.put(ADDITIONAL_INFO_ATTR_MAPPING_KEY, DEFAULT_ADDITIONAL_INFO_ATTR);
+		CANDIDATE_ATTR_MAPPINGS.put(STUDENT_NUMBER_ATTR_MAPPING_KEY, DEFAULT_STUDENT_NUMBER_ID_ATTR);
 	}
 	
 	/**

--- a/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapCandidateAttributeMapper.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapCandidateAttributeMapper.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.user.api.UserEdit;
 import org.sakaiproject.user.detail.ValueEncryptionUtilities;
@@ -49,6 +50,7 @@ public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMappe
 	
 	private static final String USER_PROP_CANDIDATE_ID = "candidateID";
 	private static final String USER_PROP_ADDITIONAL_INFO = "additionalInfo";
+	private static final String USER_PROP_STUDENT_NUMBER = "studentNumber";
 	private static final String EMPTY = "";
 
 	/** Class-specific logger */
@@ -57,6 +59,8 @@ public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMappe
 	private ValueEncryptionUtilities encryption;
 	private int candidateIdLength;
 	private int additionalInfoLength;
+	private int studentNumberLength;
+	private ServerConfigurationService scs;
 
 	public void setEncryption(ValueEncryptionUtilities encryption) {
 		this.encryption = encryption;
@@ -68,6 +72,16 @@ public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMappe
 
 	public void setAdditionalInfoLength(int additionalInfoLength) {
 		this.additionalInfoLength = additionalInfoLength;
+	}
+	
+	public void setStudentNumberLength(int value)
+	{
+		studentNumberLength = value;
+	}
+	
+	public void setServerConfigurationService(ServerConfigurationService value)
+	{
+		scs = value;
 	}
 
 	/**
@@ -177,6 +191,34 @@ public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMappe
 				}
 				userDataProperties.remove(AttributeMappingConstants.ADDITIONAL_INFO_ATTR_MAPPING_KEY);
 			}
+			
+			o_prop = userDataProperties.get(AttributeMappingConstants.STUDENT_NUMBER_ATTR_MAPPING_KEY);
+			if(o_prop != null)
+			{
+				if(o_prop instanceof String)
+				{
+					addStudentNumberProperty((String) o_prop, userEditProperties);
+				}
+				else if (o_prop instanceof List)
+				{
+					Set<String> propertySet = new HashSet<>();
+					//remove duplicate values
+					for(String value : (List<String>)o_prop)
+					{
+						propertySet.add(value);
+					}
+					//add student number, if there is only one value
+					if(propertySet.size() == 1)
+					{
+						for(String value : propertySet)
+						{
+							addStudentNumberProperty(value, userEditProperties);
+						}
+					}
+				}
+				userDataProperties.remove(AttributeMappingConstants.STUDENT_NUMBER_ATTR_MAPPING_KEY);
+			}
+			
 			// Make sure we have a value for the encrypted properties.
 			if (StringUtils.isEmpty(userEditProperties.getProperty(USER_PROP_CANDIDATE_ID))) {
 				userEditProperties.addProperty(USER_PROP_CANDIDATE_ID, encryption.encrypt(EMPTY, candidateIdLength));
@@ -185,10 +227,24 @@ public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMappe
 					userEditProperties.getPropertyList(USER_PROP_ADDITIONAL_INFO).isEmpty()) {
 				userEditProperties.addPropertyToList(USER_PROP_ADDITIONAL_INFO, encryption.encrypt(EMPTY, additionalInfoLength));
 			}
+			if (userEditProperties.getPropertyList(USER_PROP_STUDENT_NUMBER)!= null &&
+					userEditProperties.getPropertyList(USER_PROP_STUDENT_NUMBER).isEmpty()) {
+				addStudentNumberProperty(EMPTY, userEditProperties);
+			}
 
 		super.mapUserDataOntoUserEdit(userData, userEdit);
 
 		}
 
+	}
+	
+	private void addStudentNumberProperty(String number, ResourceProperties userEditProperties)
+	{
+		String studentNumber = number;
+		if (scs.getBoolean(AttributeMappingConstants.SYSTEM_PROP_ENCRYPT_NUMERIC_ID, true))
+		{
+			studentNumber = encryption.encrypt(studentNumber, studentNumberLength);
+		}
+		userEditProperties.addPropertyToList(USER_PROP_STUDENT_NUMBER, studentNumber);
 	}
 }

--- a/providers/sample/src/java/org/sakaiproject/provider/user/SampleCandidateDetailProvider.java
+++ b/providers/sample/src/java/org/sakaiproject/provider/user/SampleCandidateDetailProvider.java
@@ -50,12 +50,16 @@ public class SampleCandidateDetailProvider implements CandidateDetailProvider
 {
 	private static final String USER_PROP_CANDIDATE_ID = "candidateID";
 	private static final String USER_PROP_ADDITIONAL_INFO = "additionalInfo";
+	private static final String USER_PROP_STUDENT_NUMBER = "studentNumber";
 	
 	private final static String SITE_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID = "useInstitutionalAnonymousID";
 	private final static String SITE_PROP_DISPLAY_ADDITIONAL_INFORMATION = "displayAdditionalInformation";
+	private final static String SITE_PROP_USE_INSTITUTIONAL_NUMERIC_ID = "useInstitutionalNumericID";
 	
 	private final static String SYSTEM_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID = "useInstitutionalAnonymousID";
 	private final static String SYSTEM_PROP_DISPLAY_ADDITIONAL_INFORMATION = "displayAdditionalInformation";
+	private final static String SYSTEM_PROP_USE_INSTITUTIONAL_NUMERIC_ID = "useInstitutionalNumericID";
+	private final static String SYSTEM_PROP_ENCRYPT_NUMERIC_ID = "encryptInstitutionalNumericID";
 
 	/** Our log (commons). */
 	private final Logger log = LoggerFactory.getLogger(SampleCandidateDetailProvider.class);
@@ -200,6 +204,43 @@ public class SampleCandidateDetailProvider implements CandidateDetailProvider
 		return Optional.empty();
 	}
 	
+	@Override
+	public Optional<String> getInstitutionalNumericId(User user, Site site){
+		if(site == null) {
+			log.error("getInstitutionalNumericId: Null site.");
+			return Optional.empty();
+		}
+		try {
+			if(user != null) {
+				//check if student number is enabled (system-wide or site-based)
+				if(isInstitutionalNumericIdEnabled(site)) {
+					if(user.getProperties() != null && StringUtils.isNotBlank(user.getProperties().getProperty(USER_PROP_STUDENT_NUMBER))) {
+						log.debug("Using user candidateID property for user {}", user.getId());
+						String studentNumber = user.getProperties().getProperty(USER_PROP_STUDENT_NUMBER);
+						if (serverConfigurationService.getBoolean(SYSTEM_PROP_ENCRYPT_NUMERIC_ID, true))
+						{
+							studentNumber = encryptionUtilities.decrypt(studentNumber);
+						}
+
+						return Optional.ofNullable(studentNumber);
+					} else {
+						int hashInt = user.getId().hashCode();
+						if(hashInt % 10 == 4){
+							log.debug("Not generating random sample student number for user " + user.getId());
+							return Optional.empty();
+						} else {
+							log.debug("Generating sample candidate id for user {}", user.getId());
+							return Optional.ofNullable(String.valueOf(Math.abs(hashInt % 100000)));
+						}
+					}
+				}
+			}
+		} catch(Exception e) {
+			log.error("Error getting sample studentNumber for "+((user != null) ? user.getId() : "-null-"), e);
+		}
+		return Optional.empty();
+	}
+	
 	public boolean isAdditionalNotesEnabled(Site site) {
 		try {
 			return (serverConfigurationService.getBoolean(SYSTEM_PROP_DISPLAY_ADDITIONAL_INFORMATION, false) || (site != null && Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROP_DISPLAY_ADDITIONAL_INFORMATION))));
@@ -214,6 +255,17 @@ public class SampleCandidateDetailProvider implements CandidateDetailProvider
 			return (serverConfigurationService.getBoolean(SYSTEM_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID, false) || (site != null && Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID))));
 		} catch(Exception e) {
 			log.warn("Error on useInstitutionalAnonymousId (sample) ", e);
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean isInstitutionalNumericIdEnabled(Site site) {
+		try {
+			return (serverConfigurationService.getBoolean(SYSTEM_PROP_USE_INSTITUTIONAL_NUMERIC_ID, false)
+					|| (site != null && Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROP_USE_INSTITUTIONAL_NUMERIC_ID))));
+		} catch(Exception e) {
+			log.warn("Error on isInstitutionalNumericIdEnabled (sample) ", e);
 		}
 		return false;
 	}

--- a/providers/sample/src/java/org/sakaiproject/provider/user/SampleCandidateDetailProvider.java
+++ b/providers/sample/src/java/org/sakaiproject/provider/user/SampleCandidateDetailProvider.java
@@ -241,6 +241,12 @@ public class SampleCandidateDetailProvider implements CandidateDetailProvider
 		return Optional.empty();
 	}
 	
+	@Override
+	public Optional<String> getInstitutionalNumericIdIgnoringCandidatePermissions(User candidate, Site site)
+	{
+		return getInstitutionalNumericId(candidate, site);
+	}
+	
 	public boolean isAdditionalNotesEnabled(Site site) {
 		try {
 			return (serverConfigurationService.getBoolean(SYSTEM_PROP_DISPLAY_ADDITIONAL_INFORMATION, false) || (site != null && Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROP_DISPLAY_ADDITIONAL_INFORMATION))));

--- a/providers/userdetail/README.md
+++ b/providers/userdetail/README.md
@@ -3,7 +3,7 @@ User Detail Provider
 
 This provider allows deployments to configure a method to lookup additional
 data about users. This is aimed at providing candidate numbers associated 
-with users and additional notes about a user that are relevant to someone
+with users, student numbers, and additional notes about a user that are relevant to someone
 marking an assessment.
 
 The API that this provider is built upon in in the kernel
@@ -17,7 +17,7 @@ bean not being set. Currently the assignments tool has been updated to use
 the provider.
 
 In a typical deployment when a user is loaded the additional data about the
-user's candidate number and additional notes will also be loaded. This data
+user's candidate number, student number, and additional notes will also be loaded. This data
 is then available for the provider to get from the user object when asked.
 Alternatively the provider can do the lookup for the additional data when
 asked, if this is the case then some caching may need to be put in place as
@@ -29,4 +29,4 @@ Encryption
 
 Currently the example implementation encrypts data it stores on the user object
 so that if the object is accidentally serialised over HTTP the values that 
-should remain secret aren't exposed.
+should remain secret aren't exposed. There is an option to not encrypt student numbers.

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.sakaiproject.authz.api.SecurityService;
 
 /**
  * This candidate details provider looks up information on the user object's properties, this assumes that the
@@ -24,17 +25,23 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	
 	private static final String USER_PROP_CANDIDATE_ID = "candidateID";
 	private static final String USER_PROP_ADDITIONAL_INFO = "additionalInfo";
+	private static final String USER_PROP_STUDENT_NUMBER = "studentNumber";
+	private static final String USER_PERM_STUDENT_NUMBER_VISIBLE = "user.studentnumber.visible";
 	
 	private final static String SITE_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID = "useInstitutionalAnonymousID";
 	private final static String SITE_PROP_DISPLAY_ADDITIONAL_INFORMATION = "displayAdditionalInformation";
+	private final static String SITE_PROP_USE_INSTITUTIONAL_NUMERIC_ID = "useInstitutionalNumericID";
 	
 	private final static String SYSTEM_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID = "useInstitutionalAnonymousID";
 	private final static String SYSTEM_PROP_DISPLAY_ADDITIONAL_INFORMATION = "displayAdditionalInformation";
+	private final static String SYSTEM_PROP_USE_INSTITUTIONAL_NUMERIC_ID = "useInsitutionalNumericID";
+	private final static String SYSTEM_PROP_ENCRYPT_NUMERIC_ID = "encryptInstitutionalNumericID";
 
 	private static Logger log = LoggerFactory.getLogger(CandidateDetailProviderImpl.class);
 	
 	private ServerConfigurationService serverConfigurationService;
 	private SiteService siteService;
+	private SecurityService secServ;
 	private ToolManager toolManager;
 	private ValueEncryptionUtilities encryptionUtilities;
 	
@@ -43,6 +50,7 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 		Objects.requireNonNull(toolManager, "ToolManager must be set");
 		Objects.requireNonNull(serverConfigurationService, "ServerConfigurationService must be set");
 		Objects.requireNonNull(encryptionUtilities, "ValueEncryptionUtilities must be set");
+		Objects.requireNonNull(secServ, "SecurityService must be set");
 	}
 	
 	public Optional<String> getCandidateID(User user, Site site) {
@@ -105,6 +113,52 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 		return false;
 	}
 	
+	@Override
+	public Optional<String> getInstitutionalNumericId(User user, Site site)
+	{
+		if (user == null || site == null || !isInstitutionalNumericIdEnabled(site)
+				|| !secServ.unlock(user, USER_PERM_STUDENT_NUMBER_VISIBLE, site.getReference()))
+		{
+			return Optional.empty();
+		}
+		
+		try
+		{
+			String studentNumber = user.getProperties().getProperty(USER_PROP_STUDENT_NUMBER);
+			if (serverConfigurationService.getBoolean(SYSTEM_PROP_ENCRYPT_NUMERIC_ID, true))
+			{
+				studentNumber = encryptionUtilities.decrypt(studentNumber);
+			}
+				
+			if (StringUtils.isNotBlank(studentNumber))
+			{
+				return Optional.of(studentNumber);
+			}
+		}
+		catch (Exception e)
+		{
+			log.warn("Error getting studentNumber for {}", user.getId(), e);
+		}
+		
+		return Optional.empty();
+	}
+	
+	@Override
+	public boolean isInstitutionalNumericIdEnabled(Site site)
+	{
+		try
+		{
+			return (serverConfigurationService.getBoolean(SYSTEM_PROP_USE_INSTITUTIONAL_NUMERIC_ID, false) ||
+			(site != null && site.getProperties().getBooleanProperty(SITE_PROP_USE_INSTITUTIONAL_NUMERIC_ID)));
+		}
+		catch (Exception ignore)
+		{
+			// ignore
+		}
+		
+		return false;
+	}
+	
 
 	public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
 		this.serverConfigurationService = serverConfigurationService;
@@ -112,6 +166,11 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	
 	public void setSiteService(SiteService siteService) {
 		this.siteService = siteService;
+	}
+	
+	public void setSecurityService(SecurityService value)
+	{
+		secServ = value;
 	}
 
 	public void setToolManager(ToolManager toolManager) {

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
@@ -116,8 +116,19 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	@Override
 	public Optional<String> getInstitutionalNumericId(User user, Site site)
 	{
+		return getNumericId(user, site, true);
+	}
+	
+	@Override
+	public Optional<String> getInstitutionalNumericIdIgnoringCandidatePermissions(User candidate, Site site)
+	{
+		return getNumericId(candidate, site, false);
+	}
+	
+	private Optional<String> getNumericId(User user, Site site, boolean checkVisibilityPermission)
+	{
 		if (user == null || site == null || !isInstitutionalNumericIdEnabled(site)
-				|| !secServ.unlock(user, USER_PERM_STUDENT_NUMBER_VISIBLE, site.getReference()))
+				|| (checkVisibilityPermission && !secServ.unlock(user, USER_PERM_STUDENT_NUMBER_VISIBLE, site.getReference())))
 		{
 			return Optional.empty();
 		}

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/ChainedDetailProvider.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/ChainedDetailProvider.java
@@ -74,4 +74,33 @@ public class ChainedDetailProvider implements CandidateDetailProvider {
 		}
 		return false;
 	}
+	
+	@Override
+	public Optional<String> getInstitutionalNumericId(User user, Site site)
+	{
+		for (CandidateDetailProvider provider : getProviders())
+		{
+			String studentNumber = provider.getInstitutionalNumericId(user, site).orElse("");
+			if (StringUtils.isNotBlank(studentNumber))
+			{
+				return Optional.of(studentNumber);
+			}
+		}
+		
+		return Optional.empty();
+	}
+	
+	@Override
+	public boolean isInstitutionalNumericIdEnabled(Site site)
+	{
+		for (CandidateDetailProvider provider : getProviders())
+		{
+			if (provider.isInstitutionalNumericIdEnabled(site))
+			{
+				return true;
+			}
+		}
+		
+		return false;
+	}
 }

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/ChainedDetailProvider.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/ChainedDetailProvider.java
@@ -91,6 +91,21 @@ public class ChainedDetailProvider implements CandidateDetailProvider {
 	}
 	
 	@Override
+	public Optional<String> getInstitutionalNumericIdIgnoringCandidatePermissions(User candidate, Site site)
+	{
+		for (CandidateDetailProvider provider : getProviders())
+		{
+			String studentNumber = provider.getInstitutionalNumericIdIgnoringCandidatePermissions(candidate, site).orElse("");
+			if (StringUtils.isNotBlank(studentNumber))
+			{
+				return Optional.of(studentNumber);
+			}
+		}
+		
+		return Optional.empty();
+	}
+	
+	@Override
 	public boolean isInstitutionalNumericIdEnabled(Site site)
 	{
 		for (CandidateDetailProvider provider : getProviders())

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/FallbackDetailProvider.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/FallbackDetailProvider.java
@@ -18,14 +18,13 @@ import org.slf4j.LoggerFactory;
  */
 public class FallbackDetailProvider implements CandidateDetailProvider {
 	
-	private static final String USER_PROP_CANDIDATE_ID = "candidateID";
-	private static final String USER_PROP_ADDITIONAL_INFO = "additionalInfo";
-	
 	private final static String SITE_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID = "useInstitutionalAnonymousID";
 	private final static String SITE_PROP_DISPLAY_ADDITIONAL_INFORMATION = "displayAdditionalInformation";
+	private final static String SITE_PROP_USE_INSTITUTIONAL_NUMERIC_ID = "useInstitutionalNumericID";
 	
 	private final static String SYSTEM_PROP_USE_INSTITUTIONAL_ANONYMOUS_ID = "useInstitutionalAnonymousID";
 	private final static String SYSTEM_PROP_DISPLAY_ADDITIONAL_INFORMATION = "displayAdditionalInformation";
+	private final static String SYSTEM_PROP_USE_INSTITUTIONAL_NUMERIC_ID = "useInsitutionalNumericID";
 
 	private final Logger log = LoggerFactory.getLogger(FallbackDetailProvider.class);
 	
@@ -72,6 +71,27 @@ public class FallbackDetailProvider implements CandidateDetailProvider {
 		return false;
 	}
 	
+	@Override
+	public Optional<String> getInstitutionalNumericId(User user, Site site)
+	{
+		log.debug("Getting student number from fallback provider");
+		if (user != null && isInstitutionalNumericIdEnabled(site))
+		{
+			return Optional.of(("no-student-number:" + user.getId()));
+		}
+		
+		return Optional.empty();
+	}
+	
+	@Override
+	public boolean isInstitutionalNumericIdEnabled(Site site)
+	{
+		try {
+			return (serverConfigurationService.getBoolean(SYSTEM_PROP_USE_INSTITUTIONAL_NUMERIC_ID, false)
+					|| (site != null && Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROP_USE_INSTITUTIONAL_NUMERIC_ID))));
+		} catch(Exception ignore) {}
+		return false;
+	}
 
 	public void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
 		this.serverConfigurationService = serverConfigurationService;

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/FallbackDetailProvider.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/FallbackDetailProvider.java
@@ -84,6 +84,12 @@ public class FallbackDetailProvider implements CandidateDetailProvider {
 	}
 	
 	@Override
+	public Optional<String> getInstitutionalNumericIdIgnoringCandidatePermissions(User candidate, Site site)
+	{
+		return getInstitutionalNumericId(candidate, site);
+	}
+	
+	@Override
 	public boolean isInstitutionalNumericIdEnabled(Site site)
 	{
 		try {

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/MappingDetailProvider.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/MappingDetailProvider.java
@@ -47,6 +47,18 @@ public class MappingDetailProvider implements CandidateDetailProvider {
     public boolean isAdditionalNotesEnabled(Site site) {
         return wrapped.isAdditionalNotesEnabled(site);
     }
+	
+	@Override
+	public Optional<String> getInstitutionalNumericId(User user, Site site)
+	{
+		return wrapped.getInstitutionalNumericId(user, site);
+	}
+	
+	@Override
+	public boolean isInstitutionalNumericIdEnabled(Site site)
+	{
+		return wrapped.isInstitutionalNumericIdEnabled(site);
+	}
 
 }
 

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/MappingDetailProvider.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/MappingDetailProvider.java
@@ -55,6 +55,12 @@ public class MappingDetailProvider implements CandidateDetailProvider {
 	}
 	
 	@Override
+	public Optional<String> getInstitutionalNumericIdIgnoringCandidatePermissions(User candidate, Site site)
+	{
+		return wrapped.getInstitutionalNumericIdIgnoringCandidatePermissions(candidate, site);
+	}
+	
+	@Override
 	public boolean isInstitutionalNumericIdEnabled(Site site)
 	{
 		return wrapped.isInstitutionalNumericIdEnabled(site);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32608

Many institutions have a numeric id used to uniquely identify
students (student number) that is valuable for grading and
administrative purposes. The CandidateDetailProvider introduced in
SAK-31405 provides a similar feature, an institutional anonymous id. This patch will add a numeric id to this provider, and expose the student number as a column in Gradebook (our institution has had this column for many years). Other tools would be able to use this provider to also expose students numbers as needed (we also use it in the Certification contrib tool).