### PR TITLE
SAK-32623 - The date settings of the chat channel cannot be unset

### DIFF
--- a/chat/chat-tool/tool/pom.xml
+++ b/chat/chat-tool/tool/pom.xml
@@ -107,6 +107,10 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
     </dependency>
+        <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+    </dependency>
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>

--- a/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
+++ b/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
@@ -41,6 +41,7 @@ import javax.faces.model.SelectItem;
 import javax.faces.validator.ValidatorException;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.authz.api.PermissionsHelper;
@@ -801,11 +802,11 @@ public class ChatTool implements RoomObserver, PresenceObserver {
            Map<String, String> params = FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap();
            String startISODate = params.get(HIDDEN_START_ISO_DATE);
            String endISODate = params.get(HIDDEN_END_ISO_DATE);
-           if(DateFormatterUtil.isValidISODate(startISODate)){
+           if(StringUtils.isEmpty(startISODate) || DateFormatterUtil.isValidISODate(startISODate)){
                 channel.setStartDate(DateFormatterUtil.parseISODate(startISODate));
            }
 
-           if(DateFormatterUtil.isValidISODate(endISODate)){
+           if(StringUtils.isEmpty(endISODate) || DateFormatterUtil.isValidISODate(endISODate)){
                 channel.setEndDate(DateFormatterUtil.parseISODate(endISODate));
            }
 

--- a/library/src/webapp/js/lang-datepicker/lang-datepicker.js
+++ b/library/src/webapp/js/lang-datepicker/lang-datepicker.js
@@ -2273,6 +2273,13 @@ Za.fn=Ia.prototype;var Xd=bb(1,"add"),Yd=bb(-1,"subtract");a.defaultFormat="YYYY
 			setHiddenFields($(this).datepicker("getDate"), options, dpInst);
 		};
 
+		// When the picker allows empty dates, it should detect when the date is removed from the input, and update the hidden value.
+		cfg.onClose = function(dtObj, dpInst) {
+			if (dtObj == '' && options.allowEmptyDate){
+				setHiddenFields($(this).datepicker("getDate"), options, dpInst);
+			}
+		};
+
 		/**
 		 * takes a date string and parses it using the moment.js library
 		 * @param  {string} d date string
@@ -2361,28 +2368,30 @@ Za.fn=Ia.prototype;var Xd=bb(1,"add"),Yd=bb(-1,"subtract");a.defaultFormat="YYYY
 				jQuery.each(o.ashidden, function(i, h) {
 					var oldValue = jQuery('#' + h).val();
 					var newValue = '';
-					switch(i) {
-						case "month":
-						  newValue = d.getMonth() + 1;
-						  break;
-						case "day":
-						  newValue = d.getDate();
-						  break;
-						case "year":
-						  newValue = d.getFullYear();
-						  break;
-						case "hour":
-						  newValue = (o.ampm == true) ? moment(d).format('hh') : moment(d).format('HH');
-						  break;
-						case "minute":
-						  newValue = moment(d).format('mm');
-						  break;
-						case "ampm":
-						  newValue = moment(d).format('A').toLowerCase();
-						  break;
-						case "iso8601":
-						  newValue = moment(d).format();
-						  break;
+					if(d != null){
+						switch(i) {
+							case "month":
+							  newValue = d.getMonth() + 1;
+							  break;
+							case "day":
+							  newValue = d.getDate();
+							  break;
+							case "year":
+							  newValue = d.getFullYear();
+							  break;
+							case "hour":
+							  newValue = (o.ampm == true) ? moment(d).format('hh') : moment(d).format('HH');
+							  break;
+							case "minute":
+							  newValue = moment(d).format('mm');
+							  break;
+							case "ampm":
+							  newValue = moment(d).format('A').toLowerCase();
+							  break;
+							case "iso8601":
+							  newValue = moment(d).format();
+							  break;
+						}
 					}
 					jQuery('#' + h).val(newValue);
 					// If new value is different from the previous one, launch change event on hidden input


### PR DESCRIPTION
The date settings of the chat channel cannot be unset.

Server side: It always require a valid value in the hidden field, but
empty dates are allowed.
Client side: When someone clears the input field, the hidden value is
never updated, and it's processed in the server side. This only affects
the pickers with allowEmptyDate option set to true and the ones who
process the hidden value in the server side.