### PR TITLE
SAK-33254 - CK Editor properties documentation need sprucing up

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3493,16 +3493,17 @@
 
 ## WYSIWYG EDITOR
 # Specify the wysiwyg editor for most of Sakai
-# **NOTE:  Experimental Feature 2.8.0 
-# DEFAULT: none (null) - kernel.properties defines this as FCKeditor
+# DEFAULT: none (null) - kernel.properties defines this as CKeditor
 # wysiwyg.editor=ckeditor
 
 # Enable the twinpeaks feature in the WYSIWYG editor in legacy tools.
+# This property is DEPRECATED.
 # DEFAULT: false
 # wysiwyg.twinpeaks=true
 
 # The file browser to use for picking files in ckeditor
 # The only other option is fckeditor.
+# This property is DEPRECATED because its applicable to the old editors and anything referencing it should be removed.
 # DEFAULT: elfinder
 # wysiwyg.editor.ckeditor.browser=fckeditor
 


### PR DESCRIPTION
Noticed that the documentation about the properties for the wysiwyg editor in Sakai was out of date. Hoping this improves it.