### PR TITLE
SAK-33647 Allow searching for sample users.

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/user/api/ExternalUserSearchUDP.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/ExternalUserSearchUDP.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public interface ExternalUserSearchUDP {
 
-	/** 
+    /**
      * Search for externally provided users that match this criteria in eid, email, first or last name. 
      * 
      * <p>Returns a List of User objects. This list will be <b>empty</b> if no results are returned or <b>null</b>
@@ -36,9 +36,11 @@ public interface ExternalUserSearchUDP {
      * 		The search criteria. 
      * @param first 
      * 		The first record position to return. If the provider does not support paging, this value is unused.
+     * 		If no paging is requested <code>-1</code> will be passed.
      * @param last 
      * 		The last record position to return. If the provider does not support paging, this value is unused.
-     * @param factory 
+     * 		If no paging is requested <code>-1</code> will be passed.
+     * @param factory
      * 		Use this factory's newUser() method to create the UserEdit objects you populate and return in the List.
      * @return 
      * 		A List (UserEdit) of all the users matching the criteria or null if an error occurred.


### PR DESCRIPTION
This allows the SampleUserDirectoryProvider to return users when a search is performed for users. Previously there was no way to search for these users apart from knowing one of the IDs on them.

This makes testing Sakai easier as you can see how it behaves when deployed with a user provider that supports searching.