### PR TITLE
SAK-33301: don't call SetMaxPoint() if there are alerts/errors at the top of the page

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -26,7 +26,9 @@
 		 		});
 		 	});
 		#end
-		SetMaxPoint(document.getElementById('$name_GradeType'), document.getElementById('$name_GradePoints'));
+		if ($("#generalAlert").length <= 0) {
+			SetMaxPoint(document.getElementById('$name_GradeType'), document.getElementById('$name_GradePoints'));
+		}
 	});
 
     function SetMaxPoint(obj_option, obj_textfield)
@@ -118,7 +120,7 @@
 	</div>
 
 	#if ($alertMessage)
-		<div class="alertMessage">
+		<div class="alertMessage" id="generalAlert">
 			<strong>$tlang.getString("gen.alert")</strong> <small> $alertMessage </small>
 		</div>
 	#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33301

1) Create an assignment
2) Use grading scale, enter points possible
3) Select some settings that you know will produce an error (ex. open date after due date, no title, etc)
4) Save
5) Form refreshes, but focus is immediately put on the points possible field all the way down the screen

This results in a situation where the user is not aware of the error, which is presented at the top of the page. The same kind of problem exists when editing an existing assignment. The solution is to not call SetMaxPoint() if there are alerts/errors at the top of the page.