### PR TITLE
SAK-32645 Don't blow up if podcasts folder is hidden

### DIFF
--- a/podcasts/podcasts-impl/src/java/org/sakaiproject/component/app/podcasts/PodcastServiceImpl.java
+++ b/podcasts/podcasts-impl/src/java/org/sakaiproject/component/app/podcasts/PodcastServiceImpl.java
@@ -528,11 +528,17 @@ public class PodcastServiceImpl implements PodcastService {
 					return null;
 				}
 				// if we get here it does not exist so create
-				if (isStudent) {
-					enablePodcastSecurityAdvisor();
+				try {
+					if (isStudent) {
+						enablePodcastSecurityAdvisor();
+					}
+					createPodcastsFolder(siteCollection + COLLECTION_PODCASTS + Entity.SEPARATOR, siteId);
+					return siteCollection + COLLECTION_PODCASTS + Entity.SEPARATOR;
+				} finally {
+					if (isStudent) {
+						securityService.popAdvisor();
+					}
 				}
-				createPodcastsFolder(siteCollection + COLLECTION_PODCASTS + Entity.SEPARATOR, siteId);
-				return siteCollection + COLLECTION_PODCASTS + Entity.SEPARATOR;
 			} 
 			catch (TypeException e) {
 				LOG.error("TypeException while trying to determine correct podcast folder Id String "
@@ -540,10 +546,6 @@ public class PodcastServiceImpl implements PodcastService {
 				throw new PodcastException(e);
 			}
 		}
-		finally {
-			securityService.popAdvisor();
-		}
-		
 		return null;
 	}
 

--- a/podcasts/podcasts-impl/src/java/org/sakaiproject/component/app/podcasts/PodcastServiceImpl.java
+++ b/podcasts/podcasts-impl/src/java/org/sakaiproject/component/app/podcasts/PodcastServiceImpl.java
@@ -104,8 +104,6 @@ public class PodcastServiceImpl implements PodcastService {
 
 	private static Logger LOG = LoggerFactory.getLogger(PodcastServiceImpl.class);
 	
-	private Reference siteRef;
-
 	// injected beans
 	private ContentHostingService contentHostingService;
 	private ToolManager toolManager;
@@ -190,16 +188,6 @@ public class PodcastServiceImpl implements PodcastService {
 	 */
 	public String getUserName() {
 		return userDirectoryService.getCurrentUser().getDisplayName();
-	}
-
-	/**
-	 * Returns the site URL as a string
-	 * 
-	 * @return 
-	 * 		String containing the sites URL
-	 */
-	public String getSiteURL() {
-		return contentHostingService.getEntityUrl(siteRef);
 	}
 
 	/**


### PR DESCRIPTION
If podcasts folder is hidden don't blow up with a permission exception. The way podcasts uses security advisors isn't very good. I looked at cleaning it up a little more, but in `org.sakaiproject.component.app.podcasts.PodcastServiceImpl#filterResources(java.util.List, java.lang.String)` it looks to see if there are advisors and then removes one and then optionally pushes it back onto the stack.