### PR TITLE
KNL-1573 Log actual values in the Message

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
@@ -1469,18 +1469,11 @@ public class BasicEmailService implements EmailService
 		if (M_log.isInfoEnabled())
 		{
 			StringBuilder buf = new StringBuilder();
-			buf.append("Email.sendMail: from: ");
-			for(Address from : msg.getFrom()) {
-				buf.append(toEmail(from));
-				buf.append(" ");
-			}
+			buf.append("Email.sendMail:");
+			appendAddresses(buf, msg.getFrom(), " from:");
 			buf.append("subject: ");
 			buf.append(msg.getSubject());
-			buf.append(" to:");
-			for (InternetAddress aTo : to) {
-				buf.append(" ");
-				buf.append(toEmail(aTo));
-			}
+			appendAddresses(buf, to, " to:");
 			appendAddresses(buf, msg.getRecipients(Message.RecipientType.TO), " headerTo{to}:");
 			appendAddresses(buf, msg.getRecipients(Message.RecipientType.CC), " headerTo{cc}:");
 			appendAddresses(buf, msg.getRecipients(Message.RecipientType.BCC), " headerTo{bcc}:");
@@ -1516,9 +1509,11 @@ public class BasicEmailService implements EmailService
 	 * @param label The label for these addresses.
 	 */
 	private void appendAddresses(StringBuilder buffer, Address[] addresses, String label) {
-		if (addresses != null) {
+		if (addresses != null)
+		{
 			buffer.append(label);
-			for (Address address : addresses) {
+			for (Address address : addresses)
+			{
 				buffer.append(" ");
 				buffer.append(toEmail(address));
 			}


### PR DESCRIPTION
When sending a message out we log useful values to aid in debugging. However with the recent re-writing of From: addresses we were logging the original values, rather than the re-written values so the log entries don’t act as a good audit of what got sent.

As we now rely on the replyTo header more because of our re-writing I’ve added that as a header that’s logged as well. This will also help in debugging as it often includes details of the user who performed the action when the from address gets re-written.

Rather than passing in additional values just to be logged we just look directly at the message, this should make it less likely in future that the logged data is different from data used to send the mail.