### PR TITLE
SAM-3243: Total Scores: comment field disabled for student submissions, submit date column blank

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
@@ -58,7 +58,7 @@ public class AgentResults
 	 * 
 	 */
 	private static final long serialVersionUID = 2820488402465439395L;
-	private static Logger log = LoggerFactory.getLogger(AgentResults.class);
+	private static final Logger LOG = LoggerFactory.getLogger(AgentResults.class);
 	
   private Long assessmentGradingId;
   private Long itemGradingId;
@@ -90,7 +90,7 @@ public class AgentResults
   private List itemGradingArrayList;
   private String rationale="";
   private boolean retakeAllowed;
-  private boolean isAutoSubmitted;
+  private Boolean isAutoSubmitted;
   private boolean isAttemptDateAfterDueDate;
   private ItemGradingData itemGrading;
   private AssessmentGradingData assessmentGrading;
@@ -404,11 +404,11 @@ public class AgentResults
 		this.retakeAllowed = retakeAllowed;
 	}
 	
-	public boolean getIsAutoSubmitted() {
+	public Boolean getIsAutoSubmitted() {
 		return this.isAutoSubmitted;
 	}
 	
-	public void setIsAutoSubmitted(boolean isAutoSubmitted) {
+	public void setIsAutoSubmitted(Boolean isAutoSubmitted) {
 		this.isAutoSubmitted = isAutoSubmitted;
 	}
 	
@@ -459,7 +459,7 @@ public class AgentResults
 			  context.redirect("sakai.filepicker.helper/tool");
 		  }
 		  catch(Exception e){
-			  log.error("fail to redirect to attachment page: " + e.getMessage());
+			  LOG.error("fail to redirect to attachment page: " + e.getMessage());
 		  }
 		  return "sakai.filepicker.helper";
 	  }
@@ -503,7 +503,7 @@ public class AgentResults
 			  context.redirect("sakai.filepicker.helper/tool");
 		  }
 		  catch(Exception e){
-			  log.error("fail to redirect to attachment page: " + e.getMessage());
+			  LOG.error("fail to redirect to attachment page: " + e.getMessage());
 		  }
 		  return "sakai.filepicker.helper";
 	  }
@@ -518,9 +518,9 @@ public class AgentResults
 	
 	public String getFormatedTimeElapsed() {
 	    String timeElapsedInString = "n/a";
-	    if (this.timeElapsed!=null && this.timeElapsed.intValue() >0)
+	    if (this.timeElapsed!=null && this.timeElapsed >0)
 	    {
-	      int totalSec = this.timeElapsed.intValue();
+	      int totalSec = this.timeElapsed;
 	      int hr = totalSec / 3600;
 	      int min = (totalSec % 3600)/60;
 	      int sec = (totalSec % 3600)%60;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3243

Steps to reproduce:

1) create and publish a quiz that's set to push scores/comments to the gradebook
2) submit to the quiz as student/access member
3) as instructor/maintainer go to Total Scores (scores) for the assessment
4) find the row in the table for the student/access member you took the quiz with
5) notice there is a submission, with a grade, but the comment box is disabled and has the placeholder text "Requires student submission", and the "Submitted Date" column is blank

You'll notice the following warning in the logs:

> WARN [http-nio-8450-exec-20] org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreListener.prepareAgentResult Cannot invoke org.sakaiproject.tool.assessment.ui.bean.evaluation.AgentResults.setIsAutoSubmitted on bean class 'class org.sakaiproject.tool.assessment.ui.bean.evaluation.AgentResults' - null - had objects of type "<null>" but expected signature "boolean"

This warning is being generated from TotalScoresListener.prepareAgentResult() @ lines 598-603:

```
      try{
        BeanUtils.copyProperties(results, gdata);
      }
      catch(Exception e){
        log.warn(e.getMessage());
      }
```

BeanUtils is throwing an IllegalArgumentException because AgentResults.isAutoSubmitted is a primative boolean, white AssessmentGradingData.isAutoSubmitted is a Boolean object. So BeanUtils.copyProperties() blows up and fails to copy over all of the properties of the source object (AssessmentGradingData).

This results in the AgentResult objects not having values populated for attemptedDate and submittedDate. The presence of these values is what determines if the Total Scores' column has a value for the "Submit Date" column, and whether or not the user gets an editable/enabled text field for the comments.

Changing AgentResult.isAutoSubmitted from boolean to Boolean resolves this issue. I'm not aware of how/when this regressed, as it's not an issue in 11.x or prior versions.