### PR TITLE
SAK-33678 hide ck editor/message in instructor view

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -421,20 +421,22 @@
             #end
         #end
         #if ($submissionType == 4 && !$hasInline && $size == 0)
-        ## if this is non-electronic submission
+            ## if this is non-electronic submission
             <p class="text-warning">$tlang.getString("nonelec_instruction2")</p>
         #else
-            #if (($submission.Submitted || !$alertGradeDraft) && !$!value_feedback_text.isEmpty())
-                <p class="text-info">$tlang.getString("gradingsub.belisthe")</p>
-                <div class="textarea-holder">
-                    <textarea name="$name_feedback_text" id="$name_feedback_text" rows="30" wrap="virtual" cols="80">
-                        $validator.escapeHtmlFormattedTextarea($!value_feedback_text)
-                    </textarea>
-                    #chef_setupformattedtextarea($name_feedback_text)
-                </div>
-            #elseif($submissionType != 2 && $submissionType != 4)
-                ## This message only shows when the submission type allows submitted text and the submission doesn't contain submitted text
-                <p class="text-warning">$tlang.getString("gradingsub.nosubmittedtext")</p>
+            #if($submissionType == 1 || $submissionType == 3)
+                #if (($submission.Submitted || !$alertGradeDraft) && !$!value_feedback_text.isEmpty())
+                    <p class="text-info">$tlang.getString("gradingsub.belisthe")</p>
+                    <div class="textarea-holder">
+                        <textarea name="$name_feedback_text" id="$name_feedback_text" rows="30" wrap="virtual" cols="80">
+                            $validator.escapeHtmlFormattedTextarea($!value_feedback_text)
+                        </textarea>
+                        #chef_setupformattedtextarea($name_feedback_text)
+                    </div>
+                #else
+                    ## This message only shows when the submission type allows submitted text and the submission doesn't contain submitted text
+                    <p class="text-warning">$tlang.getString("gradingsub.nosubmittedtext")</p>
+                #end
             #end
             ## for returned submission, show the instructor comment as well
             #if ($!prevFeedbackText)


### PR DESCRIPTION
Only show them when inline text is allowed and there's text (ck editor) or there isn't/is draft (message).