### PR TITLE
SAK-33803 force formatGradeForDisplay to max two decimal places

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/CourseGradeFormatter.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/CourseGradeFormatter.java
@@ -141,10 +141,10 @@ public class CourseGradeFormatter {
 			if (mappedGrade == null) {
 				mappedGrade = new Double(0);
 			}
-			calculatedGrade = FormatHelper.formatGradeForDisplay(mappedGrade);
+			calculatedGrade = FormatHelper.formatDoubleAsPercentage(mappedGrade);
 
 		} else {
-			calculatedGrade = FormatHelper.formatGradeForDisplay(courseGrade.getCalculatedGrade());
+			calculatedGrade = FormatHelper.formatStringAsPercentage(courseGrade.getCalculatedGrade());
 		}
 
 		if (StringUtils.isNotBlank(calculatedGrade)

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -173,6 +173,7 @@ public class FormatHelper {
 
 			final DecimalFormat dfFormat = (DecimalFormat) NumberFormat.getInstance(rl.getLocale());
 			dfFormat.setMinimumFractionDigits(0);
+			dfFormat.setMaximumFractionDigits(2);
 			dfFormat.setGroupingUsed(true);
 			s = dfFormat.format(d);
 		} catch (final NumberFormatException e) {


### PR DESCRIPTION
Ensures any decimal string from the Gradebook service is displayed with a max 2 decimal places.