### PR TITLE
SAK-33295: syllabus item title requirement/validation not visible to user

### DIFF
--- a/syllabus/syllabus-app/src/webapp/js/syllabus.js
+++ b/syllabus/syllabus-app/src/webapp/js/syllabus.js
@@ -501,14 +501,17 @@ function doAddItemButtonClick( msgs, published )
 		if( $( "#successInfo" ).is( ":visible" ) )
 		{
 			location.reload();
+			return true;
 		}
 	}
+
+	return false;
 }
 
 function showConfirmAdd(msgs, mainframeId){
 	$('#container', this.top.document).append("<div></div>");
 	$('<div></div>').appendTo('body')
-		.html("<div><h6>" + msgs.syllabus_title + "</h6><input type='text' id='newTitle'/></div><div style='display:none' id='requiredTitle' class='warning'>" + msgs.required + "</div>" +
+		.html("<div><h6><span class='reqStar'>* </span>" + msgs.syllabus_title + "</h6><input type='text' id='newTitle'/></div><div style='display:none' id='requiredTitle' class='warning'>" + msgs.required + "</div>" +
 				"<h6>" + msgs.syllabus_content + "</h6><div class='bodyInput' id='newContentDiv'><textarea cols='120' id='newContentTextAreaWysiwyg'/></div>")
 		.dialog({
 			position: {
@@ -526,11 +529,11 @@ function showConfirmAdd(msgs, mainframeId){
 			buttons: [
 				{
 					text: msgs.bar_publish,
-					click: function() { doAddItemButtonClick( msgs, true ); $( this ).dialog( "close" ); }
+					click: function() { if (doAddItemButtonClick( msgs, true )) {$( this ).dialog( "close" );} }
 				},
 				{
 					text: msgs.bar_new,
-					click: function() { doAddItemButtonClick( msgs, false ); $( this ).dialog( "close" ); }
+					click: function() { if (doAddItemButtonClick( msgs, false )) {$( this ).dialog( "close" );} }
 				},
 				{
 					text: msgs.bar_cancel,


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33295

The title of a Syllabus Item is required, however has the following bugs:

* no required field indicator (asterisk)
* validation is not presented to the user

Steps to reproduce:

1) create a Syllabus Item
2) provide some content in the CKEditor, but do not specific a title
3) click either of the save options
4) notice the modal is gone, nothing was created, and no error/warning was presented to the user

There is actually validation and a validation message in place, but immediately after presenting the validation message, the JavaScript code closes the modal. The result is that the user has no opportunity to see the error, no opportunity to rectify the error, and loses all the data they may have entered in the CKEditor.

The solution to this is to:

* mark the field as required in the UI (asterisk)
* don't close the modal if the validation fails so the user can actually see the validation error and correct the issue themselves