### PR TITLE
SAK-33634 generate anonymous id

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
@@ -141,9 +141,6 @@ public class AssignmentSubmission {
     @Column(name = "HONOR_PLEDGE")
     private Boolean honorPledge = Boolean.FALSE;
 
-    @Column(name = "ANONYMOUS_SUBMISSION_ID")
-    private String anonymousSubmissionId;
-
     @Column(name = "HIDDEN_DUE_DATE")
     private Boolean hiddenDueDate = Boolean.FALSE;
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2788,8 +2788,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 // Work out if submission is late.
                                 String latenessStatus = whenSubmissionMade(s);
 
-                                String fullAnonId = s.getAnonymousSubmissionId();
                                 String anonTitle = resourceLoader.getString("grading.anonymous.title");
+                                String fullAnonId = s.getId() + " " + anonTitle;
 
                                 String[] params = new String[7];
                                 if (isAdditionalNotesEnabled && candidateDetailProvider != null) {
@@ -2828,8 +2828,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
                                 // SAK-17606
                                 if (isAnon) {
-                                    submittersName = root + s.getAnonymousSubmissionId();
-                                    submittersString = s.getAnonymousSubmissionId();
+                                    submittersString = s.getId() + " " + resourceLoader.getString("grading.anonymous.title");
+                                    submittersName = root + submittersString;
                                 }
 
                                 if (!withoutFolders) {

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/EmailUtil.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/EmailUtil.java
@@ -169,7 +169,7 @@ public class EmailUtil {
                     submitterNames = submitterNames.concat("; ");
                     submitterIds = submitterIds.concat("; ");
                 }
-                submitterNames = submitterNames.concat((isAnon ? submission.getAnonymousSubmissionId() : user.getDisplayName()));
+                submitterNames = submitterNames.concat((isAnon ? submission.getId() + " " + resourceLoader.getString("grading.anonymous.title") : user.getDisplayName()));
                 submitterIds = submitterIds.concat(user.getDisplayId());
             } catch (UserNotDefinedException e) {
                 log.warn("User not found with id = {}, {}", submitter.getSubmitter());

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
@@ -287,7 +287,7 @@ public class GradeSheetExporter {
                                 Submitter submitter = submitterMap.get(submissionSubmitters[0].getSubmitter());
                                 // Get the user ID for this result
                                 if (assignmentService.assignmentUsesAnonymousGrading(a)) {
-                                    submitter = new Submitter(submission.getAnonymousSubmissionId(), submitter);
+                                    submitter = new Submitter(submission.getId() + " " + rb.getString("grading.anonymous.title"), submitter);
                                 }
 
                                 List<Object> objects = results.get(submitter);

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AnonymousSubmissionComparator.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AnonymousSubmissionComparator.java
@@ -47,8 +47,8 @@ public class AnonymousSubmissionComparator implements Comparator<AssignmentSubmi
     @Override
     public int compare(AssignmentSubmission a1, AssignmentSubmission a2) {
         int result;
-        String name1 = a1.getAnonymousSubmissionId();
-        String name2 = a2.getAnonymousSubmissionId();
+        String name1 = a1.getId();
+        String name2 = a2.getId();
         result = collator.compare(name1, name2);
         return result;
     }

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -12903,7 +12903,7 @@ public class AssignmentAction extends PagedResourceActionII {
                             List<Reference> feedbackAttachments = entityManager.newReferenceList();
                             feedbackAttachments.addAll(s.getFeedbackAttachments().stream().map(entityManager::newReference).collect(Collectors.toList()));
                             submissionTable.put(eid, new UploadGradeWrapper(s.getGrade(), s.getSubmittedText(), s.getFeedbackComment(), hasSubmissionAttachment ? new ArrayList() : attachments, hasFeedbackAttachment ? new ArrayList() : feedbackAttachments, (s.getSubmitted() && s.getDateSubmitted() != null) ? s.getDateSubmitted().toString() : "", s.getFeedbackText()));
-                            anonymousSubmissionAndEidTable.put(s.getAnonymousSubmissionId(), eid);
+                            anonymousSubmissionAndEidTable.put(s.getId(), eid);
                         }
                     }
 
@@ -14841,8 +14841,8 @@ public class AssignmentAction extends PagedResourceActionII {
                 if (u1 == null || u2 == null || (u1.getUser() == null && u1.getGroup() == null) || (u2.getUser() == null && u2.getGroup() == null)) {
                     result = 1;
                 } else if (m_anon) {
-                    String anon1 = u1.getSubmission().getAnonymousSubmissionId();
-                    String anon2 = u2.getSubmission().getAnonymousSubmissionId();
+                    String anon1 = u1.getSubmission().getId();
+                    String anon2 = u2.getSubmission().getId();
                     result = compareString(anon1, anon2);
                 } else {
                     String lName1 = u1.getUser() == null ? u1.getGroup().getTitle() : u1.getUser().getSortName();

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -124,7 +124,7 @@
                 </th>
                 <td>
 					#if ($value_CheckAnonymousGrading.equals("true"))
-                        $validator.escapeHtml($!submission.AnonymousSubmissionId)
+                        $validator.escapeHtml($!submission.Id) $tlang.getString("grading.anonymous.title")
                     #else
                         $!submitterNames
                     #end

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -542,7 +542,7 @@ function printView(url) {
 					#end
 					#if ($!submission)## && $submission.submitted)
 						## SAK-17606
-						#set($anonymousSubmissionId = $submission.getAnonymousSubmissionId())
+						#set($anonymousSubmissionId = $submission.getId() + ' ' + ($tlang.getString("grading.anonymous.title")))
 
 						<tr>
 							<td headers="allowResubmit" class="screenOnly smallCol">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
@@ -19,7 +19,7 @@
                     $tlang.getString("gen.student")
                 </th>
                 <td>
-					#set($anonymousSubmissionId = $!submission.AnonymousSubmissionId)
+					#set($anonymousSubmissionId = $!submission.Id + ' ' + ($tlang.getString("grading.anonymous.title")))
 					#if ($value_CheckAnonymousGrading.equals("true"))
                     $anonymousSubmissionId
                 #else

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -153,7 +153,7 @@
 						#set ($submissionType = $!assignment.TypeOfSubmission)
 						#set ($typeOfGrade = $!assignment.TypeOfGrade)
 						#set ($isAnon = $!service.assignmentUsesAnonymousGrading($assignment))
-						#set ($anonymousSubmissionId = $!assignmentSubmission.AnonymousSubmissionId)
+						#set ($anonymousSubmissionId = $!assignmentSubmission.Id + ' ' + ($tlang.getString("grading.anonymous.title")))
 						<tr>
 							<td headers="studentname">
 							#if ($submission.MultiGroup)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_students_details.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_students_details.vm
@@ -33,7 +33,7 @@
       #end
       #if ($!submission)## && $submission.submitted) 
         ## SAK-17606
-        #set($anonymousSubmissionId = $submission.getAnonymousSubmissionId())
+        #set($anonymousSubmissionId = $submission.getId() + ' ' + ($tlang.getString("grading.anonymous.title")))
         #set($notes = [])
         #set($notes = $notesMap.get($siteUser.id))
         #if($notes.size() > 0)


### PR DESCRIPTION
Taking a substring from the internal id, like it was done before.

Adding the i18n anon string when needed, instead of by default (to avoid adding a resourcebundle entry inside the API).