### PR TITLE
SAK-33441 SakaiScript's addNewToolToAllWorkspaces() may not set the tool order correctly

### DIFF
--- a/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiScript.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiScript.java
@@ -3099,11 +3099,12 @@ public class SakaiScript extends AbstractWebService {
                 //KNL-250, SAK-16819 - if position too large, will throw ArrayIndexOutOfBoundsException
                 //deal with this here and just set to the number of pages - 1 so its at the bottom.
                 int numPages = siteEdit.getPages().size();
-                if (position > numPages) {
-                    position = numPages - 1;
+                int newPosition = position;
+                if (newPosition >= numPages) {
+                    newPosition = numPages - 1;
                 }
 
-                sitePageEdit.setPosition(position);
+                sitePageEdit.setPosition(newPosition);
                 sitePageEdit.setPopup(popup);
 
                 ToolConfiguration tool = sitePageEdit.addTool();


### PR DESCRIPTION
Fix for SAK-33441 addNewToolToAllWorkspaces() tool order and SAK-33428 ArrayIndexOutOfBounds