### PR TITLE
KNL-1554 Refactor of time service to aid deprecation

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/time/api/TimeService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/time/api/TimeService.java
@@ -28,8 +28,9 @@ import java.util.TimeZone;
  * <p>
  * TimeService ...
  * </p>
+ * @deprecated Please use {@link UserTimeService} or the new {@link java.time} package.
  */
-public interface TimeService
+public interface TimeService extends UserTimeService
 {
 	/** The type string for this "application": should not change over time as it may be stored in various parts of persistent entities. */
 	static final String APPLICATION_ID = "sakai:time";
@@ -218,19 +219,6 @@ public interface TimeService
 	 */
 	TimeRange newTimeRange(Time start, Time end);
 
-	/**
-	 * Access the users prefered local TimeZone.
-	 * 
-	 * @return The user's local TimeZone.
-	 */
-	TimeZone getLocalTimeZone();
-
-	/**
-	 * Clear local time zone for specified user
-	 * 
-	 * @return true if successful
-	 */
-	boolean clearLocalTimeZone(String userId);
 
 	/**
 	 * Get a Calendar, set to this zone and these values.

--- a/kernel/api/src/main/java/org/sakaiproject/time/api/UserTimeService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/time/api/UserTimeService.java
@@ -1,0 +1,26 @@
+package org.sakaiproject.time.api;
+
+import java.util.TimeZone;
+
+/**
+ * This is an extraction out the user timezone specific parts of the TimeService. Refactorings can then be
+ * done to bind to this service when the rest of TimeService isn't needed.
+ *
+ * @see TimeService
+ */
+public interface UserTimeService {
+
+    /**
+     * Access the users preferred local TimeZone.
+     *
+     * @return The user's local TimeZone.
+     */
+    TimeZone getLocalTimeZone();
+
+    /**
+     * Clear local time zone for specified user. Should be called when locale or timezone for user is changed.
+     *
+     * @return true if successful
+     */
+    boolean clearLocalTimeZone(String userId);
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/BasicTimeService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/BasicTimeService.java
@@ -25,23 +25,17 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.GregorianCalendar;
 import java.util.Hashtable;
-import java.util.Locale;
+import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 
+import org.sakaiproject.time.api.UserTimeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sakaiproject.entity.api.ResourceProperties;
-import org.sakaiproject.memory.api.Cache;
-import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.api.TimeBreakdown;
 import org.sakaiproject.time.api.TimeRange;
 import org.sakaiproject.time.api.TimeService;
-import org.sakaiproject.tool.api.SessionManager;
-import org.sakaiproject.user.api.Preferences;
-import org.sakaiproject.user.api.PreferencesService;
-import org.sakaiproject.util.ResourceLoader;
 
 /**
  * <p>
@@ -79,49 +73,29 @@ public class BasicTimeService implements TimeService
 	// Map of Timezone/Locales to LocalTzFormat objects
 	private Hashtable<String, LocalTzFormat> M_localeTzMap = new Hashtable<String, LocalTzFormat>();
 
-	// Cache of userIds to Timezone/Locales
-	private Cache<String, String[]> M_userTzCache;
-
-	// Default Timezone/Locale
-	protected String[] M_tz_locale_default = new String[] { TimeZone.getDefault().getID(), Locale.getDefault().toString() };
-
-	// Used for fetching user's default language locale
-	ResourceLoader rl = new ResourceLoader();
 
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * Dependencies and their setter methods
 	 *********************************************************************************************************************************************************************************************************************************************************/
-	private SessionManager sessionManager;
+	private UserTimeService userTimeService;
 
-	public void setSessionManager(SessionManager sessionManager) {
-		this.sessionManager = sessionManager;
+	public void setUserTimeService(UserTimeService userTimeService) {
+		this.userTimeService = userTimeService;
 	}
 
-	private PreferencesService preferencesService;
+	private UserLocaleServiceImpl userLocaleService;
 
-	public void setPreferencesService(PreferencesService preferencesService) {
-		this.preferencesService = preferencesService;
+	public void setUserLocaleService(UserLocaleServiceImpl userLocaleService) {
+		this.userLocaleService = userLocaleService;
 	}
-	
-	
-	private MemoryService memoryService;
-
-	public void setMemoryService(MemoryService memoryService) {
-		this.memoryService = memoryService;
-	}
-	
-
-	/**********************************************************************************************************************************************************************************************************************************************************
-	 * Init and Destroy
-	 *********************************************************************************************************************************************************************************************************************************************************/
-
-
 
 	/**
 	 * Final initialization, once all dependencies are set.
 	 */
 	public void init()
 	{
+		Objects.requireNonNull(userLocaleService);
+		Objects.requireNonNull(userTimeService);
 		/** The time zone for our GMT times. */
 		M_tz = TimeZone.getTimeZone("GMT");
 
@@ -130,7 +104,7 @@ public class BasicTimeService implements TimeService
 		/**
 		 * a calendar to clone for GMT time construction
 		 */
-		M_GCal = getCalendar(M_tz, 0, 0, 0, 0, 0, 0, 0);
+		M_GCal = newCalendar(M_tz, 0, 0, 0, 0, 0, 0, 0);
 
 		// Note: formatting for GMT time representations
 		M_fmtA = (DateFormat)(new SimpleDateFormat("yyyyMMddHHmmssSSS"));
@@ -146,10 +120,7 @@ public class BasicTimeService implements TimeService
 		M_fmtD.setTimeZone(M_tz);
 		M_fmtE.setTimeZone(M_tz);
 		M_fmtG.setTimeZone(M_tz);
-		
-		
-		//register the Cache
-		M_userTzCache = memoryService.getCache("org.sakaiproject.time.impl.BasicTimeService.userTimezoneCache");
+
 	}
 
 	/**
@@ -160,32 +131,13 @@ public class BasicTimeService implements TimeService
 		M_log.info("destroy()");
 	}
 
-	/** Return string with user's prefered timezone _and_ preferred locale
-	 ** (dates are formatted according to the locale)
-	 **/
 	protected String[] getUserTimezoneLocale()
 	{
-		// Check if we already cached this user's timezone
-		String userId = sessionManager.getCurrentSessionUserId();
-		if (userId == null) return M_tz_locale_default;
+	    String timeZone = userTimeService.getLocalTimeZone().getID();
+		// Now, get user's preferred locale
+		String localeId = userLocaleService.getLocalLocale();
 
-		String[] timeZoneLocale = M_userTzCache.get(userId);
-		if (timeZoneLocale != null) return timeZoneLocale;
-
-		// Otherwise, get the user's preferred time zone
-		Preferences prefs = preferencesService.getPreferences(userId);
-		ResourceProperties tzProps = prefs.getProperties(TimeService.APPLICATION_ID);
-		String timeZone = tzProps.getProperty(TimeService.TIMEZONE_KEY);
-
-		if (timeZone == null || timeZone.equals("")) 
-			timeZone = TimeZone.getDefault().getID();
-
-		// Now, get user's prefered locale
-		String localeId = rl.getLocale().toString();
-
-		timeZoneLocale = new String[] {timeZone, localeId};
-
-		M_userTzCache.put(userId, timeZoneLocale);
+		String[] timeZoneLocale = new String[] {timeZone, localeId};
 
 		return timeZoneLocale;
 	}
@@ -194,9 +146,9 @@ public class BasicTimeService implements TimeService
 	{
 		//we need to convert the String[] to a string key
 		String tzLocaleString = stringAraytoKeyString(timeZoneLocale);
-		
+
 		LocalTzFormat tzFormat = M_localeTzMap.get(tzLocaleString);
-		if (M_log.isDebugEnabled()) 
+		if (M_log.isDebugEnabled())
 		{
 			M_log.debug("M_localeTzMap contains: " + M_localeTzMap.size() + " members");
 		}
@@ -213,13 +165,13 @@ public class BasicTimeService implements TimeService
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < timeZoneLocale.length; i++ )
 		{
-			if (i > 0) 
+			if (i > 0)
 			{
 				sb.append("_");
 			}
 			sb.append(timeZoneLocale[i]);
 		}
-		
+
 		if (M_log.isDebugEnabled())
 		{
 			M_log.debug("returing key: " + sb.toString());
@@ -227,19 +179,11 @@ public class BasicTimeService implements TimeService
 		return sb.toString();
 	}
 
-	
+
 	/**********************************************************************************************************************************************************************************************************************************************************
 	 * Work interface methods: org.sakai.service.time.TimeService
 	 *********************************************************************************************************************************************************************************************************************************************************/
 
-	
-
-	/**
-	 * no arg constructor
-	 */
-	public BasicTimeService()
-	{
-	}
 
 	/**
 	 * {@inheritDoc}
@@ -294,7 +238,7 @@ public class BasicTimeService implements TimeService
 	 */
 	public Time newTimeLocal(int year, int month, int day, int hour, int minute, int second, int millisecond)
 	{
-		TimeZone tz_local = getLocalTzFormat(getUserTimezoneLocale()).M_tz_local;
+		TimeZone tz_local = userTimeService.getLocalTimeZone();
 		return new MyTime(this,tz_local, year, month, day, hour, minute, second, millisecond);
 	}
 
@@ -303,7 +247,7 @@ public class BasicTimeService implements TimeService
 	 */
 	public Time newTimeLocal(TimeBreakdown breakdown)
 	{
-		TimeZone tz_local = getLocalTzFormat(getUserTimezoneLocale()).M_tz_local;
+		TimeZone tz_local = userTimeService.getLocalTimeZone();
 		return new MyTime(this,tz_local, breakdown);
 	}
 
@@ -358,18 +302,20 @@ public class BasicTimeService implements TimeService
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public TimeZone getLocalTimeZone()
 	{
-		return getLocalTzFormat(getUserTimezoneLocale()).M_tz_local;
+		return userTimeService.getLocalTimeZone();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean clearLocalTimeZone(String userId)
 	{
-		M_userTzCache.remove(userId);
-		return true;
+		// Must not use && as need to clear them both.
+		return userTimeService.clearLocalTimeZone(userId) & userLocaleService.clearLocalLocale(userId);
 	}
 
 	/**
@@ -377,11 +323,7 @@ public class BasicTimeService implements TimeService
 	 */
 	public GregorianCalendar getCalendar(TimeZone zone, int year, int month, int day, int hour, int min, int sec, int ms)
 	{
-		GregorianCalendar rv = new GregorianCalendar(year, month, day, hour, min, sec);
-		rv.setTimeZone(zone);
-		rv.set(GregorianCalendar.MILLISECOND, ms);
-
-		return rv;
+	    return newCalendar(zone, year, month, day, hour, min, sec, ms);
 	}
 
 	/**
@@ -403,96 +345,6 @@ public class BasicTimeService implements TimeService
 
 		// now we know neither are null, so compare
 		return (!a.equals(b));
-	}
-
-	/**********************************************************************************************************************************************************************************************************************************************************
-	 * LocalTzFormat -- maintains a local timezone, locale and DateFormats
-	 *********************************************************************************************************************************************************************************************************************************************************/
-
-	protected class LocalTzFormat
-	{
-		// The time zone for our local times
-		public TimeZone M_tz_local = null;
-
-		// The Locale for our local date/time formatting
-		public Locale M_locale = null;
-
-		// a calendar to clone for GMT time construction
-		public GregorianCalendar M_GCall = null;
-
-		// The formatter for our special local timezone format(s)
-		public DateFormat M_fmtAl = null;
-
-		public DateFormat M_fmtBl = null;
-
-		public DateFormat M_fmtBlz = null;
-
-		public DateFormat M_fmtCl = null;
-
-		public DateFormat M_fmtClz = null;
-
-		public DateFormat M_fmtDl = null;
-
-		public DateFormat M_fmtD2 = null;
-
-		public DateFormat M_fmtFl = null;
-
-		private LocalTzFormat()
-		{
-		}; // disable default constructor
-
-		public LocalTzFormat(String timeZoneId, String localeId )
-		{
-			M_tz_local = TimeZone.getTimeZone(timeZoneId);
-
-			Locale M_locale = null;
-			String langLoc[] = localeId.split("_");
-			if ( langLoc.length >= 2 )
-				if (langLoc[0].equals("en") && langLoc[1].equals("ZA"))
-					M_locale = new Locale("en", "GB");
-				else
-					M_locale = new Locale(langLoc[0], langLoc[1]);
-			else
-				M_locale = new Locale(langLoc[0]);
-
-			M_fmtAl = (DateFormat)(new SimpleDateFormat("yyyyMMddHHmmssSSS"));
-			M_fmtBl = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, M_locale);
-			M_fmtBlz = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.LONG, M_locale);
-			M_fmtCl = DateFormat.getTimeInstance(DateFormat.SHORT, M_locale);
-			M_fmtClz = DateFormat.getTimeInstance(DateFormat.LONG, M_locale);
-			M_fmtDl = DateFormat.getDateInstance(DateFormat.MEDIUM, M_locale);
-			M_fmtD2 = DateFormat.getDateInstance(DateFormat.SHORT, M_locale);
-			M_fmtFl = (DateFormat)(new SimpleDateFormat("HH:mm:ss"));
-
-			// Strip the seconds from the Blz and Clz (default) formats         
-			try
-			{
-				SimpleDateFormat sdf = ((SimpleDateFormat)M_fmtBlz);
-				String pattern = sdf.toLocalizedPattern();
-				pattern = pattern.replaceAll(":ss","");
-				sdf.applyLocalizedPattern( pattern );
-
-				sdf = ((SimpleDateFormat)M_fmtClz);
-				pattern = sdf.toLocalizedPattern();
-				pattern = pattern.replaceAll(":ss","");
-				sdf.applyLocalizedPattern( pattern );
-			}
-			catch (ClassCastException e)
-			{
-				// ignore -- not all locales support this
-			}
-
-			M_fmtAl.setTimeZone(M_tz_local);
-			M_fmtBl.setTimeZone(M_tz_local);
-			M_fmtBlz.setTimeZone(M_tz_local);
-			M_fmtCl.setTimeZone(M_tz_local);
-			M_fmtClz.setTimeZone(M_tz_local);
-			M_fmtDl.setTimeZone(M_tz_local);
-			M_fmtD2.setTimeZone(M_tz_local);
-			M_fmtFl.setTimeZone(M_tz_local);
-
-			M_GCall = getCalendar(M_tz_local, 0, 0, 0, 0, 0, 0, 0);
-		}
 	}
 
 	/**********************************************************************************************************************************************************************************************************************************************************
@@ -521,7 +373,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * construct from a two times, and start and end inclusion booleans
-		 * 
+		 *
 		 * @param start:
 		 *        start time
 		 * @param end:
@@ -551,7 +403,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * construct from a string, in our format
-		 * 
+		 *
 		 * @param str
 		 *        the time range string
 		 */
@@ -563,7 +415,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * construct from a single time
-		 * 
+		 *
 		 * @param startAndEnd:
 		 *        the single time value for the range
 		 */
@@ -575,7 +427,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * construct from a time long and a duration long in ms
-		 * 
+		 *
 		 * @param start
 		 *        time value
 		 * @param duration
@@ -601,7 +453,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * construct from a two times - inclusive
-		 * 
+		 *
 		 * @param start:
 		 *        the start time
 		 * @param end:
@@ -615,7 +467,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * is this time in my range?
-		 * 
+		 *
 		 * @param time:
 		 *        the time to check for inclusion
 		 * @return true if the time is in the range, false if not
@@ -649,7 +501,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * do I overlap this other range at all?
-		 * 
+		 *
 		 * @param range:
 		 *        the time range to check for overlap
 		 * @return true if any time in range is in my range is in the other range, false if not
@@ -684,7 +536,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * do I completely contain this other range?
-		 * 
+		 *
 		 * @param range:
 		 *        the time range to check for containment
 		 * @return true if range is within my time ramge
@@ -698,7 +550,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * what is the first time range included?
-		 * 
+		 *
 		 * @return the first time actually in the range
 		 */
 		public Time firstTime()
@@ -709,7 +561,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * what is the last time range included?
-		 * 
+		 *
 		 * @return the last time actually in the range
 		 */
 		public Time lastTime()
@@ -720,7 +572,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * what is the first time range included?
-		 * 
+		 *
 		 * @param fudge
 		 *        How many ms to advance if the first is not included.
 		 * @return the first time actually in the range
@@ -742,7 +594,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * what is the last time range included?
-		 * 
+		 *
 		 * @param fudge
 		 *        How many ms to decrease if the first is not included.
 		 * @return the last time actually in the range
@@ -764,7 +616,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * format the range
-		 * 
+		 *
 		 * @return a string representation of the time range
 		 */
 		public String toString()
@@ -807,7 +659,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * format the range - human readable
-		 * 
+		 *
 		 * @return a string representation of the time range, human readable
 		 */
 		public String toStringHR()
@@ -888,7 +740,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * parse from a string - resolve fully earliest ('!') and latest ('*') and durations ('=')
-		 * 
+		 *
 		 * @param str
 		 *        the string to parse
 		 * @param earliest
@@ -1064,7 +916,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * Shift the time range back an intervel
-		 * 
+		 *
 		 * @param i
 		 *        time intervel in ms
 		 */
@@ -1076,7 +928,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * Shift the time range forward an intervel
-		 * 
+		 *
 		 * @param i
 		 *        time intervel in ms
 		 */
@@ -1088,7 +940,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * Enlarge or shrink the time range by multiplying a zooming factor
-		 * 
+		 *
 		 * @param f
 		 *        zooming factor
 		 */
@@ -1104,7 +956,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * Adjust this time range based on the difference between the origRange and the modRange, if any
-		 * 
+		 *
 		 * @param original
 		 *        the original time range.
 		 * @param modified
@@ -1126,7 +978,7 @@ public class BasicTimeService implements TimeService
 
 		/**
 		 * check if the time range is really just a single time
-		 * 
+		 *
 		 * @return true if the time range is a single time, false if it is not
 		 */
 		public boolean isSingleTime()
@@ -1137,144 +989,14 @@ public class BasicTimeService implements TimeService
 
 	} // class TimeRange
 
-	/**********************************************************************************************************************************************************************************************************************************************************
-	 * TimeBreakdown implementation
-	 *********************************************************************************************************************************************************************************************************************************************************/
 
-	public class MyTimeBreakdown implements TimeBreakdown
+	public static GregorianCalendar newCalendar(TimeZone zone, int year, int month, int day, int hour, int min, int sec, int ms)
 	{
-		/** The parts. */
-		protected int year;
+		GregorianCalendar rv = new GregorianCalendar(year, month, day, hour, min, sec);
+		rv.setTimeZone(zone);
+		rv.set(GregorianCalendar.MILLISECOND, ms);
 
-		protected int month;
-
-		protected int day;
-
-		protected int hour;
-
-		protected int min;
-
-		protected int sec;
-
-		protected int ms;
-
-		public MyTimeBreakdown(int y, int m, int d, int h, int minutes, int s, int milliseconds)
-		{
-			year = y;
-			month = m;
-			day = d;
-			hour = h;
-			min = minutes;
-			sec = s;
-			ms = milliseconds;
-		}
-
-		public MyTimeBreakdown(TimeBreakdown other)
-		{
-			year = ((MyTimeBreakdown) other).year;
-			month = ((MyTimeBreakdown) other).month;
-			day = ((MyTimeBreakdown) other).day;
-			hour = ((MyTimeBreakdown) other).hour;
-			min = ((MyTimeBreakdown) other).min;
-			sec = ((MyTimeBreakdown) other).sec;
-			ms = ((MyTimeBreakdown) other).ms;
-		}
-
-		public String toString()
-		{
-			return "year: " + year + " month: " + month + " day: " + day + " hour: " + hour + " min: " + min + " sec: " + sec
-			+ " ms: " + ms;
-		}
-
-		public int getYear()
-		{
-			return year;
-		}
-
-		public int getMonth()
-		{
-			return month;
-		}
-
-		public int getDay()
-		{
-			return day;
-		}
-
-		public int getHour()
-		{
-			return hour;
-		}
-
-		public int getMin()
-		{
-			return min;
-		}
-
-		public int getSec()
-		{
-			return sec;
-		}
-
-		public int getMs()
-		{
-			return ms;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setDay(int i)
-		{
-			day = i;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setHour(int i)
-		{
-			hour = i;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setMin(int i)
-		{
-			min = i;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setMonth(int i)
-		{
-			month = i;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setMs(int i)
-		{
-			ms = i;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setSec(int i)
-		{
-			sec = i;
-		}
-
-		/**
-		 * @param i
-		 */
-		public void setYear(int i)
-		{
-			year = i;
-		}
+		return rv;
 	}
+
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/BasicTimeService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/BasicTimeService.java
@@ -133,7 +133,7 @@ public class BasicTimeService implements TimeService
 
 	protected String[] getUserTimezoneLocale()
 	{
-	    String timeZone = userTimeService.getLocalTimeZone().getID();
+		String timeZone = userTimeService.getLocalTimeZone().getID();
 		// Now, get user's preferred locale
 		String localeId = userLocaleService.getLocalLocale();
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/LocalTzFormat.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/LocalTzFormat.java
@@ -1,0 +1,98 @@
+package org.sakaiproject.time.impl;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**********************************************************************************************************************************************************************************************************************************************************
+ * LocalTzFormat -- maintains a local timezone, locale and DateFormats
+ *********************************************************************************************************************************************************************************************************************************************************/
+
+class LocalTzFormat
+{
+    // The time zone for our local times
+    public TimeZone M_tz_local = null;
+
+    // The Locale for our local date/time formatting
+    public Locale M_locale = null;
+
+    // a calendar to clone for GMT time construction
+    public GregorianCalendar M_GCall = null;
+
+    // The formatter for our special local timezone format(s)
+    public DateFormat M_fmtAl = null;
+
+    public DateFormat M_fmtBl = null;
+
+    public DateFormat M_fmtBlz = null;
+
+    public DateFormat M_fmtCl = null;
+
+    public DateFormat M_fmtClz = null;
+
+    public DateFormat M_fmtDl = null;
+
+    public DateFormat M_fmtD2 = null;
+
+    public DateFormat M_fmtFl = null;
+
+    private LocalTzFormat()
+    {
+    }; // disable default constructor
+
+    public LocalTzFormat(String timeZoneId, String localeId )
+    {
+        M_tz_local = TimeZone.getTimeZone(timeZoneId);
+
+        Locale M_locale = null;
+        String langLoc[] = localeId.split("_");
+        if ( langLoc.length >= 2 )
+            if (langLoc[0].equals("en") && langLoc[1].equals("ZA"))
+                M_locale = new Locale("en", "GB");
+            else
+                M_locale = new Locale(langLoc[0], langLoc[1]);
+        else
+            M_locale = new Locale(langLoc[0]);
+
+        M_fmtAl = (DateFormat)(new SimpleDateFormat("yyyyMMddHHmmssSSS"));
+        M_fmtBl = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, M_locale);
+        M_fmtBlz = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.LONG, M_locale);
+        M_fmtCl = DateFormat.getTimeInstance(DateFormat.SHORT, M_locale);
+        M_fmtClz = DateFormat.getTimeInstance(DateFormat.LONG, M_locale);
+        M_fmtDl = DateFormat.getDateInstance(DateFormat.MEDIUM, M_locale);
+        M_fmtD2 = DateFormat.getDateInstance(DateFormat.SHORT, M_locale);
+        M_fmtFl = (DateFormat)(new SimpleDateFormat("HH:mm:ss"));
+
+        // Strip the seconds from the Blz and Clz (default) formats
+        try
+        {
+            SimpleDateFormat sdf = ((SimpleDateFormat)M_fmtBlz);
+            String pattern = sdf.toLocalizedPattern();
+            pattern = pattern.replaceAll(":ss","");
+            sdf.applyLocalizedPattern( pattern );
+
+            sdf = ((SimpleDateFormat)M_fmtClz);
+            pattern = sdf.toLocalizedPattern();
+            pattern = pattern.replaceAll(":ss","");
+            sdf.applyLocalizedPattern( pattern );
+        }
+        catch (ClassCastException e)
+        {
+            // ignore -- not all locales support this
+        }
+
+        M_fmtAl.setTimeZone(M_tz_local);
+        M_fmtBl.setTimeZone(M_tz_local);
+        M_fmtBlz.setTimeZone(M_tz_local);
+        M_fmtCl.setTimeZone(M_tz_local);
+        M_fmtClz.setTimeZone(M_tz_local);
+        M_fmtDl.setTimeZone(M_tz_local);
+        M_fmtD2.setTimeZone(M_tz_local);
+        M_fmtFl.setTimeZone(M_tz_local);
+
+        M_GCall = BasicTimeService.newCalendar(M_tz_local, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/MyTime.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/MyTime.java
@@ -46,12 +46,6 @@ public class MyTime implements Time
 
 	private transient BasicTimeService timeService;
 
-	public void resolveTransientFields()
-	{
-		org.sakaiproject.component.api.ComponentManager compMgr =
-			org.sakaiproject.component.cover.ComponentManager.getInstance();
-		timeService = (BasicTimeService)compMgr.get("org.sakaiproject.time.api.TimeService");
-	}
 
 	/**
 	 * construct from a string, in our format, GMT values
@@ -106,7 +100,7 @@ public class MyTime implements Time
 	 *        day in month (1..31)
 	 * @param hour
 	 *        hour in day (0..23)
-	 * @param minuet
+	 * @param minute
 	 *        minute in hour (0..59)
 	 * @param second
 	 *        second in minute (0..59)
@@ -116,7 +110,7 @@ public class MyTime implements Time
 	public MyTime(BasicTimeService timeService, TimeZone zone, int year, int month, int day, int hour, int minute, int second, int millisecond)
 	{
 		this.timeService = timeService;
-		GregorianCalendar cal = timeService.getCalendar(zone, year, month - 1, day, hour,
+		GregorianCalendar cal = BasicTimeService.newCalendar(zone, year, month - 1, day, hour,
 				minute, second, millisecond);
 		m_millisecondsSince = cal.getTimeInMillis();
 	}
@@ -132,7 +126,7 @@ public class MyTime implements Time
 	public MyTime(BasicTimeService timeService, TimeZone zone, TimeBreakdown tb)
 	{
 		this.timeService = timeService;
-		GregorianCalendar cal = timeService.getCalendar(zone, tb.getYear(), tb.getMonth() - 1,
+		GregorianCalendar cal = BasicTimeService.newCalendar(zone, tb.getYear(), tb.getMonth() - 1,
 				tb.getDay(), tb.getHour(), tb.getMin(), tb.getSec(), tb.getMs());
 		m_millisecondsSince = cal.getTimeInMillis();
 	}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/MyTimeBreakdown.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/MyTimeBreakdown.java
@@ -1,0 +1,144 @@
+package org.sakaiproject.time.impl;
+
+import org.sakaiproject.time.api.TimeBreakdown;
+
+/**********************************************************************************************************************************************************************************************************************************************************
+ * TimeBreakdown implementation
+ *********************************************************************************************************************************************************************************************************************************************************/
+
+public class MyTimeBreakdown implements TimeBreakdown
+{
+    /** The parts. */
+    protected int year;
+
+    protected int month;
+
+    protected int day;
+
+    protected int hour;
+
+    protected int min;
+
+    protected int sec;
+
+    protected int ms;
+
+    public MyTimeBreakdown(int y, int m, int d, int h, int minutes, int s, int milliseconds)
+    {
+        year = y;
+        month = m;
+        day = d;
+        hour = h;
+        min = minutes;
+        sec = s;
+        ms = milliseconds;
+    }
+
+    public MyTimeBreakdown(TimeBreakdown other)
+    {
+        year = ((MyTimeBreakdown) other).year;
+        month = ((MyTimeBreakdown) other).month;
+        day = ((MyTimeBreakdown) other).day;
+        hour = ((MyTimeBreakdown) other).hour;
+        min = ((MyTimeBreakdown) other).min;
+        sec = ((MyTimeBreakdown) other).sec;
+        ms = ((MyTimeBreakdown) other).ms;
+    }
+
+    public String toString()
+    {
+        return "year: " + year + " month: " + month + " day: " + day + " hour: " + hour + " min: " + min + " sec: " + sec
+        + " ms: " + ms;
+    }
+
+    public int getYear()
+    {
+        return year;
+    }
+
+    public int getMonth()
+    {
+        return month;
+    }
+
+    public int getDay()
+    {
+        return day;
+    }
+
+    public int getHour()
+    {
+        return hour;
+    }
+
+    public int getMin()
+    {
+        return min;
+    }
+
+    public int getSec()
+    {
+        return sec;
+    }
+
+    public int getMs()
+    {
+        return ms;
+    }
+
+    /**
+     * @param i
+     */
+    public void setDay(int i)
+    {
+        day = i;
+    }
+
+    /**
+     * @param i
+     */
+    public void setHour(int i)
+    {
+        hour = i;
+    }
+
+    /**
+     * @param i
+     */
+    public void setMin(int i)
+    {
+        min = i;
+    }
+
+    /**
+     * @param i
+     */
+    public void setMonth(int i)
+    {
+        month = i;
+    }
+
+    /**
+     * @param i
+     */
+    public void setMs(int i)
+    {
+        ms = i;
+    }
+
+    /**
+     * @param i
+     */
+    public void setSec(int i)
+    {
+        sec = i;
+    }
+
+    /**
+     * @param i
+     */
+    public void setYear(int i)
+    {
+        year = i;
+    }
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserLocaleServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserLocaleServiceImpl.java
@@ -1,0 +1,67 @@
+package org.sakaiproject.time.impl;
+
+import org.sakaiproject.memory.api.Cache;
+import org.sakaiproject.memory.api.MemoryService;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.util.ResourceLoader;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * This provides a cached lookup to the user's locale. This might not be needed but due to the number of calls
+ * made to formatting dates we need to be careful about constantly going back to the service to find out the user's
+ * locale as it isn't cached at the moment.
+ *
+ * In the future the ResourceLoader should be refactored so that getting a user's locale is separated out from the
+ * looking up of resource strings.
+ */
+public class UserLocaleServiceImpl {
+
+    // Cache of userIds to Locales
+    private Cache<String, String> userLocaleCache;
+
+    private SessionManager sessionManager;
+    private MemoryService memoryService;
+    private ResourceLoader resourceLoader;
+
+    public void setSessionManager(SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    public void setMemoryService(MemoryService memoryService) {
+        this.memoryService = memoryService;
+    }
+
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    public void init() {
+        Objects.requireNonNull(sessionManager);
+        Objects.requireNonNull(memoryService);
+        Objects.requireNonNull(resourceLoader);
+        userLocaleCache = memoryService.getCache("org.sakaiproject.time.impl.BasicTimeService.userLocaleCache");
+    }
+
+    public String getLocalLocale() {
+        String userId = sessionManager.getCurrentSessionUserId();
+        if (userId == null) {
+            return Locale.getDefault().toString();
+        }
+        String locale = userLocaleCache.get(userId);
+        if (locale == null) {
+            // Load the user's locale
+            locale = resourceLoader.getLocale().toString();
+            userLocaleCache.put(userId, locale);
+        }
+        return locale;
+    }
+
+    public boolean clearLocalLocale(String userId) {
+        userLocaleCache.remove(userId);
+        return true;
+    }
+
+
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserLocaleServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserLocaleServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  * This provides a cached lookup to the user's locale. This might not be needed but due to the number of calls
  * made to formatting dates we need to be careful about constantly going back to the service to find out the user's
  * locale as it isn't cached at the moment.
- *
+ * <p>
  * In the future the ResourceLoader should be refactored so that getting a user's locale is separated out from the
  * looking up of resource strings.
  */

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserTimeServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserTimeServiceImpl.java
@@ -51,8 +51,7 @@ public class UserTimeServiceImpl implements UserTimeService {
         M_userTzCache = memoryService.getCache("org.sakaiproject.time.impl.BasicTimeService.userTimezoneCache");
     }
 
-    protected String getUserTimezone()
-    {
+    protected String getUserTimezone() {
         // Check if we already cached this user's timezone
         String userId = sessionManager.getCurrentSessionUserId();
         if (userId == null) return defaultTimezone;
@@ -79,8 +78,7 @@ public class UserTimeServiceImpl implements UserTimeService {
      * {@inheritDoc}
      */
     @Override
-    public TimeZone getLocalTimeZone()
-    {
+    public TimeZone getLocalTimeZone() {
         String tz = getUserTimezone();
         // Not holding a cache can be slow.
         return tzCache.computeIfAbsent(tz, TimeZone::getTimeZone);
@@ -90,8 +88,7 @@ public class UserTimeServiceImpl implements UserTimeService {
      * {@inheritDoc}
      */
     @Override
-    public boolean clearLocalTimeZone(String userId)
-    {
+    public boolean clearLocalTimeZone(String userId) {
         M_userTzCache.remove(userId);
         return true;
     }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserTimeServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/time/impl/UserTimeServiceImpl.java
@@ -1,0 +1,99 @@
+package org.sakaiproject.time.impl;
+
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.memory.api.Cache;
+import org.sakaiproject.memory.api.MemoryService;
+import org.sakaiproject.time.api.TimeService;
+import org.sakaiproject.time.api.UserTimeService;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This just deals with the user specific part of what timezone they are in.
+ */
+public class UserTimeServiceImpl implements UserTimeService {
+
+    private final Logger log = LoggerFactory.getLogger(UserTimeServiceImpl.class);
+
+    // Cache of userIds to Timezone
+    private Cache<String, String> M_userTzCache;
+
+    // Map of Timezone/Locales to LocalTzFormat objects
+    private ConcurrentHashMap<String, TimeZone> tzCache = new ConcurrentHashMap<>();
+
+    // Default Timezone/Locale
+    private String defaultTimezone = TimeZone.getDefault().getID();
+
+    private MemoryService memoryService;
+    private SessionManager sessionManager;
+    private PreferencesService preferencesService;
+
+    public void setMemoryService(MemoryService memoryService) {
+        this.memoryService = memoryService;
+    }
+
+    public void setSessionManager(SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    public void setPreferencesService(PreferencesService preferencesService) {
+        this.preferencesService = preferencesService;
+    }
+
+    public void init() {
+        //register the Cache
+        M_userTzCache = memoryService.getCache("org.sakaiproject.time.impl.BasicTimeService.userTimezoneCache");
+    }
+
+    protected String getUserTimezone()
+    {
+        // Check if we already cached this user's timezone
+        String userId = sessionManager.getCurrentSessionUserId();
+        if (userId == null) return defaultTimezone;
+
+        String timeZoneLocale = M_userTzCache.get(userId);
+        if (timeZoneLocale != null) return timeZoneLocale;
+
+        // Otherwise, get the user's preferred time zone
+        Preferences prefs = preferencesService.getPreferences(userId);
+        ResourceProperties tzProps = prefs.getProperties(TimeService.APPLICATION_ID);
+        String timeZone = tzProps.getProperty(TimeService.TIMEZONE_KEY);
+
+        if (timeZone == null || timeZone.equals(""))
+            timeZone = TimeZone.getDefault().getID();
+
+        timeZoneLocale = timeZone;
+
+        M_userTzCache.put(userId, timeZoneLocale);
+
+        return timeZoneLocale;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TimeZone getLocalTimeZone()
+    {
+        String tz = getUserTimezone();
+        // Not holding a cache can be slow.
+        return tzCache.computeIfAbsent(tz, TimeZone::getTimeZone);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean clearLocalTimeZone(String userId)
+    {
+        M_userTzCache.remove(userId);
+        return true;
+    }
+
+}

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/components.xml
@@ -20,5 +20,6 @@
      <import resource="event-components.xml" />
      <import resource="memory-components.xml" />
      <import resource="util-components.xml" />
+     <import resource="time-components.xml" />
      <import resource="messagebundle-components.xml" />
 </beans>

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/time-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/time-components.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="org.sakaiproject.time.api.TimeService"
+          class="org.sakaiproject.time.impl.BasicTimeService"
+          init-method="init"
+          destroy-method="destroy">
+        <property name="userLocaleService" ref="org.sakaiproject.time.impl.UserLocaleServiceImpl"/>
+        <property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService"/>
+    </bean>
+
+    <bean id="org.sakaiproject.time.api.UserTimeService"
+          class="org.sakaiproject.time.impl.UserTimeServiceImpl"
+          init-method="init">
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService"/>
+        <property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService"/>
+    </bean>
+
+    <bean id="org.sakaiproject.time.impl.UserLocaleServiceImpl"
+          class="org.sakaiproject.time.impl.UserLocaleServiceImpl"
+          init-method="init">
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService"/>
+        <property name="resourceLoader">
+            <bean class="org.sakaiproject.util.ResourceLoader"/>
+        </property>
+    </bean>
+
+</beans>

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/util-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/util-components.xml
@@ -13,14 +13,6 @@
 			init-method="init"
 			destroy-method="destroy"/>
 
-	<bean id="org.sakaiproject.time.api.TimeService"
-			class="org.sakaiproject.time.impl.BasicTimeService"
-			init-method="init"
-			destroy-method="destroy">
-			<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
-			<property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService"/>
-			<property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService"/>
-	</bean>
 
 	<bean id="org.sakaiproject.log.api.LogConfigurationManager"
 			class="org.sakaiproject.log.impl.Log4jConfigurationManager"


### PR DESCRIPTION
This splits out a new API called UserTimeService which is just responsible for getting the user’s timezone at the moment. This allows the main TimeService to be deprecated and any place that uses TimeService to just get the user’s timezone can switch to using UserTimeService.

This also makes the current TimeService more testable as it doesn’t actually need the whole kernel to be running, just mock instances of 2 helpers that can be easily mocked with Mockito (or similar).

This also makes the classes more focused (Single Responsibility Principal).