### PR TITLE
SAK-33414 Assignments duplicating assignment assignments position

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -637,6 +637,7 @@ public class AssignmentServiceImpl implements AssignmentService {
                 assignment.setDropDeadDate(existingAssignment.getDropDeadDate());
                 assignment.setCloseDate(existingAssignment.getCloseDate());
                 assignment.setDraft(true);
+                assignment.setPosition(existingAssignment.getPosition());
                 assignment.setIsGroup(existingAssignment.getIsGroup());
 
                 Map<String, String> properties = assignment.getProperties();

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -350,6 +350,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         Assert.assertEquals(assignment.getDueDate(), duplicateAssignment.getDueDate());
         Assert.assertEquals(assignment.getDropDeadDate(), duplicateAssignment.getDropDeadDate());
         Assert.assertEquals(assignment.getCloseDate(), duplicateAssignment.getCloseDate());
+        Assert.assertEquals(assignment.getPosition(), duplicateAssignment.getPosition());
         Assert.assertEquals(
                 assignment.getProperties().entrySet().stream()
                         .filter(e -> !AssignmentServiceConstants.PROPERTIES_EXCLUDED_FROM_DUPLICATE_ASSIGNMENTS.contains(e.getKey()))

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11956,8 +11956,7 @@ public class AssignmentAction extends PagedResourceActionII {
             try {
                 Collections.sort(returnResources, ac);
             } catch (Exception e) {
-                // log exception during sorting for helping debugging
-                log.warn(this + ":sizeResources mode=" + mode + " sort=" + sort + " ascending=" + ascending + " " + e.getStackTrace());
+                log.warn("sorting mode = {}, sort = {}, ascending = {}, {}", mode, sort, ascending, e.getMessage());
             }
         }
 


### PR DESCRIPTION
While duplicating an assignment the position was not copied causing and
NPE in the comparator.
Added the original assignments position when creating the duplicate.