### PR TITLE
SAK-33498 Removed unused commons-email dependency

### DIFF
--- a/mailsender/impl/pom.xml
+++ b/mailsender/impl/pom.xml
@@ -51,17 +51,8 @@
 
         <!-- java mail -->
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>1.2</version>
         </dependency>
 
         <!-- internal -->


### PR DESCRIPTION
This dependency is no longer used and just increases the size of the
build. This probably remains from when mailsender used to send out email
directly instead of using the kernel's email service.

The activation dependency can also be removed as it isn't directly used
by the code and is correctly pulled in as a trasative dependency.