### PR TITLE
SAK-33572 - GBNG-3390 - FIX I18N - GradebookNG crashes when you type comma in a grade

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -494,6 +494,17 @@ public class GradebookNgBusinessService {
 		String oldGradeAdjusted = oldGrade;
 		String storedGradeAdjusted = storedGrade;
 
+		// Fix a problem when the grades comes from the old Gradebook API with locale separator, always compare the values using the same
+		// separator
+		if (StringUtils.isNotBlank(oldGradeAdjusted)) {
+			oldGradeAdjusted = oldGradeAdjusted.replace(newGradeAdjusted.contains(",") ? "." : ",",
+					newGradeAdjusted.contains(",") ? "," : ".");
+		}
+		if (StringUtils.isNotBlank(storedGradeAdjusted)) {
+			storedGradeAdjusted = storedGradeAdjusted.replace(newGradeAdjusted.contains(",") ? "." : ",",
+					newGradeAdjusted.contains(",") ? "," : ".");
+		}
+
 		if (gradingType == GbGradingType.PERCENTAGE) {
 			// the passed in grades represents a percentage so the number needs to be adjusted back to points
 			final Double newGradePercentage = NumberUtils.toDouble(newGrade);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -1,17 +1,39 @@
+/**
+ * Copyright (c) 2003-2017 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.sakaiproject.gradebookng.business.util;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
+import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.validator.routines.DoubleValidator;
+import org.sakaiproject.util.ResourceLoader;
 
 @Slf4j
 public class FormatHelper {
+
+	private static ResourceLoader rl = new ResourceLoader();
 
 	/**
 	 * The value is a double (ie 12.34542) that needs to be formatted as a percentage with two decimal places precision. And drop off any .0
@@ -33,18 +55,30 @@ public class FormatHelper {
 	 * @return double to n decimal places
 	 */
 	private static String formatDoubleToDecimal(final Double score, final int n) {
-		final NumberFormat df = NumberFormat.getInstance();
-		df.setMinimumFractionDigits(0);
-		df.setMaximumFractionDigits(n);
-		df.setGroupingUsed(false);
-		df.setRoundingMode(RoundingMode.HALF_DOWN);
+		return formatGrade(convertDoubleToBigDecimal(score, n).toString());
+	}
 
-		return formatGrade(df.format(score));
+	private static BigDecimal convertDoubleToBigDecimal(final Double score, final int decimalPlaces) {
+		// Rounding is problematic due to the use of Doubles in
+		// Gradebook. A number like 89.065 (which can be produced by
+		// weighted categories, for example) is stored as the double
+		// 89.06499999999999772626324556767940521240234375. If you
+		// naively round this to two decimal places, you get 89.06 when
+		// you wanted 89.07
+		//
+		// Payten devised a clever trick of rounding to some larger
+		// decimal places first, which rounds these numbers up to
+		// something more manageable. For example, if you round the
+		// above to 10 places, you get 89.0650000000, which rounds
+		// correctly when rounded up to 2 places.
+
+		return new BigDecimal(score)
+				.setScale(10, RoundingMode.HALF_UP)
+				.setScale(decimalPlaces, RoundingMode.HALF_UP);
 	}
 
 	/**
-	 * Convert a double score to match the number of decimal places exhibited in the
-	 * toMatch string representation of a number
+	 * Convert a double score to match the number of decimal places exhibited in the toMatch string representation of a number
 	 *
 	 * @param score as a double
 	 * @param toMatch the number as a string
@@ -67,8 +101,7 @@ public class FormatHelper {
 	 * @return percentage to decimal places with a '%' for good measure
 	 */
 	public static String formatDoubleAsPercentage(final Double score) {
-		// TODO does the % need to be internationalised?
-		return formatDoubleToDecimal(score) + "%";
+		return formatGradeForDisplay(score) + "%";
 	}
 
 	/**
@@ -82,32 +115,98 @@ public class FormatHelper {
 			return null;
 		}
 
-		final BigDecimal decimal = new BigDecimal(string).setScale(2, RoundingMode.HALF_DOWN);
+		final BigDecimal decimal = new BigDecimal(string).setScale(2, RoundingMode.HALF_UP);
 
 		return formatDoubleAsPercentage(decimal.doubleValue());
 	}
 
 	/**
-	 * Format a grade, e.g. 00 => 0 0001 => 1 1.0 => 1 1.25 => 1.25
+	 * Format a grade, e.g. 00 => 0 0001 => 1 1.0 => 1 1.25 => 1.25 based on the root locale
 	 *
 	 * @param grade
 	 * @return
 	 */
 	public static String formatGrade(final String grade) {
+		return formatGradeForLocale(grade, Locale.ROOT);
+	}
+
+	/**
+	 * Format a grade, e.g. 00 => 0 0001 => 1 1.0 => 1 1.25 => 1.25 based on the user's locale
+	 *
+	 * @param grade - string representation of a grade
+	 * @return
+	 */
+	public static String formatGradeFromUserLocale(final String grade) {
+		return formatGradeForLocale(grade, rl.getLocale());
+	}
+
+	/**
+	 * Format a grade, e.g. 00 => 0 0001 => 1 1.0 => 1 1.25 => 1.25
+	 *
+	 * @param grade - string representation of a grade
+	 * @return
+	 */
+	public static String formatGradeForDisplay(final Double grade) {
+		return formatGradeForDisplay(formatDoubleToDecimal(grade));
+	}
+
+	/**
+	 * Format a grade from the root locale for display using the user's locale
+	 *
+	 * @param grade - string representation of a grade
+	 * @return
+	 */
+	public static String formatGradeForDisplay(final String grade) {
 		if (StringUtils.isBlank(grade)) {
 			return "";
 		}
 
 		String s = null;
 		try {
-			final Double d = Double.parseDouble(grade);
+			final DecimalFormat dfParse = (DecimalFormat) NumberFormat.getInstance(Locale.ROOT);
+			dfParse.setParseBigDecimal(true);
+			final BigDecimal d = (BigDecimal) dfParse.parse(grade);
 
-			final DecimalFormat df = new DecimalFormat();
+			final DecimalFormat dfFormat = (DecimalFormat) NumberFormat.getInstance(rl.getLocale());
+			dfFormat.setMinimumFractionDigits(0);
+			dfFormat.setGroupingUsed(true);
+			s = dfFormat.format(d);
+		} catch (final NumberFormatException e) {
+			log.debug("Bad format, returning original string: " + grade);
+			s = grade;
+		} catch (final ParseException e) {
+			log.debug("Bad format, returning original string: " + grade);
+			s = grade;
+		}
+
+		return StringUtils.removeEnd(s, ".0");
+	}
+
+	/**
+	 * Format a grade using the locale
+	 *
+	 * @param grade - string representation of a grade
+	 * @param locale
+	 * @return
+	 */
+	private static String formatGradeForLocale(final String grade, final Locale locale) {
+		if (StringUtils.isBlank(grade)) {
+			return "";
+		}
+
+		String s = null;
+		try {
+			final DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(locale);
+			final Double d = df.parse(grade).doubleValue();
+
 			df.setMinimumFractionDigits(0);
 			df.setGroupingUsed(false);
 
 			s = df.format(d);
 		} catch (final NumberFormatException e) {
+			log.debug("Bad format, returning original string: " + grade);
+			s = grade;
+		} catch (final ParseException e) {
 			log.debug("Bad format, returning original string: " + grade);
 			s = grade;
 		}
@@ -164,5 +263,27 @@ public class FormatHelper {
 	 */
 	public static String abbreviateMiddle(final String s) {
 		return StringUtils.abbreviateMiddle(s, "...", 45);
+	}
+
+	/**
+	 * Validate if a string is a valid Double using the specified Locale.
+	 *
+	 * @param value - The value validation is being performed on.
+	 * @return true if the value is valid
+	 */
+	public static boolean isValidDouble(String value) {
+		DoubleValidator dv = new DoubleValidator();
+		return dv.isValid(value, rl.getLocale());
+	}
+
+	/**
+	 * Validate/convert a Double using the user's Locale.
+	 *
+	 * @param value - The value validation is being performed on.
+	 * @return The parsed Double if valid or null if invalid.
+	 */
+	public static Double validateDouble(String value) {
+		DoubleValidator dv = new DoubleValidator();
+		return dv.validate(value, rl.getLocale());
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.commons.validator.routines.DoubleValidator;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
@@ -206,14 +205,12 @@ public class GradeItemCellPanel extends Panel {
 					clearNotifications();
 
 					// perform validation here so we can bypass the backend
-					final DoubleValidator validator = new DoubleValidator();
-
-					if (StringUtils.isNotBlank(rawGrade) && (!validator.isValid(rawGrade) || Double.parseDouble(rawGrade) < 0)) {
+					if (StringUtils.isNotBlank(rawGrade) && FormatHelper.validateDouble(rawGrade)!= null && (!FormatHelper.isValidDouble(rawGrade) || FormatHelper.validateDouble(rawGrade) < 0)) {
 						// show warning and revert button
 						markWarning(getComponent());
 						target.add(page.updateLiveGradingMessage(getString("feedback.error")));
 					} else {
-						final String newGrade = FormatHelper.formatGrade(rawGrade);
+						final String newGrade = FormatHelper.formatGradeFromUserLocale(rawGrade);
 						
 						// for concurrency, get the original grade we have in the UI and pass it into the service as a check
 						final GradeSaveResponse result = GradeItemCellPanel.this.businessService.saveGrade(assignmentId, studentUuid,


### PR DESCRIPTION
Gradebook NG is not usable in locales with comma separator, GBNG-3390 wasn't merged back to 11.x and now differs from Master.

The resolved issues for Master that cannot be merged back to 11.x, must be resolved directly for 11.x.