### PR TITLE
SAK-33382: model answers set to display after submission are visible if the student saves as draft

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentSupplementItemServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentSupplementItemServiceImpl.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import org.hibernate.Query;
 import org.sakaiproject.assignment.api.AssignmentConstants;
-import org.sakaiproject.assignment.api.AssignmentEntity;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.assignment.api.model.AssignmentAllPurposeItem;
@@ -479,7 +478,7 @@ public class AssignmentSupplementItemServiceImpl extends HibernateDaoSupport imp
 					{
 						return true;
 					}
-					else if (show == AssignmentConstants.MODEL_ANSWER_SHOW_TO_STUDENT_AFTER_SUBMIT && s != null && s.getUserSubmission())
+					else if (show == AssignmentConstants.MODEL_ANSWER_SHOW_TO_STUDENT_AFTER_SUBMIT && s != null && s.getUserSubmission() && s.getSubmitted())
 					{
 						return true;
 					}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33382

Saving as draft allows the student to see the model answer, even though they technically haven't submitted.

This is technically a regression introduced in https://jira.sakaiproject.org/browse/SAK-32436 (07c0eff), by removing the check on s.getSubmitted(). Before Earle's Assignments refactor, the JavaDocs for this property indicated it's used to determine draft status:

```
	/**
	 * Get whether this is a final submission.
	 * 
	 * @return True if a final submission, false if still a draft.
	 */
	public boolean getSubmitted();
```