### PR TITLE
SAK-32613 Fix for the last tool in list missing border.

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
+++ b/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
@@ -367,9 +367,7 @@ dl.defList dd{
 #toolSelectionList ul li.highlightTool{
     background-color: #ffc
 }
-#toolSelectionList ul li:last-child {
-    border-top: 0 none
-}
+
 .removeTool {
     text-decoration: none !important;
 }


### PR DESCRIPTION
The last tool in the list would be missing it’s border. You would only see this problem when you had that tool added to the site and went back to the manage tools page. Typically this is the wiki tool, unless you also have some LTI tools available in the site.