### PR TITLE
SAK-33827: make GBNG category colour selection deterministic

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -495,7 +495,7 @@ public class GbGradebookData {
 
 					nullable(a1.getCategoryId()),
 					a1.getCategoryName(),
-					userSettings.getCategoryColor(a1.getCategoryName()),
+					userSettings.getCategoryColor(a1.getCategoryName(), a1.getCategoryId()),
 					nullable(categoryWeight),
 					a1.isCategoryExtraCredit(),
 
@@ -512,7 +512,7 @@ public class GbGradebookData {
 								.getString(),
 						nullable(categoryWeight),
 						a1.isCategoryExtraCredit(),
-						userSettings.getCategoryColor(a1.getCategoryName()),
+						userSettings.getCategoryColor(a1.getCategoryName(), a1.getCategoryId()),
 						!uiSettings.isCategoryScoreVisible(a1.getCategoryName())));
 			}
 		}
@@ -533,7 +533,7 @@ public class GbGradebookData {
 									.getString(),
 							nullable(categoryWeight),
 							category.isExtraCredit(),
-							userSettings.getCategoryColor(category.getName()),
+							userSettings.getCategoryColor(category.getName(), category.getId()),
 							!uiSettings.isCategoryScoreVisible(category.getName())));
 				}
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 
 public class GbGradebookData {
 
-	private int NULL_SENTINEL = 127;
+	private final int NULL_SENTINEL = 127;
 
 	@Data
 	private class StudentDefinition {
@@ -358,7 +358,7 @@ public class GbGradebookData {
 	};
 
 	private List<String[]> courseGrades() {
-		final List<String[]> result = new ArrayList<String[]>();
+		final List<String[]> result = new ArrayList<>();
 
 		final Map<String, Double> gradeMap = settings.getSelectedGradingScaleBottomPercents();
 		final List<String> ascendingGrades = new ArrayList<>(gradeMap.keySet());
@@ -409,7 +409,7 @@ public class GbGradebookData {
 	}
 
 	private List<Score> gradeList() {
-		final List<Score> result = new ArrayList<Score>();
+		final List<Score> result = new ArrayList<>();
 
 		for (GbStudentGradeInfo studentGradeInfo : GbGradebookData.this.studentGradeInfoList) {
 			for (ColumnDefinition column : GbGradebookData.this.columns) {
@@ -427,7 +427,7 @@ public class GbGradebookData {
 	}
 
 	private List<StudentDefinition> loadStudents(final List<GbStudentGradeInfo> studentInfo) {
-		final List<StudentDefinition> result = new ArrayList<StudentDefinition>();
+		final List<StudentDefinition> result = new ArrayList<>();
 
 		for (GbStudentGradeInfo student : studentInfo) {
 			final StudentDefinition studentDefinition = new StudentDefinition();
@@ -458,7 +458,7 @@ public class GbGradebookData {
 	private List<ColumnDefinition> loadColumns(final List<Assignment> assignments) {
 		final GradebookUiSettings userSettings = ((GradebookPage) parent.getPage()).getUiSettings();
 
-		final List<ColumnDefinition> result = new ArrayList<ColumnDefinition>();
+		final List<ColumnDefinition> result = new ArrayList<>();
 
 		if (assignments.isEmpty()) {
 			return result;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -118,14 +118,14 @@ public class GradebookUiSettings implements Serializable {
 		// defaults. Note there is no default for assignmentSortOrder as that
 		// requires an assignmentId which will differ between gradebooks
 		this.categoriesEnabled = false;
-		this.assignmentVisibility = new HashMap<Long, Boolean>();
-		this.categoryScoreVisibility = new HashMap<String, Boolean>();
+		this.assignmentVisibility = new HashMap<>();
+		this.categoryScoreVisibility = new HashMap<>();
 
 		// default sort order to student
 		this.nameSortOrder = GbStudentNameSortOrder.LAST_NAME;
 		this.studentSortOrder = SortDirection.ASCENDING;
 
-		this.categoryColors = new HashMap<String, String>();
+		this.categoryColors = new HashMap<>();
 		this.showPoints = false;
 		this.gradeSummaryGroupedByCategory = false;
 	}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -151,16 +151,16 @@ public class GradebookUiSettings implements Serializable {
 		this.categoryColors.put(categoryName, rgbColorString);
 	}
 
-	public String getCategoryColor(final String categoryName) {
+	public String getCategoryColor(final String categoryName, final Long categoryID) {
 		if (!this.categoryColors.containsKey(categoryName)) {
-			setCategoryColor(categoryName, generateRandomRGBColorString());
+			setCategoryColor(categoryName, generateRandomRGBColorString(categoryID));
 		}
 		return this.categoryColors.get(categoryName);
 	}
 
 	public void initializeCategoryColors(final List<CategoryDefinition> categories) {
 		for (CategoryDefinition category : categories) {
-			setCategoryColor(category.getName(), generateRandomRGBColorString());
+			setCategoryColor(category.getName(), generateRandomRGBColorString(category.getId()));
 		}
 	}
 
@@ -178,8 +178,11 @@ public class GradebookUiSettings implements Serializable {
 	/**
 	 * Helper to generate a RGB CSS color string with values between 180-250 to ensure a lighter color e.g. rgb(181,222,199)
 	 */
-	public static String generateRandomRGBColorString() {
-		final Random rand = new Random();
+	public static String generateRandomRGBColorString(Long categoryID) {
+		if (categoryID == null) {
+			categoryID = -1L;
+		}
+		final Random rand = new Random(categoryID);
 		final int min = 180;
 		final int max = 250;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -140,7 +140,7 @@ public class GradebookPage extends BasePage {
 		stopwatch.start();
 		stopwatch.time("GradebookPage init", stopwatch.getTime());
 
-		this.form = new Form<Void>("form");
+		this.form = new Form<>("form");
 		add(this.form);
 
 		form.add(new AttributeModifier("data-siteid", businessService.getCurrentSiteId()));
@@ -193,10 +193,7 @@ public class GradebookPage extends BasePage {
 
 			@Override
 			public boolean isVisible() {
-				if (GradebookPage.this.role != GbRole.INSTRUCTOR) {
-					return false;
-				}
-				return true;
+				return GradebookPage.this.role == GbRole.INSTRUCTOR;
 			}
 		};
 		addGradeItem.setDefaultFormProcessing(false);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -40,7 +40,6 @@ import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.model.GbGroup;
 import org.sakaiproject.gradebookng.business.util.GbStopWatch;
-import org.sakaiproject.gradebookng.business.util.MessageHelper;
 import org.sakaiproject.gradebookng.tool.actions.DeleteAssignmentAction;
 import org.sakaiproject.gradebookng.tool.actions.EditAssignmentAction;
 import org.sakaiproject.gradebookng.tool.actions.EditCommentAction;
@@ -483,7 +482,7 @@ public class GradebookPage extends BasePage {
 			settings = new GradebookUiSettings();
 			settings.setCategoriesEnabled(this.businessService.categoriesAreEnabled());
 			settings.initializeCategoryColors(this.businessService.getGradebookCategories());
-			settings.setCategoryColor(getString(GradebookPage.UNCATEGORISED), settings.generateRandomRGBColorString());
+			settings.setCategoryColor(getString(GradebookPage.UNCATEGORISED), GradebookUiSettings.generateRandomRGBColorString(null));
 			setUiSettings(settings);
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
@@ -66,7 +66,7 @@ public class SortGradeItemsByCategoryPanel extends Panel {
 				Collections.sort(assignments, new CategorizedAssignmentComparator());
 
 				categoryItem.add(new AttributeModifier("style",
-						String.format("border-left-color: %s", settings.getCategoryColor(category.getName()))));
+						String.format("border-left-color: %s", settings.getCategoryColor(category.getName(), category.getId()))));
 				categoryItem.add(new Label("name", category.getName()));
 				categoryItem.add(new ListView<Assignment>("gradeItemList", assignments) {
 					@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class SortGradeItemsByCategoryPanel extends Panel {
@@ -73,15 +74,15 @@ public class SortGradeItemsByCategoryPanel extends Panel {
 					protected void populateItem(final ListItem<Assignment> assignmentItem) {
 						final Assignment assignment = assignmentItem.getModelObject();
 						assignmentItem.add(new Label("name", assignment.getName()));
-						assignmentItem.add(new HiddenField<Long>("id",
+						assignmentItem.add(new HiddenField<>("id",
 								Model.of(assignment.getId())).add(
 										new AttributeModifier("name",
 												String.format("id", assignment.getId()))));
-						assignmentItem.add(new HiddenField<Integer>("order",
+						assignmentItem.add(new HiddenField<>("order",
 								Model.of(assignment.getCategorizedSortOrder())).add(
 										new AttributeModifier("name",
 												String.format("item_%s[order]", assignment.getId()))));
-						assignmentItem.add(new HiddenField<Integer>("current_order",
+						assignmentItem.add(new HiddenField<>("current_order",
 								Model.of(assignment.getCategorizedSortOrder())).add(
 										new AttributeModifier("name",
 												String.format("item_%s[current_order]", assignment.getId()))));
@@ -96,7 +97,7 @@ class CategorizedAssignmentComparator implements Comparator<Assignment> {
 	@Override
 	public int compare(final Assignment a1, final Assignment a2) {
 		// if in the same category, sort by their categorized sort order
-		if (a1.getCategoryId() == a2.getCategoryId()) {
+		if (Objects.equals(a1.getCategoryId(), a2.getCategoryId())) {
 			// handles null orders by putting them at the end of the list
 			if (a1.getCategorizedSortOrder() == null) {
 				return 1;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
@@ -54,8 +54,8 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 		super.onInitialize();
 
 		// setup
-		final List<String> categoryNames = new ArrayList<String>();
-		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<String, List<Assignment>>();
+		final Map<String, Long> categoryNameToIdMap = new HashMap<>();
+		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<>();
 
 		final Map<String, Object> model = (Map<String, Object>) getDefaultModelObject();
 		final List<Assignment> assignments = (List<Assignment>) model.get("assignments");
@@ -66,21 +66,25 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 		for (final Assignment assignment : assignments) {
 
 			final String categoryName = getCategoryName(assignment, categoriesEnabled);
+			final Long categoryID = assignment.getCategoryId();
 
 			if (!categoryNamesToAssignments.containsKey(categoryName)) {
-				categoryNames.add(categoryName);
-				categoryNamesToAssignments.put(categoryName, new ArrayList<Assignment>());
+				categoryNameToIdMap.put(categoryName, categoryID);
+				categoryNamesToAssignments.put(categoryName, new ArrayList<>());
 			}
 
 			categoryNamesToAssignments.get(categoryName).add(assignment);
 		}
 
+		List<String> categoryNames = new ArrayList<>(categoryNameToIdMap.keySet());
 		add(new ListView<String>("categoriesList", categoryNames) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
 			protected void populateItem(final ListItem<String> categoryItem) {
 				final String categoryName = categoryItem.getModelObject();
+				final Long categoryID = categoryNameToIdMap.get(categoryName);
+				final String categoryColor = settings.getCategoryColor(categoryName, categoryID);
 
 				WebMarkupContainer categoryFilter = new WebMarkupContainer("categoryFilter");
 				if (!categoriesEnabled) {
@@ -92,13 +96,11 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 				final GradebookPage gradebookPage = (GradebookPage) getPage();
 
 				final Label categoryLabel = new Label("category", categoryName);
-				categoryLabel.add(new AttributeModifier("data-category-color", settings.getCategoryColor(categoryName)));
+				categoryLabel.add(new AttributeModifier("data-category-color", categoryColor));
 				categoryFilter.add(categoryLabel);
 
 				categoryFilter.add(new WebMarkupContainer("categorySignal").add(new AttributeModifier("style",
-						String.format("background-color: %s; border-color: %s",
-								settings.getCategoryColor(categoryName),
-								settings.getCategoryColor(categoryName)))));
+						String.format("background-color: %s; border-color: %s", categoryColor, categoryColor))));
 
 				final CheckBox categoryCheckbox = new CheckBox("categoryCheckbox");
 				categoryCheckbox.add(new AttributeModifier("value", categoryName));
@@ -119,9 +121,7 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 						final WebMarkupContainer assignmentSignal = new WebMarkupContainer("assignmentSignal");
 						if (settings.isCategoriesEnabled()) {
 							assignmentSignal.add(new AttributeModifier("style",
-									String.format("background-color: %s; border-color: %s",
-											settings.getCategoryColor(getCategoryName(assignment, categoriesEnabled)),
-											settings.getCategoryColor(getCategoryName(assignment, categoriesEnabled)))));
+									String.format("background-color: %s; border-color: %s", categoryColor, categoryColor)));
 						}
 						assignmentItem.add(assignmentSignal);
 
@@ -149,9 +149,7 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 						new StringResourceModel("label.toolbar.categoryscorelabel", null, new Object[] { categoryName })));
 
 				categoryScoreFilter.add(new WebMarkupContainer("categoryScoreSignal").add(new AttributeModifier("style",
-						String.format("background-color: %s; border-color: %s",
-								settings.getCategoryColor(categoryName),
-								settings.getCategoryColor(categoryName)))));
+						String.format("background-color: %s; border-color: %s", categoryColor, categoryColor))));
 
 				final CheckBox categoryScoreCheckbox = new AjaxCheckBox("categoryScoreCheckbox",
 						new Model<Boolean>(settings.isCategoryScoreVisible(categoryName))) {// Model.of(Boolean.valueOf(settings.isCategoryScoreVisible(category))))

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
@@ -126,7 +126,7 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 						assignmentItem.add(assignmentSignal);
 
 						final CheckBox assignmentCheckbox = new AjaxCheckBox("assignmentCheckbox",
-								Model.of(Boolean.valueOf(settings.isAssignmentVisible(assignment.getId())))) {
+								Model.of(settings.isAssignmentVisible(assignment.getId()))) {
 							@Override
 							protected void onUpdate(final AjaxRequestTarget target) {
 								GradebookUiSettings settings = gradebookPage.getUiSettings();
@@ -144,7 +144,7 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 				});
 
 				final WebMarkupContainer categoryScoreFilter = new WebMarkupContainer("categoryScore");
-				categoryScoreFilter.setVisible(categoryName != getString(GradebookPage.UNCATEGORISED));
+				categoryScoreFilter.setVisible(!StringUtils.equals(categoryName, getString(GradebookPage.UNCATEGORISED)));
 				categoryScoreFilter.add(new Label("categoryScoreLabel",
 						new StringResourceModel("label.toolbar.categoryscorelabel", null, new Object[] { categoryName })));
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33827

Categories have colours to delineate the different items/columns within the category. Currently, these colours are randomly generated, and change every time you reset/visit the tool.

For users who associate colours with categories, changing the colours may throw them off each time they come to the page. We've received complaints about this, and have modified the behaviour so that the colour generation algorithm is deterministic. In this way, the colour code does not have to be stored anywhere, and the user will always see the same colours for their categories (unless a category is deleted and recreated with the same name).