### PR TITLE
SAK-33349 Fix prerequisite calculations for the lessons subnav

### DIFF
--- a/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDao.java
+++ b/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDao.java
@@ -329,5 +329,7 @@ public interface SimplePageToolDao {
 
     public boolean doesPageFolderExist(final String siteId, final String folder);
 
-    public String getLessonSubPageJSON(String userId, boolean isInstructor, List pages);
+    public String getLessonSubPageJSON(String userId, boolean isInstructor, String siteId, List pages);
+
+    public List<SimplePage> getTopLevelPages(String siteId);
 }

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -1809,7 +1809,14 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	}
 
 
-	public String getLessonSubPageJSON(final String userId, final boolean isInstructor, final List pages) {
+	public String getLessonSubPageJSON(final String userId, final boolean isInstructor, final String siteId, final List pages) {
+		final List<String> pageIds = LessonsSubNavBuilder.collectPageIds(pages);
+
+		if (pageIds.isEmpty()) {
+			// no lesson pages, so no JSON!
+			return null;
+		}
+
 		final String sql = ("SELECT p.toolId AS sakaiPageId," +
 				" p.pageId AS lessonsPageId," +
 				" s.site_id AS sakaiSiteId," +
@@ -1833,18 +1840,17 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 				" LEFT OUTER JOIN lesson_builder_log log" +
 				"   ON (log.itemId = i.id AND log.userId = ?)" +
 				" WHERE p.parent IS NULL" +
-				"   AND p.toolId IN (" + pages.stream().map(i -> "?").collect(Collectors.joining(",")) + ")" +
+				"   AND p.toolId IN (" + pageIds.stream().map(i -> "?").collect(Collectors.joining(",")) + ")" +
 				" ORDER BY i.sequence");
 
-		final Object [] fields = new Object[pages.size() + 1];
+		final Object [] fields = new Object[pageIds.size() + 1];
 		fields[0] = userId;
 
-		final List<String> pageIds = LessonsSubNavBuilder.collectPageIds(pages);
 		for (int i=0; i<pageIds.size(); i++) {
 			fields[i+1] = pageIds.get(i);
 		}
 
-		final LessonsSubNavBuilder lessonsSubNavBuilder = new LessonsSubNavBuilder(isInstructor);
+		final LessonsSubNavBuilder lessonsSubNavBuilder = new LessonsSubNavBuilder(siteId, isInstructor);
 
 		sqlService.dbRead(sql, fields, new SqlReader() {
 			public Object readSqlResultRecord(final ResultSet result) {
@@ -1857,5 +1863,21 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		});
 
 		return lessonsSubNavBuilder.toJSON();
+	}
+
+	public List<SimplePage> getTopLevelPages(final String siteId) {
+		DetachedCriteria d = DetachedCriteria.forClass(SimplePage.class).add(Restrictions.eq("siteId", siteId))
+			.add(Restrictions.disjunction()
+				.add(Restrictions.isNull("owner"))
+				.add(Restrictions.eq("owned", true)))
+			.add(Restrictions.isNull("parent"));
+
+		List<SimplePage> l = (List<SimplePage>) getHibernateTemplate().findByCriteria(d);
+
+		if (l != null && l.size() > 0) {
+			return l;
+		} else {
+			return null;
+		}
 	}
 }

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/util/LessonsSubNavBuilder.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/util/LessonsSubNavBuilder.java
@@ -45,10 +45,12 @@ public class LessonsSubNavBuilder {
 
     private static ResourceLoader rb = new ResourceLoader("subnav");
 
+    private String siteId;
     private boolean isInstructor;
     private Map<String, ArrayList<Map<String, String>>> subnavData;
 
-    public LessonsSubNavBuilder(final boolean isInstructor) {
+    public LessonsSubNavBuilder(final String siteId, final boolean isInstructor) {
+        this.siteId = siteId;
         this.isInstructor = isInstructor;
         this.subnavData = new HashMap<>();
     }
@@ -59,6 +61,8 @@ public class LessonsSubNavBuilder {
         final Map<String, Object> objectToSerialize = new HashMap<>();
         objectToSerialize.put("pages", this.subnavData);
         objectToSerialize.put("i18n", getI18n());
+        objectToSerialize.put("siteId", this.siteId);
+        objectToSerialize.put("isInstructor", this.isInstructor);
 
         return JSONObject.toJSONString(objectToSerialize);
     }
@@ -69,7 +73,10 @@ public class LessonsSubNavBuilder {
         final List<String> pageIds = new ArrayList<>(typedPages.size());
 
         for (Map<String, String> page : typedPages) {
-            pageIds.add(page.get("pageId"));
+            // try to limit to only lesson pages
+            if (!page.containsKey("wellKnownToolId") || "sakai.lessonbuildertool".equals(page.get("wellKnownToolId"))) {
+                pageIds.add(page.get("pageId"));
+            }
         }
 
         return pageIds;
@@ -91,6 +98,7 @@ public class LessonsSubNavBuilder {
 
         subnavItem.put("toolId", rs.getString("sakaiToolId"));
         subnavItem.put("siteId", rs.getString("sakaiSiteId"));
+        subnavItem.put("sakaiPageId", rs.getString("sakaiPageId"));
         subnavItem.put("itemId", rs.getString("itemId"));
         subnavItem.put("sendingPage", rs.getString("itemSakaiId"));
         subnavItem.put("name", rs.getString("itemName"));

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -757,6 +757,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				if (includeSummary) summarizePage(m, site, p);
 				if (firstTool != null)
 				{
+					m.put("wellKnownToolId", firstTool.getToolId());
 					String menuClass = firstTool.getToolId();
 					menuClass = ICON_SAKAI + menuClass.replace('.', '-');
 					m.put("menuClass", menuClass);
@@ -812,6 +813,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					m.put("toolrefUrl", toolrefUrl);
 					m.put("toolpopup", Boolean.valueOf(source!=null));
 					m.put("toolpopupurl", source);
+					m.put("wellKnownToolId", placement.getToolId());
 					String menuClass = placement.getToolId();
 					menuClass = ICON_SAKAI + menuClass.replace('.', '-');
 					m.put("menuClass", menuClass);
@@ -843,7 +845,8 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		theMap.put("pageNavTools", l);
 
 		if ("true".equals(site.getProperties().getProperty("lessons_submenu")) && !l.isEmpty()) {
-			theMap.put("additionalLessonsPages", getSimplePageToolDao().getLessonSubPageJSON(UserDirectoryService.getCurrentUser().getId(), siteUpdate, l));
+			theMap.put("additionalLessonsPages",
+					getSimplePageToolDao().getLessonSubPageJSON(UserDirectoryService.getCurrentUser().getId(), siteUpdate, site.getId(), l));
 		}
 
 		theMap.put("pageNavTools", l);


### PR DESCRIPTION
This patch updates the lessons subnav to use the lessonbuilder's `isItemAccessible` to take into account all lesson item types when calculating the prerequisites for a page in the menu.

To avoid slow-down of the page load, we've moved this calculation to an EntityProvider that is pinged via AJAX by the lessons subnav JavaScript. The menu items are then greyed out/disabled if any prerequisites apply. Note, as per the current behaviour, if a student is able to click a link before it is disabled, the Lessons tool will bounce the user back to the top level page -- so no harm done, this change just attempts to expose this state to the user in a timely manner.

https://jira.sakaiproject.org/browse/SAK-33349