### PR TITLE
SAM-3244: samigo event name refactor/standardization causing NPE on assessment submission

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -42,6 +42,7 @@ public final class SamigoConstants {
      */
     // Submission events
     public static final     String      EVENT_ASSESSMENT_SUBMITTED                          = "sam.assessment.submit";
+    public static final     String      EVENT_ASSESSMENT_SUBMITTED_NOTI                     = "sam.assessment.submit.noti";
     public static final     String      EVENT_ASSESSMENT_SUBMITTED_CHECKED                  = "sam.assessment.submit.checked";
     public static final     String      EVENT_ASSESSMENT_SUBMITTED_CLICKSUB                 = "sam.assessment.submit.click_sub";
     public static final     String      EVENT_ASSESSMENT_SUBMITTED_AUTO                     = "sam.assessment.submit.auto";

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -1697,7 +1697,7 @@ public class DeliveryBean
                                                           .collect(Collectors.joining(";")));
       }	  
 
-	  EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED, notificationValues.toString(), AgentFacade.getCurrentSiteId(), true, SamigoConstants.NOTI_EVENT_ASSESSMENT_SUBMITTED));
+	  EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED_NOTI, notificationValues.toString(), AgentFacade.getCurrentSiteId(), true, SamigoConstants.NOTI_EVENT_ASSESSMENT_SUBMITTED));
  
 	  return returnValue;
 	  }
@@ -3753,7 +3753,7 @@ public class DeliveryBean
 
 		  // We get the id of the question
 		  String radioId = (String) FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("radioId");
-		  StringBuffer redrawAnchorName = new StringBuffer("p");
+		  StringBuilder redrawAnchorName = new StringBuilder("p");
 		  String tmpAnchorName = "";
 		  List parts = this.pageContents.getPartsContents();
 

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoObserver.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoObserver.java
@@ -29,15 +29,15 @@ import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.samigo.util.SamigoConstants;
 
 public class SamigoObserver implements Observer {
-    private static final Logger log = LoggerFactory.getLogger(SamigoObserver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SamigoObserver.class);
 
     public void init() {
-        log.info("init()");
+        LOG.info("init()");
         eventTrackingService.addLocalObserver(this);
     }
 
     public void destroy(){
-        log.info("destroy");
+        LOG.info("destroy");
         eventTrackingService.deleteObserver(this);
     }
 
@@ -49,18 +49,18 @@ public class SamigoObserver implements Observer {
         Event event = (Event) arg;
         String eventType = event.getEvent();
 
-        if(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED.equals(eventType)) {
-            log.debug("Assessment Submitted Event");
+        if(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED_NOTI.equals(eventType)) {
+            LOG.debug("Assessment Submitted Event");
             String hashMapString = event.getResource();
             Map<String, Object> notiValues =  stringToHashMap(hashMapString);
             samigoETSProvider.notify(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED, notiValues, event);
         } else if(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED_AUTO.equals(eventType)){
-            log.debug("Assessment Auto Submitted Event");
+            LOG.debug("Assessment Auto Submitted Event");
             String hashMapString = event.getResource();
             Map<String, Object> notiValues =  stringToHashMap(hashMapString);
             samigoETSProvider.notify(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED_AUTO, notiValues, event);
         } else if(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED_TIMER_THREAD.equals(eventType)){
-            log.debug("Assessment Timed Submitted Event");
+            LOG.debug("Assessment Timed Submitted Event");
             String hashMapString = event.getResource();
             Map<String, Object> notiValues = stringToHashMap(hashMapString);
             samigoETSProvider.notify(SamigoConstants.EVENT_ASSESSMENT_SUBMITTED_TIMER_THREAD, notiValues, event);
@@ -72,7 +72,7 @@ public class SamigoObserver implements Observer {
      * Derived from http://stackoverflow.com/a/26486046
      */
     private Map<String, Object> stringToHashMap(String hashMapString){
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
 
         hashMapString = StringUtils.substringBetween(hashMapString, "{", "}");           //remove curly brackets
         String[] keyValuePairs = hashMapString.split(",");              //split the string to create key-value pairs


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3244

Stack trace and steps to reproduce in the JIRA.

In SAM-3012 / SAM-2669, the event names utilized in Samigo were refactored in an effort to standardize the format. This caused an unintended NPE being generated in the logs because there is a listener (SamigoObserver.java) that's listening for three specific events that happen on submission of an assessment. This listener is responsible for unpacking the relevant data from the Event, and passing it off to SamigoETSProviderImpl.java to facilitate email notifications.

The problem is that originally, SamigoObserver was listening for "sam.assessmentSubmitted" (as well as two others that aren't relevant for this ticket). This event was only fired in one specific place, which guaranteed that the necessary data would be packed into the Event's resource attribute.

However, in SAM-3012 / SAM-2669, "sam.assessmentSubmitted" was removed in favour of the previously existing "sam.assessment.submit". This historical event is generated in another place as well; so now SamigoObserver is being triggered for "sam.assessment.submit" events that it was originally not intended to listen for. It tries to parse out the data it needs from the Event's resource attribute and NPEs in the stringToHashMap() method.

We can't just NPE-proof SamigoObserver.stringToHashMap() because it then will just blow up in SamigoETSProviderImpl when it goes to retrieve values in the HashMap it expects to be there.

The solution is to create a new (standardized format) event for the one specific place that was previously firing the "sam.assessmentSubmitted" event, and also change SamigoListener to listen for this new event rather than the generic "sam.assessment.submit" event.