### PR TITLE
SAK-33264 ensure properties is collapsed when adding multiple folders/links

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -462,6 +462,10 @@
 					hideGroupsTable(index);
 				}
 			}
+			// hide the properties div by default
+			var propertiesDiv = document.getElementById("propertiesDiv$DOT" + index);
+			propertiesDiv.style.display = 'none';
+
 			setupDatePickers(newContentDiv, index);
 		}
 		


### PR DESCRIPTION
Fixes bug found in https://jira.sakaiproject.org/browse/SAK-33264, where the properties div can be expanded and out of sync with the properties toggle after clicking add another folder/link.