### PR TITLE
SAK-33253 - Move portal javascript variable up before other snippets

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -7,22 +7,6 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        #parse("/vm/morpheus/snippets/title-snippet.vm")
-
-        #parse("/vm/morpheus/snippets/portalCSS-snippet.vm")
-        
-        <link href="${pageWebjarsPath}jquery-ui/1.11.3/jquery-ui.min.css$!{portalCDNQuery}" rel="stylesheet" />  
-        <link href="${pageScriptPath}jquery/cluetip/1.2.10/css/jquery.cluetip.css$!{portalCDNQuery}" rel="stylesheet">
-        <link href="${pageScriptPath}jquery/qtip/jquery.qtip-latest.min.css$!{portalCDNQuery}" rel="stylesheet">
-        <link href="${pageWebjarsPath}pnotify/2.1.0/pnotify.core.min.css$!{portalCDNQuery}" rel="stylesheet">
-	<link href="${pageWebjarsPath}pnotify/2.1.0/pnotify.buttons.min.css$!{portalCDNQuery}" rel="stylesheet">
-        <link href="${pageWebjarsPath}cropper/2.3.2/dist/cropper.min.css$!{portalCDNQuery}" rel="stylesheet">
-        <script src="${pageSkinRepo}/${pageSkin}/js/lib/modernizr.js$!{portalCDNQuery}"></script>
-    #if ($useBullhornAlerts)
-        <script src="/profile2-tool/javascript/profile2-eb.js$!{portalCDNQuery}"></script>
-        <script src="${pageWebjarsPath}momentjs/2.11.1/min/moment-with-locales.min.js$!{portalCDNQuery}"></script>
-    #end
-
         <script> ## Include this at the top so tool markup and headscripts.js can use it
             ## SAK-16484 Allow Javascript to easily get at user details.
             ## SAK-13987, SAK-16162, SAK-19132 - Portal Logout Timer
@@ -68,6 +52,22 @@
                 "portalCDNQuery" : "$!{portalCDNQuery}"
             };
         </script>
+
+        #parse("/vm/morpheus/snippets/title-snippet.vm")
+
+        #parse("/vm/morpheus/snippets/portalCSS-snippet.vm")
+        
+        <link href="${pageWebjarsPath}jquery-ui/1.11.3/jquery-ui.min.css$!{portalCDNQuery}" rel="stylesheet" />  
+        <link href="${pageScriptPath}jquery/cluetip/1.2.10/css/jquery.cluetip.css$!{portalCDNQuery}" rel="stylesheet">
+        <link href="${pageScriptPath}jquery/qtip/jquery.qtip-latest.min.css$!{portalCDNQuery}" rel="stylesheet">
+        <link href="${pageWebjarsPath}pnotify/2.1.0/pnotify.core.min.css$!{portalCDNQuery}" rel="stylesheet">
+	<link href="${pageWebjarsPath}pnotify/2.1.0/pnotify.buttons.min.css$!{portalCDNQuery}" rel="stylesheet">
+        <link href="${pageWebjarsPath}cropper/2.3.2/dist/cropper.min.css$!{portalCDNQuery}" rel="stylesheet">
+        <script src="${pageSkinRepo}/${pageSkin}/js/lib/modernizr.js$!{portalCDNQuery}"></script>
+    #if ($useBullhornAlerts)
+        <script src="/profile2-tool/javascript/profile2-eb.js$!{portalCDNQuery}"></script>
+        <script src="${pageWebjarsPath}momentjs/2.11.1/min/moment-with-locales.min.js$!{portalCDNQuery}"></script>
+    #end
         
         <!-- inlined tool header contribution -->
         ## if any of the tools requested an inline render, their header content gets aggregated here


### PR DESCRIPTION
In the commit it doesn't actually reference the portal and it looks like everything else is just pushed down, I guess it's the same thing.