### PR TITLE
SAK-33748 solved peer revision screen errors and other refactor issues

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
@@ -217,9 +217,9 @@ public class Assignment {
     @Column(name = "ALLOW_PEER_ASSESSMENT")
     private Boolean allowPeerAssessment = Boolean.FALSE;
 
+    @Type(type = "org.sakaiproject.springframework.orm.hibernate.type.InstantType")
     @Column(name = "PEER_ASSESSMENT_PERIOD_DATE")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date peerAssessmentPeriodDate;
+    private Instant peerAssessmentPeriodDate;
 
     @Column(name = "PEER_ASSESSMENT_ANON_EVAL")
     private Boolean peerAssessmentAnonEval;

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentPeerAssessmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentPeerAssessmentServiceImpl.java
@@ -35,6 +35,7 @@ import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Restrictions;
 import org.sakaiproject.api.app.scheduler.ScheduledInvocationManager;
 import org.sakaiproject.assignment.api.AssignmentPeerAssessmentService;
+import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.AssignmentServiceConstants;
 import org.sakaiproject.assignment.api.model.AssessorSubmissionId;
@@ -124,7 +125,7 @@ public class AssignmentPeerAssessmentServiceImpl extends HibernateDaoSupport imp
                             && CollectionUtils.containsAny(submitterIdsList,submitteeIds)
                             && !s.getSubmitters().contains("admin")) {
                         //only deal with users in the submitter's list
-                        submissionIdMap.put(s.getId(), s);
+                        submissionIdMap.put(AssignmentReferenceReckoner.reckoner().submission(s).reckon().getReference(), s);
                         if (ass.isPresent()) {
                             assignedAssessmentsMap.put(ass.get().getSubmitter(), new HashMap<>());
                             studentAssessorsMap.put(ass.get().getSubmitter(), 0);

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2417,7 +2417,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     public boolean isPeerAssessmentOpen(Assignment assignment) {
         if (assignment.getAllowPeerAssessment()) {
             Instant now = Instant.now();
-            return now.isBefore(assignment.getPeerAssessmentPeriodDate().toInstant()) && now.isAfter(assignment.getCloseDate());
+            return now.isBefore(assignment.getPeerAssessmentPeriodDate()) && now.isAfter(assignment.getCloseDate());
         }
         return false;
     }
@@ -2433,7 +2433,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Override
     public boolean isPeerAssessmentClosed(Assignment assignment) {
         if (assignment.getAllowPeerAssessment()) {
-            return Instant.now().isAfter(assignment.getPeerAssessmentPeriodDate().toInstant());
+            return Instant.now().isAfter(assignment.getPeerAssessmentPeriodDate());
         }
         return false;
     }
@@ -3474,7 +3474,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     if (nAssignment.getPeerAssessmentPeriodDate() == null && nAssignment.getCloseDate() != null) {
                         // set the peer period time to be 10 mins after accept until date
                         Instant tenMinutesAfterCloseDate = Instant.from(nAssignment.getCloseDate().plus(Duration.ofMinutes(10)));
-                        nAssignment.setPeerAssessmentPeriodDate(Date.from(tenMinutesAfterCloseDate));
+                        nAssignment.setPeerAssessmentPeriodDate(tenMinutesAfterCloseDate);
                     }
 
                     // properties

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.Period;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -543,8 +542,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         assignment.setAllowPeerAssessment(true);
         Instant now = Instant.now();
         assignment.setCloseDate(now);
-        Date dateYesterday = Date.from(now.minus(Duration.ofDays(1)));
-        assignment.setPeerAssessmentPeriodDate(dateYesterday);
+        assignment.setPeerAssessmentPeriodDate(now.minus(Duration.ofDays(1)));
 
         when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference())).thenReturn(true);
         try {
@@ -558,8 +556,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         Assert.assertTrue(assignmentService.isPeerAssessmentClosed(assignment));
 
         assignment.setCloseDate(now.plus(Duration.ofDays(3)));
-        Date dateTomorrow = Date.from(now.plus(Duration.ofDays(1)));
-        assignment.setPeerAssessmentPeriodDate(dateTomorrow);
+        assignment.setPeerAssessmentPeriodDate(now.plus(Duration.ofDays(1)));
         when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference())).thenReturn(true);
         try {
             assignmentService.updateAssignment(assignment);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4292,7 +4292,7 @@ public class AssignmentAction extends PagedResourceActionII {
         }
         String submissionId = "";
         SecurityAdvisor secAdv = (userId, function, reference) -> {
-            if ("asn.submit".equals(function) || "asn.submit".equals(function) || "asn.grade".equals(function)) {
+            if ("asn.submit".equals(function) || "asn.grade".equals(function)) {
                 return SecurityAdvisor.SecurityAdvice.ALLOWED;
             }
             return null;
@@ -4311,8 +4311,20 @@ public class AssignmentAction extends PagedResourceActionII {
             }
         }
         if (s != null) {
-            submissionId = s.getId();
+            submissionId = AssignmentReferenceReckoner.reckoner().submission(s).reckon().getReference();
             context.put("submission", s);
+            context.put("submissionReference", AssignmentReferenceReckoner.reckoner().submission(s).reckon().getReference());
+
+            String submitterNames = s.getSubmitters().stream().map(u -> {
+                try {
+                    User user = userDirectoryService.getUser(u.getSubmitter());
+                    return user.getDisplayName() + " (" + user.getDisplayName() + ")";
+                } catch (UserNotDefinedException e) {
+                    log.warn("Could not find user = {}, who is a submitter on a submission (build_student_review_edit_context) , {}", u, e.getMessage());
+                }
+                return "";
+            }).collect(Collectors.joining(", "));
+            context.put("submitterNames", formattedText.escapeHtml(submitterNames));
 
             Map<String, String> p = s.getProperties();
             if (p.get(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT) != null) {
@@ -4410,7 +4422,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 //set previous/next values
                 List<SubmitterSubmission> userSubmissionsState = state.getAttribute(STATE_PAGEING_TOTAL_ITEMS) != null ? (List<SubmitterSubmission>) state.getAttribute(STATE_PAGEING_TOTAL_ITEMS) : null;
                 List<String> userSubmissions = new ArrayList<>();
-                if (userSubmissionsState != null && !userSubmissionsState.isEmpty()) {
+                if (userSubmissionsState != null && !userSubmissionsState.isEmpty() && userSubmissionsState.get(0) instanceof SubmitterSubmission) {
                     //from instructor view
                     for (SubmitterSubmission userSubmission : userSubmissionsState) {
                         if (!userSubmissions.contains(userSubmission.getSubmission().getId()) && userSubmission.getSubmission().getSubmitted()) {
@@ -8628,7 +8640,7 @@ public class AssignmentAction extends PagedResourceActionII {
 
         a.setAllowPeerAssessment(usePeerAssessment);
         if (peerAssessmentPeriodTime != null) {
-            a.setPeerAssessmentPeriodDate(Date.from(peerAssessmentPeriodTime));
+            a.setPeerAssessmentPeriodDate(peerAssessmentPeriodTime);
         }
         a.setPeerAssessmentAnonEval(peerAssessmentAnonEval);
         a.setPeerAssessmentStudentReview(peerAssessmentStudentViewReviews);
@@ -8916,7 +8928,6 @@ public class AssignmentAction extends PagedResourceActionII {
 
     } // doView_assignment_as_student
 
-    // TODO: investigate if this method can be removed
     public void doView_submissionReviews(RunData data) {
         String submissionId = data.getParameters().getString("submissionId");
         SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
@@ -8941,9 +8952,8 @@ public class AssignmentAction extends PagedResourceActionII {
         } else {
             addAlert(state, rb.getString("peerassessment.notavailable"));
         }
-    }
+    } // doView_submissionReviews
 
-    // TODO: investigate if this method can be removed
     public void doEdit_review(RunData data) {
         SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
         ParameterParser params = data.getParameters();
@@ -8989,7 +8999,7 @@ public class AssignmentAction extends PagedResourceActionII {
         } else {
             addAlert(state, rb.getString("peerassessment.notavailable"));
         }
-    }
+    } // doEdit_review
 
     /**
      * Action is to show the edit assignment screen
@@ -9130,16 +9140,16 @@ public class AssignmentAction extends PagedResourceActionII {
                 assignment_resubmission_option_into_state(a, null, state);
 
                 // set whether we use peer assessment or not
-                Date peerAssessmentPeriod = a.getPeerAssessmentPeriodDate();
+                Instant peerAssessmentPeriod = a.getPeerAssessmentPeriodDate();
                 //check if peer assessment time exist? if not, this could be an old assignment, so just set it
                 //to 10 min after accept until date
                 if (peerAssessmentPeriod == null && a.getCloseDate() != null) {
                     // set the peer period time to be 10 mins after accept until date
-                    peerAssessmentPeriod = Date.from(a.getCloseDate().plus(Duration.ofMinutes(10)));
+                    peerAssessmentPeriod = a.getCloseDate().plus(Duration.ofMinutes(10));
                 }
                 if (peerAssessmentPeriod != null) {
                     state.setAttribute(NEW_ASSIGNMENT_USE_PEER_ASSESSMENT, a.getAllowPeerAssessment().toString());
-                    putTimePropertiesInState(state, peerAssessmentPeriod.toInstant(), NEW_ASSIGNMENT_PEERPERIODMONTH, NEW_ASSIGNMENT_PEERPERIODDAY, NEW_ASSIGNMENT_PEERPERIODYEAR, NEW_ASSIGNMENT_PEERPERIODHOUR, NEW_ASSIGNMENT_PEERPERIODMIN);
+                    putTimePropertiesInState(state, peerAssessmentPeriod, NEW_ASSIGNMENT_PEERPERIODMONTH, NEW_ASSIGNMENT_PEERPERIODDAY, NEW_ASSIGNMENT_PEERPERIODYEAR, NEW_ASSIGNMENT_PEERPERIODHOUR, NEW_ASSIGNMENT_PEERPERIODMIN);
                     state.setAttribute(NEW_ASSIGNMENT_PEER_ASSESSMENT_ANON_EVAL, a.getPeerAssessmentAnonEval());
                     state.setAttribute(NEW_ASSIGNMENT_PEER_ASSESSMENT_STUDENT_VIEW_REVIEWS, a.getPeerAssessmentStudentReview());
                     state.setAttribute(NEW_ASSIGNMENT_PEER_ASSESSMENT_NUM_REVIEWS, a.getPeerAssessmentNumberReviews());
@@ -10352,16 +10362,7 @@ public class AssignmentAction extends PagedResourceActionII {
             return false;
         }
         ParameterParser params = data.getParameters();
-        String submissionRef = params.getString("submissionId");
-        String submissionId = null;
-        if (submissionRef != null) {
-            int i = submissionRef.lastIndexOf(Entity.SEPARATOR);
-            if (i == -1) {
-                submissionId = submissionRef;
-            } else {
-                submissionId = submissionRef.substring(i + 1);
-            }
-        }
+        String submissionId = params.getString("submissionId");
         if (submissionId != null) {
 
             //call the DB to make sure this user can edit this assessment, otherwise it wouldn't exist

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -612,7 +612,7 @@
                                                 value="$!group_value_grade"
                                                 id="grade"
                                                 onkeypress="return ASN.handleEnterKeyPress(event);"/>
-                                            <span>($tlang.getString("grade.max") $assignmentContent.getMaxGradePointDisplay())</span>
+                                            <span>($tlang.getString("grade.max") $!service.getMaxPointGradeDisplay($!assignment.ScaleFactor, $!assignment.MaxGradePoint))</span>
                                         </div>
                                     </div>
                                 #elseif ($gradeType == 4)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -193,11 +193,11 @@
 										</td>
 										#if ($withGrade)
 											<td headers="grade">
-													#if ($assignment.getContent().TypeOfGrade == 1)
+													#if ($assignment.TypeOfGrade.ordinal() == 1)
 														$tlang.getString("gen.nograd")
 													#else
 														#if ($assignment.isGroup())
-															#if(($assignment.getProperties().getProperty("prop_new_assignment_add_to_gradebook").trim()) && ($assignment.getContent().TypeOfGrade == 3))
+															#if(($assignment.getProperties().getProperty("prop_new_assignment_add_to_gradebook").trim()) && ($assignment.TypeOfGrade == 3))
 																#if ($submission.getGradeForUserInGradeBook($!member.getId()))
 																	$!submission.getGradeForUserInGradeBook($!member.getId()) <abbr title="Group Grades">($!submission.gradeDisplay)</abbr>
 																#else

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_students_details.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_students_details.vm
@@ -1,6 +1,4 @@
 <!-- start: chef_assignments_instructor_view_students_details.vm  -->
-#set ($submissionType = $assignmentContent.getTypeOfSubmission())
-
 <div class="portletBody container-fluid">
 
   #if ($!isAdditionalNotesEnabled && !$assignment.isGroup())

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -550,7 +550,7 @@
 												#set($anyDraftReviews = false)
 												#set($anyCompleteReviews = false)
 												#foreach ($review in $reviews)
-													#if(!$review.isSubmitted())
+													#if(!$review.getSubmitted())
 														#set($completedReviews = false)
 														#if($review.isDraft())
 															#set($anyDraftReviews = true)
@@ -582,7 +582,7 @@
 								</td>
 								<!-- due col -->
 								<td>
-									$!assignment.PeerAssessmentPeriodDate.toString()
+									$!service.getUsersLocalDateTimeString($!assignment.PeerAssessmentPeriodDate)
 								</td>
 								<!-- the following are empty columns as place holders -->
 								#if ($!allowGradeSubmission)
@@ -616,7 +616,7 @@
 										<!-- title col -->
 										<td>
 											<span class="indnt2">
-												#if($review.isSubmitted())
+												#if($review.getSubmitted())
 													$tlang.getFormattedMessage("peerassessment.student", $reviewCount)&nbsp;<img src="/library/image/silk/accept.png"/>
 												#else
 													<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_review" "assignmentId=$validator.escapeUrl($assignmentReference)&submissionId=$validator.escapeUrl($review.getSubmissionId())")">
@@ -631,7 +631,7 @@
 										#end
 										<!-- status col -->
 										<td>
-											#if($review.isSubmitted())
+											#if($review.getSubmitted())
 												$tlang.getString("peerassessment.submitted")
 											#elseif($review.isDraft())
 												$tlang.getString("peerassessment.draftInProgress")

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
@@ -34,7 +34,7 @@
 		<input type="hidden" name="option" id="option" value="" />
 		<input type="hidden" name="view" id="view" value="" />
 		<input type="hidden" name="currentAttachment" value="" />
-		<input type="hidden" name="submissionId" id="submissionId" value="$submission.Reference" />
+		<input type="hidden" name="submissionId" id="submissionId" value="$submissionReference" />
 		
 		<div class="navPanel">
 		   <div class="viewNav highlight"
@@ -48,25 +48,6 @@
 					#if(!$view_only && $assignment.getPeerAssessmentAnonEval())
 						$tlang.getString("gen.student")
 					#else
-						#set ($submitterNames = "")
-						## replace it with submitter sort names
-						#set ($count = 1)
-						#foreach ($submitter in $submission.submitters)
-							#set($submitterName = $submitter.getDisplayName())
-							#set($submitterId = $submitter.getDisplayId())
-							#if ($!submitterId)
-								##attach the displayId
-								#set($submitterName=$submitterName.concat(" (").concat($submitterId).concat(")"))
-							#end
-							#if ($!submitterName)
-								#if ($count == 1)
-									#set ($submitterNames = $!submitterName)
-								#else
-									#set ($submitterNames = $submitterNames.concat(", ").concat($!submitterName))
-								#end
-							#end
-							#set ($count = $count + 1)
-						#end
 						$validator.escapeHtml($!submitterNames)
 					#end
 					#if($view_only)
@@ -75,7 +56,7 @@
 					#else
 						($reviewNumber $tlang.getString("gen.of") $totalReviews)
 						<br/>
-						$tlang.getFormattedMessage("peerassessment.peerReviewDueDateWithDate", $!assignment.peerAssessmentPeriod.toString())
+						$tlang.getFormattedMessage("peerassessment.peerReviewDueDateWithDate", $!service.getUsersLocalDateTimeString($!assignment.PeerAssessmentPeriodDate))
 					#end
 					</span>
 				</h3>
@@ -86,11 +67,11 @@
 		   </div>
 			<div class="itemNav highlightPanel" style="float:right;text-align:right;clear:right">
 				## prev button
-				<input type="button" name="prevsubmission1" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="ASN.submitForm( 'gradeForm', 'prevsubmission_review', '$validator.escapeUrl($submission.Reference)', null ); return false;"/>
+				<input type="button" name="prevsubmission1" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="ASN.submitForm( 'gradeForm', 'prevsubmission_review', '$validator.escapeUrl($submissionReference)', null ); return false;"/>
 				## back to list button
-				<input type="button" name="cancelgradesubmission1" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="ASN.submitForm( 'gradeForm', 'cancelgradesubmission_review', '$validator.escapeUrl($submission.Reference)', null ); return false;"/>
+				<input type="button" name="cancelgradesubmission1" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="ASN.submitForm( 'gradeForm', 'cancelgradesubmission_review', '$validator.escapeUrl($submissionReference)', null ); return false;"/>
 				## next button
-				<input type="button" name="nextsubmission1" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="ASN.submitForm( 'gradeForm', 'nextsubmission_review', '$validator.escapeUrl($submission.Reference)', null ); return false;"/>
+				<input type="button" name="nextsubmission1" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="ASN.submitForm( 'gradeForm', 'nextsubmission_review', '$validator.escapeUrl($submissionReference)', null ); return false;"/>
 				#if(!$view_only)
 					<div class="instruction textPanelFooter" style="text-align:center">$tlang.getString("nav.message")</div>
 				#end
@@ -113,14 +94,14 @@
 				</p>	
 			#end
 			#if ($assignment_expand_flag)
-					#if ($assignment.getContent().getInstructions().length()>0)
-						<div class="textPanel">$validator.escapeHtmlFormattedText($assignment.getContent().getInstructions())</div>
+					#if ($assignment.Instructions.length()>0)
+						<div class="textPanel">$validator.escapeHtmlFormattedText($assignment.Instructions)</div>
 					#else
 					#end
 					## attachments of assignment
 					<h4>$tlang.getString("gen.addres2")</h4>
 					#set ($size = 0)
-					#set ($attachments = $assignment.getContent().Attachments)
+					#set ($attachments = $assignment.Attachments)
 					#set ($props = false)
 					#foreach ($attachment in $attachments) 
 						#set ($props = $attachment.Properties) 
@@ -290,7 +271,7 @@
 
 						#if ($withGrade)
 							<div class="highlightPanel" style="width:80%">
-								#set ($gradeType = $assignment.getContent().TypeOfGrade)
+								#set ($gradeType = $assignment.TypeOfGrade.ordinal())
 								<p class="shorttext">
 									<label for="grade">$tlang.getString("gen.gra2")</label>
 									#if($view_only)
@@ -302,7 +283,7 @@
 									#else
 										<input type="text" name="$name_grade" size="5" maxlength="11" value="$!value_grade" id="grade" onkeypress="return ASN.handleEnterKeyPress(event);" />
 									#end
-									<span class="instruction">($tlang.getString("grade.max") $assignment.getContent().getMaxGradePointDisplay())</span>
+									<span class="instruction">($tlang.getString("grade.max") $!service.getMaxPointGradeDisplay($!assignment.ScaleFactor, $!assignment.MaxGradePoint))</span>
 								</p>	
 							</div>	
 						#end
@@ -328,7 +309,7 @@
 							<textarea name="$name_feedback_comment" id="$name_feedback_comment" rows="30" wrap="virtual" cols="80">#if($!value_feedback_comment)$validator.escapeHtmlFormattedTextarea($!value_feedback_comment)#end</textarea>
 							#chef_setupformattedtextarea($name_feedback_comment)
 						#else
-							#if($!value_feedback_comment.length() > 0)
+							#if($!value_feedback_comment && $!value_feedback_comment.length() > 0)
 								<div class="textPanel">$validator.escapeHtmlFormattedText($!value_feedback_comment)</div>
 							#else
 								<span class="instruction">$tlang.getString("peerassessment.nocomments")</span>
@@ -445,14 +426,14 @@
 				<span class="act">
 					#if($view_only)
 						#if($item_removed)
-							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.restorereview')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'toggleremove_review', '$validator.escapeUrl($submission.Reference)', null ); return false;" title="$tlang.getString("peerassessment.restorereview")" />
+							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.restorereview')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'toggleremove_review', '$validator.escapeUrl($submissionReference)', null ); return false;" title="$tlang.getString("peerassessment.restorereview")" />
 						#else
-							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.removereview')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'toggleremove_review', '$validator.escapeUrl($submission.Reference)', null ); return false;" title="$tlang.getString("peerassessment.removereview")" />
+							<input type="button" accesskey="s" name="return" value="$tlang.getString('peerassessment.removereview')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'toggleremove_review', '$validator.escapeUrl($submissionReference)', null ); return false;" title="$tlang.getString("peerassessment.removereview")" />
 						#end
 					#else
-						<input type="button" accesskey="s" name="return" value="$tlang.getString('gen.sav')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'savegrade_review', '$validator.escapeUrl($submission.Reference)', null ); return false;" title="$tlang.getString("gen.sav")" />
+						<input type="button" accesskey="s" name="return" value="$tlang.getString('gen.sav')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'savegrade_review', '$validator.escapeUrl($submissionReference)', null ); return false;" title="$tlang.getString("gen.sav")" />
 						<input type="button" accesskey="x" name="cancel" value="$tlang.getString('cancel_changes')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgrade_review', null, null ); return false;" />
-						<input type="button" id="post" name="returnSubmit" value="$tlang.getString('gen.subm3')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'submitgrade_review', '$validator.escapeUrl($submission.Reference)', null ); return false;" title="$tlang.getString("gen.subm3")" />
+						<input type="button" id="post" name="returnSubmit" value="$tlang.getString('gen.subm3')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'submitgrade_review', '$validator.escapeUrl($submissionReference)', null ); return false;" title="$tlang.getString("gen.subm3")" />
 					#end
 					#if ($!prevSubmissionId)
 						<input type="hidden" name="prevSubmissionId" value = "$!prevSubmissionId" />
@@ -466,11 +447,11 @@
 			</div>				
 			<div class="itemNav highlightPanel" style="float:right;text-align:right;clear:right;margin-top:0">
 				## prev button				
-				<input type="button" name="prevsubmission2" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevsubmission_review', '$validator.escapeUrl($submission.Reference)', null ); return false;"/>
+				<input type="button" name="prevsubmission2" class="prevsubmission" value="$tlang.getString("nav.prev")" #if (!$!goPTButton) disabled="disabled" #end onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'prevsubmission_review', '$validator.escapeUrl($submissionReference)', null ); return false;"/>
 				## back to list button
-				<input type="button" name="cancelgradesubmission2" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgradesubmission_review', '$validator.escapeUrl($submission.Reference)', null ); return false;"/>
+				<input type="button" name="cancelgradesubmission2" class="cancelgradesubmission" value="$tlang.getString("nav.list")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'cancelgradesubmission_review', '$validator.escapeUrl($submissionReference)', null ); return false;"/>
 				## next button
-				<input type="button" name="nextsubmission2" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'nextsubmission_review', '$validator.escapeUrl($submission.Reference)', null ); return false;"/>
+				<input type="button" name="nextsubmission2" class="nextsubmission" value="$tlang.getString("nav.next")" #if (!$!goNTButton)disabled="disabled"#end onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'gradeForm', 'nextsubmission_review', '$validator.escapeUrl($submissionReference)', null ); return false;"/>
 				#if(!$view_only)
 					<div class="instruction textPanelFooter" style="text-align:center">$tlang.getString("nav.message")</div>
 				#end

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/Assignments.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/Assignments.java
@@ -425,11 +425,11 @@ public class Assignments extends AbstractWebService {
     		Date shiftedDropDeadDate = cal.getTime();
     		assignment.setDropDeadDate(shiftedDropDeadDate.toInstant());
 
-    		cal.setTimeInMillis(assignment.getPeerAssessmentPeriodDate().getTime());
+    		cal.setTimeInMillis(assignment.getPeerAssessmentPeriodDate().toEpochMilli());
     		cal.add(java.util.Calendar.DAY_OF_YEAR, shiftDays);
     		cal.add(java.util.Calendar.HOUR, shiftHours);
     		Date shiftedPeerAssessmentDate = cal.getTime();
-    		assignment.setPeerAssessmentPeriodDate(shiftedPeerAssessmentDate);
+    		assignment.setPeerAssessmentPeriodDate(shiftedPeerAssessmentDate.toInstant());
 
     		Map<String, String> aProperties = assignment.getProperties();
 


### PR DESCRIPTION
-Solved different peer revision screen errors. Main problem was a check lost after assignments refactor:

...  && userSubmissionsState.get(0) instanceof SubmitterSubmission ...

which was the reason why many state variables where not being initialized.
-Storing submission reference instead of id for PeerAssessmentItem. Easier to retrieve on the places where it's used (doEdit_review).
-Also converted peer open date to Instant (updated unit tests).
-And removed all references to old AssignmentContent class from different velocity templates.