### PR TITLE
SAK-32760 Add NYU customization to introduce Lessons subpage navigation

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2517,8 +2517,45 @@ public class SimplePageBean {
 	public String adjustPath(String op, Long pageId, Long pageItemId, String title) {
 		List<PathEntry> path = (List<PathEntry>)sessionManager.getCurrentToolSession().getAttribute(LESSONBUILDER_PATH);
 
+		// Allow the new portal lessons subnav to push a subpage on the context
+		if (op.equals("clear_and_push")) {
+			// clear path for top level subpage
+			path = new ArrayList<PathEntry>();
+
+			// add an entry for the parent page
+			SimplePage parentPage = null;
+
+			// the current page may have a parent
+			if (currentPage.getParent() != null && currentPage.getParent() != 0) {
+				parentPage = getPage(currentPage.getParent());
+
+			// try and get it from the current item
+			} else if (currentPageItemId != null) {
+				SimplePageItem item = getCurrentPageItem(currentPageItemId);
+				parentPage = getPage(item.getPageId());
+			}
+
+			PathEntry parentEntry = new PathEntry();
+			parentEntry.pageItemId = -1L;
+			if (parentPage == null) {
+				// we tried our best, default these values so things don't break
+				parentEntry.pageId = -1L;
+				parentEntry.title = "";
+			} else {
+				parentEntry.pageId = parentPage.getPageId();
+				parentEntry.title = parentPage.getTitle();
+			}
+			path.add(parentEntry);
+
+			// add the subpage
+			PathEntry entry = new PathEntry();
+			entry.pageId = pageId;
+			entry.pageItemId = pageItemId;
+			entry.title = title;
+			path.add(entry);  // put it on the end
+
 		// if no current path, op doesn't matter. we can just do the current page
-		if (path == null || path.size() == 0) {
+		} else if (path == null || path.size() == 0) {
 			PathEntry entry = new PathEntry();
 			entry.pageId = pageId;
 			entry.pageItemId = pageItemId;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -3478,6 +3478,24 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		}
 
 		createDialogs(tofill, currentPage, pageItem, cssLink);
+
+		// Add pageids to the page so the portal lessons subnav menu can update its state
+		List<SimplePageBean.PathEntry> path = simplePageBean.getHierarchy();
+		if (path.size() > 2) {
+			SimplePageBean.PathEntry topLevelSubPage = path.get(1);
+			UIOutput.make(tofill, "lessonsSubnavTopLevelPageId")
+				.decorate(new UIFreeAttributeDecorator("value", String.valueOf(topLevelSubPage.pageId)));
+		} else {
+			UIOutput.make(tofill, "lessonsSubnavPageId")
+				.decorate(new UIFreeAttributeDecorator("value", String.valueOf(simplePageBean.getCurrentPage().getPageId())));
+		}
+		UIOutput.make(tofill, "lessonsSubnavToolId")
+			.decorate(new UIFreeAttributeDecorator("value", String.valueOf(placement.getId())));
+		UIOutput.make(tofill, "lessonsSubnavItemId")
+			.decorate(new UIFreeAttributeDecorator("value", String.valueOf(pageItem.getId())));
+
+		UIOutput.make(tofill, "lessonsCurrentPageId")
+			.decorate(new UIFreeAttributeDecorator("value", String.valueOf(simplePageBean.getCurrentPage().getPageId())));
 	}
 	
 	public void makeCsrf(UIContainer tofill, String rsfid) {

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -48,6 +48,19 @@
  </head>
 
  <body rsf:id="scr=sakai-body">
+ <input type='hidden' rsf:id="lessonsSubnavToolId" id="lessonsSubnavToolId"/>
+ <input type='hidden' rsf:id="lessonsSubnavTopLevelPageId" id="lessonsSubnavTopLevelPageId"/>
+ <input type='hidden' rsf:id="lessonsSubnavPageId" id="lessonsSubnavPageId"/>
+ <input type='hidden' rsf:id="lessonsSubnavItemId" id="lessonsSubnavItemId"/>
+ <input type='hidden' rsf:id="lessonsCurrentPageId" id="lessonsCurrentPageId"/>
+ <script>
+     if (sakai) {
+         if (sakai.lessons_subnav) {
+             // Notify the lessons_subnav that we're on a lessons page
+             sakai.lessons_subnav.set_current_lessons_page();
+         }
+     }
+ </script>
  <script type="text/javascript" src="$context/js/jquery-1.9.1.min.js"></script>
  <script type="text/javascript" src="$context/js/jquery-ui-1.11.1.custom.min.js"></script>
  <script rsf:id="datepicker" type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>

--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -44,7 +44,7 @@ body.is-logged-out{
 			}
 			ul{
 				li{
-					a{
+					.Mrphs-toolsNav__menuitem--link{
 						min-height: 1.7em;
 						text-align: center;
 						&:hover{
@@ -81,7 +81,7 @@ body.is-logged-out{
 						}
 					}
 					&.is-current{
-						a{
+						.Mrphs-toolsNav__menuitem--link{
 							&:hover{
 								.#{$namespace}toolsNav__menuitem--title{
 									background: $tool-menu-item-selected-hover-background-color;
@@ -90,7 +90,7 @@ body.is-logged-out{
 						}
 					}
 					&.is-current{
-						a{
+						.Mrphs-toolsNav__menuitem--link{
 							&:hover{
 								.#{$namespace}toolsNav__menuitem--title{
 									background: $tool-menu-item-selected-hover-background-color;
@@ -99,7 +99,7 @@ body.is-logged-out{
 						}
 					}
  					&:nth-of-type(2){
-						a{
+						.Mrphs-toolsNav__menuitem--link{
 							&:hover{
 								border-top: 1px solid $tool-menu-item-separator-color;
 							}
@@ -364,7 +364,7 @@ nav#subSites{
 					}
 				}
 			}
-			a{
+			.Mrphs-toolsNav__menuitem--link{
 				display: block;
 				font-family: $header-font-family;
 				font-weight: 400;
@@ -486,7 +486,7 @@ nav#subSites{
 				position: relative;
 				margin-right: -1px;
 
-				a{
+				.Mrphs-toolsNav__menuitem--link{
 					color: $tool-menu-item-selected-text-color;
 					background: $tool-menu-item-selected-background-color;
 
@@ -559,6 +559,358 @@ nav#subSites{
 				background-color: darken( $tool-sub-menu-background-color, 5% );
 				@media #{$phone}{
 					display: none;
+				}
+			}
+		}
+	}
+}
+
+// -------------------------------------------------------------------------------------------------------------------
+//  Lessons-Tool Subpage Menu
+// -------------------------------------------------------------------------------------------------------------------
+body {
+	#toolMenu {
+		li.has-lessons-sub-pages {
+			margin-right: 0;
+
+			&.is-parent-of-current.expanded {
+				.Mrphs-toolsNav__menuitem--link {
+					&:before {
+						border-left: $tool-menu-item-border-left !important;
+					}
+				}
+			}
+
+			> .Mrphs-toolsNav__menuitem--link {
+				.#{$namespace}toolsNav__menuitem--icon {
+					&:before {
+						content: '\f0da';
+					}
+				}
+			}
+
+			&.has-lessons-sub-pages {
+				> .Mrphs-toolsNav__menuitem--link {
+					background-color: $tool-menu-item-background-color !important;
+
+					&.is-current, &.is-parent-of-current {
+						.#{$namespace}toolsNav__menuitem--title {
+							font-weight: bold !important;
+						}
+					}
+
+					&:hover {
+						background-color: $tool-menu-item-hover-background-color !important;
+					}
+				}
+
+				.lessons-top-level-placeholder {
+					.lessons-expand-collapse-icon {
+						// Morpheus default clips tool menu by default, so cannot use absolute here:
+						//position: absolute;
+						// Instead tinker the marge right on the icon so things line up ok:
+						margin-right: 3.5px;
+
+						.Mrphs-toolsNav__menuitem--icon {
+							position: relative;
+						}
+					}
+
+					.lessons-goto-top-page {
+						.Mrphs-toolsNav__menuitem--title {
+							color: $tool-menu-item-text-color;
+						}
+						&:hover {
+							.Mrphs-toolsNav__menuitem--title {
+								color: $tool-menu-item-hover-text-color;
+							}
+						}
+					}
+
+					&:hover {
+						.lessons-goto-top-page {
+							.Mrphs-toolsNav__menuitem--title {
+								&:after {
+									font-family: 'FontAwesome';
+									content: '\f0a9';
+									padding-left: 4px;
+								}
+							}
+						}
+					}
+					.lessons-goto-top-page {
+						&:focus {
+							.Mrphs-toolsNav__menuitem--title {
+								&:after {
+									font-family: 'FontAwesome';
+									content: '\f0a9';
+									padding-left: 4px;
+								}
+							}
+						}
+					}
+				}
+			}
+
+			&.expanded {
+				background-color: $tool-menu-item-selected-background-color;
+
+				&.is-parent-of-current {
+					> .Mrphs-toolsNav__menuitem--link {
+						.#{$namespace}toolsNav__menuitem--icon {
+							color: $tool-menu-item-icon-color !important;
+						}
+						.#{$namespace}toolsNav__menuitem--title {
+							color: $tool-menu-item-text-color !important;
+							font-weight: normal !important;
+						}
+						&:hover {
+							color: $tool-menu-item-hover-text-color !important;
+							&:before {
+								border-left: $tool-menu-item-hover-border-left !important;
+							}
+
+							.#{$namespace}toolsNav__menuitem--icon {
+								color: $tool-menu-item-hidden-icon-color !important;
+							}
+						}
+					}
+				}
+
+				> .Mrphs-toolsNav__menuitem--link {
+					background-color: $tool-menu-item-selected-background-color !important;
+
+					&:hover {
+						background-color: $tool-menu-item-selected-hover-background-color !important;
+					}
+
+					.#{$namespace}toolsNav__menuitem--icon {
+						&:before {
+							//content: '\f0d7';
+						}
+
+						-ms-transform: rotate(90deg);
+						-webkit-transform: rotate(90deg);
+						transform: rotate(90deg);
+					}
+				}
+			}
+
+			&.sliding-down {
+					background-color: $tool-menu-item-selected-background-color !important;
+
+					.Mrphs-toolsNav__menuitem--link {
+							.#{$namespace}toolsNav__menuitem--icon {
+									-webkit-transition-duration: 0.5s;
+									-moz-transition-duration: 0.5s;
+									-o-transition-duration: 0.5s;
+									transition-duration: 0.5s;
+
+									-webkit-transition-property: -webkit-transform;
+									-moz-transition-property: -moz-transform;
+									-o-transition-property: -o-transform;
+									transition-property: transform;
+
+									-ms-transform: rotate(90deg);
+									-webkit-transform: rotate(90deg);
+									transform: rotate(90deg);
+							}
+							background-color: $tool-menu-item-selected-background-color !important;
+
+							&:hover {
+									background-color: $tool-menu-item-selected-background-color !important;
+							}
+					}
+			}
+
+			&.sliding-up {
+					.Mrphs-toolsNav__menuitem--link {
+							.#{$namespace}toolsNav__menuitem--icon {
+									-webkit-transition-duration: 0.5s;
+									-moz-transition-duration: 0.5s;
+									-o-transition-duration: 0.5s;
+									transition-duration: 0.5s;
+
+									-webkit-transition-property: -webkit-transform;
+									-moz-transition-property: -moz-transform;
+									-o-transition-property: -o-transform;
+									transition-property: transform;
+
+									-ms-transform: rotate(0deg);
+									-webkit-transform: rotate(0deg);
+									transform: rotate(0deg);
+							}
+					}
+			}
+
+			ul.lessons-sub-page-menu {
+				display: none;
+
+				li {
+					display: block;
+					border-bottom: none;
+					min-height: 28px;
+					max-height: 100px;
+					text-overflow: ellipsis;
+					overflow:hidden;
+					background-color: #FFFFFF;
+
+					&:last-child{
+							margin-bottom: 8px;
+					}
+
+					a {
+						text-align: left;
+						padding: 3.5px 3.5px 3.5px 40px;
+						font-size: 12px !important;
+						min-height: 28px;
+						max-height: 100px;
+						text-overflow: ellipsis;
+						overflow:hidden;
+						border-left: $tool-menu-item-border-left !important;
+						color: $tool-menu-item-text-color !important;
+						display: flex;
+						align-items: center;
+						text-decoration: none;
+
+						&:hover {
+							border-left: $tool-menu-item-hover-border-left !important;
+							background-color: $tool-menu-item-hover-background-color !important;
+							color: $tool-menu-item-hover-text-color !important;
+						}
+
+						&.is-invisible {
+							color: $tool-menu-item-hidden-text-color !important;
+							font-style: italic;
+							position: relative;
+
+							.#{$namespace}toolsNav__menuitem--icon {
+								font-style: normal !important;
+								color: $tool-menu-item-hidden-icon-color !important;
+							}
+
+							&:hover {
+								color: $tool-menu-item-hidden-hover-color !important;
+
+								.#{$namespace}toolsNav__menuitem--icon {
+									color: $tool-menu-item-hidden-hover-icon-color !important;
+								}
+							}
+
+							&:after {
+								@extend .fa-lg;
+								@extend .fa;
+								content: '\f070';
+								position: absolute;
+								top: 8px;
+								right: 4px;
+							}
+						}
+						&.has-prerequisite {
+							color: $tool-menu-item-hidden-text-color !important;
+							position: relative;
+
+							&.disabled {
+								cursor: not-allowed;
+							}
+
+							&:hover {
+								color: $tool-menu-item-hidden-hover-color !important;
+
+								&:after {
+									@extend .fa-lg;
+									@extend .fa;
+									content: '\f05e';
+									position: absolute;
+									top: 8px;
+									right: 4px;
+								}
+							}
+						}
+					}
+					&.is-current {
+						margin-right: 0;
+
+						a {
+							font-weight: bold !important;
+							color: $tool-menu-item-selected-text-color !important;
+							border-left: $tool-menu-item-selected-border-left !important;
+							margin-right: 0;
+
+							&:hover {
+								color: $tool-menu-item-selected-hover-text-color !important;
+								border-left: $tool-menu-item-selected-hover-border-left !important;
+								background-color: $tool-menu-item-selected-hover-background-color !important;
+							}
+						}
+					}
+				}
+			}
+
+			&.is-current {
+				.lessons-goto-top-page {
+					.Mrphs-toolsNav__menuitem--title {
+						color: $tool-menu-item-selected-text-color !important;
+					}
+					&:hover {
+						.Mrphs-toolsNav__menuitem--title {
+							color: $tool-menu-item-selected-hover-text-color !important;
+						}
+					}
+				}
+			}
+
+			&.is-current.is-parent-of-current {
+				.lessons-goto-top-page {
+					.Mrphs-toolsNav__menuitem--title {
+						color: $tool-menu-item-text-color !important;
+					}
+					&:hover {
+						.Mrphs-toolsNav__menuitem--title {
+							color: $tool-menu-item-hover-text-color !important;
+						}
+					}
+				}
+			}
+
+			@media #{$tablet} {
+				&.expanded {
+					.lessons-goto-top-page {
+						display: inline-block;
+					}
+				}
+			}
+		}
+	}
+	&.#{$namespace}toolMenu-collapsed {
+		#toolMenu {
+			li {
+				&.has-lessons-sub-pages {
+					.lessons-sub-page-menu {
+						display: none !important;
+					}
+					.#{$namespace}toolsNav__menuitem--icon {
+						-ms-transform: rotate(0deg) !important;
+						-webkit-transform: rotate(0deg) !important;
+						transform: rotate(0deg) !important;
+						&:before {
+							content: '\f212';
+						}
+					}
+					&.is-current, &.is-parent-of-current,
+					&.expanded.is-current, &.expanded.is-parent-of-current {
+						.#{$namespace}toolsNav__menuitem--link {
+							border-left: $tool-menu-item-selected-border-left !important;
+							.#{$namespace}toolsNav__menuitem--icon {
+								color: $tool-menu-item-selected-icon-color !important;
+							}
+							&:hover {
+								.#{$namespace}toolsNav__menuitem--icon {
+									color: $tool-menu-item-selected-hover-icon-color !important;
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/library/src/webapp/js/lessons-subnav.js
+++ b/library/src/webapp/js/lessons-subnav.js
@@ -1,0 +1,387 @@
+(function() {
+    var LESSONS_SUBPAGE_TOOLTIP_MAX_LENGTH = 90;
+
+    function LessonsSubPageNavigation(data) {
+        if (!data.hasOwnProperty('pages')) {
+          console.warn('No page data for LessonsSubPageNavigation');
+          return;
+        }
+
+        if (!data.hasOwnProperty('i18n')) {
+          console.warn('No i18n data for LessonsSubPageNavigation');
+          return;
+        }
+
+        this.data = data.pages;
+        this.i18n = data.i18n;
+        this.has_current = false;
+        this.setup();
+    };
+
+    LessonsSubPageNavigation.prototype.setup = function() {
+        var self = this;
+
+        for (var page_id in self.data) {
+            if (self.data.hasOwnProperty(page_id)) {
+                var sub_pages = self.data[page_id];
+                self.render_subnav_for_page(page_id, sub_pages);
+            }
+        }
+    };
+
+    LessonsSubPageNavigation.prototype.render_subnav_for_page = function(page_id, sub_pages) {
+        var self = this;
+
+        var submenu_id = "lessonsSubMenu_" + page_id;
+
+        var $menu = document.querySelector('#toolMenu a[href$="/tool/'+page_id+'"], #toolMenu [href$="/tool-reset/'+page_id+'"]');
+        var $li = $menu.parentElement;
+
+        var $submenu = document.createElement('ul');
+        $submenu.classList.add('lessons-sub-page-menu');
+        $submenu.setAttribute('aria-hidden', true);
+        $submenu.style.display = 'none';
+        $submenu.id = submenu_id;
+
+        sub_pages.forEach(function(sub_page) {
+            var $submenu_item = document.createElement('li');
+            var $submenu_action = document.createElement('a');
+
+            $submenu_action.href = self.build_sub_page_url_for(sub_page);
+            $submenu_action.innerText = sub_page.name;
+            $submenu_action.setAttribute('data-sendingPage', sub_page.sendingPage);
+
+            var title_string = sub_page.name;
+            if (title_string.length < LESSONS_SUBPAGE_TOOLTIP_MAX_LENGTH - 20) { // only show description if there's room
+                if (sub_page.description) {
+                  if (sub_page.description.length > (LESSONS_SUBPAGE_TOOLTIP_MAX_LENGTH - title_string.length)) {
+                    title_string += " - " + sub_page.description.substring(0, LESSONS_SUBPAGE_TOOLTIP_MAX_LENGTH) + "...";
+                  } else {
+                    title_string += " - " + sub_page.description;
+                  }
+                }
+            }
+
+            if (sub_page.hidden == 'true') {
+                $submenu_action.classList.add('is-invisible');
+                if (sub_page.releaseDate) {
+                    title_string += ' ' + self.i18n.hidden_with_release_date.replace(/\{releaseDate\}/, sub_page.releaseDate);
+                } else {
+                    title_string += ' ' + self.i18n.hidden;
+                }
+            }
+
+            if (sub_page.disabledDueToPrerequisite == 'true') {
+                $submenu_action.classList.add('has-prerequisite');
+                if (sub_page.disabled == 'true') {
+                    $submenu_action.classList.add('disabled');
+                    $submenu_action.setAttribute('href', 'javascript:void(0);')
+                    title_string += ' ' + self.i18n.prerequisite_and_disabled;
+                } else {
+                    title_string += ' ' + self.i18n.prerequisite;
+                }
+
+            } else if(sub_page.required == 'true') {
+                if (sub_page.completed == 'false') {
+                    $submenu_action.classList.add('is-required');
+                } else {
+                    $submenu_action.classList.add('is-complete');
+                }
+            }
+
+            $submenu_action.setAttribute('title', title_string);
+
+            $submenu_item.appendChild($submenu_action);
+
+            $submenu.appendChild($submenu_item);
+
+            sub_page['submenu_item'] = $submenu_item;
+        });
+
+        $li.appendChild($submenu);
+        self.setup_parent_menu($li, $menu, submenu_id);
+    };
+
+
+    LessonsSubPageNavigation.prototype.expand = function($expandMe, doNotAnimate, callback) {
+        $expandMe.hide().show(0);
+        $expandMe.addClass('sliding-down');
+        $expandMe.find('.lessons-sub-page-menu').slideDown((doNotAnimate == true) ? 0 : 500, function() {
+            var $submenu = $(this);
+
+            $expandMe.removeClass('sliding-down');
+            $expandMe.addClass('expanded');
+
+            var $expandMeLink = $expandMe.find('> a.Mrphs-toolsNav__menuitem--link');
+            var $placeholderMenuLink = $expandMe.find('> span.Mrphs-toolsNav__menuitem--link');
+
+            $expandMeLink.hide().attr('aria-hidden', true);
+            $placeholderMenuLink.show().attr('aria-hidden', false);
+
+            $submenu.attr('aria-hidden', false);
+
+            // To better provide screenreader continuity, focus the collapse button
+            // as the expand button is hidden from the user and can no longer be clicked
+            // Also, blur it soon after so mouse users don't get a facefull of focus-outline
+            $placeholderMenuLink.find('.lessons-expand-collapse-icon').focus();
+            setTimeout(function() {
+                $placeholderMenuLink.find('.lessons-expand-collapse-icon').blur();
+            });
+
+            if (callback) {
+                setTimeout(callback);
+            }
+        });
+    };
+
+    LessonsSubPageNavigation.prototype.collapse = function($collapseMe, callback) {
+        $collapseMe.addClass('sliding-up');
+        $collapseMe.find('.lessons-sub-page-menu').slideUp(500, function() {
+            var $submenu = $(this);
+
+            $collapseMe.removeClass('sliding-up');
+            $collapseMe.removeClass('expanded');
+
+            var $expandMeLink = $collapseMe.find('> a.Mrphs-toolsNav__menuitem--link');
+            var $placeholderMenuLink = $collapseMe.find('> span.Mrphs-toolsNav__menuitem--link');
+
+            $expandMeLink.show().attr('aria-hidden', false);
+            $placeholderMenuLink.hide().attr('aria-hidden', true);
+
+            $submenu.attr('aria-hidden', true);
+
+            // To better provide screenreader continuity, focus the expand button
+            // as the collapse button is hidden from the user and can no longer be clicked
+            // Also, blur it soon after so mouse users don't get a facefull of focus-outline
+            $expandMeLink.focus();
+            setTimeout(function() {
+                $expandMeLink.blur();
+            });
+
+            if (callback) {
+                setTimeout(callback);
+            }
+        });
+    };
+
+
+    LessonsSubPageNavigation.prototype.setup_parent_menu = function($li, $menu, submenu_id) {
+        var self = this;
+
+        // stash the top level Lessons page URL
+        var topLevelPageHref = $menu.href;
+        // force it to be a tool-reset so the session state/breadcrumb
+        // is cleared when visiting this top level page
+        topLevelPageHref = topLevelPageHref.replace(/\/tool\//, "/tool-reset/");
+
+        // add a wrapper CSS class so we can style things fancy-like
+        $li.classList.add('has-lessons-sub-pages');
+
+        // create a span to replace the original top level icon
+        // it will contain two links, one to collapse the menu and another to visit the lessons page
+        var $expandedMenuPlaceholder = document.createElement('span');
+        $expandedMenuPlaceholder.classList.add('Mrphs-toolsNav__menuitem--link');
+        $expandedMenuPlaceholder.classList.add('lessons-top-level-placeholder');
+        $expandedMenuPlaceholder.style.display = 'none';
+
+        // create a link to close an expanded menu
+        var $collapseToggle = document.createElement('a');
+        $collapseToggle.setAttribute('href', 'javascript:void(0);');
+        $collapseToggle.setAttribute('aria-controls', submenu_id);
+        $collapseToggle.setAttribute('aria-expanded', true);
+        $collapseToggle.setAttribute('title', self.i18n.collapse);
+        $collapseToggle.classList.add("lessons-expand-collapse-icon");
+        $collapseToggle.innerHTML = $menu.querySelector('.Mrphs-toolsNav__menuitem--icon').outerHTML;
+        $expandedMenuPlaceholder.appendChild($collapseToggle);
+
+        // create a link to go to the top level page (only visible when expanded)
+        var $expandedGoToTopItem = document.createElement('a');
+        $expandedGoToTopItem.setAttribute('href', topLevelPageHref);
+        $expandedGoToTopItem.setAttribute('title', self.i18n.open_top_level_page);
+        $expandedGoToTopItem.classList.add("lessons-goto-top-page");
+        $expandedGoToTopItem.innerHTML = $menu.querySelector('.Mrphs-toolsNav__menuitem--title').outerHTML;
+        $expandedMenuPlaceholder.appendChild($expandedGoToTopItem);
+
+        // insert the placeholder menu item before the $menu link
+        $li.insertBefore($expandedMenuPlaceholder, $menu);
+
+        $menu.href = 'javascript:void(0);';
+        $menu.setAttribute('aria-controls', submenu_id);
+        $menu.setAttribute('aria-expanded', false);
+        $menu.setAttribute('aria-hidden', false);
+        $menu.setAttribute('title', self.i18n.expand);
+
+        $menu.addEventListener('click', function(event) {
+            event.preventDefault();
+
+            // We have jQuery now... YAY, get on that.
+            var $li = $PBJQ(event.target).closest('li');
+
+            // when the tool menu is collapsed, a click should take you to the top page
+            // and not toggle the menu
+            if ($(document.body).is('.Mrphs-toolMenu-collapsed')) {
+                location.href = topLevelPageHref;
+                return false;
+            }
+
+            // the $menu expands the submenu
+            // but collapse any other menus first
+            $li.closest('ul').find('.expanded').each(function() {
+                self.collapse($PBJQ(this));
+            });
+
+            self.expand($li);
+        });
+
+        $menu.addEventListener('keyup', function(event) {
+            // We have jQuery now... YAY, get on that.
+            var $li = $PBJQ(event.target).closest('li');
+
+            if (event.keyCode == '13') {
+                if (!$li.is('.expanded')) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+
+                    self.expand($li, true, function() {
+                        $collapseToggle.focus();
+                    });
+
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        $collapseToggle.addEventListener('click', function(event) {
+            // We have jQuery now... YAY, get on that.
+            var $li = $PBJQ(event.target).closest('li');
+
+            self.collapse($li);
+        });
+
+        $collapseToggle.addEventListener('keyup', function(event) {
+             // We have jQuery now... YAY, get on that.
+             var $li = $PBJQ(event.target).closest('li');
+
+             if (event.keyCode == '13') {
+                 if ($li.is('.expanded')) {
+                     event.preventDefault();
+                     event.stopImmediatePropagation();
+
+                     self.collapse($li, function() {
+                         $menu.focus();
+                     });
+
+                     return false;
+                 }
+             }
+
+             return true;
+         });
+
+        if ($li.classList.contains('is-current')) {
+            $expandedMenuPlaceholder.style.display = 'block';
+            $menu.style.display = 'none';
+
+            $li.classList.add('expanded');
+            var $submenu = $li.querySelector('.lessons-sub-page-menu');
+            $submenu.style.display = 'block';
+            $submenu.setAttribute('aria-hidden', false);
+        }
+    };
+
+
+    LessonsSubPageNavigation.prototype.build_sub_page_url_for = function(sub_page) {
+        var url = '/portal/site/' + sub_page.siteId;
+        url += '/tool/' + sub_page.toolId;
+        url += '/ShowPage?sendingPage='+sub_page.sendingPage;
+        url += '&itemId='+sub_page.itemId;
+        url += '&path=clear_and_push';
+        url += '&title=' + sub_page.name;
+        url += '&newTopLevel=false';
+        return url;
+    };
+
+
+    LessonsSubPageNavigation.prototype.set_current_for_page_id = function(page_id, context_id) {
+        var self = this;
+
+        if (self.data.hasOwnProperty(context_id)) {
+            self.data[context_id].forEach(function(sub_page) {
+                if (sub_page.sendingPage == page_id) {
+                    var li = sub_page.submenu_item;
+                    var parent = li.parentElement.parentElement;
+                    parent.classList.add('is-parent-of-current');
+                    li.classList.add('is-current');
+                }
+            });
+        }
+    };
+
+    LessonsSubPageNavigation.prototype.set_current_for_item_and_page_id = function(item_id, page_id, context_id) {
+        var self = this;
+
+        if (self.data.hasOwnProperty(context_id)) {
+            self.data[context_id].forEach(function(sub_page) {
+                if (sub_page.sendingPage == page_id) {
+                    if (sub_page.itemId == item_id) {
+                        var li = sub_page.submenu_item;
+                        var parent = li.parentElement.parentElement;
+                        parent.classList.add('is-parent-of-current');
+                        li.classList.add('is-current');
+                    }
+                }
+            });
+        }
+    };
+
+
+    LessonsSubPageNavigation.prototype.set_current_for_item_id = function(item_id, context_id) {
+        var self = this;
+
+        if (self.data.hasOwnProperty(context_id)) {
+            self.data[context_id].forEach(function(sub_page) {
+                if (sub_page.itemId == item_id) {
+                    var li = sub_page.submenu_item;
+                    var parent = li.parentElement.parentElement;
+                    parent.classList.add('is-parent-of-current');
+                    li.classList.add('is-current');
+                }
+            });
+        }
+    };
+
+
+    LessonsSubPageNavigation.prototype.set_current_lessons_page = function() {
+        // We're on a lessons page, so try to set the respective subnav menu item
+        // as being 'current'
+        var lessonsSubnavToolIdInput = document.getElementById('lessonsSubnavToolId');
+        var lessonsSubnavTopLevelPageIdInput = document.getElementById('lessonsSubnavTopLevelPageId');
+        var lessonsSubnavPageIdInput = document.getElementById('lessonsSubnavPageId');
+        var lessonsSubnavItemIdInput = document.getElementById('lessonsSubnavItemId');
+
+        if (lessonsSubnavToolIdInput) {
+            var lessonsSubnavToolId = lessonsSubnavToolIdInput.value;
+
+            if (lessonsSubnavTopLevelPageIdInput) {
+                var lessonsSubnavTopLevelPageId = lessonsSubnavTopLevelPageIdInput.value;
+                sakai.lessons_subnav.set_current_for_page_id(lessonsSubnavTopLevelPageId, lessonsSubnavToolId);
+            } else if (lessonsSubnavItemIdInput && lessonsSubnavPageIdInput) {
+                var lessonsSubnavItemId = lessonsSubnavItemIdInput.value;
+                var lessonsSubnavPageId = lessonsSubnavPageIdInput.value;
+                sakai.lessons_subnav.set_current_for_item_and_page_id(lessonsSubnavItemId, lessonsSubnavPageId, lessonsSubnavToolId);
+            } else if (lessonsSubnavPageIdInput) {
+                var lessonsSubnavPageId = lessonsSubnavPageIdInput.value;
+                sakai.lessons_subnav.set_current_for_page_id(lessonsSubnavPageId, lessonsSubnavToolId);
+            } else if (lessonsSubnavItemIdInput) {
+                // This is a last resort as we when items are reused we cannot be sure of their parent page
+                var lessonsSubnavItemId = lessonsSubnavItemIdInput.value;
+                sakai.lessons_subnav.set_current_for_item_id(lessonsSubnavItemId, lessonsSubnavToolId);
+            }
+        }
+    };
+
+
+    window.LessonsSubPageNavigation = LessonsSubPageNavigation;
+})();

--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -183,3 +183,11 @@ pic_changer_cancel = Cancel
 pic_changer_remove = Remove
 pic_changer_remove_error = Error removing image
 pic_changer_upload_error = Error uploading image
+
+lessons_subnav.expand = Expand to show subpages
+lessons_subnav.collapse = Collapse to hide subpages
+lessons_subnav.open_top_level_page: Click to open top-level page
+lessons_subnav.hidden: [Hidden]
+lessons_subnav.hidden_with_release_date: [Not released until {releaseDate}]
+lessons_subnav.prerequisite: [Has prerequisites]
+lessons_subnav.prerequisite_and_disabled: [You must complete all prerequisites before viewing this item]

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/LessonsTreeView.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/LessonsTreeView.java
@@ -1,0 +1,262 @@
+/**********************************************************************************
+ *
+ * Copyright (c) 2017 The Sakai Foundation
+ *
+ * Original developers:
+ *
+ *   New York University
+ *   Payten Giles
+ *   Mark Triggs
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.portal.charon.site;
+
+import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.time.cover.TimeService;
+import org.sakaiproject.db.cover.SqlService;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.json.simple.JSONObject;
+import org.sakaiproject.util.ResourceLoader;
+
+@Slf4j
+public class LessonsTreeView {
+
+    private static ResourceLoader rb = new ResourceLoader("sitenav");
+
+    private String userId;
+    private boolean isInstructor;
+
+    public LessonsTreeView(final String userId, final boolean isInstructor) {
+        this.isInstructor = isInstructor;
+        this.userId = userId;
+    }
+
+    public String lessonsPagesJSON(final List pages) {
+        final List<Map<String,String>> typedPages = (List<Map<String,String>>) pages;
+        final List<String> pageIds = new ArrayList<>(typedPages.size());
+
+        for (Map<String, String> page : typedPages) {
+            pageIds.add(page.get("pageId"));
+        }
+
+        final Map<String, List<Map<String, String>>> pageData = getAdditionalLessonsPages(pageIds);
+        applyPrerequisites(pageData);
+
+        final Map<String, Object> objectToSerialize = new HashMap<>();
+        objectToSerialize.put("pages", pageData);
+        objectToSerialize.put("i18n", getI18n());
+
+        return JSONObject.toJSONString(objectToSerialize);
+    }
+
+    // Return a mapping of PageID -> list of additional items to show
+    private Map<String, List<Map<String, String>>> getAdditionalLessonsPages(final List<String> pageIds) {
+        Connection connection = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        final Map<String, List<Map<String, String>>> result = new HashMap<>();
+
+        try {
+            try {
+                connection = SqlService.borrowConnection();
+                ps = connection.prepareStatement(buildSQL(connection, pageIds));
+
+                ps.setString(1, this.userId);
+
+                for (int i = 0; i < pageIds.size(); i++) {
+                    ps.setString(i + 2, pageIds.get(i));
+                }
+
+                rs = ps.executeQuery();
+
+                while (rs.next()) {
+                    if (!this.isInstructor && hiddenFromStudents(rs)) {
+                        continue;
+                    }
+
+                    if (!result.containsKey(rs.getString("sakaiToolId"))) {
+                        result.put(rs.getString("sakaiToolId"), new ArrayList<Map<String, String>>());
+                    }
+
+                    result.get(rs.getString("sakaiToolId")).add(makeMap(rs));
+                }
+
+            } finally {
+                if (ps != null) { ps.close(); }
+                if (rs != null) { rs.close(); }
+
+                if (connection != null) {
+                    SqlService.returnConnection(connection);
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Failed to get lessons tree: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+
+    private String buildSQL(final Connection conn, final List<String> pageIds) {
+        return ("SELECT p.toolId as sakaiPageId," +
+            " p.pageId as lessonsPageId," +
+            " s.site_id as sakaiSiteId," +
+            " s.tool_id as sakaiToolId," +
+            " i.id as lessonsItemId," +
+            " i.name as name," +
+            " i.description as description," +
+            " " + toChar(conn, "i.sakaiId") + " as sendingPage," +
+            " p2.hidden as hidden," +
+            " p2.releaseDate as releaseDate," +
+            " log.complete as completed," +
+            " i.required," +
+            " i.prerequisite" +
+            " FROM lesson_builder_pages p" +
+            " INNER JOIN SAKAI_SITE_TOOL s" +
+            "   on p.toolId = s.page_id" +
+            " INNER JOIN lesson_builder_items i" +
+            "   on (i.pageId = p.pageId AND type = 2)" +
+            " INNER JOIN lesson_builder_pages p2" +
+            "   on (p2.pageId = i.sakaiId)" +
+            " LEFT OUTER JOIN lesson_builder_log log" +
+            "   on (log.itemId = i.id AND log.userId = ?)" +
+            " WHERE p.parent IS NULL" +
+            "   AND p.toolId in (" + placeholdersFor(pageIds) + ")" +
+            " ORDER BY i.sequence");
+    }
+
+    private String toChar(final Connection conn, final String expr) {
+        try {
+            final String dbFamily = conn.getMetaData().getDatabaseProductName().toLowerCase(java.util.Locale.ROOT);
+
+            if ("mysql".equals(dbFamily)) {
+                return String.format("cast(%s AS CHAR)", expr);
+            } else if ("oracle".equals(dbFamily)) {
+                return String.format("to_char(%s)", expr);
+            } else {
+                return expr;
+            }
+        } catch (SQLException e) {
+            return expr;
+        }
+    }
+
+    private Map<String, String> makeMap(final ResultSet rs) throws SQLException {
+        final Map<String, String> result = new HashMap<>();
+
+        result.put("toolId", rs.getString("sakaiToolId"));
+        result.put("siteId", rs.getString("sakaiSiteId"));
+        result.put("itemId", rs.getString("lessonsItemId"));
+        result.put("sendingPage", rs.getString("sendingPage"));
+        result.put("name", rs.getString("name"));
+        result.put("description", rs.getString("description"));
+        result.put("hidden", rs.getInt("hidden") == 1 ? "true" : "false");
+
+        result.put("required", rs.getInt("required") == 1 ? "true" : "false");
+        result.put("completed", rs.getInt("completed") == 1 ? "true" : "false");
+        result.put("prerequisite", rs.getInt("prerequisite") == 1 ? "true" : "false");
+
+        if (rs.getTimestamp("releaseDate") != null) {
+            final Timestamp releaseDate = rs.getTimestamp("releaseDate");
+            if (releaseDate.getTime() > System.currentTimeMillis()) {
+                result.put("hidden", "true");
+                final DateFormat df = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, rb.getLocale());
+                final TimeZone tz = TimeService.getLocalTimeZone();
+                df.setTimeZone(tz);
+                result.put("releaseDate", df.format(releaseDate));
+            }
+        }
+
+        return result;
+    }
+
+    private boolean hiddenFromStudents(final ResultSet rs) throws SQLException {
+        if (rs.getInt("hidden") == 1) {
+            return true;
+        } else if (rs.getTimestamp("releaseDate") != null) {
+            if (rs.getTimestamp("releaseDate").getTime() > System.currentTimeMillis()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private <E> String placeholdersFor(final List<E> list) {
+        final StringBuilder placeholders = new StringBuilder();
+        for (E elt : list) {
+            if (placeholders.length() > 0) {
+                placeholders.append(", ");
+            }
+
+            placeholders.append("?");
+        }
+
+        return placeholders.toString();
+    }
+
+    private Map<String, String> getI18n() {
+        final Map<String, String> translations = new HashMap<>();
+
+        translations.put("expand", rb.getString("lessons_subnav.expand"));
+        translations.put("collapse", rb.getString("lessons_subnav.collapse"));
+        translations.put("open_top_level_page", rb.getString("lessons_subnav.open_top_level_page"));
+        translations.put("hidden", rb.getString("lessons_subnav.hidden"));
+        translations.put("hidden_with_release_date", rb.getString("lessons_subnav.hidden_with_release_date"));
+        translations.put("prerequisite", rb.getString("lessons_subnav.prerequisite"));
+        translations.put("prerequisite_and_disabled", rb.getString("lessons_subnav.prerequisite_and_disabled"));
+
+        return translations;
+    }
+
+    private void applyPrerequisites(final Map<String, List<Map<String, String>>> data) {
+        for (final String pageId : data.keySet()) {
+            boolean prerequisiteApplies = false;
+            final List<Map<String, String>> pages = data.get(pageId);
+            for (Map<String, String> pageData : pages) {
+                // If a sibling item with a smaller sequence is required
+                // we want to disable the current item for students
+                if (pageData.get("prerequisite").equals("true") && prerequisiteApplies) {
+                    pageData.put("disabledDueToPrerequisite", "true");
+                    pageData.put("disabled", String.valueOf(!this.isInstructor));
+                }
+
+                // Only disable items that have prerequisites below the current item
+                // when the current item is required and the user is yet to complete it
+                if (pageData.get("required").equals("true")) {
+                    if (pageData.get("completed").equals("false")) {
+                        prerequisiteApplies = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -633,6 +633,8 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		String htmlInclude = site.getProperties().getProperty(PROP_HTML_INCLUDE);
 		if (htmlInclude != null) theMap.put("siteHTMLInclude", htmlInclude);
 
+		boolean siteUpdate = SecurityService.unlock("site.upd", site.getReference());
+
 		// theMap.put("pageNavSitToolsHead",
 		// Web.escapeHtml(rb.getString("sit_toolshead")));
 
@@ -708,7 +710,6 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					}
 				}
 
-				boolean siteUpdate = SecurityService.unlock("site.upd", site.getReference());
 				if ( ! siteUpdate ) addMoreToolsUrl = null;
 
 				boolean legacyAddMoreToolsPropertyValue = ServerConfigurationService.getBoolean("portal.experimental.addmoretools", false);
@@ -828,6 +829,13 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			theMap.put("pageNavCanAddMoreTools", true);
 		} else {
 			theMap.put("pageNavCanAddMoreTools", false);
+		}
+
+		theMap.put("pageNavTools", l);
+
+		if ("true".equals(site.getProperties().getProperty("lessons_submenu")) && !l.isEmpty()) {
+			LessonsTreeView lessonsTreeView = new LessonsTreeView(UserDirectoryService.getCurrentUser().getId(), siteUpdate);
+			theMap.put("additionalLessonsPages", lessonsTreeView.lessonsPagesJSON(l));
 		}
 
 		theMap.put("pageNavTools", l);

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
@@ -203,6 +203,13 @@
 	
 		#end ## END of IF ( $subSites )
 	</div>
+
+	#if (${sitePages.additionalLessonsPages})
+		<script src="/library/js/lessons-subnav.js$!{portalCDNQuery}"></script>
+		<script>
+			sakai.lessons_subnav = new LessonsSubPageNavigation($sitePages.additionalLessonsPages);
+		</script>
+	#end
 </div>
 
 <!-- END VM includePageNav.vm -->

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1255,3 +1255,8 @@ sitegen.sitedel.hard = NOTE: You chose Hard Delete so these sites will have thei
 sitegen.sitedel.hard.button = Hard delete
 
 import.newtool = Note: If you choose to import content from the tools marked with a +, the tools will be added to your site.
+
+sinfo.lessonbuildersubnav.name=Lessons subpage navigation
+sinfo.lessonbuildersubnav.allowForSite=Enable <strong>Lessons subpage navigation</strong> in the left tool menu.
+sinfo.lessonbuildersubnav.confirmEnabled=You have enabled the Lessons subpage navigation for this site.
+sinfo.lessonbuildersubnav.enabled=Enabled for the site

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/LessonsSubnavEnabler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/LessonsSubnavEnabler.java
@@ -1,0 +1,157 @@
+package org.sakaiproject.site.tool;
+
+import org.sakaiproject.cheftool.Context;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.SessionState;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.util.ParameterParser;
+
+public class LessonsSubnavEnabler {
+
+    private static final String SITE_PROPERTY = "lessons_submenu";
+    private static final String STATE_KEY = "isLessonsSubNavEnabledForSite";
+    private static final String FORM_INPUT_ID = "isLessonsSubNavEnabledForSite";
+    private static final String CONTEXT_ENABLED_KEY = "isLessonsSubNavEnabledForSite";
+
+
+    /**
+     * Add MathJax settings to the context for the edit tools page
+     * @param context the context
+     * @param site the site
+     * @param state the state
+     * @return true if context was modified
+     */
+    public static boolean addToEditToolsContext(Context context, Site site, SessionState state)
+    {
+        if (context == null || site == null || state == null)
+        {
+            return false;
+        }
+
+        context.put(CONTEXT_ENABLED_KEY, isEnabledForSite(site));
+
+        return true;
+    }
+
+
+    /**
+     * Add Lesson subnav settings to the Site Info (view, edit, or confirm) context
+     * @param context the context
+     * @param site the site
+     * @param state the session state
+     * @return true if the context was modified
+     */
+    public static boolean addToSiteInfoContext(Context context, Site site, SessionState state)
+    {
+        if (context == null || site == null || state == null)
+        {
+            return false;
+        }
+
+        context.put(CONTEXT_ENABLED_KEY, isEnabledForSite(site));
+
+        return true;
+    }
+
+
+    /**
+     * Applies the Lessons sub-nav settings to the workflow state
+     * @param state the state
+     * @param params the params
+     * @return true if the state was modified
+     */
+    public static boolean applyToolSettingsToState(SessionState state, Site site, ParameterParser params)
+    {
+        // Allow checkbox to set the isLessonsSubNavEnabledForSite site property
+        // If checked, add this to the state
+        if ("on".equals(params.getString(FORM_INPUT_ID)))
+        {
+            state.setAttribute(STATE_KEY, true);
+        } else {
+            state.setAttribute(STATE_KEY, false);
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Add Lessons subnav settings to the context for the edit tools confirmation page
+     * @param context the context
+     * @param site the site
+     * @param state the state
+     * @return true if the context was modified
+     */
+    public static boolean addSettingsToEditToolsConfirmationContext(Context context, Site site, SessionState state)
+    {
+
+        if (site == null || context == null || state == null)
+        {
+            return false;
+        }
+
+        // Show a message on the confirmation screen if Lesson subnav is enabled for the site
+        final boolean isEnabled = (Boolean) state.getAttribute(STATE_KEY);
+        if (isEnabled)
+        {
+            context.put(CONTEXT_ENABLED_KEY, Boolean.TRUE);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * When user selects to enable the Lessons subnav, update the site property
+     * @param site The site
+     * @param state the session state
+     * @return true if the site properties were modified
+     */
+    public static boolean prepareSiteForSave(Site site, SessionState state)
+    {
+        if (site == null || state == null)
+        {
+            return false;
+        }
+
+        if (state.getAttribute(STATE_KEY) != null) {
+            final boolean isEnabled = (Boolean) state.getAttribute(STATE_KEY);
+            final ResourcePropertiesEdit props = site.getPropertiesEdit();
+            if (isEnabled) {
+                props.addProperty(SITE_PROPERTY, Boolean.TRUE.toString());
+            } else {
+                props.removeProperty(SITE_PROPERTY);
+            }
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Remove the Lessons subnav keys from the given state
+     * @param state the state
+     * @return true if the state was modifed
+     */
+    public static boolean removeFromState(SessionState state)
+    {
+        if (state != null)
+        {
+            state.removeAttribute(STATE_KEY);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Check the site's properties for the Lessons sub nav property
+     * @param site The site to check
+     * @return true if the lessons subnav is enabled for the site
+     */
+    private static boolean isEnabledForSite(Site site) {
+        return Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROPERTY));
+    }
+}

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1782,6 +1782,7 @@ public class SiteAction extends PagedResourceActionII {
 			if (site != null)
 			{
 				MathJaxEnabler.addMathJaxSettingsToEditToolsContext(context, site, state);  // SAK-22384
+				LessonsSubnavEnabler.addToEditToolsContext(context, site, state);
 				context.put("SiteTitle", site.getTitle());
 				context.put("existSite", Boolean.TRUE);
 				context.put("backIndex", "12");	// back to site info list page
@@ -2501,6 +2502,7 @@ public class SiteAction extends PagedResourceActionII {
 
 			// SAK-22384 mathjax support
 			MathJaxEnabler.addMathJaxSettingsToSiteInfoContext(context, site, state);
+			LessonsSubnavEnabler.addToSiteInfoContext(context, site, state);
 
 			return (String) getContext(data).get("template") + TEMPLATE[12];
 
@@ -2650,6 +2652,7 @@ public class SiteAction extends PagedResourceActionII {
 
 			// SAK-22384 mathjax support
 			MathJaxEnabler.addMathJaxSettingsToSiteInfoContext(context, site, state);
+			LessonsSubnavEnabler.addToSiteInfoContext(context, site, state);
 						
 			return (String) getContext(data).get("template") + TEMPLATE[13];
 		case 14:
@@ -2714,6 +2717,7 @@ public class SiteAction extends PagedResourceActionII {
 
 			// SAK-22384 mathjax support
 			MathJaxEnabler.addMathJaxSettingsToSiteInfoContext(context, site, state);
+			LessonsSubnavEnabler.addToSiteInfoContext(context, site, state);
 
 			return (String) getContext(data).get("template") + TEMPLATE[14];
 		case 15:
@@ -2737,6 +2741,7 @@ public class SiteAction extends PagedResourceActionII {
 			// put tool selection into context
 			toolSelectionIntoContext(context, state, site_type, site.getId(), overridePageOrderSiteTypes);
 			MathJaxEnabler.addMathJaxSettingsToEditToolsConfirmationContext(context, site, state, STATE_TOOL_REGISTRATION_TITLE_LIST);  // SAK-22384            
+			LessonsSubnavEnabler.addSettingsToEditToolsConfirmationContext(context, site, state);
 
 			return (String) getContext(data).get("template") + TEMPLATE[15];
 		case 18:
@@ -7552,6 +7557,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		} else if (getStateSite(state) != null && ("13".equals(currentIndex) || "14".equals(currentIndex)))
 		{
 			MathJaxEnabler.removeMathJaxAllowedAttributeFromState(state);  // SAK-22384
+			LessonsSubnavEnabler.removeFromState(state);
 			state.setAttribute(STATE_TEMPLATE_INDEX, "12");
 		} else if ("15".equals(currentIndex)) {
 			params = data.getParameters();
@@ -8246,6 +8252,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 
 		// SAK-22384 mathjax support
 		MathJaxEnabler.prepareMathJaxAllowedSettingsForSave(Site, state);
+		LessonsSubnavEnabler.prepareSiteForSave(Site, state);
 				
 		if (state.getAttribute(STATE_MESSAGE) == null) {
 			try {
@@ -11529,7 +11536,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		{
 			commitSite(site);
 		}
-		
+
+		if (LessonsSubnavEnabler.prepareSiteForSave(site, state)) {
+			commitSite(site);
+		}
 	} // saveFeatures
 
 	/**
@@ -12614,6 +12624,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		state.removeAttribute(STATE_TOOL_REGISTRATION_LIST);
 		state.removeAttribute(STATE_TOOL_REGISTRATION_TITLE_LIST);
 		state.removeAttribute(STATE_TOOL_REGISTRATION_SELECTED_LIST);
+		LessonsSubnavEnabler.removeFromState(state);
 	}
 
 	private List orderToolIds(SessionState state, String type, List<String> toolIdList, boolean synoptic) {
@@ -12821,6 +12832,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		} else if (option.equalsIgnoreCase("continue")) {
 			// continue
 			MathJaxEnabler.applySettingsToState(state, params);  // SAK-22384
+			LessonsSubnavEnabler.applyToolSettingsToState(state, site, params);
 
 			doContinue(data);
 		} else if (option.equalsIgnoreCase("back")) {

--- a/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
+++ b/site-manage/site-manage-tool/tool/src/webapp/css/site-manage.css
@@ -632,7 +632,8 @@ td.grayText {
 }
 /* end SAK-32087 */
 
-#toolHolderWW .mathJaxToggleArea {
+#toolHolderWW .mathJaxToggleArea,
+#toolHolderWW .lessonsSubNavToggleArea {
     border: 1px solid #DDDDDD;
     border-radius: 5px;
     padding: 10px;

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-addRemoveFeatureConfirm.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-addRemoveFeatureConfirm.vm
@@ -205,6 +205,12 @@
         $tlang.getString("sinfo.mathjax.confirmEnabled")   
     </p>
     #end
+
+    #if($!isLessonsSubNavEnabledForSite)
+    <p class="instruction">
+        $tlang.getString("sinfo.lessonbuildersubnav.confirmEnabled")
+    </p>
+    #end
 	
 	<form name="addRemoveFeaturnConfirmForm" id="addRemoveFeaturnConfirmForm" action="#toolForm("$action")" method="post">
 		<input type="hidden" name="cancelIndex" value="$continueIndex" />

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -391,6 +391,18 @@
                 </td>
             </tr>
             #end			
+
+		#if ($isLessonsSubNavEnabledForSite)
+			<tr class="summary-lessons-subnav-enabled">
+				<th>
+					$tlang.getString("sinfo.lessonbuildersubnav.name")
+				</th>
+				<td>
+					$tlang.getString("sinfo.lessonbuildersubnav.enabled")
+				</td>
+			</tr>
+		#end
+
 		</table>
 
 		#set ($desc = $siteDescription) 

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/toolGroupMultipleDisplay.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/toolGroupMultipleDisplay.vm
@@ -150,6 +150,49 @@
           </label>
       </div>
     </div>
+    <div class="lessonsSubNavToggleArea" style='display: none'>
+      <p>$tlang.getString("sinfo.lessonbuildersubnav.allowForSite")</p>
+      <div class="onoffswitch">
+          <input type="checkbox" name="isLessonsSubNavEnabledForSite" class="onoffswitch-checkbox" id="isLessonsSubNavEnabledForSite" #if($isLessonsSubNavEnabledForSite)checked="checked"#end>
+          <label class="onoffswitch-label" for="isLessonsSubNavEnabledForSite">
+              <span class="onoffswitch-inner"></span>
+              <span class="onoffswitch-switch"></span>
+          </label>
+      </div>
+    </div>
+    <script>
+        $(function() {
+            var lessonsSubNavToggleArea = $('.lessonsSubNavToggleArea');
+            var toolSelectionList = $('#toolSelectionList');
+            var toolList = $('#toolHolderW');
+            var isLessonsSubNavEnabledForSiteCheckbox = $('#isLessonsSubNavEnabledForSite');
+
+            function checkForSelectedLessonsTools() {
+              if (toolSelectionList.find('li[id*=sakai_lessonbuildertool]:visible').length > 0) {
+                  lessonsSubNavToggleArea.show();
+              } else {
+                  lessonsSubNavToggleArea.hide();
+              }
+            };
+
+            toolList.find('input[type=checkbox]').on('click', function() {
+                setTimeout(checkForSelectedLessonsTools, 200); // fade out on selected item takes ~100ms
+                return true;
+            });
+
+            toolSelectionList.on('click', '.removeTool', function() {
+                setTimeout(checkForSelectedLessonsTools, 200); // fade out on selected item takes ~100ms
+                return true;
+            });
+
+            toolSelectionList.on('click mouseup keyup', '#alertBoxYes', function() {
+                setTimeout(checkForSelectedLessonsTools, 0);
+                return true;
+            });
+
+            checkForSelectedLessonsTools();
+        });
+    </script>
     </div>
   </div> <!-- row -->
 </div> <!-- toolHolderWW -->


### PR DESCRIPTION
This PR delivers NYU's lessons subnav behaviour as outlined in https://jira.sakaiproject.org/browse/SAK-32760.

Similar to MathJax, the lessons subnav can be enabled via "Site Info > Manage Tools":
<img width="415" alt="screen shot 2017-08-10 at 9 04 01 am" src="https://user-images.githubusercontent.com/608337/29147625-8e730b72-7dab-11e7-8bdd-b1bdc731345b.png">

When enabled, lessons subpages are surfaced in the portal tool navigation:
<img width="213" alt="screen shot 2017-08-10 at 9 05 09 am" src="https://user-images.githubusercontent.com/608337/29147633-a25f5f6e-7dab-11e7-8b86-27e565ad602b.png">

While most behaviour is in the portal to generate the lessons page data as JSON for JavaScript to consume (see `LessonsTreeView.java`), some changes to lessonbuilder were  required.  These include: 
* adding a new `op` to allow an link external to lessons to populate the breadcrumb trail (see `adjustPath` and the new `clear_and_push` directive.
* output of some hidden inputs containing the current lesson page's pageId, top-most pageId and context Id.  This allows the JavaScript to select the current page (or parent of the current page) in the new sub-navigation.

The menu should be completely keyboard navigable and also offers screenreader support.  To improve accessibility, the navigation introduces a link to collapse an expanded lessons subpage menu.  This required a slight tinkering of the `_toolmenu.scss` to target explicit CSS classes instead of an `a` (or anchor).  This allows us to add multiple links to a single menu item and still retain the desired styling.  Also, we've tried to use `aria` attributes as per the expand-collapse spec.  