### PR TITLE
SAK-33897 - Restore + symbols in folders (regression)

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -247,4 +247,39 @@
 		color : $primary-color;
 		text-decoration: none;
 	}
+	
+	/* SAK-33897 - Restore + symbols in folders */
+	a.nil.fa-folder {
+		position: static;
+		&::after {
+			color: #fff;
+			content: "+";
+			display: inline-block;
+			position: absolute;
+			margin: 0.45em 0 0 -2.2em;
+			text-align: center;
+			font-size: 11px;
+			font-family: monospace;
+			@media #{$tablet} {
+				margin: 0.75em 0 0 -2.2em;
+			}
+		}
+	}
+
+	a.nil.fa-folder-open {
+		position: static;
+		&::after {
+			color: #FFF;
+			content: "-";
+			display: inline-block;
+			position: absolute;
+			margin: 0.55em 0 0 -2.2em;
+			text-align: center;
+			font-size: 11px;
+			font-family: monospace;
+			@media #{$tablet} {
+				margin: 0.85em 0 0 -2.2em;
+			}
+		}
+	}
 }


### PR DESCRIPTION
This would be the state of the icons after this PR

![sak-33897](https://user-images.githubusercontent.com/3238226/35851273-cf3a54c6-0b27-11e8-97d0-9a1ecec729ec.PNG)

It's not a big deal users that never had used Resources but returning users, used to watch a "plus" and a "minus" on the folder, would be less lost on what's empty and what's not.
