### PR TITLE
Remove workspace welcome pronouns

### DIFF
--- a/library/src/webapp/content/myworkspace_info.html
+++ b/library/src/webapp/content/myworkspace_info.html
@@ -37,7 +37,7 @@
 	<body>
 		<div class="portletBody"> 
 		<h3> Welcome to your personal workspace.</h3>
-			<p>In Sakai each user has his or her own individual worksite called "Home".
+			<p>In Sakai each user has their own individual worksite called "Home".
 			Home is a place where you can keep personal documents, create new sites, maintain a
 			schedule, store resources, and much more.</p>
 			<p class="instruction">The default information displayed here for a new user can be modified by the Sakai

--- a/library/src/webapp/content/myworkspace_info.html
+++ b/library/src/webapp/content/myworkspace_info.html
@@ -37,7 +37,7 @@
 	<body>
 		<div class="portletBody"> 
 		<h3> Welcome to your personal workspace.</h3>
-			<p>In Sakai each user has their own individual worksite called "Home".
+			<p>In Sakai each user has an individual worksite called "Home".
 			Home is a place where you can keep personal documents, create new sites, maintain a
 			schedule, store resources, and much more.</p>
 			<p class="instruction">The default information displayed here for a new user can be modified by the Sakai


### PR DESCRIPTION
Why use gender related pronouns here?

By removing them the sentence is shorter and therefore simpler while removing reference to irrelevant user details.

Thank you for the great project by the way.