### PR TITLE
SAK-33410 'Filter Students' activates the 'Add Gradebook Item' panel on return

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -911,6 +911,17 @@ GbGradeTable.renderTable = function (elementId, tableData) {
   }).on("focus", function() {
     // deselect the table so subsequent keyboard entry isn't entered into cells
     GbGradeTable.instance.deselectCell();
+  }).on("keydown", function(event) {
+    // Disable the Wicket behavior that triggers the click on the form's first button
+    // after a 'return' keypress within a text input
+    //
+    // See https://issues.apache.org/jira/browse/WICKET-4499
+    if (event.keyCode == 13) {
+      clearTimeout(filterTimeout);
+      GbGradeTable.redrawTable(true);
+
+      return false;
+    }
   });
   $(document).on('click', '.gb-student-filter-clear-button', function(event) {
     event.preventDefault();


### PR DESCRIPTION
Disable the Wicket/browser behavior that triggers click on the form's first button after a 'return' keypress within the filter input field.

https://jira.sakaiproject.org/browse/SAK-33410