### PR TITLE
SAK-32707 NumberFormatException: For input string: ":0" when generating PDF with timezone <= GMT -10

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1789,6 +1789,12 @@
         <version>1.0_01-ea</version>
         <scope>provided</scope>
       </dependency>
+      <!-- SAK-32707 -->
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>xmlgraphics-commons</artifactId>
+        <version>1.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
added xmlgraphics-commons 1.5 to master pom.
This fixes a bug in rwiki, site-manage, and rwiki tools when downloading PDFs and the server's timezone <= GMT -10