### PR TITLE
SAM-3246: Individual user-level comments aren't sync'd to the Gradebook

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreUpdateListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreUpdateListener.java
@@ -88,10 +88,10 @@ public class StudentScoreUpdateListener
     AbortProcessingException
   {
     log.debug("Student Score Update LISTENER.");
-    StudentScoresBean bean = (StudentScoresBean) cu.lookupBean("studentScores");
-    TotalScoresBean tbean = (TotalScoresBean) cu.lookupBean("totalScores");
+    StudentScoresBean bean = (StudentScoresBean) ContextUtil.lookupBean("studentScores");
+    TotalScoresBean tbean = (TotalScoresBean) ContextUtil.lookupBean("totalScores");
     tbean.setAssessmentGradingHash(tbean.getPublishedAssessment().getPublishedAssessmentId());
-    DeliveryBean delivery = (DeliveryBean) cu.lookupBean("delivery");
+    DeliveryBean delivery = (DeliveryBean) ContextUtil.lookupBean("delivery");
     log.debug("Calling saveStudentScores.");
     try {
       if (!saveStudentScores(bean, tbean, delivery))
@@ -100,7 +100,7 @@ public class StudentScoreUpdateListener
       }
     } catch (GradebookServiceException ge) {
        FacesContext context = FacesContext.getCurrentInstance();
-       String err=(String)cu.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AuthorMessages", "gradebook_exception_error");
+       String err=(String)ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AuthorMessages", "gradebook_exception_error");
        context.addMessage(null, new FacesMessage(err));
 
     }
@@ -157,10 +157,8 @@ public class StudentScoreUpdateListener
           
           log.debug("****3a Gradingarray length2 = " + gradingarray.size());
           log.debug("****3b set points = " + question.getExactPoints() + ", comments to " + question.getGradingComment());
-          Iterator iter3 = gradingarray.iterator();
-          while (iter3.hasNext())
+          for (ItemGradingData data : gradingarray)
           {
-            ItemGradingData data = (ItemGradingData) iter3.next();
             if (adata == null && data.getAssessmentGradingId() != null){
               adata = delegate.load(data.getAssessmentGradingId().toString());
             }
@@ -181,7 +179,7 @@ public class StudentScoreUpdateListener
             }
             double oldAutoScore = 0;
             if (data.getAutoScore() !=null) {
-              oldAutoScore=data.getAutoScore().doubleValue();
+              oldAutoScore=data.getAutoScore();
             }
             String newComments = TextFormat.convertPlaintextToFormattedTextNoHighUnicode(log, question.getGradingComment());
             if (newComments != null) {
@@ -201,14 +199,14 @@ public class StudentScoreUpdateListener
             // if newAutoScore != oldAutoScore then updateScore = true
             boolean updateScore = !(Precision.equalsIncludingNaN(newAutoScore, oldAutoScore, 0.0001));
             boolean updateComments = !newComments.equals(oldComments);
-            StringBuffer logString = new StringBuffer();
+            StringBuilder logString = new StringBuilder();
             logString.append("gradedBy=");
             logString.append(AgentFacade.getAgentString());
             logString.append(", itemGradingId=");
             logString.append(data.getItemGradingId());
             
             if (updateScore) {
-              data.setAutoScore(Double.valueOf(newAutoScore));
+              data.setAutoScore(newAutoScore);
               logString.append(", newAutoScore=");
               logString.append(newAutoScore);
               logString.append(", oldAutoScore=");
@@ -238,7 +236,7 @@ public class StudentScoreUpdateListener
         if (adata==null){
           // this is for cases when studnet submitted an assessment but skipped all teh questions
           // when we won't be able to get teh assessmentGrading based on itemGrdaing ('cos there is none).
-          String assessmentGradingId = cu.lookupParam("gradingData");
+          String assessmentGradingId = ContextUtil.lookupParam("gradingData");
           adata = delegate.load(assessmentGradingId);
         }
         adata.setItemGradingSet(itemGradingSet);
@@ -262,7 +260,7 @@ public class StudentScoreUpdateListener
     	  oldComments = "";
       }
 
-      StringBuffer logString = new StringBuffer();
+      StringBuilder logString = new StringBuilder();
       logString.append("gradedBy=");
       logString.append(AgentFacade.getAgentString());
       logString.append(", assessmentGradingId=");
@@ -288,13 +286,13 @@ public class StudentScoreUpdateListener
 
     } catch (GradebookServiceException ge) {
        FacesContext context = FacesContext.getCurrentInstance();
-       String err=(String)cu.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AuthorMessages", "gradebook_exception_error");
+       String err=(String)ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AuthorMessages", "gradebook_exception_error");
        context.addMessage(null, new FacesMessage(err));
 
     }
     catch (Exception e)
     {
-      e.printStackTrace();
+      log.warn("Error saving scores", e);
       return false;
     }
     return true;
@@ -318,7 +316,7 @@ public class StudentScoreUpdateListener
     				ItemGradingData itemGradingData = iter3.next();
     				List oldList = itemGradingData.getItemGradingAttachmentList();
     				List newList = question.getItemGradingAttachmentList();
-    				if ((oldList == null || oldList.size() == 0 ) && (newList == null || newList.size() == 0)) {
+    				if ((oldList == null || oldList.isEmpty() ) && (newList == null || newList.isEmpty())) {
     					continue;
     				}
     				

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreUpdateListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreUpdateListener.java
@@ -279,7 +279,7 @@ public class StudentScoreUpdateListener
       }
 
       if (updateFlag) {
-    	  delegate.updateAssessmentGradingScore(adata, tbean.getPublishedAssessment());
+    	  delegate.updateAssessmentGradingScore(adata, tbean.getPublishedAssessment(), newComments, oldComments);
     	  eventTrackingService.post(eventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE, logString.toString(), AgentFacade.getCurrentSiteId(), true, NotificationService.NOTI_OPTIONAL, SamigoLRSStatements.getStatementForStudentScoreUpdate(adata, tbean.getPublishedAssessment())));
       }
       log.debug("Saved student scores.");

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -27,6 +27,7 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -253,7 +254,7 @@ public class GradingService
   {
       //log.debug("**** GradingService: saveTotalScores");
     try {
-     AssessmentGradingData gdata = null;
+     AssessmentGradingData gdata;
       if (gdataList.size()>0)
         gdata = (AssessmentGradingData) gdataList.get(0);
       else return;
@@ -296,7 +297,7 @@ public class GradingService
 
   public void notifyDeleteToGradebook(List gdataList, PublishedAssessmentIfc pub, String studentId){
     try {
-      AssessmentGradingData gdata = null;
+      AssessmentGradingData gdata;
       if (gdataList.size()>0) {
         gdata = (AssessmentGradingData) gdataList.get(0);
       } 
@@ -317,7 +318,7 @@ public class GradingService
       
       //When there is no more submission left for this student, update
       //this student's grade on gradebook as null(the initial state).
-      if(l.size() == 0)
+      if(l.isEmpty())
     	  l.add(gdata);
 
       notifyGradebook(l, pub);
@@ -365,7 +366,7 @@ public class GradingService
 
   public List getAssessmentGradingsByScoringType(
        Integer scoringType, Long publishedAssessmentId){
-    List l = null;
+    List l;
     // get the list of highest score
     if ((scoringType).equals(EvaluationModelIfc.HIGHEST_SCORE)){
       l = getHighestSubmittedOrGradedAssessmentGradingList(publishedAssessmentId);
@@ -794,7 +795,7 @@ public class GradingService
       Set itemGradingSet = adata.getItemGradingSet();
       Iterator iter = itemGradingSet.iterator();
       double totalAutoScore = 0;
-      double totalOverrideScore = adata.getTotalOverrideScore().doubleValue();
+      double totalOverrideScore = adata.getTotalOverrideScore();
       while (iter.hasNext()){
         ItemGradingData i = (ItemGradingData)iter.next();
         if (i.getItemGradingId().equals(gdata.getItemGradingId())){
@@ -804,14 +805,14 @@ public class GradingService
           i.setGradedDate(new Date());
 	}
         if (i.getAutoScore()!=null)
-          totalAutoScore += i.getAutoScore().doubleValue();
+          totalAutoScore += i.getAutoScore();
       }
       
-      adata.setTotalAutoScore( Double.valueOf(totalAutoScore));
-      if (Double.compare((totalAutoScore+totalOverrideScore),Double.valueOf("0").doubleValue())<0){
+      adata.setTotalAutoScore(totalAutoScore);
+      if (Double.compare((totalAutoScore+totalOverrideScore),Double.valueOf("0"))<0){
     	  adata.setFinalScore(Double.valueOf("0"));
       }else{
-    	  adata.setFinalScore(Double.valueOf(totalAutoScore+totalOverrideScore));
+    	  adata.setFinalScore(totalAutoScore+totalOverrideScore);
       }
       saveOrUpdateAssessmentGrading(adata);
       if (scoreDifference != 0){
@@ -879,10 +880,10 @@ public class GradingService
       // calculate scores for new ones)
       Set<ItemGradingData> itemGradingSet = data.getItemGradingSet();
       if (itemGradingSet == null)
-        itemGradingSet = new HashSet<ItemGradingData>();
+        itemGradingSet = new HashSet<>();
       log.debug("****itemGrading size="+itemGradingSet.size());
       
-      List<ItemGradingData> tempItemGradinglist = new ArrayList<ItemGradingData>(itemGradingSet);
+      List<ItemGradingData> tempItemGradinglist = new ArrayList<>(itemGradingSet);
       
       // CALCULATED_QUESTION - if this is a calc question. Carefully sort the list of answers
       if (isCalcQuestion(tempItemGradinglist, publishedItemHash)) {
@@ -913,12 +914,12 @@ public class GradingService
       // For EMI: This keeps track of how many answers were given so we don't give
       // extra marks for to many answers.
       Map fibEmiAnswersMap = new HashMap();
-      Map<Long, Map<Long,Set<EMIScore>>> emiScoresMap = new HashMap<Long, Map<Long,Set<EMIScore>>>();
+      Map<Long, Map<Long,Set<EMIScore>>> emiScoresMap = new HashMap<>();
       
       //change algorithm based on each question (SAK-1930 & IM271559) -cwen
       Map totalItems = new HashMap();
       log.debug("****x2. {}", (new Date()).getTime());
-      double autoScore = (double) 0;
+      double autoScore;
       Long itemId = (long)0;
       int calcQuestionAnswerSequence = 1; // sequence of answers for CALCULATED_QUESTION
       while(iter.hasNext())
@@ -941,10 +942,8 @@ public class GradingService
         	log.error("unable to retrive itemDataIfc for: {}", publishedItemHash.get(itemId));
         	continue;
         }
-        Iterator i = item.getItemMetaDataSet().iterator();
-        while (i.hasNext())
+        for (ItemMetaDataIfc meta : item.getItemMetaDataSet())
         {
-          ItemMetaDataIfc meta = (ItemMetaDataIfc) i.next();
           if (meta.getLabel().equals(ItemMetaDataIfc.REQUIRE_ALL_OK))
           {
             if (meta.getEntry().equals("true"))
@@ -960,7 +959,6 @@ public class GradingService
           }
         }
         Long itemType = item.getTypeId();  
-    	autoScore = (double) 0;
         itemGrading.setAssessmentGradingId(data.getAssessmentGradingId());
         //itemGrading.setSubmittedDate(new Date());
         itemGrading.setAgentId(agent);
@@ -1001,12 +999,12 @@ public class GradingService
         
         log.debug("**!regrade, autoScore="+autoScore);
         if (!(TypeIfc.MULTIPLE_CORRECT).equals(itemType) && !(TypeIfc.EXTENDED_MATCHING_ITEMS).equals(itemType))
-          totalItems.put(itemId, Double.valueOf(autoScore));
+          totalItems.put(itemId, autoScore);
         
         if (regrade && TypeIfc.AUDIO_RECORDING.equals(itemType))
         	itemGrading.setAttemptsRemaining(item.getTriesAllowed());
 	
-        itemGrading.setAutoScore(Double.valueOf(autoScore));
+        itemGrading.setAutoScore(autoScore);
       }
 
       if ((invalidFINMap != null && invalidFINMap.size() > 0) || (invalidSALengthList != null && invalidSALengthList.size() > 0)) {
@@ -1023,22 +1021,22 @@ public class GradingService
       
       log.debug("****x3. {}", (new Date()).getTime());
       
-      List<ItemGradingData> emiItemGradings = new ArrayList<ItemGradingData>();
+      List<ItemGradingData> emiItemGradings = new ArrayList<>();
       // the following procedure ensure total score awarded per question is no less than 0
       // this probably only applies to MCMR question type - daisyf
       iter = itemGradingSet.iterator();
       //since the itr goes through each answer (multiple answers for a signle mc question), keep track
       //of its total score by itemId -> autoScore[]{user's score, total possible}
-      Map<Long, Double[]> mcmcAllOrNothingCheck = new HashMap<Long, Double[]>();
+      Map<Long, Double[]> mcmcAllOrNothingCheck = new HashMap<>();
       
       //collect min score information to determine if the auto score will need to be adjusted
       //since there can be multiple questions store in map: itemId -> {user's score, minScore, # of answers}
-      Map<Long, Double[]> minScoreCheck = new HashMap<Long, Double[]>();
+      Map<Long, Double[]> minScoreCheck = new HashMap<>();
       double totalAutoScoreCheck = 0;
-      Map<Long, Integer> countMcmcAllItemGradings = new HashMap<Long, Integer>();
+      Map<Long, Integer> countMcmcAllItemGradings = new HashMap<>();
       //get item information to check if it's MCMS and Not Partial Credit
-      Long itemType2 = -1l;
-      String mcmsPartialCredit = "";
+      Long itemType2;
+      String mcmsPartialCredit;
       double itemScore = -1;
       while(iter.hasNext())
       {
@@ -1064,7 +1062,7 @@ public class GradingService
         	continue;
         }
 
-        double eachItemScore = ((Double) totalItems.get(itemId)).doubleValue();
+        double eachItemScore = ((Double) totalItems.get(itemId));
         if((eachItemScore < 0) && !((TypeIfc.MULTIPLE_CHOICE).equals(itemType2)||(TypeIfc.TRUE_FALSE).equals(itemType2)||(TypeIfc.MULTIPLE_CORRECT_SINGLE_SELECTION).equals(itemType2)))
         {
         	itemGrading.setAutoScore( Double.valueOf(0));
@@ -1079,12 +1077,12 @@ public class GradingService
         	mcmcAllOrNothingCheck.put(itemId, new Double[]{accumulatedScore, item.getScore()});
         	int count = 0;
         	if(countMcmcAllItemGradings.containsKey(itemId))
-        		count = ((Integer)countMcmcAllItemGradings.get(itemId)).intValue();
-        	countMcmcAllItemGradings.put(itemId, new Integer(++count));
+        		count = (countMcmcAllItemGradings.get(itemId));
+        	countMcmcAllItemGradings.put(itemId, ++count);
         }
         //min score check
         if(item.getMinScore() != null){
-        	Double accumulatedScore = new Double(itemGrading.getAutoScore());
+        	Double accumulatedScore = itemGrading.getAutoScore();
         	Double itemParts = 1d;
         	if(minScoreCheck.containsKey(itemId)){
         		Double[] accumulatedScoreArr = minScoreCheck.get(itemId);
@@ -1103,7 +1101,7 @@ public class GradingService
       // for the grading we only know scores after grading so we need
       // to reset the grading score here to the correct scores
       // this currently only applies to EMI question type
-      if (emiItemGradings != null && !emiItemGradings.isEmpty()) {
+      if (!emiItemGradings.isEmpty()) {
     	  Map<Long, Map<Long, Map<Long, EMIScore>>> emiOrderedScoresMap = reorderEMIScoreMap(emiScoresMap);
     	  iter = emiItemGradings.iterator();
     	  while (iter.hasNext()) {
@@ -1168,10 +1166,10 @@ public class GradingService
       					  	log.error("unable to retrieve itemGrading's counter for: " + itemId2);
       					  	continue;
       				  }	  
-      				  double discount = (Math.abs(answer.getDiscount().doubleValue()) * ((double) -1));
-      				  int count = ((Integer)countMcmcAllItemGradings.get(itemId2)).intValue();
+      				  double discount = (Math.abs(answer.getDiscount()) * ((double) -1));
+      				  int count = (countMcmcAllItemGradings.get(itemId2));
       				  double itemGrDisc = discount/count;
-      				  itemGrading.setAutoScore(Double.valueOf(itemGrDisc));
+      				  itemGrading.setAutoScore(itemGrDisc);
     			  }
     		  }
     	  }
@@ -1188,7 +1186,7 @@ public class GradingService
     		  while(iter.hasNext()){
     			  ItemGradingData itemGrading = (ItemGradingData) iter.next();
     			  if(itemGrading.getPublishedItemId().equals(entry.getKey())){
-    				  itemGrading.setAutoScore(new Double(entry.getValue()[1]/entry.getValue()[2]));
+    				  itemGrading.setAutoScore(entry.getValue()[1]/entry.getValue()[2]);
     			  }
     		  }
     	  }
@@ -1212,13 +1210,13 @@ public class GradingService
       // whole assessment.
       Set fullItemGradingSet = getItemGradingSet(data.getAssessmentGradingId().toString());
       double totalAutoScore = getTotalAutoScore(fullItemGradingSet);
-      data.setTotalAutoScore( Double.valueOf(totalAutoScore));
+      data.setTotalAutoScore(totalAutoScore);
      
       //log.debug("**#1 total AutoScore"+totalAutoScore);
-      if (Double.compare((totalAutoScore + data.getTotalOverrideScore().doubleValue()),new Double("0").doubleValue())<0){
+      if (Double.compare((totalAutoScore + data.getTotalOverrideScore()), new Double("0"))<0){
     	  data.setFinalScore( Double.valueOf("0"));
       }else{
-    	  data.setFinalScore(Double.valueOf(totalAutoScore + data.getTotalOverrideScore().doubleValue()));
+    	  data.setFinalScore(totalAutoScore + data.getTotalOverrideScore());
       }
       log.debug("****x6. "+(new Date()).getTime());
     } catch (GradebookServiceException ge) {
@@ -1262,7 +1260,7 @@ public class GradingService
       ItemGradingData i = (ItemGradingData)iter.next();
       //log.debug(i.getItemGradingId()+"->"+i.getAutoScore());
       if (i.getAutoScore()!=null)
-	totalAutoScore += i.getAutoScore().doubleValue();
+	totalAutoScore += i.getAutoScore();
     }
     return totalAutoScore;
   }
@@ -1284,9 +1282,9 @@ public class GradingService
                                        Map publishedAnswerHash, boolean regrade,
                                        int calcQuestionAnswerSequence) throws FinFormatException {
     //double score = (double) 0;
-    double initScore = (double) 0;
+    double initScore;
     double autoScore = (double) 0;
-    double accumelateScore = (double) 0;
+    double accumelateScore;
     Long itemId = item.getItemId();
     int type = itemType.intValue();
     switch (type){ 
@@ -1298,8 +1296,8 @@ public class GradingService
     	}
     	//overridescore
     	if (itemGrading.getOverrideScore() != null)
-    		autoScore += itemGrading.getOverrideScore().doubleValue();
-    	totalItems.put(itemId, new Double(autoScore));
+    		autoScore += itemGrading.getOverrideScore();
+    	totalItems.put(itemId, autoScore);
     	break;// MC Single Correct
       case 12: // MC Multiple Correct Single Selection    	  
       case 3: // MC Survey
@@ -1307,8 +1305,8 @@ public class GradingService
               autoScore = getAnswerScore(itemGrading, publishedAnswerHash);
               //overridescore
               if (itemGrading.getOverrideScore() != null)
-                autoScore += itemGrading.getOverrideScore().doubleValue();
-	      totalItems.put(itemId,  Double.valueOf(autoScore));
+                autoScore += itemGrading.getOverrideScore();
+	      totalItems.put(itemId, autoScore);
               break;
       case 2: // MC Multiple Correct
               ItemTextIfc itemText = (ItemTextIfc) publishedItemTextHash.get(itemGrading.getPublishedItemTextId());
@@ -1317,7 +1315,7 @@ public class GradingService
               if (answerArray != null){
                 for (int i =0; i<answerArray.size(); i++){
                   AnswerIfc a = (AnswerIfc) answerArray.get(i);
-                  if (a.getIsCorrect().booleanValue())
+                  if (a.getIsCorrect())
                     correctAnswers++;
                 }
               }
@@ -1329,18 +1327,18 @@ public class GradingService
 
               //overridescore?
               if (itemGrading.getOverrideScore() != null)
-                autoScore += itemGrading.getOverrideScore().doubleValue();
+                autoScore += itemGrading.getOverrideScore();
               if (!totalItems.containsKey(itemId)){
-                totalItems.put(itemId,  Double.valueOf(autoScore));
+                totalItems.put(itemId, autoScore);
                 //log.debug("****0. first answer score = "+autoScore);
               }
               else{
-                accumelateScore = ((Double)totalItems.get(itemId)).doubleValue();
+                accumelateScore = ((Double)totalItems.get(itemId));
                 //log.debug("****1. before adding new score = "+accumelateScore);
                 //log.debug("****2. this answer score = "+autoScore);
                 accumelateScore += autoScore;
                 //log.debug("****3. add 1+2 score = "+accumelateScore);
-                totalItems.put(itemId,  Double.valueOf(accumelateScore));
+                totalItems.put(itemId, accumelateScore);
                 //log.debug("****4. what did we put in = "+((Double)totalItems.get(itemId)).doubleValue());
               }
               break;
@@ -1360,14 +1358,14 @@ public class GradingService
               	}
               //overridescore?
               if (itemGrading.getOverrideScore() != null)
-                autoScore += itemGrading.getOverrideScore().doubleValue();
+                autoScore += itemGrading.getOverrideScore();
 
               if (!totalItems.containsKey(itemId))
-                totalItems.put(itemId,  Double.valueOf(autoScore));
+                totalItems.put(itemId, autoScore);
               else {
-                accumelateScore = ((Double)totalItems.get(itemId)).doubleValue();
+                accumelateScore = ((Double)totalItems.get(itemId));
                 accumelateScore += autoScore;
-                totalItems.put(itemId,  Double.valueOf(accumelateScore));
+                totalItems.put(itemId, accumelateScore);
               }
               break;
 
@@ -1375,14 +1373,14 @@ public class GradingService
               autoScore = getFIBScore(itemGrading, fibAnswersMap, item, publishedAnswerHash) / (double) ((ItemTextIfc) item.getItemTextSet().toArray()[0]).getAnswerSet().size();
               //overridescore - cwen
               if (itemGrading.getOverrideScore() != null)
-                autoScore += itemGrading.getOverrideScore().doubleValue();
+                autoScore += itemGrading.getOverrideScore();
 
               if (!totalItems.containsKey(itemId))
-                totalItems.put(itemId, Double.valueOf(autoScore));
+                totalItems.put(itemId, autoScore);
               else {
-                accumelateScore = ((Double)totalItems.get(itemId)).doubleValue();
+                accumelateScore = ((Double)totalItems.get(itemId));
                 accumelateScore += autoScore;
-                totalItems.put(itemId, Double.valueOf(accumelateScore));
+                totalItems.put(itemId, accumelateScore);
               }
               break;
       case 15:  // CALCULATED_QUESTION
@@ -1540,7 +1538,7 @@ public class GradingService
     				data.setFinalScore(data.getFinalScore());
     			} else {
     				Double averageScore = PersistenceService.getInstance().getAssessmentGradingFacadeQueries().
-    				getAverageSubmittedAssessmentGrading(Long.valueOf(pub.getPublishedAssessmentId()), data.getAgentId());
+    				getAverageSubmittedAssessmentGrading(pub.getPublishedAssessmentId(), data.getAgentId());
     				data.setFinalScore(averageScore);
     			}
     		}
@@ -1587,7 +1585,7 @@ public class GradingService
 	  log.warn("retry....");
       retryCount--;
       try {
-    	  int deadlockInterval = PersistenceService.getInstance().getPersistenceHelper().getDeadlockInterval().intValue();
+    	  int deadlockInterval = PersistenceService.getInstance().getPersistenceHelper().getDeadlockInterval();
     	  Thread.sleep(deadlockInterval);
       }
       catch(InterruptedException ex){
@@ -1735,7 +1733,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
             }
 
             if (!alreadyused) {
-              totalScore += ((AnswerIfc) publishedAnswerHash.get(data.getPublishedAnswerId())).getScore().doubleValue();
+              totalScore += ((AnswerIfc) publishedAnswerHash.get(data.getPublishedAnswerId())).getScore();
               data.setIsCorrect(Boolean.TRUE);
             }
 
@@ -1834,7 +1832,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  double totalScore = (double) 0;
 	  boolean matchresult = getFINResult(data, itemdata, publishedAnswerHash);
 	  if (matchresult){
-		  totalScore += ((AnswerIfc) publishedAnswerHash.get(data.getPublishedAnswerId())).getScore().doubleValue();
+		  totalScore += ((AnswerIfc) publishedAnswerHash.get(data.getPublishedAnswerId())).getScore();
 		  data.setIsCorrect(Boolean.TRUE);
 	  }	
 	  return totalScore;
@@ -1848,8 +1846,8 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  boolean matchresult = false;
 	  ComplexFormat complexFormat = new ComplexFormat();
 	  Complex answerComplex = null;
-	  Complex studentAnswerComplex = null;
-	  BigDecimal answerNum = null, answer1Num = null, answer2Num = null, studentAnswerNum = null;
+	  Complex studentAnswerComplex;
+	  BigDecimal answerNum = null, answer1Num = null, answer2Num = null, studentAnswerNum;
 
 	  if (data.getPublishedAnswerId() == null) {
 		  return false;
@@ -1996,7 +1994,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 
   /**
    * Validate a students numeric answer 
-   * @param The answer to validate
+   * @param value answer to validate
    * @return a Map containing either Real or Complex answer keyed by {@link #ANSWER_TYPE_REAL} or {@link #ANSWER_TYPE_COMPLEX} 
    */
   public Map validate(String value) {
@@ -2059,10 +2057,10 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 			Map publishedItemTextHash, Map publishedAnswerHash) {
 
 		log.debug("getEMIScore( " + itemGrading +", " + itemId);
-		double autoScore = 0.0;
+		double autoScore;
 		if (!totalItems.containsKey(itemId)) {
 			totalItems.put(itemId, new HashMap());
-			emiScoresMap.put(itemId, new HashMap<Long, Set<EMIScore>>());
+			emiScoresMap.put(itemId, new HashMap<>());
 		}
 
 		autoScore = getAnswerScore(itemGrading, publishedAnswerHash);
@@ -2082,11 +2080,11 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		// place the answer scores in a sorted set.
 		// so now we can mark the correct ones and discount the extra incorrect
 		// ones.
-		Set<EMIScore> scores = null;
+		Set<EMIScore> scores;
 		if (emiItemScoresMap.containsKey(itemTextId)) {
 			scores = emiItemScoresMap.get(itemTextId);
 		} else {
-			scores = new TreeSet<EMIScore>();
+			scores = new TreeSet<>();
 			emiItemScoresMap.put(itemTextId, scores);
 		}
 		scores.add(new EMIScore(itemId, itemTextId, itemGrading
@@ -2119,10 +2117,10 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 
 		// override score
 		if (itemGrading.getOverrideScore() != null)
-			autoScore += itemGrading.getOverrideScore().doubleValue();
+			autoScore += itemGrading.getOverrideScore();
 
 		Map totalItemTextScores = (Map) totalItems.get(itemId);
-		totalItemTextScores.put(itemTextId, Double.valueOf(autoScore));
+		totalItemTextScores.put(itemTextId, autoScore);
 		return autoScore;
 	}
   /**
@@ -2142,14 +2140,14 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		  return totalScore;
 	  }
 	  // this variable should look something like this "42.1|2,2"
-	  String allAnswerText = calculatedAnswersMap.get(calcQuestionAnswerSequence).toString();
+	  String allAnswerText = calculatedAnswersMap.get(calcQuestionAnswerSequence);
 	  
 	  // NOTE: this correctAnswer will already have been trimmed to the appropriate number of decimals
 	  BigDecimal correctAnswer = new BigDecimal(getAnswerExpression(allAnswerText));
 	  
 	  // Determine if the acceptable variance is a constant or a % of the answer
 	  String varianceString = allAnswerText.substring(allAnswerText.indexOf("|")+1, allAnswerText.indexOf(","));
-	  BigDecimal acceptableVariance = BigDecimal.ZERO;
+	  BigDecimal acceptableVariance;
 	  if (varianceString.contains("%")){
 		  double percentage = Double.valueOf(varianceString.substring(0, varianceString.indexOf("%")));
 		  acceptableVariance = correctAnswer.multiply( new BigDecimal(percentage / 100) );
@@ -2188,14 +2186,14 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		  return result;
 	  }
 	  // this variable should look something like this "42.1|2,2"
-	  String allAnswerText = calculatedAnswersMap.get(calcQuestionAnswerSequence).toString();
+	  String allAnswerText = calculatedAnswersMap.get(calcQuestionAnswerSequence);
 
 	  // NOTE: this correctAnswer will already have been trimmed to the appropriate number of decimals
 	  BigDecimal correctAnswer = new BigDecimal(getAnswerExpression(allAnswerText));
 
 	  // Determine if the acceptable variance is a constant or a % of the answer
 	  String varianceString = allAnswerText.substring(allAnswerText.indexOf("|")+1, allAnswerText.indexOf(","));
-	  BigDecimal acceptableVariance = BigDecimal.ZERO;
+	  BigDecimal acceptableVariance;
 	  if (varianceString.contains("%")){
 		  double percentage = Double.valueOf(varianceString.substring(0, varianceString.indexOf("%")));
 		  acceptableVariance = correctAnswer.multiply( new BigDecimal(percentage / 100) );
@@ -2227,13 +2225,13 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
     AnswerIfc answer = (AnswerIfc) publishedAnswerHash.get(data.getPublishedAnswerId());
     if (answer == null || answer.getScore() == null)
       return (double) 0;
-    return answer.getScore().doubleValue();
+    return answer.getScore();
   }
 
   private void setIsLate(AssessmentGradingData data, PublishedAssessmentIfc pub){
 	  // If submit from timeout popup, we don't record LATE
 	  if (data.getSubmitFromTimeoutPopup()) {
-		  data.setIsLate( Boolean.valueOf(false));
+		  data.setIsLate(false);
 	  }
 	  else {
 		  if (pub.getAssessmentAccessControl() != null
@@ -2241,11 +2239,11 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 				  pub.getAssessmentAccessControl().getDueDate().before(new Date()))
 			  data.setIsLate(Boolean.TRUE);
 		  else
-			  data.setIsLate( Boolean.valueOf(false));
+			  data.setIsLate(false);
 	  }
 	  
-    if (data.getForGrade().booleanValue())
-      data.setStatus( Integer.valueOf(1));
+    if (data.getForGrade())
+      data.setStatus(1);
     
     data.setTotalOverrideScore(Double.valueOf(0));
   }
@@ -2268,19 +2266,19 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
       Set itemGradingSet = adata.getItemGradingSet();
       Iterator iter = itemGradingSet.iterator();
       double totalAutoScore = 0;
-      double totalOverrideScore = adata.getTotalOverrideScore().doubleValue();
+      double totalOverrideScore = adata.getTotalOverrideScore();
       while (iter.hasNext()){
         ItemGradingData i = (ItemGradingData)iter.next();
         if (i.getAutoScore()!=null)
-          totalAutoScore += i.getAutoScore().doubleValue();
+          totalAutoScore += i.getAutoScore();
         }
-        double oldAutoScore = adata.getTotalAutoScore().doubleValue();
+        double oldAutoScore = adata.getTotalAutoScore();
         double scoreDifference = totalAutoScore - oldAutoScore;
-        adata.setTotalAutoScore(Double.valueOf(totalAutoScore));
-        if (Double.compare((totalAutoScore+totalOverrideScore),Double.valueOf("0").doubleValue())<0){
+        adata.setTotalAutoScore(totalAutoScore);
+        if (Double.compare((totalAutoScore+totalOverrideScore),Double.valueOf("0"))<0){
         	adata.setFinalScore(Double.valueOf("0"));
         }else{
-        	adata.setFinalScore(Double.valueOf(totalAutoScore+totalOverrideScore));
+        	adata.setFinalScore(totalAutoScore+totalOverrideScore);
         }
         saveOrUpdateAssessmentGrading(adata);
         if (scoreDifference != 0 || !newComment.equals(oldComment)){
@@ -2393,12 +2391,12 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		 
 		 String REGEX = answer.replaceAll("\\*", "|*|");
 		 String[] oneblank = REGEX.split("\\|");
-		 for (int j = 0; j < oneblank.length; j++) {
-			 if ("*".equals(oneblank[j])) {
+		 for (String str : oneblank) {
+			 if ("*".equals(str)) {
 				 regex_quotebuf.append(".+");
 			 }
 			 else {
-				 regex_quotebuf.append(Pattern.quote(oneblank[j]));
+				 regex_quotebuf.append(Pattern.quote(str));
 			 }
 		 }
 
@@ -2434,8 +2432,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
   
   
   public List<ItemGradingData> getAllItemGradingDataForItemInGrading(Long assesmentGradingId, Long publihsedItemId) {
-	  List<ItemGradingData> results = new ArrayList<ItemGradingData>();
-	  results = PersistenceService.getInstance().getAssessmentGradingFacadeQueries().getAllItemGradingDataForItemInGrading(assesmentGradingId, publihsedItemId);
+	  List<ItemGradingData> results = PersistenceService.getInstance().getAssessmentGradingFacadeQueries().getAllItemGradingDataForItemInGrading(assesmentGradingId, publihsedItemId);
 	  return results;
   }
   
@@ -2617,7 +2614,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * @return map of calc answers
    */
   private Map<Integer, String> getCalculatedAnswersMap(ItemGradingData itemGrading, ItemDataIfc item) {
-      Map<Integer, String> calculatedAnswersMap = new HashMap<Integer, String>();
+      Map<Integer, String> calculatedAnswersMap = new HashMap<>();
       // return value from extractCalcQAnswersArray is not used, calculatedAnswersMap is populated by this call
       extractCalcQAnswersArray(calculatedAnswersMap, item, itemGrading.getAssessmentGradingId(), itemGrading.getAgentId());
       return calculatedAnswersMap;
@@ -2689,7 +2686,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * @return a list of matching key values OR empty if none are found
    */
   private List<String> extractCalculatedQuestionKeyFromItemText(String itemText, Pattern identifierPattern) {
-      LinkedHashSet<String> keys = new LinkedHashSet<String>();
+      LinkedHashSet<String> keys = new LinkedHashSet<>();
       if (itemText != null && itemText.trim().length() > 0) {
           Matcher keyMatcher = identifierPattern.matcher(itemText);
           while (keyMatcher.find()) {
@@ -2706,7 +2703,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
               }*/
           }
       }
-      return new ArrayList<String>(keys);
+      return new ArrayList<>(keys);
   }
 
   /**
@@ -2746,12 +2743,10 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * @return the original string, broken up based on the formula name delimiters
    */
   protected List<String> extractInstructionSegments(String instructions) {
-      List<String> segments = new ArrayList<String>();
+      List<String> segments = new ArrayList<>();
       if (instructions != null && instructions.length() > 0) {
           String[] results = CALCQ_FORMULA_SPLIT_PATTERN.split(instructions); // only works because all variables and calculations are already replaced
-          for (String part : results) {
-              segments.add(part);
-          }
+          segments.addAll(Arrays.asList(results));
           if (segments.size() == 1) {
               // add in the trailing segment
               segments.add("");
@@ -2860,7 +2855,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * when the question is saved, or if a divide by zero error occurs.
    */
   private Map<Integer, String> calculateFormulaValues(Map<String, String> variables, ItemDataIfc item) throws Exception {
-      Map<Integer, String> values = new HashMap<Integer, String>();
+      Map<Integer, String> values = new HashMap<>();
       String instructions = item.getInstruction();
       List<String> formulaNames = this.extractFormulas(instructions);
       for (int i = 0; i < formulaNames.size(); i++) {
@@ -2898,7 +2893,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
       final int MAX_ERROR_TRIES = 100;
       boolean hasErrors = true;
       Map<String, String> variableRangeMap = buildVariableRangeMap(item);
-      List<String> instructionSegments = new ArrayList<String>(0);
+      List<String> instructionSegments = new ArrayList<>(0);
 
       int attemptCount = 1;
       while (hasErrors && attemptCount <= MAX_ERROR_TRIES) {
@@ -2995,8 +2990,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  String NaN = "NaN";
 	  if (answer.length() == 0) return false;
 	  if (answer.equals(INFINITY)) return false;
-	  if (answer.equals(NaN)) return false;	  
-	  return true;
+	  return !answer.equals(NaN);
   }
   
   /**
@@ -3019,7 +3013,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
       }
 
       if (variables == null) {
-          variables = new HashMap<String, String>();
+          variables = new HashMap<>();
       }
 
       for (Map.Entry<String, String> entry : variables.entrySet()) {
@@ -3074,7 +3068,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
           expression = "";
       } else {
           Matcher keyMatcher = CALCQ_CALCULATION_PATTERN.matcher(expression);
-          List<String> toReplace = new ArrayList<String>();
+          List<String> toReplace = new ArrayList<>();
           while (keyMatcher.find()) {
               String match = keyMatcher.group(1);
               toReplace.add(match); // should be the formula
@@ -3187,7 +3181,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * Takes a map of ranges and randomly chooses values for those ranges and stores them in a new map.
    */
    public Map<String, String> determineRandomValuesForRanges(Map<String, String> variableRangeMap, long itemId, long gradingId, String agentId, int validAnswersAttemptCount) {
-	  Map<String, String> variableValueMap = new HashMap<String, String>();
+	  Map<String, String> variableValueMap = new HashMap<>();
 	  
 	  // seed random number generator
 	  long seed = getCalcuatedQuestionSeed(itemId, gradingId, agentId, validAnswersAttemptCount);
@@ -3232,7 +3226,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * variable names and variable ranges.
    */
    private Map<String, String> buildVariableRangeMap(ItemDataIfc item) {
-       Map<String, String> variableRangeMap = new HashMap<String, String>();
+       Map<String, String> variableRangeMap = new HashMap<>();
 
        String instructions = item.getInstruction();
        List<String> variables = this.extractVariables(instructions);
@@ -3274,7 +3268,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    */
   private boolean isCalcQuestion(List tempItemGradinglist, Map publishedItemHash) {
 	  if (tempItemGradinglist == null) return false;
-	  if (tempItemGradinglist.size() == 0) return false;
+	  if (tempItemGradinglist.isEmpty()) return false;
 	  
 	  Iterator iter = tempItemGradinglist.iterator();
 	  while(iter.hasNext()){
@@ -3415,30 +3409,30 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  if (answer == null || answer.getScore() == null) {
 		  return 0d;
 	  }
-	  else if (answer.getIsCorrect().booleanValue()){ // instead of using answer score Item score needs to be used here 
-		  return (answer.getItem().getScore().doubleValue()); //--mustansar 
+	  else if (answer.getIsCorrect()){ // instead of using answer score Item score needs to be used here 
+		  return (answer.getItem().getScore()); //--mustansar 
 	  }
-	  return (answer.getItem().getScore().doubleValue()*answer.getPartialCredit().doubleValue())/100d;
+	  return (answer.getItem().getScore()*answer.getPartialCredit())/100d;
   }
   
   /**
-   *  Reoder a map of EMI scores
+   *  Reorder a map of EMI scores
    * @param emiScoresMap
    * @return
    */
   private Map<Long, Map<Long, Map<Long, EMIScore>>> reorderEMIScoreMap(Map<Long, Map<Long,Set<EMIScore>>> emiScoresMap){
-	  Map<Long, Map<Long, Map<Long, EMIScore>>> scoresMap = new HashMap<Long, Map<Long, Map<Long, EMIScore>>>();
+	  Map<Long, Map<Long, Map<Long, EMIScore>>> scoresMap = new HashMap<>();
 	  for(Map<Long,Set<EMIScore>> emiItemScoresMap: emiScoresMap.values()){
 		  for(Set<EMIScore> scoreSet: emiItemScoresMap.values()){
 			  for(EMIScore s: scoreSet){
 				  Map<Long, Map<Long, EMIScore>> scoresItem = scoresMap.get(s.itemId);
 				  if(scoresItem == null){
-					  scoresItem = new HashMap<Long, Map<Long, EMIScore>>();
+					  scoresItem = new HashMap<>();
 					  scoresMap.put(s.itemId, scoresItem);
 				  }
 				  Map<Long, EMIScore> scoresItemText = scoresItem.get(s.itemTextId);
 				  if(scoresItemText == null){
-					  scoresItemText = new HashMap<Long, EMIScore>();
+					  scoresItemText = new HashMap<>();
 					  scoresItem.put(s.itemTextId, scoresItemText);
 				  }
 				  scoresItemText.put(s.answerId, s);
@@ -3484,7 +3478,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		Iterator<AnswerIfc> answerIter = answers.iterator();
 		while (answerIter.hasNext()) {
 			AnswerIfc answer = answerIter.next();
-			if (answer.getIsCorrect() != null && answer.getIsCorrect().booleanValue()) {
+			if (answer.getIsCorrect() != null && answer.getIsCorrect()) {
 				hasCorrectAnswer = true;
 				break;
 			}
@@ -3520,11 +3514,11 @@ class EMIScore implements Comparable<EMIScore>{
 	 * @param score
 	 */
 	public EMIScore(Long itemId, Long itemTextId, Long answerId, boolean correct, Double score){
-		this.itemId = itemId == null? 0L : itemId.longValue();
-		this.itemTextId = itemTextId == null? 0L : itemTextId.longValue();
-		this.answerId = answerId == null? 0L : answerId.longValue();
+		this.itemId = itemId == null? 0L : itemId;
+		this.itemTextId = itemTextId == null? 0L : itemTextId;
+		this.answerId = answerId == null? 0L : answerId;
 		this.correct = correct;
-		this.score = score == null? 0L : score.doubleValue();
+		this.score = score == null? 0L : score;
 	}
 
 	public int compareTo(EMIScore o) {
@@ -3578,4 +3572,3 @@ class EMIScore implements Comparable<EMIScore>{
 		return itemId + ":" + itemTextId + ":" + answerId + "(" + correct + ":" + score + ":" + effectiveScore + ")";
 	}
 }
-

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -2263,7 +2263,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
   /* Note:
    * assessmentGrading contains set of itemGrading that are not saved in the DB yet
    */
-  public void updateAssessmentGradingScore(AssessmentGradingData adata, PublishedAssessmentIfc pub){
+  public void updateAssessmentGradingScore(AssessmentGradingData adata, PublishedAssessmentIfc pub, String newComment, String oldComment){
     try {
       Set itemGradingSet = adata.getItemGradingSet();
       Iterator iter = itemGradingSet.iterator();
@@ -2283,7 +2283,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
         	adata.setFinalScore(Double.valueOf(totalAutoScore+totalOverrideScore));
         }
         saveOrUpdateAssessmentGrading(adata);
-        if (scoreDifference != 0){
+        if (scoreDifference != 0 || !newComment.equals(oldComment)){
           notifyGradebookByScoringType(adata, pub);
         }
      } catch (GradebookServiceException ge) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3246

There are two places in Samigo where the instructor/maintainer can provide grades and comments for a user's submission:

1) the table in the 'Total Scores' tab
2) a student's individual submission grading UI (Total Scores > click on student's name link)

If you have an assessment set to publish grades and comments to the gradebook, using the comment box (at the top of the screen) in the student's individual submission grading UI without updating the grade for the submission, these new/updated comments will not be pushed to the gradebook. This results in comments being out of sync between Samigo and the Gradebook.

Steps to reproduce:

1) create and publish an assessment which is set to push grades/comments to the Gradebook
2) take the assessment as a student/access member
3) as instructor/maintainer, enter a comment into the corresponding comment box in the 'Total Scores' UI
4) verify that the comment is pushed to the Gradebook
5) as instructor/maintainer, update the comment in the student's individual submission grading UI
6) notice that the comment is synchronized in Samigo (both locations show the same comment), but the comment in the Gradebook is still the text you entered in step 3)

The problem is that the save routine for the individual user submission grading UI is only taking into account grade changes to determine if it needs to push information to the Gradebook. The solution is to also check if the comment is updated as well as the grade. This issue is similar to the one identified in SAM-3163, but is controlled by different code.