### PR TITLE
SAK-33798: Version all JS/CSS loaded from JSF tools

### DIFF
--- a/jsf/jsf-widgets/pom.xml
+++ b/jsf/jsf-widgets/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.sakaiproject.portal</groupId>
+            <artifactId>sakai-portal-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-kernel-util</artifactId>
         </dependency>

--- a/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ScriptRenderer.java
+++ b/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ScriptRenderer.java
@@ -30,6 +30,7 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.render.Renderer;
 
 import org.sakaiproject.jsf.util.RendererUtil;
+import org.sakaiproject.portal.util.PortalUtils;
 
 /**
  * <p>Description: </p>
@@ -113,7 +114,7 @@ public class ScriptRenderer extends Renderer
     }
 
 
-    writer.write("<script src=\"" + contextPath + path + "\" type=\"" + type + "\">");
+    writer.write("<script src=\"" + contextPath + path + PortalUtils.getCDNQuery() + "\" type=\"" + type + "\">");
     // ie requires
     writer.write("</script>");
   }

--- a/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/StylesheetRenderer.java
+++ b/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/StylesheetRenderer.java
@@ -30,6 +30,7 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.render.Renderer;
 
 import org.sakaiproject.jsf.util.RendererUtil;
+import org.sakaiproject.portal.util.PortalUtils;
 
 /**
  * <p>Description: </p>
@@ -101,6 +102,7 @@ public class StylesheetRenderer extends Renderer
 
     writer.write(contextPath);
     writer.write( (String) RendererUtil.getAttribute(context, component, "path"));
+    writer.write(PortalUtils.getCDNQuery());
     writer.write("\"/>");
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/ScriptRenderer.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/ScriptRenderer.java
@@ -30,6 +30,7 @@ import javax.faces.component.UIOutput;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.render.Renderer;
+import org.sakaiproject.portal.util.PortalUtils;
 
 /**
  * <p>Description: </p>
@@ -101,7 +102,7 @@ public class ScriptRenderer extends Renderer
     ResponseWriter writer = context.getResponseWriter();
     String contextPath = context.getExternalContext()
       .getRequestContextPath();
-    writer.write("<script src=\"" + contextPath + path + "\" type=\"" + type + "\">");
+    writer.write("<script src=\"" + contextPath + path + PortalUtils.getCDNQuery() + "\" type=\"" + type + "\">");
     // ie requires
     writer.write("</script>");
   }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/StylesheetRenderer.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/StylesheetRenderer.java
@@ -30,6 +30,7 @@ import javax.faces.component.UIOutput;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.render.Renderer;
+import org.sakaiproject.portal.util.PortalUtils;
 
 /**
  * <p>Description: </p>
@@ -95,6 +96,7 @@ public class StylesheetRenderer extends Renderer
 
     writer.write(contextPath);
     writer.write( (String) component.getAttributes().get("path"));
+    writer.write(PortalUtils.getCDNQuery());
     writer.write("\"/>");
   }
 


### PR DESCRIPTION
When **script** tag (sakai:script / samigo:script) and **stylsheet** tag (sakai:stylesheet / samigo:stylesheet) are included in a Jsf tool, the version and the expired time are included to source path according to _portal.cdn.version_ and _portal.cdn.expire_ properties.