### PR TITLE
SAM-3240: bug with calculated question's upper threshold on converting to scientific notation

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -26,7 +26,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -3199,14 +3198,14 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  {
 		  Map.Entry<String, String>entry = i.next();
 		  
-		  String delimRange = entry.getValue().toString(); // ie. "-100|100,2"
+		  String delimRange = entry.getValue(); // ie. "-100|100,2"
 		  		  
-		  double minVal = Double.valueOf(delimRange.substring(0, delimRange.indexOf('|')));
-		  double maxVal = Double.valueOf(delimRange.substring(delimRange.indexOf('|')+1, delimRange.indexOf(',')));
+		  BigDecimal minVal = new BigDecimal(delimRange.substring(0, delimRange.indexOf('|')));
+		  BigDecimal maxVal = new BigDecimal(delimRange.substring(delimRange.indexOf('|')+1, delimRange.indexOf(',')));
 		  int decimalPlaces = Integer.valueOf(delimRange.substring(delimRange.indexOf(',')+1, delimRange.length()));
 		  		  
 		  // This line does the magic of creating the random variable value within the range.
-		  Double randomValue = minVal + (maxVal - minVal) * generator.nextDouble();
+		  BigDecimal randomValue = maxVal.subtract(minVal).multiply(new BigDecimal(generator.nextDouble())).add(minVal);
 		  
 		  // Trim off excess decimal points based on decimalPlaces value
 		  /*BigDecimal bd = new BigDecimal(randomValue);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3240

The upper threshold is not obeyed (as advertised). The bug is just that in the determineRandomValuesForRanges() method, some doubles weren't converted to BigDecimal:

```
		  double minVal = Double.valueOf(delimRange.substring(0, delimRange.indexOf('|')));
		  double maxVal = Double.valueOf(delimRange.substring(delimRange.indexOf('|')+1, delimRange.indexOf(',')));
		  int decimalPlaces = Integer.valueOf(delimRange.substring(delimRange.indexOf(',')+1, delimRange.length()));
		  		  
		  // This line does the magic of creating the random variable value within the range.
		  Double randomValue = minVal + (maxVal - minVal) * generator.nextDouble();
		  
		  // Trim off excess decimal points based on decimalPlaces value
		  /*BigDecimal bd = new BigDecimal(randomValue);
		  bd = bd.setScale(decimalPlaces,BigDecimal.ROUND_HALF_UP);
		  randomValue = bd.doubleValue();
		  String displayNumber = randomValue.toString();*/
		  
		  String displayNumber = toScientificNotation(randomValue.toString(), decimalPlaces);
```

So if the upper threshold is greater than possibly stored in a double, maxVal ends up with scientific notation in it already, which in turn leads to scientific notation in randomValue object, which then gets passed to the toScientificNotation() method which looks for the occurrence of 'e' or 'E' in the string, and if so, keeps it in scientific notation. this results in numbers less than the upper threshold still being converted into scientific notation.