### PR TITLE
SAK-32709 Fix for page order options going offscreen

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -1,12 +1,4 @@
 .#{$namespace}sakai-siteinfo{
-	.open > .dropdown-menu{
-		left: -124px;
-		width: 160px;
-		> li > a {
-			white-space: normal;
-		}
-	}
-	
 	.groups-site{
 		list-style: none;
 		

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -56,7 +56,7 @@
 										<a data-target="#" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
 											<span class="glyphicon glyphicon-cog"></span>
 										</a>
-										<ul class="dropdown-menu">
+										<ul class="dropdown-menu dropdown-menu-right">
 											<li>
 												<a href="#" rsf:id="edit-link" class="item_control" title="Edit This Item" alt="Edit This Page" onclick="showEditPage(this); return false;">
 													<span class="glyphicon glyphicon-pencil"></span>


### PR DESCRIPTION
The previous fix caused any other dropdowns used in tools used as a helper from site-info to be incorrectly positioned.

It’s also the cleaner and more correct fix for the issue in the first place.