### PR TITLE
SAK-32744 FA icon parameter is misnamed in LTI portlet config

### DIFF
--- a/basiclti/basiclti-portlet/src/webapp/WEB-INF/sakai/IMSBLTIPortlet.xml
+++ b/basiclti/basiclti-portlet/src/webapp/WEB-INF/sakai/IMSBLTIPortlet.xml
@@ -50,7 +50,7 @@
                 <configuration name="imsti.allowoutcomes" />
                 <configuration name="imsti.contentlink" />
                 <configuration name="imsti.splash" />
-                <configuration name="imsti.fa-icon" /> <!-- A font awesome icon line "fa-adjust" -->
+                <configuration name="imsti.fa_icon" /> <!-- A font awesome icon line "fa-adjust" -->
 
                 <!-- Setting these to true means the corresponding above values 
 		     cannot be altered by by the instructor.  -->
@@ -74,7 +74,7 @@
                 <configuration name="final.allowoutcomes" value="false"/>
                 <configuration name="final.contentlink" value="false"/>
                 <configuration name="final.splash" value="false"/>
-                <configuration name="final.fa-icon" value="false"/>
+                <configuration name="final.fa_icon" value="false"/>
 
                 <!-- Allow multiple instances of this tool within one site -->
                 <configuration name="allowMultipleInstances" value="true" />


### PR DESCRIPTION
Code uses fa_icon so config needs to match, otherwise you can't configure this properly from the xml.
