### PR TITLE
SAK-33617 : Content-review-impl Urkund : Include OptOutUrl

### DIFF
--- a/assignment/assignment-api/api/pom.xml
+++ b/assignment/assignment-api/api/pom.xml
@@ -40,5 +40,9 @@
             <groupId>org.sakaiproject.scheduler</groupId>
             <artifactId>scheduler-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.contentreview</groupId>
+            <artifactId>contentreview-model-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/assignment/assignment-api/api/src/java/org/sakaiproject/assignment/api/ContentReviewResult.java
+++ b/assignment/assignment-api/api/src/java/org/sakaiproject/assignment/api/ContentReviewResult.java
@@ -1,6 +1,7 @@
 package org.sakaiproject.assignment.api;
 
 import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.contentreview.model.ContentReviewItem;
 import org.sakaiproject.entity.api.ResourceProperties;
 
 /**
@@ -38,6 +39,8 @@ public class ContentReviewResult
 	 * An error string, if any, return from the review service
 	 */
 	private String reviewError;
+	
+	private ContentReviewItem contentReviewItem;
 
 
 	/**
@@ -143,5 +146,13 @@ public class ContentReviewResult
 	public void setReviewError(String reviewError)
 	{
 		this.reviewError = reviewError;
+	}
+
+	public ContentReviewItem getContentReviewItem() {
+		return contentReviewItem;
+	}
+
+	public void setContentReviewItem(ContentReviewItem contentReviewItem) {
+		this.contentReviewItem = contentReviewItem;
 	}
 }

--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -702,6 +702,7 @@ review.allow = Allow students to view report
 review.report = Report
 review.report.expand = Expand reports
 review.report.collapse = Collapse reports
+review.report.urkund.optoutlink = Exempt from Urkund
 review.reports = reports
 review.submit.papers.repository=Submit papers to the following repository:
 review.submit.papers.repository.none=None

--- a/assignment/assignment-bundles/resources/assignment_es.properties
+++ b/assignment/assignment-bundles/resources/assignment_es.properties
@@ -697,6 +697,7 @@ review.allow=Permitir al alumnado revisar el informe
 review.report=Informe de revisi\u00f3n
 review.report.expand=Expandir los informes
 review.report.collapse=Contraer los informes
+review.report.urkund.optoutlink = Exenci\u00f3n en Urkund
 review.reports=informes
 review.submit.papers.repository=Enviar documentos al siguiente repositorio\:
 review.submit.papers.repository.none=Ninguno

--- a/assignment/assignment-bundles/resources/assignment_sv.properties
+++ b/assignment/assignment-bundles/resources/assignment_sv.properties
@@ -545,6 +545,7 @@ review.allow=Till\u00e5t studenter att se rapporten
 review.report=Rapport
 review.report.expand=Expandera rapporter
 review.report.collapse=Kollapsa rapporter
+review.report.urkund.optoutlink=Exkludera fr\u00e5n Urkund
 review.reports=rapporter
 review.submit.papers.repository=Skicka in dokument till f\u00f6ljande arkiv\: 
 review.submit.papers.repository.none=Inget 

--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -765,6 +765,7 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
  		{
  			contentReviewService = (ContentReviewService) ComponentManager.get(ContentReviewService.class.getName());
  		}
+ 		
 	} // init
 
 	/**
@@ -10905,6 +10906,9 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 				String iconUrl = contentReviewService.getIconUrlforScore(Long.valueOf(reviewScore));
 				reviewResult.setReviewIconURL(iconUrl);
 				reviewResult.setReviewError(getReviewError(cr));
+				
+				ContentReviewItem cri = findReportByContentId(cr.getId());
+				reviewResult.setContentReviewItem(cri);
 
 				if ("true".equals(cr.getProperties().getProperty(PROP_INLINE_SUBMISSION)))
 				{
@@ -10916,6 +10920,30 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 				}
 			}
 			return reviewResults;
+		}
+		
+		/**
+		 * Gets a report from contentReviewService given its contentId
+		 * This function should be provided by content-review in Sakai 12+,
+		 * meanwhile in Sakai 11.x we need to get the full report list and iterate over it.
+		 */
+		private ContentReviewItem findReportByContentId(String contentId){
+			String siteId = this.m_context;
+			if(StringUtils.isBlank(contentId)){
+				return null;
+			}
+			try{
+				List<ContentReviewItem> reports = contentReviewService.getReportList(siteId);
+				
+				for(ContentReviewItem item : reports) {
+					if(StringUtils.isNotBlank(item.getContentId()) && contentId.equals(item.getContentId())){
+						return item;
+					}
+				}
+			}catch(Exception e){
+				M_log.error("Error getting reports list for site "+siteId, e);
+			}
+			return null;
 		}
 		
 		/**

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -226,6 +226,11 @@
 										#else
 											$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
 										#end
+
+										#if (!$submission.getReviewReport().equals("Error") &&
+											$reviewResult.contentReviewItem.optOutUrl)
+												(<a href="$!reviewResult.contentReviewItem.optOutUrl" target="_blank">$tlang.getString("review.report.urkund.optoutlink")</a>)
+										#end
 									</div>
 								#end
 								#if ($reviewResults.size() >= 3)

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -197,6 +197,10 @@
 										#else
 											$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
 										#end
+										#if (!$submission.getReviewReport().equals("Error") &&
+											$reviewResult.contentReviewItem.optOutUrl)
+												(<a href="$!reviewResult.contentReviewItem.optOutUrl" target="_blank">$tlang.getString("review.report.urkund.optoutlink")</a>)
+										#end
 									</div>
 								#end
 								#if ($reviewResults.size() >= 3)

--- a/content-review/content-review-api/model/src/java/org/sakaiproject/contentreview/model/ContentReviewItemUrkund.java
+++ b/content-review/content-review-api/model/src/java/org/sakaiproject/contentreview/model/ContentReviewItemUrkund.java
@@ -1,0 +1,52 @@
+/**********************************************************************************
+ *
+ * Copyright (c) 2017 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.contentreview.model;
+
+import java.util.Date;
+
+
+public class ContentReviewItemUrkund extends ContentReviewItem {
+
+	private String reportUrl = "";
+	private String optOutUrl = "";
+
+	public ContentReviewItemUrkund() {
+	}
+	
+	public ContentReviewItemUrkund(String userId, String siteId, String taskId, String contentId, Date dateQueued, Long status) {
+		super(userId, siteId, taskId, contentId, dateQueued, status);
+	}
+
+
+	public String getReportUrl() {
+		return reportUrl;
+	}
+
+	public void setReportUrl(String reportUrl) {
+		this.reportUrl = reportUrl;
+	}
+
+	public String getOptOutUrl() {
+		return optOutUrl;
+	}
+
+	public void setOptOutUrl(String optOutUrl) {
+		this.optOutUrl = optOutUrl;
+	}
+}


### PR DESCRIPTION
As the content-review API does not offer a method to get only one ContentReviewItem by id, we need to get all reports and store them in a cache indexed by ContentId.