### PR TITLE
SAK-32677: fix spinner algorithm applying textContent on invalid input types

### DIFF
--- a/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/library/src/morpheus-master/sass/base/_defaults.scss
@@ -215,6 +215,20 @@ button[class="disabled"]:hover,
 	text-decoration: none;
 }
 
+input[type="checkbox"].formButtonDisabled{
+	@include border-radius(3px);
+	&:checked{
+		background-image: url("images/check.png") !important;
+		background-size: 16px !important;
+	}
+}
+input[type="radio"].formButtonDisabled{
+	@include border-radius(24px);
+	&:checked{
+		background: radial-gradient(#60b3e3, #FFF 5px) !important;
+	}
+}
+
 ul, ol {
     padding: 0 0 0 1.5em;
 }

--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -294,12 +294,15 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
     newElement.setAttribute( "value", element.getAttribute( "value" ) );
     newElement.setAttribute( "disabled", "true" );
     newElement.style.display = origDisplay;
-    newElement.textContent = element.getAttribute( "value" );
     newElement.className = activateSpinner ? "spinButton formButtonDisabled" : "formButtonDisabled";
 
     if( element.type === "checkbox" || element.type === "radio" )
     {
         newElement.checked = element.checked;
+    }
+    else
+    {
+        newElement.textContent = element.getAttribute( "value" );
     }
 
     if( "" !== divID )

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages_pt_BR.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages_pt_BR.properties
@@ -41,7 +41,6 @@ anonymous_users=Usu\u00e1rios An\u00f4nimos
 select_action=A\u00e7\u00e3o
 entire_site=Todo o Site
 
-# bjones86 - OWL-1146
 selected_groups=Grupos Selecionados
 selected_group=Grupo Selecionado
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32677

In it's current state, the spinner algorithm is applying the textContent attribute to inputs of type checkbox and radio. This ends up making things look really bad, as the cloned elements end up looking like text rather than a radio or checkbox which clutters up the interface and causes text to overlap.

Steps to reproduce in the JIRA ticket.