### PR TITLE
SAK-33303: Site Info > Tool Order > hide 'URL' label when not needed

### DIFF
--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageListProducer.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/rsf/PageListProducer.java
@@ -146,6 +146,7 @@ public class PageListProducer
                     //for all tools that want special configuration and/or allow multiple instances 
                     //per site
                     if ("sakai.iframe".equals(tool.getToolId())) {
+                        UIMessage.make(pagerow, "page-config-label", "url");
                         UIInput.make(pagerow, "page-config-input", "#{SitePageEditHandler.nil}", 
                                 tool.getPlacementConfig().getProperty("source"));
                     }

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -37,7 +37,7 @@
 											<input rsf:id="page-name-input" class="new_title" id="page-name-input"></input>
 										</div>
 										<div>
-											<label rsf:id="msg=url" for="page-config-input">URL</label>
+											<label rsf:id="page-config-label" for="page-config-input">URL</label>
 											<input rsf:id="page-config-input" id="page-config-input" class="new_config" ></input>
 											<a href="#" onclick="doBrowseLocalContent(this)" rsf:id="browse-link">Browse</a>
 										</div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33303

The "URL" label appears in the Tool Order > Edit Tool Title panel in Site Info even when there is no URL field to edit. Hide the label if we're hiding the corresponding input field.