### PR TITLE
SAK-33830: GBNG's "All changes saved" message shouldn't be on the page by deafult

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -15,6 +15,11 @@
  */
 package org.sakaiproject.gradebookng.tool.pages;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
@@ -71,8 +76,6 @@ import org.sakaiproject.service.gradebook.shared.GradingType;
 import org.sakaiproject.service.gradebook.shared.PermissionDefinition;
 import org.sakaiproject.service.gradebook.shared.SortType;
 import org.sakaiproject.tool.gradebook.Gradebook;
-
-import java.util.*;
 
 /**
  * Grades page. Instructors and TAs see this one. Students see the {@link StudentPage}.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -101,6 +101,7 @@ public class GradebookPage extends BasePage {
 
 	Label liveGradingFeedback;
 	boolean hasAssignmentsAndGrades;
+	private static final AttributeModifier DISPLAY_NONE = new AttributeModifier("style", "display: none");
 
 	Form<Void> form;
 
@@ -549,6 +550,7 @@ public class GradebookPage extends BasePage {
 		this.liveGradingFeedback = new Label("liveGradingFeedback", getString("feedback.saved"));
 		this.liveGradingFeedback.setVisible(this.hasAssignmentsAndGrades);
 		this.liveGradingFeedback.setOutputMarkupId(true);
+		liveGradingFeedback.add(DISPLAY_NONE);
 
 		// add the 'saving...' message to the DOM as the JavaScript will
 		// need to be the one that displays this message (Wicket will handle
@@ -559,7 +561,9 @@ public class GradebookPage extends BasePage {
 
 	public Component updateLiveGradingMessage(final String message) {
 		this.liveGradingFeedback.setDefaultModel(Model.of(message));
-
+		if (liveGradingFeedback.getBehaviors().contains(DISPLAY_NONE)) {
+			liveGradingFeedback.remove(DISPLAY_NONE);
+		}
 		return this.liveGradingFeedback;
 	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33830

On the "Grades" page, there is a message that appears in the top left beside the "Add Gradebook Item" button that says 'All changes saved." This message shouldn't be there by default; it should only appear after a change has actually been made and saved.

Putting it on the page by default can confuse users as to what it's saving, especially in scenarios where nothing has been changed by the user.