### PR TITLE
SAK-33564 Don’t load all sites in the system.

### DIFF
--- a/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
+++ b/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
@@ -131,7 +131,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction
 	private static String ATTR_SORT_PAGESIZE = "SORT_PAGESIZE";
 	private static String ATTR_SEARCH_LAST_FIELD = "SEARCH_LAST_FIELD";
 	private static String ATTR_SEARCH_MAP = "search_map";
-	private static String ATTR_ATTRIBUTION_VALUES = "attribution_values";
 
 	/** Service Implementations */
 	protected static ToolManager toolManager = null;
@@ -366,7 +365,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction
 		state.setAttribute(ATTR_SORT_INDEX, 0);
 		state.setAttribute(ATTR_LAST_SORTED_FIELD, null);
 		state.setAttribute(ATTR_ASCENDING_ORDER, true);
-		state.setAttribute(ATTR_ATTRIBUTION_VALUES, null);
 	}
 	
 	public String buildToolSitePanelContext(VelocityPortlet portlet, Context context,
@@ -498,33 +496,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction
 				attribution_name = aux;
 			}
 			context.put("attribution_name", attribution_name);
-			
-			//join all available attribution values in a single set
-			SortedSet<String> availableAttributionValues = (SortedSet<String>)state.getAttribute(ATTR_ATTRIBUTION_VALUES);
-			
-			//just the first time
-			if(availableAttributionValues == null) {
-				availableAttributionValues = new TreeSet<String>();
-				
-				//if we are not in !admin site, we don't want to look for other sites
-				if(ltiService.isAdmin(getSiteId(state))) {
-					String attribution_key = serverConfigurationService.getString(LTIService.LTI_SITE_ATTRIBUTION_PROPERTY_KEY, LTIService.LTI_SITE_ATTRIBUTION_PROPERTY_KEY_DEFAULT);
-					Map propertyCriteria = new HashMap();			
-					propertyCriteria.put(attribution_key, "");
-					
-					List<Site> list = SiteService.getSites(org.sakaiproject.site.api.SiteService.SelectionType.ANY, null, null, propertyCriteria, org.sakaiproject.site.api.SiteService.SortType.NONE, null);			
-					if(list != null && list.size() > 0) {
-						for(Site s : list) {
-							String prop = s.getProperties().getProperty(attribution_key);
-							if (StringUtils.isNotEmpty(prop)) {
-								availableAttributionValues.add(prop);
-							}
-						}
-					}
-				}
-			}
-			context.put(ATTR_ATTRIBUTION_VALUES, availableAttributionValues);
-			state.setAttribute(ATTR_ATTRIBUTION_VALUES, availableAttributionValues);
 		}
 		
 		// top navigation menu

--- a/basiclti/basiclti-tool/src/webapp/vm/lti_tool_site.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_tool_site.vm
@@ -170,16 +170,7 @@ ${includeLatestJQuery}
 					<td><input class="tablesorter-filter" id="input_SITE_CONTACT_NAME" #if($search_map && $search_map.get('SITE_CONTACT_NAME')) value="$search_map.get('SITE_CONTACT_NAME')" #end /></td>
 					<td><input class="tablesorter-filter" id="input_SITE_CONTACT_EMAIL" #if($search_map && $search_map.get('SITE_CONTACT_EMAIL')) value="$search_map.get('SITE_CONTACT_EMAIL')" #end /></td>
 					#if ($attribution_name)
-					<td>
-						#if ($attribution_values && $attribution_values.size() > 0)
-						<select class="tablesorter-filter" id="input_ATTRIBUTION">
-							<option #if($search_map && $search_map.get('ATTRIBUTION') && $search_map.get('ATTRIBUTION') == '') selected="selected" #end value="">$tlang.getString('select.showall')</option>
-							#foreach ($attribution_value in $attribution_values)
-								<option #if($search_map && $search_map.get('ATTRIBUTION') && $search_map.get('ATTRIBUTION') == $attribution_value) selected="selected" #end value="$attribution_value">$attribution_value</option>
-							#end
-						</select>
-						#end
-					</td>
+					<td><input class="tablesorter-filter" id="input_ATTRIBUTION" #if($search_map && $search_map.get('ATTRIBUTION')) value="$search_map.get('ATTRIBUTION')" #end /></td>
 					#end
 				#end
 				<td></td>


### PR DESCRIPTION
In order to populate the department dropdown the LTI Admin tool was loading all sites in the system. The fix is to no load this dropdown and just have a text search field. The alternatives would have been to have go directly to the site tables and query the columns there (but then we end up with direct binding across services), or to have added stuff to the SiteService API to load distinct property values for a property key.

Growing the SiteService API would have been the cleanest solution, however I’m not sure the extra complexity is worth it for this feature.