### PR TITLE
SAM-3258 BigDecimal divide with no rounding mode causes bug in calc qs

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoExpressionParser.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoExpressionParser.java
@@ -61,6 +61,7 @@ public class SamigoExpressionParser
       // initialize all variables
       expr = new_expr;     // copy the given expression to expr
       ans = BigDecimal.valueOf(0.0);
+      this.decimals = decimals;
 
       // get the first character in expr
       getFirstChar();
@@ -703,7 +704,7 @@ public class SamigoExpressionParser
 
       // level 5
       case MULTIPLY:  return bdlhs.multiply(bdrhs);
-      case DIVIDE:    return bdlhs.divide(bdrhs);
+      case DIVIDE:    return bdlhs.divide(bdrhs, decimals, BigDecimal.ROUND_HALF_UP);
 
       case MODULUS:   return BigDecimal.valueOf(SamigoExpressionFunctions.modulus(lhs, rhs));
       case XOR:       return BigDecimal.valueOf((int)lhs ^ (int)rhs);
@@ -822,6 +823,7 @@ public class SamigoExpressionParser
   private String token;         /// holds the token
   private TOKENTYPE token_type; /// type of the token
 
+  private int decimals;
   private BigDecimal ans;           /// holds the result of the expression
   private String ans_str;       /// holds a string containing the result
                                 /// of the expression


### PR DESCRIPTION
There is an uncaught exception when evaluting division in
calculated questions where the answer is a non-terminating decimal.
This fixes the issue by setting the rounding mode and number of decimal
places desired.