### PR TITLE
SAK-33821: site title is truncated after HTML transformation

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -457,7 +457,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				&& (s.getId().equals(myWorkspaceSiteId) || effectiveSite
 						.equals(myWorkspaceSiteId))));
 		
-		String siteTitle = getUserSpecificSiteTitle(s, false, true, siteProviders);
+		String siteTitle = getUserSpecificSiteTitle(s, false, false, siteProviders);
 		String siteTitleTruncated = FormattedText.makeShortenedText(siteTitle, null, null, null);
 		m.put("siteTitle", siteTitle);
 		m.put("siteTitleTrunc", siteTitleTruncated);
@@ -503,7 +503,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					Map<String, Object> pm = new HashMap<>();
 					List<String> providers = getProviderIDsForSite(site);
 
-					String parentSiteTitle = getUserSpecificSiteTitle(site, false, true, providers);
+					String parentSiteTitle = getUserSpecificSiteTitle(site, false, false, providers);
 					String parentSiteTitleTruncated = FormattedText.makeShortenedText(parentSiteTitle, null, null, null);
 					pm.put("siteTitle", parentSiteTitle);
 					pm.put("siteTitleTrunc", parentSiteTitleTruncated);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33821

In the screenshot (JIRA ticket) is an example. Using the title: "This is a sentence Iám happy"
You could replace á with any special character that you want (but in that position).

In html the title is: "This is a sentence I&aacute;m happy"

This size is bigger than 25 (default max) so it's time to cut the title, the default method is get the first 21 characters and add "..." at the end... so the result is:

"This is a sentence I&..."

But this has no sense because & is a fragment of an html entity. The method should use the original title (not the html encoded one) to get the size and decided how to cut and encode after truncate the title.