### PR TITLE
SAK-33683 commenting all submission log appearances for the moment

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/conversion/api/SerializableSubmissionAccess.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/conversion/api/SerializableSubmissionAccess.java
@@ -277,8 +277,6 @@ public interface SerializableSubmissionAccess
 	 * @param id the submitter id to set
 	 */
 	public void setSubmitterId(String id);
-        public void setSubmissionLog(List<String> log);
-        public List<String> getSubmissionLog();
         public void setGrades(List<String> grades);
         public List<String> getGrades();
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/conversion/impl/AssignmentSubmissionAccess.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/conversion/impl/AssignmentSubmissionAccess.java
@@ -108,8 +108,6 @@ public class AssignmentSubmissionAccess implements SerializableSubmissionAccess,
 	
 	protected List<String> feedbackattachments = new ArrayList<String>();
 
-        protected List<String> submissionLog = new ArrayList<String>();
-
 	protected List<String> grades = new ArrayList<String>();
 
 	protected String datesubmitted = null;
@@ -205,17 +203,6 @@ public class AssignmentSubmissionAccess implements SerializableSubmissionAccess,
 		{
 			attributeString = "submitter" + x;
 			itemString = (String) this.submitters.get(x);
-			if (itemString != null)
-			{
-				submission.setAttribute(attributeString, itemString);
-			}
-		}
-
-        // SAVE THE SUBMISSION LOGS
-		for (int x = 0; x < this.submissionLog.size(); x++)
-		{
-			attributeString = "log" + x;
-			itemString = (String) this.submissionLog.get(x);
 			if (itemString != null)
 			{
 				submission.setAttribute(attributeString, itemString);
@@ -486,7 +473,6 @@ public class AssignmentSubmissionAccess implements SerializableSubmissionAccess,
 					if (getSubmitterId() == null && submitters.size() > 0) {
 						setSubmitterId(submitters.get(0));
 					}
-					addElementsToList("log",submissionLog,attributes,false);
 					addElementsToList("grade",grades,attributes,false);
 				}
 			}
@@ -927,12 +913,6 @@ public class AssignmentSubmissionAccess implements SerializableSubmissionAccess,
 		return submitters;
 	}
 
-        public List<String>getSubmissionLog() {
-            return submissionLog;
-        }
-        public void setSubmissionLog(List<String> log) {
-            this.submissionLog = log;
-        }
         public List<String>getGrades() { return grades; }
         public void setGrades(List<String> gr) { this.grades = gr; }
 

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6118,7 +6118,7 @@ public class AssignmentAction extends PagedResourceActionII {
                         }
 
                         // SAK-17606
-                        String logEntry = new Date().toString() + " ";
+                        /*String logEntry = new Date().toString() + " ";
                         boolean anonymousGrading = Boolean.parseBoolean(a.getProperties().get(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING));
                         if (!anonymousGrading) {
                             String subOrDraft = post ? "submitted" : "saved draft";
@@ -6129,7 +6129,7 @@ public class AssignmentAction extends PagedResourceActionII {
                             } else {
                                 logEntry += u.getDisplayName() + " (" + u.getEid() + ") " + subOrDraft;
                             }
-                        }
+                        }*/
 // TODO submissionLog
 //						submission.addSubmissionLogEntry( logEntry );
                         try {
@@ -6190,7 +6190,7 @@ public class AssignmentAction extends PagedResourceActionII {
                                 }
 
                                 // SAK-17606
-                                String logEntry = new Date().toString() + " ";
+                                /*String logEntry = new Date().toString() + " ";
                                 boolean anonymousGrading = Boolean.parseBoolean(a.getProperties().get(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING));
                                 if (!anonymousGrading) {
                                     String subOrDraft = post ? "submitted" : "saved draft";
@@ -6201,7 +6201,7 @@ public class AssignmentAction extends PagedResourceActionII {
                                     } else {
                                         logEntry += u.getDisplayName() + " (" + u.getEid() + ") " + subOrDraft;
                                     }
-                                }
+                                }*/
 //							TODO submission log entry
 //							submission.addSubmissionLogEntry( logEntry );
                                 assignmentService.updateSubmission(submission);

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -342,20 +342,21 @@ $(document).ready(function(){
 					</div>
 				</div>
 			#end
-			#if ($!submission && $!submission.getSubmissionLog().size() > 0)
-				<div class="row">
-					<div class="col-lg-4 col-sm-6 col-xs-12">
-						<div class="itemSummaryHeader">$tlang.getString("gen.history")</div>
-					</div>
-					<div class="col-lg-4 col-sm-6 col-xs-12">
-						<div class="itemSummaryValue">
-							#foreach ($entry in $submission.getSubmissionLog())
-								$entry<br>
-							#end
-						</div>
-					</div>
-				</div>
-			#end
+##			TODO Submission Log
+##			#if ($!submission && $!submission.getSubmissionLog().size() > 0)
+##				<div class="row">
+##					<div class="col-lg-4 col-sm-6 col-xs-12">
+##						<div class="itemSummaryHeader">$tlang.getString("gen.history")</div>
+##					</div>
+##					<div class="col-lg-4 col-sm-6 col-xs-12">
+##						<div class="itemSummaryValue">
+##							#foreach ($entry in $submission.getSubmissionLog())
+##								$entry<br>
+##							#end
+##						</div>
+##					</div>
+##				</div>
+##			#end
 		</div>
 		<div class="clearfix"></div>
 		<h4>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -110,16 +110,17 @@
                     </td>
                 </tr>
             #end
-            #if ($!submission && $!submission.getSubmissionLog().size() > 0)
-                <tr>
-                    <th>$tlang.getString('gen.history')</th>
-                    <td>
-                        #foreach ($entry in $submission.getSubmissionLog())
-                            $entry<br>
-                        #end
-                    </td>
-                </tr>
-            #end
+##          TODO Submission Log
+##          #if ($!submission && $!submission.getSubmissionLog().size() > 0)
+##              <tr>
+##                  <th>$tlang.getString('gen.history')</th>
+##                  <td>
+##                      #foreach ($entry in $submission.getSubmissionLog())
+##                          $entry<br>
+##                      #end
+##                  </td>
+##              </tr>
+##          #end
         </table>
         <h4>
             #if ($!submission.Submitted)


### PR DESCRIPTION
The appearances from the SubmissionAccess classes can be directly removed. The other references are keeped in case they're used in the future.