### PR TITLE
SAK-33438 - Upgrade to CKEditor 4.7.3

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>war</packaging>
 	<properties>
 		<!-- This is used in re-write rules as well -->
-		<ckeditor.version>4.5.11</ckeditor.version>
+		<ckeditor.version>4.7.3</ckeditor.version>
 		<bootstrap-version>3.3.7</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<!-- Default extra plugins enabled, currently autosave disabled via SAK-33362 -->

--- a/library/src/morpheus-master/sass/modules/editor/_base.scss
+++ b/library/src/morpheus-master/sass/modules/editor/_base.scss
@@ -2,7 +2,7 @@
 .cke {
 	.cke_button__sakaipreview {
 		.cke_button__sakaipreview_icon {
-			background: url(/library/webjars/ckeditor/4.5.11/full/skins/moono/icons_hidpi.png) no-repeat 0 -1632px !important;
+			background: url(/library/webjars/ckeditor/4.7.3/full/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1632px !important;
 			background-size: 16px !important;
 		}
 	}

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -108,7 +108,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             "attemptAllowed" : Number.MAX_VALUE,
             "attemptsRemaining": Number.MAX_VALUE
         },
-        skin: 'moono',
+        skin: 'moono-lisa',
         defaultLanguage: 'en',
         
         // SAK-31829, SAK-33279 Disable functionality in table plugin

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
@@ -36,8 +36,8 @@ public class EditorRegistryImpl implements EditorRegistry {
 		//TODO: pull this out to somewhere appropriate
 		register("textarea", "textarea", "/library/editor/textarea/textarea.js", "/library/editor/textarea.launch.js", "");
 		register("fckeditor", "FCKeditor", "/library/editor/FCKeditor/fckeditor.js", "/library/editor/fckeditor.launch.js", "");
-		register("ckeditor", "CKEditor", "/library/webjars/ckeditor/4.5.11/full/ckeditor.js", "/library/editor/ckeditor.launch.js",
-				"var CKEDITOR_BASEPATH='/library/webjars/ckeditor/4.5.11/full/';\n");
+		register("ckeditor", "CKEditor", "/library/webjars/ckeditor/4.7.3/full/ckeditor.js", "/library/editor/ckeditor.launch.js",
+				"var CKEDITOR_BASEPATH='/library/webjars/ckeditor/4.7.3/full/';\n");
 	}
 	
 	public void destroy() {


### PR DESCRIPTION
Upgrade CK Editor from 4.5.11 to 4.7.3.

The new default skin is moono-lisa instead of moono.

I've tested all the buttons, options and plugins (Except autosave), everything is working as expected.

Autosave should be upgraded from "b88e3878f0c7442a52e542f67e76d97e2ce32f8" to "786318aefed553a62cebbe4cd10b67c3ab266437".