### PR TITLE
SAK-32389 Restoring behavior of tool menu toggle button 

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
@@ -21,7 +21,7 @@ portal.toggleMinimizeNav = function () {
 	$PBJQ('#subSites.floating').css({'display': 'none'});
 
 	var el = $PBJQ(this);
-	el.toggleClass('min max').parent().toggleClass('min max');
+	el.toggleClass('min max').children().toggleClass('min max');
 
 	if (portal.toolsCollapsed) {
 		portal.updateToolsCollapsedPref(false);
@@ -34,4 +34,4 @@ portal.toggleMinimizeNav = function () {
 	}
 };
 
-$PBJQ(".js-toggle-nav").on("click", portal.toggleMinimizeNav);
+$PBJQ("#toolsNav-toggle-li").on("click", portal.toggleMinimizeNav);

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
@@ -19,8 +19,8 @@
 	<div id="toolSubsitesContainer">
 		<nav id="toolMenu" role="navigation" aria-label="${rloader.sit_toolshead}" class="Mrphs-toolsNav__menu">
 			<ul>
-				<li class="Mrphs-toolsNav__menuitem Mrphs-collapseTools #if ( ${toolsCollapsed} ) min #else max #end" style='display: none;'>
-					<button type="button" tabindex="0" aria-pressed="#if ( ${toolsCollapsed} )false#elsetrue#end" title="${rloader.sit_toggle_nav}" class="Mrphs-toggleNav js-toggle-nav btn-link  #if ( ${toolsCollapsed} ) min #else max #end">
+				<li id="toolsNav-toggle-li" class="Mrphs-toolsNav__menuitem Mrphs-collapseTools #if ( ${toolsCollapsed} ) min #else max #end" style='display: none;'>
+					<button type="button" tabindex="0" aria-pressed="#if ( ${toolsCollapsed} ) false #else true #end" title="${rloader.sit_toggle_nav}" class="Mrphs-toggleNav js-toggle-nav btn-link  #if ( ${toolsCollapsed} ) min #else max #end">
 						<span class="fa fa-lg fa-angle-double-left" aria-hidden="true"></span>
 						<span class="sr-only">${rloader.sit_toggle_nav}</span>
 					</button>


### PR DESCRIPTION
Before commit 3103b77 clicking anywhere in the <li> for the collapse button would toggle the menu. Changes made in that commit made it so that the double arrows needed to be clicked directly. This commit is an attempt to restore the previous behavior and preserve the changes made in 3103b77.