### PR TITLE
SAK-32627 Upgrade jGroups to latest 3.x

### DIFF
--- a/portal/portal-chat/tool/pom.xml
+++ b/portal/portal-chat/tool/pom.xml
@@ -19,29 +19,11 @@
     <inceptionYear>2003</inceptionYear>
     <packaging>war</packaging>
 
-    <repositories>
-        <repository>
-            <id>jboss</id>
-            <name>JBoss Maven Repo</name>
-            <layout>default</layout>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencies>
-    	<dependency>
-			<groupId>org.sakaiproject.portal</groupId>
-   			<artifactId>sakai-portal-api</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-    	</dependency>
-    
+        <dependency>
+            <groupId>org.sakaiproject.portal</groupId>
+            <artifactId>sakai-portal-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-kernel-api</artifactId>
@@ -81,7 +63,7 @@
         <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
-            <version>3.0.10.Final</version>
+            <version>3.6.13.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This is includes lots of jGroups fixes but doesn’t have a change of API.
Also remove the additional maven repository as it’s in central now.