### PR TITLE
SAK-33304: Site Info > Manage Groups > Joinable Set drop down is duplicated on add or update

### DIFF
--- a/site-manage/site-manage-group-helper/tool/src/webapp/content/templates/GroupEdit.html
+++ b/site-manage/site-manage-group-helper/tool/src/webapp/content/templates/GroupEdit.html
@@ -94,7 +94,7 @@
 		<input rsf:id="groupId" id="groupId" type="hidden"/>
 		<p class="act">
 
-			<input accesskey="s" rsf:id="save" class="active" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, escapeList );" />
+			<input accesskey="s" rsf:id="save" class="active" value="Save" type="submit" />
 			<input accesskey="x" rsf:id="cancel" value="Cancel" type="submit" onclick="SPNR.disableControlsAndSpin( this, escapeList );" />
 		</p>			
 	</form>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
@@ -162,7 +162,7 @@
 		<input rsf:id="groupId" id="groupId" type="hidden"/>
 		<p class="act">
 
-			<input accesskey ="s" id="save" rsf:id="save" class="active" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, escapeList );" />
+			<input accesskey ="s" id="save" rsf:id="save" class="active" value="Save" type="submit" />
 			<input accesskey ="x" id="cancel" rsf:id="cancel" value="Cancel" type="submit" onclick="SPNR.disableControlsAndSpin( this, escapeList );" />
 		</p>			
 	</form>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33304

When you "add"/"update" the form to create a group, the joinable set drop down control is duplicated. This is a result of the spinner function being called twice on click of the 'save'/'update' button.