### PR TITLE
SAK-33851 Assignment iterating over submissions outside the service

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -3026,7 +3026,7 @@ public class AssignmentAction extends PagedResourceActionII {
             Assignment a = getAssignment(assignmentId, "build_instructor_delete_assignment_context", state);
             if (a != null) {
                 int submittedCount = 0;
-                Set<AssignmentSubmission> submissions = a.getSubmissions();
+                Set<AssignmentSubmission> submissions = assignmentService.getSubmissions(a);
                 for (AssignmentSubmission submission : submissions) {
                     if (submission.getSubmitted() && submission.getDateSubmitted() != null) {
                         submittedCount++;


### PR DESCRIPTION
Can cause cached entity initialization issues for a lack of a session