### PR TITLE
SAK-33836: GBNG > allow configuration of max comment length via sakai.properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1812,6 +1812,11 @@
 # Default: true
 # gradebook.settings.gradeEntry.showToNonAdmins=false
 
+# SAK-33836: control the maximum character length of gradebook item comments.
+# NOTE: this property is not enforced in Gradebook Classic.
+# Default: 20,000
+# gradebookng.maxCommentLength=500
+
 # ASSIGNMENT 1
 # Allows an instructor or any user with assignments management permissions to submit the assignment on behalf of a student 
 # who has no submission yet (via the View Assignment list by student)

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -228,7 +228,6 @@ importExport.selection.previewGrades.studentName.heading = Student Name
 importExport.selection.previewGrades.grade.heading = Grade
 
 importExport.error.grade = An error occurred importing a grade. Please check the file.
-importExport.error.comment = An error occurred importing a comment. Please check the file.
 importExport.commentname = + comments
 importExport.error.incorrecttype = The file you uploaded is not recognised as a CSV or Excel file.
 importExport.error.nullFile = The file you have selected is empty or invalid. Please try selecting a different file.
@@ -238,6 +237,7 @@ importExport.error.duplicateColumns = The following columns are duplicated in th
 importExport.error.invalidColumns = The following columns are invalid or are not formatted properly: {0}. Please review the uploaded file.
 importExport.error.blankHeadings = The uploaded file contains {0} blank column headings. Please ensure each column has a valid heading and try again.
 importExport.error.invalidGradeData = The uploaded file contains invalid grades. {0} Please remove or correct the invalid data and re-upload the file. The following student/grade pairs in the file are invalid: {1}
+importExport.error.invalidComments = The uploaded file contains invalid comments. Comments cannot be longer than {0} characters. Please remove or correct the invalid data and re-upload the file. The following gradebook item:student pairs in the file have invalid comments: {1}
 importExport.error.noValidStudents = The uploaded file contains no students that are enrolled in this site. Importing requires at least one valid student entry in the file.
 importExport.error.duplicateStudents = The following students appear multiple times in the uploaded file: {0}. Please ensure that each student appears only once.
 importExport.error.orphanedComments = The uploaded file contains the following orphaned comment columns: {0}. Please review the file and ensure all comment columns have a corresponding gradebook item.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -39,9 +39,7 @@ import org.apache.commons.lang.StringUtils;
 
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityService;
-import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.coursemanagement.api.CourseManagementService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.gradebookng.business.exception.GbAccessDeniedException;
@@ -129,13 +127,7 @@ public class GradebookNgBusinessService {
 	private GradebookExternalAssessmentService gradebookExternalAssessmentService;
 
 	@Setter
-	private CourseManagementService courseManagementService;
-
-	@Setter
 	private SecurityService securityService;
-
-	@Setter
-	private ServerConfigurationService serverConfigurationService;
 
 	public static final String ASSIGNMENT_ORDER_PROP = "gbng_assignment_order";
 	public static final String ICON_SAKAI = "icon-sakai--";

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -46,6 +46,7 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.gradebookng.business.exception.GbAccessDeniedException;
 import org.sakaiproject.gradebookng.business.exception.GbException;
+import org.sakaiproject.gradebookng.business.importExport.CommentValidator;
 import org.sakaiproject.gradebookng.business.model.GbCourseGrade;
 import org.sakaiproject.gradebookng.business.model.GbGradeCell;
 import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
@@ -670,11 +671,10 @@ public class GradebookNgBusinessService {
 			log.debug("newGradeAdjusted: " + newGradeAdjusted);
 		}
 
-		// if comment longer than 500 chars, error.
-		// the field is a CLOB, probably by mistake. Loading this field up may cause performance issues
-		// see SAK-29595
-		if (StringUtils.length(comment) > 500) {
-			log.error("Comment too long. Maximum 500 characters.");
+		// if comment longer than MAX_COMMENT_LENGTH chars, error.
+		// SAK-33836 - MAX_COMMENT_LENGTH controlled by sakai.property 'gradebookng.maxCommentLength'; defaults to 20,000
+		if (CommentValidator.isCommentInvalid(comment)) {
+			log.error("Comment too long. Maximum {} characters.", CommentValidator.MAX_COMMENT_LENGTH);
 			return GradeSaveResponse.ERROR;
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/CommentValidationReport.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/CommentValidationReport.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2003-2018 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.gradebookng.business.importExport;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import lombok.Getter;
+
+/**
+ * Contains the data relevant to comment validation (comments that are too long).
+ *
+ * @author bjones86
+ */
+public class CommentValidationReport
+{
+    @Getter
+    private final SortedMap<String, List<String>> invalidComments;
+
+    public CommentValidationReport()
+    {
+        invalidComments = new ConcurrentSkipListMap<>();
+    }
+
+    public void addInvalidComment( String columnTitle, String studentIdentifier )
+    {
+        List<String> columnStudentsWithInvalidComments = invalidComments.get( columnTitle );
+        if( columnStudentsWithInvalidComments == null )
+        {
+            columnStudentsWithInvalidComments = new ArrayList<>();
+            columnStudentsWithInvalidComments.add( studentIdentifier );
+            invalidComments.put( columnTitle, columnStudentsWithInvalidComments );
+        }
+        else
+        {
+            columnStudentsWithInvalidComments.add( studentIdentifier );
+        }
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/CommentValidator.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/CommentValidator.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2003-2018 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.gradebookng.business.importExport;
+
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.gradebookng.business.model.ImportedCell;
+import org.sakaiproject.gradebookng.business.model.ImportedColumn;
+import org.sakaiproject.gradebookng.business.model.ImportedColumn.Type;
+import org.sakaiproject.gradebookng.business.model.ImportedRow;
+
+/**
+ * Used to validate comments in an imported file.
+ *
+ * @author bjones86
+ */
+public class CommentValidator
+{
+    private CommentValidationReport report;
+
+    private static final String SAK_PROP_MAX_COMMENT_LENGTH = "gradebookng.maxCommentLength";
+    private static final int SAK_PROP_MAX_COMMENT_LENGTH_DEFAULT = 20000;
+    public static final int MAX_COMMENT_LENGTH = ServerConfigurationService.getInt(SAK_PROP_MAX_COMMENT_LENGTH, SAK_PROP_MAX_COMMENT_LENGTH_DEFAULT);
+
+    /**
+     * Validate the comments contained within the list of imported rows.
+     *
+     * @param rows the list of data parsed from the input file
+     * @param columns the list of parsed columns, so we can access the column type and name
+     * @return the {@link CommentValidationReport}
+     */
+    public CommentValidationReport validate( List<ImportedRow> rows, List<ImportedColumn> columns )
+    {
+        report = new CommentValidationReport();
+
+        for( ImportedColumn column : columns )
+        {
+            Type columnType = column.getType();
+            String columnTitle = column.getColumnTitle();
+            if( columnType == Type.COMMENTS )
+            {
+                for( ImportedRow row : rows )
+                {
+                    ImportedCell cell = row.getCellMap().get( columnTitle );
+                    if( cell != null )
+                    {
+                        String studentIdentifier = row.getStudentEid();
+                        validateComment( columnTitle, studentIdentifier, cell.getComment() );
+                    }
+                }
+            }
+        }
+
+        return report;
+    }
+
+    /**
+     * Validates the given comment for the user/gradebook item.
+     *
+     * @param columnTitle
+     * @param studentIdentifer
+     * @param comment
+     */
+    private void validateComment( String columnTitle, String studentIdentifer, String comment )
+    {
+        // Empty comments are valid
+        if( StringUtils.isBlank( comment ) )
+        {
+            return;
+        }
+
+        if( isCommentInvalid( comment ) )
+        {
+            report.addInvalidComment( columnTitle, studentIdentifer );
+        }
+    }
+
+    /**
+     * Test the given comment string for validity (character length).
+     * Max length is defined by sakai.property 'gradebookng.maxCommentLength'; defaults to 20,000
+     *
+     * @param comment the comment string to test
+     * @return true if the given comment is invalid; false otherwise
+     */
+    public static boolean isCommentInvalid( String comment )
+    {
+        return StringUtils.length(comment) > MAX_COMMENT_LENGTH;
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -50,6 +50,8 @@ import org.apache.wicket.markup.html.panel.Panel;
 
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.gradebookng.business.exception.GbImportExportInvalidFileTypeException;
+import org.sakaiproject.gradebookng.business.importExport.CommentValidationReport;
+import org.sakaiproject.gradebookng.business.importExport.CommentValidator;
 import org.sakaiproject.gradebookng.business.importExport.GradeValidationReport;
 import org.sakaiproject.gradebookng.business.importExport.GradeValidator;
 import org.sakaiproject.gradebookng.business.importExport.HeadingValidationReport;
@@ -381,6 +383,22 @@ public class ImportGradesHelper {
 
 			String badGrades = StringUtils.join(badGradeEntries, ", ");
 			sourcePanel.error(MessageHelper.getString("importExport.error.invalidGradeData", MessageHelper.getString("grade.notifications.invalid"), badGrades));
+			hasValidationErrors = true;
+		}
+
+		// Perform comment validation; present error message with invalid gradebook items and corresponding student identifiers on current page
+		CommentValidationReport commentReport = new CommentValidator().validate(rows, columns);
+		SortedMap<String, List<String>> invalidCommentsMap = commentReport.getInvalidComments();
+		if (!invalidCommentsMap.isEmpty()) {
+			List<String> badCommentEntries = new ArrayList<>();
+			for (String columnTitle : invalidCommentsMap.keySet()) {
+				for (String student : invalidCommentsMap.get(columnTitle)) {
+					badCommentEntries.add(columnTitle + ":" + student);
+				}
+			}
+
+			String badComments = StringUtils.join(badCommentEntries, ", ");
+			sourcePanel.error(MessageHelper.getString("importExport.error.invalidComments", CommentValidator.MAX_COMMENT_LENGTH, badComments));
 			hasValidationErrors = true;
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -33,6 +33,7 @@ import org.sakaiproject.service.gradebook.shared.Assignment;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.sakaiproject.gradebookng.business.importExport.CommentValidator;
 
 /**
  *
@@ -121,7 +122,7 @@ public class EditGradeCommentPanel extends BasePanel {
 
 		// textarea
 		form.add(new TextArea<String>("comment", new PropertyModel<String>(formModel, "gradeComment"))
-				.add(StringValidator.maximumLength(500)));
+				.add(StringValidator.maximumLength(CommentValidator.MAX_COMMENT_LENGTH)));
 
 		// instant validation
 		// AjaxFormValidatingBehavior.addToAllFormComponents(form, "onkeyup", Duration.ONE_SECOND);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -27,13 +27,14 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.validation.validator.StringValidator;
+
+import org.sakaiproject.gradebookng.business.importExport.CommentValidator;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.sakaiproject.gradebookng.business.importExport.CommentValidator;
 
 /**
  *
@@ -69,11 +70,11 @@ public class EditGradeCommentPanel extends BasePanel {
 		// form model
 		final GradeComment gradeComment = new GradeComment();
 		gradeComment.setGradeComment(this.comment);
-		final CompoundPropertyModel<GradeComment> formModel = new CompoundPropertyModel<GradeComment>(gradeComment);
+		final CompoundPropertyModel<GradeComment> formModel = new CompoundPropertyModel<>(gradeComment);
 
 		// build form
 		// modal window forms must be submitted via AJAX so we do not specify an onSubmit here
-		final Form<GradeComment> form = new Form<GradeComment>("form", formModel);
+		final Form<GradeComment> form = new Form<>("form", formModel);
 
 		final GbAjaxButton submit = new GbAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
@@ -121,7 +122,7 @@ public class EditGradeCommentPanel extends BasePanel {
 						new Object[] { user.getDisplayName(), user.getDisplayId(), assignment.getName() })).getString());
 
 		// textarea
-		form.add(new TextArea<String>("comment", new PropertyModel<String>(formModel, "gradeComment"))
+		form.add(new TextArea<>("comment", new PropertyModel<>(formModel, "gradeComment"))
 				.add(StringValidator.maximumLength(CommentValidator.MAX_COMMENT_LENGTH)));
 
 		// instant validation

--- a/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -8,19 +8,13 @@
 		id="org.sakaiproject.gradebookng.business.GradebookNgBusinessService"
 		class="org.sakaiproject.gradebookng.business.GradebookNgBusinessService">
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
-		<property name="userDirectoryService"
-			ref="org.sakaiproject.user.api.UserDirectoryService" />
+		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
 		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
-		<property name="gradebookService"
-			ref="org.sakaiproject.service.gradebook.GradebookService" />
-		<property name="gradebookPermissionService"
-			ref="org.sakaiproject.service.gradebook.GradebookPermissionService" />
+		<property name="gradebookService" ref="org.sakaiproject.service.gradebook.GradebookService" />
+		<property name="gradebookPermissionService" ref="org.sakaiproject.service.gradebook.GradebookPermissionService" />
 		<property name="gradebookFrameworkService" ref="org.sakaiproject.service.gradebook.GradebookFrameworkService"/>
-		<property name="courseManagementService"
-			ref="org.sakaiproject.coursemanagement.api.CourseManagementService" />
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 		<property name="gradebookExternalAssessmentService" ref="org.sakaiproject.service.gradebook.GradebookExternalAssessmentService"/>
-		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 	</bean>
 
 	<bean


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33836

This PR will implement a sakai.property to allow configuration of the maximum number of characters allowed in a gradebook item comment. The sakai.property will default to 20,000 characters.

This value will be used for the maxlength attribute of the modal form for viewing/editing a single user's comment. It will also be used for a new comment validation routine for the Import process. This comment validation will inform the user up front which students have invalid comments for which gradebook items in the file, allowing them to correct the problem(s) and re-upload the file without having to go all the way through the wizard.

Please see the screenshots on the JIRA ticket for the Import process comment validation error message, the corresponding import file used, and the sakai.property used (set to max of 10 characters for ease of testing).