### PR TITLE
KNL-1567 FormattedText exception for page anchor links when adding target blank

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -276,9 +276,9 @@ public class FormattedTextImpl implements FormattedText
     /** Matches all anchor tags that have target="_blank" not accompanied by a rel attribute. */
     public final Pattern M_patternAnchorTagWithTargetBlankAndWithOutRel = Pattern.compile("([<]a\\s[^<>]*?)(?![^>]*rel[^<>\\s]*=)(target[^<>\\s]*=[^<>\\s]*_blank)([^<>]*?)[>]",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-    /** Matches all anchor tags that do not have a target attribute. */
-    public final Pattern M_patternAnchorTagWithOutTarget = 
-            Pattern.compile("([<]a\\s)(?![^>]*target=)([^>]*?)[>]",
+    /** Matches all anchor tags that do not have a target attribute AND href not starting with # AND href exists */
+    public final Pattern M_patternAnchorTagWithOutTargetAndWithHrefAndHrefNotStartingWithHash =
+            Pattern.compile("([<]a\\s)(?=[^>]*href=)(?![^>]*href=\"#)(?![^>]*target=)([^>]*?)[>]",
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     /** Matches href attribute */
@@ -403,7 +403,7 @@ public class FormattedTextImpl implements FormattedText
 
                     // now replace all the A tags WITHOUT a target with _blank (to match the old functionality)
                     if (addBlankTargetToLinks() && StringUtils.isNotBlank(val)) {
-                        Matcher m = M_patternAnchorTagWithOutTarget.matcher(val);
+                        Matcher m = M_patternAnchorTagWithOutTargetAndWithHrefAndHrefNotStartingWithHash.matcher(val);
                         if (m.find()) {
                             if (StringUtils.isNotBlank(referrerPolicy)) {
                                 val = m.replaceAll("$1$2 target=\"_blank\" rel=\"" + referrerPolicy + "\">"); // adds a target and rel to A tags without one
@@ -536,7 +536,7 @@ public class FormattedTextImpl implements FormattedText
         // added for KNL-526
 
         if (addBlankTargetToLinks()) {
-            Matcher m = M_patternAnchorTagWithOutTarget.matcher(value);
+            Matcher m = M_patternAnchorTagWithOutTargetAndWithHrefAndHrefNotStartingWithHash.matcher(value);
             if (m.find()) {
                 if (StringUtils.isNotBlank(referrerPolicy)) {
                     value = m.replaceAll("$1$2 target=\"_blank\" rel=\"" + referrerPolicy + "\">"); // adds a target and rel to A tags without one
@@ -712,7 +712,9 @@ public class FormattedTextImpl implements FormattedText
             hrefTarget = " target=\"" + hrefTarget + "\"";
         } else {
             // default to _blank if not set and configured to force
-            if (addBlankTargetToLinks()) {
+            // do not add if anchor link to same page (editor page)
+            if (addBlankTargetToLinks() &&
+                    !(href != null && href.startsWith("#"))) {
                 hrefTarget = " target=\"_blank\"";
             }
         }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -141,14 +141,18 @@ public class FormattedTextTest {
 
     @Test
     public void testRegexTargetMatch() {
-        Pattern patternAnchorTagWithOutTarget = formattedText.M_patternAnchorTagWithOutTarget;
-        /*  Pattern.compile("([<]a\\s)(?![^>]*target=)([^>]*?)[>]",
+        Pattern patternAnchorTagWithOutTarget = formattedText.M_patternAnchorTagWithOutTargetAndWithHrefAndHrefNotStartingWithHash;
+        /*  Pattern.compile("([<]a\s)(?=[^>]*href=)(?![^>]*href="#)(?![^>]*target=)([^>]*?)[>]",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL); */
         Assert.assertTrue(patternAnchorTagWithOutTarget.matcher("<a href=\"other.html\">link</a>").find());
         Assert.assertFalse(patternAnchorTagWithOutTarget.matcher("<a target=\"AZ\" href=\"other.html\">link</a>").find());
         Assert.assertTrue(patternAnchorTagWithOutTarget.matcher("<a href=\"other.html\" class=\"AZ\">link</a>").find());
         Assert.assertFalse(patternAnchorTagWithOutTarget.matcher("<a target=\"AZ\" href=\"other.html\">link</a>").find());
         Assert.assertFalse(patternAnchorTagWithOutTarget.matcher("<a href=\"other.html\" target=\"AZ\">link</a>").find());
+
+        Assert.assertFalse(patternAnchorTagWithOutTarget.matcher("<a name=\"anchor\">link</a>").find());
+        Assert.assertFalse(patternAnchorTagWithOutTarget.matcher("<a href=\"#other\" target=\"AZ\">link</a>").find());
+        Assert.assertFalse(patternAnchorTagWithOutTarget.matcher("<a href=\"#other\">link</a>").find());
     }
 
     @Test


### PR DESCRIPTION
I applied our 11.x patch to master, seems to work OK.

