### PR TITLE
SAK-33833: GBNG new sakai.property to control visibility of 'Grade Entry' panel in 'Settings' UI

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1802,6 +1802,10 @@
 # Default: false
 # gradebook_enable_letter_grade=true
 
+# SAK-33833: hide the 'Grade Entry' panel in 'Settings' from non-admin users.
+# Default: false
+# gradebook.settings.gradeEntry.hideFromNonAdmins=true
+
 # ASSIGNMENT 1
 # Allows an instructor or any user with assignments management permissions to submit the assignment on behalf of a student 
 # who has no submission yet (via the View Assignment list by student)

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1802,9 +1802,9 @@
 # Default: false
 # gradebook_enable_letter_grade=true
 
-# SAK-33833: hide the 'Grade Entry' panel in 'Settings' from non-admin users.
-# Default: false
-# gradebook.settings.gradeEntry.hideFromNonAdmins=true
+# SAK-33833: show the 'Grade Entry' panel in 'Settings' to non-admin users.
+# Default: true
+# gradebook.settings.gradeEntry.showToNonAdmins=false
 
 # ASSIGNMENT 1
 # Allows an instructor or any user with assignments management permissions to submit the assignment on behalf of a student 

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -87,6 +87,8 @@ import org.springframework.orm.hibernate4.HibernateCallback;
 import org.springframework.orm.hibernate4.HibernateOptimisticLockingFailureException;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.authz.cover.SecurityService;
+import org.sakaiproject.component.cover.ServerConfigurationService;
 
 /**
  * A Hibernate implementation of GradebookService.
@@ -3441,8 +3443,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			}
 		});
 
-		//set grade type
-		gradebook.setGrade_type(gbInfo.getGradeType());
+		//set grade type, but only if sakai.property is false OR sakai.property is true and user is admin
+		boolean onlyAdminsSetGradeType = ServerConfigurationService.getBoolean("gradebook.settings.gradeEntry.hideFromNonAdmins", false);
+		if(!onlyAdminsSetGradeType || (onlyAdminsSetGradeType && SecurityService.isSuperUser())) {
+			gradebook.setGrade_type(gbInfo.getGradeType());
+		}
 
 		//set category type
 		gradebook.setCategory_type(gbInfo.getCategoryType());

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3444,7 +3444,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		});
 
 		//set grade type, but only if sakai.property is false OR sakai.property is true and user is admin
-		boolean onlyAdminsSetGradeType = ServerConfigurationService.getBoolean("gradebook.settings.gradeEntry.hideFromNonAdmins", false);
+		boolean onlyAdminsSetGradeType = ServerConfigurationService.getBoolean("gradebook.settings.gradeEntry.showToNonAdmins", true);
 		if(!onlyAdminsSetGradeType || (onlyAdminsSetGradeType && SecurityService.isSuperUser())) {
 			gradebook.setGrade_type(gbInfo.getGradeType());
 		}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -286,12 +286,12 @@ public class GradebookNgBusinessService {
 		try {
 			gradebook = (Gradebook) this.gradebookService.getGradebook(siteId);
 		} catch (final GradebookNotFoundException e) {
-			log.debug("Request made for inaccessible, adding gradebookUid=" + siteId);
+			log.debug("Request made for inaccessible, adding gradebookUid={}", siteId);
 			this.gradebookFrameworkService.addGradebook(siteId, siteId);
 			try {
 				gradebook = (Gradebook) this.gradebookService.getGradebook(siteId);
 			} catch (final GradebookNotFoundException e2) {
-				log.error("Request made and could not add inaccessible gradebookUid=" + siteId);
+				log.error("Request made and could not add inaccessible gradebookUid={}", siteId);
 			}
 		}
 		return gradebook;
@@ -678,7 +678,7 @@ public class GradebookNgBusinessService {
 
 			// if over limit, still save but return the warning
 			if (newGradePoints.compareTo(maxPoints) > 0) {
-				log.debug("over limit. Max: " + maxPoints);
+				log.debug("over limit. Max: {}", maxPoints);
 				rval = GradeSaveResponse.OVER_LIMIT;
 			}
 		}
@@ -694,7 +694,7 @@ public class GradebookNgBusinessService {
 				rval = GradeSaveResponse.OK;
 			}
 		} catch (InvalidGradeException | GradebookNotFoundException | AssessmentNotFoundException e) {
-			log.error("An error occurred saving the grade. " + e.getClass() + ": " + e.getMessage());
+			log.error("An error occurred saving the grade. {}: {}", e.getClass(), e.getMessage());
 			rval = GradeSaveResponse.ERROR;
 		}
 		return rval;
@@ -879,7 +879,7 @@ public class GradebookNgBusinessService {
 			// access to this one, skip it
 			if (role == GbRole.TA) {
 
-				log.debug("TA processing category: " + categoryId);
+				log.debug("TA processing category: {}", categoryId);
 
 				if (!categoryIds.isEmpty() && categoryId != null && !categoryIds.contains(categoryId)) {
 					continue;
@@ -907,7 +907,7 @@ public class GradebookNgBusinessService {
 					values = categoryAssignments.get(categoryId);
 					values.add(assignmentId);
 				} else {
-					values = new HashSet<Long>();
+					values = new HashSet<>();
 					values.add(assignmentId);
 				}
 				categoryAssignments.put(categoryId, values);
@@ -925,8 +925,7 @@ public class GradebookNgBusinessService {
 				final GbStudentGradeInfo sg = matrix.get(def.getStudentUid());
 
 				if (sg == null) {
-					log.warn("No matrix entry seeded for: " + def.getStudentUid()
-							+ ". This user may be been removed from the site");
+					log.warn("No matrix entry seeded for: {}. This user may be been removed from the site", def.getStudentUid());
 				} else {
 					// this will overwrite the stub entry for the TA matrix if
 					// need be
@@ -987,7 +986,7 @@ public class GradebookNgBusinessService {
 			// get permissions
 			final List<PermissionDefinition> permissions = getPermissionsForUser(currentUserUuid);
 
-			log.debug("All permissions: " + permissions.size());
+			log.debug("All permissions: {}", permissions.size());
 
 			// only need to process this if some are defined
 			// again only concerned with grade permission, so parse the list to
@@ -1003,7 +1002,7 @@ public class GradebookNgBusinessService {
 				}
 			}
 
-			log.debug("Filtered permissions: " + permissions.size());
+			log.debug("Filtered permissions: {}", permissions.size());
 
 			// if we still have permissions, they will be of type grade, so we
 			// need to enrich the students grades
@@ -1022,7 +1021,7 @@ public class GradebookNgBusinessService {
 				// for every student
 				for (final User student : students) {
 
-					log.debug("Processing student: " + student.getEid());
+					log.debug("Processing student: {}", student.getEid());
 
 					final GbStudentGradeInfo sg = matrix.get(student.getId());
 
@@ -1035,7 +1034,7 @@ public class GradebookNgBusinessService {
 						// categoryId
 						final Long gradeCategoryId = assignmentCategoryMap.get(entry.getKey());
 
-						log.debug("Grade: " + entry.getValue());
+						log.debug("Grade: {}", entry.getValue());
 
 						// iterate the permissions
 						// if category, compare the category,
@@ -1054,8 +1053,8 @@ public class GradebookNgBusinessService {
 							final Long permissionCategoryId = permission.getCategoryId();
 							final String permissionGroupReference = permission.getGroupReference();
 
-							log.debug("permissionCategoryId: " + permissionCategoryId);
-							log.debug("permissionGroupReference: " + permissionGroupReference);
+							log.debug("permissionCategoryId: {}", permissionCategoryId);
+							log.debug("permissionGroupReference: {}", permissionGroupReference);
 
 							// if permissions category is null (can grade all categories) or they match (can grade this category)
 							if (!categoriesEnabled || (permissionCategoryId == null || permissionCategoryId.equals(gradeCategoryId))) {
@@ -1071,7 +1070,7 @@ public class GradebookNgBusinessService {
 								log.debug("Group check passed #1");
 							} else {
 								final List<String> groupMembers = groupMembershipsMap.get(permissionGroupReference);
-								log.debug("groupMembers: " + groupMembers);
+								log.debug("groupMembers: {}", groupMembers);
 
 								if (groupMembers != null && groupMembers.contains(student.getId())) {
 									groupOk = true;
@@ -1388,8 +1387,7 @@ public class GradebookNgBusinessService {
 	 */
 	private void updateAssignmentCategorizedOrder(final String gradebookId, final Long categoryId,
 			final Long assignmentId, final int order) {
-		this.gradebookService.updateAssignmentCategorizedOrder(gradebookId, categoryId, assignmentId,
-				new Integer(order));
+		this.gradebookService.updateAssignmentCategorizedOrder(gradebookId, categoryId, assignmentId, order);
 	}
 
 	/**
@@ -1600,8 +1598,7 @@ public class GradebookNgBusinessService {
 			// for each student remaining, add the grade
 			for (final String studentUuid : studentUuids) {
 
-				log.debug("Setting default grade. Values of assignmentId: " + assignmentId + ", studentUuid: "
-						+ studentUuid + ", grade: " + grade);
+				log.debug("Setting default grade. Values of assignmentId: {}, studentUuid: {}, grade: {}", assignmentId, studentUuid, grade);
 
 				// TODO if this is slow doing it one by one, might be able to
 				// batch it
@@ -1680,7 +1677,7 @@ public class GradebookNgBusinessService {
 				return def.getCommentText();
 			}
 		} catch (GradebookNotFoundException | AssessmentNotFoundException e) {
-			log.error("An error occurred retrieving the comment. " + e.getClass() + ": " + e.getMessage());
+			log.error("An error occurred retrieving the comment. {}: {}", e.getClass(), e.getMessage());
 		}
 		return null;
 	}
@@ -1705,7 +1702,7 @@ public class GradebookNgBusinessService {
 			this.gradebookService.setAssignmentScoreComment(gradebook.getUid(), assignmentId, studentUuid, comment);
 			return true;
 		} catch (GradebookNotFoundException | AssessmentNotFoundException | IllegalArgumentException e) {
-			log.error("An error occurred saving the comment. " + e.getClass() + ": " + e.getMessage());
+			log.error("An error occurred saving the comment. {}: {}", e.getClass(), e.getMessage());
 		}
 
 		return false;
@@ -1812,7 +1809,7 @@ public class GradebookNgBusinessService {
 		final Gradebook gradebook = getGradebook();
 
 		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getId(), studentUuid, categoryId);
-		log.info("Category score for category: " + categoryId + ", student: " + studentUuid + ":" + score);
+		log.info("Category score for category: {}, student: {}:{}", categoryId, studentUuid, score);
 
 		return score;
 	}
@@ -1965,7 +1962,7 @@ public class GradebookNgBusinessService {
 		}
 
 		// other roles not yet catered for, catch all.
-		log.warn("User: " + userUuid + " does not have a valid Gradebook related role in site: " + siteId);
+		log.warn("User: {} does not have a valid Gradebook related role in site: {}", userUuid, siteId);
 		return false;
 	}
 
@@ -2009,7 +2006,7 @@ public class GradebookNgBusinessService {
 		try {
 			site = this.siteService.getSite(siteId);
 		} catch (final IdUnusedException e) {
-			log.error("Error looking up site: " + siteId, e);
+			log.error("Error looking up site: {}", siteId, e);
 			return null;
 		}
 
@@ -2081,7 +2078,7 @@ public class GradebookNgBusinessService {
 			this.gradebookService.updateCourseGradeForStudent(gradebook.getUid(), studentUuid, grade);
 			return true;
 		} catch (final Exception e) {
-			log.error("An error occurred saving the course grade. " + e.getClass() + ": " + e.getMessage());
+			log.error("An error occurred saving the course grade. {}: {}", e.getClass(), e.getMessage());
 		}
 
 		return false;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1252,6 +1252,15 @@ public class GradebookNgBusinessService {
 	}
 
 	/**
+	 * Determine if the current user is an admin user.
+	 *
+	 * @return true if the current user is admin, false otherwise.
+	 */
+	public boolean isSuperUser() {
+		return securityService.isSuperUser();
+	}
+
+	/**
 	 * Add a new assignment definition to the gradebook
 	 *
 	 * @param assignment

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -54,6 +54,10 @@ public class SettingsPage extends BasePage {
 	private boolean categoryExpanded = false;
 	private boolean gradingSchemaExpanded = false;
 
+	private boolean hideGradeEntryFromNonAdmins;
+	private static final String SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS = "gradebook.settings.gradeEntry.hideFromNonAdmins";
+	private static final boolean SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS_DEFAULT = false;
+
 	SettingsGradeEntryPanel gradeEntryPanel;
 	SettingsGradeReleasePanel gradeReleasePanel;
 	SettingsCategoryPanel categoryPanel;
@@ -61,6 +65,7 @@ public class SettingsPage extends BasePage {
 
 	public SettingsPage() {
 		disableLink(this.settingsPageLink);
+		setHideGradeEntryFromNonAdmins();
 	}
 
 	public SettingsPage(final boolean gradeEntryExpanded, final boolean gradeReleaseExpanded,
@@ -70,6 +75,11 @@ public class SettingsPage extends BasePage {
 		this.gradeReleaseExpanded = gradeReleaseExpanded;
 		this.categoryExpanded = categoryExpanded;
 		this.gradingSchemaExpanded = gradingSchemaExpanded;
+		setHideGradeEntryFromNonAdmins();
+	}
+
+	private void setHideGradeEntryFromNonAdmins() {
+		hideGradeEntryFromNonAdmins = ServerConfigurationService.getBoolean(SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS, SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS_DEFAULT);
 	}
 
 	@Override
@@ -87,6 +97,11 @@ public class SettingsPage extends BasePage {
 		this.gradeReleasePanel = new SettingsGradeReleasePanel("gradeReleasePanel", formModel, this.gradeReleaseExpanded);
 		this.categoryPanel = new SettingsCategoryPanel("categoryPanel", formModel, this.categoryExpanded);
 		this.gradingSchemaPanel = new SettingsGradingSchemaPanel("gradingSchemaPanel", formModel, this.gradingSchemaExpanded);
+
+		// Hide the panel if sakai.property is true and user is not admin
+		if (hideGradeEntryFromNonAdmins && !businessService.isSuperUser()) {
+			gradeEntryPanel.setVisible(false);
+		}
 
 		// form
 		final Form<GbSettings> form = new Form<GbSettings>("form", formModel) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -91,7 +91,7 @@ public class SettingsPage extends BasePage {
 
 		// setup page model
 		final GbSettings gbSettings = new GbSettings(settings);
-		final CompoundPropertyModel<GbSettings> formModel = new CompoundPropertyModel<GbSettings>(gbSettings);
+		final CompoundPropertyModel<GbSettings> formModel = new CompoundPropertyModel<>(gbSettings);
 
 		this.gradeEntryPanel = new SettingsGradeEntryPanel("gradeEntryPanel", formModel, this.gradeEntryExpanded);
 		this.gradeReleasePanel = new SettingsGradeReleasePanel("gradeReleasePanel", formModel, this.gradeReleaseExpanded);
@@ -131,8 +131,8 @@ public class SettingsPage extends BasePage {
 						}
 
 						// ensure we don't have drop highest and keep highest at the same time
-						if ((cat.getDropHighest().intValue() > 0 && cat.getKeepHighest().intValue() > 0)
-								|| (cat.getDropLowest().intValue() > 0 && cat.getKeepHighest().intValue() > 0)) {
+						if ((cat.getDropHighest() > 0 && cat.getKeepHighest() > 0)
+								|| (cat.getDropLowest() > 0 && cat.getKeepHighest() > 0)) {
 							error(getString("settingspage.update.failure.categorydropkeepenabled"));
 						}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -55,8 +55,8 @@ public class SettingsPage extends BasePage {
 	private boolean gradingSchemaExpanded = false;
 
 	private boolean hideGradeEntryFromNonAdmins;
-	private static final String SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS = "gradebook.settings.gradeEntry.hideFromNonAdmins";
-	private static final boolean SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS_DEFAULT = false;
+	private static final String SAK_PROP_SHOW_GRADE_ENTRY_TO_NON_ADMINS = "gradebook.settings.gradeEntry.showToNonAdmins";
+	private static final boolean SAK_PROP_SHOW_GRADE_ENTRY_TO_NON_ADMINS_DEFAULT = true;
 
 	SettingsGradeEntryPanel gradeEntryPanel;
 	SettingsGradeReleasePanel gradeReleasePanel;
@@ -79,7 +79,7 @@ public class SettingsPage extends BasePage {
 	}
 
 	private void setHideGradeEntryFromNonAdmins() {
-		hideGradeEntryFromNonAdmins = ServerConfigurationService.getBoolean(SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS, SAK_PROP_HIDE_GRADE_ENTRY_FROM_NON_ADMINS_DEFAULT);
+		hideGradeEntryFromNonAdmins = ServerConfigurationService.getBoolean(SAK_PROP_SHOW_GRADE_ENTRY_TO_NON_ADMINS, SAK_PROP_SHOW_GRADE_ENTRY_TO_NON_ADMINS_DEFAULT);
 	}
 
 	@Override


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33833

We had an institutional requirement to hide the 'Grade Entry' panel in GBNG's 'Settings' UI from non-admin users. We found that users were flipping these settings without realizing the consequences, which resulted in a lot of support calls.

We implemented this behaviour behind a new sakai.property (gradebook.settings.gradeEntry.hideFromNonAdmins) which defaults to false to preserve OOTB functionality.

For those who wish to hide this setting from end users, but still be able to make the changes with an admin account, simply set the property to true.