### PR TITLE
SAK-33822: GradebookServiceHibernateImpl.setAssignmentScoreString() logging level change

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2542,7 +2542,9 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			}
 		});
 
-		if (log.isInfoEnabled()) log.info("Score updated in gradebookUid=" + gradebookUid + ", assignmentId=" + assignmentId + " by userUid=" + getUserUid() + " from client=" + clientServiceDescription + ", new score=" + score);
+		if (log.isDebugEnabled()) {
+			log.debug("Score updated in gradebookUid=" + gradebookUid + ", assignmentId=" + assignmentId + " by userUid=" + getUserUid() + " from client=" + clientServiceDescription + ", new score=" + score);
+		}
 	}
   	
   	@Override


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33822

Every time a grade is sent to the Gradebook, it outputs grades with identifiers to the logs by default (INFO). We've found this to be an issue for two reasons:

1. it can bloat the logs significantly in certain scenarios
2. its leaking user identifiers and grades to the application server logs OOTB, which can be a security concern

It would be more appropriate to change this logger to DEBUG.