### PR TITLE
SAM-3174 avoid students answering during timeout messages

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/TimerBarRenderer.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/TimerBarRenderer.java
@@ -117,9 +117,8 @@ public class TimerBarRenderer extends Renderer
          writer.write("\n");
          writer.write("\n  var action = function()");
          writer.write("\n {");
-         writer.write ("\n showTimerExpiredWarning (function (){");
          writer.write("\n   " + attrMap.get("expireScript") + "clickSubmitForGrade();");
-         writer.write("\n });}");
+         writer.write("\n }");
          writer.write("\n");
          writer.write("\n  var action2 = function()");
          writer.write("\n {");

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -82,28 +82,6 @@
       	 </h:panelGrid>
       </div>
       
-		<div id="timer-expired-warning" style="display:none;">
-			<h3><h:outputText value="#{deliveryMessages.time_expired1}" /></h3>
-      		<p><h:outputText value="#{deliveryMessages.time_expired3}" /></p>
-      		<div id="squaresWaveG">
-				<div id="squaresWaveG_1" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_2" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_3" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_4" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_5" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_6" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_7" class="squaresWaveG">
-				</div>
-				<div id="squaresWaveG_8" class="squaresWaveG">
-				</div>
-			</div>
-		</div>
 		
 		<div id="time-30-warning" style="display:none;text-align:center">
 		<h:outputFormat value="#{deliveryMessages.time_30_warning}" escape="false">

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
@@ -54,6 +54,9 @@
 		//Disable the back button
 		disableBackButton("<h:outputText value="#{deliveryMessages.use_form_navigation}"/>");
 
+		if($('#submittedForm\\:renderTimeoutMessage').length > 0){
+			showTimerExpiredWarning(function() { ($('#timer-expired-warning').parent()).css('display', 'none');});
+		}
 	});
 
 	function checkIfHonorPledgeIsChecked() {

--- a/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
@@ -78,11 +78,36 @@ window.close();
   </h1>
 </div>
 
-<h:outputText styleClass="messageSamigo3" value="#{deliveryMessages.timeOutSubmission}" rendered="#{delivery.timeOutSubmission=='true'}"/>
+<%@ include file="/jsf/delivery/deliveryjQuery.jsp" %>
+<div id="timer-expired-warning" style="display:none;">
+	<h3><h:outputText value="#{deliveryMessages.time_expired1}" /></h3>
+    <p><h:outputText value="#{deliveryMessages.time_expired3}" /></p>
+    <div id="squaresWaveG">
+		<div id="squaresWaveG_1" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_2" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_3" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_4" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_5" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_6" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_7" class="squaresWaveG">
+		</div>
+		<div id="squaresWaveG_8" class="squaresWaveG">
+		</div>
+	</div>
+</div>
 
 <div class="table-responsive">
 
 <h:form id="submittedForm">
+
+	<h:outputText id="renderTimeoutMessage" styleClass="messageSamigo3" value="#{deliveryMessages.timeOutSubmission}" rendered="#{delivery.timeOutSubmission=='true'}"/>
+
 <h:messages styleClass="messageSamigo" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
 
 	<h:outputText value="#{deliveryMessages.submission_confirmation_message_1}" rendered="#{!delivery.actionString=='takeAssessmentViaUrl'}"/>


### PR DESCRIPTION
Basically we have reformatted the process once the end time is reached: the redirection takes place and THEN the message is shown. It makes no sense to throw a timeout on the delivery screen because it was allowing users to change answers during that time.