### PR TITLE
SAK-33353 Grade override with numerical values fails when minimum per…

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
@@ -254,7 +254,7 @@ public class CourseGradeOverridePanel extends BasePanel {
 						newGrade=entry.getKey();
 					}
 				}
-				if (dValue.compareTo(maxValue) > 0) throw new NumberFormatException("Grade exceeds the maximum number allowed in current scale.");
+				if (dValue.compareTo(maxValue) > 0 && dValue > 100) throw new NumberFormatException("Grade exceeds the maximum number allowed in current scale.");
 			}
 			return newGrade;
 		}


### PR DESCRIPTION
…centage on maximum grade is lesser than 100%