### PR TITLE
SAK-14766 Only people with permission see dropbox.

### DIFF
--- a/content/content-tool/tool/src/webapp/WEB-INF/tools/sakai.dropbox.xml
+++ b/content/content-tool/tool/src/webapp/WEB-INF/tools/sakai.dropbox.xml
@@ -12,6 +12,10 @@
 		<category name="course" />
 		<category name="project" />
 
+		<!-- This is final because it's being added long after the tool has rolled out so making it final means
+		     all existing placements get this in their configuration without backfilling -->
+		<configuration name="functions.require" type="final"
+					   value="dropbox.own | dropbox.maintain | dropbox.maintain.own.groups" />
 	</tool>
 
 </registration>


### PR DESCRIPTION
This prevents people without a dropbox permission from seeing the dropbox tool in the site. Dropbox has an issue where it will allow people who don’t have this permission to have a folder created for them when they access the site, however this folder doesn’t have any of the normal dropbox permissions or display name set.