### PR TITLE
SAK-32718 Correctly shutdown the portal chat EB

### DIFF
--- a/portal/portal-chat/tool/src/java/org/sakaiproject/portal/chat/entity/PCServiceEntityProvider.java
+++ b/portal/portal-chat/tool/src/java/org/sakaiproject/portal/chat/entity/PCServiceEntityProvider.java
@@ -199,8 +199,8 @@ public final class PCServiceEntityProvider extends AbstractEntityProvider implem
         heartbeatMap = new ConcurrentHashMap<String,UserMessage>(heartbeatMapSize,0.75F,64);
     }
     
-    public void destroy() {
-    	
+    public void destroy() throws Exception {
+    	super.destroy();
     	if (clusterChannel != null && clusterChannel.isConnected()) {
     		// This calls disconnect() first
     		clusterChannel.close();

--- a/portal/portal-chat/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/portal/portal-chat/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean parent="org.sakaiproject.entitybroker.entityprovider.AbstractEntityProvider" 
-		class="org.sakaiproject.portal.chat.entity.PCServiceEntityProvider" init-method="init">
+		class="org.sakaiproject.portal.chat.entity.PCServiceEntityProvider" init-method="init" destroy-method="destroy">
 		<property name="developerService"><ref bean="org.sakaiproject.entitybroker.DeveloperHelperService"/></property>
 		<property name="userDirectoryService"><ref bean="org.sakaiproject.user.api.UserDirectoryService"/></property>
 		<property name="emailService"><ref bean="org.sakaiproject.email.api.EmailService"/></property>


### PR DESCRIPTION
When the portal chat code was getting shut down it’s destroy method wasn’t getting called so it wasn’t unregistering itself from the cluster and this combined with the problem of node failure detection not working was causing new nodes not being able to connect to the cluster. Although it shouldn’t be needed it’s cleaner to un-register from the cluster so we’re putting this back in.

This also has the entitybroker registration de-registered.