### PR TITLE
SAK-33594 transfer attachments on assignments when importing from site

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -3461,16 +3461,11 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     Set<String> oAttachments = oAssignment.getAttachments();
                     List<Reference> nAttachments = entityManager.newReferenceList();
                     for (String oAttachment : oAttachments) {
-                        if (entityManager.checkReference(oAttachment)) {
-                            Reference oReference = entityManager.newReference(oAttachment);
-                            String oAttachmentId = oReference.getId();
-                            if (oAttachmentId.contains(fromContext)) {
-                                // transfer attachment, replace the context string and add new attachment if necessary
-                                transferAttachment(fromContext, toContext, nAttachments, oAttachmentId);
-                            } else {
-                                nAttachments.add(oReference);
-                            }
-                        }
+                        Reference oReference = entityManager.newReference(oAttachment);
+                        String oAttachmentId = oReference.getId();
+                        // transfer attachment, replace the context string if necessary and add new attachment
+                        String nReference = transferAttachment(fromContext, toContext, oAttachmentId);
+                        nAssignment.getAttachments().add(nReference);
                     }
 
                     // peer review
@@ -3542,7 +3537,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                         for (AssignmentSupplementItemAttachment oAttachment : oModelAnswerItemAttachments) {
                             AssignmentSupplementItemAttachment nAttachment = assignmentSupplementItemService.newAttachment();
                             // New attachment creation
-                            String nAttachmentId = transferAttachment(fromContext, toContext, null, oAttachment.getAttachmentId().replaceFirst("/content", ""));
+                            String nAttachmentId = transferAttachment(fromContext, toContext, oAttachment.getAttachmentId().replaceFirst("/content", ""));
                             if (StringUtils.isNotEmpty(nAttachmentId)) {
                                 nAttachment.setAssignmentSupplementItemWithAttachment(nModelAnswerItem);
                                 nAttachment.setAttachmentId(nAttachmentId);
@@ -3582,7 +3577,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                         for (AssignmentSupplementItemAttachment oAttachment : oAllPurposeItemAttachments) {
                             AssignmentSupplementItemAttachment nAttachment = assignmentSupplementItemService.newAttachment();
                             // New attachment creation
-                            String nAttachId = transferAttachment(fromContext, toContext, null, oAttachment.getAttachmentId().replaceFirst("/content", ""));
+                            String nAttachId = transferAttachment(fromContext, toContext, oAttachment.getAttachmentId().replaceFirst("/content", ""));
                             if (StringUtils.isNotEmpty(nAttachId)) {
                                 nAttachment.setAssignmentSupplementItemWithAttachment(nAllPurposeItem);
                                 nAttachment.setAttachmentId(nAttachId);
@@ -3645,14 +3640,11 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         return transversalMap;
     }
 
-    private String transferAttachment(String fromContext, String toContext, List<Reference> nAttachments, String oAttachmentId) {
+    private String transferAttachment(String fromContext, String toContext, String oAttachmentId) {
         String reference = "";
         String nAttachmentId = oAttachmentId.replaceAll(fromContext, toContext);
         try {
             ContentResource attachment = contentHostingService.getResource(nAttachmentId);
-            if (nAttachments != null) {
-                nAttachments.add(entityManager.newReference(attachment.getReference()));
-            }
             reference = attachment.getReference();
         } catch (IdUnusedException iue) {
             try {
@@ -3667,10 +3659,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 oAttachment.getContentType(),
                                 content,
                                 oAttachment.getProperties());
-                        // add to attachment list
-                        if (nAttachments != null) {
-                            nAttachments.add(entityManager.newReference(attachment.getReference()));
-                        }
                         reference = attachment.getReference();
                     } else {
                         // add the new resource into resource area
@@ -3686,10 +3674,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 null,
                                 null,
                                 NotificationService.NOTI_NONE);
-                        // add to attachment list
-                        if (nAttachments != null) {
-                            nAttachments.add(entityManager.newReference(attachment.getReference()));
-                        }
                         reference = attachment.getReference();
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
The checkReference method will crash with the '/' character, I think it's not needed. 
There was also missing an update on the attachments list of the new assignment.
Plus I have removed nAttachments parameter from the header, as it wasn't actually used anymore.