### PR TITLE
LSNBLDR-940: NPE protection for missing comments section on student page

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -26,7 +26,13 @@ package org.sakaiproject.lessonbuildertool.tool.beans;
 
 import au.com.bytecode.opencsv.CSVParser;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -34,8 +40,23 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
-import java.util.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,17 +70,11 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import org.springframework.web.multipart.MultipartFile;
-
-import uk.org.ponder.messageutil.MessageLocator;
-import uk.org.ponder.rsf.components.UIContainer;
-import uk.org.ponder.rsf.components.UIInternalLink;
-
 import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
-import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.basiclti.util.SakaiBLTIUtil;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.*;
@@ -77,16 +92,16 @@ import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.id.cover.IdManager;
 import org.sakaiproject.lessonbuildertool.*;
 import org.sakaiproject.lessonbuildertool.api.LessonBuilderEvents;
-import org.sakaiproject.lessonbuildertool.tool.beans.helpers.ResourceHelper;
 import org.sakaiproject.lessonbuildertool.cc.CartridgeLoader;
 import org.sakaiproject.lessonbuildertool.cc.Parser;
 import org.sakaiproject.lessonbuildertool.cc.PrintHandler;
 import org.sakaiproject.lessonbuildertool.cc.ZipLoader;
 import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
 import org.sakaiproject.lessonbuildertool.service.*;
+import org.sakaiproject.lessonbuildertool.tool.beans.helpers.ResourceHelper;
+import org.sakaiproject.lessonbuildertool.tool.producers.PagePickerProducer;
 import org.sakaiproject.lessonbuildertool.tool.producers.ShowItemProducer;
 import org.sakaiproject.lessonbuildertool.tool.producers.ShowPageProducer;
-import org.sakaiproject.lessonbuildertool.tool.producers.PagePickerProducer;
 import org.sakaiproject.lessonbuildertool.tool.view.GeneralViewParameters;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.memory.api.Cache;
@@ -105,7 +120,13 @@ import org.sakaiproject.util.FormattedText;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Validator;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import org.tsugi.lti2.ContentItem;
+
+import uk.org.ponder.messageutil.MessageLocator;
+import uk.org.ponder.rsf.components.UIContainer;
+import uk.org.ponder.rsf.components.UIInternalLink;
 
 /**
  * Backing bean for Simple pages
@@ -345,7 +366,7 @@ public class SimplePageBean {
 		this.rubricRow = rubricRow;
 		
 		if(rubricRows==null) {
-			rubricRows = new HashMap<Integer, String>();
+			rubricRows = new HashMap<>();
 		}
 		rubricRows.put(rubricRows.size(), rubricRow);
 	}
@@ -363,7 +384,7 @@ public class SimplePageBean {
 		date = date.substring(0,19);
 		this.peerEvalDueDate = isoDateFormat.parse(date);
 	    } catch (Exception e) {
-		log.info(e + "bad format duedate " + date);
+		log.info("{} bad format duedate {}", e, date);
 	    }
 	}
 	
@@ -376,7 +397,7 @@ public class SimplePageBean {
 		date = date.substring(0,19);
 		this.peerEvalOpenDate = isoDateFormat.parse(date);
 	    } catch (Exception e) {
-		log.info(e + "bad format duedate " + date);
+		log.info("{} bad format duedate {}", e, date);
 	    }
 	}
 	
@@ -396,7 +417,7 @@ public class SimplePageBean {
 		this.rubricPeerGrade = rubricPeerGrade;
 		
 		if(rubricPeerGrades == null) {
-			rubricPeerGrades = new ArrayList<String>();
+			rubricPeerGrades = new ArrayList<>();
 		}
 		rubricPeerGrades.add(rubricPeerGrade);
 	}
@@ -427,12 +448,12 @@ public class SimplePageBean {
     // all the stuff associated with items. Then the producer would manipulate items. Thus the things in
     // these caches would be held in the Items.
 
-	private Map<Long, SimplePageItem> itemCache = new HashMap<Long, SimplePageItem> ();
-	private Map<Long, SimplePage> pageCache = new HashMap<Long, SimplePage> ();
-	private Map<Long, List<SimplePageItem>> itemsCache = new HashMap<Long, List<SimplePageItem>> ();
-	private Map<String, SimplePageLogEntry> logCache = new HashMap<String, SimplePageLogEntry>();
-	private Map<Long, Boolean> completeCache = new HashMap<Long, Boolean>();
-	private Map<Long, Boolean> visibleCache = new HashMap<Long, Boolean>();
+	private Map<Long, SimplePageItem> itemCache = new HashMap<> ();
+	private Map<Long, SimplePage> pageCache = new HashMap<> ();
+	private Map<Long, List<SimplePageItem>> itemsCache = new HashMap<> ();
+	private Map<String, SimplePageLogEntry> logCache = new HashMap<>();
+	private Map<Long, Boolean> completeCache = new HashMap<>();
+	private Map<Long, Boolean> visibleCache = new HashMap<>();
 	// this one needs to be global
 	static MemoryService memoryService = (MemoryService)org.sakaiproject.component.cover.ComponentManager.get("org.sakaiproject.memory.api.MemoryService");
 	private static Cache<String, Object> groupCache = memoryService.getCache("org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.groupCache");  // itemId => grouplist
@@ -482,28 +503,28 @@ public class SimplePageBean {
 	    if (bltiToolLines == null || bltiToolLines.length == 0)
 		return null;
 	    CSVParser csvParser = new CSVParser();
-	    Map<Integer,BltiTool> ret = new HashMap<Integer,BltiTool>();
+	    Map<Integer,BltiTool> ret = new HashMap<>();
 	    for (int i = 0; i < bltiToolLines.length; i++) {
-		String[] items = null;
+		String[] items;
 		try {
 		    items = csvParser.parseLine(bltiToolLines[i]);
 		} catch (Exception e) {
-		    log.info("bad blti tool spec in lessonbuilder.blti_tools " + i + " " + bltiToolLines[i]);		    
+		    log.info("bad blti tool spec in lessonbuilder.blti_tools {} {}", i, bltiToolLines[i]);
 		    continue;
 		}
 		if (items.length < 5) {
-		    log.info("bad blti tool spec in lessonbuilder.blti_tools " + i + " " + bltiToolLines[i]);
+		    log.info("bad blti tool spec in lessonbuilder.blti_tools {} {}", i, bltiToolLines[i]);
 		    continue;
 		}
 		BltiTool bltiTool = new BltiTool();
 		try {
 		    bltiTool.id = Integer.parseInt(items[0]);
 		} catch (Exception e) {
-		    log.info("first item in line not integer in lessonbuilder.blti_tools " + i + " " + bltiToolLines[i]);		    
+		    log.info("first item in line not integer in lessonbuilder.blti_tools {} {}", i, bltiToolLines[i]);
 		    continue;
 		}
 		if (items[1] == null || items[1].length() == 0) {
-		    log.info("second item in line missing in lessonbuilder.blti_tools " + i + " " + bltiToolLines[i]);		    
+		    log.info("second item in line missing in lessonbuilder.blti_tools {} {}", i, bltiToolLines[i]);
 		    continue;
 		}
 		bltiTool.title = items[1];
@@ -513,7 +534,7 @@ public class SimplePageBean {
 		else
 		    bltiTool.description = items[2];
 		if (items[3] == null || items[3].length() == 0) {
-		    log.info("third item in line missing in lessonbuilder.blti_tools " + i + " " + bltiToolLines[i]);		    
+		    log.info("third item in line missing in lessonbuilder.blti_tools {} {}", i, bltiToolLines[i]);
 		    continue;
 		}
 		bltiTool.addText = items[3];
@@ -525,7 +546,7 @@ public class SimplePageBean {
 		ret.put(bltiTool.id, bltiTool);
 	    }
 	    for (BltiTool tool: ret.values()) {
-		log.info(tool.id + " " + tool.title + " " + tool.description + " " + tool.addText);
+		log.info("{} {} {} {}", tool.id, tool.title, tool.description, tool.addText);
 	    }
 	    return ret;
 	}
@@ -547,7 +568,7 @@ public class SimplePageBean {
 	public static ArrayList<String> imageTypes;
 
 	static {
-		imageTypes = new ArrayList<String>();
+		imageTypes = new ArrayList<>();
 		imageTypes.add("bmp");
 		imageTypes.add("gif");
 		imageTypes.add("icns");
@@ -648,7 +669,7 @@ public class SimplePageBean {
 	static Object ftInstance = setupFtStuff();
 
 	static Object setupFtStuff () {
-	    Object ret = null;
+	    Object ret;
 	    try {
 		levelClass = Class.forName("org.sakaiproject.util.api.FormattedText$Level");
 		levels = levelClass.getEnumConstants();
@@ -658,7 +679,7 @@ public class SimplePageBean {
 		ret = org.sakaiproject.component.cover.ComponentManager.get("org.sakaiproject.util.api.FormattedText");
 		return ret;
 	    } catch (Exception e) {
-		log.error("Formatted Text with levels not available: " + e);
+		log.error("Formatted Text with levels not available: {}", e.toString());
 		return null;
 	    }
 	}
@@ -735,12 +756,12 @@ public class SimplePageBean {
 	public void setErrMessage(String s) {
 		ToolSession toolSession = sessionManager.getCurrentToolSession();
 		if (toolSession == null) {
-		    log.info("Lesson Builder error not in tool: " + s);
+		    log.info("Lesson Builder error not in tool: {}", s);
 		    return;
 		}
 		List<String> errors = (List<String>)toolSession.getAttribute("lessonbuilder.errors");
 		if (errors == null)
-		    errors = new ArrayList<String>();
+		    errors = new ArrayList<>();
 		errors.add(s);
 		toolSession.setAttribute("lessonbuilder.errors", errors);
 	}
@@ -838,7 +859,7 @@ public class SimplePageBean {
 		date = date.substring(0,19);
 		this.releaseDate = isoDateFormat.parse(date);
 	    } catch (Exception e) {
-		log.info(e + "bad format releasedate " + date);
+		log.info("{}bad format releasedate {}", e, date);
 	    }
 	}
 
@@ -1027,7 +1048,7 @@ public class SimplePageBean {
     // since it's the root cause.
 	public boolean saveItem(Object i, boolean requiresEditPermission) {       
 		String err = null;
-		List<String>elist = new ArrayList<String>();
+		List<String>elist = new ArrayList<>();
 		
 		try {
 			simplePageToolDao.saveItem(i,  elist, messageLocator.getMessage("simplepage.nowrite"), requiresEditPermission);
@@ -1056,7 +1077,7 @@ public class SimplePageBean {
 	
 	public boolean saveOrUpdate(Object i) {
 		String err = null;
-		List<String>elist = new ArrayList<String>();
+		List<String>elist = new ArrayList<>();
 		
 		try {
 			simplePageToolDao.saveOrUpdate(i,  elist, messageLocator.getMessage("simplepage.nowrite"), true);
@@ -1089,7 +1110,7 @@ public class SimplePageBean {
 	// edit permissions before making the update
 	boolean update(Object i, boolean requiresEditPermission) {       
 		String err = null;
-		List<String>elist = new ArrayList<String>();
+		List<String>elist = new ArrayList<>();
 		try {
 			simplePageToolDao.update(i,  elist, messageLocator.getMessage("simplepage.nowrite"), requiresEditPermission);
 		} catch (Throwable t) {
@@ -1123,10 +1144,7 @@ public class SimplePageBean {
 			return true;
 		SimplePageItem item = findItem(itemId);
 		
-		if (item.getPageId() != getCurrentPageId()) {
-			return false;
-		}
-		return true;
+		return item.getPageId() == getCurrentPageId();
 	}
 	
 	public Integer getFilterLevel(Placement placement) {
@@ -1134,7 +1152,7 @@ public class SimplePageBean {
 			placement = toolManager.getCurrentPlacement();
 		}
 
-	    Integer filter = FILTER_DEFAULT;
+	    Integer filter;
         if (getCurrentPage().getOwner() != null) {
             filter = FILTER_DEFAULT; // always filter student content
         } else {
@@ -1188,7 +1206,7 @@ public class SimplePageBean {
 			// to their HTML. I think enforcing that makes Sakai less than useful.
 			// So check config options to see whether to do that check
 
-			String html = contents;
+			String html;
 
 			// figure out how to filter
 			Integer filter = getFilterLevel(placement);
@@ -1200,7 +1218,7 @@ public class SimplePageBean {
 			} else if (ftInstance != null) {
 			    try {
 				// now filter is set. Implement it. Depends upon whether we have the anti-samy code
-				Object level = null;
+				Object level;
 				if (filter.equals(FILTER_HIGH))
 				    level = levels[1];
 				else
@@ -1307,7 +1325,7 @@ public class SimplePageBean {
 		Long max = simplePageToolDao.maxChecklistItem(item);
 
 		// Get existing item ids
-		List<Long> previousIds = new ArrayList<Long>();
+		List<Long> previousIds = new ArrayList<>();
 		for(SimpleChecklistItem checklistItem : simplePageToolDao.findChecklistItems(item)) {
 			previousIds.add(checklistItem.getId());
 		}
@@ -1438,13 +1456,13 @@ public class SimplePageBean {
 		    mimeType = t;
 		}
 	    } catch (Exception e) {
-		log.error("getTypeOfUrl connection error " + e);
+		log.error("getTypeOfUrl connection error {}", e.toString());
 	    } finally {
 		if (conn != null) {
 		    try {
 			conn.getInputStream().close();
 		    } catch (Exception e) {
-			log.error("getTypeOfUrl unable to close " + e);
+			log.error("getTypeOfUrl unable to close {}", e.toString());
 		    }
 		}
 	    }
@@ -1470,7 +1488,7 @@ public class SimplePageBean {
 
 		// if itemId specified, better only be one resource, since we replacing an existing one
 
-		List<Reference> refs = null;
+		List<Reference> refs;
 		String returnMesssage = null;
 
 		if (toolSession.getAttribute(FilePickerHelper.FILE_PICKER_CANCEL) == null && toolSession.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS) != null) {
@@ -1504,7 +1522,6 @@ public class SimplePageBean {
 	//This method is written to enable user to select multiple Resources from the tool
 	private String processSingleResource(Reference reference,int type, boolean isWebSite, boolean isCaption, Long itemId){
 
-		ToolSession toolSession = sessionManager.getCurrentToolSession();
 		String id  = reference.getId();
 		String description = reference.getProperties().getProperty(ResourceProperties.PROP_DESCRIPTION);
 		String name = this.name; // user specified name overrides file name
@@ -1654,15 +1671,7 @@ public class SimplePageBean {
 			pushed = pushAdvisor();
 			res = contentHostingService.getResource(id);
 		}
-		catch (PermissionException pe)
-		{
-			// ignore
-		}
-		catch (IdUnusedException iue)
-		{
-			// ignore
-		}
-		catch (TypeException te)
+		catch (PermissionException | IdUnusedException | TypeException ex)
 		{
 			// ignore
 		}
@@ -1826,11 +1835,7 @@ public class SimplePageBean {
 	 * @return
 	 */
 	public boolean canEditPage() {
-		if(getEditPrivs() <= 1) {
-			return true;
-		}else {
-			return false;
-		}
+		return getEditPrivs() <= 1;
 	}
 
 	public boolean canReadPage() {
@@ -1943,7 +1948,7 @@ public class SimplePageBean {
 
 		SimplePageItem i = findItem(itemId);
 		if(i == null) {
-			log.warn("deleteItem: null item.  id: " + itemId);
+			log.warn("deleteItem: null item.  id: {}", itemId);
 			return "failure";
 		}
 
@@ -1954,7 +1959,7 @@ public class SimplePageBean {
 
 		int seq = i.getSequence();
 
-		boolean b = false;
+		boolean b;
 
 		// if access controlled, clear it before deleting item
 		if (i.isPrerequisite()) {
@@ -1991,7 +1996,7 @@ public class SimplePageBean {
 
 			return "successDelete";
 		} else {
-			log.warn("deleteItem error deleting Item: " + itemId);
+			log.warn("deleteItem error deleting Item: {}", itemId);
 			return "failure";
 		}
 	}
@@ -2118,7 +2123,6 @@ public class SimplePageBean {
 			nextItem = simplePageToolDao.findNextItemOnPage(nextItem.getPageId(), nextItem.getSequence());		
 		}
 
-		boolean available = false;
 		if (nextItem != null) {
 
 			int itemType = nextItem.getType();
@@ -2181,14 +2185,14 @@ public class SimplePageBean {
 	    		else
 	    			view.setPath("push");  // item to page, have to push the page
 	    	} else if (itemType == SimplePageItem.RESOURCE) { /// must be a same page resource
-	    		view.setSendingPage(Long.valueOf(item.getPageId()));
+	    		view.setSendingPage(item.getPageId());
 	    		// to the check. We need the check to set access control appropriately
 	    		// if the user has passed.
 	    		if (!isItemAvailable(nextItem, nextItem.getPageId()))
 	    			view.setRecheck("true");
 	    		view.viewID = ShowItemProducer.VIEW_ID;
 	    	} else {
-	    		view.setSendingPage(Long.valueOf(item.getPageId()));
+	    		view.setSendingPage(item.getPageId());
 
 	    		// normally we won't send someone to an item that
 	    		// isn't available. But if the current item is a test, etc, we can't
@@ -2246,7 +2250,7 @@ public class SimplePageBean {
 			else
 				view.setPath("push");  // item to page, have to push the page
 		} else if (itemType == SimplePageItem.RESOURCE) { // must be a samepage resource
-			view.setSendingPage(Long.valueOf(item.getPageId()));
+			view.setSendingPage(item.getPageId());
 			view.viewID = ShowItemProducer.VIEW_ID;
 		}else if(itemType == SimplePageItem.STUDENT_CONTENT) {
 			view.setSendingPage(prevEntry.pageId);
@@ -2259,7 +2263,7 @@ public class SimplePageBean {
 				view.setPath("next");
 			}
 		} else {
-			view.setSendingPage(Long.valueOf(item.getPageId()));
+			view.setSendingPage(item.getPageId());
 			if (item.getType() == SimplePageItem.PAGE)
 				view.setPath("pop");  // now on a page, have to pop it off
 			view.viewID = ShowItemProducer.VIEW_ID;
@@ -2303,7 +2307,7 @@ public class SimplePageBean {
 		SimplePageItem i = findItem(item);
 			if (i != null) {
 			if (i.getType() != SimplePageItem.STUDENT_CONTENT && (long)currentPageId != (long)Long.valueOf(i.getSakaiId())) {
-				log.warn("updatePageItem permission failure " + i + " " + Long.valueOf(i.getSakaiId()) + " " + currentPageId);
+				log.warn("updatePageItem permission failure {} {} {}", i, Long.valueOf(i.getSakaiId()), currentPageId);
 				throw new PermissionException(getCurrentUserId(), "set item", Long.toString(item));
 			}
 		}
@@ -2375,7 +2379,7 @@ public class SimplePageBean {
 		// we're only checking when you first go into a tool
 		Properties roleConfig = placement.getPlacementConfig();
 		String roleList = roleConfig.getProperty("functions.require");
-		boolean siteHidden = (roleList != null && roleList.indexOf(SITE_UPD) > -1);
+		boolean siteHidden = (roleList != null && roleList.contains(SITE_UPD));
 
 		// Let's go back to where we were last time.
 		Long l = (Long) sessionManager.getCurrentToolSession().getAttribute("current-pagetool-page");
@@ -2397,7 +2401,7 @@ public class SimplePageBean {
 		} else {
 			// No recent activity. Let's go to the top level page.
 
-			l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) placement).getPageId());;
+			l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) placement).getPageId());
 			// l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) toolManager.getCurrentPlacement()).getPageId());
 
 			if (l != null) {
@@ -2521,7 +2525,7 @@ public class SimplePageBean {
 		// Allow the new portal lessons subnav to push a subpage on the context
 		if (op.equals("clear_and_push")) {
 			// clear path for top level subpage
-			path = new ArrayList<PathEntry>();
+			path = new ArrayList<>();
 
 			// add an entry for the parent page
 			SimplePage parentPage = null;
@@ -2556,17 +2560,17 @@ public class SimplePageBean {
 			path.add(entry);  // put it on the end
 
 		// if no current path, op doesn't matter. we can just do the current page
-		} else if (path == null || path.size() == 0) {
+		} else if (path == null || path.isEmpty()) {
 			PathEntry entry = new PathEntry();
 			entry.pageId = pageId;
 			entry.pageItemId = pageItemId;
 			entry.title = title;
-			path = new ArrayList<PathEntry>();
+			path = new ArrayList<>();
 			path.add(entry);
 	    } else if (path.get(path.size()-1).pageId.equals(pageId)) {
 	    	// nothing. we're already there. this is to prevent 
 	    	// oddities if we refresh the page
-	    } else if (op == null || op.equals("") || op.equals("next")) {
+	    } else if (op.equals("") || op.equals("next")) {
 	    	PathEntry entry = path.get(path.size()-1); // overwrite last item
 	    	entry.pageId = pageId;
 	    	entry.pageItemId = pageItemId;
@@ -2585,7 +2589,7 @@ public class SimplePageBean {
 	    	// set path to what was saved in the last log entry for this item
 	    	// this is used for users who go directly to a page from the 
 	    	// main list of pages.
-	    	path = new ArrayList<PathEntry>();
+	    	path = new ArrayList<>();
 	    	SimplePageLogEntry logEntry = getLogEntry(pageItemId);
 	    	if (logEntry != null) {
 	    		String items[] = null;
@@ -2595,17 +2599,17 @@ public class SimplePageBean {
 	    			for(String s: items) {
 	    				// don't see how this could happen, but it did
 	    				if (s.trim().equals("")) {
-	    					log.warn("adjustPath attempt to set invalid path: invalid item: " + op + ":" + logEntry.getPath());
+	    					log.warn("adjustPath attempt to set invalid path: invalid item: {}:{}", op, logEntry.getPath());
 	    					return null;
 	    				}
 	    				SimplePageItem i = findItem(Long.valueOf(s));
 	    				if (i == null || i.getType() != SimplePageItem.PAGE) {
-	    					log.warn("adjustPath attempt to set invalid path: invalid item: " + op);
+	    					log.warn("adjustPath attempt to set invalid path: invalid item: {}", op);
 	    					return null;
 	    				}
 	    				SimplePage p = getPage(Long.valueOf(i.getSakaiId()));
 	    				if (p == null || !currentPage.getSiteId().equals(p.getSiteId())) {
-	    					log.warn("adjustPath attempt to set invalid path: invalid page: " + op);
+	    					log.warn("adjustPath attempt to set invalid path: invalid page: {}", op);
 	    					return null;
 	    				}
 	    				PathEntry entry = new PathEntry();
@@ -2651,7 +2655,7 @@ public class SimplePageBean {
 
 	    List<PathEntry> backPath = (List<PathEntry>)sessionManager.getCurrentToolSession().getAttribute(LESSONBUILDER_BACKPATH);
 	    if (backPath == null)
-		backPath = new ArrayList<PathEntry>();
+		backPath = new ArrayList<>();
 
 	    // default case going directly to something.
 	    // normally we want to push it, but if it's already there,
@@ -2676,7 +2680,7 @@ public class SimplePageBean {
 	    }
 		
 
-	    if (op.equals("pop")) {
+	    if (StringUtils.equals(op, "pop")) {
 		if (backPath.size() > 0)
 		    backPath.remove(backPath.size()-1);
 	    } else {  // push or no operation
@@ -2744,7 +2748,7 @@ public class SimplePageBean {
 		if (!makeNewPage) {
 		    SimplePage p = getPage(Long.valueOf(selectedEntity));
 		    if (p == null || !getCurrentSiteId().equals(p.getSiteId())) {
-			log.warn("addpage tried to add invalid page: " + selectedEntity);
+			log.warn("addpage tried to add invalid page: {}", selectedEntity);
 			return "invalidpage";
 		    }
 		}
@@ -2768,7 +2772,7 @@ public class SimplePageBean {
 		}
 
 		String toolId = ((ToolConfiguration) toolManager.getCurrentPlacement()).getPageId();
-		SimplePage subpage = null;
+		SimplePage subpage;
 		if (makeNewPage) {
 		    subpage = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, parent, topParent);
 		    subpage.setOwner(owner);
@@ -2780,7 +2784,7 @@ public class SimplePageBean {
 		    subpage = getPage(Long.valueOf(selectedEntity));
 		}
 
-		SimplePageItem i = null;
+		SimplePageItem i;
 		if (makeNewItem)
 		    i = appendItem(selectedEntity, subpage.getTitle(), SimplePageItem.PAGE);
 		else {
@@ -2856,7 +2860,7 @@ public class SimplePageBean {
 	//Service method for deleting pages
 	protected String deletePagesInternal() {
 	    String siteId = getCurrentSiteId();
-	    log.debug("Found "+ selectedEntities.length + " pages to delete");
+	    log.debug("Found {} pages to delete", selectedEntities.length);
 	    for (int i = 0; i < selectedEntities.length; i++) {
 		deletePage(siteId, Long.valueOf(selectedEntities[i]));
 		if ((i % 10) == 0) {
@@ -2994,7 +2998,7 @@ public class SimplePageBean {
 			else
 			    i.setFormat("");
 
-			if (points != "") {
+			if (!"".equals(points)) {
 				i.setRequirementText(points);
 			} else {
 				i.setRequirementText(dropDown);
@@ -3074,7 +3078,7 @@ public class SimplePageBean {
 		    return;
 
 		SimplePageGroup group = simplePageToolDao.findGroup(i.getSakaiId());
-		String ourGroupName = null;
+		String ourGroupName;
 		try {
 		    // correct is the correct setting, i.e. if there is supposed to be
 		    // a group or not. We only change if reality disagrees with it.
@@ -3172,10 +3176,10 @@ public class SimplePageBean {
 			return tc.getId();
 		} catch (IdUnusedException e) {
 			// This really shouldn't happen.
-		    log.warn("getToolId 1 attempt to get tool config for " + tool + " failed. Tool missing from site?");
+		    log.warn("getToolId 1 attempt to get tool config for {} failed. Tool missing from site?", tool);
 		    return null;
 		} catch (java.lang.NullPointerException e) {
-		    log.warn("getToolId 2 attempt to get tool config for " + tool + " failed. Tool missing from site?");
+		    log.warn("getToolId 2 attempt to get tool config for {} failed. Tool missing from site?", tool);
 		    return null;
 		}
 	}
@@ -3187,7 +3191,7 @@ public class SimplePageBean {
 	public List<PathEntry> getHierarchy() {
 	    List<PathEntry> path = (List<PathEntry>)sessionManager.getCurrentToolSession().getAttribute(LESSONBUILDER_PATH);
 	    if (path == null)
-		return new ArrayList<PathEntry>();
+		return new ArrayList<>();
 
 	    return path;
 	}
@@ -3214,11 +3218,7 @@ public class SimplePageBean {
 
         public boolean checkCsrf() {
 	    Object sessionToken = sessionManager.getCurrentSession().getAttribute("sakai.csrf.token");
-	    if (sessionToken != null && sessionToken.toString().equals(csrfToken)) {
-		return true;
-	    }
-	    else
-		return false;
+		return sessionToken != null && sessionToken.toString().equals(csrfToken);
 	}
 
     // called by add forum dialog. Create a new item that points to a forum or
@@ -3442,7 +3442,7 @@ public class SimplePageBean {
 		ret = "";
 	    else {
 
-	    List<String> groupNames = new ArrayList<String>();
+	    List<String> groupNames = new ArrayList<>();
 	    Site site = getCurrentSite();
 	    String[] groupIds = split(itemGroups, ",");
 	    for (int i = 0; i < groupIds.length; i++) {
@@ -3481,7 +3481,7 @@ public class SimplePageBean {
 
     // too much existing code to convert to throw at the moment
         public String getItemGroupString (SimplePageItem i, LessonEntity entity, boolean nocache) {
-	    String groups = null;
+	    String groups;
 	    try {
 		groups = getItemGroupStringOrErr (i, entity, nocache);
 	    } catch (IdUnusedException exp) {
@@ -3496,7 +3496,7 @@ public class SimplePageBean {
         public String getItemGroupStringOrErr (SimplePageItem i, LessonEntity entity, boolean nocache)
 	           throws IdUnusedException{
 	    StringBuilder ret = new StringBuilder("");
-	    Collection<String> groups = null;
+	    Collection<String> groups;
 	    // may throw IdUnUsed
 	    groups = getItemGroups (i, entity, nocache);
 	    if (groups == null)
@@ -3545,7 +3545,7 @@ public class SimplePageBean {
 	public Collection<String>getItemGroups (SimplePageItem i, LessonEntity entity, boolean nocache)
 	    throws IdUnusedException {
 
-	    Collection<String> ret = new ArrayList<String>();
+	    Collection<String> ret = new ArrayList<>();
 
 	    if (!nocache && i.getType() != SimplePageItem.PAGE 
 		         && i.getType() != SimplePageItem.TEXT
@@ -3739,13 +3739,10 @@ public class SimplePageBean {
     		   AccessMode access = resource.getAccess();
     		   if(AccessMode.INHERITED.equals(access) || inheritingPubView) {
     			   access = resource.getInheritedAccess();
-    			   // inherited means that we can't set it locally
-    			   // an inherited value of site is OK
-    			   // anything else can't be changed, so we set inherited
-    			   if (AccessMode.SITE.equals(access) && ! inheritingPubView)
-    				   inherited = false;
-    			   else
-    				   inherited = true;
+				  // inherited means that we can't set it locally
+				  // an inherited value of site is OK
+				  // anything else can't be changed, so we set inherited
+				  inherited = !(AccessMode.SITE.equals(access) && ! inheritingPubView);
     			   if (AccessMode.GROUPED.equals(access))
     				   groups = resource.getInheritedGroups();
     		   } else {
@@ -3756,7 +3753,7 @@ public class SimplePageBean {
     		   }
     		   
     		   if (groups != null) {
-    			   ret = new ArrayList<String>();
+    			   ret = new ArrayList<>();
     			   for (String group: groups) {
     				   int n = group.indexOf("/group/");
     				   ret.add(group.substring(n+7));
@@ -3778,7 +3775,6 @@ public class SimplePageBean {
 
     // no obvious need to cache
        public Collection<String>getLBItemGroups (SimplePageItem i) {
-	   List<String> ret = null;
 
 	   String groupString = i.getGroups();
 	   if (groupString == null || groupString.equals("")) {
@@ -3831,17 +3827,17 @@ public class SimplePageBean {
 	   }
 	   if (lessonEntity != null) {
 	       // need a list to sort it.
-	       Collection oldGroupCollection = null;
+	       Collection oldGroupCollection;
 	       try {
 		   oldGroupCollection = getItemGroups(i, lessonEntity, true);
 	       } catch (IdUnusedException exc) {
 		   return null; // no such entity
 	       }
-	       List<String>oldGroups = null;
+	       List<String>oldGroups;
 	       if (oldGroupCollection == null)
-		   oldGroups = new ArrayList<String>();
+		   oldGroups = new ArrayList<>();
 	       else
-		   oldGroups = new ArrayList<String>(oldGroupCollection);
+		   oldGroups = new ArrayList<>(oldGroupCollection);
 
 	       Collections.sort(oldGroups);
 	       List<String>newGroups = Arrays.asList(groups);
@@ -3892,7 +3888,7 @@ public class SimplePageBean {
 		   if (oldGroups instanceof List)
 		       ret = (List<String>)oldGroups;
 		   else if (oldGroups != null)
-		       ret = new ArrayList<String>(oldGroups);
+		       ret = new ArrayList<>(oldGroups);
 	       }
 	       // else null
 
@@ -3943,12 +3939,12 @@ public class SimplePageBean {
 	       
 	   groupString = null;
 	   if (groups != null) {
-	       for (int n = 0; n < groups.length; n++) {
-		   if (groupString == null)
-		       groupString = groups[n];
-		   else
-		       groupString = groupString + "," + groups[n];
-	       }
+		   for (String group : groups) {
+			   if (groupString == null)
+				   groupString = group;
+			   else
+				   groupString = groupString + "," + group;
+		   }
 	   }
 	   i.setGroups(groupString);
 
@@ -3960,7 +3956,7 @@ public class SimplePageBean {
 	       return myGroups;
 	   String userId = getCurrentUserId();
 	   Collection<Group> groups = getCurrentSite().getGroupsWithMember(userId);
-	   Set<String>ret = new HashSet<String>();
+	   Set<String>ret = new HashSet<>();
 	   if (groups == null)
 	       return ret;
 	   for (Group group: groups)
@@ -3973,7 +3969,7 @@ public class SimplePageBean {
     // only called if the item has groups. If there are specified groups
     // use them, otherwise get all groups
 	public Set<String> getOwnerGroups(SimplePageItem item) {
-	    Set<String> ret = new HashSet<String>();
+	    Set<String> ret = new HashSet<>();
 	    String ownerGroups = item.getOwnerGroups();
 	    if (ownerGroups == null || ownerGroups.equals("")) {
 		List<GroupEntry> groupEntries = getCurrentGroups();
@@ -3997,7 +3993,7 @@ public class SimplePageBean {
 
 	   Site site = getCurrentSite();
 	   Collection<Group> groups = site.getGroups();
-	   List<GroupEntry> groupEntries = new ArrayList<GroupEntry>();
+	   List<GroupEntry> groupEntries = new ArrayList<>();
 	   for (Group g: groups) {
 	       if (g.getProperties().getProperty("lessonbuilder_ref") != null ||
 		   g.getTitle().startsWith("Access: "))
@@ -4104,7 +4100,7 @@ public class SimplePageBean {
 		    if (i >= 0)
 			atom = atom.substring(0, i);
 		    // first atom is hostname
-		    if (atom.indexOf(".") >= 0) {
+		    if (atom.contains( "." )) {
 			String server= ServerConfigurationService.getServerUrl();
 			if (server.startsWith("https:"))
 			    url = "https://" + url;
@@ -4191,7 +4187,7 @@ public class SimplePageBean {
 			update(i);
 			return "success";
 		} else {
-			log.warn("editMultimedia Could not find multimedia object: " + itemId);
+			log.warn("editMultimedia Could not find multimedia object: {}", itemId);
 			return "cancel";
 		}
 	}
@@ -4254,7 +4250,7 @@ public class SimplePageBean {
 			if (add)
 			    page.setGradebookPoints(newPoints);
 
-			isOwner = currentUserId!=null && page!=null && currentUserId.equals(page.getOwner());
+			isOwner = currentUserId!=null && currentUserId.equals(page.getOwner());
 			if (newOwner==null){
 				page.setOwner(newOwner);
 				page.setOwned(false);
@@ -4270,11 +4266,11 @@ public class SimplePageBean {
 					User user = null;
 					try {
 						user = UserDirectoryService.getUser(newOwner);
+						String displayName = user.getDisplayName();
+						setErrMessage(messageLocator.getMessage("simplepage.not-member").replace("{}", displayName));
 					} catch (UserNotDefinedException e) {
-						log.warn("Can't find user from owner:" + newOwner);
+						log.warn("Can't find user from owner:{}", newOwner);
 					}
-					String displayName = user.getDisplayName();
-					setErrMessage(messageLocator.getMessage("simplepage.not-member").replace("{}", displayName));
 				}
 			}
 		}
@@ -4418,8 +4414,8 @@ public class SimplePageBean {
 	}
 
 	private String uploadFile(String collectionId) {
-		String name = null;
-		String mimeType = null;
+		String name;
+		String mimeType;
 		MultipartFile file = null;
 		
 		if (multipartMap.size() > 0) {
@@ -4478,7 +4474,7 @@ public class SimplePageBean {
 				return null;
 			} catch (Exception e) {
 				setErrMessage(messageLocator.getMessage("simplepage.resourceerror").replace("{}", e.toString()));
-				log.error("addMultimedia error 1 " + e);
+				log.error("addMultimedia error 1 {}", e.toString());
 				return null;
 			}
 		}else {
@@ -4564,7 +4560,7 @@ public class SimplePageBean {
 		ToolConfiguration tool = sitePage.addTool(LESSONBUILDER_ID);
 		String toolId = tool.getPageId();
 		
-		SimplePage page = null;
+		SimplePage page;
 		
 		if(pageId == null) {
 			page = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, null, null);
@@ -4589,7 +4585,7 @@ public class SimplePageBean {
 		    try {
 			siteService.save(site);
 		    } catch (Exception e) {
-			log.error("addPage unable to save site " + e);
+			log.error("addPage unable to save site {}", e.toString());
 		    }
 		    currentSite = null; // force refetch, since we've changed it. note sure this is strictly needed
 		}
@@ -4619,7 +4615,7 @@ public class SimplePageBean {
         // add or update all student entries for the page
         // this only updates grades for users that are complete. Others should have 0 score, which won't change
 	public void recomputeGradebookEntries(Long pageId, String newPoints) {
-	    Map<String, String> userMap = new HashMap<String,String>();
+	    Map<String, String> userMap = new HashMap<>();
 	    List<SimplePageItem> items = simplePageToolDao.findPageItemsBySakaiId(Long.toString(pageId));
 	    if (items == null)
 		return;
@@ -4666,11 +4662,7 @@ public class SimplePageBean {
 
 		String extension = getExtension(item.getSakaiId());
 
-		if (imageTypes.contains(extension)) {
-			return true;
-		} else {
-			return false;
-		}
+		return imageTypes.contains(extension);
 	}
 
 	public boolean isHtmlType(SimplePageItem item) {
@@ -4687,11 +4679,7 @@ public class SimplePageBean {
 
 		String extension = getExtension(item.getSakaiId());
 
-		if (Arrays.binarySearch(htmlTypes, extension) >= 0) {
-			return true;
-		} else {
-			return false;
-		}
+		return Arrays.binarySearch(htmlTypes, extension) >= 0;
 
 	}
 
@@ -4756,7 +4744,7 @@ public class SimplePageBean {
 		    SimplePage secondPage = getPage(secondPageId);
 		    if (secondPage != null && secondPage.getSiteId().equals(getCurrentPage().getSiteId())) {
 			secondItems = getItemsOnPage(secondPageId);
-			if (secondItems.size() == 0)
+			if (secondItems.isEmpty())
 			    secondItems = null;
 			else {
 			    for(int i = 0; i < secondItems.size(); i++) {
@@ -4773,7 +4761,7 @@ public class SimplePageBean {
 
 		// make sure nothing is duplicated. I know it shouldn't be, but
 		// I saw the Fluid reorderer get confused once.
-		Set<String> used = new HashSet<String>();
+		Set<String> used = new HashSet<>();
 		for (int i = 0; i < split.length; i++) {
 			if (!used.add(split[i].trim())) {
 				log.warn("reorder: duplicate value");
@@ -4784,7 +4772,7 @@ public class SimplePageBean {
 
 		// keep track of which old items are used so we can remove the ones that aren't.
 		// items in set are indices into "items"
-		Set<Integer>keep = new HashSet<Integer>();
+		Set<Integer>keep = new HashSet<>();
 
 		// now do the reordering
 		for (int i = 0; i < split.length; i++) {
@@ -4875,7 +4863,7 @@ public class SimplePageBean {
 	
 	public void track(long itemId, String path, Long studentPageId) {
 		if (path != null) {
-		    List<String> pathItems = new ArrayList<String>(Arrays.asList(path.split(",")));
+		    List<String> pathItems = new ArrayList<>(Arrays.asList(path.split(",")));
 		    int last = pathItems.size();
 		    path = "";
 		    for (int i = 0; i < last; i ++) {
@@ -4939,7 +4927,6 @@ public class SimplePageBean {
 				EventTrackingService.post(EventTrackingService.newEvent(LessonBuilderEvents.ITEM_READ, "/lessonbuilder/item/" + item.getId(), complete));
 				if (complete != wasComplete)
 				    trackComplete(item, complete);
-				studentPageId = -1L;
 			}else if(path != null) {
 				entry.setComplete(true);
 				entry.setPath(path);
@@ -5121,7 +5108,7 @@ public class SimplePageBean {
 		} finally {
 		    popAdvisor(advisor);
 		}
-		if (itemGroups == null || itemGroups.size() == 0) {
+		if (itemGroups == null || itemGroups.isEmpty()) {
 		    // this includes items for which for which visibility doesn't apply
 		    visibleCache.put(item.getId(), true);
 		    return true;
@@ -5261,7 +5248,7 @@ public class SimplePageBean {
 			    completeCache.put(itemId, false);
 			    return false;
 			}
-			User user = null;
+			User user;
 			try {
 			    user = UserDirectoryService.getUser(getCurrentUserId());
 			} catch (Exception ignore) {
@@ -5336,7 +5323,7 @@ public class SimplePageBean {
 			}
 		} else if (item.getType() == SimplePageItem.PEEREVAL){
 			SimplePagePeerEval peerEval = simplePageToolDao.findPeerEval(item.getId());
-			boolean result = peerEval ==null? true:false;
+			boolean result = peerEval == null;
 				completeCache.put(itemId, result);
 				return result;
 		} else if (item.getType() == SimplePageItem.CHECKLIST) {
@@ -5354,17 +5341,9 @@ public class SimplePageBean {
 		String grade = submission.getGradeString();
 
 		if (type == SimplePageItem.ASSESSMENT) {
-			if (grade.equals("Pass")) {
-				return true;
-			} else {
-				return false;
-			}
+			return grade.equals("Pass");
 		} else if (type == SimplePageItem.TEXT) {
-			if (grade.equals("Checked")) {
-				return true;
-			} else {
-				return false;
-			}
+			return grade.equals("Checked");
 		} else if (type == SimplePageItem.PAGE) {
 			if (grade.equals("ungraded")) {
 				return false;
@@ -5386,11 +5365,7 @@ public class SimplePageBean {
 			if (requiredIndex == -1 || currentIndex == -1) {
 				return false;
 			} else {
-				if (requiredIndex >= currentIndex) {
-					return true;
-				} else {
-					return false;
-				}
+				return requiredIndex >= currentIndex;
 			}
 		} else if (type == SimplePageItem.ASSIGNMENT) {
 			// assignment 2 uses gradebook, so we have a float value
@@ -5398,11 +5373,7 @@ public class SimplePageBean {
 			if (submission.getGrade() != null)
 				return (submission.getGrade() + 0.0001d) >= Double.valueOf(requirementString);
 			// otherwise use the String. With two strings we can use exact decimal arithmetic
-			if (new BigDecimal(grade).compareTo(new BigDecimal(requirementString).multiply(new BigDecimal(10))) >= 0) {
-				return true;
-			} else {
-				return false;
-			}
+			return new BigDecimal(grade).compareTo(new BigDecimal(requirementString).multiply(new BigDecimal(10))) >= 0;
 		} else {
 			return false;
 		}
@@ -5452,6 +5423,7 @@ public class SimplePageBean {
 	/**
 	 * @param itemId
 	 *            The ID of the page from the <b>items</b> table (not the page table).
+	 * @param alreadySeen
 	 * @return
 	 */
 	public boolean isPageComplete(long itemId,Set<Long>alreadySeen) {
@@ -5478,7 +5450,7 @@ public class SimplePageBean {
 				    return false;
 				}
 				if (alreadySeen == null)
-				    alreadySeen = new HashSet<Long>();
+				    alreadySeen = new HashSet<>();
 				alreadySeen.add(itemId);
 				// recursive check to see whether page is complete
 				boolean subOK = isPageComplete(item.getId(), alreadySeen);
@@ -5505,7 +5477,7 @@ public class SimplePageBean {
     // multiple places, but we're passing the item, so we've got the right one
 	public List<String> pagesNeeded(SimplePageItem item) {
 		String currentPageId = Long.toString(getCurrentPageId());
-		List<String> needed = new ArrayList<String>();
+		List<String> needed = new ArrayList<>();
 
 	    // authorized or maybe user is gaming us, or maybe next page code
 	    // sent them to something that isn't available.
@@ -5576,7 +5548,7 @@ public class SimplePageBean {
 		    updated = simplePageToolDao.clearNeedsFixup(getCurrentSiteId());
 		} catch (Exception e) {
 		    // should get here if the flag has been removed already by another process
-		    log.warn("clearneedsfixup " + e);
+		    log.warn("clearneedsfixup {}", e.toString());
 		}
 		// only do this if there was a flag to delete
 		if (updated != 0) {
@@ -5706,7 +5678,7 @@ public class SimplePageBean {
 
 	public String getYoutubeKey(SimplePageItem i) {
 		String sakaiId = i.getSakaiId();
-		String URL = null;
+		String URL;
 
 		URL = i.getAttribute("multimediaUrl");
 		if (URL != null)
@@ -5730,7 +5702,7 @@ public class SimplePageBean {
 				securityService.pushAdvisor(advisor);
 			// }
 			// find the resource
-			ContentResource resource = null;
+			ContentResource resource;
 			try {
 				resource = contentHostingService.getResource(sakaiId);
 			} catch (Exception ignore) {
@@ -5750,9 +5722,6 @@ public class SimplePageBean {
 			try {
 				URL = new String(resource.getContent());
 			} catch (Exception ignore) {
-				return null;
-			}
-			if (URL == null) {
 				return null;
 			}
 			
@@ -5834,7 +5803,7 @@ public class SimplePageBean {
 			}
 		}
 
-		boolean success = true;
+		boolean success;
 		String groupId = group.getGroupId();
 
 		try {
@@ -5864,10 +5833,10 @@ public class SimplePageBean {
 				
 			} catch (Exception e) {
 			    // some other failure from getAuthzGroup, shouldn't be possible
-			    log.warn("checkItemPermissions unable to join or unjoin group " + groupId);
+			    log.warn("checkItemPermissions unable to join or unjoin group {}", groupId);
 			}
 
-			log.warn("checkItemPermissions: User seems to have deleted group " + groupId + ". We'll recreate it.");
+			log.warn("checkItemPermissions: User seems to have deleted group {}. We'll recreate it.", groupId);
 
 			// OK, group doesn't exist. When we recreate it, it's going to have a 
 			// different groupId, so we have to back out of everything and reset it
@@ -5988,7 +5957,7 @@ public class SimplePageBean {
 		boolean hiddenDir = ServerConfigurationService.getBoolean("lessonbuilder.folder.hidden",false);
 		String pageOwner = getCurrentPage().getOwner();
 		String collectionId;
-		String folder = null;
+		String folder;
 		// for owned pages, use the same kind of hierarchy. One exception: use site name as basedir
 		if (pageOwner != null) {
 		    String title = getCurrentSite().getTitle();
@@ -6026,7 +5995,7 @@ public class SimplePageBean {
 			if (folderString != null) {
 			    folder = collectionId + folderString; 
 			} else {
-			    Path path = getPagePath(page, new HashSet<Long>());
+			    Path path = getPagePath(page, new HashSet<>());
 			    String title = path.title;
 
 			    // there's a limit of 255 to resource names. Leave 30 chars for the file.
@@ -6127,7 +6096,7 @@ public class SimplePageBean {
 	public Path getPagePath(SimplePage page, Set<Long>seen) {
 	    seen.add(page.getPageId());
 	    List<SimplePageItem> items = simplePageToolDao.findPageItemsBySakaiId(Long.toString(page.getPageId()));
-	    if (items == null || items.size() == 0) {
+	    if (items == null || items.isEmpty()) {
 		return new Path(0, Validator.escapeResourceName(org.apache.commons.lang.StringUtils.abbreviateMiddle(page.getTitle(),"_",30)) + "/");
 	    }
 	    else {
@@ -6170,11 +6139,8 @@ public class SimplePageBean {
 		if (mimeType != null && (mimeType.startsWith("http") || mimeType.equals("")))
 			mimeType = null;
 	    
-		if (mimeType != null && (mimeType.equals("text/html") || mimeType.equals("application/xhtml+xml"))
-				|| mimeType == null && (extension.equals("html") || extension.equals("htm"))) {
-			return true;
-		}
-		return false;
+		return mimeType != null && (mimeType.equals("text/html") || mimeType.equals("application/xhtml+xml"))
+			   || mimeType == null && (extension.equals("html") || extension.equals("htm"));
 	}
 
 	public static final int MAXIMUM_ATTEMPTS_FOR_UNIQUENESS = 100;
@@ -6269,7 +6235,7 @@ public class SimplePageBean {
 
 				mimeType = file.getContentType();
 				try {
-					ContentResourceEdit res = null;
+					ContentResourceEdit res;
 					if (itemId != -1 && replacefile) {
 					    // upload new version -- get existing file
 					    SimplePageItem item = findItem(itemId);
@@ -6333,9 +6299,9 @@ public class SimplePageBean {
 					return;
 				} catch (Exception e) {
 					setErrMessage(messageLocator.getMessage("simplepage.resourceerror").replace("{}", e.toString()));
-					log.error("addMultimedia error 1 " + e);
+					log.error("addMultimedia error 1 {}", e.toString());
 					return;
-				};
+				}
 				// if user supplied name use it, else the filename
 				// if multiple files, the user supplied name is for first only, or we'd
 				// have several links with the same name
@@ -6393,7 +6359,7 @@ public class SimplePageBean {
 			//   	for existing items it should be set to the passed value for HTML/XMTL, false otherwise
 			//   	it is ignored for isMultimedia, as those are always displayed inline in the current page
 			
-			SimplePageItem item = null;
+			SimplePageItem item;
 			if (itemId == -1 && isMultimedia) {
 			    item = appendItem(sakaiId, name, SimplePageItem.MULTIMEDIA);
 			} else if (itemId == -1) {
@@ -6464,7 +6430,7 @@ public class SimplePageBean {
 			    //		  else
 					saveOrUpdate(item);
 			} catch (Exception e) {
-			    log.info("save error " + e);
+			    log.info("save error {}", e.toString());
 				// 	saveItem and update produce the errors
 			}
 		}catch(Exception ex) {
@@ -6518,7 +6484,7 @@ public class SimplePageBean {
                 }
 
                 // Parse, validate and check OAuth signature for the incoming ContentItem
-                ContentItem contentItem = null;
+                ContentItem contentItem;
                 try {
                         contentItem = SakaiBLTIUtil.getContentItemFromRequest(tool);
                 } catch(Exception e) {
@@ -6538,7 +6504,7 @@ public class SimplePageBean {
 		String localUrl = (String) item.get("url");
 		// log.info("localUrl="+localUrl);
 
-		InputStream fis = null;
+		InputStream fis;
 		if ( localUrl != null && localUrl.length() > 1 ) {
 			try {
 				URL parsedUrl = new URL(localUrl);
@@ -6556,7 +6522,6 @@ public class SimplePageBean {
 				String successMessage = messageLocator.getMessage("simplepage.lti-import-success-length").replace("{}", length+"");
 				toolSession.setAttribute("lessonbuilder.fileImportDone", successMessage);
 			}
-			return;
 		} else {
 			setErrKey("simplepage.lti-import-missing-url", null);
 		}
@@ -6576,7 +6541,7 @@ public class SimplePageBean {
 		file = multipartMap.values().iterator().next();
 	    }
 
-	    InputStream fis = null;
+	    InputStream fis;
 	    if (file != null) {
 		if (!uploadSizeOk(file))
 		    return;
@@ -6612,17 +6577,19 @@ public class SimplePageBean {
 			setErrMessage("unable to create temp directory for load");
 			return -1;
 		    }
-		    BufferedInputStream bis = new BufferedInputStream(fis);
-		    BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(cc));
-		    byte[] buffer = new byte[8096];
-		    int n = 0;
-		    while ((n = bis.read(buffer, 0, 8096)) >= 0) {
-			if (n > 0) {
-			    bos.write(buffer, 0, n);
-			    length += n;
+			BufferedOutputStream bos;
+			try (BufferedInputStream bis = new BufferedInputStream(fis))
+			{
+				bos = new BufferedOutputStream(new FileOutputStream(cc));
+				byte[] buffer = new byte[8096];
+				int n = 0;
+				while ((n = bis.read(buffer, 0, 8096)) >= 0) {
+					if (n > 0) {
+						bos.write(buffer, 0, n);
+						length += n;
+					}
+				}
 			}
-		    }
-		    bis.close();
 		    bos.close();
 
 		    CartridgeLoader cartridgeLoader = ZipLoader.getUtilities(cc, root.getCanonicalPath());
@@ -6693,7 +6660,7 @@ public class SimplePageBean {
 
 		// if there's a new youtube URL, and it's different from
 		// the old one, update the URL if they are different
-		if (key != null && !key.equals(oldkey)) {
+		if (!key.equals(oldkey)) {
 		    String url = "https://youtu.be/" + key;
 		    item.setName("youtub.be/" + key);
 		    item.setSakaiId(sakaiIdFromUrl(url, item));
@@ -6734,19 +6701,18 @@ public class SimplePageBean {
 			ToolConfiguration placement = iterator.next();
 			Properties roleConfig = placement.getPlacementConfig();
 			String roleList = roleConfig.getProperty("functions.require");
-			String visibility = roleConfig.getProperty("sakai-portal:visible");
 			boolean saveChanges = false;
 
 			if (roleList == null) {
 				roleList = "";
 			}
-			if (!(roleList.indexOf(SITE_UPD) > -1) && !visible) {
+			if (!roleList.contains( SITE_UPD ) && !visible) {
 				if (roleList.length() > 0) {
 					roleList += ",";
 				}
 				roleList += SITE_UPD;
 				saveChanges = true;
-			} else if ((roleList.indexOf(SITE_UPD) > -1) && visible) {
+			} else if ((roleList.contains( SITE_UPD )) && visible) {
 				roleList = roleList.replaceAll("," + SITE_UPD, "");
 				roleList = roleList.replaceAll(SITE_UPD, "");
 				saveChanges = true;
@@ -6813,17 +6779,16 @@ public class SimplePageBean {
 	 *  or not the current user can edit the page, without having to hit the
 	 *  database each time.
 	 *  
+	 * @param c
+	 * @param canEditPage
+	 * @return
 	 */
 	public boolean canModifyComment(SimplePageComment c, boolean canEditPage) {
 		if(canEditPage) return true;
 		
 		if(c.getAuthor().equals(UserDirectoryService.getCurrentUser().getId())){
 			// Author can edit for 30 minutes.
-			if(System.currentTimeMillis() - c.getTimePosted().getTime() <= 1800000) {
-				return true;
-			}else {
-				return false;
-			}
+			return System.currentTimeMillis() - c.getTimePosted().getTime() <= 1800000;
 		}else {
 			return false;
 		}
@@ -6854,7 +6819,7 @@ public class SimplePageBean {
 		
 		// get this from itemId to avoid issues if someone has opened
 		// a different page in another window
-		Long currentPageId = null;
+		Long currentPageId;
 		SimplePageItem commentItem = findItem(itemId);
 		if (commentItem == null) {
 		    // should be impossible
@@ -6876,10 +6841,6 @@ public class SimplePageBean {
 		    // that seems good enough for testing whether the user has successfully gotten to the page
 		    if (studentPage != null)
 			currentPageId = studentPage.getPageId();
-		}
-		if (currentPageId == null) {
-		    // should be impossible
-		    return "failure";
 		}
 		SimplePage currentPage = getPage(currentPageId);
 		if (currentPage == null) {
@@ -6969,8 +6930,8 @@ public class SimplePageBean {
 				}
 				
 				if(comment.getGradebookId() == null || !comment.getGradebookPoints().equals(points)) {
-					String pageTitle = "";
-					String gradebookId = "";
+					String pageTitle;
+					String gradebookId;
 					
 					boolean add = true;
 					
@@ -7037,6 +6998,8 @@ public class SimplePageBean {
 	 * This is so that the namings remain consistent when the comment section
 	 * is set to show names as anonymous.  Otherwise, deleting a post could change
 	 * the numbering, which hinders discussion.
+	 * @param commentUUID
+	 * @return
 	 */
 	public String deleteComment(String commentUUID) {
 		SimplePageComment comment = simplePageToolDao.findCommentByUUID(commentUUID);
@@ -7073,8 +7036,6 @@ public class SimplePageBean {
 	}
 	
 	public boolean myStudentPageGroupsOk (SimplePageItem item) {
-	    Group group = null;
-	    String groupId = null;
 	    if (item.isGroupOwned()) {
 		// all groups we are a member of
 		Collection<Group> groups = getCurrentSite().getGroupsWithMember(getCurrentUserId());
@@ -7085,8 +7046,8 @@ public class SimplePageBean {
 		    return groups != null && groups.size() > 0;
 
 		// otherwise have to check 
-		HashSet<String> allowedIds = new HashSet<String>(Arrays.asList(allowedString.split(",")));
-		HashSet<String> inIds = new HashSet<String>();
+		HashSet<String> allowedIds = new HashSet<>(Arrays.asList(allowedString.split(",")));
+		HashSet<String> inIds = new HashSet<>();
 		for (Group g: groups)
 		    inIds.add(g.getId());
 
@@ -7131,15 +7092,15 @@ public class SimplePageBean {
 			    String allowedString = containerItem.getOwnerGroups();
 			    HashSet<String> allowedGroups = null;
 			    if (allowedString != null && allowedString.length() > 0)
-				allowedGroups = new HashSet<String>(Arrays.asList(allowedString.split(",")));
+				allowedGroups = new HashSet<>(Arrays.asList(allowedString.split(",")));
 			    Collection<Group> groups = getCurrentSite().getGroupsWithMember(user.getId());
-			    if (groups.size() == 0) {
+			    if (groups.isEmpty()) {
 				setErrMessage(messageLocator.getMessage("simplepage.owner-groups-nogroup"));
 				return "permission-failed";
 			    }
 			    // ideally just one matches. But if more than one does, let's be deterministic
 			    // about which one we use.
-			    List<GroupEntry> groupEntries = new ArrayList<GroupEntry>();
+			    List<GroupEntry> groupEntries = new ArrayList<>();
 			    for (Group g: groups) {
 				if (allowedGroups != null && ! allowedGroups.contains(g.getId()))
 				    continue;
@@ -7151,7 +7112,7 @@ public class SimplePageBean {
 				e.id = g.getId();
 				groupEntries.add(e);
 			    }
-			    if (groupEntries.size() == 0) {
+			    if (groupEntries.isEmpty()) {
 				setErrMessage(messageLocator.getMessage("simplepage.owner-groups-nogroup"));
 				return "permission-failed";
 			    }
@@ -7221,7 +7182,7 @@ public class SimplePageBean {
 	public HashMap<Long, SimplePageLogEntry> cacheStudentPageLogEntries(long itemId) {
 		List<SimplePageLogEntry> entries = simplePageToolDao.getStudentPageLogEntries(itemId, UserDirectoryService.getCurrentUser().getId());
 		
-		HashMap<Long, SimplePageLogEntry> map = new HashMap<Long, SimplePageLogEntry>();
+		HashMap<Long, SimplePageLogEntry> map = new HashMap<>();
 		for(SimplePageLogEntry entry : entries) {
 			logCache.put(entry.getItemId() + "-" + entry.getStudentPageId(), entry);
 			map.put(entry.getStudentPageId(), entry);
@@ -7275,7 +7236,7 @@ public class SimplePageBean {
 		// I think this method should only be called from one thread
 		// so this should be safe.
 		if(questionAnswers == null) {
-			questionAnswers = new HashMap<Integer, String>();
+			questionAnswers = new HashMap<>();
 			log.info("setAddAnswer: it was null");
 		}
 		
@@ -7305,7 +7266,7 @@ public class SimplePageBean {
 		
 		SimplePageItem item;
 		if(itemId != null && itemId != -1) {
-			item = findItem(Long.valueOf(itemId));
+			item = findItem(itemId);
 		}else {
 			// Adding a question to the page
 			item = appendItem("", messageLocator.getMessage("simplepage.questionName"), SimplePageItem.QUESTION);
@@ -7320,10 +7281,10 @@ public class SimplePageBean {
 		if(questionType.equals("shortanswer")) {
 			String shortAnswers[] = questionAnswer.split("\n");
 			questionAnswer = "";
-			for (int i = 0; i < shortAnswers.length; i ++) {
-			    String a = shortAnswers[i].trim();
-			    if (! a.equals(""))
-				questionAnswer = questionAnswer + a + "\n";
+			for (String shortAnswer : shortAnswers) {
+				String a = shortAnswer.trim();
+				if (! a.equals(""))
+					questionAnswer = questionAnswer + a + "\n";
 			}
 			item.setAttribute("questionAnswer", questionAnswer);
 		}else if(questionType.equals("multipleChoice")) {
@@ -7437,7 +7398,7 @@ public class SimplePageBean {
 	private boolean gradeQuestionResponse(SimplePageQuestionResponse response) {
 		SimplePageItem question = findItem(response.getQuestionId());
 		if(question == null) {
-			log.warn("Invalid question for QuestionResponse " + response.getId());
+			log.warn("Invalid question for QuestionResponse {}", response.getId());
 			return false;
 		}
 		
@@ -7445,7 +7406,7 @@ public class SimplePageBean {
 		if (question.getGradebookPoints() != null)
 		    gradebookPoints = (double)question.getGradebookPoints();
 
-		boolean correct = true;
+		boolean correct;
 		if(response.isOverridden()) {
 			// The teacher set this score manually, so we'd rather not mess with it.
 			correct = response.isCorrect();
@@ -7484,7 +7445,7 @@ public class SimplePageBean {
 				gradebookPoints = 0.0;
 			}
 		}else {
-			log.warn("Invalid question type for question " + question.getId());
+			log.warn("Invalid question type for question {}", question.getId());
 			correct = false;
 		}
 		
@@ -7596,19 +7557,20 @@ public class SimplePageBean {
 			else {
 			    StringBuilder ownerGroups = new StringBuilder();
 			    boolean first = true;
-			    for (int i = 0; i < studentSelectedGroups.length; i++) {
-				// ignore groups that don't exist or aren't in this site
-				if (getCurrentSite().getGroup(studentSelectedGroups[i]) == null)
-				    continue;
-				if (first)
-				    first = false;
-				else
-				    ownerGroups.append(",");
-				ownerGroups.append(studentSelectedGroups[i]);
-			    }
+				for (String studentSelectedGroup : studentSelectedGroups) {
+					// ignore groups that don't exist or aren't in this site
+					if (getCurrentSite().getGroup(studentSelectedGroup) == null )
+						continue;
+					if (first)
+						first = false;
+					else
+						ownerGroups.append(",");
+					ownerGroups.append(studentSelectedGroup);
+				}
 			    page.setOwnerGroups(ownerGroups.toString());
 			}
-			
+
+			// TODO: this section currently does nothing but do a database call to get an item... Can it be removed?
 			// Update the comments tools to reflect any changes
 			if(comments) {
 				List<SimpleStudentPage> pages = simplePageToolDao.findStudentPages(itemId);
@@ -7630,7 +7592,7 @@ public class SimplePageBean {
 			if(rubricRows==null)log.info("rubricRows is null");else	log.info("rubricRows is not null");
 			if(peerEval){
 				String result = addPeerEval();
-				log.info("peerEval"+result);
+				log.info("peerEval{}", result);
 			}
 		
 			if(maxPoints == null || maxPoints.equals("")) {
@@ -7652,7 +7614,7 @@ public class SimplePageBean {
 				}
 				
 				if(page.getGradebookId() == null || !page.getGradebookPoints().equals(points)) {
-				 	boolean add = false;
+				 	boolean add;
 					if (page.getGradebookId() != null && !page.getGradebookPoints().equals(points))
 					    add = gradebookIfc.updateExternalAssessment(getCurrentSiteId(), "lesson-builder:page:" + page.getId(), null, getPage(page.getPageId()).getTitle() + " Student Pages (item:" + page.getId() + ")", Integer.valueOf(maxPoints), null);
 					else 
@@ -7685,7 +7647,7 @@ public class SimplePageBean {
 				
 				if(page.getAltGradebook() == null || !page.getAltPoints().equals(points)) {
 					String title = getPage(page.getPageId()).getTitle() + " Student Page Comments (item:" + page.getId() + ")";
-					boolean add = false;
+					boolean add;
 					if(page.getAltGradebook() != null && !page.getAltPoints().equals(points))
 					    add = gradebookIfc.updateExternalAssessment(getCurrentSiteId(), "lesson-builder:page-comment:" + page.getId(), null,
 											title, points, null);
@@ -7734,11 +7696,11 @@ public class SimplePageBean {
 	    }
 
 	    // initialize notsubmitted to all userids or groupids
-	    Set<String> notSubmitted = new HashSet<String>();
+	    Set<String> notSubmitted = new HashSet<>();
 	    if (item.isGroupOwned()) {
 		notSubmitted = getOwnerGroups(item);
 	    } else {
-		Set<Member> members = new HashSet<Member>();
+		Set<Member> members = new HashSet<>();
 		try {
 		    members = authzGroupService.getAuthzGroup(siteService.siteReference(getCurrentSiteId())).getMembers();
 		} catch (Exception e) {
@@ -7765,11 +7727,11 @@ public class SimplePageBean {
 	    
 	    // now zero the grades
 	    for (String owner: notSubmitted) {
-		List<String> owners = null;
+		List<String> owners;
 		if (item.isGroupOwned()) {
 		    owners = studentPageGroupMembers(item, owner);
 		} else {
-		    owners = new ArrayList<String>();
+		    owners = new ArrayList<>();
 		    owners.add(owner);
 		}
 		for (String userid: owners) {
@@ -7806,8 +7768,8 @@ public class SimplePageBean {
 	    }
 
 	    // initialize notsubmitted to all userids or groupids
-	    Set<String> notSubmitted = new HashSet<String>();
-	    Set<Member> members = new HashSet<Member>();
+	    Set<String> notSubmitted = new HashSet<>();
+	    Set<Member> members = new HashSet<>();
 	    try {
 		members = authzGroupService.getAuthzGroup(siteService.siteReference(getCurrentSiteId())).getMembers();
 	    } catch (Exception e) {
@@ -7824,7 +7786,7 @@ public class SimplePageBean {
 	    }else {
 		List<SimpleStudentPage> studentPages = simplePageToolDao.findStudentPages(itemId);
 		
-		List<Long> commentsItemIds = new ArrayList<Long>();
+		List<Long> commentsItemIds = new ArrayList<>();
 		for(SimpleStudentPage p : studentPages) {
 		    // If the page is deleted, don't show the comments
 		    if(!p.isDeleted()) {
@@ -7870,8 +7832,8 @@ public class SimplePageBean {
 	    }
 
 	    // initialize notsubmitted to all userids or groupids
-	    Set<String> notSubmitted = new HashSet<String>();
-	    Set<Member> members = new HashSet<Member>();
+	    Set<String> notSubmitted = new HashSet<>();
+	    Set<Member> members = new HashSet<>();
 	    try {
 		members = authzGroupService.getAuthzGroup(siteService.siteReference(getCurrentSiteId())).getMembers();
 	    } catch (Exception e) {
@@ -7937,7 +7899,7 @@ public class SimplePageBean {
 					      m.getUserId(), String.valueOf(c.getPoints()));
 				    }
 				} catch (Exception e) {
-				    log.info("unable to get members of group " + group);
+				    log.info("unable to get members of group {}", group);
 				}
 			    }
 			}
@@ -8089,8 +8051,8 @@ public class SimplePageBean {
     // otherwise, if it's an HTML file, look for a folder with the same name
 	public static String associatedFolder(String resourceId) {
 	    int i = resourceId.lastIndexOf("/");
-	    String folder = null;
-	    String name = null;
+	    String folder;
+	    String name;
 	    if (i >= 0) {
 		folder = resourceId.substring(0, i+1);  // include trailing
 		name = resourceId.substring(i+1);
@@ -8160,16 +8122,17 @@ public class SimplePageBean {
 	 * One entry may be null, to separate system-wide from site-wide.
 	 * 
 	 * Caches lookups, to prevent extra database hits.
+	 * @return
 	 */
 	public ArrayList<ContentResource> getAvailableCss() {
-		ArrayList<ContentResource> list = new ArrayList<ContentResource>();
+		ArrayList<ContentResource> list = new ArrayList<>();
 		
 		String collectionId = contentHostingService.getSiteCollection(getCurrentSiteId()) + "LB-CSS/";
 		
 		List<ContentResource> resources = (List<ContentResource>) resourceCache.get(collectionId);
 		if(resources == null) {
 			resources = contentHostingService.getAllResources(collectionId);
-			if(resources == null) resources = new ArrayList<ContentResource>();
+			if(resources == null) resources = new ArrayList<>();
 			
 			resourceCache.put(collectionId, resources);
 		}
@@ -8187,11 +8150,10 @@ public class SimplePageBean {
 		
 		collectionId = "/public/LB-CSS/";
 		
-		resources = null;
 		resources = (List<ContentResource>) resourceCache.get(collectionId);
 		if(resources == null) {
 			resources = contentHostingService.getAllResources(collectionId);
-			if(resources == null) resources = new ArrayList<ContentResource>();
+			if(resources == null) resources = new ArrayList<>();
 			
 			resourceCache.put(collectionId, resources);
 		}
@@ -8216,9 +8178,10 @@ public class SimplePageBean {
 	 * system level.
 	 * 
 	 * Caches lookups to prevent too many lookups in the database.
+	 * @return
 	 */
 	public ContentResource getCssForCurrentPage() {
-		ContentResource resource = null;
+		ContentResource resource;
 		
 		// I'm always using ArrayList for the resourceCache so that I can distinguish
 		// between never having looked up the resource, and the resource not being there.
@@ -8231,7 +8194,7 @@ public class SimplePageBean {
 				ArrayList<ContentResource> resources = (ArrayList<ContentResource>) resourceCache.get(collectionId);
 				if(resources == null) {
 					resource = contentHostingService.getResource(collectionId);
-					resources = new ArrayList<ContentResource>();
+					resources = new ArrayList<>();
 					resources.add(resource);
 					resourceCache.put(collectionId, resources);
 				}
@@ -8242,7 +8205,7 @@ public class SimplePageBean {
 					throw new Exception();
 				}
 			}catch(Exception ex) {
-				resourceCache.put(collectionId, new ArrayList<ContentResource>());
+				resourceCache.put(collectionId, new ArrayList<>());
 			}
 		}
 		
@@ -8253,7 +8216,7 @@ public class SimplePageBean {
 			ArrayList<ContentResource> resources = (ArrayList<ContentResource>) resourceCache.get(collectionId);
 			if(resources == null) {
 				resource = contentHostingService.getResource(collectionId);
-				resources = new ArrayList<ContentResource>();
+				resources = new ArrayList<>();
 				resources.add(resource);
 				resourceCache.put(collectionId, resources);
 			}
@@ -8262,7 +8225,7 @@ public class SimplePageBean {
 				return resources.get(0);
 			}
 		}catch(Exception ignore) {
-			resourceCache.put(collectionId, new ArrayList<ContentResource>());
+			resourceCache.put(collectionId, new ArrayList<>());
 		}
 		
 		collectionId = "/public/LB-CSS/" + ServerConfigurationService.getString("lessonbuilder.default.css", "default.css");
@@ -8271,7 +8234,7 @@ public class SimplePageBean {
 			ArrayList<ContentResource> resources = (ArrayList<ContentResource>) resourceCache.get(collectionId);
 			if(resources == null) {
 				resource = contentHostingService.getResource(collectionId);
-				resources = new ArrayList<ContentResource>();
+				resources = new ArrayList<>();
 				resources.add(resource);
 				resourceCache.put(collectionId, resources);
 			}
@@ -8280,7 +8243,7 @@ public class SimplePageBean {
 				return resources.get(0);
 			}
 		}catch(Exception ignore) {
-			resourceCache.put(collectionId, new ArrayList<ContentResource>());
+			resourceCache.put(collectionId, new ArrayList<>());
 		}
 				
 		return null;
@@ -8298,7 +8261,7 @@ public class SimplePageBean {
 		
 		SimplePageItem item;
 		if(itemId != null && itemId != -1) {
-			item = findItem(Long.valueOf(itemId));
+			item = findItem(itemId);
 			
 		}else {
 			
@@ -8338,7 +8301,7 @@ public class SimplePageBean {
 			
 			// split the data into the actual fields
 			String[] fields = data.split(":", 2);
-			Long rowId= 0L;
+			Long rowId;
 			if (("").equals(fields[0]))
 			    rowId = -1L;
 			else
@@ -8413,7 +8376,7 @@ public class SimplePageBean {
 		// construct row text -> row id
 		// old entries are by text, so need to be able to map them to id
 
-		Map<String, Long> rowMap = new HashMap<String, Long>();
+		Map<String, Long> rowMap = new HashMap<>();
 
 		SimplePageItem i = findItem(itemId);
                 List<Map> categories = (List<Map>) i.getJsonAttribute("rows");
@@ -8436,12 +8399,12 @@ public class SimplePageBean {
 
 		// data from user: build map target --> <category --> grades>
 
-		Map<String, Map<Long, Integer>> dataMap = new HashMap<String, Map<Long, Integer>>();
+		Map<String, Map<Long, Integer>> dataMap = new HashMap<>();
 		for (String gradeLine: rubricPeerGrades) {
 		    String[] items = gradeLine.split(":", 3);
 		    Map<Long, Integer> catMap = dataMap.get(items[2]);
 		    if (catMap == null) {
-			catMap = new HashMap<Long, Integer>();
+			catMap = new HashMap<>();
 			dataMap.put(items[2], catMap);
 		    }
 		    catMap.put(new Long(items[0]), new Integer(items[1]));
@@ -8452,7 +8415,7 @@ public class SimplePageBean {
 		// evalTargets are targets that it's legal to evaluate for this page
 		// owner, or if evaluating individuals on a gorup page, all members of the group
 
-		Set<String>evalTargets = new HashSet<String>();
+		Set<String>evalTargets = new HashSet<>();
 
 		if (evalIndividual) {
 		    String group = getCurrentPage().getGroup();
@@ -8465,7 +8428,7 @@ public class SimplePageBean {
 			    evalTargets.add(m.getUserId());
 			}
 		    } catch (Exception e) {
-			log.info("unable to get members of group " + group);
+			log.info("unable to get members of group {}", group);
 		    }
 		} else {
 		    evalTargets.add(getCurrentPage().getOwner());
@@ -8517,7 +8480,7 @@ public class SimplePageBean {
 	}
 	
 	public List<String>studentPageGroupMembers(SimplePageItem item, String group) {
-	    List<String>groupMembers = new ArrayList<String>();
+	    List<String>groupMembers = new ArrayList<>();
 	    if (item.isGroupOwned()) {
 		if (group == null) {
 		    SimplePage page = getCurrentPage();
@@ -8532,7 +8495,7 @@ public class SimplePageBean {
 			groupMembers.add(m.getUserId());
 		    }
 		} catch (Exception e) {
-		    log.info("unable to get members of group " + group);
+		    log.info("unable to get members of group {}", group);
 		}
 	    }
 	    return groupMembers;
@@ -8599,9 +8562,12 @@ public class SimplePageBean {
      *
      * For discussion of why you might want to do this, see
      * http://lpar.ath0.com/2011/06/07/unicode-alchemy-with-db2/
+     * @param input
+     * @param length
+     * @return
      */
 	public static String utf8truncate(String input, int length) {
-	StringBuffer result = new StringBuffer(length);
+	StringBuilder result = new StringBuilder(length);
 	int resultlen = 0;
 	for (int i = 0; i < input.length(); i++) {
 	    char c = input.charAt(i);
@@ -8630,6 +8596,7 @@ public class SimplePageBean {
 
 	/**
 	 * To add latest conversations in a div on Lessons Page
+	 * @return
 	 */
 	public String addForumSummary(){
 		if (!itemOk(itemId) || !checkCsrf()) {
@@ -8663,6 +8630,7 @@ public class SimplePageBean {
 
 	/**
 	 * Method to add Resources folder into Lessons tool
+	 * @return
 	 */
 	public String folderPickerSubmit(){
 		if (!itemOk(itemId))
@@ -8698,6 +8666,7 @@ public class SimplePageBean {
 	}
 	/**
 	 * Method to add calendar component in the Lessons Page
+	 * @param ab
 	 * @return
 	 */
 	public String addCalendar(String ab){

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -1917,7 +1917,10 @@ public class SimplePageBean {
 					}
 					if(item != null && item.getShowComments() != null && item.getShowComments()) {
 						//copy the attribute string from the top student section page  to each student page
-						items.add(0, simplePageToolDao.findItem(student.getCommentsSection()));
+						SimplePageItem commentsSection = simplePageToolDao.findItem(student.getCommentsSection());
+						if(commentsSection != null) {
+							items.add(0, commentsSection);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/LSNBLDR-940

Western recently ran into an issue where somehow a student page's comment section was deleted (every student page has a comment section by default). We haven't been able to identify exact steps to reproduce the ability to delete the comments section as a student, but the result was that trying to navigate to the student page in question would throw an uncaught NPE. The stacktrace would take over the entire portal, meaning the user had no way to reset the tool, or navigate back to the site without either manually entering the URL, or closing and re-opening their browser, etc.

The problem manifests because the ID of the comments section is stored in the student page object. However, when the comments section gets deleted, the ID for it remains in the page object. So when SimplePageBean.getItemsOnPage() runs, it detects that is had an ID for a comments section, asks the service for that item (which returns null), and then it tries to access the ID of this null object to stick in the itemCache map, which throws the NPE.