### PR TITLE
LSNBLDR-843 Fix for stack trace parsing bad URL.

### DIFF
--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -169,6 +169,11 @@
             <version>1.10.2</version>
         </dependency>
         
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1225,6 +1225,8 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	   return false;
        String id = reference.substring(i);
        i = id.indexOf("/", 1);
+       if (i < 0)
+	   return false;
        type = id.substring(1, i);
        String numstring = id.substring(i+1);
        i = numstring.indexOf("/");

--- a/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducerTest.java
+++ b/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducerTest.java
@@ -1,0 +1,96 @@
+package org.sakaiproject.lessonbuildertool.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.sakaiproject.entity.api.Reference;
+import org.sakaiproject.lessonbuildertool.SimplePage;
+import org.sakaiproject.lessonbuildertool.SimplePageItem;
+import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LessonBuilderEntityProducerTest {
+
+    private LessonBuilderEntityProducer producer;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private SimplePageToolDao dao;
+
+    @Mock
+    private Reference ref;
+
+    @Before
+    public void setUp() {
+        producer = new LessonBuilderEntityProducer();
+        producer.setSimplePageToolDao(dao);
+    }
+
+    @Test
+    public void testParseEntityReferenceNotOurs() {
+        assertFalse(producer.parseEntityReference("/else", ref));
+        assertFalse(producer.parseEntityReference("/", ref));
+        assertFalse(producer.parseEntityReference("", ref));
+    }
+
+    @Test
+    public void testParseEntityReferenceNoItem() {
+        assertFalse(producer.parseEntityReference("/lessonbuilder/item", ref));
+    }
+
+    @Test
+    public void testParseEntityReferenceNoSite() {
+        assertFalse(producer.parseEntityReference("/lessonbuilder/site", ref));
+    }
+
+    @Test
+    public void testParseEntityReferenceNoPage() {
+        assertFalse(producer.parseEntityReference("/lessonbuilder/page", ref));
+    }
+
+    @Test
+    public void testParseEntityReferencePageNotInt() {
+        assertFalse(producer.parseEntityReference("/lessonbuilder/page/notNumber", ref));
+    }
+
+    @Test
+    public void testParseEntityReferencePageMissingId() {
+        assertFalse(producer.parseEntityReference("/lessonbuilder/page/10", ref));
+    }
+
+    @Test
+    public void testParseEntityReferencePageWithId() {
+        SimplePage page = Mockito.mock(SimplePage.class);
+        Mockito.when(page.getSiteId()).thenReturn("siteId");
+        Mockito.when(dao.getPage(10)).thenReturn(page);
+        assertTrue(producer.parseEntityReference("/lessonbuilder/page/10", ref));
+        Mockito.verify(ref).set("sakai:lessonbuilder", "page", "/page/10", null, "siteId");
+    }
+
+    @Test
+    public void testParseEntityReferenceItemWithId() {
+        SimplePageItem item = Mockito.mock(SimplePageItem.class);
+        Mockito.when(dao.findItem(10)).thenReturn(item);
+        Mockito.when(item.getPageId()).thenReturn(11L);
+        SimplePage page = Mockito.mock(SimplePage.class);
+        Mockito.when(page.getSiteId()).thenReturn("siteId");
+        Mockito.when(dao.getPage(11)).thenReturn(page);
+        assertTrue(producer.parseEntityReference("/lessonbuilder/item/10", ref));
+        Mockito.verify(ref).set("sakai:lessonbuilder", "item", "/item/10", null, "siteId");
+    }
+
+    @Test
+    public void testParseEntityReferenceSite() {
+        assertTrue(producer.parseEntityReference("/lessonbuilder/site/siteId", ref));
+        Mockito.verify(ref).set("sakai:lessonbuilder", "site", "/site/siteId", null, "/site/siteId");
+    }
+
+}


### PR DESCRIPTION
When accessing a URL without an id rather than generating a stack trace
lessonbuilder would throw a 500 error.