### PR TITLE
KNL-1583 Replace Hibernate SessionFactory with JPA EntityManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ velocity.log
 node_modules
 bower_components
 rebel.xml
+rsf/sakai-rsf-web/templates/overlays
+rsf/sakai-rsf-web/test/overlays

--- a/kernel/component-manager/src/main/java/org/sakaiproject/util/ComponentsLoader.java
+++ b/kernel/component-manager/src/main/java/org/sakaiproject/util/ComponentsLoader.java
@@ -129,7 +129,7 @@ public class ComponentsLoader
 		ClassLoader current = Thread.currentThread().getContextClassLoader();
 		ClassLoader loader = newPackageClassLoader(dir);
 
-		log.info("loadComponentPackage: " + dir);
+		log.info(dir.toString());
 
 		Thread.currentThread().setContextClassLoader(loader);
 
@@ -181,7 +181,7 @@ public class ComponentsLoader
 		}
 		catch (Exception e)
 		{
-			log.error("loadComponentPackage: exception loading: " + xml + " : " + e, e);
+			log.error("exception loading: " + xml + " : " + e, e);
 		}
 		finally
 		{

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
@@ -427,7 +427,7 @@
             parent="javax.sql.BaseDataSource">
     </bean>
 
-    <!--  The "Global" Hibernate Session Factory -->
+	<!--  The "Global" Hibernate Session Factory -->
 	<bean id="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"
 		  class="org.sakaiproject.springframework.orm.hibernate.AddableSessionFactoryBean"
 		  init-method="init">
@@ -451,13 +451,65 @@
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
 	</bean>
 
-	<!--  The "Global" Transaction Manager -->
-	<bean id="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager"
-		  class="org.springframework.orm.hibernate4.HibernateTransactionManager">
-
-		<property name="sessionFactory" ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-		<property name="dataSource" ref="javax.sql.LazyDataSource" />
+	<!-- To use the EntityManager you will need to comment the bean above this and uncomment the following 3 beans -->
+	<!-- uncomment this bean for EntityManager
+	<bean id="org.sakaiproject.springframework.orm.hibernate.SakaiPersistenceUnitManager"
+		  class="org.sakaiproject.springframework.orm.hibernate.SakaiPersistenceUnitManager">
+		<property name="dataSource" ref="javax.sql.LazyDataSource"/>
+		<property name="persistenceUnitPostProcessors">
+			<list>
+				<bean class="org.sakaiproject.springframework.orm.hibernate.AddablePersistenceUnit"/>
+			</list>
+		</property>
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
 	</bean>
+	-->
+
+	<!--  The "Global" JPA Entity Manager Factory -->
+	<!-- uncomment this bean for EntityManager
+	<bean id="org.sakaiproject.springframework.orm.jpa.EntityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+		<property name="jpaVendorAdapter">
+			<bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter"/>
+		</property>
+		<property name="jpaDialect">
+			<bean class="org.springframework.orm.jpa.vendor.HibernateJpaDialect"/>
+		</property>
+		<property name="persistenceUnitManager" ref="org.sakaiproject.springframework.orm.hibernate.SakaiPersistenceUnitManager"/>
+		<property name="jpaProperties">
+			<props>
+				<prop key="hibernate.dialect">${hibernate.dialect}</prop>
+				<prop key="hibernate.show_sql">${hibernate.show_sql}</prop>
+				<prop key="hibernate.query.substitutions">true 1, false 0, yes 'Y', no 'N'</prop>
+				<prop key="hibernate.jdbc.use_streams_for_binary">true</prop>
+				<prop key="hibernate.cache.use_query_cache">true</prop>
+				<prop key="hibernate.cache.region.factory_class">org.hibernate.cache.SingletonEhCacheRegionFactory</prop>
+				<prop key="hibernate.hbm2ddl.auto">${hibernate.hbm2ddl.auto}</prop>
+				<prop key="hibernate.generate_statistics">true</prop>
+				<prop key="hibernate.enable_lazy_load_no_trans">true</prop>
+				<prop key="net.sf.ehcache.configurationResourceName">/org/sakaiproject/memory/api/ehcache.xml</prop>
+				<prop key="hibernate.current_session_context_class">org.springframework.orm.hibernate4.SpringSessionContext</prop>
+			</props>
+		</property>
+	</bean>
+	-->
+
+	<!--  The "Global" Session Factory -->
+	<!-- uncomment this bean for EntityManager
+	<bean id="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"
+		  class="org.springframework.orm.jpa.vendor.HibernateJpaSessionFactoryBean">
+		<property name="entityManagerFactory" ref="org.sakaiproject.springframework.orm.jpa.EntityManagerFactory"/>
+	</bean>
+	-->
+
+	<!--  The "Global" Transaction Manager -->
+	<bean id="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+		<property name="sessionFactory" ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/>
+	</bean>
+	<!-- This jpa tx manager currently does not work as it behaves differently than hibernate's tx manager
+	<bean id="org.sakaiproject.springframework.orm.jpa.GlobalTransactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+		<property name="entityManagerFactory" ref="org.sakaiproject.springframework.orm.jpa.EntityManagerFactory"/>
+	</bean>
+	-->
 
 	<!-- enables JMX on hibernate -->
 	<bean id="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory.statistics"

--- a/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/AddablePersistenceUnit.java
+++ b/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/AddablePersistenceUnit.java
@@ -1,0 +1,36 @@
+package org.sakaiproject.springframework.orm.hibernate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
+import org.springframework.orm.jpa.persistenceunit.PersistenceUnitPostProcessor;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Created by enietzel on 6/21/17.
+ */
+@Slf4j
+public class AddablePersistenceUnit implements PersistenceUnitPostProcessor, ApplicationContextAware {
+
+    @Setter private ApplicationContext applicationContext;
+
+    @Override
+    public void postProcessPersistenceUnitInfo(MutablePersistenceUnitInfo pui) {
+        List<AdditionalHibernateMappings> units = new ArrayList<>();
+        String[] unitNames = applicationContext.getBeanNamesForType(AdditionalHibernateMappings.class, false, false);
+
+        for (String name : unitNames) {
+            units.add((AdditionalHibernateMappings) applicationContext.getBean(name));
+        }
+
+        Collections.sort(units);
+
+        units.forEach(u -> u.processAdditionalUnit(pui));
+    }
+}

--- a/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/AdditionalHibernateMappings.java
+++ b/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/AdditionalHibernateMappings.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import org.springframework.core.io.Resource;
 import org.springframework.orm.hibernate4.LocalSessionFactoryBuilder;
+import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
 
 /**
  * When the kernel starts up it will ask the component manager for all instances of this interface and then
@@ -36,6 +37,7 @@ public interface AdditionalHibernateMappings extends Comparable<AdditionalHibern
 {
 	Integer getSortOrder();
 	void processAdditionalMappings(LocalSessionFactoryBuilder localSessionFactoryBuilder) throws IOException;
+	void processAdditionalUnit(MutablePersistenceUnitInfo pui);
 	void setAnnotatedClasses(Class<?>... annotatedClasses);
 	void setAnnotatedPackages(String... annotatedPackages);
 	void setCacheableMappingLocations(Resource... mappingLocations);

--- a/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/SakaiPersistenceUnitManager.java
+++ b/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/SakaiPersistenceUnitManager.java
@@ -1,0 +1,48 @@
+package org.sakaiproject.springframework.orm.hibernate;
+
+import javax.persistence.spi.PersistenceUnitInfo;
+import javax.sql.DataSource;
+
+import lombok.Setter;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.springframework.orm.jpa.persistenceunit.DefaultPersistenceUnitManager;
+import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
+
+/**
+ * Created by enietzel on 6/22/17.
+ */
+public class SakaiPersistenceUnitManager extends DefaultPersistenceUnitManager {
+
+    private String defaultPersistenceUnitName = "sakai";
+    private PersistenceUnitInfo defaultPersistenceUnitInfo;
+    @Setter private DataSource dataSource;
+    @Setter private DataSource jtaDataSource;
+    @Setter private ServerConfigurationService serverConfigurationService;
+
+    @Override
+    public void preparePersistenceUnitInfos() {
+        MutablePersistenceUnitInfo pui = new MutablePersistenceUnitInfo();
+        pui.setPersistenceUnitName(defaultPersistenceUnitName);
+        pui.setExcludeUnlistedClasses(true);
+
+        if (pui.getJtaDataSource() == null) {
+            pui.setJtaDataSource(jtaDataSource);
+        }
+        if (pui.getNonJtaDataSource() == null) {
+            pui.setNonJtaDataSource(dataSource);
+        }
+
+//        TODO register AssignableUUIDGenerator
+//        AssignableUUIDGenerator.setServerConfigurationService(serverConfigurationService);
+//        pui.getIdentifierGeneratorFactory().register("uuid2", AssignableUUIDGenerator.class);
+
+        postProcessPersistenceUnitInfo(pui);
+
+        defaultPersistenceUnitInfo = pui;
+    }
+
+    @Override
+    public PersistenceUnitInfo obtainDefaultPersistenceUnitInfo() {
+        return defaultPersistenceUnitInfo;
+    }
+}

--- a/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/impl/AdditionalHibernateMappingsImpl.java
+++ b/kernel/kernel-private/src/main/java/org/sakaiproject/springframework/orm/hibernate/impl/AdditionalHibernateMappingsImpl.java
@@ -28,6 +28,7 @@ import org.sakaiproject.springframework.orm.hibernate.AdditionalHibernateMapping
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.orm.hibernate4.LocalSessionFactoryBuilder;
+import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -44,7 +45,7 @@ public class AdditionalHibernateMappingsImpl implements AdditionalHibernateMappi
     @Setter private Resource[] mappingLocations;
     @Setter private String[] mappingResources;
     @Setter private String[] packagesToScan;
-    @Getter @Setter private Integer sortOrder = Integer.valueOf(Integer.MAX_VALUE);
+    @Getter @Setter private Integer sortOrder = Integer.MAX_VALUE;
 
     @Override
     public void processAdditionalMappings(LocalSessionFactoryBuilder sfb) throws IOException {
@@ -107,6 +108,81 @@ public class AdditionalHibernateMappingsImpl implements AdditionalHibernateMappi
             for (String scanPackage : packagesToScan) {
                 log.info("Hibernate add package [{}]", scanPackage.trim());
                 sfb.addPackage(scanPackage);
+            }
+        }
+    }
+
+    @Override
+    public void processAdditionalUnit(MutablePersistenceUnitInfo pui) {
+        if (annotatedClasses != null) {
+            for (Class<?> clazz : annotatedClasses) {
+                pui.addManagedClassName(clazz.getName());
+                log.info("Add annotated class [{}]", clazz.getCanonicalName());
+            }
+        }
+        if (annotatedPackages != null) {
+            for (String aPackage : annotatedPackages) {
+                pui.addManagedPackage(aPackage);
+                log.info("Add annotated package [{}]", aPackage.trim());
+            }
+        }
+
+        if (cacheableMappingLocations != null) {
+            for (Resource resource : cacheableMappingLocations) {
+                try {
+                    pui.addMappingFileName(resource.getURL().toString());
+                    log.info("Add cacheable mapping location [{}]", resource.getFilename());
+                } catch (IOException e) {
+                    log.error("Invalid mapping location [{}]", resource, e);
+                }
+            }
+        }
+
+        if (mappingDirectoryLocations != null) {
+            for (Resource resource : mappingDirectoryLocations) {
+                try {
+                    pui.addMappingFileName(resource.getURL().toString());
+                    log.info("Add mapping directory location [{}]", resource.getFilename());
+                } catch (IOException e) {
+                    log.error("Invalid mapping directory location [{}]", resource, e);
+                }
+            }
+        }
+
+        if (mappingJarLocations != null) {
+            for (Resource resource : mappingJarLocations) {
+                try {
+                    pui.addJarFileUrl(resource.getURL());
+                    log.info("Add mapping jar location [{}]", resource.getFilename());
+                } catch (IOException e) {
+                    log.error("Invalid mapping jar location [{}]", resource, e);
+                }
+            }
+        }
+
+        if (mappingLocations != null) {
+            for (Resource resource : mappingLocations) {
+                pui.addMappingFileName(resource.getFilename());
+                log.info("Add mapping location [{}]", resource.getFilename());
+            }
+        }
+
+        if (mappingResources != null) {
+            for (String resource : mappingResources) {
+                Resource r = new ClassPathResource(resource.trim(), this.getClass().getClassLoader());
+                try {
+                    pui.addMappingFileName(r.getURL().toString());
+                    log.info("Add mapping resource [{}]", resource.trim());
+                } catch (IOException e) {
+                    log.error("Invalid mapping resource [{}]", resource);
+                }
+            }
+        }
+
+        if (packagesToScan != null) {
+            for (String scanPackage : packagesToScan) {
+                log.info("Add package [{}]", scanPackage.trim());
+                pui.addManagedPackage(scanPackage);
             }
         }
     }


### PR DESCRIPTION
This at this moment doesn't replace Hibernate LocalSessionFactory but allows the ability to simply switch to the EntityManager via a few bean changes. The idea being one could easily switch to running Sakai using the JPA EntityManager.

One nice feature about this change is that there is no change for tools including contrib tools.

At some future point Sakai will run by default using the EntityManager.