### PR TITLE
SAK-32625 Don’t fail when site has deleted users.

### DIFF
--- a/profile2/api/src/java/org/sakaiproject/profile2/logic/ProfileLogic.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/logic/ProfileLogic.java
@@ -148,8 +148,8 @@ public interface ProfileLogic {
 	
 	/**
 	 * Get a Person
-	 * @param userUuid
-	 * @return
+	 * @param userUuid The user to lookup
+	 * @return The found person or <code>null</code> if the person can't be found.
 	 */
 	public Person getPerson(String userUuid);
 	

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/SakaiProxyImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/SakaiProxyImpl.java
@@ -251,7 +251,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		try {
 			type = this.userDirectoryService.getUser(userId).getType();
 		} catch (final UserNotDefinedException e) {
-			log.info("User with eid: " + userId + " does not exist : " + e.getClass() + " : " + e.getMessage());
+			log.debug("User with eid: " + userId + " does not exist : " + e.getClass() + " : " + e.getMessage());
 		}
 		return type;
 	}
@@ -265,7 +265,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 		try {
 			u = this.userDirectoryService.getUser(userId);
 		} catch (final UserNotDefinedException e) {
-			log.info("User with id: " + userId + " does not exist : " + e.getClass() + " : " + e.getMessage());
+			log.debug("User with id: " + userId + " does not exist : " + e.getClass() + " : " + e.getMessage());
 		}
 
 		return u;


### PR DESCRIPTION
Calls to /direct/roster/site/….json would fail if the site contained a deleted users. This fixes it so that they aren’t included in the results, just like inactive users.

I also downgraded the logging from info to debug for failure to find users as in production this is an expected case.

I also changed handling of a group not being found, rather than returning an empty collection, it throws an error which gets transformed to a HTTP 404 error. This matches the error handling when a site isn’t found.