### PR TITLE
SAK-33824: standardize the verification/success message in Preferences

### DIFF
--- a/user/user-tool-prefs/tool/src/webapp/prefs/editor.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/editor.jsp
@@ -29,26 +29,20 @@
 
 						<%@ include file="toolbar.jspf"%>
 
-                        <h:panelGroup rendered="#{UserPrefsTool.editorUpdated}"  style="margin-top:1em;display:inline-block;font-weight:normal">
+                        <t:div rendered="#{UserPrefsTool.editorUpdated}">
                                 <jsp:include page="prefUpdatedMsg.jsp"/>
-                        </h:panelGroup>
+                        </t:div>
 
-                        <h3>
+                        <h3 style="display: inline-block;">
                                 <h:outputText rendered="#{UserPrefsTool.prefShowTabLabelOption==true}" value="#{msgs.prefs_editor_tab_options}" />
                         </h3>
 
-                        <f:verbatim>
-                        <div>
-                        </f:verbatim>
-                        <h:outputText value="#{msgs.editor_prompt}"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}"/>
+                        <p class="instruction"><h:outputText value="#{msgs.editor_prompt}"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}"/></p>
                         <h:selectOneRadio value="#{UserPrefsTool.selectedEditorType}" layout="pageDirection"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}">
                                                 <f:selectItem itemValue="auto" itemLabel="#{msgs.editor_auto}"/>
                                                 <f:selectItem itemValue="basic" itemLabel="#{msgs.editor_basic}"/>
                                                 <f:selectItem itemValue="full" itemLabel="#{msgs.editor_full}"/>
                         </h:selectOneRadio>
-                        <f:verbatim>
-                        </div>
-                        </f:verbatim>
                         
                         <div class="submit-buttons">
                                 <h:commandButton accesskey="s" id="submit" styleClass="active formButton" value="#{msgs.update_pref}" action="#{UserPrefsTool.processActionEditorSave}" onclick="SPNR.disableControlsAndSpin( this, null );" />

--- a/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
@@ -29,28 +29,28 @@
 
 						<%@ include file="toolbar.jspf"%>
 
-                        <h:panelGroup rendered="#{UserPrefsTool.hiddenUpdated}"  style="margin-top:1em;display:inline-block;font-weight:normal">
+                        <h:panelGroup rendered="#{UserPrefsTool.prefShowTabLabelOption==true}">
+                            <t:div rendered="#{UserPrefsTool.prefShowTabLabelOption==true and UserPrefsTool.hiddenUpdated}">
                                 <jsp:include page="prefUpdatedMsg.jsp"/>
+                            </t:div>
+                            <t:htmlTag value="h3" rendered="#{UserPrefsTool.prefShowTabLabelOption==true}">
+                                <h:outputText value="#{msgs.prefs_site_tab_display_format}" />
+                            </t:htmlTag>
+
+                            <%-- ## SAK-23895 :Display full name of course, not just code, in site tab  --%>
+                            <t:div rendered="#{UserPrefsTool.prefShowTabLabelOption==true}">
+                                <h:outputText value="#{msgs.tabDisplay_prompt}" rendered="#{UserPrefsTool.prefShowTabLabelOption==true}"/>
+                                <h:selectOneRadio value="#{UserPrefsTool.selectedTabLabel}" layout="pageDirection" rendered="#{UserPrefsTool.prefShowTabLabelOption==true}">
+                                    <f:selectItem itemValue="1" itemLabel="#{msgs.tabDisplay_coursecode}"/>
+                                    <f:selectItem itemValue="2" itemLabel="#{msgs.tabDisplay_coursename}"/>
+                                </h:selectOneRadio>
+                            </t:div>
                         </h:panelGroup>
 
-                        <h3>
-                                <h:outputText rendered="#{UserPrefsTool.prefShowTabLabelOption==true}" value="#{msgs.prefs_site_tab_display_format}" />
-                        </h3>
-
-                        <%-- ## SAK-23895 :Display full name of course, not just code, in site tab  --%>
-                        <f:verbatim>
-                        <div>
-                        </f:verbatim>
-                        <h:outputText value="#{msgs.tabDisplay_prompt}"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}"/>
-                        <h:selectOneRadio value="#{UserPrefsTool.selectedTabLabel}" layout="pageDirection"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}">
-                                                <f:selectItem itemValue="1" itemLabel="#{msgs.tabDisplay_coursecode}"/>
-                                                <f:selectItem itemValue="2" itemLabel="#{msgs.tabDisplay_coursename}"/>
-                        </h:selectOneRadio>
-                        <f:verbatim>
-                        </div>
-                        </f:verbatim>
-
-                        <h3>
+                        <t:div rendered="#{UserPrefsTool.prefShowTabLabelOption==false and UserPrefsTool.hiddenUpdated}">
+                            <jsp:include page="prefUpdatedMsg.jsp"/>
+                        </t:div>
+                        <h3 style="display: inline-block;">
                                 <h:outputText value="#{msgs.hidden_title}" />
                         </h3>
 

--- a/user/user-tool-prefs/tool/src/webapp/prefs/locale.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/locale.jsp
@@ -4,6 +4,7 @@
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%-- Sakai JSF tag library --%>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+<%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t"%>
 <%-- Core JSTL tag library --%>
 <%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
 
@@ -28,16 +29,14 @@
 				<%@ include file="toolbar.jspf"%>
 	
 				<sakai:messages rendered="#{!empty facesContext.maximumSeverity}" />
-				
-				<h3>
+
+				<t:div rendered="#{UserPrefsTool.locUpdated}">
+					<jsp:include page="prefUpdatedMsg.jsp"/>
+				</t:div>
+				<h3 style="display: inline-block;">
 					<h:outputText value="#{msgs.prefs_lang_title}" />
-					<h:panelGroup rendered="#{UserPrefsTool.locUpdated}" style="margin:0 3em;font-weight:normal">
-						<jsp:include page="prefUpdatedMsg.jsp"/>	
-					</h:panelGroup>
 				</h3>
 
-
-				
 				<p class="instruction"><h:outputText value="#{msgs.locale_msg}"/> <h:outputText value="#{UserPrefsTool.selectedLocaleName}"  styleClass="highlight" style="font-weight:bold !important;"/></p>
 				
     			 <h:selectOneListbox 

--- a/user/user-tool-prefs/tool/src/webapp/prefs/noti.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/noti.jsp
@@ -46,15 +46,14 @@
 			<c:set var="cTemplate" value = "noti" scope = "session" />
 
 			<%@ include file="toolbar.jspf"%>
-				
-				<h3>
+
+				<t:div rendered="#{UserPrefsTool.notiUpdated}">
+					<jsp:include page="prefUpdatedMsg.jsp"/>
+				</t:div>
+				<h3 style="display: inline-block;">
 					<h:outputText value="#{msgs.prefs_noti_title}" />
-					<h:panelGroup rendered="#{UserPrefsTool.notiUpdated}"  style="margin:0 3em;font-weight:normal">
-						<jsp:include page="prefUpdatedMsg.jsp"/>	
-					</h:panelGroup>
 				</h3>
 
-	
 				<sakai:messages rendered="#{!empty facesContext.maximumSeverity}" />
 				
 

--- a/user/user-tool-prefs/tool/src/webapp/prefs/prefUpdatedMsg.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/prefUpdatedMsg.jsp
@@ -1,5 +1,5 @@
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
 <%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %> 
- 
-<h:outputText styleClass="messageSuccess success" value="#{msgs.update_success}" style="display:inline" />
+
+<h:outputText styleClass="messageSuccess success" value="#{msgs.update_success}" />

--- a/user/user-tool-prefs/tool/src/webapp/prefs/privacy.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/privacy.jsp
@@ -3,6 +3,7 @@
 <%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+<%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t"%>
 <%-- Core JSTL tag library --%>
 <%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
 <% response.setContentType("text/html; charset=UTF-8"); %>
@@ -27,19 +28,16 @@
 		<%-- Set current value for template --%> 
 		<c:set var="cTemplate" value = "privacy" scope = "session" />
 		<%@ include file="toolbar.jspf"%>
-			
-		<f:verbatim><div><h3></f:verbatim>
-     
-     	<h:outputText value="#{msgs.privacy_title}" rendered="#{privacyBean.myWorkspace}" />
 
-         <!--SAK-18566 -->
-        <h3>
-		 <h:panelGroup rendered="#{privacyBean.updateMessage}" style="margin:0 3em;font-weight:normal">
-		 <jsp:include page="prefUpdatedMsg.jsp"/>
-		 </h:panelGroup>
-	   </h3>
-
-		<f:verbatim></h3></div></f:verbatim>
+		<!--SAK-18566 -->
+		<t:div rendered="#{privacyBean.updateMessage}">
+			<jsp:include page="prefUpdatedMsg.jsp"/>
+		</t:div>
+		<h:panelGroup rendered="#{privacyBean.myWorkspace}" >
+			<h3>
+				<h:outputText value="#{msgs.privacy_title}" />
+			</h3>
+		</h:panelGroup>
 	 	<%--  Message if Show All or Hide All has been clicked --%>
 	 	<f:verbatim><div></f:verbatim>
 	 	<h:outputText value="#{privacyBean.changeAllMsg}" styleClass="success" rendered="#{privacyBean.allChanged}" />

--- a/user/user-tool-prefs/tool/src/webapp/prefs/refresh.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/refresh.jsp
@@ -4,6 +4,7 @@
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%-- Sakai JSF tag library --%>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+<%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t"%>
 
 <f:view>
 	<sakai:view_container title="Preferences">
@@ -19,9 +20,9 @@
 				
 				<br>
 
-				<h:panelGroup rendered="#{UserPrefsTool.refreshUpdated}">
+				<t:div rendered="#{UserPrefsTool.refreshUpdated}">
 					<jsp:include page="prefUpdatedMsg.jsp"/>	
-				</h:panelGroup>
+				</t:div>
 				
 				<sakai:messages />
 				

--- a/user/user-tool-prefs/tool/src/webapp/prefs/timezone.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/timezone.jsp
@@ -4,6 +4,7 @@
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <%-- Sakai JSF tag library --%>
 <%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" %>
+<%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t"%>
 <%-- Core JSTL tag library --%>
 <%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
 
@@ -26,14 +27,13 @@
 				<%@ include file="toolbar.jspf"%>
 				
 				<sakai:messages rendered="#{!empty facesContext.maximumSeverity}" />
-				<h3>
+				<t:div rendered="#{UserPrefsTool.tzUpdated}">
+					<jsp:include page="prefUpdatedMsg.jsp"/>
+				</t:div>
+				<h3 style="display: inline-block;">
 					<h:outputText value="#{msgs.prefs_timezone_title}" />
-					<h:panelGroup rendered="#{UserPrefsTool.tzUpdated}"   style="margin:0 3em;font-weight:normal">
-						<jsp:include page="prefUpdatedMsg.jsp"/>	
-					</h:panelGroup>
 				</h3>
 
-				
 				<p class="instruction">
 				<h:outputFormat value="#{msgs.time_inst}">
 					<f:param value="#{UserPrefsTool.serviceName}"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33824

The verification/success message (green bar, "Your preferences have been updated successfully.") is noticeably larger than it is in other tools in Sakai. It also doesn't look good at smaller/mobile screen sizes.

Improvements:

* don't wrap it in `<h3>`
* remove some inline styles
* standardize location of message
* standardize layout of 'Editor' UI