### PR TITLE
SAK-31520 Restore and fix the 'Add Another Web Link' action

### DIFF
--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -201,7 +201,7 @@ Copyright: It is your personal responsibility to verify that you have permission
 to upload the file(s) to this website. Text, graphics and other media files may all be subject to copyright control \
 even if your site is restricted to site members.
 instr.url			 = Copy-and-paste or type in the web address (URL) and then click 'Continue' at the bottom.
-instr.urls		 	= Add both the address and name for a web link (URL). Click the 'Add Web Link Now' button when you have finished.
+instr.urls		 	= Press the 'Add Web Links Now' button when you have finished.
 instr.ezproxy   = If linking to a library database that you would like to make available off-campus, enter the URL and click 'Make Library Link Available Off-Campus.'
 label.addfile		 = Add Another File
 label.addFolder		 = Add Another Folder
@@ -231,7 +231,7 @@ label.update		 = Update
 label.upl		 = Upload New Version Now
 label.upload		 = File To Upload
 label.url			 = URL
-label.urlnow		 = Add Web Link Now
+label.urlnow		 = Add Web Links Now
 label.urls		 = Web Address (URL)
 label.ezproxy  = Make Library Link Available Off-Campus
 label.version		 = Upload a new version

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourceTypeLabeler.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourceTypeLabeler.java
@@ -51,7 +51,7 @@ public class ResourceTypeLabeler
 					label = ResourcesAction.trb.getString("create.folder");
 					break;
 				case NEW_URLS:
-					label = ResourcesAction.trb.getString("create.url");
+					label = ResourcesAction.trb.getString("create.urls");
 					break;
 				case CREATE:
 					ResourceTypeRegistry registry = (ResourceTypeRegistry) ComponentManager.get("org.sakaiproject.content.api.ResourceTypeRegistry");

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -70,9 +70,7 @@
 				</div>
 			#end
 		</div>
-		<!-- Disabled - See SAK-31520
 		<p><a href="#" onclick="addFileInput();return false">$tlang.getString("label.addurl")</a><br></p>
-		-->
 
 		#if ($model.resourceTypeDef.hasNotificationDialog())
 			#if($model.isDropbox())

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -1,7 +1,7 @@
 <!-- resources/sakai_create_uploads.vm, use with org.sakaiproject.tool.content.ResourcesHelperAction.java -->
 <div class="portletBody specialLink">
 	<h3>
-		$tlang.getString("create.url")
+		$tlang.getString("create.urls")
 	</h3>
 	#if ($itemAlertMessage)
 		<div class="alertMessage">$tlang.getString("label.alert") $validator.escapeHtml($itemAlertMessage)</div>

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -396,14 +396,7 @@
 		{
 			var newContentDiv = copyTree(modelContentDiv, index);
 			fileInputDiv.appendChild(newContentDiv);
-		}
-		
-		var modelPropertiesDiv = document.getElementById("propertiesDiv$DOT" + prevIndex);
-		if(modelPropertiesDiv)
-		{
-			var newPropertiesDiv = copyTree(modelPropertiesDiv, index);
-			newPropertiesDiv.style.display = "none";
-			fileInputDiv.appendChild(newPropertiesDiv);
+
 			var addDetailsLink = document.getElementById("propsTrigger${DOT}" + index);
 			if(addDetailsLink)
 			{
@@ -1476,7 +1469,11 @@
 	
 	
 	attachEventHandlers();
-	
+
+// default these values always
+document.calendars = new Array();
+document.calendarcounter = 0;
+
 #if($calendarcounter > 0)	
 	document.calendars = new Array();
 	document.calendarcounter = $calendarcounter;

--- a/content/content-types/src/java/org/sakaiproject/content/types/UrlResourceType.java
+++ b/content/content-types/src/java/org/sakaiproject/content/types/UrlResourceType.java
@@ -82,7 +82,7 @@ public class UrlResourceType extends BaseResourceType
 	
 	public UrlResourceType()
 	{		
-		actions.put(CREATE, new BaseInteractionAction(CREATE, ActionType.NEW_URLS, typeId, helperId, localizer("create.url")));
+		actions.put(CREATE, new BaseInteractionAction(CREATE, ActionType.NEW_URLS, typeId, helperId, localizer("create.urls")));
 		actions.put(REVISE_CONTENT, new BaseInteractionAction(REVISE_CONTENT, ActionType.REVISE_CONTENT, typeId, helperId, localizer("action.revise")));
 		actions.put(ACCESS_PROPERTIES, new BaseServiceLevelAction(ACCESS_PROPERTIES, ActionType.VIEW_METADATA, typeId, false, localizer("action.access")));
 		actions.put(REVISE_METADATA, new BaseServiceLevelAction(REVISE_METADATA, ActionType.REVISE_METADATA, typeId, false, localizer("action.props")));

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ResourceToolAction.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ResourceToolAction.java
@@ -64,7 +64,7 @@ public interface ResourceToolAction
 		NEW_FOLDER,
 		
 		/**
-		 * Create a URL -- Handled by Resources tool.  Can create one link to a URL at a time (previously was multiple links).  
+		 * Create URLs -- Handled by Resources tool.  Can create multiple URLs at once.  
 		 * 		No content; requires metadata only.  Requires content.new permission in parent 
 		 * 		folder.
 		 */


### PR DESCRIPTION
This PR looks to reinstate the 'Add Another Web Link' on the 'Add Web Links (URLs)'.  I've reverted two commits that previously hid the link and renamed the verbiage to remove the plurals.

It looks like there were two issues affecting this workflow.  The first was updating the JavaScript to take into account a restructure of the DOM (for bootstrap styling I think).  And secondly, ensuring the `document.calendars` and `document.calendarcounter` were initialised regardless of the `$calendarcounter` value.

Delivers https://jira.sakaiproject.org/browse/SAK-31520.
