### PR TITLE
SAK-33840: New feature: GBNG > Import > "Omissions" and "Preview Grades" panels

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -216,6 +216,16 @@ importExport.selection.points = Points
 importExport.selection.status = Status
 importExport.selection.noneselected = You must select at least one item.
 
+importExport.selection.omissions.missingUsers.header.plural = {0} students were found in the Gradebook who are missing from the import file
+importExport.selection.omissions.missingUsers.header.singular = {0} student were found in the Gradebook who are missing from the import file
+importExport.selection.omissions.unknownUsers.header.plural = {0} students in the import file could not be found in the Gradebook
+importExport.selection.omissions.unknownUsers.header.singular = {0} student in the import file could not be found in the Gradebook
+importExport.selection.omissions.unknownUsers.info.plural = Grade entries for these students will not be imported.
+importExport.selection.omissions.unknownUsers.info.singular = Grade entries for this student will not be imported.
+importExport.selection.previewGrades.header = Preview Grades for '{0}'
+importExport.selection.previewGrades.studentID.heading = Student ID
+importExport.selection.previewGrades.studentName.heading = Student Name
+importExport.selection.previewGrades.grade.heading = Grade
 
 importExport.createItem.heading = New Item Creation ({0} of {1})
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -270,6 +270,42 @@ public class GradebookNgBusinessService {
 	}
 
 	/**
+	* Create a map so that we can use the user's EID (from the imported file) to lookup their UUID (used to store the grade by the backend service).
+	*
+	* @return Map where the user's EID is the key and the {@link GbUser} object is the value
+	*/
+	public Map<String, GbUser> getUserEidMap() {
+		final List<GbUser> users = getGbUsers(getGradeableUsers());
+		final Map<String, GbUser> userEidMap = new HashMap<>();
+		for (GbUser user : users) {
+			String eid = user.getDisplayId();
+			if (StringUtils.isNotBlank(eid)) {
+				userEidMap.put(eid, user);
+			}
+		}
+
+		return userEidMap;
+	}
+
+	/**
+	 * Gets a List of GbUsers for the specified userUuids without any filtering.
+	 * Appropriate only for back end business like grade exports, statistics, etc.
+	 * @param userUuids
+	 * @return
+	 */
+	public List<GbUser> getGbUsers(final List<String> userUuids)
+	{
+		List<GbUser> gbUsers = new ArrayList<>(userUuids.size());
+		List<User> users = getUsers(userUuids);
+
+		for (User u : users) {
+			gbUsers.add(new GbUser(u));
+		}
+
+		return gbUsers;
+	}
+
+	/**
 	 * Helper to get a reference to the gradebook for the current site
 	 *
 	 * @return the gradebook for the site

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UserIdentificationReport.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UserIdentificationReport.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2003-2018 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.gradebookng.business.importExport;
+
+import java.io.Serializable;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import lombok.Getter;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.sakaiproject.gradebookng.business.model.GbUser;
+
+/**
+ * Contains the data relevant to user identification: identified users, missing users, unknown users and duplicate users.
+ *
+ * @author plukasew, bjones86
+ */
+public class UserIdentificationReport implements Serializable
+{
+    @Getter
+    private final SortedSet<GbUser> identifiedUsers; // users that were matched against an id
+
+    @Getter
+    private final SortedSet<GbUser> missingUsers; // users that could have been matched against an id but weren't
+
+    @Getter
+    private final SortedSet<String> unknownUsers; // ids that couldn't be matched against a user
+
+    @Getter
+    private final SortedSet<GbUser> duplicateUsers; // users that have more than one entry in the sheet
+
+    public UserIdentificationReport(Set<GbUser> allUsers)
+    {
+        missingUsers = new ConcurrentSkipListSet<>(allUsers);
+        identifiedUsers = new ConcurrentSkipListSet<>();
+        unknownUsers = new ConcurrentSkipListSet<>();
+        duplicateUsers = new ConcurrentSkipListSet<>();
+    }
+
+    public void addIdentifiedUser(GbUser user)
+    {
+        if (user.isValid())
+        {
+            if (identifiedUsers.contains(user))
+            {
+                duplicateUsers.add(user);
+            }
+            else
+            {
+                identifiedUsers.add(user);
+                missingUsers.remove(user);
+            }
+        }
+    }
+
+    public void addUnknownUser(String user)
+    {
+        if (StringUtils.isNotBlank(user))
+        {
+            unknownUsers.add(user);
+        }
+    }
+
+    public int getOmittedUserCount()
+    {
+        return unknownUsers.size() + missingUsers.size();
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2003-2018 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.gradebookng.business.importExport;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.business.model.ImportedRow;
+
+/**
+ * Identifier utility for user EIDs.
+ * 
+ * @author plukasew, bjones86
+ */
+@Slf4j
+public class UsernameIdentifier implements Serializable
+{
+    private final Map<String, GbUser> userEidMap;
+
+    @Getter
+    private final UserIdentificationReport report;
+
+    public UsernameIdentifier(List<ImportedRow> rows, Map<String, GbUser> eidMap)
+    {
+        userEidMap = eidMap;
+        report = new UserIdentificationReport(new HashSet<>(userEidMap.values()));
+        validateUsers(rows);
+    }
+
+    /**
+     * Finds the user by the given identifier
+     * @param userID a string that uniquely identifies a user
+     * @return the user
+     */
+    private GbUser getUser(String userEID)
+    {
+        GbUser user = userEidMap.get(userEID);
+        if (user != null)
+        {
+            report.addIdentifiedUser(user);
+            log.debug("User {} identified as UUID: {}", userEID, user.getUserUuid());
+        }
+        else
+        {
+            user = new GbUser(userEID, "");
+            report.addUnknownUser(userEID);
+            log.debug("User {} is unknown to this gradebook", userEID);
+        }
+
+        return user;
+    }
+
+    /**
+     * Validate all users for the imported data.
+     *
+     * @param userIdentifier
+     * @param rows
+     * @param rosterMap
+     */
+    private void validateUsers(List<ImportedRow> rows)
+    {
+        for (ImportedRow row : rows)
+        {
+            GbUser user = getUser(row.getStudentEid());
+            if (user != null)
+            {
+                row.setUser(user);
+            }
+        }
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUser.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUser.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import org.sakaiproject.user.api.User;
 
 import lombok.Getter;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * DTO for a user. Enhance as required.
@@ -27,7 +28,7 @@ import lombok.Getter;
  * @author Steve Swinsburg (steve.swinsburg@gmail.com)
  *
  */
-public class GbUser implements Serializable {
+public class GbUser implements Serializable, Comparable<GbUser> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -49,4 +50,25 @@ public class GbUser implements Serializable {
 		this.displayName = u.getDisplayName();
 	}
 
+	public GbUser(final String displayID, final String displayName) {
+		this.userUuid = "";
+		this.displayId = displayID;
+		this.displayName = displayName;
+	}
+
+	public boolean isValid() {
+		return StringUtils.isNotBlank(userUuid);
+	}
+
+	@Override
+	public int compareTo(GbUser user)
+	{
+		int comp = displayId.compareToIgnoreCase(user.displayId);
+		if (comp == 0)
+		{
+			comp = displayName.compareToIgnoreCase(user.displayName);
+		}
+
+		return comp;
+	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedRow.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedRow.java
@@ -42,10 +42,17 @@ public class ImportedRow implements Serializable {
 	private String studentName;
 
 	@Getter
+	private GbUser user;
+
+	@Getter
 	@Setter
 	private Map<String, ImportedCell> cellMap;
 
 	public ImportedRow() {
 		this.cellMap = new HashMap<String, ImportedCell>();
+	}
+
+	public void setUser(GbUser gbUser) {
+		user = gbUser;
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedRow.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedRow.java
@@ -49,7 +49,7 @@ public class ImportedRow implements Serializable {
 	private Map<String, ImportedCell> cellMap;
 
 	public ImportedRow() {
-		this.cellMap = new HashMap<String, ImportedCell>();
+		this.cellMap = new HashMap<>();
 	}
 
 	public void setUser(GbUser gbUser) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedSpreadsheetWrapper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedSpreadsheetWrapper.java
@@ -18,9 +18,11 @@ package org.sakaiproject.gradebookng.business.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.sakaiproject.gradebookng.business.importExport.UsernameIdentifier;
 
 /**
  * Wraps an imported file
@@ -37,8 +39,18 @@ public class ImportedSpreadsheetWrapper implements Serializable {
 	@Setter
 	private List<ImportedColumn> columns;
 
+	@Getter
+	@Setter
+	private UsernameIdentifier userIdentifier;
+
 	public ImportedSpreadsheetWrapper() {
-		this.rows = new ArrayList<>();
-		this.columns = new ArrayList<>();
+		rows = new ArrayList<>();
+		columns = new ArrayList<>();
+		userIdentifier = null;
+	}
+
+	public void setRows(List<ImportedRow> rows, Map<String, GbUser> rosterMap) {
+		this.rows = rows;
+		userIdentifier = new UsernameIdentifier(rows, rosterMap);
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItemDetail.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItemDetail.java
@@ -42,5 +42,4 @@ public class ProcessedGradeItemDetail implements Serializable {
 	@Getter
 	@Setter
 	private String comment;
-
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItemDetail.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItemDetail.java
@@ -33,11 +33,7 @@ public class ProcessedGradeItemDetail implements Serializable {
 
 	@Getter
 	@Setter
-	private String studentEid;
-
-	@Getter
-	@Setter
-	private String studentUuid;
+	private GbUser user;
 
 	@Getter
 	@Setter

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -87,6 +87,7 @@ public class ImportGradesHelper {
 	 *
 	 * @param is
 	 * @param mimetype
+	 * @param filename
 	 * @param businessService
 	 * @return
 	 * @throws GbImportExportInvalidColumnException
@@ -106,6 +107,7 @@ public class ImportGradesHelper {
 	 *
 	 * @param is
 	 * @param mimetype
+	 * @param filename
 	 * @param businessService
 	 * @param userCSVSeparator
 	 * @return
@@ -145,7 +147,7 @@ public class ImportGradesHelper {
 			throws GbImportExportInvalidColumnException, IOException, GbImportExportDuplicateColumnException {
 
 		// manually parse method so we can support arbitrary columns
-		CSVReader reader = null;
+		CSVReader reader;
 		if(StringUtils.isEmpty(userCSVSeparator)){
 			reader = new CSVReader(new InputStreamReader(is));
 		}else{
@@ -153,7 +155,7 @@ public class ImportGradesHelper {
 		}
 		String[] nextLine;
 		int lineCount = 0;
-		final List<ImportedRow> list = new ArrayList<ImportedRow>();
+		final List<ImportedRow> list = new ArrayList<>();
 		Map<Integer, ImportedColumn> mapping = new LinkedHashMap<>();
 		Map<String, GbUser> userEidMap = businessService.getUserEidMap();
 
@@ -363,7 +365,7 @@ public class ImportGradesHelper {
 			processedGradeItem.setStatus(status);
 			processedGradeItem.setItemTitle(columnTitle);
 
-			log.debug("Column name: " + columnTitle + ", type: " + column.getType() + ", status: " + status);
+			log.debug("Column name: {}, type: {}, status: {}", columnTitle, column.getType(), status);
 
 			// process the header as applicable
 			switch (column.getType()) {
@@ -388,15 +390,15 @@ public class ImportGradesHelper {
 					// never hit
 					break;
 				default:
-					log.warn("Bad column. Type: " + column.getType() + ", header: " + columnTitle + ".  Skipping.");
+					log.warn("Bad column. Type: {}, header: {}.  Skipping.", column.getType(), columnTitle);
 					break;
 			}
 
 			// process the data
 			final List<ProcessedGradeItemDetail> processedGradeItemDetails = new ArrayList<>();
 			for (final ImportedRow row : spreadsheetWrapper.getRows()) {
-				log.debug("row: " + row.getStudentEid());
-				log.debug("columnTitle: " + columnTitle);
+				log.debug("row: {}", row.getStudentEid());
+				log.debug("columnTitle: {}", columnTitle);
 
 				final ImportedCell cell = row.getCellMap().get(columnTitle);
 
@@ -447,7 +449,7 @@ public class ImportGradesHelper {
 		// default
 		Status status = null;
 
-		log.debug("Determining status for column: " + column.getColumnTitle() + ", type: " + column.getType());
+		log.debug("Determining status for column: {}, type: {}", column.getColumnTitle(), column.getType());
 
 		if (column.isGradeItem()) {
 			if (assignment == null) {
@@ -477,7 +479,7 @@ public class ImportGradesHelper {
 				// imported data setup
 				final ImportedCell importedCell = row.getCellMap().get(column.getColumnTitle());
 
-				log.debug("Checking cell data: " + importedCell);
+				log.debug("Checking cell data: {}", importedCell);
 
 				String importedScore = null;
 				String importedComment = null;
@@ -508,7 +510,7 @@ public class ImportGradesHelper {
 					importedScore = StringUtils.removeEnd(importedScore, ".0");
 					existingScore = StringUtils.removeEnd(existingScore, ".0");
 
-					log.debug("Comparing data, importedScore: " + importedScore + ", existingScore: " + existingScore);
+					log.debug("Comparing data, importedScore: {}, existingScore: {}", importedScore, existingScore);
 
 					if (StringUtils.isNotBlank(importedScore) && !StringUtils.equals(importedScore, existingScore)) {
 						status = Status.UPDATE;
@@ -519,7 +521,7 @@ public class ImportGradesHelper {
 				// handle comments
 				if (column.isComment()) {
 
-					log.debug("Comparing data, importedComment: " + importedComment + ", existingComment: " + existingComment);
+					log.debug("Comparing data, importedComment: {}, existingComment: {}", importedComment, existingComment);
 
 					if (StringUtils.isBlank(importedComment)) {
 						status = Status.SKIP;
@@ -540,7 +542,7 @@ public class ImportGradesHelper {
 			status = Status.SKIP;
 		}
 
-		log.debug("Status: " + status);
+		log.debug("Status: {}", status);
 
 		return status;
 	}
@@ -581,14 +583,14 @@ public class ImportGradesHelper {
 			throws GbImportExportInvalidColumnException, GbImportExportDuplicateColumnException {
 
 		// retain order
-		final Map<Integer, ImportedColumn> mapping = new LinkedHashMap<Integer, ImportedColumn>();
+		final Map<Integer, ImportedColumn> mapping = new LinkedHashMap<>();
 
 		for (int i = 0; i < line.length; i++) {
 
-			ImportedColumn column = null;
+			ImportedColumn column;
 
-			log.debug("i: " + i);
-			log.debug("line[i]: " + line[i]);
+			log.debug("i: {}", i);
+			log.debug("line[i]: {}", line[i]);
 
 			if (i == USER_ID_POS) {
 				column = new ImportedColumn();
@@ -624,12 +626,12 @@ public class ImportGradesHelper {
 			throw new GbImportExportInvalidColumnException("Invalid column header: " + headerValue);
 		}
 
-		log.debug("headerValue: " + headerValue);
+		log.debug("headerValue: {}", headerValue);
 
 		final ImportedColumn column = new ImportedColumn();
 
 		if (headerValue.startsWith("#")) {
-			log.info("Found header: " + headerValue + " but ignoring it as it is prefixed with a #.");
+			log.info("Found header: {} but ignoring it as it is prefixed with a #.", headerValue);
 			column.setType(ImportedColumn.Type.IGNORE);
 			return column;
 		}
@@ -712,5 +714,4 @@ public class ImportGradesHelper {
 	private static String trim(final String s) {
 		return StringUtils.trimToNull(s);
 	}
-
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/ImportWizardModel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/ImportWizardModel.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sakaiproject.gradebookng.business.importExport.UserIdentificationReport;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
@@ -81,4 +82,10 @@ public class ImportWizardModel implements Serializable {
 	@Setter
 	private List<Assignment> assignmentsToCreate = new ArrayList<Assignment>();
 
+	/**
+	 * The {@link UserIdentificationReport} generated during parsing of the raw import file
+	 */
+	@Getter
+	@Setter
+	private UserIdentificationReport report;
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.html
@@ -6,6 +6,10 @@
 
         <div wicket:id="subComponents" class="form-horizontal"></div>
 
+        <div class="panel-group" id="previewGradesAccordion" role="tablist" aria-multiselectable="true">
+            <wicket:container wicket:id="previewGradesPanel" />
+        </div>
+
         <div class="act">
             <input type="submit" wicket:id="backbutton" wicket:message="value:importExport.button.back"/>
             <input type="submit" class="active" wicket:message="value:importExport.button.next"/>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
@@ -105,7 +105,7 @@ public class CreateGradeItemStep extends BasePanel {
 
 					// Figure out if there are more steps
 					// If so, go to the next step (ie do it all over again)
-					Component newPanel = null;
+					Component newPanel;
 					if (step < importWizardModel.getTotalSteps()) {
 						importWizardModel.setStep(step + 1);
 						newPanel = new CreateGradeItemStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
@@ -136,7 +136,7 @@ public class CreateGradeItemStep extends BasePanel {
 				final ImportExportPage page = (ImportExportPage) getPage();
 				page.clearFeedback();
 
-				Component newPanel = null;
+				Component newPanel;
 				if (step > 1) {
 					importWizardModel.setStep(step - 1);
 					newPanel = new CreateGradeItemStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
@@ -45,6 +45,8 @@ public class CreateGradeItemStep extends BasePanel {
 	private final String panelId;
 	private final IModel<ImportWizardModel> model;
 
+	PreviewImportedGradesPanel previewGradesPanel;
+
 	public CreateGradeItemStep(final String id, final IModel<ImportWizardModel> importWizardModel) {
 		super(id);
 		this.panelId = id;
@@ -169,6 +171,8 @@ public class CreateGradeItemStep extends BasePanel {
 				new StringResourceModel("importExport.createItem.heading", this, null, step, importWizardModel.getTotalSteps())));
 		form.add(new AddOrEditGradeItemPanelContent("subComponents", assignmentModel));
 
+		previewGradesPanel = new PreviewImportedGradesPanel("previewGradesPanel", model);
+		form.add(previewGradesPanel);
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -141,18 +141,18 @@ public class GradeImportConfirmationStep extends BasePanel {
 				// add/update the data
 				if (!GradeImportConfirmationStep.this.errors) {
 
-					final List<ProcessedGradeItem> itemsToSave = new ArrayList<ProcessedGradeItem>();
+					final List<ProcessedGradeItem> itemsToSave = new ArrayList<>();
 					itemsToSave.addAll(itemsToUpdate);
 					itemsToSave.addAll(itemsToCreate);
 					itemsToSave.addAll(itemsToModify);
 
 					itemsToSave.forEach(processedGradeItem -> {
-						log.debug("Processing item: " + processedGradeItem);
+						log.debug("Processing item: {}", processedGradeItem);
 
 						final List<ProcessedGradeItemDetail> processedGradeItemDetails = processedGradeItem.getProcessedGradeItemDetails();
 
 						processedGradeItemDetails.forEach(processedGradeItemDetail -> {
-							log.debug("Processing detail: " + processedGradeItemDetail);
+							log.debug("Processing detail: {}", processedGradeItemDetail);
 
 							// get data
 							// if its an update/modify, this will get the id
@@ -199,9 +199,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 									default:
 										break;
 								}
-								log.info("Saved grade for assignment id: " + assignmentId + ", student: "
-										+ processedGradeItemDetail.getUser().getDisplayId() + ", grade: " + processedGradeItemDetail.getGrade()
-										+ ", comment: " + processedGradeItemDetail.getComment() + ", status: " + response);
+								log.info("Saved grade for assignment id: {}, student: {}, grade: {}, comment: {}, status: {}", assignmentId, processedGradeItemDetail.getUser().getDisplayId(), processedGradeItemDetail.getGrade(), processedGradeItemDetail.getComment(), response);
 							}
 
 						});
@@ -228,7 +226,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 				final ImportExportPage page = (ImportExportPage) getPage();
 				page.clearFeedback();
 
-				Component newPanel = null;
+				Component newPanel;
 				if (assignmentsToCreate.size() > 0) {
 					newPanel = new CreateGradeItemStep(GradeImportConfirmationStep.this.panelId, Model.of(importWizardModel));
 				} else {
@@ -356,8 +354,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 		if (!StringUtils.equals(currentComment, newComment)) {
 			final boolean success = GradeImportConfirmationStep.this.businessService.updateAssignmentGradeComment(assignmentId,
 					processedGradeItemDetail.getUser().getUserUuid(), newComment);
-			log.info("Saving comment: " + success + ", " + assignmentId + ", " + processedGradeItemDetail.getUser().getDisplayId() + ", "
-					+ processedGradeItemDetail.getComment());
+			log.info("Saving comment: {}, {}, {}, {}", success, assignmentId, processedGradeItemDetail.getUser().getDisplayId(), processedGradeItemDetail.getComment());
 			if (!success) {
 				getSession().error(new ResourceModel("importExport.error.comment").getObject());
 				this.errors = true;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -200,7 +200,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 										break;
 								}
 								log.info("Saved grade for assignment id: " + assignmentId + ", student: "
-										+ processedGradeItemDetail.getStudentEid() + ", grade: " + processedGradeItemDetail.getGrade()
+										+ processedGradeItemDetail.getUser().getDisplayId() + ", grade: " + processedGradeItemDetail.getGrade()
 										+ ", comment: " + processedGradeItemDetail.getComment() + ", status: " + response);
 							}
 
@@ -350,13 +350,13 @@ public class GradeImportConfirmationStep extends BasePanel {
 
 	private void saveComment(final Long assignmentId, final ProcessedGradeItemDetail processedGradeItemDetail) {
 		final String currentComment = StringUtils.trimToNull(GradeImportConfirmationStep.this.businessService
-				.getAssignmentGradeComment(assignmentId, processedGradeItemDetail.getStudentUuid()));
+				.getAssignmentGradeComment(assignmentId, processedGradeItemDetail.getUser().getUserUuid()));
 		final String newComment = StringUtils.trimToNull(processedGradeItemDetail.getComment());
 
 		if (!StringUtils.equals(currentComment, newComment)) {
 			final boolean success = GradeImportConfirmationStep.this.businessService.updateAssignmentGradeComment(assignmentId,
-					processedGradeItemDetail.getStudentUuid(), newComment);
-			log.info("Saving comment: " + success + ", " + assignmentId + ", " + processedGradeItemDetail.getStudentEid() + ", "
+					processedGradeItemDetail.getUser().getUserUuid(), newComment);
+			log.info("Saving comment: " + success + ", " + assignmentId + ", " + processedGradeItemDetail.getUser().getDisplayId() + ", "
 					+ processedGradeItemDetail.getComment());
 			if (!success) {
 				getSession().error(new ResourceModel("importExport.error.comment").getObject());
@@ -367,7 +367,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 
 	private GradeSaveResponse saveGrade(final Long assignmentId, final ProcessedGradeItemDetail processedGradeItemDetail) {
 		return GradeImportConfirmationStep.this.businessService.saveGrade(assignmentId,
-				processedGradeItemDetail.getStudentUuid(),
+				processedGradeItemDetail.getUser().getUserUuid(),
 				FormatHelper.formatGradeForDisplay(processedGradeItemDetail.getGrade()), processedGradeItemDetail.getComment());
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -117,7 +117,7 @@ public class GradeImportUploadStep extends BasePanel {
 
 				// turn file into list
 				// TODO would be nice to capture the values from these exceptions
-				ImportedSpreadsheetWrapper spreadsheetWrapper = null;
+				ImportedSpreadsheetWrapper spreadsheetWrapper;
 				try {
 					spreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(upload.getInputStream(), upload.getContentType(),
 							upload.getClientFileName(), businessService, FormattedText.getDecimalSeparator());
@@ -149,7 +149,7 @@ public class GradeImportUploadStep extends BasePanel {
 				final List<GbStudentGradeInfo> grades = GradeImportUploadStep.this.businessService.buildGradeMatrix(assignments);
 
 				// process file
-				List<ProcessedGradeItem> processedGradeItems = null;
+				List<ProcessedGradeItem> processedGradeItems;
 				try {
 					processedGradeItems = ImportGradesHelper.processImportedGrades(spreadsheetWrapper, assignments, grades);
 				} catch (final GbImportCommentMissingItemException e) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+    <body>
+        <wicket:panel>
+            <div wicket:id="omissionsContainer">
+                <div wicket:id="missingUsersContainer">
+                    <div class="panel panel-default">
+                        <div class="panel-heading" role="tab" id="missingUsersHeader">
+                            <h3 class="panel-title">
+                                <a role="button" data-toggle="collapse" href="#missingUsers" aria-expanded="false" aria-controls="missingUsers">
+                                    <wicket:message wicket:id="missingUsersHeader">{0} students were found in the Gradebook who are missing from the import file</wicket:message>
+                                </a>
+                            </h3>
+                        </div>
+                        <div id="missingUsers" class="panel-collapse collapse" role="tabpanel" aria-labelledby="missingUsersHeader">
+                            <div class="panel-body">
+                                <ul id="missingUsersContent">
+                                    <li wicket:id="missingUsers">
+                                        <span wicket:id="missingUser">student0001 (firstName lastName)</span>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div wicket:id="unknownUsersContainer">
+                    <div class="panel panel-default">
+                        <div class="panel-heading" role="tab" id="unknownUsersHeader">
+                            <h3 class="panel-title">
+                                <a role="button" data-toggle="collapse" href="#unknownUsers" aria-expanded="false" aria-controls="unknownUsers">
+                                    <wicket:message wicket:id="unknownUsersHeader">{0} students in the import file could not be found in the Gradebook</wicket:message>
+                                </a>
+                            </h3>
+                        </div>
+                        <div id="unknownUsers" class="panel-collapse collapse" role="tabpanel" aria-labelledby="unknownUsersHeader">
+                            <div class="panel-body">
+                                <p class="messageInformation">
+                                    <wicket:message wicket:id="unknownUsersInfo">Grade entries for these students will not be imported.</wicket:message>
+                                </p>
+                                <ul id="unknownUsersContent">
+                                    <li wicket:id="unknownUsers">
+                                        <span wicket:id="unknownUser">student0001</span>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </wicket:panel>
+    </body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2003-2018 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.gradebookng.tool.panels.importExport;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxEventBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.StringResourceModel;
+
+import org.sakaiproject.gradebookng.business.importExport.UserIdentificationReport;
+import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
+
+/**
+ * This panel provides two tables displaying students in the Gradebook that were not found in the imported file, and students found in the imported file
+ * but are not in the Gradebook. The tables are conditionally displayed based on the count of users in each table. If neither table has data to present,
+ * the entire panel is hidden.
+ *
+ * @author bjones86
+ */
+public class GradeItemImportOmissionsPanel extends Panel
+{
+    IModel<ImportWizardModel> model;
+
+    public GradeItemImportOmissionsPanel( final String id, final IModel<ImportWizardModel> importWizardModel )
+    {
+        super( id, importWizardModel );
+        model = importWizardModel;
+    }
+
+    @Override
+    public void onInitialize()
+    {
+        super.onInitialize();
+        UserIdentificationReport report = model.getObject().getReport();
+        final WebMarkupContainer omissionsContainer = new WebMarkupContainer( "omissionsContainer" );
+
+        // Create the accordion headers and unknown users supplemental information message
+        final Label missingUsersHeader;
+        final Label unknownUsersHeader;
+        final Label unknownUsersInfo;
+        String missingUsersHeaderMsgKey = "importExport.selection.omissions.missingUsers.header.singular";
+        String unknownUsersHeaderMsgKey = "importExport.selection.omissions.unknownUsers.header.singular";
+        String unknownUsersInfoMsgKey = "importExport.selection.omissions.unknownUsers.info.singular";
+        final int numMissingUsers = report.getMissingUsers().size();
+        final int numUnknownUsers = report.getUnknownUsers().size();
+        if( numMissingUsers > 1 )
+        {
+            missingUsersHeaderMsgKey = "importExport.selection.omissions.missingUsers.header.plural";
+        }
+        if( numUnknownUsers > 1 )
+        {
+            unknownUsersHeaderMsgKey = "importExport.selection.omissions.unknownUsers.header.plural";
+            unknownUsersInfoMsgKey = "importExport.selection.omissions.unknownUsers.info.plural";
+        }
+        missingUsersHeader = new Label( "missingUsersHeader", new StringResourceModel( missingUsersHeaderMsgKey, null, numMissingUsers ) );
+        unknownUsersHeader = new Label( "unknownUsersHeader", new StringResourceModel( unknownUsersHeaderMsgKey, null, numUnknownUsers ) );
+        unknownUsersInfo = new Label( "unknownUsersInfo", new StringResourceModel( unknownUsersInfoMsgKey, null, new Object[] {} ) );
+
+        // Missing users accordion and collapse/expand behaviour
+        final WebMarkupContainer missingUsersContainer = new WebMarkupContainer( "missingUsersContainer" );
+        missingUsersContainer.add( new AjaxEventBehavior( "shown.bs.collapse" )
+        {
+            @Override
+            protected void onEvent( final AjaxRequestTarget ajaxRequestTarget )
+            {
+                missingUsersContainer.add( new AttributeModifier( "class", "panel-collapse collapse in" ) );
+            }
+        });
+        missingUsersContainer.add( new AjaxEventBehavior( "hidden.bs.collapse" )
+        {
+            @Override
+            protected void onEvent( final AjaxRequestTarget ajaxRequestTarget )
+            {
+                missingUsersContainer.add( new AttributeModifier( "class", "panel-collapse collapse" ) );
+            }
+        });
+
+        // Unknown users accordion and collapse/expand behaviour
+        final WebMarkupContainer unknownUsersContainer = new WebMarkupContainer( "unknownUsersContainer" );
+        unknownUsersContainer.add( new AjaxEventBehavior( "shown.bs.collapse" )
+        {
+            @Override
+            protected void onEvent( final AjaxRequestTarget ajaxRequestTarget )
+            {
+                unknownUsersContainer.add( new AttributeModifier( "class", "panel-collapse collapse in" ) );
+            }
+        });
+        unknownUsersContainer.add( new AjaxEventBehavior( "hidden.bs.collapse" )
+        {
+            @Override
+            protected void onEvent( final AjaxRequestTarget ajaxRequestTarget )
+            {
+                unknownUsersContainer.add( new AttributeModifier( "class", "panel-collapse collapse" ) );
+            }
+        });
+
+        // Sort the omission lists alphabetically
+        List<GbUser> missingUsersSorted = new ArrayList<>( report.getMissingUsers() );
+        List<String> unknownUsersSorted = new ArrayList<>( report.getUnknownUsers() );
+        Collections.sort( missingUsersSorted );
+        Collections.sort( unknownUsersSorted );
+
+        // Create and populate the list of missing users
+        final ListView<GbUser> missingUsers = new ListView<GbUser>( "missingUsers", missingUsersSorted )
+        {
+            @Override
+            protected void populateItem( final ListItem<GbUser> item )
+            {
+                final GbUser user = item.getModelObject();
+                item.add( new Label( "missingUser", user.getDisplayId() + " (" + user.getDisplayName() + ")" ) );
+            }
+        };
+
+        // Create and populate the list of unknown users
+        final ListView<String> unknownUsers = new ListView<String>( "unknownUsers", unknownUsersSorted )
+        {
+            @Override
+            protected void populateItem( final ListItem<String> item )
+            {
+                final String user = item.getModelObject();
+                item.add( new Label( "unknownUser", user ) );
+            }
+        };
+
+        // Conditionally hide sub-sections or entire container based on counts
+        missingUsersContainer.setVisible( numMissingUsers > 0 );
+        unknownUsersContainer.setVisible( numUnknownUsers > 0 );
+        omissionsContainer.setVisible( report.getOmittedUserCount() > 0 );
+
+        // Add the components to the page
+        missingUsersContainer.add( missingUsersHeader );
+        missingUsersContainer.add( missingUsers );
+        unknownUsersContainer.add( unknownUsersHeader );
+        unknownUsersContainer.add( unknownUsersInfo );
+        unknownUsersContainer.add( unknownUsers );
+        omissionsContainer.add( missingUsersContainer );
+        omissionsContainer.add( unknownUsersContainer );
+        add( omissionsContainer );
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.html
@@ -2,6 +2,11 @@
 
     <h2><wicket:message key="importExport.selection.heading" /></h2>
     <p><wicket:message key="importExport.selection.description" /></p>
+
+    <div class="panel-group" id="omissionsAccordion" role="tablist" aria-multiselectable="true">
+        <wicket:container wicket:id="omissionsPanel" />
+    </div>
+
     <p><wicket:message key="importExport.selection.note" /></p>
 
 	<button wicket:id="hideNoChanges" id="hideNoChanges" class="button" aria-controls="grade_import_selection"><wicket:message key="importExport.selection.hideitems" /></button>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
@@ -66,6 +66,8 @@ public class GradeItemImportSelectionStep extends BasePanel {
 	// flag indicating if the 'N/A / no changes' items are hidden
 	private boolean naHidden = false;
 
+	GradeItemImportOmissionsPanel omissionsPanel;
+
 	public GradeItemImportSelectionStep(final String id, final IModel<ImportWizardModel> importWizardModel) {
 		super(id);
 		this.panelId = id;
@@ -82,6 +84,9 @@ public class GradeItemImportSelectionStep extends BasePanel {
 		// get the count of items that are selectable
 		GradeItemImportSelectionStep.this.selectableItems = importWizardModel.getProcessedGradeItems().stream()
 				.filter(item -> item.getStatus() != Status.SKIP).collect(Collectors.toList()).size();
+
+		omissionsPanel = new GradeItemImportOmissionsPanel("omissionsPanel", model);
+		add(omissionsPanel);
 
 		// label to show if all items are actually hidden
 		final Label allHiddenLabel = new Label("allHiddenLabel", new ResourceModel("importExport.selection.hideitemsallhidden")) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
@@ -154,11 +154,11 @@ public class GradeItemImportSelectionStep extends BasePanel {
 				final List<ProcessedGradeItem> selectedCommentItems = filterListByType(
 						allItems.stream().filter(item -> item.isSelected()).collect(Collectors.toList()), Type.COMMENT);
 
-				log.debug("Selected grade items: " + selectedGradeItems.size());
-				log.debug("Selected grade items: " + selectedGradeItems);
+				log.debug("Selected grade items: {}", selectedGradeItems.size());
+				log.debug("Selected grade items: {}", selectedGradeItems);
 
-				log.debug("Selected comment items: " + selectedCommentItems.size());
-				log.debug("Selected comment items: " + selectedCommentItems);
+				log.debug("Selected comment items: {}", selectedCommentItems.size());
+				log.debug("Selected comment items: {}", selectedCommentItems);
 
 				// combine the two lists. since comments can be toggled independently, the selectedGradeItems may not contain the item we
 				// need to update
@@ -168,7 +168,7 @@ public class GradeItemImportSelectionStep extends BasePanel {
 				itemsToProcess.addAll(selectedCommentItems);
 
 				// this has an odd model so we need to have the validation in the onSubmit.
-				if (itemsToProcess.size() == 0) {
+				if (itemsToProcess.isEmpty()) {
 					validated = false;
 					error(getString("importExport.selection.noneselected"));
 				}
@@ -187,9 +187,9 @@ public class GradeItemImportSelectionStep extends BasePanel {
 					final List<ProcessedGradeItem> itemsToModify = filterListByType(filterListByStatus(itemsToProcess, Status.MODIFIED),
 							Type.GB_ITEM);
 
-					log.debug("Items to create: " + itemsToCreate.size());
-					log.debug("Items to update: " + itemsToUpdate.size());
-					log.debug("Items to modify: " + itemsToModify.size());
+					log.debug("Items to create: {}", itemsToCreate.size());
+					log.debug("Items to update: {}", itemsToUpdate.size());
+					log.debug("Items to modify: {}", itemsToModify.size());
 
 					// set data for next page
 					importWizardModel.setItemsToCreate(itemsToCreate);
@@ -197,7 +197,7 @@ public class GradeItemImportSelectionStep extends BasePanel {
 					importWizardModel.setItemsToModify(itemsToModify);
 
 					// repaint panel
-					Component newPanel = null;
+					Component newPanel;
 
 					// create those that need to be created. When finished all, continue.
 					if (itemsToCreate.size() > 0) {
@@ -264,8 +264,8 @@ public class GradeItemImportSelectionStep extends BasePanel {
 				final ProcessedGradeItem gradeItem = gradeItemMap.get(key);
 				final ProcessedGradeItem commentItem = (commentMap.get(key) != null) ? commentMap.get(key) : setupBlankCommentItem();
 
-				log.debug("grade item: " + gradeItem);
-				log.debug("matching comment: " + commentItem);
+				log.debug("grade item: {}", gradeItem);
+				log.debug("matching comment: {}", commentItem);
 
 				// setup our wrappers
 				final GbStyleableWebMarkupContainer gbItemWrap = new GbStyleableWebMarkupContainer("gb_item");

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+    <body>
+        <wicket:panel>
+            <div class="panel panel-default">
+                <div class="panel-heading" role="tab" id="previewGradesHeader">
+                    <h3 class="panel-title">
+                        <a role="button" data-toggle="collapse" href="#previewGrades" aria-expanded="false" aria-controls="previewGrades">
+                            <wicket:message wicket:id="previewGradesHeader">Preview Grades for '{0}'</wicket:message>
+                        </a>
+                    </h3>
+                </div>
+                <div wicket:id="previewGradesPanel" id="previewGrades" class="panel-collapse collapse" role="tabpanel" aria-labelledby="previewGradesHeader">
+                    <div class="panel-body">
+                        <div wicket:id="previewGradesContainer" class="previewGradesContainer">
+                            <table class="table table-striped table-bordered table-hover">
+                                <thead>
+                                    <tr>
+                                        <th>
+                                            <wicket:message key="importExport.selection.previewGrades.studentID.heading">Student ID</wicket:message>
+                                        </th>
+                                        <th>
+                                            <wicket:message key="importExport.selection.previewGrades.studentName.heading">Student Name</wicket:message>
+                                        </th>
+                                        <th>
+                                            <wicket:message key="importExport.selection.previewGrades.grade.heading">Grade</wicket:message>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr wicket:id="previewGrades">
+                                        <td>
+                                            <span wicket:id="studentID">student0001</span>
+                                        </td>
+                                        <td>
+                                            <span wicket:id="studentName">firstName lastName</span>
+                                        </td>
+                                        <td>
+                                            <span wicket:id="studentGrade">85</span>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </wicket:panel>
+    </body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2003-2018 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.gradebookng.tool.panels.importExport;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxEventBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.StringResourceModel;
+
+import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
+import org.sakaiproject.gradebookng.business.model.ProcessedGradeItemDetail;
+import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
+
+/**
+ * This panel provides a table previewing the grades that will be imported for the current item in the {@link ImportWizardModel}.
+ *
+ * @author bjones86
+ */
+public class PreviewImportedGradesPanel extends Panel
+{
+    IModel<ImportWizardModel> model;
+
+    public PreviewImportedGradesPanel( final String id, final IModel<ImportWizardModel> importWizardModel )
+    {
+        super( id, importWizardModel );
+        model = importWizardModel;
+    }
+
+    @Override
+    public void onInitialize()
+    {
+        super.onInitialize();
+        final ImportWizardModel importWizardModel = model.getObject();
+        final ProcessedGradeItem processedGradeItem = importWizardModel.getItemsToCreate().get( importWizardModel.getStep() - 1 );
+
+        // Create the accordion header
+        final Label previewGradesHeader = new Label( "previewGradesHeader", new StringResourceModel( "importExport.selection.previewGrades.header",
+                null, new Object[] {processedGradeItem.getItemTitle()} ) );
+
+        // Add the accordion collapse/expand behaviour
+        final WebMarkupContainer previewGradesPanel = new WebMarkupContainer( "previewGradesPanel" );
+        previewGradesPanel.add( new AjaxEventBehavior( "shown.bs.collapse" )
+        {
+            @Override
+            protected void onEvent( final AjaxRequestTarget ajaxRequestTarget )
+            {
+                previewGradesPanel.add( new AttributeModifier( "class", "panel-collapse collapse in" ) );
+            }
+        });
+        previewGradesPanel.add( new AjaxEventBehavior( "hidden.bs.collapse" )
+        {
+            @Override
+            protected void onEvent( final AjaxRequestTarget ajaxRequestTarget )
+            {
+                previewGradesPanel.add( new AttributeModifier( "class", "panel-collapse collapse" ) );
+            }
+        });
+
+        // Create and populate the list of grades that will be imported for the current item
+        final WebMarkupContainer previewGradesContainer = new WebMarkupContainer( "previewGradesContainer" );
+        final ListView<ProcessedGradeItemDetail> previewGrades = new ListView<ProcessedGradeItemDetail>( "previewGrades", processedGradeItem.getProcessedGradeItemDetails() )
+        {
+            @Override
+            protected void populateItem( final ListItem<ProcessedGradeItemDetail> item )
+            {
+                final ProcessedGradeItemDetail details = item.getModelObject();
+                final GbUser user = details.getUser();
+                item.add( new Label( "studentID", user.getDisplayId() ) );
+                item.add( new Label( "studentName", user.getDisplayName() ) );
+                item.add( new Label( "studentGrade", details.getGrade() ) );
+            }
+        };
+
+        // Add the components to the page
+        previewGradesContainer.add( previewGrades );
+        previewGradesPanel.add( previewGradesContainer );
+        add( previewGradesHeader );
+        add( previewGradesPanel );
+    }
+}

--- a/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestImportGradesHelper.java
+++ b/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestImportGradesHelper.java
@@ -24,13 +24,16 @@ import java.util.regex.Matcher;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.exception.GbImportExportDuplicateColumnException;
 import org.sakaiproject.gradebookng.business.exception.GbImportExportInvalidFileTypeException;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
+import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.business.model.ImportedCell;
 import org.sakaiproject.gradebookng.business.model.ImportedColumn;
 import org.sakaiproject.gradebookng.business.model.ImportedRow;
@@ -45,6 +48,16 @@ import org.sakaiproject.user.api.User;
  * Tests for the ImportGradesHelper class.
  */
 public class TestImportGradesHelper {
+
+	private final Map<String, GbUser> USER_MAP = mockUserMap();
+	private GradebookNgBusinessService service;
+
+	@Before
+	public void setUp() throws Exception {
+		service = Mockito.mock(GradebookNgBusinessService.class);
+		Assert.assertNotNull(service);
+		Mockito.when(service.getUserEidMap()).thenReturn(USER_MAP);
+	}
 
 	@Test
 	public void when_pointsHasDecimal_thenImportSucceeds() throws Exception {
@@ -110,7 +123,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_textcsv_thenCsvImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -118,7 +131,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_textcsv_i18n_thenCsvImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_i18n.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import_i18n.csv", mockUserMap(), ",");
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import_i18n.csv", service, ",");
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -126,7 +139,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_textplain_thenCsvImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/plain", "grades_import.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/plain", "grades_import.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -134,7 +147,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_textcommaseparatedvalues_thenCsvImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/comma-separated-values", "grades_import.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/comma-separated-values", "grades_import.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -142,7 +155,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_textapplicationcsv_thenCsvImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -151,7 +164,7 @@ public class TestImportGradesHelper {
 	public void when_browser_says_applicationvndmsexcel_thenCsvImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
 		// Windows machine with MS Office installed is going to send this CSV with an Excel mimetype
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -159,7 +172,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_applicationvndmsexcel_thenXlsImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.xls");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.xls", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.xls", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -167,7 +180,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_applicationvndopenxmlformatsofficedocumentspreadsheetmlsheet_thenXlsImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.xls");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "grades_import.xls", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "grades_import.xls", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -175,7 +188,7 @@ public class TestImportGradesHelper {
 	@Test(expected=GbImportExportInvalidFileTypeException.class)
 	public void when_anythingelse_thenImportFails() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.pdf");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/pdf", "grades_import.pdf", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/pdf", "grades_import.pdf", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -183,7 +196,7 @@ public class TestImportGradesHelper {
 	@Test
 	public void when_caseSensitiveDupes_thenImportSucceeds() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_with_case_sensitive_dupes.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_case_sensitive_dupes.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_case_sensitive_dupes.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -191,7 +204,7 @@ public class TestImportGradesHelper {
 	@Test(expected=GbImportExportDuplicateColumnException.class)
 	public void when_exactDupes_thenImportFails() throws Exception {
 		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_with_exact_dupes.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_exact_dupes.csv", mockUserMap());
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_exact_dupes.csv", service);
 		is.close();
 		testImport(importedSpreadsheetWrapper);
 	}
@@ -410,11 +423,16 @@ public class TestImportGradesHelper {
 		return importedSpreadsheetWrapper;
 	}
 
-	private Map<String, String> mockUserMap() {
-		final Map<String, String> userMap = new HashMap<String, String>();
-		userMap.put("student1", "student name 1");
-		userMap.put("student2", "student name 2");
+	private Map<String, GbUser> mockUserMap() {
+		final Map<String, GbUser> userMap = new HashMap<>();
+		final GbUser user1 = Mockito.mock(GbUser.class);
+		Mockito.when(user1.getUserUuid()).thenReturn("student name 1");
+		Mockito.when(user1.getDisplayId()).thenReturn("student1");
+		final GbUser user2 = Mockito.mock(GbUser.class);
+		Mockito.when(user2.getUserUuid()).thenReturn("student name 2");
+		Mockito.when(user2.getDisplayId()).thenReturn("student2");
+		userMap.put("student1", user1);
+		userMap.put("student2", user2);
 		return userMap;
 	}
-
 }

--- a/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestImportGradesHelper.java
+++ b/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestImportGradesHelper.java
@@ -64,8 +64,8 @@ public class TestImportGradesHelper {
 		String headerValue = "Week #1: Intro to A-B-C [55.4]";
 		Matcher m1 = ImportGradesHelper.ASSIGNMENT_WITH_POINTS_PATTERN.matcher(headerValue);
 		Assert.assertTrue(m1.matches());
-		Assert.assertEquals(StringUtils.trimToNull(m1.group(1)), "Week #1: Intro to A-B-C");
-		Assert.assertEquals(m1.group(2), "55.4");
+		Assert.assertEquals("Week #1: Intro to A-B-C", StringUtils.trimToNull(m1.group(1)));
+		Assert.assertEquals("55.4", m1.group(2));
 	}
 
 	@Test
@@ -73,8 +73,8 @@ public class TestImportGradesHelper {
 		String headerValue = "Week #1: Intro to A-B-C [55,4]";
 		Matcher m1 = ImportGradesHelper.ASSIGNMENT_WITH_POINTS_PATTERN.matcher(headerValue);
 		Assert.assertTrue(m1.matches());
-		Assert.assertEquals(StringUtils.trimToNull(m1.group(1)), "Week #1: Intro to A-B-C");
-		Assert.assertEquals(m1.group(2), "55,4");
+		Assert.assertEquals("Week #1: Intro to A-B-C", StringUtils.trimToNull(m1.group(1)));
+		Assert.assertEquals("55,4", m1.group(2));
 	}
 
 	@Test
@@ -88,10 +88,10 @@ public class TestImportGradesHelper {
 		Matcher m2 = ImportGradesHelper.ASSIGNMENT_WITH_POINTS_PATTERN.matcher(headerValueB);
 		Assert.assertTrue(m2.matches());
 
-		Assert.assertEquals(StringUtils.trimToNull(m1.group(1)), "Week #1");
-		Assert.assertEquals(StringUtils.trimToNull(m2.group(1)), "Week #2");
-		Assert.assertEquals(m1.group(2), "55.1");
-		Assert.assertEquals(m2.group(2), "55.2");
+		Assert.assertEquals("Week #1", StringUtils.trimToNull(m1.group(1)));
+		Assert.assertEquals("Week #2", StringUtils.trimToNull(m2.group(1)));
+		Assert.assertEquals("55.1", m1.group(2));
+		Assert.assertEquals("55.2", m2.group(2));
 	}
 
 	@Test
@@ -105,10 +105,10 @@ public class TestImportGradesHelper {
 		Matcher m2 = ImportGradesHelper.ASSIGNMENT_WITH_POINTS_PATTERN.matcher(headerValueB);
 		Assert.assertTrue(m2.matches());
 
-		Assert.assertEquals(StringUtils.trimToNull(m1.group(1)), "Week #1");
-		Assert.assertEquals(StringUtils.trimToNull(m2.group(1)), "Week #2");
-		Assert.assertEquals(m1.group(2), "55,1");
-		Assert.assertEquals(m2.group(2), "55,2");
+		Assert.assertEquals("Week #1", StringUtils.trimToNull(m1.group(1)));
+		Assert.assertEquals("Week #2", StringUtils.trimToNull(m2.group(1)));
+		Assert.assertEquals("55,1", m1.group(2));
+		Assert.assertEquals("55,2", m2.group(2));
 	}
 
 	@Test
@@ -116,96 +116,108 @@ public class TestImportGradesHelper {
 		String headerValue = "Week #2 [5]";
 		Matcher m1 = ImportGradesHelper.ASSIGNMENT_WITH_POINTS_PATTERN.matcher(headerValue);
 		Assert.assertTrue(m1.matches());
-		Assert.assertEquals(StringUtils.trimToNull(m1.group(1)), "Week #2");
-		Assert.assertEquals(m1.group(2), "5");
+		Assert.assertEquals("Week #2", StringUtils.trimToNull(m1.group(1)));
+		Assert.assertEquals("5", m1.group(2));
 	}
 
 	@Test
 	public void when_textcsv_thenCsvImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import.csv", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_textcsv_i18n_thenCsvImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_i18n.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import_i18n.csv", service, ",");
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_i18n.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/csv", "grades_import_i18n.csv", service, ",");
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_textplain_thenCsvImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/plain", "grades_import.csv", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/plain", "grades_import.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_textcommaseparatedvalues_thenCsvImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/comma-separated-values", "grades_import.csv", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "text/comma-separated-values", "grades_import.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_textapplicationcsv_thenCsvImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import.csv", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_browser_says_applicationvndmsexcel_thenCsvImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv");
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
 		// Windows machine with MS Office installed is going to send this CSV with an Excel mimetype
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.csv", service);
-		is.close();
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.csv")) {
+			// Windows machine with MS Office installed is going to send this CSV with an Excel mimetype
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_applicationvndmsexcel_thenXlsImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.xls");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.xls", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.xls")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.ms-excel", "grades_import.xls", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_applicationvndopenxmlformatsofficedocumentspreadsheetmlsheet_thenXlsImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.xls");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "grades_import.xls", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.xls")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "grades_import.xls", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test(expected=GbImportExportInvalidFileTypeException.class)
 	public void when_anythingelse_thenImportFails() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.pdf");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/pdf", "grades_import.pdf", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import.pdf")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/pdf", "grades_import.pdf", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test
 	public void when_caseSensitiveDupes_thenImportSucceeds() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_with_case_sensitive_dupes.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_case_sensitive_dupes.csv", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_with_case_sensitive_dupes.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_case_sensitive_dupes.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
 	@Test(expected=GbImportExportDuplicateColumnException.class)
 	public void when_exactDupes_thenImportFails() throws Exception {
-		final InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_with_exact_dupes.csv");
-		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_exact_dupes.csv", service);
-		is.close();
+		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("grades_import_with_exact_dupes.csv")) {
+			importedSpreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(is, "application/csv", "grades_import_with_exact_dupes.csv", service);
+		}
 		testImport(importedSpreadsheetWrapper);
 	}
 
@@ -285,7 +297,7 @@ public class TestImportGradesHelper {
 	 * @return List of mocked assignments
 	 */
 	private List<Assignment> mockAssignments() {
-		final List<Assignment> assignments = new ArrayList<Assignment>();
+		final List<Assignment> assignments = new ArrayList<>();
 		final Assignment assignment1 = new Assignment();
 		assignment1.setId(1L);
 		assignment1.setName("GradebookAssignment 1");
@@ -315,7 +327,7 @@ public class TestImportGradesHelper {
 	 * @return
 	 */
 	private List<GbStudentGradeInfo> mockExistingStudentGrades() {
-		final List<GbStudentGradeInfo> grades = new ArrayList<GbStudentGradeInfo>();
+		final List<GbStudentGradeInfo> grades = new ArrayList<>();
 
 		final User user1 = Mockito.mock(User.class);
 		Mockito.when(user1.getId()).thenReturn("user1");
@@ -356,7 +368,7 @@ public class TestImportGradesHelper {
 
 	private ImportedSpreadsheetWrapper mockImportedSpreadsheetData() {
 		final ImportedSpreadsheetWrapper importedSpreadsheetWrapper = new ImportedSpreadsheetWrapper();
-		final List<ImportedColumn> columns = new ArrayList<ImportedColumn>();
+		final List<ImportedColumn> columns = new ArrayList<>();
 
 		// only list actual columns to be turned into the import here
 		columns.add(new ImportedColumn("Student ID", null, ImportedColumn.Type.GB_ITEM_WITHOUT_POINTS));
@@ -371,7 +383,7 @@ public class TestImportGradesHelper {
 
 		importedSpreadsheetWrapper.setColumns(columns);
 
-		final List<ImportedRow> rows = new ArrayList<ImportedRow>();
+		final List<ImportedRow> rows = new ArrayList<>();
 
 		final ImportedRow row1 = new ImportedRow();
 		row1.setStudentUuid("user1");

--- a/gradebookng/tool/src/webapp/styles/gradebook-importexport.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-importexport.css
@@ -85,4 +85,11 @@
   width: 100%;
 }
 
+div.previewGradesContainer, #missingUsersContent, #unknownUsersContent {
+  max-height: 20em;
+  overflow-y: scroll;
+}
 
+div.previewGradesContainer table {
+  width: 100%;
+ }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33840

This PR introduces three new collapsible panels into the Import wizard. Please see the screenshots in the JIRA ticket.

On the "Gradebook Item Import Selection" UI:
 * Students found in the Gradebook, but are not present in the imported file (screenshots 1 & 2)
 ** This panel allows instructors/maintainers to quickly/visually ascertain if the imported file is missing entries.
 * Students found in the imported file, but are not members of the Site/Gradebook (screenshots 1 & 3)
 ** This panel allows instructors/maintainers to quickly/visually identify bogus entries in the selected file

These two panels allow the user to abort the process early in order to add or remove data as necessary in the imported file, rather than moving completely through the wizard and realizing after the fact that the file was missing something, or had invalid data, or was intended for another site, etc. The "omission" panels are conditionally rendered, so if either of the two lists are empty, their respective panels are not shown on the UI.

On the "New Item Creation (x of y)" UI, a "Preview Grades" panel has been introduced (screenshots 4 & 5). This panel serves many of the same incentives as the other two:
* It allows the user to quickly/visually verify the data for the Gradebook Item
* Gives the user the opportunity to abort early, rather than proceed through the wizard and finish the importing, only to realize that they made a mistake in the imported file