### PR TITLE
SAK-31490 : Removing Home tool will remove other tools renamed to Home

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -15327,17 +15327,8 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 	 */
 	private boolean isHomePage(SitePage page)
 	{
-		if (page.getProperties().getProperty(SitePage.IS_HOME_PAGE) != null)
-		{
-			// check based on the page property first
-			return true;
-		}
-		else
-		{
-			// if above fails, check based on the page title
-			String pageTitle = page.getTitle();
-			return TOOL_ID_HOME.equalsIgnoreCase(pageTitle) || rb.getString("java.home").equalsIgnoreCase(pageTitle);
-		}
+		//removed "check by title" : that creates unexpected results with normal pages titled as "HOME"
+		return page.isHomePage();
 	}
 
 	public boolean displaySiteAlias() {


### PR DESCRIPTION
I don't know if this fix will cause more bugs than it solves. Someone can confirm, please.