### PR TITLE
SAK-33300: assignments paginators' items per page spinner is in an awkward location

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -47,7 +47,7 @@
 ## Macro for the paginator
 #macro( paginator $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
     <nav class="assignment-pager panel panel-default">
-        <div class="panel-heading">
+        <div class="panel-heading" id="pagingHeader">
             $tlang.getString( "gen.viewing" ) $topMsgPos - $btmMsgPos $tlang.getString( "gen.of" ) $allMsgNumber $tlang.getString( "gen.items" )
         </div>
         <div class="panel-body">
@@ -67,7 +67,7 @@
         <form id="pagesizeForm" name="pagesizeForm" class="inlineForm" method="post" action="#toolForm("$action")">
             <input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
             <label for="selectPageSize" class="skip">$tlang.getString("newassig.selectmessage")</label>
-            <select id="selectPageSize" name="selectPageSize" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'pagesizeForm', null, null, null );">
+            <select id="selectPageSize" name="selectPageSize" onchange="SPNR.insertSpinnerAfter( this, null, 'pagingHeader' ); ASN.submitForm( 'pagesizeForm', null, null, null );">
                 #foreach( $i in $!pagesizes )
                     <option value="$i" #if( $pagesize == $i ) selected="selected" #end>$tlang.getString( "list.show" ) $i $tlang.getString( "list.itemsper" )</option>
                 #end

--- a/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
+++ b/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
@@ -464,4 +464,12 @@
 		@extend .contentReviewIconDraft;
 		color: #9E9E9E;
 	}
+
+	div#pagingHeader {
+		height: 20px;
+		padding: 15px;
+		@include display-flex;
+		@include align-items(center);
+		@include justify-content(center);
+	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33300

The spinner animation pops up beside the drop down, which pushes the buttons to the right and can cause button(s) to fall to the next line in smaller browser windows.

Relocate the spinner to appear beside the header text ("Viewing x-y of z items").