### PR TITLE
SAK-33681 some changes to add and edit AllPurposeItems

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentAllPurposeItem.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentAllPurposeItem.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.persistence.*;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /**
@@ -38,6 +39,7 @@ import lombok.NoArgsConstructor;
             query = "from AssignmentAllPurposeItem m where m.assignmentId = :id")
 @Data
 @NoArgsConstructor
+@EqualsAndHashCode(of = "id")
 public class AssignmentAllPurposeItem extends AssignmentSupplementItemWithAttachment {
 
     @Column(name = "ASSIGNMENT_ID", nullable = false)

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentAllPurposeItemAccess.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentAllPurposeItemAccess.java
@@ -24,6 +24,7 @@ package org.sakaiproject.assignment.api.model;
 import javax.persistence.*;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /**
@@ -38,6 +39,7 @@ import lombok.NoArgsConstructor;
             query = "select access from AssignmentAllPurposeItemAccess a where a.assignmentAllPurposeItem = :item")
 @Data
 @NoArgsConstructor
+@EqualsAndHashCode(of = "id")
 public class AssignmentAllPurposeItemAccess {
 
     @Id

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7924,13 +7924,14 @@ public class AssignmentAction extends PagedResourceActionII {
                 assignmentSupplementItemService.removeAllPurposeItem(nAllPurpose);
             }
         } else if (state.getAttribute(ALLPURPOSE_TITLE) != null) {
-            // edit/add private note
+            // edit/add allPurpose item
             AssignmentAllPurposeItem nAllPurpose = assignmentSupplementItemService.getAllPurposeItem(aId);
             if (nAllPurpose == null) {
                 nAllPurpose = assignmentSupplementItemService.newAllPurposeItem();
+                nAllPurpose.setAssignmentId(a.getId());
+                nAllPurpose.setHide(false);//SAK-33681
                 assignmentSupplementItemService.saveAllPurposeItem(nAllPurpose);
             }
-            nAllPurpose.setAssignmentId(a.getId());
             nAllPurpose.setTitle((String) state.getAttribute(ALLPURPOSE_TITLE));
             nAllPurpose.setText((String) state.getAttribute(ALLPURPOSE_TEXT));
 
@@ -9339,13 +9340,13 @@ public class AssignmentAction extends PagedResourceActionII {
         // default to assignment close time
         Instant retractTime = a.getCloseDate();
         if (aItem != null) {
-            Instant releaseDate = aItem.getReleaseDate().toInstant();
+            Instant releaseDate = aItem.getReleaseDate() != null ? aItem.getReleaseDate().toInstant() : null;
             if (releaseDate != null) {
                 // overwrite if there is a release date
                 releaseTime = releaseDate;
             }
 
-            Instant retractDate = aItem.getRetractDate().toInstant();
+            Instant retractDate = aItem.getRetractDate() != null ? aItem.getRetractDate().toInstant() : null;
             if (retractDate != null) {
                 // overwriteif there is a retract date
                 retractTime = retractDate;


### PR DESCRIPTION
Quite a few different things where needed here: firstly id and hide fields couldn't be null, so we initialized them (as hide has to be updated later, we just put a default value).
Then there was a weird infinite loop:

_at org.sakaiproject.assignment.api.model.AssignmentAllPurposeItem.hashCode(AssignmentAllPurposeItem.java:39)
	at org.sakaiproject.assignment.api.model.AssignmentAllPurposeItemAccess.hashCode(AssignmentAllPurposeItemAccess.java:39)
	at java.util.AbstractSet.hashCode(AbstractSet.java:126)
at org.sakaiproject.assignment.api.model.AssignmentAllPurposeItem.hashCode(AssignmentAllPurposeItem.java:39)
	at org.sakaiproject.assignment.api.model.AssignmentAllPurposeItemAccess.hashCode(AssignmentAllPurposeItemAccess.java:39)
	at java.util.AbstractSet.hashCode(AbstractSet.java:126)_

We solved it by adding the hashcode/equals to both classes. Then finally there was a problem when editing, related to a NullPointer on a dates verification.