### PR TITLE
SAK-33418 Switch to use standard loggers.

### DIFF
--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
@@ -236,7 +236,7 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 		}
 		catch (Exception e)
 		{
-			e.printStackTrace();
+			logger.warn("Failed to send HTML page.", e);
 		}
 
 	}
@@ -487,7 +487,7 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 				} 
 				catch (Exception e)
 				{
-					e.printStackTrace();
+					logger.warn("Failed to track event.", e);
 				}
 
 			}
@@ -580,15 +580,8 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 				
 					SiteService.save(site);
 				}
-			} catch (IdUnusedException ie) {
-				// This would be thrown by SiteService.getSite(siteId)
-				ie.printStackTrace();
-			} catch (PermissionException pe) {
-				// This would be thrown by SiteService.save(site)
-				pe.printStackTrace();
 			} catch (Exception e) {
-				// This is a generic exception that would be thrown by the BasicLTIArchiveBean constructor.
-				e.printStackTrace();
+				logger.warn("Failed to merge site: {}", siteId, e);
 			}
 
 			results.append(".");
@@ -639,7 +632,7 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 			}
 			// Something we did not expect
 			catch (Exception e) {
-				e.printStackTrace();
+				logger.warn("Failed to archive: {}", siteId, e);
 				results.append("basiclti exception:"+e.getClass().getName()+"\n");
 			}
 			results.append("archiving basiclti ("+count+") tools archived\n");

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/SiteMembershipsSynchroniserImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/SiteMembershipsSynchroniserImpl.java
@@ -157,7 +157,7 @@ public class SiteMembershipsSynchroniserImpl implements SiteMembershipsSynchroni
 
             processMembershipsResponse(connection, site, oauth_consumer_key, isEmailTrustedConsumer);
         } catch (Exception e) {
-            e.printStackTrace();
+            M_log.warn("Problem synchronizing LTI1 memberships.", e);
         }
     }
 
@@ -231,7 +231,7 @@ public class SiteMembershipsSynchroniserImpl implements SiteMembershipsSynchroni
 
             processMembershipsResponse(connection, site, oauth_consumer_key, isEmailTrustedConsumer);
         } catch (Exception e) {
-            e.printStackTrace();
+            M_log.warn("Problem synchronizing Mooodle memberships.", e);
         }
     }
 


### PR DESCRIPTION
Using ex.printStackTrace() can result in logs ending up in a different place from the rest of the logging setup.