### PR TITLE
SAK-33349 Fix prerequisite calculations for the lessons subnav

### DIFF
--- a/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDao.java
+++ b/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDao.java
@@ -329,5 +329,7 @@ public interface SimplePageToolDao {
 
     public boolean doesPageFolderExist(final String siteId, final String folder);
 
-    public String getLessonSubPageJSON(String userId, boolean isInstructor, List pages);
+    public String getLessonSubPageJSON(String userId, boolean isInstructor, String siteId, List pages);
+
+    public List<SimplePage> getTopLevelPages(String siteId);
 }

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -1809,7 +1809,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	}
 
 
-	public String getLessonSubPageJSON(final String userId, final boolean isInstructor, final List pages) {
+	public String getLessonSubPageJSON(final String userId, final boolean isInstructor, final String siteId, final List pages) {
 		final String sql = ("SELECT p.toolId AS sakaiPageId," +
 				" p.pageId AS lessonsPageId," +
 				" s.site_id AS sakaiSiteId," +
@@ -1844,7 +1844,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 			fields[i+1] = pageIds.get(i);
 		}
 
-		final LessonsSubNavBuilder lessonsSubNavBuilder = new LessonsSubNavBuilder(isInstructor);
+		final LessonsSubNavBuilder lessonsSubNavBuilder = new LessonsSubNavBuilder(siteId, isInstructor);
 
 		sqlService.dbRead(sql, fields, new SqlReader() {
 			public Object readSqlResultRecord(final ResultSet result) {
@@ -1857,5 +1857,21 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		});
 
 		return lessonsSubNavBuilder.toJSON();
+	}
+
+	public List<SimplePage> getTopLevelPages(final String siteId) {
+		DetachedCriteria d = DetachedCriteria.forClass(SimplePage.class).add(Restrictions.eq("siteId", siteId))
+			.add(Restrictions.disjunction()
+				.add(Restrictions.isNull("owner"))
+				.add(Restrictions.eq("owned", true)))
+			.add(Restrictions.isNull("parent"));
+
+		List<SimplePage> l = (List<SimplePage>) getHibernateTemplate().findByCriteria(d);
+
+		if (l != null && l.size() > 0) {
+			return l;
+		} else {
+			return null;
+		}
 	}
 }

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/util/LessonsSubNavBuilder.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/util/LessonsSubNavBuilder.java
@@ -45,10 +45,12 @@ public class LessonsSubNavBuilder {
 
     private static ResourceLoader rb = new ResourceLoader("subnav");
 
+    private String siteId;
     private boolean isInstructor;
     private Map<String, ArrayList<Map<String, String>>> subnavData;
 
-    public LessonsSubNavBuilder(final boolean isInstructor) {
+    public LessonsSubNavBuilder(final String siteId, final boolean isInstructor) {
+        this.siteId = siteId;
         this.isInstructor = isInstructor;
         this.subnavData = new HashMap<>();
     }
@@ -59,6 +61,8 @@ public class LessonsSubNavBuilder {
         final Map<String, Object> objectToSerialize = new HashMap<>();
         objectToSerialize.put("pages", this.subnavData);
         objectToSerialize.put("i18n", getI18n());
+        objectToSerialize.put("siteId", this.siteId);
+        objectToSerialize.put("isInstructor", this.isInstructor);
 
         return JSONObject.toJSONString(objectToSerialize);
     }
@@ -91,6 +95,7 @@ public class LessonsSubNavBuilder {
 
         subnavItem.put("toolId", rs.getString("sakaiToolId"));
         subnavItem.put("siteId", rs.getString("sakaiSiteId"));
+        subnavItem.put("sakaiPageId", rs.getString("sakaiPageId"));
         subnavItem.put("itemId", rs.getString("itemId"));
         subnavItem.put("sendingPage", rs.getString("itemSakaiId"));
         subnavItem.put("name", rs.getString("itemName"));

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/entityproviders/LessonsEntityProvider.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/entityproviders/LessonsEntityProvider.java
@@ -38,6 +38,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.apache.commons.lang.StringUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -410,6 +412,50 @@ public class LessonsEntityProvider extends AbstractEntityProvider implements Ent
 		if (ret != null && ret.size() > 0)
 		    return ret.get(0);
 		return ret;
+	}
+
+
+	/**
+	 * subnav-prerequisites
+	 * example: /direct/lessons/subnav-prerequisites/SITEID.xml
+	 */
+	@EntityCustomAction(action = "subnav-prerequisites", viewKey = EntityView.VIEW_LIST)
+	public String getPrerequisiteDataForSubNav(final EntityView view, final Map<String, Object> params) {
+		final String siteId = view.getPathSegment(2);
+
+		if (siteId == null || "".equals(siteId)) {
+			throw new IllegalArgumentException("siteId is required");
+		}
+
+		try {
+			siteService.getSiteVisit(siteId);
+		} catch (IdUnusedException e) {
+			throw new EntityNotFoundException("Invalid siteId: " + siteId, siteId);
+		} catch (PermissionException e) {
+			throw new EntityNotFoundException("No access to site: " + siteId, siteId);
+		}
+
+		final JSONObject result = new JSONObject();
+
+		final List<SimplePage> topLevelPages = simplePageToolDao.getTopLevelPages(siteId);
+		SimplePageBean simplePageBean = null;
+		final String currentUserId = sessionManager.getCurrentSessionUserId();
+
+		for (SimplePage topLevelPage : topLevelPages) {
+			final List<SimplePageItem> itemsOnPage = simplePageToolDao.findItemsOnPage(topLevelPage.getPageId());
+			final JSONArray inaccessibleItems = new JSONArray();
+
+			for (SimplePageItem item : itemsOnPage) {
+				simplePageBean = makeSimplePageBean(simplePageBean, siteId, item);
+				if (!lessonsAccess.isItemAccessible(item.getId(), siteId, currentUserId, simplePageBean)) {
+					inaccessibleItems.add(String.valueOf(item.getId()));
+				}
+			}
+
+			result.put(topLevelPage.getToolId(), inaccessibleItems);
+		}
+
+		return result.toJSONString();
 	}
 	
 	

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -843,7 +843,8 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		theMap.put("pageNavTools", l);
 
 		if ("true".equals(site.getProperties().getProperty("lessons_submenu")) && !l.isEmpty()) {
-			theMap.put("additionalLessonsPages", getSimplePageToolDao().getLessonSubPageJSON(UserDirectoryService.getCurrentUser().getId(), siteUpdate, l));
+			theMap.put("additionalLessonsPages",
+					getSimplePageToolDao().getLessonSubPageJSON(UserDirectoryService.getCurrentUser().getId(), siteUpdate, site.getId(), l));
 		}
 
 		theMap.put("pageNavTools", l);


### PR DESCRIPTION
This patch updates the lessons subnav to use the LessonsAccess API and take into account all lesson item types when calculating the prerequisites for a page in the menu. 

To avoid slow-down of the page load, we've moved this calculation to an EntityProvider that is pinged via AJAX by the lessons subnav JavaScript.  The menu items are then greyed out/disabled if any prerequisites apply.  Note, as per the current behaviour, if a student is able to click a link before it is disabled, the Lessons tool will bounce the user back to the top level page -- so no harm done, this change just attempts to expose this state to the user in a timely manner.

https://jira.sakaiproject.org/browse/SAK-33349