### PR TITLE
SAK-30944 AntiSamy alert is not dismissible

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -18,6 +18,7 @@
         <link href="${pageScriptPath}jquery/cluetip/1.2.10/css/jquery.cluetip.css$!{portalCDNQuery}" rel="stylesheet">
         <link href="${pageScriptPath}jquery/qtip/jquery.qtip-latest.min.css$!{portalCDNQuery}" rel="stylesheet">
         <link href="${pageWebjarsPath}pnotify/2.1.0/pnotify.core.min.css$!{portalCDNQuery}" rel="stylesheet">
+	<link href="${pageWebjarsPath}pnotify/2.1.0/pnotify.buttons.min.css$!{portalCDNQuery}" rel="stylesheet">
         <link href="${pageWebjarsPath}cropper/2.3.2/dist/cropper.min.css$!{portalCDNQuery}" rel="stylesheet">
         <script src="${pageSkinRepo}/${pageSkin}/js/lib/modernizr.js$!{portalCDNQuery}"></script>
     #if ($useBullhornAlerts)

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
@@ -129,6 +129,7 @@
         <script src="${pageSkinRepo}/${pageSkin}/js/morpheus.plugins.min.js$!{portalCDNQuery}"></script>
         <script src="${pageSkinRepo}/${pageSkin}/js/morpheus.scripts.min.js$!{portalCDNQuery}"></script>
         <script src="${pageWebjarsPath}/pnotify/2.1.0/pnotify.core.min.js$!{portalCDNQuery}"></script>
+	<script src="${pageWebjarsPath}/pnotify/2.1.0/pnotify.buttons.min.js$!{portalCDNQuery}"></script>
         <script src="${pageScriptPath}jquery/qtip/jquery.qtip-latest.min.js$!{portalCDNQuery}"></script>
         <script src="${pageScriptPath}jquery/qtip/tutorial.js$!{portalCDNQuery}"></script>
         <script src="${pageWebjarsPath}cropper/2.3.2/dist/cropper.min.js$!{portalCDNQuery}"></script>


### PR DESCRIPTION
Looks like PNotify went through some refactoring between 1.2.0 (used in Sakai 10) and 2.1.0 (used in Sakai 11+) that created new files, but those files were not added as dependencies in portal and so the pin and close buttons weren't rendering.