### PR TITLE
 SAK-32285 Fix bug with user ID.

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
@@ -895,7 +895,7 @@ RESTful, ActionsExecutable {
                 catch (UserNotDefinedException e) {
                     log.error(".createEntity: User with id {} doesn't exist", userIds[i]);
                 }
-                userAuditString = new String[]{sg.site.getId(),user.getDisplayId(), roleId, UserAuditService.USER_AUDIT_ACTION_ADD,
+                userAuditString = new String[]{sg.site.getId(),user.getEid(), roleId, UserAuditService.USER_AUDIT_ACTION_ADD,
                                                userAuditRegistration.getDatabaseSourceKey(), currentUserId};
                 userAuditList.add(userAuditString);
             } else {
@@ -962,14 +962,14 @@ RESTful, ActionsExecutable {
 
                 // Add change to user_audits_log table.
                 String role = site.getUserRole(userIds[i]).getId();
-                String displayId = null;
+                String userEid = null;
                 try {
-                    displayId = userDirectoryService.getUser(userIds[i]).getDisplayId();
+                    userEid = userDirectoryService.getUser(userIds[i]).getEid();
                 } catch (UserNotDefinedException e) {
                     log.error(".deleteEntity: User with id {} not defined", userIds[i]);
                 }
 
-                userAuditString = new String[]{site.getId(), displayId, role, UserAuditService.USER_AUDIT_ACTION_REMOVE,
+                userAuditString = new String[]{site.getId(), userEid, role, UserAuditService.USER_AUDIT_ACTION_REMOVE,
                                                userAuditRegistration.getDatabaseSourceKey(), developerHelperService.getCurrentUserId()};
                 userAuditList.add(userAuditString);
 

--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
@@ -896,7 +896,7 @@ RESTful, ActionsExecutable {
                     log.error(".createEntity: User with id {} doesn't exist", userIds[i]);
                 }
                 userAuditString = new String[]{sg.site.getId(),user.getEid(), roleId, UserAuditService.USER_AUDIT_ACTION_ADD,
-                                               userAuditRegistration.getDatabaseSourceKey(), currentUserId};
+                                               userAuditRegistration.getDatabaseSourceKey(), userDirectoryService.getCurrentUser().getEid()};
                 userAuditList.add(userAuditString);
             } else {
                 // group and site
@@ -970,7 +970,7 @@ RESTful, ActionsExecutable {
                 }
 
                 userAuditString = new String[]{site.getId(), userEid, role, UserAuditService.USER_AUDIT_ACTION_REMOVE,
-                                               userAuditRegistration.getDatabaseSourceKey(), developerHelperService.getCurrentUserId()};
+                                               userAuditRegistration.getDatabaseSourceKey(), userDirectoryService.getCurrentUser().getEid()};
                 userAuditList.add(userAuditString);
 
                 site.removeMember(userIds[i]);

--- a/entitybroker/core-providers/src/test/org/sakaiproject/entitybroker/providers/MembershipEntityProviderTest.java
+++ b/entitybroker/core-providers/src/test/org/sakaiproject/entitybroker/providers/MembershipEntityProviderTest.java
@@ -436,6 +436,11 @@ public class MembershipEntityProviderTest {
         when(userEntityProvider.findAndCheckUserId("user-foo", "user-foo")).thenReturn("user-foo");
         when(developerHelperService.getCurrentUserReference()).thenReturn("/user/me");
 
+        EntityUser user = new EntityUser();
+        user.setId("user-foo");
+        user.setEid("user-foo@school.edu");
+        when(userDirectoryService.getCurrentUser()).thenReturn(user);
+
         String entityId = provider.createEntity(null, member, new HashMap<String, Object>());
 
         verify(siteService).saveSiteMembership(site);
@@ -491,6 +496,7 @@ public class MembershipEntityProviderTest {
         when(site.getMembers()).thenReturn(members);
 
         when(siteService.getSite("site.with.dots")).thenReturn(site);
+        when(userDirectoryService.getCurrentUser()).thenReturn(user);
 
         provider.deleteEntity(ref, new HashMap<String, Object>());
 


### PR DESCRIPTION
We found a bug here at Ox, audit records were created via entity broker if an external user was added to a site but not for an official user.  Also, the incorrect user ID for the person doing the change was used.  These two bugs have been fixed in these commits.