### PR TITLE
SAM-725 - Anonymous grading property is documented incorrectly

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3138,7 +3138,11 @@
 # DEFAULT: true.
 # samigo.editPubAssessment.restricted=false
 
-# When samigo.editPubAnonyGrading.restricted is set to true, the Students' Identities section in published settings is editable. 
+# When samigo.editPubAnonyGrading.restricted is set to true, the Students' Identities section in published settings is not editable.
+# The default is false, setting grading anonymity is editable. Look for "Hide student identity from grader" checkbox in 
+# Settings -> Grading and Feedback. When false, default, this checkbox can be unchecked even after publishing the test and at least
+# one student taking the test. 
+# When true, the checkbox cannot be unchecked. Once you set the test to anonymous grading, it stays that way. 
 # DEFAULT: false.
 # samigo.editPubAnonyGrading.restricted=true
 


### PR DESCRIPTION
When samigo.editPubAnonyGrading.restricted is set to true, the Students' Identities section in published settings is NOT editable. This is opposite of what had been documented in default.sakai.properties.