### PR TITLE
SAK-32647 Allow CORS checks for all font files.

### DIFF
--- a/library/src/webapp/WEB-INF/web.xml
+++ b/library/src/webapp/WEB-INF/web.xml
@@ -28,6 +28,17 @@
 	</filter>
 
 	<filter>
+		<description>Response Header Filter to allow CORS on fonts</description>
+		<display-name>CORS Allow Filter</display-name>
+		<filter-name>CORSAllowFilter</filter-name>
+		<filter-class>org.sakaiproject.util.ResponseHeaderFilter</filter-class>
+		<init-param>
+			<param-name>Access-Control-Allow-Origin</param-name>
+			<param-value>*</param-value>
+		</init-param>
+	</filter>
+
+	<filter>
 		<filter-name>sakai.request</filter-name>
 		<filter-class>org.sakaiproject.util.RequestFilter</filter-class>
 		<init-param>
@@ -45,7 +56,27 @@
 	<filter-mapping>
 		<filter-name>CacheFilterForWeek</filter-name>
 		<url-pattern>/*</url-pattern>
-	</filter-mapping>	
+	</filter-mapping>
+
+	<!-- Allow cross origin requests for our font files, due to the restrictions lessons places on pages served
+	     from content hosting this is needed to get fontawesome icons working -->
+	<filter-mapping>
+		<filter-name>CORSAllowFilter</filter-name>
+		<url-pattern>*.ttf</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CORSAllowFilter</filter-name>
+		<url-pattern>*.woff</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CORSAllowFilter</filter-name>
+		<url-pattern>*.woff2</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CORSAllowFilter</filter-name>
+		<url-pattern>*.eot</url-pattern>
+	</filter-mapping>
+
 	<!-- 
 	<filter-mapping>
 		<filter-name>CacheFilterForWeek</filter-name>


### PR DESCRIPTION
Lessons serves up HTML pages from resources with a stricter content security policy that the standard /access view. This causes the browser to check for a CORS header on the font files and refuse to load them when it can’t find the header. This allows request from anywhere for the standard font file extensions. We could be more restrictive and only allow it from known hostnames, but this is more error prone and these fonts are available on CDNs anyway.