### PR TITLE
SAK-33834: GBNG isn't using i18l strings in certain places

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.html
@@ -5,8 +5,12 @@
 <wicket:panel>
 
 <div id="gradeItemsToolbarItemPanel" role="menu">
-  <a href="javascript:void(0)" id="hideAllGradeItems" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhideall">Hide All</span></a>
-  <a href="javascript:void(0)" id="showAllGradeItems" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowall">Show All</span></a>
+  <a href="javascript:void(0)" id="hideAllGradeItems" role="menuitem">
+        <wicket:message key="label.toolbar.gradeitemhideall" />
+  </a>
+  <a href="javascript:void(0)" id="showAllGradeItems" role="menuitem">
+        <wicket:message key="label.toolbar.gradeitemshowall" />
+  </a>
   <div wicket:id="categoriesList" class="gb-item-filter-group">
     <div wicket:id="categoryFilter" class="gb-item-category-filter">
       <label tabindex="0" role="menuitem">
@@ -20,9 +24,21 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
-          <li><a class="gb-show-only-this-category" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowonlythiscategory">Show only this category</span></a></li>
-          <li><a class="gb-toggle-this-category gb-show-this-category" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowthiscategory">Show this category</span></a></li>
-          <li><a class="gb-toggle-this-category gb-hide-this-category" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhidethiscategory">Hide this category</span></a></li>
+          <li>
+              <a class="gb-show-only-this-category" href="#" role="menuitem">
+                    <wicket:message key="label.toolbar.gradeitemshowonlythiscategory" />
+              </a>
+          </li>
+          <li>
+              <a class="gb-toggle-this-category gb-show-this-category" href="#" role="menuitem">
+                    <wicket:message key="label.toolbar.gradeitemshowthiscategory" />
+              </a>
+          </li>
+          <li>
+              <a class="gb-toggle-this-category gb-hide-this-category" href="#" role="menuitem">
+                    <wicket:message key="label.toolbar.gradeitemhidethiscategory" />
+              </a>
+          </li>
         </ul>
       </div>
     </div>
@@ -37,9 +53,21 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
-          <li><a class="gb-show-only-this-item" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowonlythisitem">Show only this item</span></a></li>
-          <li><a class="gb-toggle-this-item gb-show-this-item" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowthisitem">Show this item</span></a></li>
-          <li><a class="gb-toggle-this-item gb-hide-this-item" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhidethisitem">Hide this item</span></a></li>
+          <li>
+              <a class="gb-show-only-this-item" href="#" role="menuitem">
+                    <wicket:message key="label.toolbar.gradeitemshowonlythisitem" />
+              </a>
+          </li>
+          <li>
+              <a class="gb-toggle-this-item gb-show-this-item" href="#" role="menuitem">
+                    <wicket:message key="label.toolbar.gradeitemshowthisitem" />
+              </a>
+          </li>
+          <li>
+              <a class="gb-toggle-this-item gb-hide-this-item" href="#" role="menuitem">
+                    <wicket:message key="label.toolbar.gradeitemhidethisitem" />
+              </a>
+          </li>
         </ul>
       </div>
     </div>
@@ -54,9 +82,21 @@
               <span class="caret"></span>
           </a>
           <ul class="dropdown-menu dropdown-menu-right" role="menu">
-              <li><a class="gb-show-only-this-category-score" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowonlythiscategoryscore">Show only this category score</span></a></li>
-              <li><a class="gb-toggle-this-category-score gb-show-this-category-score" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowthiscategoryscore">Show this category score</span></a></li>
-              <li><a class="gb-toggle-this-category-score gb-hide-this-category-score" href="#" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemhidethiscategoryscore">Hide this category score</span></a></li>
+              <li>
+                  <a class="gb-show-only-this-category-score" href="#" role="menuitem">
+                        <wicket:message key="label.toolbar.gradeitemshowonlythiscategoryscore" />
+                  </a>
+              </li>
+              <li>
+                  <a class="gb-toggle-this-category-score gb-show-this-category-score" href="#" role="menuitem">
+                        <wicket:message key="label.toolbar.gradeitemshowthiscategoryscore" />
+                  </a>
+              </li>
+              <li>
+                  <a class="gb-toggle-this-category-score gb-hide-this-category-score" href="#" role="menuitem">
+                        <wicket:message key="label.toolbar.gradeitemhidethiscategoryscore" />
+                  </a>
+              </li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33834

Consider the following Wicket markup:

`<a href="javascript:void(0)" id="showAllGradeItems" role="menuitem"><span wicket:message="value:label.toolbar.gradeitemshowall">Show All</span></a>`

This is only sticking the i18n string (label.toolbar.gradeitemshowall) in the 'value' attribute of the span tag. The text that is actually displayed is the hardcoded value of 'Show All'. If you changed the corresponding message bundle value, the text displayed will remain as 'Show All', and only the text in the 'value' attribute will be changed accordingly.

A more appropriate way to do this is to use a <wicket:message> element for the actual text content:

```
      <a href="javascript:void(0)" id="showAllGradeItems" role="menuitem" class="button">
        <span wicket:message="value:label.toolbar.gradeitemshowall">
          <wicket:message key="label.toolbar.gradeitemshowall" />
        </span>
      </a>
```