### PR TITLE
SAM-3242: User Activity Report circumvents anonymous grading

### DIFF
--- a/edu-services/sections-service/sections-api/src/java/org/sakaiproject/section/api/SectionAwareness.java
+++ b/edu-services/sections-service/sections-api/src/java/org/sakaiproject/section/api/SectionAwareness.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
+import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
 import org.sakaiproject.section.api.facade.Role;
 
 /**
@@ -86,6 +87,7 @@ public interface SectionAwareness {
      * Gets the site membership for a given context.
      * 
 	 * @param siteContext The site context
+	 * @param role Required role
 	 * 
      * @return A {@link java.util.List List} of
      * {@link org.sakaiproject.section.api.coursemanagement.ParticipationRecord
@@ -93,7 +95,7 @@ public interface SectionAwareness {
      * the given {@link org.sakaiproject.section.api.facade.Role Role}.
      * 
      */
-    public List getSiteMembersInRole(String siteContext, Role role);
+    public List<EnrollmentRecord> getSiteMembersInRole(String siteContext, Role role);
 
     /**
      * Finds site members in the given context and {@link org.sakaiproject.section.api.facade.Role Role}

--- a/samigo/samigo-api/pom.xml
+++ b/samigo/samigo-api/pom.xml
@@ -39,6 +39,10 @@
         <groupId>org.sakaiproject.kernel</groupId>
         <artifactId>sakai-kernel-api</artifactId>
       </dependency>
+      <dependency>
+        <groupId>org.sakaiproject.edu-services.sections</groupId>
+        <artifactId>sections-api</artifactId>
+      </dependency>
     </dependencies>
     
 	<build>

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/EvaluationModelIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/EvaluationModelIfc.java
@@ -33,20 +33,20 @@ public interface EvaluationModelIfc
     extends java.io.Serializable
 {
 
-  public static final Integer ANONYMOUS_GRADING = Integer.valueOf(1);
-  public static final Integer NON_ANONYMOUS_GRADING = Integer.valueOf(2);
-  public static final Integer GRADEBOOK_NOT_AVAILABLE = Integer.valueOf(0);
-  public static final Integer TO_DEFAULT_GRADEBOOK = Integer.valueOf(1);
+  public static final Integer ANONYMOUS_GRADING = 1;
+  public static final Integer NON_ANONYMOUS_GRADING = 2;
+  public static final Integer GRADEBOOK_NOT_AVAILABLE = 0;
+  public static final Integer TO_DEFAULT_GRADEBOOK = 1;
   //public static Integer TO_SELECTED_GRADEBOOK = new Integer(2);  // this is confusing, we are using 2 for 'None' but the name is confusing, 
-  public static final Integer NOT_TO_GRADEBOOK = Integer.valueOf(2);		// so now we added this new constant, SAK-7162
-  public static final Integer TO_SELECTED_GRADEBOOK = Integer.valueOf(3);  // not used, but leave it for now 
+  public static final Integer NOT_TO_GRADEBOOK = 2;		// so now we added this new constant, SAK-7162
+  public static final Integer TO_SELECTED_GRADEBOOK = 3;  // not used, but leave it for now 
 
   // scoring type 
-  public static final Integer HIGHEST_SCORE = Integer.valueOf(1);
+  public static final Integer HIGHEST_SCORE = 1;
   //public static Integer AVERAGE_SCORE = new Integer(2);
-  public static final Integer LAST_SCORE= Integer.valueOf(2);
-  public static final Integer ALL_SCORE= Integer.valueOf(3);
-  public static final Integer AVERAGE_SCORE= Integer.valueOf(4);
+  public static final Integer LAST_SCORE= 2;
+  public static final Integer ALL_SCORE= 3;
+  public static final Integer AVERAGE_SCORE= 4;
 
   Long getId();
 

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/shared/api/grading/GradingSectionAwareServiceAPI.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/shared/api/grading/GradingSectionAwareServiceAPI.java
@@ -25,6 +25,7 @@
 package org.sakaiproject.tool.assessment.shared.api.grading;
 
 import java.util.List;
+import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
 
 /**
  *
@@ -51,8 +52,7 @@ public interface GradingSectionAwareServiceAPI
   *      an EnrollmentRecord list for each student that the current user
   *  is allowed to grade.
   */
-  public List getAvailableEnrollments(String siteId, String userUid);
-
+  public List<EnrollmentRecord> getAvailableEnrollments(String siteId, String userUid);
 
   /**
   * @return

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/SectionActivityMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/SectionActivityMessages.properties
@@ -9,6 +9,7 @@ date_completed=Submit Date
 percent_correct=Percentage
 correct_possible=Score/Total Points
 not_available=N/A
+anon_grading_info=This assessment is graded anonymously
 
 t_sortTitle=Sort by Title
 alt_sortTitleAscending=Sort by Title in Ascending

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/SectionActivityBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/SectionActivityBean.java
@@ -17,6 +17,8 @@ package org.sakaiproject.tool.assessment.ui.bean.author;
 
 import java.io.Serializable;
 import java.util.List;
+import javax.faces.model.SelectItem;
+import org.sakaiproject.tool.assessment.ui.listener.author.SectionActivityListener.SectionActivityData;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,11 +28,11 @@ public class SectionActivityBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(SectionActivityBean.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SectionActivityBean.class);
 
-    private List displayNamesList;
+    private List<SelectItem> displayNamesList;
     private String selectedUser;
-    private List sectionActivityDataList;
+    private List<SectionActivityData> sectionActivityDataList;
     private String sortType="assessmentName";
     private boolean sortAscending = true;
 
@@ -38,7 +40,7 @@ public class SectionActivityBean implements Serializable {
         return displayNamesList;
     }
 
-    public void setDisplayNamesList(List displayNamesList) {
+    public void setDisplayNamesList(List<SelectItem> displayNamesList) {
         this.displayNamesList = displayNamesList;
     }
 
@@ -55,7 +57,7 @@ public class SectionActivityBean implements Serializable {
     }
    
 
-    public void setSectionActivityDataList(List sectionActivityDataList) {
+    public void setSectionActivityDataList(List<SectionActivityData> sectionActivityDataList) {
         this.sectionActivityDataList = sectionActivityDataList;
     }
 
@@ -64,7 +66,7 @@ public class SectionActivityBean implements Serializable {
         try {      
             displayName = UserDirectoryService.getUser(selectedUser).getDisplayName();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.debug("Can't find user", e);
         }
         return displayName ;
     }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -50,6 +49,7 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessCont
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
 import org.sakaiproject.tool.assessment.facade.AuthzQueriesFacadeAPI;
@@ -84,7 +84,7 @@ public class SaveAssessmentSettings
     // #1 - set Assessment
     Long assessmentId = assessmentSettings.getAssessmentId();
     ItemAuthorBean iAuthor=new ItemAuthorBean();
-    iAuthor.setShowFeedbackAuthoring(assessmentSettings.getFeedbackAuthoring());;
+    iAuthor.setShowFeedbackAuthoring(assessmentSettings.getFeedbackAuthoring());
     AssessmentService assessmentService = new AssessmentService();
     AssessmentFacade assessment = assessmentService.getAssessment(
         assessmentId.toString());
@@ -274,21 +274,21 @@ public class SaveAssessmentSettings
     
     String firstTargetSelected = assessmentSettings.getFirstTargetSelected();
 	if ("Anonymous Users".equals(firstTargetSelected)) {
-		evaluation.setAnonymousGrading(Integer.valueOf("1"));
-		evaluation.setToGradeBook("2");
+		evaluation.setAnonymousGrading(EvaluationModelIfc.ANONYMOUS_GRADING);
+		evaluation.setToGradeBook(Integer.toString(EvaluationModelIfc.NOT_TO_GRADEBOOK));
 	}
 	else {
 		if (assessmentSettings.getAnonymousGrading()) {
-		      evaluation.setAnonymousGrading(1);
+			evaluation.setAnonymousGrading(EvaluationModelIfc.ANONYMOUS_GRADING);
 		}
 		else {
-			evaluation.setAnonymousGrading(2);
+			evaluation.setAnonymousGrading(EvaluationModelIfc.NON_ANONYMOUS_GRADING);
 		}
 		if (assessmentSettings.getToDefaultGradebook()) {
-			evaluation.setToGradeBook("1");
+			evaluation.setToGradeBook(Integer.toString(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK));
 		}
 		else {
-			evaluation.setToGradeBook("2");
+			evaluation.setToGradeBook(Integer.toString(EvaluationModelIfc.NOT_TO_GRADEBOOK));
 		}
 	}
     

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -726,19 +726,19 @@ implements ActionListener
 			evaluation.setAssessmentBase(assessment.getData());
 		}
 		if (assessmentSettings.getAnonymousGrading()) {
-			evaluation.setAnonymousGrading(1);
+			evaluation.setAnonymousGrading(EvaluationModelIfc.ANONYMOUS_GRADING);
 		}
 		else {
-			evaluation.setAnonymousGrading(2);
+			evaluation.setAnonymousGrading(EvaluationModelIfc.NON_ANONYMOUS_GRADING);
 		}
 	    
 		// If there is value set for toDefaultGradebook, we reset it
 		// Otherwise, do nothing
 		if (assessmentSettings.getToDefaultGradebook()) {
-			evaluation.setToGradeBook("1");
+			evaluation.setToGradeBook(Integer.toString(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK));
 		}
 		else {
-			evaluation.setToGradeBook("2");
+			evaluation.setToGradeBook(Integer.toString(EvaluationModelIfc.NOT_TO_GRADEBOOK));
 		}
 
 		if (assessmentSettings.getScoringType() != null) {
@@ -983,5 +983,3 @@ implements ActionListener
 		return setToReturn;
 	}
 }
-
-

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SectionActivityListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SectionActivityListener.java
@@ -23,12 +23,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.faces.event.ActionEvent;
@@ -42,10 +42,8 @@ import org.slf4j.LoggerFactory;
 
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAssessmentData;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
-import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 
-import org.sakaiproject.tool.assessment.services.GradingService;
 import org.sakaiproject.tool.assessment.services.PersistenceService;
 
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
@@ -56,12 +54,12 @@ import org.sakaiproject.tool.assessment.ui.bean.util.Validator;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.util.BeanSort;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
-import org.sakaiproject.user.cover.UserDirectoryService;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
 
-public class SectionActivityListener
-implements ActionListener, ValueChangeListener
+public class SectionActivityListener implements ActionListener, ValueChangeListener
 {
-    private static Logger log = LoggerFactory.getLogger(SectionActivityListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SectionActivityListener.class);
     private static BeanSort bs;
 
     public SectionActivityListener()
@@ -70,51 +68,51 @@ implements ActionListener, ValueChangeListener
 
     public void processAction(ActionEvent ae)
     {
-        log.debug("*****Log: inside SectionActivityListener =debugging ActionEvent: " + ae);
+        LOG.debug("*****Log: inside SectionActivityListener =debugging ActionEvent: " + ae);
 
         // get service and managed bean    
         GradingSectionAwareServiceAPI service = new GradingSectionAwareServiceImpl();
         SectionActivityBean sab = (SectionActivityBean) ContextUtil.lookupBean("sectionActivity");
 
-        List list = service.getAvailableEnrollments(AgentFacade.getCurrentSiteId(), AgentFacade.getAgentString());
-        Map userNamesMap = getUserIdNameMap(list);     
-        List userNamesList = new ArrayList();
-        Iterator it = userNamesMap.entrySet().iterator();
-        while(it.hasNext()) {
-            Map.Entry pairs =(Map.Entry)it.next();
+        List<EnrollmentRecord> list = service.getAvailableEnrollments(AgentFacade.getCurrentSiteId(), AgentFacade.getAgentString());
+        Map<String, String> userNamesMap = getUserIdNameMap(list);
+        List<SelectItem> userNamesList = new ArrayList();
+        for (Map.Entry pairs : userNamesMap.entrySet()) {
             userNamesList.add(new SelectItem((String)pairs.getKey(), (String)pairs.getValue()));
         }
         sab.setDisplayNamesList(userNamesList);
 
         //initial selectedUser
-        if(sab.getSelectedUser() == null || sab.getSelectedUser() == "") {
-            Iterator it2 = userNamesMap.entrySet().iterator();
-            while(it2.hasNext()) {
-                Map.Entry pairs =(Map.Entry)it2.next();
+        if(sab.getSelectedUser() == null || "".equals(sab.getSelectedUser())) {
+            for (Map.Entry pairs : userNamesMap.entrySet()){
                 String firstUserId = (String)pairs.getKey();
                 sab.setSelectedUser(firstUserId);
                 break;
             }
         }
-        List dataList = getSectionActivityDataList(sab.getSelectedUser());
+        List<SectionActivityData> dataList = getSectionActivityDataList(sab.getSelectedUser());
 
-        if (ContextUtil.lookupParam("sortBy") != null &&
-                !ContextUtil.lookupParam("sortBy").trim().equals("")){
+        if (ContextUtil.lookupParam("sortBy") != null && !ContextUtil.lookupParam("sortBy").trim().equals("")){
             sab.setSortType(ContextUtil.lookupParam("sortBy"));
-
         }
-        boolean sortAscending = true;
-        if (ContextUtil.lookupParam("sortAscending") != null &&
-                !ContextUtil.lookupParam("sortAscending").trim().equals("")){
-            sortAscending = Boolean.valueOf(ContextUtil.lookupParam("sortAscending")).booleanValue();
+
+        boolean sortAscending;
+        if (ContextUtil.lookupParam("sortAscending") != null && !ContextUtil.lookupParam("sortAscending").trim().equals("")){
+            sortAscending = Boolean.valueOf(ContextUtil.lookupParam("sortAscending"));
             sab.setSortAscending(sortAscending);
         }
 
         String sortProperty = sab.getSortType();
         bs = new BeanSort(dataList, sortProperty);
-        if ((sortProperty).equals("assessmentName")) bs.toStringSort();
-        if ((sortProperty).equals("assessmentId")) bs.toNumericSort();
-        if ((sortProperty).equals("submitDate")) bs.toDateSort();
+        if ((sortProperty).equals("assessmentName")) {
+            bs.toStringSort();
+        }
+        if ((sortProperty).equals("assessmentId")) {
+            bs.toNumericSort();
+        }
+        if ((sortProperty).equals("submitDate")) {
+            bs.toDateSort();
+        }
         if (sab.isSortAscending()) {
             dataList = (ArrayList)bs.sort();
         }
@@ -125,16 +123,12 @@ implements ActionListener, ValueChangeListener
 
     }
 
-    public List getSectionActivityDataList(String selectedUser) {
+    public List<SectionActivityData> getSectionActivityDataList(String selectedUser) {
         PublishedAssessmentService assessmentService = new PublishedAssessmentService();
-        List list = new ArrayList();
-        List dataList = new ArrayList();
+        List<SectionActivityData> dataList = new ArrayList<>();
         String siteId = AgentFacade.getCurrentSiteId();
-        list = assessmentService.getAllAssessmentsGradingDataByAgentAndSiteId(selectedUser, siteId);   
-        Iterator it = list.iterator();
-        while(it.hasNext()) {
-            SectionActivityData sad = new SectionActivityData();
-            AssessmentGradingData agd = (AssessmentGradingData)it.next();
+        List<AssessmentGradingData> list = assessmentService.getAllAssessmentsGradingDataByAgentAndSiteId(selectedUser, siteId);
+        for (AssessmentGradingData agd : list) {
             Long publishAssessmentId = agd.getPublishedAssessmentId();
             PublishedAssessmentData publishedAssessmentData = assessmentService.getBasicInfoOfPublishedAssessment(publishAssessmentId.toString()); 
             String title = publishedAssessmentData.getTitle();
@@ -142,31 +136,27 @@ implements ActionListener, ValueChangeListener
             Double finalScore = agd.getFinalScore();
             Long assessmentGradingId = agd.getAssessmentGradingId();
 
-            GradingService gradingService = new GradingService();
-            PublishedAssessmentIfc pub = (PublishedAssessmentIfc) gradingService.getPublishedAssessmentByAssessmentGradingId(agd.getAssessmentGradingId().toString());
-
-
             PublishedAssessmentData assessmentData =PersistenceService.getInstance().getPublishedAssessmentFacadeQueries().loadPublishedAssessment(publishAssessmentId);
 
             // sectionSet of publishedAssessment is defined as lazy loading in
             // Hibernate, so we need to initialize them. Unfortunately the current
             // spring-1.0.2.jar does not support HibernateTemplate.intialize(Object)
             // so we need to do it ourselves
-            Set sectionSet = PersistenceService.getInstance().
-            getPublishedAssessmentFacadeQueries().getSectionSetForAssessment(assessmentData);
+            Set<PublishedSectionData> sectionSet = PersistenceService.getInstance().getPublishedAssessmentFacadeQueries().getSectionSetForAssessment(assessmentData);
             assessmentData.setSectionSet(sectionSet);
 
-            Double maxScore = new Double(assessmentData.getTotalScore().doubleValue());
-            Double percentage = new Double(0.0);
+            Double maxScore = assessmentData.getTotalScore();
+            Double percentage = 0.0;
             boolean notAvailableGrade = false;
-            if(maxScore != null && maxScore.doubleValue() != 0) {
+            if(maxScore != null && maxScore != 0) {
                 BigDecimal finalScoreBigDecimal = new BigDecimal(finalScore.toString());
                 BigDecimal maxScoreBigDecimal = new BigDecimal(maxScore.toString());
                 BigDecimal grade_temp = (finalScoreBigDecimal.divide(maxScoreBigDecimal, new MathContext(10))).multiply(new BigDecimal(100));
-                percentage = new Double(grade_temp.doubleValue());
+                percentage = grade_temp.doubleValue();
             } else {
                 notAvailableGrade = true;
             }
+            SectionActivityData sad = new SectionActivityData();
             sad.setAssessmentId(publishAssessmentId);
             sad.setAssessmentName(title);
             sad.setSubmitDate(submitDate);
@@ -175,16 +165,15 @@ implements ActionListener, ValueChangeListener
             sad.setTotal(maxScore);
             sad.setAssessmentGradingId(assessmentGradingId);
             sad.setNotAvailableGrade(notAvailableGrade);
+            sad.setAnonymousGrading(Objects.equals(EvaluationModelIfc.ANONYMOUS_GRADING, assessmentData.getEvaluationModel().getAnonymousGrading()));
             dataList.add(sad);
         }      
         return dataList;
     }
 
-    private Map getUserIdNameMap(List list) {
-        Map nameMap = new HashMap();
-        Iterator it = list.iterator();
-        while (it.hasNext()) {
-            EnrollmentRecord enr = (EnrollmentRecord) it.next();
+    private Map<String, String> getUserIdNameMap(List<EnrollmentRecord> list) {
+        Map<String, String> nameMap = new HashMap();
+        for (EnrollmentRecord enr : list) {
             String uid = enr.getUser().getUserUid();
             String displayName = enr.getUser().getDisplayName();
 
@@ -198,8 +187,7 @@ implements ActionListener, ValueChangeListener
         List list = new LinkedList(map.entrySet());
         Collections.sort(list, new Comparator() {
             public int compare(Object o1, Object o2) {
-                return ((Comparable) ((String)((Map.Entry) (o1)).getValue()).toLowerCase())
-                .compareTo(((String)((Map.Entry) (o2)).getValue()).toLowerCase());
+                return ((Comparable) ((String)((Map.Entry) (o1)).getValue()).toLowerCase()).compareTo(((String)((Map.Entry) (o2)).getValue()).toLowerCase());
             }
         });
 
@@ -218,7 +206,7 @@ implements ActionListener, ValueChangeListener
         sab.setSelectedUser(selectUser);
         sab.setSortAscending(true);
         sab.setSortType("assessmentName");
-        List dataList = getSectionActivityDataList(sab.getSelectedUser());
+        List<SectionActivityData> dataList = getSectionActivityDataList(sab.getSelectedUser());
         bs = new BeanSort(dataList, "assessmentName");
         dataList = (ArrayList)bs.sort();
         sab.setSectionActivityDataList(dataList);
@@ -234,6 +222,7 @@ implements ActionListener, ValueChangeListener
         private Double total;
         private Long assessmentGradingId;
         private boolean notAvailableGrade;
+        private boolean anonymousGrading;
 
         public Long getAssessmentId() {
             return assessmentId;
@@ -283,6 +272,12 @@ implements ActionListener, ValueChangeListener
         }
         public void setNotAvailableGrade(boolean notAvailableGrade) {
             this.notAvailableGrade = notAvailableGrade;
+        }
+        public boolean isAnonymousGrading() {
+            return anonymousGrading;
+        }
+        public void setAnonymousGrading(boolean anonymousGrading) {
+            this.anonymousGrading = anonymousGrading;
         }
 
         //This is borrowed from Total Score page for grade display. We'd like to keep consistent for displaying the grade in all pages.

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResultFromSectionActivity.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResultFromSectionActivity.jsp
@@ -248,7 +248,7 @@ document.location='../evaluation/gradeStudentResult';
 <h:inputHidden value="#{author.currentFormTime}" />
 
 <h:outputLink id="createEmail1" onclick="clickEmailLink(this, \"#{totalScores.graderName}\", '#{totalScores.graderEmailInfo}', \"#{studentScores.firstName} #{studentScores.lastName}\", '#{studentScores.email}', '#{totalScores.assessmentName}');" value="#"> 
-  <h:outputText value="  #{evaluationMessages.email} #{studentScores.firstName}" rendered="#{studentScores.email != null && studentScores.email != '' && email.fromEmailAddress != null && email.fromEmailAddress != ''}" />
+  <h:outputText value="  #{evaluationMessages.email} #{studentScores.firstName}" rendered="#{totalScores.anonymous eq 'false' && studentScores.email != null && studentScores.email != '' && email.fromEmailAddress != null && email.fromEmailAddress != ''}" />
 </h:outputLink>
 
 <h:commandLink id="hiddenlink1" value="" action="studentScores">

--- a/samigo/samigo-app/src/webapp/jsf/section-activity/sectionActivity.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/section-activity/sectionActivity.jsp
@@ -8,7 +8,8 @@
   <f:view>
     <html xmlns="http://www.w3.org/1999/xhtml">
       <head><%= request.getAttribute("html.head") %>
-      <title><h:outputText value="User Activity Report"/></title>
+      <title><h:outputText value="#{sectionActivityMessages.section_activity_report}"/></title>
+      <script type="text/javascript" language="JavaScript" src="/samigo-app/js/eventInfo.js"></script>
       <samigo:stylesheet path="/css/tool_sam.css"/>
       </head>
     <body onload="<%= request.getAttribute("html.body.onload") %>">
@@ -51,7 +52,7 @@
         <f:param name="sortAscending" value="true"/>
         </h:commandLink>
      </f:facet>
-     <h:panelGroup>	 
+     <h:panelGroup rendered="#{!pageData.anonymousGrading}">
 		<h:commandLink title ="#{sectionActivityMessages.assessment_name}" action="gradeStudentResultFromSectionActivity" immediate="true" >
 		  <h:outputText value="#{pageData.assessmentName}"/>
 		   <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.ResetTotalScoreListener" />
@@ -61,7 +62,16 @@
         	  <f:param name="studentid" value="#{sectionActivity.selectedUser}" />
        		  <f:param name="publishedIdd" value="#{pageData.assessmentId}" />
       		  <f:param name="gradingData" value="#{pageData.assessmentGradingId}" />	
-	    </h:commandLink>	
+	    </h:commandLink>
+     </h:panelGroup>
+     <h:panelGroup rendered="#{pageData.anonymousGrading}">
+         <h:outputText value="#{pageData.assessmentName}"/>
+         <f:verbatim><span class="info"></f:verbatim>
+            <h:graphicImage url="/images/info_icon.gif" alt="" styleClass="infoDiv"/>
+            <h:panelGroup styleClass="makeLogInfo" style="display:none;z-index:2000;" >
+                <h:outputText value="#{sectionActivityMessages.anon_grading_info}"/>
+            </h:panelGroup>
+        <f:verbatim></span></f:verbatim>
      </h:panelGroup>
      </h:column>
      
@@ -75,7 +85,7 @@
              type="org.sakaiproject.tool.assessment.ui.listener.author.SectionActivityListener" />
           </h:commandLink>    
       </f:facet>
-      <h:panelGroup>	 
+      <h:panelGroup rendered="#{!pageData.anonymousGrading}">
 		<h:commandLink title ="#{sectionActivityMessages.assessment_name}" action="gradeStudentResultFromSectionActivity" immediate="true" >
 		  <h:outputText value="#{pageData.assessmentName}"/>
 		   <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.ResetTotalScoreListener" />
@@ -86,6 +96,15 @@
        		  <f:param name="publishedIdd" value="#{pageData.assessmentId}" />
       		  <f:param name="gradingData" value="#{pageData.assessmentGradingId}" />	
 	    </h:commandLink>	
+     </h:panelGroup>
+     <h:panelGroup rendered="#{pageData.anonymousGrading}">
+         <h:outputText value="#{pageData.assessmentName}"/>
+         <f:verbatim><span class="info"></f:verbatim>
+            <h:graphicImage url="/images/info_icon.gif" alt="" styleClass="infoDiv"/>
+            <h:panelGroup styleClass="makeLogInfo" style="display:none;z-index:2000;" >
+                <h:outputText value="#{sectionActivityMessages.anon_grading_info}"/>
+            </h:panelGroup>
+        <f:verbatim></span></f:verbatim>
      </h:panelGroup>
     </h:column>
     
@@ -99,7 +118,7 @@
              type="org.sakaiproject.tool.assessment.ui.listener.author.SectionActivityListener" />
       </h:commandLink> 
       </f:facet>
-	 <h:panelGroup>	 
+	 <h:panelGroup rendered="#{!pageData.anonymousGrading}">
 		<h:commandLink title ="#{sectionActivityMessages.assessment_name}" action="gradeStudentResultFromSectionActivity" immediate="true" >
 		  <h:outputText value="#{pageData.assessmentName}"/>
 		   <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.ResetTotalScoreListener" />
@@ -110,6 +129,15 @@
        		  <f:param name="publishedIdd" value="#{pageData.assessmentId}" />
       		  <f:param name="gradingData" value="#{pageData.assessmentGradingId}" />	
 	    </h:commandLink>	
+     </h:panelGroup>
+     <h:panelGroup rendered="#{pageData.anonymousGrading}">
+         <h:outputText value="#{pageData.assessmentName}"/>
+         <f:verbatim><span class="info"></f:verbatim>
+            <h:graphicImage url="/images/info_icon.gif" alt="" styleClass="infoDiv"/>
+            <h:panelGroup styleClass="makeLogInfo" style="display:none;z-index:2000;" >
+                <h:outputText value="#{sectionActivityMessages.anon_grading_info}"/>
+            </h:panelGroup>
+        <f:verbatim></span></f:verbatim>
      </h:panelGroup>
 	</h:column>
 	<!-- Assessment ID... -->

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/SectionAwareServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/SectionAwareServiceHelperImpl.java
@@ -74,24 +74,23 @@ public class SectionAwareServiceHelperImpl extends AbstractSectionsImpl implemen
 
 	/**
 	 */
-	public List getAvailableEnrollments(String siteid, String userUid) {
-		List enrollments;
+	public List<EnrollmentRecord> getAvailableEnrollments(String siteid, String userUid) {
+		List<EnrollmentRecord> enrollments;
 		if ("-1".equals(userUid) || isUserAbleToGradeAll(siteid, userUid)) {
 			enrollments = getSectionAwareness().getSiteMembersInRole(siteid, Role.STUDENT);
 		} else {
 			// We use a map because we may have duplicate students among the section
 			// participation records.
-			Map enrollmentMap = new HashMap();
-			List sections = getAvailableSections(siteid, userUid);
-			for (Iterator iter = sections.iterator(); iter.hasNext(); ) {
-				CourseSection section = (CourseSection)iter.next();
+			Map<String, EnrollmentRecord> enrollmentMap = new HashMap();
+			List<CourseSection> sections = getAvailableSections(siteid, userUid);
+			for (CourseSection section : sections) {
 				List sectionEnrollments = getSectionEnrollmentsTrusted(section.getUuid(), userUid);
 				for (Iterator eIter = sectionEnrollments.iterator(); eIter.hasNext(); ) {
 					EnrollmentRecord enr = (EnrollmentRecord)eIter.next();
 					enrollmentMap.put(enr.getUser().getUserUid(), enr);
 				}
 			}
-			enrollments = new ArrayList(enrollmentMap.values());
+			enrollments = new ArrayList<>(enrollmentMap.values());
 		}
 		return enrollments;
 	}
@@ -100,12 +99,12 @@ public class SectionAwareServiceHelperImpl extends AbstractSectionsImpl implemen
 		List availEnrollments = getAvailableEnrollments(siteid, userUid);
 		List enrollments = new ArrayList();
 
-		HashSet<String> membersInReleaseGroups = new HashSet<String>(0);
+		HashSet<String> membersInReleaseGroups = new HashSet<>(0);
 		try {
 		    List releaseGroupIds = PersistenceService.getInstance().getPublishedAssessmentFacadeQueries().getReleaseToGroupIdsForPublishedAssessment(publishedAssessmentId);
-		    Set<String> releaseGroupIdsSet = new HashSet<String>(releaseGroupIds);
-		    Site site = siteService.getInstance().getSite(siteid); // this follows the way the service is already written but it is a bad practice
-			membersInReleaseGroups = new HashSet<String>( site.getMembersInGroups(releaseGroupIdsSet) );
+		    Set<String> releaseGroupIdsSet = new HashSet<>(releaseGroupIds);
+		    Site site = SiteService.getInstance().getSite(siteid); // this follows the way the service is already written but it is a bad practice
+			membersInReleaseGroups = new HashSet<>( site.getMembersInGroups(releaseGroupIdsSet) );
 		} catch (IdUnusedException ex) {
 			// no site found, just log a warning
 		    log.warn("Unable to find a site with id ("+siteid+") in order to get the enrollments, will return 0 enrollments");
@@ -130,7 +129,7 @@ public class SectionAwareServiceHelperImpl extends AbstractSectionsImpl implemen
 		//String functionName="assessment.takeAssessment";
 		Collection siteGroups = null;
 		try {
-			siteGroups = siteService.getSite(siteId).getGroupsWithMember(userId);
+			siteGroups = SiteService.getSite(siteId).getGroupsWithMember(userId);
 		}
 		catch (IdUnusedException ex) {
 			// no site found
@@ -157,9 +156,9 @@ public class SectionAwareServiceHelperImpl extends AbstractSectionsImpl implemen
 	}
 	
 	
-	public List getAvailableSections(String siteid, String userUid) {
+	public List<CourseSection> getAvailableSections(String siteid, String userUid) {
 
-		List availableSections = new ArrayList();
+		List<CourseSection> availableSections = new ArrayList<>();
 
 		SectionAwareness sectionAwareness = getSectionAwareness();
 		if (sectionAwareness ==null) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
@@ -21,11 +21,9 @@ package org.sakaiproject.tool.assessment.services.assessment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentAccessControl;
@@ -726,7 +724,7 @@ public class PublishedAssessmentService extends AssessmentService{
 	   getBasicInfoOfLastOrHighestOrAverageSubmittedAssessmentsByScoringOption(agentId, siteId, allAssessments);
    }
 
-	public List getAllAssessmentsGradingDataByAgentAndSiteId(String agentId, String siteId) {
+	public List<AssessmentGradingData> getAllAssessmentsGradingDataByAgentAndSiteId(String agentId, String siteId) {
 		return PersistenceService.getInstance().getPublishedAssessmentFacadeQueries()
 				.getAllAssessmentsGradingDataByAgentAndSiteId(agentId, siteId);
 	}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradingSectionAwareServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/grading/GradingSectionAwareServiceImpl.java
@@ -23,6 +23,7 @@
 package org.sakaiproject.tool.assessment.shared.impl.grading;
 
 import java.util.List;
+import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
 
 import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.SectionAwareServiceHelper;
@@ -68,7 +69,7 @@ public class GradingSectionAwareServiceImpl implements GradingSectionAwareServic
   *      an EnrollmentRecord list for each student that the current user
   *  is allowed to grade.
   */
-  public List getAvailableEnrollments(String Uid, String userUid){
+  public List<EnrollmentRecord> getAvailableEnrollments(String Uid, String userUid){
     return helper.getAvailableEnrollments(Uid, userUid);
   }
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3242

The 'User Activity Report' allows the instructor/maintainer to view submissions by user, and provides a link to the user's submission to facilitate grading and commenting. In the context of an anonymously graded assessment, this link allows the instructor/maintainer to circumvent the anonymity feature.

Steps to reproduce:

1) Create and publish an assessment that is graded anonymously
2) Take the assessment as a student/access member
3) As instructor/maintainer, view 'User Activity Report' for the user you took the assessment as in step 2)
4) Click the link to take you to the user's submission for the anonymously graded assessment
5) You can now grade/comment on the 'anonymous' submission, but you know exactly who's submission it is

A solution to this problem is not to render anonymous submissions as a link in the 'User Activity Report' UI, but rather as plain text. There is also an icon beside the plain text name that on hover, produces a tool tip with an explanation of why there is no link for the submission: "This assessment is graded anonymously".