### PR TITLE
SAK-32702 add ability to control more UI strings inside the permissions widget

### DIFF
--- a/admin-tools/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
+++ b/admin-tools/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
@@ -26,6 +26,7 @@ import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +87,21 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 
 	/** State attribute for the description of what's being edited - users should set before starting. */
 	public static final String STATE_DESCRIPTION = "permission.description";
+
+	/** Set this tool state attribute to control the page header. */
+	public static final String STATE_PAGE_HEADER = "permission.page.header";
+
+	/** Set this tool state attribute to control the table header. */
+	public static final String STATE_TABLE_HEADER = "permission.table.header";
+
+	/** Set this tool state attribute to control the table header title. */
+	public static final String STATE_TABLE_HEADER_TITLE = "permission.table.header.title";
+
+	/** Set this tool state attribute to control the role header title. */
+	public static final String STATE_TABLE_ROLE_HEADER_TITLE = "permission.table.role.title";
+
+	/** set this tool state attribute to control the row header title. */
+	public static final String STATE_TABLE_ROW_TITLE = "permission.table.row.title";
 
 	/** State attribute for the lock/ability string prefix to be presented / edited - users should set before starting. */
 	public static final String STATE_PREFIX = "permission.prefix";
@@ -204,6 +220,11 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 		String prefix = (String) toolSession.getAttribute(PermissionsHelper.PREFIX);
 		String targetRef = (String) toolSession.getAttribute(PermissionsHelper.TARGET_REF);
 		String description = (String) toolSession.getAttribute(PermissionsHelper.DESCRIPTION);
+		String pageHeader = (String) toolSession.getAttribute(PermissionsHelper.PAGE_HEADER);
+		String tableHeader = (String) toolSession.getAttribute(PermissionsHelper.TABLE_HEADER);
+		String tableHeaderTitle = (String) toolSession.getAttribute(PermissionsHelper.TABLE_HEADER_TITLE);
+		String tableRoleHeaderTitle = (String) toolSession.getAttribute(PermissionsHelper.TABLE_ROLE_HEADER_TITLE);
+		String tableRowTitle = (String) toolSession.getAttribute(PermissionsHelper.TABLE_ROW_TITLE);
 		Object rolesRef = toolSession.getAttribute(PermissionsHelper.ROLES_REF);
 		if (rolesRef == null) rolesRef = targetRef;
 
@@ -224,6 +245,21 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 
 		// ... with this description
 		state.setAttribute(STATE_DESCRIPTION, description);
+
+		// ... with this page header
+		state.setAttribute(STATE_PAGE_HEADER, pageHeader);
+
+		// ... with this table header
+		state.setAttribute(STATE_TABLE_HEADER, tableHeader);
+
+		// ... with this table header title
+		state.setAttribute(STATE_TABLE_HEADER_TITLE, tableHeaderTitle);
+
+		// ... with this table role header title
+		state.setAttribute(STATE_TABLE_ROLE_HEADER_TITLE, tableRoleHeaderTitle);
+
+		// ... with this table row title
+		state.setAttribute(STATE_TABLE_ROW_TITLE, tableRowTitle);
 
 		// ... showing only locks that are prpefixed with this
 		state.setAttribute(STATE_PREFIX, prefix);
@@ -475,6 +511,38 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 				rolesAbilities.put(role.getId(), locks);
 			}
 		}
+
+		// Put the page and table headers into the context
+		String pageHeader = (String) state.getAttribute(STATE_PAGE_HEADER);
+		String tableHeader = (String) state.getAttribute(STATE_TABLE_HEADER);
+		String tableHeaderTitle = (String) state.getAttribute(STATE_TABLE_HEADER_TITLE);
+		String tableRoleHeaderTitle = (String) state.getAttribute(STATE_TABLE_ROLE_HEADER_TITLE);
+		String tableRowTitle = (String) state.getAttribute(STATE_TABLE_ROW_TITLE);
+		if (StringUtils.isBlank(pageHeader))
+		{
+			pageHeader = rb.getString("per.lis.title");
+		}
+		if (StringUtils.isBlank(tableHeader))
+		{
+			tableHeader = rb.getString("per.lis.head");
+		}
+		if (StringUtils.isBlank(tableHeaderTitle))
+		{
+			tableHeaderTitle = rb.getString("per.lis.head.title");
+		}
+		if (StringUtils.isBlank(tableRoleHeaderTitle))
+		{
+			tableRoleHeaderTitle = rb.getString("per.lis.role.title");
+		}
+		if (StringUtils.isBlank(tableRowTitle))
+		{
+			tableRowTitle = rb.getString("per.lis.perm.title");
+		}
+		context.put("pageHeader", pageHeader);
+		context.put("tableHeader", tableHeader);
+		context.put("tableHeaderTitle", tableHeaderTitle);
+		context.put("tableRoleHeaderTitle", tableRoleHeaderTitle);
+		context.put("tableRowTitle", tableRowTitle);
 
 		PermissionLimiter limiter = getPermissionLimiter();
 

--- a/admin-tools/src/webapp/vm/authz-helper/chef_permissions-Main.vm
+++ b/admin-tools/src/webapp/vm/authz-helper/chef_permissions-Main.vm
@@ -8,7 +8,7 @@
 #end
 
 	<h3>
-		$thelp.getString("per.lis.title")
+		$pageHeader
 	</h3>
 		<div class="alertMessage">
 			$thelp.getString("gen.alert")

--- a/admin-tools/src/webapp/vm/authz-helper/chef_permissions.vm
+++ b/admin-tools/src/webapp/vm/authz-helper/chef_permissions.vm
@@ -9,7 +9,7 @@
 #end
 	
 	<h3>
-		$thelp.getString("per.lis.title")
+		$pageHeader
 	</h3>
 		#if ($alertMessage)<div class="alertMessage">$thelp.getString("gen.alert") $validator.escapeHtml($alertMessage)</div><div class="clear"></div>#end
 
@@ -56,17 +56,17 @@
 				<table class="listHier checkGrid specialLink" cellspacing="0" summary ="$thelp.getString("per.lis")" border="0" style="width:auto">
 					<tr>
 						<th id="permission">
-							<a href="#" title="$thelp.getString("per.lis.head.title")">$thelp.getString("per.lis.head")</a>
+							<a href="#" title="$tableHeaderTitle">$tableHeader</a>
 						</th>
 						#foreach($role in $roles)
-							<th class="role"><a href="#"  title="$thelp.getString("per.lis.role.title")">$roleName.getName($role.Id)</a></th>
+							<th class="role"><a href="#" title="$tableRoleHeaderTitle">$roleName.getName($role.Id)</a></th>
 						#end
 					</tr>
 						#foreach($lock in $abilities)
 
 							<tr>
 							<td class="permissionDescription unclicked" scope="row">
-								<a href="#" title="$thelp.getString("per.lis.perm.title")">
+								<a href="#" title="$tableRowTitle">
 									#set($desc = $lock)
 									#set($desc = $!functionDescriptions.get($lock))
 									$desc

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/PermissionsHelper.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/PermissionsHelper.java
@@ -34,6 +34,21 @@ public interface PermissionsHelper
 	/** Set this tool state attribute with descriptive text for the editor. */
 	static final String DESCRIPTION = "sakaiproject.permissions.description";
 
+	/** Set this tool state attribute to control the page header. */
+	static final String PAGE_HEADER = "sakaiproject.permissions.page.header";
+
+	/** Set this tool state attribute to control the table header. */
+	static final String TABLE_HEADER = "sakaiproject.permissions.table.header";
+
+	/** Set this tool state attribute to control the table header title attribute. */
+	static final String TABLE_HEADER_TITLE = "sakaiproject.permissions.table.header.title";
+
+	/** Set this tool state attribute to control the role header title attribute. */
+	static final String TABLE_ROLE_HEADER_TITLE = "sakaiproject.permissions.table.role.title";
+
+	/** Set this tool state attribute to control the row title attribute. */
+	static final String TABLE_ROW_TITLE = "sakaiproject.permissions.table.row.title";
+
 	/** Set this tool state attribute to the entity reference of the entity whose AuthzGroup is to be edited. */
 	static final String TARGET_REF = "sakaiproject.permissions.targetRef";
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32702

For those who want to be able to control more UI strings inside the permissions widget:

* page header
* table header
* table header tool tip
* table role header tool tip
* table row header tool tip

If any of these are not supplied by the tool using the permissions widget, it just falls back to the default text, making it fully backwards compatible.