### PR TITLE
SAK-30793 - Revert SAK-23076 since KNL-1536 fixes it properly

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -3311,7 +3311,6 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 			// now we have the primary event, if we have a recurring event sequence time range selector, use it
 			if ((e != null) && (timeRange != null))
 			{
-				timeRange.adjust(timeRange, e.getRange());
 				e = new BaseCalendarEventEdit(e, new RecurrenceInstance(timeRange, sequence));
 			}
 


### PR DESCRIPTION
This is 1/2 of the fix for SAK-30793 - it reverts the change for SAK-23076 which caused the date not to advance for repeated events.  The other half is to properly fix SAK-23076 (times end like 1:59 instead of 2:00) - but since the bug is in kernel, it is in under KNL-1536.

These can be applied in any order but both must be in for SAK-23076 and SAK-30793 to be working *at the same time* :)