### PR TITLE
SAK-33812 Removed the Create New Site option from the Account Menu

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
@@ -133,20 +133,6 @@
 
                                     #end ## END of IF (${tabsSites.prefsToolUrl})
 
-                                    #if (${tabsSites.worksiteToolUrl})
-
-                                        #if ($allowAddSite)
-
-                                            <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented">
-                                                <a id="addNewSiteLink" role="menuitem" href="${tabsSites.mrphs_worksiteToolUrl}?panel=Shortcut&amp;sakai_action=doNew_site" class="Mrphs-userNav__submenuitem--newsite">
-                                            <span>${rloader.sit_newsite}</span>
-                                                </a>
-                                            </li>
-
-                                        #end ## END of IF ($allowAddSite)
-
-                                    #end ## END of IF (${tabsSites.prefsToolUrl})
-
                                     #if (${tabsSites.tutorial})
 
                                         <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented">


### PR DESCRIPTION
There is a "Create New Site" option in two spots at the top of Sakai: one in "Sites" and one in the account menu. Since the option is site-related, it makes sense to be in Sites and not with your account.

I have removed the option from the account menu:

![accountmenu](https://user-images.githubusercontent.com/12685096/34531927-19b07bd6-f082-11e7-877b-a3b111808e9a.png)


