### PR TITLE
SAK-33864: GBNG > improve performance of Gradebook Import process

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -176,14 +177,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			throw new GradebookSecurityException();
 			}
 
-		@SuppressWarnings({ "unchecked", "rawtypes" })
-		final
-        GradebookAssignment assignment = (GradebookAssignment)getHibernateTemplate().execute(new HibernateCallback() {
-			@Override
-			public Object doInHibernate(final Session session) throws HibernateException {
-				return getAssignmentWithoutStats(gradebookUid, assignmentId);
-			}
-		});
+		GradebookAssignment assignment = getAssignmentWithoutStatsByID(gradebookUid, assignmentId);
 
 		if (assignment == null) {
 			throw new AssessmentNotFoundException("No gradebook item exists with gradable object id = " + assignmentId);
@@ -1697,12 +1691,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
           return new HashMap<>();
       }
 
-      final GradebookAssignment gradebookItem = (GradebookAssignment)getHibernateTemplate().execute(new HibernateCallback() {
-          @Override
-		public Object doInHibernate(final Session session) throws HibernateException {
-              return getAssignmentWithoutStats(gradebookUid, gradableObjectId);
-          }
-      });
+      final GradebookAssignment gradebookItem = getAssignmentWithoutStatsByID(gradebookUid, gradableObjectId);
 
       if (gradebookItem == null) {
           log.debug("The gradebook item does not exist, so returning empty set");
@@ -1805,12 +1794,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 	  if (studentIds != null && !studentIds.isEmpty()) {
 		  // first, we need to make sure the current user is authorized to view the
 		  // grades for all of the requested students
-		  final GradebookAssignment gbItem = (GradebookAssignment)getHibernateTemplate().execute(new HibernateCallback() {
-			  @Override
-			public Object doInHibernate(final Session session) throws HibernateException {
-				  return getAssignmentWithoutStats(gradebookUid, gradableObjectId);
-			  }
-		  });
+		  final GradebookAssignment gbItem = getAssignmentWithoutStatsByID(gradebookUid, gradableObjectId);
 
 		  if (gbItem != null) {
 			  final Gradebook gradebook = gbItem.getGradebook();
@@ -2144,7 +2128,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		  throw new IllegalArgumentException("Null gradebookUid or gradableObjectId passed to saveGradesAndComments");
 	  }
 
-	  if (gradeDefList != null) {
+	  if (CollectionUtils.isNotEmpty(gradeDefList)) {
 		  Gradebook gradebook;
 
 		  try {
@@ -2154,13 +2138,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 					  gradebookUid + "Error: " + gnfe.getMessage());
 		  }
 
-		  final GradebookAssignment assignment = (GradebookAssignment)getHibernateTemplate().execute(new HibernateCallback() {
-			  @Override
-			public Object doInHibernate(final Session session) throws HibernateException {
-				  return getAssignmentWithoutStats(gradebookUid, gradableObjectId);
-			  }
-		  });
-
+		  final GradebookAssignment assignment = getAssignmentWithoutStatsByID(gradebookUid, gradableObjectId);
 		  if (assignment == null) {
 			  throw new AssessmentNotFoundException("No gradebook item exists with gradable object id = " + gradableObjectId);
 		  }
@@ -2170,7 +2148,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			  throw new GradebookSecurityException();
 		  }
 
-		  // let's identify all of the students being updated first
+		  // identify all of the students being updated first
 		  final Map<String, GradeDefinition> studentIdGradeDefMap = new HashMap<>();
 		  final Map<String, String> studentIdToGradeMap = new HashMap<>();
 
@@ -2179,59 +2157,49 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			  studentIdToGradeMap.put(gradeDef.getStudentUid(), gradeDef.getGrade());
 		  }
 
-		  // check for invalid grades
-		  final List invalidStudents = identifyStudentsWithInvalidGrades(gradebookUid, studentIdToGradeMap);
-		  if (invalidStudents != null && !invalidStudents.isEmpty()) {
-			  throw new InvalidGradeException ("At least one grade passed to be updated is invalid. No grades or comments were updated.");
+		  /* TODO: this check may be unnecessary if we're validating grades in the first step of the grade import wizard
+				BUT, this can only be removed if the only place it's used is in the grade import (other places may not
+				perform the grade validation prior to calling this
+		  */
+		  // Check for invalid grades
+		  List<String> invalidStudentUUIDs = identifyStudentsWithInvalidGrades(gradebookUid, studentIdToGradeMap);
+		  if (CollectionUtils.isNotEmpty(invalidStudentUUIDs)) {
+			  throw new InvalidGradeException("At least one grade passed to be updated is " + "invalid. No grades or comments were updated.");
 		  }
 
-		  final boolean userHasGradeAllPerm = currentUserHasGradeAllPerm(gradebookUid);
-
-		  // let's retrieve all of the existing grade recs for the given students
-		  // and assignments
-		  final List<AssignmentGradeRecord> allGradeRecs =
-			  getAllAssignmentGradeRecordsForGbItem(gradableObjectId, studentIdGradeDefMap.keySet());
-
-
-		  // put in map for easier accessibility
-		  final Map<String, AssignmentGradeRecord> studentIdToAgrMap = new HashMap<>();
-		  if (allGradeRecs != null) {
-			  for (final AssignmentGradeRecord rec : allGradeRecs) {
-				  studentIdToAgrMap.put(rec.getStudentId(), rec);
+		  // Retrieve all existing grade records for the given students and assignment
+		  List<AssignmentGradeRecord> existingGradeRecords = getAllAssignmentGradeRecordsForGbItem(gradableObjectId, studentIdGradeDefMap.keySet());
+		  Map<String, AssignmentGradeRecord> studentIdGradeRecordMap = new HashMap<>();
+		  if (CollectionUtils.isNotEmpty(existingGradeRecords)) {
+			  for (AssignmentGradeRecord agr : existingGradeRecords) {
+				  studentIdGradeRecordMap.put(agr.getStudentId(), agr);
 			  }
 		  }
 
-		  // set up the grader and grade time
-		  final String graderId = getAuthn().getUserUid();
-		  final Date now = new Date();
+		  // Retrieve all existing comments for the given students and assignment
+		  List<Comment> existingComments = getComments(assignment, studentIdGradeDefMap.keySet());
+		  final Map<String, Comment> studentIdCommentMap = new HashMap<>();
+		  if (CollectionUtils.isNotEmpty(existingComments)) {
+			  for (Comment comment : existingComments) {
+				  studentIdCommentMap.put(comment.getStudentId(), comment);
+			  }
+		  }
 
-		  // get grade mapping, if nec, to convert grades to points
+		  boolean userHasGradeAllPerm = currentUserHasGradeAllPerm(gradebookUid);
+		  String graderId = getAuthn().getUserUid();
+		  Date now = new Date();
 		  LetterGradePercentMapping mapping = null;
 		  if (gradebook.getGrade_type() == GradebookService.GRADE_TYPE_LETTER) {
 			  mapping = getLetterGradePercentMapping(gradebook);
 		  }
 
-		  // get all of the comments, as well
-		  final List<Comment> allComments = getComments(assignment, studentIdGradeDefMap.keySet());
-		  // put in a map for easier accessibility
-		  final Map<String, Comment> studentIdCommentMap = new HashMap<>();
-		  if (allComments != null) {
-			  for (final Comment comment : allComments) {
-				  studentIdCommentMap.put(comment.getStudentId(), comment);
-			  }
-		  }
-
-		  // these are the records that will need to be updated. iterate through
-		  // everything and then we'll save it all at once
-		  final Set<AssignmentGradeRecord> agrToUpdate = new HashSet<>();
-		  // do not use a HashSet b/c you may have multiple Comments with null id and the same comment at this point.
-		  // the Comment object defines objects as equal if they have the same id, comment text, and gb item. the
-		  // only difference may be the student ids
+		  // Don't use a HashSet because you may have multiple Comments with null ID and the same comment at this point.
+		  // The Comment object defines objects as equal if they have the same ID, comment text, and gradebook item. The
+		  // only difference may be the student IDs
 		  final List<Comment> commentsToUpdate = new ArrayList<>();
 		  final Set<GradingEvent> eventsToAdd = new HashSet<>();
-
+		  Set<AssignmentGradeRecord> gradeRecordsToUpdate = new HashSet<>();
 		  for (final GradeDefinition gradeDef : gradeDefList) {
-
 			  final String studentId = gradeDef.getStudentUid();
 
 			  // use the grader ID from the definition if it is not null, otherwise use the current user ID
@@ -2239,86 +2207,76 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			  // use the grade date from the definition if it is not null, otherwise use the current date
 			  final Date gradedDate = gradeDef.getDateRecorded() != null ? gradeDef.getDateRecorded() : now;
 
-			  // check specific grading privileges if user does not have
-			  // grade all perm
+			  // check specific grading privileges if user does not have grade all perm
 			  if (!userHasGradeAllPerm) {
 				  if (!isUserAbleToGradeItemForStudent(gradebookUid, gradableObjectId, studentId)) {
 					  log.warn("User {} attempted to save a grade for {} without authorization", graderId, studentId);
-
 					  throw new GradebookSecurityException();
 				  }
 			  }
 
-			  final Double convertedGrade = convertInputGradeToPoints(gradebook.getGrade_type(), mapping, assignment.getPointsPossible(), gradeDef.getGrade());
-
-			  // let's see if this agr needs to be updated
-			  AssignmentGradeRecord gradeRec = studentIdToAgrMap.get(studentId);
+			  // Determine if the AssignmentGradeRecord needs to be updated
+			  String newGrade = StringUtils.trimToEmpty(gradeDef.getGrade());
+			  Double convertedGrade = convertInputGradeToPoints(gradebook.getGrade_type(), mapping, assignment.getPointsPossible(), newGrade);
+			  AssignmentGradeRecord gradeRec = studentIdGradeRecordMap.get(studentId);
 			  if (gradeRec != null) {
-				  if ((convertedGrade == null && gradeRec.getPointsEarned() != null) ||
-						  (convertedGrade != null && gradeRec.getPointsEarned() == null) ||
-						  (convertedGrade != null && gradeRec.getPointsEarned() != null &&
-								  !convertedGrade.equals(gradeRec.getPointsEarned()))) {
+				  Double pointsEarned = gradeRec.getPointsEarned();
+				  if ((convertedGrade == null && pointsEarned != null)
+						  || (convertedGrade != null && pointsEarned == null)
+						  || (convertedGrade != null && pointsEarned != null && !convertedGrade.equals(pointsEarned))) {
 
 					  gradeRec.setPointsEarned(convertedGrade);
 					  gradeRec.setGraderId(graderUid);
 					  gradeRec.setDateRecorded(gradedDate);
+					  gradeRecordsToUpdate.add(gradeRec);
 
-					  agrToUpdate.add(gradeRec);
-
-					  // we also need to add a GradingEvent
-					  // the event stores the actual input grade, not the converted one
-					  final GradingEvent event = new GradingEvent(assignment, graderUid, studentId, gradeDef.getGrade());
+					  // Add a GradingEvent, which stores the actual input grade rather than the converted one
+					  GradingEvent event = new GradingEvent(assignment, graderId, studentId, newGrade);
 					  eventsToAdd.add(event);
 				  }
 			  } else {
 				  // if the grade is something other than null, add a new AGR
-				  if (gradeDef.getGrade() != null && !gradeDef.getGrade().trim().equals("")) {
+				  if (StringUtils.isNotBlank(newGrade)) {
 					  gradeRec =  new AssignmentGradeRecord(assignment, studentId, convertedGrade);
-					  gradeRec.setPointsEarned(convertedGrade);
 					  gradeRec.setGraderId(graderUid);
 					  gradeRec.setDateRecorded(gradedDate);
+					  gradeRecordsToUpdate.add(gradeRec);
 
-					  agrToUpdate.add(gradeRec);
-
-					  // we also need to add a GradingEvent
-					  // the event stores the actual input grade, not the converted one
-					  final GradingEvent event = new GradingEvent(assignment, graderUid, studentId, gradeDef.getGrade());
+					  // Add a GradingEvent, which stores the actual input grade rather than the converted one
+					  final GradingEvent event = new GradingEvent(assignment, graderId, studentId, newGrade);
 					  eventsToAdd.add(event);
 				  }
 			  }
 
-			  // let's see if the comment needs to be updated
+			  // Determine if the Comment needs to be updated
 			  Comment comment = studentIdCommentMap.get(studentId);
+			  String newCommentText = StringUtils.trimToEmpty(gradeDef.getGradeComment());
 			  if (comment != null) {
-				  final boolean oldCommentIsNull = comment.getCommentText() == null || comment.getCommentText().equals("");
-				  final boolean newCommentIsNull = gradeDef.getGradeComment() == null || gradeDef.getGradeComment().equals("");
-
-				  if ((oldCommentIsNull && !newCommentIsNull) ||
-						  (!oldCommentIsNull && newCommentIsNull) ||
-						  (!oldCommentIsNull && !newCommentIsNull &&
-								  !gradeDef.getGradeComment().equals(comment.getCommentText()))) {
-					  // update this comment
-					  comment.setCommentText(gradeDef.getGradeComment());
-					  comment.setGraderId(graderUid);
+				  String existingCommentText = StringUtils.trimToEmpty(comment.getCommentText());
+				  boolean existingCommentTextIsEmpty = existingCommentText.isEmpty();
+				  boolean newCommentTextIsEmpty = newCommentText.isEmpty();
+				  if ((existingCommentTextIsEmpty && !newCommentTextIsEmpty)
+						  || (!existingCommentTextIsEmpty && newCommentTextIsEmpty)
+						  || (!existingCommentTextIsEmpty && !newCommentTextIsEmpty && !newCommentText.equals(existingCommentText))) {
+					  comment.setCommentText(newCommentText);
+					  comment.setGraderId(graderId);
 					  comment.setDateRecorded(gradedDate);
-
 					  commentsToUpdate.add(comment);
 				  }
 			  } else {
-				  // if there is a comment, add it
-				  if (gradeDef.getGradeComment() != null && !gradeDef.getGradeComment().trim().equals("")) {
-					  comment = new Comment(studentId, gradeDef.getGradeComment(), assignment);
-					  comment.setGraderId(graderUid);
+				  // If the comment is something other than null, add a new Comment
+				  if (!newCommentText.isEmpty()) {
+					  comment = new Comment(studentId, newCommentText, assignment);
+					  comment.setGraderId(graderId);
 					  comment.setDateRecorded(gradedDate);
-
 					  commentsToUpdate.add(comment);
 				  }
 			  }
 		  }
 
-		  // now let's save them
+		  // Save or update the necessary items
 		  try {
-			for (final AssignmentGradeRecord assignmentGradeRecord : agrToUpdate) {
+			for (final AssignmentGradeRecord assignmentGradeRecord : gradeRecordsToUpdate) {
 				getHibernateTemplate().saveOrUpdate(assignmentGradeRecord);
 			}
 			for (final Comment comment : commentsToUpdate) {
@@ -2327,19 +2285,30 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			for (final GradingEvent gradingEvent : eventsToAdd) {
 				getHibernateTemplate().saveOrUpdate(gradingEvent);
 			}
-		  }	catch (final HibernateOptimisticLockingFailureException holfe) {
+		  } catch (final HibernateOptimisticLockingFailureException | StaleObjectStateException holfe) {
 			  if(log.isInfoEnabled()) {
 				log.info("An optimistic locking failure occurred while attempting to save scores and comments for gb Item " + gradableObjectId);
-			}
+			  }
 			  throw new StaleObjectModificationException(holfe);
-		  } catch (final StaleObjectStateException sose) {
-			  if(log.isInfoEnabled()) {
-				log.info("An optimistic locking failure occurred while attempting to save scores and comments for gb Item " + gradableObjectId);
-			}
-			  throw new StaleObjectModificationException(sose);
 		  }
 	  }
   }
+
+	/**
+	 * Helper method to retrieve Assignment by ID without stats for the given gradebook.
+	 * Reduces code duplication in several areas.
+	 *
+	 * @param gradebookUID
+	 * @param gradeableObjectID
+	 * @return
+	 */
+	private GradebookAssignment getAssignmentWithoutStatsByID(final String gradebookUID, final Long gradeableObjectID) {
+		return (GradebookAssignment) getHibernateTemplate().execute(new HibernateCallback() {
+			public Object doInHibernate(Session session) throws HibernateException {
+				return getAssignmentWithoutStats(gradebookUID, gradeableObjectID);
+			}
+		});
+	}
 
   /**
    *
@@ -2665,12 +2634,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 	        		gradebookUid + " gradebookItemId:" + gradebookItemId);
 	    }
 
-	    final GradebookAssignment gbItem = (GradebookAssignment)getHibernateTemplate().execute(new HibernateCallback() {
-            @Override
-			public Object doInHibernate(final Session session) throws HibernateException {
-                return getAssignmentWithoutStats(gradebookUid, gradebookItemId);
-            }
-        });
+	    final GradebookAssignment gbItem = getAssignmentWithoutStatsByID(gradebookUid, gradebookItemId);
 
 	    if (gbItem == null) {
 	        throw new AssessmentNotFoundException("No gradebook item found with id " + gradebookItemId);

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -36,8 +36,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections.CollectionUtils;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -2780,7 +2780,6 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
      * of the n highest and the n lowest scores of a
      * student based on the assignment's category
      * @param gradeRecords
-     * @return void
      *
      * NOTE: When the UI changes, this needs to be made private again
      */
@@ -2832,7 +2831,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
             }
         }
 
-        if(categories == null || categories.size() < 1) {
+        if(categories.size() < 1) {
             return;
         }
         for(final Category cat : categories) {
@@ -3876,7 +3875,5 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
         final List<GradebookAssignment> assignments = allAssignments.stream().filter(a -> a.getCategory() == null).collect(Collectors.toList());
         assignments.forEach(a -> a.setCounted(false));
         batchPersistEntities(assignments);
-
 	}
-
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -127,6 +127,7 @@ label.addgradeitem.nocategories = Categories have not been configured.
 label.addgradeitem.categorywithweight = {0} ({1})
 error.addgradeitem.points = Points required and must be a number greater than zero.
 error.addgradeitem.title = Title required and must be unique.
+error.addgradeitem.title.duplicate = The title ''{0}'' is a duplicate. Titles must be unique.
 error.addgradeitem.exception = Error creating Assignment.
 notification.addgradeitem.success = Gradebook item ''{0}'' has been created.
 
@@ -257,6 +258,12 @@ importExport.confirmation.modify.heading = Modifying existing Gradebook Item(s):
 
 importExport.confirmation.title = Title
 importExport.confirmation.points = Points
+importExport.confirmation.extraCredit = Extra Credit
+importExport.confirmation.dueDate = Due date
+importExport.confirmation.releaseToStudents = Release item to students
+importExport.confirmation.includeInCourseGrades = Include item in course grade calculations
+importExport.confirmation.yes = Yes
+importExport.confirmation.no = No
 
 importExport.confirmation.commentsdisplay = {0} (Comments)
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -153,6 +153,7 @@ public class GradebookNgBusinessService {
 	/**
 	 * Get a list of all users in the given site that can have grades
 	 *
+	 * @param siteId
 	 * @return a list of users as uuids or null if none
 	 */
 	public List<String> getGradeableUsers(final String siteId) {
@@ -349,6 +350,7 @@ public class GradebookNgBusinessService {
 	/**
 	 * Get a list of assignments in the gradebook in the current site that the current user is allowed to access
 	 *
+	 * @param siteId
 	 * @return a list of assignments or empty list if none/no gradebook
 	 */
 	public List<Assignment> getGradebookAssignments(final String siteId) {
@@ -359,6 +361,7 @@ public class GradebookNgBusinessService {
 	 * Get a list of assignments in the gradebook in the current site that the current user is allowed to access sorted by the provided
 	 * SortType
 	 *
+	 * @param sortBy
 	 * @return a list of assignments or empty list if none/no gradebook
 	 */
 	public List<Assignment> getGradebookAssignments(final SortType sortBy) {
@@ -372,6 +375,7 @@ public class GradebookNgBusinessService {
 	 * This should only be called if you are wanting to view the assignments that a student would see (ie if you ARE a student, or if you
 	 * are an instructor using the student review mode)
 	 *
+	 * @param studentUuid
 	 * @return a list of assignments or empty list if none/no gradebook
 	 */
 	public List<Assignment> getGradebookAssignmentsForStudent(final String studentUuid) {
@@ -402,6 +406,7 @@ public class GradebookNgBusinessService {
 	 * Get a list of assignments in the gradebook in the specified site that the current user is allowed to access, sorted by sort order
 	 *
 	 * @param siteId the siteId
+	 * @param sortBy
 	 * @return a list of assignments or empty list if none/no gradebook
 	 */
 	public List<Assignment> getGradebookAssignments(final String siteId, final SortType sortBy) {
@@ -748,11 +753,10 @@ public class GradebookNgBusinessService {
 	 * student summary but could be more for paging etc
 	 *
 	 * @param assignments list of assignments
-	 * @param list of uuids
+	 * @param studentUuids of uuids
 	 * @return
 	 */
-	public List<GbStudentGradeInfo> buildGradeMatrix(final List<Assignment> assignments,
-			final List<String> studentUuids) throws GbException {
+	public List<GbStudentGradeInfo> buildGradeMatrix(final List<Assignment> assignments, final List<String> studentUuids) throws GbException {
 		return this.buildGradeMatrix(assignments, studentUuids, null);
 	}
 
@@ -1570,8 +1574,6 @@ public class GradebookNgBusinessService {
 	 * @param siteId the siteId
 	 * @param assignmentId the assignment we are reordering
 	 * @param order the new order
-	 * @throws IdUnusedException
-	 * @throws PermissionException
 	 */
 	public void updateAssignmentOrder(final String siteId, final long assignmentId, final int order) {
 
@@ -1688,7 +1690,6 @@ public class GradebookNgBusinessService {
 	/**
 	 * Get an GradebookAssignment in the current site given the assignment id
 	 *
-	 * @param siteId
 	 * @param assignmentId
 	 * @return
 	 */

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -565,27 +565,6 @@ public class GradebookNgBusinessService {
 	}
 
 	/**
-	 * Save the grade and comment for a student's assignment. Ignores the concurrency check.
-	 *
-	 * @param assignmentId id of the gradebook assignment
-	 * @param studentUuid uuid of the user
-	 * @param grade grade for the assignment/user
-	 * @param comment optional comment for the grade. Can be null.
-	 *
-	 * @return
-	 */
-	public GradeSaveResponse saveGrade(final Long assignmentId, final String studentUuid, final String grade,
-			final String comment) {
-
-		final Gradebook gradebook = this.getGradebook();
-		if (gradebook == null) {
-			return GradeSaveResponse.ERROR;
-		}
-
-		return this.saveGrade(assignmentId, studentUuid, null, grade, comment);
-	}
-
-	/**
 	 * Save the grade and comment for a student's assignment and do concurrency checking
 	 *
 	 * @param assignmentId id of the gradebook assignment
@@ -738,6 +717,20 @@ public class GradebookNgBusinessService {
 			rval = GradeSaveResponse.ERROR;
 		}
 		return rval;
+	}
+
+	public GradeSaveResponse saveGradesAndCommentsForImport(final Gradebook gradebook, final Assignment assignment, final List<GradeDefinition> gradeDefList) {
+		if (gradebook == null) {
+			return GradeSaveResponse.ERROR;
+		}
+
+		try {
+			gradebookService.saveGradesAndComments(gradebook.getUid(), assignment.getId(), gradeDefList);
+			return GradeSaveResponse.OK;
+		} catch (InvalidGradeException | GradebookNotFoundException | AssessmentNotFoundException e) {
+			log.error("An error occurred saving the grade. {}: {}", e.getClass(), e.getMessage());
+			return GradeSaveResponse.ERROR;
+		}
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItem.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItem.java
@@ -19,11 +19,11 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.builder.CompareToBuilder;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import org.apache.commons.lang.builder.CompareToBuilder;
 
 /**
  * Holds the data about a grade item that is imported from the spreadsheet as well as any edits that happen through the wizard
@@ -118,10 +118,7 @@ public class ProcessedGradeItem implements Serializable, Comparable {
 	 * @return
 	 */
 	public boolean isSelectable() {
-		if (this.status == Status.NEW || this.status == Status.UPDATE || this.status == Status.MODIFIED) {
-			return true;
-		}
-		return false;
+		return this.status == Status.NEW || this.status == Status.UPDATE || this.status == Status.MODIFIED;
 	}
 
 	@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItem.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ProcessedGradeItem.java
@@ -134,4 +134,14 @@ public class ProcessedGradeItem implements Serializable, Comparable {
 				.toComparison();
 	}
 
+	/**
+	 * Collection of fields from the edited assignment. These may differ to the imported fields and need to be used on the confirmation screen.
+	 */
+	@Getter
+	@Setter
+	private String assignmentTitle;
+
+	@Getter
+	@Setter
+	private Double assignmentPoints;
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -690,7 +690,6 @@ public class ImportGradesHelper {
 				}
 				assignmentStudentGradeInfo.addGrade(studentGradeInfo.getStudentEid(), entry.getValue());
 			}
-
 		}
 
 		return assignmentMap;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -288,17 +288,13 @@ public class ImportGradesHelper {
 					row.setStudentName(lineVal);
 					break;
 				case GB_ITEM_WITH_POINTS:
-					//Fix the separator for the comparison with the current values
-					if(",".equals(userCSVSeparator) && StringUtils.isNotBlank(lineVal)){
-						lineVal = lineVal.replace(",",".");
-					}
-					cell.setScore(lineVal);
-					row.getCellMap().put(columnTitle, cell);
-					break;
+					// fall into next case (same impl)
 				case GB_ITEM_WITHOUT_POINTS:
-					//Fix the separator for the comparison with the current values
-					if(",".equals(userCSVSeparator) && StringUtils.isNotBlank(lineVal)){
-						lineVal = lineVal.replace(",",".");
+					// fix the separator for the comparison with the current values
+					if (StringUtils.isNotBlank(lineVal)) {
+						if (",".equals(userCSVSeparator)) {
+							lineVal = lineVal.replace(",",".");
+						}
 						cell.setScore(lineVal);
 					}
 					row.getCellMap().put(columnTitle, cell);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/ImportWizardModel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/ImportWizardModel.java
@@ -16,8 +16,9 @@
 package org.sakaiproject.gradebookng.tool.model;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -91,11 +92,11 @@ public class ImportWizardModel implements Serializable {
 	private List<ProcessedGradeItem> itemsToModify;
 
 	/**
-	 * The list of assignments to be created once the form has been filled in
+	 * Maps items from the spreadsheet to the assignments that need to be created once the wizard has been completed
 	 */
 	@Getter
 	@Setter
-	private List<Assignment> assignmentsToCreate = new ArrayList<Assignment>();
+	private Map<ProcessedGradeItem, Assignment> assignmentsToCreate = new LinkedHashMap<>();
 
 	/**
 	 * The {@link UserIdentificationReport} generated during parsing of the raw import file

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.html
@@ -12,7 +12,7 @@
 
         <div class="act">
             <input type="submit" wicket:id="backbutton" wicket:message="value:importExport.button.back"/>
-            <input type="submit" class="active" wicket:message="value:importExport.button.next"/>
+            <input type="submit" wicket:id="nextbutton" wicket:message="value:importExport.button.next" class="active"/>
             <input type="submit" wicket:id="cancelbutton" wicket:message="value:importExport.button.cancel"/>
         </div>
     </form>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
@@ -18,25 +18,26 @@ package org.sakaiproject.gradebookng.tool.panels.importExport;
 import java.util.Collection;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
+
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
+import org.sakaiproject.gradebookng.business.util.ImportGradesHelper;
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.gradebookng.tool.panels.AddOrEditGradeItemPanelContent;
 import org.sakaiproject.gradebookng.tool.panels.BasePanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
-
-import lombok.extern.slf4j.Slf4j;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
-import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.sakaiproject.gradebookng.business.util.ImportGradesHelper;
 
 /**
  * Importer has detected that items need to be created so extract the data and wrap the 'AddOrEditGradeItemPanelContent' panel
@@ -212,6 +213,12 @@ public class CreateGradeItemStep extends BasePanel {
 				.isPresent());
 	}
 
+	/**
+	 * Checks if a new assignment's name is unique amongst the list of assignments to be created.
+	 * @param newAssignment
+	 * @param assignmentsToCreate
+	 * @return
+	 */
 	private boolean assignmentNameIsUnique(final Assignment newAssignment, final Collection<Assignment> assignmentsToCreate) {
 		boolean retVal = true;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
@@ -15,12 +15,12 @@
  */
 package org.sakaiproject.gradebookng.tool.panels.importExport;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -33,6 +33,10 @@ import org.sakaiproject.gradebookng.tool.panels.BasePanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.sakaiproject.gradebookng.business.util.ImportGradesHelper;
 
 /**
  * Importer has detected that items need to be created so extract the data and wrap the 'AddOrEditGradeItemPanelContent' panel
@@ -65,43 +69,48 @@ public class CreateGradeItemStep extends BasePanel {
 		// original data
 		final ProcessedGradeItem processedGradeItem = importWizardModel.getItemsToCreate().get(step - 1);
 
-		// setup new assignment for populating
-		final Assignment assignment = new Assignment();
-		assignment.setName(StringUtils.trim(processedGradeItem.getItemTitle()));
-		if (StringUtils.isNotBlank(processedGradeItem.getItemPointValue())) {
-			assignment.setPoints(Double.parseDouble(processedGradeItem.getItemPointValue()));
+		// if using spreadsheet data, we'll create a blank assignment and fill the fields accordingly; otherwise, the assignment is already in the wizard (Ie. back button)
+		Assignment assignmentFromModel = importWizardModel.getAssignmentsToCreate().get(processedGradeItem);
+		final Assignment assignment = assignmentFromModel == null ? new Assignment() : assignmentFromModel;
+		if (assignmentFromModel == null) {
+			assignment.setName(StringUtils.trim(processedGradeItem.getItemTitle()));
+			if(StringUtils.isNotBlank(processedGradeItem.getItemPointValue())) {
+				assignment.setPoints(Double.parseDouble(processedGradeItem.getItemPointValue()));
+			}
 		}
 
 		final Model<Assignment> assignmentModel = new Model<>(assignment);
+		final Form<Assignment> form = new Form("form", assignmentModel);
+		add(form);
 
-		final Form<Assignment> form = new Form<Assignment>("form", assignmentModel) {
+		final AjaxButton nextButton = new AjaxButton("nextbutton") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			protected void onSubmit() {
+			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
 
-				final Assignment newAssignment = (Assignment) getDefaultModel().getObject();
-
+				final Assignment newAssignment = (Assignment) form.getDefaultModel().getObject();
+				final ImportExportPage page = (ImportExportPage) getPage();
 				log.debug("GradebookAssignment: {}", newAssignment);
 
+				// validate name is unique, first among existing gradebook items, second against new items to be created
 				boolean validated = true;
-
-				// validate name is unique
 				final List<Assignment> existingAssignments = CreateGradeItemStep.this.businessService.getGradebookAssignments();
-				existingAssignments.addAll(importWizardModel.getAssignmentsToCreate());
-
-				if (!assignmentNameIsUnique(existingAssignments, newAssignment.getName())) {
+				if (!assignmentNameIsUnique(existingAssignments, newAssignment.getName())
+						|| !assignmentNameIsUnique(newAssignment, importWizardModel.getAssignmentsToCreate().values())) {
 					validated = false;
 					error(getString("error.addgradeitem.title"));
+					page.updateFeedback(target);
 				}
 
 				if (validated) {
-					// add to model
-					importWizardModel.getAssignmentsToCreate().add(newAssignment);
 
 					// sync up the assignment data so we can present it for confirmation
 					processedGradeItem.setItemTitle(newAssignment.getName());
 					processedGradeItem.setItemPointValue(String.valueOf(newAssignment.getPoints()));
+
+					// add to model
+					importWizardModel.getAssignmentsToCreate().put(processedGradeItem, newAssignment);
 
 					// Figure out if there are more steps
 					// If so, go to the next step (ie do it all over again)
@@ -115,51 +124,66 @@ public class CreateGradeItemStep extends BasePanel {
 					}
 
 					// clear any previous errors
-					final ImportExportPage page = (ImportExportPage) getPage();
 					page.clearFeedback();
+					page.updateFeedback(target);
 
+					// AJAX the new panel into place
 					newPanel.setOutputMarkupId(true);
-					CreateGradeItemStep.this.replaceWith(newPanel);
+					WebMarkupContainer container = page.container;
+					container.addOrReplace(newPanel);
+					target.add(newPanel);
 				}
+			}
 
+			@Override
+			protected void onError(AjaxRequestTarget target, Form<?> form) {
+				final ImportExportPage page = (ImportExportPage) getPage();
+				page.updateFeedback(target);
 			}
 		};
-		add(form);
+		form.add(nextButton);
 
-		final Button backButton = new Button("backbutton") {
+		final AjaxButton backButton = new AjaxButton("backbutton") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void onSubmit() {
+			public void onSubmit(AjaxRequestTarget target, Form<?> form) {
 
 				// clear any previous errors
 				final ImportExportPage page = (ImportExportPage) getPage();
 				page.clearFeedback();
+				page.updateFeedback(target);
 
-				Component newPanel;
+				// Create the previous panel
+				Component previousPanel;
 				if (step > 1) {
 					importWizardModel.setStep(step - 1);
-					newPanel = new CreateGradeItemStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
+					previousPanel = new CreateGradeItemStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
 				} else {
-					newPanel = new GradeItemImportSelectionStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
+					// Reload everything. Rationale: final step can have partial success and partial failure. If content was imported from the spreadsheet, the item selection page should reflect this when we return to it
+					ImportGradesHelper.setupImportWizardModelForSelectionStep(page, CreateGradeItemStep.this, importWizardModel, businessService, target);
+					previousPanel = new GradeItemImportSelectionStep(CreateGradeItemStep.this.panelId, Model.of(importWizardModel));
 				}
 
-				newPanel.setOutputMarkupId(true);
-				CreateGradeItemStep.this.replaceWith(newPanel);
+				// AJAX the previous panel into place
+				previousPanel.setOutputMarkupId(true);
+				WebMarkupContainer container = page.container;
+				container.addOrReplace(previousPanel);
+				target.add(container);
 			}
 		};
 		backButton.setDefaultFormProcessing(false);
 		form.add(backButton);
 
-		final Button cancelButton = new Button("cancelbutton") {
+		final AjaxButton cancelButton = new AjaxButton("cancelbutton") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void onSubmit() {
+			public void onSubmit(AjaxRequestTarget target, Form<?> form) {
 				// clear any previous errors
 				final ImportExportPage page = (ImportExportPage) getPage();
 				page.clearFeedback();
-
+				page.updateFeedback(target);
 				setResponsePage(ImportExportPage.class);
 			}
 		};
@@ -167,10 +191,8 @@ public class CreateGradeItemStep extends BasePanel {
 		form.add(cancelButton);
 
 		// wrap the form create panel
-		form.add(new Label("createItemHeader",
-				new StringResourceModel("importExport.createItem.heading", this, null, step, importWizardModel.getTotalSteps())));
+		form.add(new Label("createItemHeader", new StringResourceModel("importExport.createItem.heading", this, null, step, importWizardModel.getTotalSteps())));
 		form.add(new AddOrEditGradeItemPanelContent("subComponents", assignmentModel));
-
 		previewGradesPanel = new PreviewImportedGradesPanel("previewGradesPanel", model);
 		form.add(previewGradesPanel);
 	}
@@ -188,5 +210,20 @@ public class CreateGradeItemStep extends BasePanel {
 				.filter(a -> StringUtils.equals(a.getName(), name))
 				.findFirst()
 				.isPresent());
+	}
+
+	private boolean assignmentNameIsUnique(final Assignment newAssignment, final Collection<Assignment> assignmentsToCreate) {
+		boolean retVal = true;
+
+		for (Assignment assignmentToCreate : assignmentsToCreate) {
+
+			// Skip comparison of itself; if newAssignment name equals assignmentToCreate name, name is not unique
+			if (!newAssignment.equals(assignmentToCreate) && StringUtils.equals(newAssignment.getName(), assignmentToCreate.getName())) {
+				retVal = false;
+				break;
+			}
+		}
+
+		return retVal;
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -123,8 +123,8 @@
                             </wicket:enclosure>
                         </div>
                     </div>
-                    <div class="modal-footer">
-                        <button wicket:id="downloadCustomGradebook" type="button" class="button_color pull-left" data-dismiss="modal">
+                    <div class="modal-footer act">
+                        <button wicket:id="downloadCustomGradebook" type="button" class="button_color pull-left active" data-dismiss="modal">
                             <wicket:message key="importExport.template.button.customGradebook"/>
                         </button>
                         <button type="button" class="pull-right" data-dismiss="modal">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -245,8 +245,8 @@ public class ExportPanel extends BasePanel {
 
 			//CSV separator is comma unless the comma is the decimal separator, then is ;
 			try (FileWriter fw = new FileWriter(tempFile);
-					CSVWriter csvWriter = new CSVWriter(fw, ".".equals(FormattedText.getDecimalSeparator()) ? CSVWriter.DEFAULT_SEPARATOR : CSV_SEMICOLON_SEPARATOR))
-{
+					CSVWriter csvWriter = new CSVWriter(fw, ".".equals(FormattedText.getDecimalSeparator()) ? CSVWriter.DEFAULT_SEPARATOR : CSV_SEMICOLON_SEPARATOR)) {
+
 				// Create csv header
 				final List<String> header = new ArrayList<>();
 				if (!isCustomExport || this.includeStudentId) {
@@ -276,7 +276,7 @@ public class ExportPanel extends BasePanel {
 					// ignore
 					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.example.ignore")));
 				}
-				
+
 				// build column header
 				assignments.forEach(assignment -> {
 					final String assignmentPoints = assignment.getPoints().toString();
@@ -296,6 +296,9 @@ public class ExportPanel extends BasePanel {
 				}
 				if (isCustomExport && this.includeCourseGrade) {
 					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.courseGrade")));
+				}
+				if (isCustomExport && this.includeGradeOverride) {
+					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.gradeOverride")));
 				}
 				if (isCustomExport && this.includeLastLogDate) {
 					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.lastLogDate")));
@@ -372,9 +375,7 @@ public class ExportPanel extends BasePanel {
 					}
 
 					csvWriter.writeNext(line.toArray(new String[] {}));
-
 				});
-
 			}
 		} catch (final IOException e) {
 			throw new RuntimeException(e);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.html
@@ -28,12 +28,20 @@
               <tr>
                 <th><wicket:message key="importExport.confirmation.title" /></th>
                 <th><wicket:message key="importExport.confirmation.points" /></th>
+                <th><wicket:message key="importExport.confirmation.extraCredit" /></th>
+                <th><wicket:message key="importExport.confirmation.dueDate" /></th>
+                <th><wicket:message key="importExport.confirmation.releaseToStudents" /></th>
+                <th><wicket:message key="importExport.confirmation.includeInCourseGrades" /></th>
               </tr>
             </thead>
             <tbody>
                 <tr wicket:id="grades_create">
                     <td><span wicket:id="title">[assignment 1]</span></td>
                     <td><span wicket:id="points">[50]</span></td>
+                    <td><span wicket:id="extraCredit"></span></td>
+                    <td><span wicket:id="dueDate"></span></td>
+                    <td><span wicket:id="releaseToStudents"></span></td>
+                    <td><span wicket:id="includeInCourseGrades"></span></td>
                 </tr>
             </tbody>
         </table>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -24,9 +24,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
@@ -35,10 +39,12 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
+
 import org.sakaiproject.gradebookng.business.GradeSaveResponse;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem.Type;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItemDetail;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.gradebookng.business.util.MessageHelper;
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -48,11 +54,6 @@ import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
 import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameException;
 import org.sakaiproject.service.gradebook.shared.ConflictingExternalIdException;
-
-import lombok.extern.slf4j.Slf4j;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
-import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.service.gradebook.shared.GradeDefinition;
 import org.sakaiproject.tool.gradebook.Gradebook;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -27,7 +27,6 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormSubmitBehavior;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
 import org.apache.wicket.markup.html.form.upload.FileUploadField;
@@ -71,7 +70,7 @@ public class GradeImportUploadStep extends BasePanel {
 	private class UploadForm extends Form<Void> {
 
 		FileUploadField fileUploadField;
-		Button continueButton;
+		AjaxButton continueButton;
 
 		public UploadForm(final String id) {
 			super(id);
@@ -117,9 +116,9 @@ public class GradeImportUploadStep extends BasePanel {
 			this.continueButton.setEnabled(false);
 			add(this.continueButton);
 
-			final Button cancel = new Button("cancelbutton") {
+			final AjaxButton cancel = new AjaxButton("cancelbutton") {
 				@Override
-				public void onSubmit() {
+				public void onSubmit(AjaxRequestTarget target, Form<?> form) {
 					setResponsePage(GradebookPage.class);
 				}
 			};

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
@@ -23,12 +23,16 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -37,6 +41,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
+
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem.Status;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem.Type;
@@ -45,10 +50,6 @@ import org.sakaiproject.gradebookng.tool.component.GbStyleableWebMarkupContainer
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.gradebookng.tool.panels.BasePanel;
-
-import lombok.extern.slf4j.Slf4j;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
-import org.apache.wicket.markup.html.WebMarkupContainer;
 
 /**
  * Page to allow the user to select which items in the imported file are to be imported
@@ -399,7 +400,6 @@ public class GradeItemImportSelectionStep extends BasePanel {
 
 		final List<ProcessedGradeItem> gbItems = filterListByType(items, Type.GB_ITEM);
 		final List<ProcessedGradeItem> commentItems = filterListByType(items, Type.COMMENT);
-
 		final Map<String, ProcessedGradeItem> rval = new HashMap<>();
 
 		// match up the gradebook items with the comment columns. comment columns have the same title.

--- a/gradebookng/tool/src/webapp/styles/gradebook-importexport.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-importexport.css
@@ -93,3 +93,7 @@ div.previewGradesContainer, #missingUsersContent, #unknownUsersContent {
 div.previewGradesContainer table {
   width: 100%;
  }
+
+div.modal-footer.act {
+	padding: 15px;
+}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33864

This PR contains several changes to the back-end code that performs the Gradebook Import:

 * Reduce the amount of logging performed during the saving routine, change the log level appropriately
 ** Currently an INFO level log message is produced for each grade, and each comment, for each user in each "sheet" that is processed
 ** For large imports, this equates to a *lot* of logging statements, which contributes to log bloat and probably reduces performance on some level
 ** It also could be argued that it's a security concern to log grades and user identifiers at INFO level OOTB
 * Bulk save grades and comments per assignment/gradebook item
 ** The current process saves each grade and each comment for each student in each item serially, and waits for a return code from each save/update
 ** This slows down the import process immensely; massive improvements in processing time are achieved by saving grades and comments in bulk, one assignment/grade item at a time
 ** Also, the return value was never being used. I think originally it was designed this way to have real-time feedback in case someone else was editing the same item/grade/comment; however there's no code to actually perform this. Even if we were to implement this, what decision should be made? Does the Import suddenly abort or fail? Does the exact item that was concurrently edited get skipped? In our opinion, concurrent edits don't really matter for the context of an Import; the last saved value should always take precedence and there is always the grade log to see who made changes and when.
 ** Instead of returning one return code per grade/student/assignment, return one code per saveGradesAndComments() call
 * Eliminate String->Double conversion where appropriate
 * Reduce double/triple/etc querying
 ** There are multiple places where the same data is being re-queried multiple times and then tossed out, rather than being passed down the line for use in other places. Refactoring these places to utilize the already retrieved data correlates to large performance increases
 * AJAX panel swap the CreateGradeItemStep/GradeImportConfirmationStep panels into place to avoid a page refresh and the associated loading/rendering time between each step
 * Fixed a bug when navigating back and forwards through the Import wizard, which causes loss of user data:
 ** To reproduce, import a gradebook item with no points, assign points in the import wizard, hit next, hit back, and see that your points are now missing.
 ** Also, when going back and forth in the wizard and changing your mind about things like points, you'll be presented with "Title required and must be unique" when you finally try to save, although it does still create your item, but only the first version you set up (ie. if you picked 10 points and then went back to make it 15 points, you'll be presented with the title error but the item will be created with 10 points behind the scenes even if you just leave the wizard.
 * Fixed a bug where if you import an item with no points possible in the header, grading data would not be imported for this column. The item would be created, but all the grades in the corresponding spreadsheet column would be ignored.
 ** To reproduce, import a spreadsheet containing one new gradebook item and a corresponding comment column. Do not give the item a points possible value in the header, but give some students both grades and comments. Import the file, notice that the wizard forces you to give the item a points possible value in the next step, finish the wizard; notice the item was created, all comments were imported but none of the grades were imported.