### PR TITLE
SAK-33593 Solving issues related with in/new submission count

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/persistence/AssignmentRepositoryImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/persistence/AssignmentRepositoryImpl.java
@@ -173,6 +173,7 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
                 .add(Restrictions.eq("assignment.id", assignmentId))
                 .add(Restrictions.eq("submitted", Boolean.TRUE))
                 .add(Restrictions.eq("userSubmission", Boolean.TRUE))
+                .add(Restrictions.isNotNull("dateSubmitted"))
                 .uniqueResult();
         return number.longValue();
     }
@@ -183,7 +184,8 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
                 .setProjection(Projections.rowCount())
                 .add(Restrictions.eq("assignment.id", assignmentId))
                 .add(Restrictions.eq("submitted", Boolean.TRUE))
-                .add(Restrictions.eq("graded", Boolean.TRUE))
+                .add(Restrictions.eq("graded", Boolean.FALSE))
+                .add(Restrictions.isNotNull("dateSubmitted"))
                 .uniqueResult();
         return number.longValue();
     }

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5970,6 +5970,7 @@ public class AssignmentAction extends PagedResourceActionII {
                             submission.setGroupId(group_id);
                         }
 
+                        submission.setUserSubmission(true);
                         submission.setSubmittedText(text);
                         submission.setHonorPledge(Boolean.valueOf(honorPledgeYes));
                         submission.setDateSubmitted(Instant.now());
@@ -6166,6 +6167,7 @@ public class AssignmentAction extends PagedResourceActionII {
                                     submission.setGroupId(group_id);
                                     log.debug("NEW SUBMISSION: group: {}", group_id);
                                 }
+                                submission.setUserSubmission(true);
                                 submission.setSubmittedText(text);
                                 submission.setHonorPledge(Boolean.valueOf(honorPledgeYes));
                                 submission.setDateSubmitted(Instant.now());


### PR DESCRIPTION
The ungraded count was wrongly checking 'graded -> true' cases.
Also, userSubmission should be set to default as true (SAK-29314), otherwise it will always be 0 and the total count won't work.
Finally, looking at the old behavior (11.x for example), I guess we should check the submitted date field for both cases too.