### PR TITLE
SAK-33492 Assignment move asn.new.asignment event to after its fully …

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -690,9 +690,10 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
         log.debug("Created new assignment {}", assignment.getId());
 
-        String reference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
-        // event for tracking
-        eventTrackingService.post(eventTrackingService.newEvent(AssignmentConstants.EVENT_ADD_ASSIGNMENT, reference, true));
+        // String reference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+        // AssignmentAction#post_save_assignment contains the logic for adding a new assignment
+        // the event should come at the end of that logic, eventually that logic should be moved here
+        // eventTrackingService.post(eventTrackingService.newEvent(AssignmentConstants.EVENT_ADD_ASSIGNMENT, reference, true));
 
         return assignment;
     }

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7465,11 +7465,13 @@ public class AssignmentAction extends PagedResourceActionII {
         }
 
         Assignment a;
+        boolean newAssignment = false;
         // if there is no assignmentId
         if (StringUtils.isBlank(assignmentId)) {
             //  create a new assignment
             try {
                 a = assignmentService.addAssignment(siteId);
+                newAssignment = true;
             } catch (PermissionException e) {
                 log.warn("Could not create new assignment for site: {}, {}", siteId, e.getMessage());
                 addAlert(state, rb.getFormattedMessage("youarenot_editAssignment", siteId));
@@ -7845,6 +7847,10 @@ public class AssignmentAction extends PagedResourceActionII {
                         }
                     }
                 }
+            }
+            if (newAssignment) {
+                // post new assignment event since it is fully initialized by now
+                eventTrackingService.post(eventTrackingService.newEvent(AssignmentConstants.EVENT_ADD_ASSIGNMENT, assignmentReference, true));
             }
         }
     }


### PR DESCRIPTION
…initialized

Until the logic is moved fully into service it doesn't make sense to post asn.new.assignment event .