### PR TITLE
SAK-33826: update the tool description for GBNG

### DIFF
--- a/gradebookng/tool/src/webapp/WEB-INF/tools/sakai.gradebookng.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/tools/sakai.gradebookng.xml
@@ -2,7 +2,7 @@
 <registration>
 	<tool id="sakai.gradebookng" 
 		title="Gradebook" 
-		description="The next generation gradebook tool for the Sakai CLE">
+		description="For storing, calculating, distributing, and submitting grades">
 
 		<!--  This tool will be made available to the following site types via Site Info > Edit Tools -->
 		<category name="course" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33826

The current tool description for GBNG is:

> The next generation gradebook tool for the Sakai CLE

This isn't the best user facing message for several reasons:

* it doesn't explain what the tool does or it's purpose
* some institutions don't call their instance 'Sakai', and users might not know what either or both 'Sakai' or 'CLE' refers to.

This ticket proposes to change the description to:

> For storing, calculating, distributing, and submitting grades