### PR TITLE
Updated maven version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the source code for the Sakai CLE.
 [![Build Status](https://travis-ci.org/sakaiproject/sakai.svg?branch=master)](https://travis-ci.org/sakaiproject/sakai)
 
 
-To build Sakai you need Java 1.8 and Maven 3.2. Once you have clone a copy of this repository you can
+To build Sakai you need Java 1.8 and Maven 3.2.5+. Once you have clone a copy of this repository you can
 build it by running:
 ```
 mvn install


### PR DESCRIPTION
The plugin org.sakaiproject.maven.plugins:sakai:1.4.4 requires Maven version 3.2.5. Even v3.2.3 won't work.