### PR TITLE
SAK-33684 Handle SMTP FROM that isn’t email better

### DIFF
--- a/mailarchive/mailarchive-subetha/src/java/org/sakaiproject/mailarchive/SakaiMessageHandlerFactory.java
+++ b/mailarchive/mailarchive-subetha/src/java/org/sakaiproject/mailarchive/SakaiMessageHandlerFactory.java
@@ -183,8 +183,13 @@ public class SakaiMessageHandlerFactory implements MessageHandlerFactory {
 
             @Override
             public void from(String from) throws RejectException {
-                SplitEmailAddress address = SplitEmailAddress.parse(from);
-                this.from = address.getLocal() + "@" + address.getDomain();
+                try {
+                    SplitEmailAddress address = SplitEmailAddress.parse(from);
+                    this.from = address.getLocal() + "@" + address.getDomain();
+                } catch (IllegalArgumentException iae) {
+                    log.debug("Not allowing return path of: {}", from);
+                    throw new RejectException("Not allowing return path of: "+ from);
+                }
             }
 
             @Override

--- a/mailarchive/mailarchive-subetha/src/java/org/sakaiproject/mailarchive/SplitEmailAddress.java
+++ b/mailarchive/mailarchive-subetha/src/java/org/sakaiproject/mailarchive/SplitEmailAddress.java
@@ -57,7 +57,7 @@ public class SplitEmailAddress {
     public static SplitEmailAddress parse(String address) {
         int atPos = address.indexOf('@');
         if (atPos < 1 || atPos == address.length() -1) {
-            throw new IllegalArgumentException("Can't find @ or it's at the start or end.");
+            throw new IllegalArgumentException("Can't find @ or it's at the start or end of: "+ address);
         }
         String local = address.substring(0, atPos);
         Matcher rfcMatcher = BATV_RFC.matcher(local);

--- a/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
+++ b/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
@@ -287,6 +287,22 @@ public class SakaiMessageHandlerTest {
         writeData(client, "/no-permission.txt");
     }
 
+    @Test(expected = SMTPException.class)
+    public void testNoReturnPath() throws Exception {
+        // Here there isn't a good email in the from address to make a return path
+        String reference = "/mailarchive/no-good-mail/main";
+        SmartClient client = createClient();
+        client.from("");
+    }
+
+    @Test(expected = SMTPException.class)
+    public void testEmptyReturnPath() throws Exception {
+        // Here there isn't a good email in the from address to make a return path
+        String reference = "/mailarchive/empty-return-path/main";
+        SmartClient client = createClient();
+        client.from("");
+    }
+
     @Test
     public void testPostmaster() throws Exception {
         // Here there is no postmaster which may happen and should be dealt with


### PR DESCRIPTION
Have better handling of a client attempting to send an email where the FROM address isn’t an email address that we can parse. This may be because it’s empty or it’s not an email address.