### PR TITLE
LSNBLDR-910 Split the composite ID into it’s own class

### DIFF
--- a/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/ChecklistItemStatus.java
+++ b/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/ChecklistItemStatus.java
@@ -26,13 +26,10 @@ package org.sakaiproject.lessonbuildertool;
 public interface ChecklistItemStatus {
 
     long getChecklistId();
-    void setChecklistId(long checklistId);
 
     long getChecklistItemId();
-    void setChecklistItemId(long checklistItemId);
 
     String getOwner();
-    void setOwner(String owner);
 
     boolean isDone();
     void setDone(boolean done);

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -1773,9 +1773,9 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	@SuppressWarnings("unchecked")
 	public boolean isChecklistItemChecked(long checklistId, long checklistItemId, String userId) {
 		DetachedCriteria d = DetachedCriteria.forClass(ChecklistItemStatus.class)
-				.add(Restrictions.eq("checklistId", checklistId))
-				.add(Restrictions.eq("checklistItemId", checklistItemId))
-				.add(Restrictions.eq("owner", userId));
+				.add(Restrictions.eq("id.checklistId", checklistId))
+				.add(Restrictions.eq("id.checklistItemId", checklistItemId))
+				.add(Restrictions.eq("id.owner", userId));
 
 		List<ChecklistItemStatus> list = (List<ChecklistItemStatus>) getHibernateTemplate().findByCriteria(d);
 
@@ -1789,7 +1789,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	@SuppressWarnings("unchecked")
 	public List<ChecklistItemStatus> findChecklistItemStatusesForChecklist(long checklistId) {
 		DetachedCriteria d = DetachedCriteria.forClass(ChecklistItemStatus.class)
-				.add(Restrictions.eq("checklistId", checklistId));
+				.add(Restrictions.eq("id.checklistId", checklistId));
 		List<ChecklistItemStatus> list = (List<ChecklistItemStatus>) getHibernateTemplate().findByCriteria(d);
 
 		if(list.size() > 0) {
@@ -1802,8 +1802,8 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	@SuppressWarnings("unchecked")
 	public List<ChecklistItemStatus> findChecklistItemStatusesForChecklistItem(long checklistId, long checklistItemId) {
 		DetachedCriteria d = DetachedCriteria.forClass(ChecklistItemStatus.class)
-				.add(Restrictions.eq("checklistId", checklistId))
-				.add(Restrictions.eq("checklistItemId", checklistItemId));
+				.add(Restrictions.eq("id.checklistId", checklistId))
+				.add(Restrictions.eq("id.checklistItemId", checklistItemId));
 		List<ChecklistItemStatus> list = (List<ChecklistItemStatus>) getHibernateTemplate().findByCriteria(d);
 
 		if(list.size() > 0) {
@@ -1816,9 +1816,9 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	@SuppressWarnings("unchecked")
 	public ChecklistItemStatus findChecklistItemStatus(long checklistId, long checklistItemId, String userId) {
 		DetachedCriteria d = DetachedCriteria.forClass(ChecklistItemStatus.class)
-				.add(Restrictions.eq("checklistId", checklistId))
-				.add(Restrictions.eq("checklistItemId", checklistItemId))
-				.add(Restrictions.eq("owner", userId));
+				.add(Restrictions.eq("id.checklistId", checklistId))
+				.add(Restrictions.eq("id.checklistItemId", checklistItemId))
+				.add(Restrictions.eq("id.owner", userId));
 		List<ChecklistItemStatus> list = (List<ChecklistItemStatus>) getHibernateTemplate().findByCriteria(d);
 
 		if(list.size() > 0) {

--- a/lessonbuilder/components/src/webapp/WEB-INF/components.xml
+++ b/lessonbuilder/components/src/webapp/WEB-INF/components.xml
@@ -66,4 +66,6 @@
         <property name="autoDdl" value="${auto.ddl}"/>
   </bean>
 
+
+
 </beans>

--- a/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/ChecklistItemStatusId.java
+++ b/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/ChecklistItemStatusId.java
@@ -1,0 +1,57 @@
+package org.sakaiproject.lessonbuildertool;
+
+import java.io.Serializable;
+
+/**
+ * Composite ID for checklist item status.
+ */
+public class ChecklistItemStatusId implements Serializable {
+
+    private long checklistId; // ID of the Checklist to which the checklist item belongs
+    private long checklistItemId; // ID of the Checklist Item to which this belongs
+    private String owner;
+
+    public long getChecklistId() {
+        return checklistId;
+    }
+
+    public void setChecklistId(long checklistId) {
+        this.checklistId = checklistId;
+    }
+
+    public long getChecklistItemId() {
+        return checklistItemId;
+    }
+
+    public void setChecklistItemId(long checklistItemId) {
+        this.checklistItemId = checklistItemId;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ChecklistItemStatusId that = (ChecklistItemStatusId) o;
+
+        if (checklistId != that.checklistId) return false;
+        if (checklistItemId != that.checklistItemId) return false;
+        return owner != null ? owner.equals(that.owner) : that.owner == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (checklistId ^ (checklistId >>> 32));
+        result = 31 * result + (int) (checklistItemId ^ (checklistItemId >>> 32));
+        result = 31 * result + (owner != null ? owner.hashCode() : 0);
+        return result;
+    }
+}

--- a/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/ChecklistItemStatusImpl.java
+++ b/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/ChecklistItemStatusImpl.java
@@ -28,50 +28,47 @@ public class ChecklistItemStatusImpl implements ChecklistItemStatus, Serializabl
 
     private static final long serialVersionUID = 1L;
 
-    private long checklistId; // ID of the Checklist to which the checklist item belongs
-    private long checklistItemId; // ID of the Checklist Item to which this belongs
-    private String owner; // The user associated with this checklist item
+    private ChecklistItemStatusId id;
     private boolean done; // Has this item been completed?
 
     public ChecklistItemStatusImpl() {
+        id = new ChecklistItemStatusId();
     }
 
     public ChecklistItemStatusImpl(long checklistId, long checklistItemId, String owner) {
-        this.checklistId = checklistId;
-        this.checklistItemId = checklistItemId;
-        this.owner = owner;
+        this.id = new ChecklistItemStatusId();
+        this.id.setChecklistId(checklistId);
+        this.id.setChecklistItemId(checklistItemId);
+        this.id.setOwner(owner);
         this.done = false;
     }
 
     public ChecklistItemStatusImpl(long checklistId, long checklistItemId, String owner, boolean done) {
-        this.checklistId = checklistId;
-        this.checklistItemId = checklistItemId;
-        this.owner = owner;
+        this.id = new ChecklistItemStatusId();
+        this.id.setChecklistId(checklistId);
+        this.id.setChecklistItemId(checklistItemId);
+        this.id.setOwner(owner);
         this.done = done;
     }
 
-    public long getChecklistId() {
-        return checklistId;
+    public ChecklistItemStatusId getId() {
+        return id;
     }
 
-    public void setChecklistId(long checklistId) {
-        this.checklistId = checklistId;
+    public void setId(ChecklistItemStatusId id) {
+        this.id = id;
+    }
+
+    public long getChecklistId() {
+        return id.getChecklistId();
     }
 
     public long getChecklistItemId() {
-        return checklistItemId;
-    }
-
-    public void setChecklistItemId(long checklistItemId) {
-        this.checklistItemId = checklistItemId;
+        return id.getChecklistItemId();
     }
 
     public String getOwner() {
-        return owner;
-    }
-
-    public void setOwner(String owner) {
-        this.owner = owner;
+        return id.getOwner();
     }
 
     public boolean isDone() {
@@ -81,4 +78,6 @@ public class ChecklistItemStatusImpl implements ChecklistItemStatus, Serializabl
     public void setDone(boolean done) {
         this.done = done;
     }
+
+
 }

--- a/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/checklistitemstatus.hbm.xml
+++ b/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/checklistitemstatus.hbm.xml
@@ -6,7 +6,7 @@
 
         <cache usage="nonstrict-read-write" />
 
-        <composite-id>
+        <composite-id name="id" class="org.sakaiproject.lessonbuildertool.ChecklistItemStatusId">
             <key-property name="checklistId" type="long"/>
             <key-property name="checklistItemId" type="long"/>
             <key-property name="owner" type="string" length="99"/>


### PR DESCRIPTION
The composite ID should be in it’s own class so that it’s equals and hashCode can work correctly. This doesn’t seem to have any affect on Sakai apart from fixing the startup warning about a composite ID class not overriding hashcode() and equals().

This may have caused some caching issues, but I didn’t investigate.