### PR TITLE
SAK-33259: LDAP student/employee numbers not appearing

### DIFF
--- a/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapCandidateAttributeMapper.java
+++ b/providers/jldap/src/java/edu/amc/sakai/user/SimpleLdapCandidateAttributeMapper.java
@@ -245,6 +245,6 @@ public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMappe
 		{
 			studentNumber = encryption.encrypt(studentNumber, studentNumberLength);
 		}
-		userEditProperties.addPropertyToList(USER_PROP_STUDENT_NUMBER, studentNumber);
+		userEditProperties.addProperty(USER_PROP_STUDENT_NUMBER, studentNumber);
 	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33259

There is a bug in the code when mapping the 'studentNumber' LDAP attribute into the user object's properties. The method SimpleLdapCandidateAttributeMapper.addStudentNumberProperty() adds the property as a list:

```
userEditProperties.addPropertyToList(USER_PROP_STUDENT_NUMBER, studentNumber);
```

Later on, when the student number is requested, it tries to access this user property in CandidateDetailProviderImpl.getNumericId():

```
String studentNumber = user.getProperties().getProperty(USER_PROP_STUDENT_NUMBER);
```

And the implementation of getProperty() will return null because the property is a list rather than a String object:

```
	public String getProperty(String name)
	{
		Object value = m_props.get(name);
		if (value instanceof String) return (String) value;

		return null;
	}
```

The result of this is that the list ends up containing two values, one is the encrypted value of the user's actual student/employee number; the other is the encrypted value of empty string. The duplication is a result of a StringUtils.isEmpty() call returning true because you're passing it a list rather than a String, so it then adds the value of empty string into the list:

```
			if (StringUtils.isEmpty(userEditProperties.getProperty(USER_PROP_STUDENT_NUMBER))) {
				addStudentNumberProperty(EMPTY, userEditProperties);
			}
```

The solution is to simply change the SimpleLdapCandidateAttributeMapper.addStudentNumberProperty() method to add the property as a String, rather than as a list:

```
userEditProperties.addProperty(USER_PROP_STUDENT_NUMBER, studentNumber);
```