### PR TITLE
SAK-33657 improve submitted checks and remove useless method

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -614,13 +614,6 @@ public interface AssignmentService extends EntityProducer {
     public Integer getScaleFactor();
 
     /**
-     * This method allows you to know if there are submissions submitted
-     *
-     * Params: AssignmentSubmission s
-     */
-    public boolean hasBeenSubmitted(AssignmentSubmission s);
-
-    /**
      * Get a link directly into an assignment itself, supplying the permissions to use when
      * generating the link. Depending on your status, you get a different view on the assignment.
      *

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1758,7 +1758,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             // return true if resubmission is allowed and current time is before resubmission close time
             // get the resubmit settings from submission object first
             String allowResubmitNumString = submission != null ? submission.getProperties().get(AssignmentConstants.ALLOW_RESUBMIT_NUMBER) : null;
-            if (allowResubmitNumString != null && submission.getDateSubmitted() != null && this.hasBeenSubmitted(submission)) {
+            if (allowResubmitNumString != null && submission.getDateSubmitted() != null && submission.getSubmitted()) {
                 try {
                     int allowResubmitNumber = Integer.parseInt(allowResubmitNumString);
                     String allowResubmitCloseTime = submission.getProperties().get(AssignmentConstants.ALLOW_RESUBMIT_CLOSETIME);
@@ -2137,26 +2137,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     public Integer getScaleFactor() {
         Integer decimals = serverConfigurationService.getInt("assignment.grading.decimals", AssignmentConstants.DEFAULT_DECIMAL_POINT);
         return Double.valueOf(Math.pow(10.0, decimals)).intValue();
-    }
-
-    @Override
-    public boolean hasBeenSubmitted(AssignmentSubmission submission) {
-        try {
-            List<String> submissionLog = new ArrayList<>(); // TODO - submission.getSubmissionLog();
-
-            //Special case for old submissions prior to Sakai 10 where the submission log did not exist. Just return true for backward compatibility.
-            if (submissionLog == null || submissionLog.size() == 0) {
-                return true;
-            }
-            for (String itemString : submissionLog) {
-                if (itemString.contains("submitted")) {
-                    return true;
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Could not get submission log, {}", e.getMessage());
-        }
-        return false;
     }
 
     @Override

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5953,7 +5953,7 @@ public class AssignmentAction extends PagedResourceActionII {
                          * SAK-22150 We will need to know later if there was a previous submission time. DH
                          */
                         boolean isPreviousSubmissionTime = true;
-                        if (submission.getDateSubmitted() == null || "".equals(submission.getDateSubmitted()) || !assignmentService.hasBeenSubmitted(submission)) {
+                        if (submission.getDateSubmitted() == null || "".equals(submission.getDateSubmitted()) || !submission.getSubmitted()) {
                             isPreviousSubmissionTime = false;
                         }
 


### PR DESCRIPTION
Talked with Earle and he agreed the hasBeenSubmitted method is not necessary anymore. Submitted field and submitted date cover all cases.

I have also added one test method for the peer assessment dates.