### PR TITLE
SAM-3248: Total Scores > Questions > restore the 'Responses' heading

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
@@ -373,7 +373,7 @@ function hiddenLinkOnClick(){
   </t:dataList>
   </div>
 
-  <h2 class="hide">
+  <h2>
     <p class="navView navModeAction">
       <h:outputText value="#{evaluationMessages.responses}"/>
     </p>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3248

SAM-2721 refactored a lot of Samigo HTML for bootstrap. In commit f726ace, the "Responses" heading was refactored and the class "hide" was added to the `<h2>` element. This was most likely just an oversight. This PR simply removes the class so that the header is visible once again.