### PR TITLE
SAK-33561 Support for filter custom properties.

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -38,7 +38,7 @@ import org.sakaiproject.site.api.Site;
  * Location is a combination of site id, (optional) page id and (optional) tool id
  * </p>
  */
-public interface LTIService {
+public interface LTIService extends LTISubstitutionsFilter {
     /**
      * This string starts the references to resources in this service.
      */
@@ -510,4 +510,16 @@ public interface LTIService {
     String formInput(Object row, String[] fieldInfo);
 
     boolean isAdmin(String siteId);
+
+    /**
+     * This adds a filter for the custom properties.
+     * @param filter The filter to add.
+     */
+    void registerPropertiesFilter(LTISubstitutionsFilter filter);
+
+    /**
+     * This removes a filter for custom properties.
+     * @param filter The filter to remove.
+     */
+    void removePropertiesFilter(LTISubstitutionsFilter filter);
 }

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTISubstitutionsFilter.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTISubstitutionsFilter.java
@@ -1,0 +1,21 @@
+package org.sakaiproject.lti.api;
+
+import org.sakaiproject.site.api.Site;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This allows additional LTI custom substitution filtering to happen that is deployment specific.
+ */
+public interface LTISubstitutionsFilter {
+
+    /**
+     * This is called on the custom substitution properties to perform custom filtering.
+     * @param properties The custom properties ready to be substituted.
+     * @param tool The LTI tool.
+     * @param site The site in which the launch is happening.
+     */
+    void filterCustomSubstitutions(Properties properties, Map<String, Object> tool, Site site);
+
+}

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTISubstitutionsFilter.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTISubstitutionsFilter.java
@@ -12,7 +12,8 @@ public interface LTISubstitutionsFilter {
 
     /**
      * This is called on the custom substitution properties to perform custom filtering.
-     * @param properties The custom properties ready to be substituted.
+     * @param properties The custom properties ready to be substituted. The filter should directly change this
+     *                   object to pass changes back to the caller.
      * @param tool The LTI tool.
      * @param site The site in which the launch is happening.
      */

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -1012,6 +1012,9 @@ public class SakaiBLTIUtil {
 			LTI2Util.filterLTI1LaunchProperties(ltiProps, enabledCapabilities, allowExt);
 		}
 
+		// See if there are any locally deployed substitutions
+		ltiService.filterCustomSubstitutions(lti2subst, tool, site);
+
 		M_log.debug("ltiProps="+ltiProps);
 		M_log.debug("lti2subst="+lti2subst);
 		M_log.debug("before custom="+custom);

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.List;
 import java.util.Map;
 
+import org.sakaiproject.lti.api.LTISubstitutionsFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.authz.api.SecurityService;
@@ -46,7 +47,11 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.foorm.SakaiFoorm;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * <p>
@@ -70,6 +75,9 @@ public abstract class BaseLTIService implements LTIService {
 
 	/** Dependency: SessionManager */
 	protected SessionManager m_sessionManager = null;
+
+	// The filters that are applied to custom properties.
+	protected List<LTISubstitutionsFilter> filters = new CopyOnWriteArrayList<>();
 
 	/**
 	 * Dependency: SessionManager.
@@ -854,5 +862,20 @@ public abstract class BaseLTIService implements LTIService {
 	public abstract boolean deleteProxyBindingDao(Long key);
 	public abstract Map<String, Object> getProxyBindingDao(Long key);
 	public abstract Map<String, Object> getProxyBindingDao(Long tool_id, String siteId);
+
+	@Override
+	public void registerPropertiesFilter(LTISubstitutionsFilter filter) {
+		filters.add(filter);
+	}
+
+	@Override
+	public void removePropertiesFilter(LTISubstitutionsFilter filter) {
+		filters.remove(filter);
+	}
+
+	@Override
+	public void filterCustomSubstitutions(Properties properties, Map<String, Object> tool, Site site) {
+		filters.forEach(filter -> filter.filterCustomSubstitutions(properties, tool, site));
+	}
 
 }

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/SampleLTISubstitutionsFilter.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/SampleLTISubstitutionsFilter.java
@@ -1,0 +1,43 @@
+package org.sakaiproject.lti.impl;
+
+import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.api.LTISubstitutionsFilter;
+import org.sakaiproject.site.api.Site;
+
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+
+/**
+ * This is an example of the LTI Subsitutions filter. It just add a random number from 0 to 9 to the substitions
+ * that are available. It puts this under the key of <code>random</code>. This can then be substituted by a custom
+ * property value such as <code>lucky=$random</code>.
+ */
+public class SampleLTISubstitutionsFilter implements LTISubstitutionsFilter {
+
+    public final static String RANDOM = "random";
+
+    private LTIService ltiService;
+    private Random random;
+
+    public void setLtiService(LTIService ltiService) {
+        this.ltiService = ltiService;
+    }
+
+    public void init() {
+        ltiService.registerPropertiesFilter(this);
+        random = new SecureRandom();
+    }
+
+    public void destroy() {
+        ltiService.removePropertiesFilter(this);
+    }
+
+    @Override
+    public void filterCustomSubstitutions(Properties properties, Map<String, Object> tool, Site site) {
+        if (properties.getProperty(RANDOM) == null) {
+            properties.setProperty(RANDOM, String.valueOf(random.nextInt(10)));
+        }
+    }
+}

--- a/basiclti/basiclti-impl/src/webapp/WEB-INF/components-demo.xml
+++ b/basiclti/basiclti-impl/src/webapp/WEB-INF/components-demo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- This adds a substitution to the properties, the key is "random" and the value is a random number -->
+    <bean class="org.sakaiproject.lti.impl.SampleLTISubstitutionsFilter" init-method="init" destroy-method="destroy">
+        <property name="ltiService" ref="org.sakaiproject.lti.api.LTIService"/>
+    </bean>
+</beans>


### PR DESCRIPTION
This allows local deployments to customise the LTI substitution
properties that are used for custom property subsitution.