### PR TITLE
SAK-33249 Support annotations for non-IP restricted WS

### DIFF
--- a/webservices/cxf/pom.xml
+++ b/webservices/cxf/pom.xml
@@ -182,6 +182,22 @@
             <artifactId>OkiSID</artifactId>
             <version>rc6.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webservices/cxf/src/java/org/sakaiproject/rest/HostFilter.java
+++ b/webservices/cxf/src/java/org/sakaiproject/rest/HostFilter.java
@@ -1,0 +1,43 @@
+package org.sakaiproject.rest;
+
+import org.sakaiproject.webservices.interceptor.RemoteHostMatcher;
+import org.sakaiproject.webservices.interceptor.NoIPRestriction;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+/**
+ * Checks to see if a request should be allowed because it's a public method or if it should be
+ * blocked because it's not on the allowed IP range.
+ */
+@Provider
+public class HostFilter implements ContainerRequestFilter {
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Context
+    private RemoteHostMatcher remoteHostMatcher;
+
+    @Context
+    private HttpServletRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (resourceInfo != null) {
+            if (resourceInfo.getResourceMethod().getAnnotation(NoIPRestriction.class) == null) {
+                requestContext.abortWith(Response.serverError().build());
+            }
+            if (!remoteHostMatcher.isAllowed(request)) {
+                requestContext.abortWith(Response.serverError().build());
+            }
+        }
+
+    }
+}

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiI18n.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiI18n.java
@@ -17,6 +17,7 @@ package org.sakaiproject.webservices;
 
 import org.sakaiproject.util.Resource;
 import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.webservices.interceptor.NoIPRestriction;
 
 import javax.jws.WebMethod;
 import javax.jws.WebParam;
@@ -57,6 +58,7 @@ public class SakaiI18n extends AbstractWebService {
     @Path("/getI18nProperties")
     @Produces("text/plain")
     @GET
+    @NoIPRestriction
     public String getI18nProperties(
             @WebParam(name = "locale", partName = "locale") @QueryParam("locale") String locale,
             @WebParam(name = "resourceclass", partName = "resourceclass") @QueryParam("resourceclass") String resourceClass,

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/interceptor/NetworkAddressValidatingInterceptor.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/interceptor/NetworkAddressValidatingInterceptor.java
@@ -1,0 +1,75 @@
+package org.sakaiproject.webservices.interceptor;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.security.AccessDeniedException;
+import org.apache.cxf.logging.FaultListener;
+import org.apache.cxf.logging.NoOpFaultListener;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.invoker.MethodDispatcher;
+import org.apache.cxf.service.model.BindingOperationInfo;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.util.ResourceBundle;
+
+/**
+ * This checks SOAP requests to make sure that they are permitted based on the IP restrictions and also checks the
+ * target of the request to see if it's annotated to mark it as a public method. This is used rather than a servlet
+ * filter so that we can look for an annotation on the endpoint that's being accessed.
+ *
+ * @see NoIPRestriction
+ * @see RemoteHostMatcher
+ */
+public class NetworkAddressValidatingInterceptor extends AbstractPhaseInterceptor<Message> {
+
+    private RemoteHostMatcher remoteHostMatcher;
+
+    public NetworkAddressValidatingInterceptor(RemoteHostMatcher remoteHostHandler) {
+        // This needs to be registered to a late phase so that the lookup to the final method has been done.
+        super(Phase.USER_LOGICAL);
+        this.remoteHostMatcher = remoteHostHandler;
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        // JAX-RS
+        Method method = getTargetMethod(message);
+        HttpServletRequest request = (HttpServletRequest) message.getContextualProperty("HTTP.REQUEST");
+        if (!hasAnnotation(method) && (request == null || !remoteHostMatcher.isAllowed(request))) {
+            // This is to prevent a full stack trace getting logged for a denied request
+            message.put(FaultListener.class.getName(), new NoOpFaultListener());
+            Fault fault = new Fault(
+                    new org.apache.cxf.common.i18n.Message("Not permitted", (ResourceBundle) null),
+                    Fault.FAULT_CODE_CLIENT
+            );
+            fault.setStatusCode(HttpServletResponse.SC_FORBIDDEN);
+            throw fault;
+        }
+    }
+
+    protected boolean hasAnnotation(Method method) {
+        return method.getAnnotation(NoIPRestriction.class) != null;
+    }
+
+    protected Method getTargetMethod(Message m) {
+        // Used the SOAP
+        BindingOperationInfo bop = m.getExchange().get(BindingOperationInfo.class);
+        if (bop != null) {
+            MethodDispatcher md = (MethodDispatcher)
+                    m.getExchange().get(Service.class).get(MethodDispatcher.class.getName());
+            return md.getMethod(bop);
+        }
+        // Used for JAX-RS
+        // This doesn't work for JAX-RS sub-resources as the lookup is only done on the original method, not the
+        // sub-resource
+        Method method = (Method) m.get("org.apache.cxf.resource.method");
+        if (method != null) {
+            return method;
+        }
+        throw new AccessDeniedException("Method is not available : Unauthorized");
+    }
+}

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/interceptor/NoIPRestriction.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/interceptor/NoIPRestriction.java
@@ -1,0 +1,16 @@
+package org.sakaiproject.webservices.interceptor;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Simple marker annotation to say that a REST request shouldn't have IP restrictions on it and should bypass
+ * any filter restrictions.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoIPRestriction {
+}

--- a/webservices/cxf/src/resources/applicationContext.xml
+++ b/webservices/cxf/src/resources/applicationContext.xml
@@ -3,22 +3,22 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jaxrs="http://cxf.apache.org/jaxrs"
        xmlns:jaxws="http://cxf.apache.org/jaxws"
-       xsi:schemaLocation="
-	       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	       http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd
-	       http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd">
+       xmlns:cxf="http://cxf.apache.org/core"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd
+           http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
+           http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd
+           ">
 
 
     <import resource="classpath:META-INF/cxf/cxf.xml" />
     <!--import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" /-->
     <import resource="classpath:META-INF/cxf/cxf-servlet.xml" />
 
-    <bean id="RemoteHostFilter" class="org.sakaiproject.util.RemoteHostFilter" init-method="init">
+    <bean id="RemoteHostFilter" class="org.sakaiproject.webservices.interceptor.RemoteHostMatcher" init-method="init">
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
         <property name="allowRequests">
             <list>
-                <value>/sakai-ws/rest/i18n/getI18nProperties</value>
-                <value>/sakai-ws/soap/i18n/getI18nProperties</value>
             </list>
         </property>
         <property name="allow">
@@ -40,6 +40,15 @@
         <property name="logAllowed" value="false"/>
         <property name="logDenied" value="true"/>
     </bean>
+
+    <!-- This registers a matcher for all requests -->
+    <cxf:bus>
+        <cxf:inInterceptors>
+            <bean class="org.sakaiproject.webservices.interceptor.NetworkAddressValidatingInterceptor">
+                <constructor-arg ref="RemoteHostFilter"/>
+            </bean>
+        </cxf:inInterceptors>
+    </cxf:bus>
 
     <!-- JAX-RS -->
     <jaxrs:server id="SakaiLoginRS" address="/rest/login">

--- a/webservices/cxf/src/webapp/WEB-INF/web.xml
+++ b/webservices/cxf/src/webapp/WEB-INF/web.xml
@@ -1,19 +1,12 @@
-<!DOCTYPE web-app PUBLIC
-        "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd" >
-
-<web-app>
+<web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
     <display-name>Sakai Soap Web Service (CXF)</display-name>
     <filter>
         <filter-name>sakai.request</filter-name>
         <filter-class>org.sakaiproject.util.RequestFilter</filter-class>
     </filter>
 
-    <filter>
-        <filter-name>RemoteHostFilter</filter-name>
-        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
-    </filter>
-
     <filter-mapping>
         <filter-name>sakai.request</filter-name>
         <servlet-name>
@@ -23,18 +16,6 @@
         <dispatcher>FORWARD</dispatcher>
         <dispatcher>INCLUDE</dispatcher>
     </filter-mapping>
-
-    <filter-mapping>
-        <filter-name>RemoteHostFilter</filter-name>
-        <servlet-name>
-            CXFServlet
-        </servlet-name>
-        <dispatcher>REQUEST</dispatcher>
-        <dispatcher>FORWARD</dispatcher>
-        <dispatcher>INCLUDE</dispatcher>
-    </filter-mapping>
-
-
 
     <!-- Context Params -->
     <context-param>
@@ -49,7 +30,6 @@
     <!-- Servlets -->
     <servlet>
         <servlet-name>CXFServlet</servlet-name>
-        <display-name>CXF Servlet</display-name>
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>


### PR DESCRIPTION
#This moves the the IP address range filter from the kernel to the web services. The reason for doing this is that it was explicitly setup to just use the web services configuration properties so it didn’t make sense to use as it is anywhere apart from the web services without further refactoring.

This moves the filtering of requests from a servlet filter to a CXF interceptor, this allows us to examine the method that is going to handle the request and so look for annotations on that method.

We couldn’t do this as a JAX-RS filter as that wouldn’t have prevented requests to the non JAX-WS endpoints.