### PR TITLE
SAK-33572 - The grades appear with the point as separator, it should use the user's locale

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeItemCellPanel.java
@@ -133,7 +133,7 @@ public class GradeItemCellPanel extends Panel {
 		this.formattedGrade = FormatHelper.formatGrade(this.rawGrade);
 		
 		//TODO move this to the format helper?
-		this.displayGrade = formatDisplayGrade(this.formattedGrade);
+		this.displayGrade = formatDisplayGrade(FormatHelper.formatGradeForDisplay(this.formattedGrade));
 
 		// RENDER
 		if (isExternal || !this.gradeable) {


### PR DESCRIPTION
I've made the 11.x PR because Master has diverged and it's not affected by this issue.