### PR TITLE
SAK-33836: GBNG remove the 500 character limit on comments

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -646,14 +646,6 @@ public class GradebookNgBusinessService {
 			log.debug("newGradeAdjusted: " + newGradeAdjusted);
 		}
 
-		// if comment longer than 500 chars, error.
-		// the field is a CLOB, probably by mistake. Loading this field up may cause performance issues
-		// see SAK-29595
-		if (StringUtils.length(comment) > 500) {
-			log.error("Comment too long. Maximum 500 characters.");
-			return GradeSaveResponse.ERROR;
-		}
-
 		// no change
 		if (StringUtils.equals(storedGradeAdjusted, newGradeAdjusted)) {
 			final Double storedGradePoints = FormatHelper.validateDouble(storedGradeAdjusted);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -67,11 +67,11 @@ public class EditGradeCommentPanel extends BasePanel {
 		// form model
 		final GradeComment gradeComment = new GradeComment();
 		gradeComment.setGradeComment(this.comment);
-		final CompoundPropertyModel<GradeComment> formModel = new CompoundPropertyModel<GradeComment>(gradeComment);
+		final CompoundPropertyModel<GradeComment> formModel = new CompoundPropertyModel<>(gradeComment);
 
 		// build form
 		// modal window forms must be submitted via AJAX so we do not specify an onSubmit here
-		final Form<GradeComment> form = new Form<GradeComment>("form", formModel);
+		final Form<GradeComment> form = new Form<>("form", formModel);
 
 		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
@@ -119,7 +119,7 @@ public class EditGradeCommentPanel extends BasePanel {
 						new Object[] { user.getDisplayName(), user.getDisplayId(), assignment.getName() })).getString());
 
 		// textarea
-		form.add(new TextArea<String>("comment", new PropertyModel<String>(formModel, "gradeComment")));
+		form.add(new TextArea<>("comment", new PropertyModel<>(formModel, "gradeComment")));
 
 		// instant validation
 		// AjaxFormValidatingBehavior.addToAllFormComponents(form, "onkeyup", Duration.ONE_SECOND);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -26,7 +26,6 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.StringResourceModel;
-import org.apache.wicket.validation.validator.StringValidator;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.service.gradebook.shared.Assignment;
@@ -120,8 +119,7 @@ public class EditGradeCommentPanel extends BasePanel {
 						new Object[] { user.getDisplayName(), user.getDisplayId(), assignment.getName() })).getString());
 
 		// textarea
-		form.add(new TextArea<String>("comment", new PropertyModel<String>(formModel, "gradeComment"))
-				.add(StringValidator.maximumLength(500)));
+		form.add(new TextArea<String>("comment", new PropertyModel<String>(formModel, "gradeComment")));
 
 		// instant validation
 		// AjaxFormValidatingBehavior.addToAllFormComponents(form, "onkeyup", Duration.ONE_SECOND);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33836

https://jira.sakaiproject.org/browse/SAK-29595 proposed changing the database column backing the Gradebook's comment text field. There was significant push back on this, considering that institutions have been running without this limitation for some time, and there is a lot of historical data that would violate this change, and losing or truncating data is not an option. As such, the proposal was closed as "Won't Fix".

However, somewhere along the lines, the front and backend checks to enforce a limit of 500 characters were introduced into GBNG. **This has been a point of contention for many of our users, who consider it a regression from behaviour in Gradebook Classic**.

As the database column type change was denied, it is our opinion that the front/backend checks enforcing the 500 character limit should be removed.