### PR TITLE
SAM-3286 - If auto-submit runs after excepted due date while excepted…

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -3035,8 +3035,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
                     //If it has extended time, just continue for now, no method to tell if the time is passed
                     if (assessmentExtended.hasExtendedTime()) {
                         //If the due date or retract date hasn't passed yet, go on to the next one, don't consider it yet
-                        if (currentTime.before(assessmentExtended.getRetractDate()) || currentTime.before(
-                                assessmentExtended.getDueDate())) {
+                        if ((assessmentExtended.getRetractDate()!=null && currentTime.before(assessmentExtended.getRetractDate())) || (assessmentExtended.getDueDate() != null && currentTime.before(
+                                assessmentExtended.getDueDate()))) {
                             continue;
                         }
                         //Continue on and try to submit it but it may be late, just change the due date


### PR DESCRIPTION
… student is in quiz, quiz is not auto-submitted, Total Score page is incorrect

I noticed an NPE because the retractDate or dueDate can be null, avoiding the "before" comparison in that case seems that fix the problem.