### PR TITLE
SAK-31520 SAK-33264 Restore 'Add Another Web Link'  and 'Add Another Folder'

### DIFF
--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -201,7 +201,7 @@ Copyright: It is your personal responsibility to verify that you have permission
 to upload the file(s) to this website. Text, graphics and other media files may all be subject to copyright control \
 even if your site is restricted to site members.
 instr.url			 = Copy-and-paste or type in the web address (URL) and then click 'Continue' at the bottom.
-instr.urls		 	= Add both the address and name for a web link (URL). Click the 'Add Web Link Now' button when you have finished.
+instr.urls		 	= Press the 'Add Web Links Now' button when you have finished.
 instr.ezproxy   = If linking to a library database that you would like to make available off-campus, enter the URL and click 'Make Library Link Available Off-Campus.'
 label.addfile		 = Add Another File
 label.addFolder		 = Add Another Folder
@@ -231,7 +231,7 @@ label.update		 = Update
 label.upl		 = Upload New Version Now
 label.upload		 = File To Upload
 label.url			 = URL
-label.urlnow		 = Add Web Link Now
+label.urlnow		 = Add Web Links Now
 label.urls		 = Web Address (URL)
 label.ezproxy  = Make Library Link Available Off-Campus
 label.version		 = Upload a new version

--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -179,7 +179,7 @@ instr.access.fldr	 = Folders and their contents can be scheduled to be visible b
 instr.access		 = Resources can be scheduled to be visible between certain dates only. Site administrators will always be able to see hidden items, even when they are hidden from other users.
 instr.create		 = Enter the name of the {0} (required), set any other properties you wish, and then click "Finish" to create the {0}.
 instr.folder		 = Type the name of each folder in a separate box and then click 'Continue' at the bottom.
-instr.folders		= Press the 'Create Folders Now'  button when you have finished.
+instr.folders		= Create as many folders as you like! If you change your mind about needing one of your folders, click the 'X' icon beside it. Press the 'Create Folders Now'  button when you have finished.
 instr.html		 	= Type in the text for your page (use the toolbar to format it) and click 'Continue' at the bottom.
 instr.options		 = Select or unselect resources types to indicate whether resources of that type can be created in this site. 
 instr.props		 	= Change the resource's details and then choose 'Update' at the bottom. 
@@ -201,7 +201,7 @@ Copyright: It is your personal responsibility to verify that you have permission
 to upload the file(s) to this website. Text, graphics and other media files may all be subject to copyright control \
 even if your site is restricted to site members.
 instr.url			 = Copy-and-paste or type in the web address (URL) and then click 'Continue' at the bottom.
-instr.urls		 	= Press the 'Add Web Links Now' button when you have finished.
+instr.urls		 	= Add as many web links (URLs) as you like. If you change your mind about needing one of your web links, click the 'X' icon beside it. Press the 'Add Web Links Now' button when you have finished.
 instr.ezproxy   = If linking to a library database that you would like to make available off-campus, enter the URL and click 'Make Library Link Available Off-Campus.'
 label.addfile		 = Add Another File
 label.addFolder		 = Add Another Folder

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourceTypeLabeler.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourceTypeLabeler.java
@@ -51,7 +51,7 @@ public class ResourceTypeLabeler
 					label = ResourcesAction.trb.getString("create.folder");
 					break;
 				case NEW_URLS:
-					label = ResourcesAction.trb.getString("create.url");
+					label = ResourcesAction.trb.getString("create.urls");
 					break;
 				case CREATE:
 					ResourceTypeRegistry registry = (ResourceTypeRegistry) ComponentManager.get("org.sakaiproject.content.api.ResourceTypeRegistry");

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_folders.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_folders.vm
@@ -53,10 +53,10 @@
 					</div>
 					<input type="hidden" id="prev${DOT}$i" name="prev${DOT}$i" value="#if($prev >= 0)${prev}#end" />
 					<input type="hidden" id="next${DOT}$i" name="next${DOT}$i" value="#if($next < $pipes.size())${next}#end" />
-				</div>
-				<div id="propertiesDiv${DOT}$i" style="display:none;" aria-expanded="false">
-#parse("/vm/resources/sakai_properties.vm")
-					<hr class="itemSeparator" />
+					<div id="propertiesDiv${DOT}$i" style="display:none;" aria-expanded="false">
+						#parse("/vm/resources/sakai_properties.vm")
+						<hr class="itemSeparator" />
+					</div>
 				</div>
 			#end
 		</div>

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_folders.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_folders.vm
@@ -60,11 +60,9 @@
 				</div>
 			#end
 		</div>
-		<!-- Disabled See SAK-32136
 		<p class="act">
 			<a href="#" onclick="addFileInput();return false">$tlang.getString("label.addFolder")</a>
 		</p>
-		-->
 #*
 		#if ($model.resourceTypeDef.hasNotificationDialog())
 			<p class="shorttext">

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -70,9 +70,7 @@
 				</div>
 			#end
 		</div>
-		<!-- Disabled - See SAK-31520
 		<p><a href="#" onclick="addFileInput();return false">$tlang.getString("label.addurl")</a><br></p>
-		-->
 
 		#if ($model.resourceTypeDef.hasNotificationDialog())
 			#if($model.isDropbox())

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -1,7 +1,7 @@
 <!-- resources/sakai_create_uploads.vm, use with org.sakaiproject.tool.content.ResourcesHelperAction.java -->
 <div class="portletBody specialLink">
 	<h3>
-		$tlang.getString("create.url")
+		$tlang.getString("create.urls")
 	</h3>
 	#if ($itemAlertMessage)
 		<div class="alertMessage">$tlang.getString("label.alert") $validator.escapeHtml($itemAlertMessage)</div>

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
@@ -270,10 +270,10 @@
 									#set($release_day = $model.getReleaseDate().breakdownLocal().day)
 									#set($release_hour = $model.getReleaseDate().breakdownLocal().hour)
 									#set($release_minute = $model.getReleaseDate().breakdownLocal().min)
-									<input type="text" id="releaseDatePicker" name="releaseDatePicker" class="datepicker" value="">
+									<input type="text" id="releaseDatePicker${DOT}$i" name="releaseDatePicker${DOT}$i" class="datepicker" value="">
 									<script type="text/javascript">
 										localDatePicker({
-											input:'#releaseDatePicker',
+											input:'#releaseDatePicker${DOT}$i',
 											useTime:1,
 											val:"$release_year$H$release_month$H$release_day $release_hour:$release_minute",
 											parseFormat: 'YYYY-MM-DD HH:mm',
@@ -300,10 +300,10 @@
 									#set($retract_day = $model.getRetractDate().breakdownLocal().day)
 									#set($retract_hour = $model.getRetractDate().breakdownLocal().hour)
 									#set($retract_minute = $model.getRetractDate().breakdownLocal().min)
-									<input type="text" id="retractDatePicker" name="retractDatePicker" class="datepicker" value="">
+									<input type="text" id="retractDatePicker${DOT}$i" name="retractDatePicker${DOT}$i" class="datepicker" value="">
 									<script type="text/javascript">
 										localDatePicker({
-											input:'#retractDatePicker',
+											input:'#retractDatePicker${DOT}$i',
 											useTime:1,
 											val:"$retract_year$H$retract_month$H$retract_day $retract_hour:$retract_minute",
 											parseFormat: 'YYYY-MM-DD HH:mm',

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -396,14 +396,7 @@
 		{
 			var newContentDiv = copyTree(modelContentDiv, index);
 			fileInputDiv.appendChild(newContentDiv);
-		}
-		
-		var modelPropertiesDiv = document.getElementById("propertiesDiv$DOT" + prevIndex);
-		if(modelPropertiesDiv)
-		{
-			var newPropertiesDiv = copyTree(modelPropertiesDiv, index);
-			newPropertiesDiv.style.display = "none";
-			fileInputDiv.appendChild(newPropertiesDiv);
+
 			var addDetailsLink = document.getElementById("propsTrigger${DOT}" + index);
 			if(addDetailsLink)
 			{
@@ -1476,7 +1469,11 @@
 	
 	
 	attachEventHandlers();
-	
+
+// default these values always
+document.calendars = new Array();
+document.calendarcounter = 0;
+
 #if($calendarcounter > 0)	
 	document.calendars = new Array();
 	document.calendarcounter = $calendarcounter;

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -174,6 +174,50 @@
 			}
 		}
 	}      
+	function setupDatePickers(contentDiv, index) {
+		// remove the hasDatepicker CSS class so localDatePicker does the business
+		document.getElementById('releaseDatePicker${DOT}'+index).classList.remove('hasDatepicker');
+		document.getElementById('retractDatePicker${DOT}'+index).classList.remove('hasDatepicker');
+		// also remove the icon that will soon be recreated by localDatePicker
+		var icons = contentDiv.querySelectorAll('.ui-datepicker-trigger');
+		for (var i=0; i<icons.length; i++) {
+			icons[i].remove();
+		}
+
+		// build up a new value
+		var now = new Date();
+		var valueString = '' + now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + ' ' + now.getHours() + ':' + now.getMinutes();
+
+		// setup the date pickers
+		localDatePicker({
+			input:'#releaseDatePicker${DOT}'+index,
+			useTime:1,
+			parseFormat: 'YYYY-MM-DD HH:mm',
+			val: valueString,
+			ashidden:{
+				month: 'release_month${DOT}'+index,
+				day: 'release_day${DOT}'+index,
+				year: 'release_year${DOT}'+index,
+				hour: 'release_hour${DOT}'+index,
+				minute: 'release_minute${DOT}'+index,
+				ampm: 'release_ampm${DOT}'+index
+			}
+		});
+		localDatePicker({
+			input:'#retractDatePicker${DOT}'+index,
+			useTime:1,
+			parseFormat: 'YYYY-MM-DD HH:mm',
+			val: valueString,
+			ashidden:{
+				month: 'retract_month${DOT}'+index,
+				day: 'retract_day${DOT}'+index,
+				year: 'retract_year${DOT}'+index,
+				hour: 'retract_hour${DOT}'+index,
+				minute: 'retract_minute${DOT}'+index,
+				ampm: 'retract_ampm${DOT}'+index
+			}
+		});
+	}
 	function handleReleaseDatePopupRequest(evt)
 	{
 		evt = (typeof(evt)!= 'undefined') ? evt : ((typeof(event) != 'undefined') ? event : null);
@@ -418,6 +462,7 @@
 					hideGroupsTable(index);
 				}
 			}
+			setupDatePickers(newContentDiv, index);
 		}
 		
 		var prevNext = document.getElementById("next$DOT" + prevIndex);

--- a/content/content-types/src/java/org/sakaiproject/content/types/UrlResourceType.java
+++ b/content/content-types/src/java/org/sakaiproject/content/types/UrlResourceType.java
@@ -82,7 +82,7 @@ public class UrlResourceType extends BaseResourceType
 	
 	public UrlResourceType()
 	{		
-		actions.put(CREATE, new BaseInteractionAction(CREATE, ActionType.NEW_URLS, typeId, helperId, localizer("create.url")));
+		actions.put(CREATE, new BaseInteractionAction(CREATE, ActionType.NEW_URLS, typeId, helperId, localizer("create.urls")));
 		actions.put(REVISE_CONTENT, new BaseInteractionAction(REVISE_CONTENT, ActionType.REVISE_CONTENT, typeId, helperId, localizer("action.revise")));
 		actions.put(ACCESS_PROPERTIES, new BaseServiceLevelAction(ACCESS_PROPERTIES, ActionType.VIEW_METADATA, typeId, false, localizer("action.access")));
 		actions.put(REVISE_METADATA, new BaseServiceLevelAction(REVISE_METADATA, ActionType.REVISE_METADATA, typeId, false, localizer("action.props")));

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ResourceToolAction.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ResourceToolAction.java
@@ -64,7 +64,7 @@ public interface ResourceToolAction
 		NEW_FOLDER,
 		
 		/**
-		 * Create a URL -- Handled by Resources tool.  Can create one link to a URL at a time (previously was multiple links).  
+		 * Create URLs -- Handled by Resources tool.  Can create multiple URLs at once.  
 		 * 		No content; requires metadata only.  Requires content.new permission in parent 
 		 * 		folder.
 		 */


### PR DESCRIPTION
First attempt didn't quite cut the mustard, https://github.com/sakaiproject/sakai/pull/4816

As documented in SAK-33264, we discovered that the date pickers were not being initialised within the details sub-form for web links added to the form.  We've fixed that by ensuring these pickers are setup upon cloning of the form elements (see `setupDatePickers`).

@jonespm now the date pickers are behaving themselves, we were also able to restore the 'Add Another Folder' workflow by tinkering making the DOM structure consistent with the web link form DOM.

Delivers https://jira.sakaiproject.org/browse/SAK-31520 and _ALTERNATIVE D_ from https://jira.sakaiproject.org/browse/SAK-33264.