### PR TITLE
SAK-32714 Drop display- prefix from demo provided.

### DIFF
--- a/providers/sample/src/java/org/sakaiproject/provider/user/SampleUserDirectoryProvider.java
+++ b/providers/sample/src/java/org/sakaiproject/provider/user/SampleUserDirectoryProvider.java
@@ -411,7 +411,7 @@ public class SampleUserDirectoryProvider implements UserDirectoryProvider, Users
 	 */
 	public String getDisplayId(User user)
 	{
-		return "display-"+user.getEid();
+		return user.getEid();
 	}
 
 	/**


### PR DESCRIPTION
When running in demo mode the provided users all get a prefix on their display ID of 'display-' to make testing easier, however this breaks functionality in Sakai and shouldn't have been committed.