### PR TITLE
SAK-33377 - Upgrade JavaMail from 1.5.6 to 1.6.0

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -97,6 +97,7 @@
     <sakai.lombok.version>1.16.16</sakai.lombok.version>
     <sakai.jackson.version>2.8.6</sakai.jackson.version>
     <sakai.lucene.version>4.10.4</sakai.lucene.version>
+    <sakai.mail.version>1.6.0</sakai.mail.version>
     <sakai.org.json.version>20160810</sakai.org.json.version>
     <sakai.pluto.version>1.1.7</sakai.pluto.version>
     <sakai.quartz.version>2.2.2</sakai.quartz.version>
@@ -836,7 +837,7 @@
       <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>javax.mail</artifactId>
-        <version>1.5.6</version>
+        <version>${sakai.mail.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Upgrade JavaMail from 1.5.6 to 1.6.0