### PR TITLE
SAK-32683: spinner overlay not being applied on inputs of type='button'

### DIFF
--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -279,7 +279,7 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
 
     // Now create a new disabled button with the same attributes as the existing button
     var newElement;
-    if( element.type === "submit" )
+    if( element.type === "submit" || element.type === "button" )
     {
         newElement = document.createElement( "button" );
     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32683

The new animated spinner overlay is not being applied to input elements of type="button". We found that this is due to the fact that types button and submit are currently not able to have CSS :after selectors applied.

We were already handling this for type="submit" by cloning the element as a `<button>`, we just need to do the same for type="button".