### PR TITLE
Fix SAK-33451 and SAK-33371: Save the owner of an external calendar and his time zone.

### DIFF
--- a/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/api/CalendarImporterService.java
+++ b/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/api/CalendarImporterService.java
@@ -64,4 +64,20 @@ public interface CalendarImporterService
 	public List<CalendarEvent> doImport(String importType, InputStream importStream, Map<String, String> columnMapping, String[] customFieldPropertyNames)
 		throws ImportException;
 
+	/**
+	 * Perform an import given the import type. (SAK-33451)
+	 * @param importType Type such as Outlook, MeetingMaker, etc. defined in the CalendarImporterService interface.
+	 * @param importStream Stream of data to be imported
+	 * @param columnMapping Map of column headers (keys) to property names (values)
+	 * @param customFieldPropertyNames Array of custom properties that we want to import.  null if there are no custom properties.
+	 * @param userTzid Id of user's time zone when the user subscribed to calendar.
+	 * @return A list of CalendarEvent objects.  These objects are not "real", so their copies
+	 * must be copied into CalendarEvents created by the Calendar service.
+	 * @throws ImportException
+	 */
+	public List<CalendarEvent> doImport(String importType, InputStream importStream, Map<String, String> columnMapping,
+			String[] customFieldPropertyNames, String userTzid)
+			throws ImportException;
+
+
 }

--- a/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/api/ExternalCalendarSubscriptionService.java
+++ b/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/api/ExternalCalendarSubscriptionService.java
@@ -66,6 +66,7 @@ public interface ExternalCalendarSubscriptionService
 
 	/** Key value for ToolConfig */
 	public final static String TC_PROP_SUBCRIPTIONS = "externalCalendarSubscriptions";
+	public final static String TC_PROP_SUBCRIPTIONS_WITH_TZ = "externalCalendarSubscriptionsWithTZ";
 
 	/** Value delimiter for subscription reference in ToolConfig */
 	public final static String SUBS_REF_DELIMITER = "_,_";
@@ -81,14 +82,15 @@ public interface ExternalCalendarSubscriptionService
 
 	/** Get Calendar object from Calendar Subscription */
 	public Calendar getCalendarSubscription(String reference);
+	public Calendar getCalendarSubscription(String reference, String userId, String tzid);
 
 	/** Get Calendar Subscriptions for specified Calendar channels */
-	public Set<String> getCalendarSubscriptionChannelsForChannels(
+	public Set<ExternalSubscriptionDetails> getCalendarSubscriptionChannelsForChannels(
 			String primaryCalendarReference,
 			Collection<Object> channels);
 
 	/** Get Calendar channels for specified Calendar channels */
-	public Set<String> getCalendarSubscriptionChannelsForChannel(String reference);
+	public Set<ExternalSubscriptionDetails> getCalendarSubscriptionChannelsForChannel(String reference);
 
 	/**
 	 * Get list of available institutional calendar subscriptions for a given

--- a/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/api/ExternalSubscriptionDetails.java
+++ b/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/api/ExternalSubscriptionDetails.java
@@ -42,4 +42,9 @@ public interface ExternalSubscriptionDetails extends ExternalSubscription {
 	 */
 	State getState();
 
+	/** Owner of calendar subscription **/
+	String getUserId();
+	
+	/** Time Zone Id of user, is used when calendar has not time zone defined */
+	String getTzid();
 }

--- a/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/cover/CalendarImporterService.java
+++ b/calendar/calendar-api/api/src/java/org/sakaiproject/calendar/cover/CalendarImporterService.java
@@ -88,11 +88,16 @@ public class CalendarImporterService
 	 */
 	public static List doImport(String importType, InputStream importStream, Map columnMapping, String[] customFieldPropertyNames) throws ImportException
 	{
+		return doImport(importType, importStream, columnMapping, customFieldPropertyNames, null);
+	}
+	
+	public static List doImport(String importType, InputStream importStream, Map columnMapping, String[] customFieldPropertyNames, String userTzid) throws ImportException
+	{
 		org.sakaiproject.calendar.api.CalendarImporterService service = getInstance();
 		
 		if ( service != null )
 		{
-			return service.doImport(importType, importStream, columnMapping, customFieldPropertyNames);
+			return service.doImport(importType, importStream, columnMapping, customFieldPropertyNames, userTzid);
 		}
 		else
 		{

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -797,11 +797,15 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	 * @exception PermissionException
 	 *            If the user does not have any permissions to the calendar.
 	 */
-	public Calendar getCalendar(String ref) throws IdUnusedException, PermissionException
+	public Calendar getCalendar(String ref) throws IdUnusedException, PermissionException {
+		return getCalendar(ref, null, null);
+	}
+	
+	public Calendar getCalendar(String ref, String userId, String tzid) throws IdUnusedException, PermissionException
 	{
 		Reference _ref = m_entityManager.newReference(ref);
 		if(REF_TYPE_CALENDAR_SUBSCRIPTION.equals(_ref.getSubType())) {
-			Calendar c = externalCalendarSubscriptionService.getCalendarSubscription(ref);
+			Calendar c = externalCalendarSubscriptionService.getCalendarSubscription(ref, userId, tzid);
 			if (c == null) throw new IdUnusedException(ref);
 			return c;
 		}
@@ -5893,8 +5897,8 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		
 		// add external calendar subscriptions
 		List referenceList = mergedCalendarList.getReferenceList();
-		Set subscriptionRefList = externalCalendarSubscriptionService.getCalendarSubscriptionChannelsForChannels(primaryCalendarReference,referenceList);
-		referenceList.addAll(subscriptionRefList);
+		Set<ExternalSubscriptionDetails> subscriptionDetailsList = externalCalendarSubscriptionService.getCalendarSubscriptionChannelsForChannels(primaryCalendarReference,referenceList);
+        subscriptionDetailsList.stream().forEach(x->referenceList.add(x.getReference()));
 		
 		return referenceList;
 	}

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalSubscriptionDetails.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalSubscriptionDetails.java
@@ -40,6 +40,10 @@ public class BaseExternalSubscriptionDetails implements ExternalSubscriptionDeta
 	private boolean isInstitutional;
 
 	private Status status;
+	
+	private String userId;
+	
+	private String tzid;
 
 	public BaseExternalSubscriptionDetails() {
 	}
@@ -55,6 +59,8 @@ public class BaseExternalSubscriptionDetails implements ExternalSubscriptionDeta
 		this.calendar = other.calendar;
 		this.isInstitutional = other.isInstitutional;
 		this.status = other.status;
+		this.userId = other.userId;
+		this.tzid = other.tzid;
 	}
 
 	/**
@@ -70,11 +76,19 @@ public class BaseExternalSubscriptionDetails implements ExternalSubscriptionDeta
 		setContext(context);
 		setInstitutional(isInstitutional);
 	}
-
+	
 	public BaseExternalSubscriptionDetails(String subscriptionName,
-										   String subscriptionUrl, String context, ExternalCalendarSubscription calendar,
-										   boolean isInstitutional, boolean ok, String error, Instant instant) {
+			   String subscriptionUrl, String context, ExternalCalendarSubscription calendar,
+			   boolean isInstitutional, String userId, String tzid) {
 	    this(subscriptionName, subscriptionUrl, context, calendar, isInstitutional);
+		this.userId = userId;
+		this.tzid = tzid;
+	}
+	
+	public BaseExternalSubscriptionDetails(String subscriptionName,
+			   String subscriptionUrl, String context, ExternalCalendarSubscription calendar,
+			   boolean isInstitutional, String userId, String tzid, boolean ok, String error, Instant instant) {
+		this(subscriptionName, subscriptionUrl, context, calendar, isInstitutional, userId, tzid);
 		status = new Status(ok, error, instant);
 	}
 
@@ -136,6 +150,22 @@ public class BaseExternalSubscriptionDetails implements ExternalSubscriptionDeta
 
 	public Instant getRefreshed() {
 		return status != null? status.getRefreshed(): null;
+	}
+	
+	public String getUserId() {
+		return userId;
+	}
+
+	public void setUserId(String userId) {
+		this.userId = userId;
+	}
+
+	public String getTzid() {
+		return tzid;
+	}
+	
+	public void setTzid(String tzid) {
+		this.tzid = tzid;
 	}
 
 	@Override

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/GenericCalendarImporter.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/GenericCalendarImporter.java
@@ -185,6 +185,8 @@ public class GenericCalendarImporter implements CalendarImporterService
 		private TimeRange timeRange;
 
 		private int lineNumber;
+		
+		private String creator;
 
 		/**
 		 * Default constructor
@@ -440,7 +442,7 @@ public class GenericCalendarImporter implements CalendarImporterService
 		}
 
 		/**
-		* Returns true if current user is thhe event's owner/creator
+		* Returns true if current user is the event's owner/creator
 		* @return boolean true or false
 		*/
 		public boolean isUserOwner()
@@ -469,6 +471,11 @@ public class GenericCalendarImporter implements CalendarImporterService
 			// Stub routine only
 
 		} // setCreator
+		
+		public void setCreator(String creator)
+		{
+			this.creator = creator;
+		}
 
 		/**
 		* Gets the event modifier (userid), if any (cover for PROP_MODIFIED_BY).
@@ -702,6 +709,13 @@ public class GenericCalendarImporter implements CalendarImporterService
 	public List doImport(String importType, InputStream importStream, Map columnMapping, String[] customFieldPropertyNames)
 			throws ImportException
 	{
+		return doImport(importType, importStream, columnMapping, customFieldPropertyNames, null);
+	}
+	
+
+	public List doImport(String importType, InputStream importStream, Map columnMapping, String[] customFieldPropertyNames, String userTzid)
+			throws ImportException
+	{
 		final List rowList = new ArrayList();
 		final Reader scheduleImport;
 
@@ -740,7 +754,7 @@ public class GenericCalendarImporter implements CalendarImporterService
 		columnMap = scheduleImport.getDefaultColumnMap();
 		
 		// Read in the file.
-		scheduleImport.importStreamFromDelimitedFile(importStream, new Reader.ReaderImportRowHandler()
+		String calendarTzid = scheduleImport.importStreamFromDelimitedFile(importStream, new Reader.ReaderImportRowHandler()
 		{
 			String frequencyColumn = columnMap.get(FREQUENCY_DEFAULT_COLUMN_HEADER);
 			String startTimeColumn = columnMap.get(START_TIME_DEFAULT_COLUMN_HEADER);
@@ -934,7 +948,10 @@ public class GenericCalendarImporter implements CalendarImporterService
 			}
 		});
 
-		return getPrototypeEvents(scheduleImport.filterEvents(rowList, customFieldPropertyNames), customFieldPropertyNames);
+		// Calendar time zone remains over user time zone
+		String tzid = calendarTzid==null ? userTzid:calendarTzid;
+		
+		return getPrototypeEvents(scheduleImport.filterEvents(rowList, customFieldPropertyNames, tzid), customFieldPropertyNames);
 	}
 
 	/**

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/CSVReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/CSVReader.java
@@ -24,9 +24,11 @@ package org.sakaiproject.calendar.impl.readers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -34,7 +36,6 @@ import java.util.Map;
 
 import org.sakaiproject.calendar.impl.GenericCalendarImporter;
 import org.sakaiproject.exception.ImportException;
-import org.sakaiproject.time.api.TimeBreakdown;
 import org.sakaiproject.util.ResourceLoader;
 
 /**
@@ -73,8 +74,9 @@ public class CSVReader extends Reader
 	 * Import a CSV file from a stream and callback on each row.
 	 * @param stream Stream of CSV (or other delimited data)
 	 * @param handler Callback for each row.
+	 * @return tzid of calendar (returns null if it does not exist) 
 	 */
-	public void importStreamFromDelimitedFile(
+	public String importStreamFromDelimitedFile(
 		InputStream stream,
 		ReaderImportRowHandler handler) throws ImportException
 	{
@@ -137,6 +139,9 @@ public class CSVReader extends Reader
 			// If we get this far, increment the line counter.
 			lineNumber++;
 		}
+		
+		// tzid of calendar
+		return null;
 	}
 
 	/**
@@ -208,10 +213,18 @@ public class CSVReader extends Reader
 	}
 
 	/* (non-Javadoc)
-	 * @see org.sakaiproject.tool.calendar.schedimportreaders.Reader#filterEvents(java.util.List, java.lang.String[])
+	 * @see org.sakaiproject.tool.calendar.schedimportreaders.Reader#filterEvents(java.util.List, java.lang.String[], String)
 	 */
-	public List filterEvents(List events, String[] customFieldNames) throws ImportException
+	public List filterEvents(List events, String[] customFieldNames, String tzid) throws ImportException
 	{
+		ZoneId dstZoneId = ZoneId.of(getTimeService().getLocalTimeZone().getID());		
+		ZoneId srcZoneId;
+		if (tzid != null) {
+			srcZoneId = ZoneId.of(tzid);
+		} else {
+			srcZoneId = dstZoneId;
+		}
+		
 		setColumnDelimiter(",");
 		
 		Map augmentedMapping = getDefaultColumnMap();
@@ -240,87 +253,39 @@ public class CSVReader extends Reader
 		{
 			Map eventProperties = (Map)it.next();
 
+			Date startDate = (Date) eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.DATE_DEFAULT_COLUMN_HEADER));
 			Date startTime = (Date) eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.START_TIME_DEFAULT_COLUMN_HEADER));
-			TimeBreakdown startTimeBreakdown = null;
-			
-			if ( startTime != null )
-			{
-            // if the source time zone were known, this would be
-            // a good place to set it: startCal.setTimeZone()
-            GregorianCalendar startCal = new GregorianCalendar();
-            startCal.setTimeInMillis( startTime.getTime() );
-            startTimeBreakdown = 
-                    getTimeService().newTimeBreakdown( 0, 0, 0, 
-                       startCal.get(Calendar.HOUR_OF_DAY),
-                       startCal.get(Calendar.MINUTE),
-                       startCal.get(Calendar.SECOND),
-                        0 );
-			}
-			
 			Integer durationInMinutes = (Integer)eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.DURATION_DEFAULT_COLUMN_HEADER));
 
-			if ( durationInMinutes == null )
-			{
-            Integer line = Integer.valueOf(lineNumber);
-				String msg = (String)rb.getFormattedMessage("err_no_dur", 
-                                                        new Object[]{line});
+			if (startTime == null ) {
+				Integer line = Integer.valueOf(lineNumber);
+				String msg = (String)rb.getFormattedMessage("err_no_stime_on", new Object[]{line});
+				throw new ImportException( msg );
+			}
+			if (startDate == null) {
+	            Integer line = Integer.valueOf(lineNumber);
+				String msg = (String)rb.getFormattedMessage("err_no_start", new Object[]{line});
+				throw new ImportException( msg );
+			}
+			if (durationInMinutes == null) {
+				Integer line = Integer.valueOf(lineNumber);
+				String msg = (String)rb.getFormattedMessage("err_no_dur", new Object[]{line});
 				throw new ImportException( msg );
 			}
 			
-			Date endTime =
-				new Date(
-					startTime.getTime()
-						+ (durationInMinutes.longValue() * 60 * 1000));
+			// Raw date + raw time
+			Instant startInstant = startDate.toInstant().plusMillis(startTime.getTime());
 
-			TimeBreakdown endTimeBreakdown = null;
-
-			if ( endTime != null )
-			{
-            // if the source time zone were known, this would be
-            // a good place to set it: endCal.setTimeZone()
-            GregorianCalendar endCal = new GregorianCalendar();
-            endCal.setTimeInMillis( endTime.getTime() );
-            endTimeBreakdown = 
-                    getTimeService().newTimeBreakdown( 0, 0, 0, 
-                       endCal.get(Calendar.HOUR_OF_DAY),
-                       endCal.get(Calendar.MINUTE),
-                       endCal.get(Calendar.SECOND),
-                       0 );
-			}
-
-			Date startDate = (Date) eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.DATE_DEFAULT_COLUMN_HEADER));
-			TimeBreakdown startDateBreakdown = null;
+			// Raw + calendar/owner TZ's offset
+			ZonedDateTime srcZonedDateTime = startInstant.atZone(srcZoneId);
+			long millis = startInstant.plusMillis(srcZonedDateTime.getOffset().getTotalSeconds() * 1000).toEpochMilli();
 			
-			if ( startDate != null )
-			{
-            // if the source time zone were known, this would be
-            // a good place to set it: endCal.setTimeZone()
-            GregorianCalendar startCal = new GregorianCalendar();
-            startCal.setTimeInMillis( startDate.getTime() );
-            
-            startTimeBreakdown.setYear( startCal.get(Calendar.YEAR) );
-            startTimeBreakdown.setMonth( startCal.get(Calendar.MONTH)+1 );
-            startTimeBreakdown.setDay( startCal.get(Calendar.DAY_OF_MONTH) );
-            
-            endTimeBreakdown.setYear( startCal.get(Calendar.YEAR) );
-            endTimeBreakdown.setMonth( startCal.get(Calendar.MONTH)+1 );
-            endTimeBreakdown.setDay( startCal.get(Calendar.DAY_OF_MONTH) );
-			}
-			else
-			{
-            Integer line = Integer.valueOf(lineNumber);
-				String msg = (String)rb.getFormattedMessage("err_no_start", 
-                                                        new Object[]{line});
-				throw new ImportException( msg );
-			}
+			// Duration of event
+			Duration gapMinutes = Duration.ofMinutes(durationInMinutes);
 			
-			eventProperties.put(
-				GenericCalendarImporter.ACTUAL_TIMERANGE,
-				getTimeService().newTimeRange(
-               getTimeService().newTimeLocal(startTimeBreakdown),
-               getTimeService().newTimeLocal(endTimeBreakdown),
-					true,
-					false));
+			// Time Service will ajust to current user's TZ
+			eventProperties.put(GenericCalendarImporter.ACTUAL_TIMERANGE,
+				getTimeService().newTimeRange(millis, gapMinutes.toMillis()));
 					
 			lineNumber++;
 		}

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/MeetingMakerReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/MeetingMakerReader.java
@@ -24,9 +24,11 @@ package org.sakaiproject.calendar.impl.readers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Calendar;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -34,7 +36,6 @@ import java.util.Map;
 
 import org.sakaiproject.calendar.impl.GenericCalendarImporter;
 import org.sakaiproject.exception.ImportException;
-import org.sakaiproject.time.api.TimeBreakdown;
 import org.sakaiproject.util.ResourceLoader;
 
 /**
@@ -60,7 +61,7 @@ public class MeetingMakerReader extends Reader
 	/* (non-Javadoc)
 	 * @see org.sakaiproject.tool.calendar.ImportReader#importStreamFromDelimitedFile(java.io.InputStream, org.sakaiproject.tool.calendar.ImportReader.ReaderImportRowHandler)
 	 */
-	public void importStreamFromDelimitedFile(
+	public String importStreamFromDelimitedFile(
 		InputStream stream,
 		ReaderImportRowHandler handler)
 		throws ImportException
@@ -205,13 +206,25 @@ public class MeetingMakerReader extends Reader
 			// If we get this far, increment the line counter.
 			lineNumber++;
 		}
+		
+		// tzid of calendar
+		return null;
+
 	}
 
 	/* (non-Javadoc)
-	 * @see org.sakaiproject.tool.calendar.schedimportreaders.Reader#filterEvents(java.util.List, java.lang.String[])
+	 * @see org.sakaiproject.tool.calendar.schedimportreaders.Reader#filterEvents(java.util.List, java.lang.String[], String)
 	 */
-	public List filterEvents(List events, String[] customFieldNames) throws ImportException
+	public List filterEvents(List events, String[] customFieldNames, String tzid) throws ImportException
 	{
+		ZoneId dstZoneId = ZoneId.of(getTimeService().getLocalTimeZone().getID());		
+		ZoneId srcZoneId;
+		if (tzid != null) {
+			srcZoneId = ZoneId.of(tzid);
+		} else {
+			srcZoneId = dstZoneId;
+		}
+		
 		Iterator it = events.iterator();
 		int lineNumber = 1;
 		
@@ -224,82 +237,38 @@ public class MeetingMakerReader extends Reader
 			Map eventProperties = (Map)it.next();
 
 			Date startTime = (Date) eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.START_TIME_DEFAULT_COLUMN_HEADER));
-			TimeBreakdown startTimeBreakdown = null;
-			
-			if ( startTime != null )
-			{
-            // if the source time zone were known, this would be
-            // a good place to set it: startCal.setTimeZone()
-            GregorianCalendar startCal = new GregorianCalendar();
-            startCal.setTimeInMillis( startTime.getTime() );
-            startTimeBreakdown = 
-                    getTimeService().newTimeBreakdown( 0, 0, 0, 
-                       startCal.get(Calendar.HOUR_OF_DAY),
-                       startCal.get(Calendar.MINUTE),
-                       startCal.get(Calendar.SECOND),
-                        0 );
-			}
-			else
-			{
-            Integer line = Integer.valueOf(lineNumber);
-				String msg = (String)rb.getFormattedMessage("err_no_stime_on", 
-                                                        new Object[]{line});
-				throw new ImportException( msg );
-			}
-			
-			Integer durationInMinutes = (Integer)eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.DURATION_DEFAULT_COLUMN_HEADER));
-
-			if ( durationInMinutes == null )
-			{
-            Integer line = Integer.valueOf(lineNumber);
-				String msg = (String)rb.getFormattedMessage("err_no_dtime_on", 
-                                                        new Object[]{line});
-				throw new ImportException( msg );
-			}
-			
-			Date endTime =
-				new Date(
-					startTime.getTime() + (durationInMinutes.longValue() * 60 * 1000) );
-					
-			TimeBreakdown endTimeBreakdown = null;
-
-			if ( endTime != null )
-			{
-            // if the source time zone were known, this would be
-            // a good place to set it: endCal.setTimeZone()
-            GregorianCalendar endCal = new GregorianCalendar();
-            endCal.setTimeInMillis( endTime.getTime() );
-            endTimeBreakdown = 
-                    getTimeService().newTimeBreakdown( 0, 0, 0, 
-                       endCal.get(Calendar.HOUR_OF_DAY),
-                       endCal.get(Calendar.MINUTE),
-                       endCal.get(Calendar.SECOND),
-                       0 );
-			}
-
 			Date startDate = (Date) eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.DATE_DEFAULT_COLUMN_HEADER));
+			Integer durationInMinutes = (Integer)eventProperties.get(defaultHeaderMap.get(GenericCalendarImporter.DURATION_DEFAULT_COLUMN_HEADER));
 			
-         // if the source time zone were known, this would be
-         // a good place to set it: startCal.setTimeZone()
-         GregorianCalendar startCal = new GregorianCalendar();
-			if ( startDate != null )
-            startCal.setTimeInMillis( startDate.getTime() );
-            
-         startTimeBreakdown.setYear( startCal.get(Calendar.YEAR) );
-         startTimeBreakdown.setMonth( startCal.get(Calendar.MONTH)+1 );
-         startTimeBreakdown.setDay( startCal.get(Calendar.DAY_OF_MONTH) );
-            
-         endTimeBreakdown.setYear( startCal.get(Calendar.YEAR) );
-         endTimeBreakdown.setMonth( startCal.get(Calendar.MONTH)+1 );
-         endTimeBreakdown.setDay( startCal.get(Calendar.DAY_OF_MONTH) );
+			if (startTime == null ) {
+				Integer line = Integer.valueOf(lineNumber);
+				String msg = (String)rb.getFormattedMessage("err_no_stime_on", new Object[]{line});
+				throw new ImportException( msg );
+			}
+			if (startDate == null) {
+	            Integer line = Integer.valueOf(lineNumber);
+				String msg = (String)rb.getFormattedMessage("err_no_start", new Object[]{line});
+				throw new ImportException( msg );
+			}
+			if (durationInMinutes == null) {
+				Integer line = Integer.valueOf(lineNumber);
+				String msg = (String)rb.getFormattedMessage("err_no_dur", new Object[]{line});
+				throw new ImportException( msg );
+			}
 			
-			eventProperties.put(
-				GenericCalendarImporter.ACTUAL_TIMERANGE,
-				getTimeService().newTimeRange(
-                    getTimeService().newTimeLocal(startTimeBreakdown),
-                    getTimeService().newTimeLocal(endTimeBreakdown),
-					true,
-					false));
+			// Raw date + raw time
+			Instant startInstant = startDate.toInstant().plusMillis(startTime.getTime());
+
+			// Raw + calendar/owner TZ's offset
+			ZonedDateTime srcZonedDateTime = startInstant.atZone(srcZoneId);
+			long millis = startInstant.plusMillis(srcZonedDateTime.getOffset().getTotalSeconds() * 1000).toEpochMilli();
+			
+			// Duration of event
+			Duration gapMinutes = Duration.ofMinutes(durationInMinutes);
+			
+			// Time Service will ajust to current user's TZ
+			eventProperties.put(GenericCalendarImporter.ACTUAL_TIMERANGE,
+				getTimeService().newTimeRange(millis, gapMinutes.toMillis()));
 					
 			lineNumber++;
 		}

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/Reader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/Reader.java
@@ -282,8 +282,9 @@ public abstract class Reader
 	 * Import a CSV file from a stream and callback on each row.
 	 * @param stream Stream of CSV (or other delimited data)
 	 * @param handler Callback for each row.
+	 * @return tzid of calendar (returns null if it does not exist)
 	 */
-	abstract public void importStreamFromDelimitedFile(
+	abstract public String importStreamFromDelimitedFile(
 		InputStream stream,
 		ReaderImportRowHandler handler)
 		throws ImportException;
@@ -305,9 +306,10 @@ public abstract class Reader
 	 * that will define the actual start time/date of the event.
 	 * @param importStream
 	 * @param customFieldNames
+	 * @param tzid
 	 * @throws ImportException
 	 */
-	abstract public List filterEvents(List events, String[] customFieldNames) throws ImportException;
+	abstract public List filterEvents(List events, String[] customFieldNames, String tzid) throws ImportException;
 
 	/**
 	 * Derived classes must provide a default mapping of text column header labels in the import file to

--- a/calendar/calendar-impl/impl/src/test/org/sakaiproject/calendar/impl/SubscriptionCacheTest.java
+++ b/calendar/calendar-impl/impl/src/test/org/sakaiproject/calendar/impl/SubscriptionCacheTest.java
@@ -71,7 +71,7 @@ public class SubscriptionCacheTest {
     @Test
     public void testCacheGetPresent() {
         BaseExternalSubscriptionDetails value = new BaseExternalSubscriptionDetails(
-                "test", "http://example.com/", "siteId", null, false, true, null, Instant.now(clock));
+                "test", "http://example.com/", "siteId", null, false, null, null, true, null, Instant.now(clock));
         when(cache.get("http://example.com/")).thenReturn(value);
         assertEquals(value, subscriptionCache.get("http://example.com/"));
         assertEquals(value, subscriptionCache.get("http://example.com/"));
@@ -80,7 +80,7 @@ public class SubscriptionCacheTest {
     @Test
     public void testCacheGetFailureNew() {
         BaseExternalSubscriptionDetails value = new BaseExternalSubscriptionDetails(
-                "test", "http://example.com/", "siteId", null, false, false, null, Instant.now(clock));
+                "test", "http://example.com/", "siteId", null, false, null, null, false, null, Instant.now(clock));
         when(cache.get("http://example.com/")).thenReturn(value);
         // Still not expired.
         assertEquals(value, subscriptionCache.get("http://example.com/"));
@@ -89,7 +89,7 @@ public class SubscriptionCacheTest {
     @Test
     public void testCacheGetFailureOld() {
         BaseExternalSubscriptionDetails value = new BaseExternalSubscriptionDetails(
-                "test", "http://example.com/", "siteId", null, false, false, null, Instant.now(clock).minus(2, ChronoUnit.MINUTES));
+                "test", "http://example.com/", "siteId", null, false, null, null, false, null, Instant.now(clock).minus(2, ChronoUnit.MINUTES));
         when(cache.get("http://example.com/")).thenReturn(value);
         // Now should have expired.
         assertNull(subscriptionCache.get("http://example.com/"));

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.Vector;
+import java.util.stream.Collectors;
 import java.util.Map.Entry;
 
 import lombok.extern.slf4j.Slf4j;
@@ -1713,7 +1714,10 @@ extends VelocityPortletStateAction
 						.getIdFromSubscriptionUrl(calendarUrl);
 				String ref = externalCalendarSubscriptionService
 						.calendarSubscriptionReference(contextId, id);
-				addSubscriptions.add(new SubscriptionWrapper(calendarName, ref, true));
+				String currentUserId = sessionManager.getCurrentSessionUserId();
+				String currentUserTzid = TimeService.getLocalTimeZone().getID();
+				
+				addSubscriptions.add(new SubscriptionWrapper(calendarName, ref, currentUserId, currentUserTzid, true));
 
 				// Sort collections by name
 				Collections.sort(addSubscriptions);
@@ -1769,6 +1773,7 @@ extends VelocityPortletStateAction
 			List<SubscriptionWrapper> addSubscriptions = (List<SubscriptionWrapper>) sstate
 					.getAttribute(CalendarAction.SSTATE_ATTRIBUTE_ADDSUBSCRIPTIONS);
 			List<String> subscriptionTC = new LinkedList<String>();
+			List<String> subscriptionTCWithTZ = new LinkedList<String>();
 			ParameterParser params = runData.getParameters();
 
 			// Institutional Calendars
@@ -1792,7 +1797,24 @@ extends VelocityPortletStateAction
 					{
 						String name = add.getDisplayName();
 						if (name == null || name.equals("")) name = add.getUrl();
-						subscriptionTC.add(add.getReference() + ExternalCalendarSubscriptionService.SUBS_NAME_DELIMITER + name);
+
+						if (add.getUserId()==null) {
+							// Backward compatibility: reference/name
+							StringBuilder sb = new StringBuilder(add.getReference());
+							sb.append(ExternalCalendarSubscriptionService.SUBS_NAME_DELIMITER);
+							sb.append(name);
+							subscriptionTC.add(sb.toString());
+						} else {
+							// With TZ: reference/user/tzid/name
+							StringBuilder sb = new StringBuilder(add.getReference());
+							sb.append(ExternalCalendarSubscriptionService.SUBS_NAME_DELIMITER);
+							sb.append(add.getUserId());
+							sb.append(ExternalCalendarSubscriptionService.SUBS_NAME_DELIMITER);
+							sb.append(add.getUserTzid());
+							sb.append(ExternalCalendarSubscriptionService.SUBS_NAME_DELIMITER);
+							sb.append(name);
+							subscriptionTCWithTZ.add(sb.toString());
+						}
 					}
 				}
 			}
@@ -1804,18 +1826,19 @@ extends VelocityPortletStateAction
 				Properties config = placement.getPlacementConfig();
 				if (config != null)
 				{
-					boolean first = true;
-					StringBuilder propValue = new StringBuilder();
-					for (String ref : subscriptionTC)
-					{
-						if (!first) propValue.append(ExternalCalendarSubscriptionService.SUBS_REF_DELIMITER);
-						first = false;
-						propValue.append(ref);
+					String propValue = "";
+					if (!subscriptionTC.isEmpty()) {
+						propValue = subscriptionTC.stream().collect(Collectors.joining(ExternalCalendarSubscriptionService.SUBS_REF_DELIMITER));										
 					}
-					config.setProperty(
-							ExternalCalendarSubscriptionService.TC_PROP_SUBCRIPTIONS,
-							propValue.toString());
-	
+					
+					String propValueWithTZ = "";
+					if (!subscriptionTCWithTZ.isEmpty()) {
+						propValueWithTZ = subscriptionTCWithTZ.stream().collect(Collectors.joining(ExternalCalendarSubscriptionService.SUBS_REF_DELIMITER));										
+					}
+					
+					config.setProperty(ExternalCalendarSubscriptionService.TC_PROP_SUBCRIPTIONS, propValue);
+					config.setProperty(ExternalCalendarSubscriptionService.TC_PROP_SUBCRIPTIONS_WITH_TZ, propValueWithTZ);
+					
 					// commit the change
 					saveOptions();
 				}
@@ -1848,6 +1871,10 @@ extends VelocityPortletStateAction
 
 			private boolean isSelected;
 
+			private String userId;
+			
+			private String userTzid;
+			
 			public SubscriptionWrapper()
 			{
 			}
@@ -1859,9 +1886,13 @@ extends VelocityPortletStateAction
 				this.displayName = subscription.getSubscriptionName();
 				this.isInstitutional = subscription.isInstitutional();
 				this.isSelected = selected;
+				if (subscription.getUserId()!=null) {
+					this.setUserId(subscription.getUserId());
+				}
+				this.setUserTzid(subscription.getTzid());
 			}
 
-			public SubscriptionWrapper(String calendarName, String ref, boolean selected)
+			public SubscriptionWrapper(String calendarName, String ref, String userId, String userTzid, boolean selected)
 			{
 				Reference _reference = EntityManager.newReference(ref);
 				this.reference = ref;
@@ -1872,6 +1903,8 @@ extends VelocityPortletStateAction
 				this.isInstitutional = externalCalendarSubscriptionService
 						.isInstitutionalCalendar(ref);
 				this.isSelected = selected;
+				this.setUserId(userId);
+				this.setUserTzid(userTzid);
 			}
 
 			public String getReference()
@@ -1922,6 +1955,22 @@ extends VelocityPortletStateAction
 			public void setSelected(boolean isSelected)
 			{
 				this.isSelected = isSelected;
+			}
+			
+			public String getUserId() {
+				return userId;
+			}
+			
+			public void setUserId(String userId) {
+				this.userId = userId;
+			}
+			
+			public String getUserTzid() {
+				return userTzid;
+			}
+			
+			public void setUserTzid(String userTzid) {
+				this.userTzid = userTzid;
 			}
 
 			public int compareTo(SubscriptionWrapper sub)
@@ -2324,12 +2373,12 @@ extends VelocityPortletStateAction
 		
 		// add external calendar subscriptions
       List referenceList = mergedCalendarList.getReferenceList();
-      Set subscriptionRefList = externalCalendarSubscriptionService.getCalendarSubscriptionChannelsForChannels(
+      Set<ExternalSubscriptionDetails> subscriptionDetailsList = externalCalendarSubscriptionService.getCalendarSubscriptionChannelsForChannels(
     		  primaryCalendarReference,
     		  referenceList);
-      referenceList.addAll(subscriptionRefList);
-        
-		return referenceList;
+      subscriptionDetailsList.stream().forEach(x->referenceList.add(x.getReference()));
+      
+      return referenceList;
 	}
 	
 	/**


### PR DESCRIPTION
Calendar tool saves info in tool properties.

**externalCalendarSubscriptions**: tool property for older subscriptions, it contains URL of calendar and a name.
**externalCalendarSubscriptionsWithTZ**: tool property for new subscriptions, it so includes the creator and his time zone.

When calendar subscription is loaded, if the component VTIMEZONE is defined with TZID property, all events will move to *calendar's time zone*.
If VTIMEZONE is not defined in the iCal, all events will move to *owner's time zone*. (Owner's TZ is stored in the new tool property).
If VTIMEZONE is not defined and the calendar owner is not known, the events will move to *current user's time zone*. (It works as before).

Additionally this PR incorporates a fix for SAK-33371.