### PR TITLE
SAK-33662: abbreviated site title missing in Sakai 11.5+

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -458,7 +458,9 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 						.equals(myWorkspaceSiteId))));
 		
 		String siteTitle = getUserSpecificSiteTitle(s, false, true, siteProviders);
+		String siteTitleTruncated = FormattedText.makeShortenedText(siteTitle, null, null, null);
 		m.put("siteTitle", siteTitle);
+		m.put("siteTitleTrunc", siteTitleTruncated);
 		m.put("fullTitle", siteTitle);
 		
 		m.put("siteDescription", s.getHtmlDescription());
@@ -500,7 +502,11 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					log.debug("PWD[{}]={}{}", i, site.getId(), site.getTitle());
 					Map<String, Object> pm = new HashMap<>();
 					List<String> providers = getProviderIDsForSite(site);
-					pm.put("siteTitle", getUserSpecificSiteTitle(site, false, true, providers));
+
+					String parentSiteTitle = getUserSpecificSiteTitle(site, false, true, providers);
+					String parentSiteTitleTruncated = FormattedText.makeShortenedText(parentSiteTitle, null, null, null);
+					pm.put("siteTitle", parentSiteTitle);
+					pm.put("siteTitleTrunc", parentSiteTitleTruncated);
 					pm.put("siteUrl", siteUrl + Web.escapeUrl(getSiteEffectiveId(site)));
 
 					l.add(pm);

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
@@ -20,7 +20,7 @@
                 #if (!${site.isMyWorkspace} && (${site.favorite} == "true" || ${site.isCurrentSite} || !${userIsLoggedIn}))
                     <li class="Mrphs-sitesNav__menuitem #if (${site.isCurrentSite}) is-selected #end">
                         <a class="link-container" href="${site.siteUrl}" title="${site.fullTitle}">
-                            <span>#if ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )${site.shortDescription}#else${site.siteTitle}#end</span>
+                            <span>#if ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )${site.shortDescription}#else${site.siteTitleTrunc}#end</span>
                         </a>
                         <a class="Mrphs-sitesNav__dropdown" href="#" data-site-id="${site.siteId}" role="separator"></a>
                     </li>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -76,13 +76,13 @@
                             #end
 							
                             <div class="fav-title #if (${site.isMyWorkspace}) fav-title-myworkspace #end">
-                            	<a href="${site.siteUrl}" title="${site.siteUrl}">
+                            	<a href="${site.siteUrl}" title="${site.siteTitle}">
                                     #if (${site.isMyWorkspace})
                                         <i class="fa fa-home" aria-hidden="true"></i><span class="fullTitle">${rloader.sit_mywor}</span>
                                     #elseif ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )
                                         <span class="fullTitle">${site.shortDescription}</span>
                                     #else
-                                        <span class="fullTitle">${site.siteTitle}</span>
+                                        <span class="fullTitle">${site.siteTitleTrunc}</span>
                                     #end
                                 </a>
                             </div>

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages_pt_BR.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages_pt_BR.properties
@@ -41,6 +41,7 @@ anonymous_users=Usu\u00e1rios An\u00f4nimos
 select_action=A\u00e7\u00e3o
 entire_site=Todo o Site
 
+# bjones86 - OWL-1146
 selected_groups=Grupos Selecionados
 selected_group=Grupo Selecionado
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages_pt_BR.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorFrontDoorMessages_pt_BR.properties
@@ -41,7 +41,6 @@ anonymous_users=Usu\u00e1rios An\u00f4nimos
 select_action=A\u00e7\u00e3o
 entire_site=Todo o Site
 
-# bjones86 - OWL-1146
 selected_groups=Grupos Selecionados
 selected_group=Grupo Selecionado
 

--- a/user/user-tool-prefs/tool/src/webapp/js/manage-hidden-sites.js
+++ b/user/user-tool-prefs/tool/src/webapp/js/manage-hidden-sites.js
@@ -16,7 +16,8 @@ $(function () {
             return {
                 siteid: $(this).find('.site-id').text(),
                 title: $(this).find('.site-title').text(),
-                description: $(this).find('.site-short-description').text()
+                description: $(this).find('.site-short-description').text(),
+                tooltip: $(this).find('.site-titleFull').text()
             };
         }).toArray();
 
@@ -31,10 +32,10 @@ $(function () {
             var item = $('<div class="manage-hidden-entry site-entry" />');
             item.append($('<i class="fa site-entry-star" />'));
 
-            if ($('#selectedTabLabelValue').text().trim() == '2' && site.description) {
-                item.append($('<span class="title" />').text(site.description));
+            if ($('#selectedTabLabelValue').text().trim() === '2' && site.description) {
+                item.append($('<span class="title" title="' + site.tooltip + '" />').text(site.description));
             } else {
-                item.append($('<span class="title" />').text(site.title));
+                item.append($('<span class="title" title="' + site.tooltip + '" />').text(site.title));
             }
 
             item.append($('<input type="checkbox" class="site-hidden hidden-checkbox">').data('site-id', site.siteid));
@@ -61,14 +62,14 @@ $(function () {
 
     var update_term_state = function (term) {
         // If an entire section's sites are checked, check the title too
-        var checks = $('.site-hidden', term).map(function () { return $(this).prop('checked') }).toArray();
+        var checks = $('.site-hidden', term).map(function () { return $(this).prop('checked'); }).toArray();
         var allTermSitesChecked = (checks.indexOf(false) < 0);
         $('.term-hidden', term).prop('checked', allTermSitesChecked);
 
         // Apply our 'entry-hidden' styles to anything checked
         $('.entry-hidden', term).removeClass('entry-hidden');
         $('.hidden-checkbox:checked', term).closest('.manage-hidden-entry').addClass('entry-hidden');
-    }
+    };
 
     // Set the initial state upon load
     $('.term-section', target).each(function (i, term) {
@@ -126,7 +127,7 @@ $(function () {
             }
 
             var siteList = $('.site-hidden:checked').map(function (i, checkbox) {
-                return $(checkbox).data('site-id')
+                return $(checkbox).data('site-id');
             }).toArray().join(",");
 
             $('#hidden_sites_form\\:hiddenSites').val(siteList);
@@ -141,7 +142,7 @@ $(function () {
             method: 'GET',
             success: function (data) {
                 favoritesList = data.split(';').filter(function (e, i) {
-                    return e != '';
+                    return e !== '';
                 });
 
                 callback(favoritesList);

--- a/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
@@ -96,6 +96,10 @@
                                                 <h:outputText value="#{site.title}" />
                                                 <f:verbatim></span></f:verbatim>
 
+                                                <f:verbatim><span class="site-titleFull"></f:verbatim>
+                                                <h:outputText value="#{site.infoUrl}" />
+                                                <f:verbatim></span></f:verbatim>
+
                                                 <f:verbatim><span class="site-short-description"></f:verbatim>
                                                 <h:outputText value="#{site.shortDescription}" />
                                                 <f:verbatim></span></f:verbatim>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33662

The skin is not truncating the site title in any place.
In Sakai 11/10 the site title was truncated in some places to avoid use too much space.
In Sakai 12/13 this truncate process is completely removed.

See the screenshots in the JIRA ticket.