### PR TITLE
KNL-1572 Load caches for hibernate.

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/memory/api/ehcache.xml
+++ b/kernel/api/src/main/java/org/sakaiproject/memory/api/ehcache.xml
@@ -339,14 +339,14 @@
     It is important that the cache timeout of the underlying cache implementation be set to a
     higher value than the timeouts of any of the query caches. In fact, it is recommended that
     the the underlying cache not be configured for expiry at all. -->
-   <cache name="org.hibernate.cache.UpdateTimestampsCache"
+   <cache name="org.hibernate.cache.spi.UpdateTimestampsCache"
       maxElementsInMemory="6000"
       eternal="true"
       statistics="true"
       overflowToDisk="false" />
 
     <!-- this cache stores the actual objects pulled out of the DB by hibernate -->
-    <cache name="org.hibernate.cache.StandardQueryCache"
+    <cache name="org.hibernate.cache.internal.StandardQueryCache"
       maxElementsInMemory="12000"
       eternal="false"
       timeToIdleSeconds="600"

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
@@ -445,6 +445,7 @@
 				<prop key="hibernate.hbm2ddl.auto">${hibernate.hbm2ddl.auto}</prop>
 				<prop key="hibernate.generate_statistics">true</prop>
 				<prop key="hibernate.enable_lazy_load_no_trans">true</prop>
+				<prop key="net.sf.ehcache.configurationResourceName">/org/sakaiproject/memory/api/ehcache.xml</prop>
 			</props>
 		</property>
 	</bean>


### PR DESCRIPTION
There were previously caches defined in the memory service’s ehcache.xml file, but this doesn’t appear to be being used as Hibernate is starting it’s own cache manager. This moves the hibernate caches to a hibernate specific cache configuration and points the caching factory at it.

This also gets rid of the WARN messages at startup about this.