### PR TITLE
SAK-32541 Fix handling of expired cache entries.

### DIFF
--- a/profile2/api/src/java/org/sakaiproject/profile2/cache/CacheManager.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/cache/CacheManager.java
@@ -30,14 +30,12 @@ public interface CacheManager {
 	 * @param cacheName
 	 * @return
 	 */
-	@SuppressWarnings("rawtypes")
-	Cache createCache(String cacheName);
+	<K, V>Cache<K, V> createCache(String cacheName);
 
 	/**
 	 * Helper to evict an item from a given cache. 
 	 * @param cache the cache to evict from
 	 * @param cacheKey	the id for the data in the cache
 	 */
-	@SuppressWarnings("rawtypes")
-	void evictFromCache(Cache cache, String cacheKey);
+	<K, V>void evictFromCache(Cache<K, V> cache, K cacheKey);
 }

--- a/profile2/impl/src/java/org/sakaiproject/profile2/cache/CacheManagerImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/cache/CacheManagerImpl.java
@@ -33,14 +33,12 @@ public class CacheManagerImpl implements CacheManager {
 	private static final Logger log = LoggerFactory.getLogger(CacheManagerImpl.class);
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public Cache createCache(String cacheName) {
+	public <K, V>Cache<K, V> createCache(String cacheName) {
 		return memoryService.getCache(cacheName);
 	}
 	
 	@Override
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	public void evictFromCache(Cache cache, String cacheKey) {
+	public <K, V>void evictFromCache(Cache<K, V> cache, K cacheKey) {
 		cache.remove(cacheKey);
 		log.debug("Evicted data in cache: " + cache.getName() + ", key: " + cacheKey);
 	}

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileSearchLogicImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileSearchLogicImpl.java
@@ -151,7 +151,7 @@ public class ProfileSearchLogicImpl implements ProfileSearchLogic {
 	 */
 	@Override
 	public List<ProfileSearchTerm> getSearchHistory(String userUuid) {
-		log.debug("Fetching searchHistory from cache for: " + userUuid);
+		log.debug("Fetching searchHistory from cache for: {}", userUuid);
 		//TODO this could do with a refactor
 		Map<String, ProfileSearchTerm> termMap = cache.get(userUuid);
 		if (termMap != null) {

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileSearchLogicImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileSearchLogicImpl.java
@@ -52,7 +52,7 @@ public class ProfileSearchLogicImpl implements ProfileSearchLogic {
 
 	private static final Logger log = LoggerFactory.getLogger(ProfileSearchLogicImpl.class);
 	
-	private Cache cache;
+	private Cache<String, Map<String, ProfileSearchTerm>> cache;
 	private final String CACHE_NAME = "org.sakaiproject.profile2.cache.search";
 	
 	/**
@@ -151,18 +151,12 @@ public class ProfileSearchLogicImpl implements ProfileSearchLogic {
 	 */
 	@Override
 	public List<ProfileSearchTerm> getSearchHistory(String userUuid) {
-
-		if (cache.containsKey(userUuid)) {
-
-			log.debug("Fetching searchHistory from cache for: " + userUuid);
-		
-			//TODO this could do with a refactor
-			List<ProfileSearchTerm> searchHistory = new ArrayList<ProfileSearchTerm>(
-					((Map<String, ProfileSearchTerm>) cache.get(userUuid))
-							.values());
-
+		log.debug("Fetching searchHistory from cache for: " + userUuid);
+		//TODO this could do with a refactor
+		Map<String, ProfileSearchTerm> termMap = cache.get(userUuid);
+		if (termMap != null) {
+			List<ProfileSearchTerm> searchHistory = new ArrayList<>(termMap.values());
 			Collections.sort(searchHistory);
-
 			return searchHistory;
 		} else {
 			return null;
@@ -187,16 +181,9 @@ public class ProfileSearchLogicImpl implements ProfileSearchLogic {
 			throw new IllegalArgumentException("userUuid must match search term userUuid");
 		}
 		
-		Map<String, ProfileSearchTerm> searchHistory = null;
-		if (cache.containsKey(userUuid)) {
-			searchHistory = (HashMap<String, ProfileSearchTerm>) cache.get(userUuid);
-			if(searchHistory == null) {
-				// This means that the cache has expired. evict the key from the cache
-				log.debug("SearchHistory cache appears to have expired for " + userUuid);
-				this.cacheManager.evictFromCache(this.cache, userUuid);
-			}
-		} else {
-			searchHistory = new HashMap<String, ProfileSearchTerm>();
+		Map<String, ProfileSearchTerm> searchHistory = cache.get(userUuid);
+		if(searchHistory == null) {
+			searchHistory = new HashMap<>();
 		}
 
 		// if search term already in history, remove old one (do BEFORE checking size)


### PR DESCRIPTION
If you perform a search in the profile tool and then wait for the cache entry to have expired and attempt to view the search page again, or perform another search the profile tool falls over as it expects to get an item from the cache and when it’s returned as null due to being expired it NPEs. There are several stack traces that you can end up having but they appear to resolve around the search cache.

This changes means we don’t bother testing to see if an item is in the cache and just try to get it and check if it’s null. While looking at this I also added generics to the caching to reduce the amount of casting.