### PR TITLE
SAM-3255 do a simple query to see if assessment id is valid instead of doing a Hibernate load

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -645,6 +645,21 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 		return h;
 	}
 
+	/**
+	 * This was created for GradebookExternalAssessmentService.
+	 * We just want a quick answer whether Samigo is responsible for an id.
+	 */
+	public boolean isPublishedAssessmentIdValid(Long publishedAssessmentId) {
+		List<PublishedAssessmentData> list = (List<PublishedAssessmentData>) getHibernateTemplate()
+				.findByNamedParam("from PublishedAssessmentData where publishedAssessmentId = :id", "id", publishedAssessmentId);
+
+		if (!list.isEmpty()) {
+			PublishedAssessmentData f = list.get(0);
+			return f.getPublishedAssessmentId() > 0;
+		}
+		return false;
+	}
+
 	public PublishedAssessmentFacade getPublishedAssessment(Long assessmentId) {
 		return getPublishedAssessment(assessmentId, true);
 	}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueriesAPI.java
@@ -111,6 +111,8 @@ public interface PublishedAssessmentFacadeQueriesAPI
   public Set preparePublishedAnswerFeedbackSet(PublishedAnswer publishedAnswer,
       Set answerFeedbackSet);
 
+  public boolean isPublishedAssessmentIdValid(Long publishedAssessmentId);
+
   public PublishedAssessmentFacade getPublishedAssessment(Long assessmentId);
   
   public PublishedAssessmentFacade getPublishedAssessment(Long assessmentId, boolean withGroupsInfo);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/AssessmentGradeInfoProvider.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/AssessmentGradeInfoProvider.java
@@ -87,11 +87,6 @@ public class AssessmentGradeInfoProvider implements ExternalAssignmentProvider, 
 
     
     private PublishedAssessmentIfc getPublishedAssessment(String id) {
-        // SAM-3068 avoid looking up another tool's id
-        if (!StringUtils.isNumeric(id)) {
-            return null;
-        }
-
         PublishedAssessmentIfc a = (PublishedAssessmentIfc) pubAssessmentCache.get(id);
         if (a != null) {
             log.debug("Returning assessment {} from cache", id);
@@ -116,17 +111,24 @@ public class AssessmentGradeInfoProvider implements ExternalAssignmentProvider, 
     }
 
     public boolean isAssignmentDefined(String id) {
-        if (log.isDebugEnabled()) {
-            log.debug("Samigo provider isAssignmentDefined: " + id);
+        // SAM-3068 avoid looking up another tool's id
+        if (!StringUtils.isNumeric(id)) {
+            return false;
         }
-        return getPublishedAssessment(id) != null;
+
+        log.debug("Samigo provider isAssignmentDefined: {}", id);
+        Long longId = Long.parseLong(id);
+        return PersistenceService.getInstance().getPublishedAssessmentFacadeQueries().isPublishedAssessmentIdValid(longId);
     }
 
     
     public boolean isAssignmentGrouped(String id) {
-        if (log.isDebugEnabled()) {
-            log.debug("Samigo provider isAssignmentGrouped: " + id);
+        // SAM-3068 avoid looking up another tool's id
+        if (!StringUtils.isNumeric(id)) {
+            return false;
         }
+
+        log.debug("Samigo provider isAssignmentGrouped: {}", id);
         
         Boolean g = null;
         if (groupedCache.containsKey(id)) {


### PR DESCRIPTION
This solves an issue we found with GradebookNG where a bad HibernateTransaction load would cause the entire transaction to be put into rollback state