### PR TITLE
SAK-33390 - International characters lost resizing

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -18,6 +18,12 @@
   .selectPageSize {
     margin-right: 0.7em;
   }
+  .truncate{
+    width: 180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 </style>
 
 #javascript("/sakai-content-tool/js/content.js")
@@ -397,12 +403,6 @@
 					</td>
 					<td style="text-indent:$width" class="specialLink title" scope="row">
 					#if($item.isHot("$!dropboxHighlight")) #set($iconDecor="recentItem") #set($newNote="new") #else  #set($iconDecor="nil")  #set($newNote="")#end 
-              #if($validator.escapeHtml($item.name).length() > 25)
-                #set($trimmed = $validator.escapeHtml($item.name).substring(0,25))
-                #set($trimmedTitle = "$trimmed ...")
-              #else
-                #set($trimmedTitle = $validator.escapeHtml($item.name))
-              #end
 
               #if ($item.canRead())
 								#if($item.isCollection()) 
@@ -447,23 +447,23 @@
 									&#169;
 								#elseif($item.isCollection())
     								#if($item.isTooBigNav())
-                      <span class="visible-sm-inline visible-xs-inline">$trimmedTitle</span>
+                      <span class="visible-sm-inline-block visible-xs-inline-block truncate">$validator.escapeHtml($item.name)</span>
                       <span class="hidden-sm hidden-xs">$validator.escapeHtml($item.name)</span>
 									#else
 										<a href="#"
     										onclick="document.getElementById('sakai_action').value='doNavigate';document.getElementById('collectionId').value='$qid';document.getElementById('navRoot').value='$validator.escapeUrl($item.root)';document.getElementById('showForm').submit();"
     										title= "$item.hoverText">
-                        <span class="visible-sm-inline visible-xs-inline">$trimmedTitle</span>
+                        <span class="visible-sm-inline-block visible-xs-inline-block truncate">$validator.escapeHtml($item.name)</span>
                         <span class="hidden-sm hidden-xs">$validator.escapeHtml($item.name)</span>
     									</a>
 									#end	
 								#else
 									#if($item.isTooBigNav())
-                        <span class="visible-sm-inline visible-xs-inline">$trimmedTitle</span>
+                        <span class="visible-sm-inline-block visible-xs-inline-block truncate">$validator.escapeHtml($item.name)</span>
                         <span class="hidden-sm hidden-xs">$validator.escapeHtml($item.name)</span>
 									#else
 										<a href="$item.accessUrl" target="$item.target" title="$item.hoverText">
-                        <span class="visible-sm-inline visible-xs-inline">$trimmedTitle</span>
+                        <span class="visible-sm-inline-block visible-xs-inline-block truncate">$validator.escapeHtml($item.name)</span>
                         <span class="hidden-sm hidden-xs">$validator.escapeHtml($item.name)</span>
     									</a>
 									#end
@@ -475,7 +475,7 @@
 									<span class="fa fa-lock" aria-hidden="true"></span>
 									<span class="sr-only">$clang.getString('locked')</span>
 								#end
-                <span class="visible-sm-inline visible-xs-inline">$trimmedTitle</span>
+                <span class="visible-sm-inline-block visible-xs-inline-block truncate">$validator.escapeHtml($item.name)</span>
                 <span class="hidden-sm hidden-xs">$validator.escapeHtml($item.name)</span>
 								#if ($item.hasCopyrightAlert())
 									&#169;


### PR DESCRIPTION
It trims the item name when has more than 25 characters, trimming HTML entities if are present.

The current solution is a really bad practice, this request proposes another approach using the ellipsis, will be good if some expert can throw feedback.

I've tested it and works fine.