### PR TITLE
SAM-1579: Matching questions with distractors - Incorrect scoring and display of answer keys in several areas

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -137,7 +137,9 @@ public final class SamigoConstants {
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_ENABLED     = "samigo.email.autoSubmit.errorNotification.enabled";
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_TO_ADDRESS  = "samigo.email.autoSubmit.errorNotification.toAddress";
     public static final     String      SAK_PROP_SUPPORT_EMAIL_ADDRESS                      = "mail.support";
-    
+
+    public static final     String      ALPHABET                                            = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
     private SamigoConstants() {
     	throw new AssertionError();
     }

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/ItemTextIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/ItemTextIfc.java
@@ -33,6 +33,7 @@ public interface ItemTextIfc
   public static Long EMI_THEME_TEXT_SEQUENCE = Long.valueOf(-1);
   public static Long EMI_ANSWER_OPTIONS_SEQUENCE = Long.valueOf(-2);
   public static Long EMI_LEAD_IN_TEXT_SEQUENCE = Long.valueOf(-3);
+  public static String NONE_OF_THE_ABOVE = "None of the above";
  
   Long getId();
 

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/ItemTextIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/ItemTextIfc.java
@@ -57,6 +57,8 @@ public interface ItemTextIfc
   List<AnswerIfc> getAnswerArray();
 
   List<AnswerIfc> getAnswerArraySorted();
+
+  List<AnswerIfc> getAnswerArrayWithDistractorSorted();
   
   Set<ItemTextAttachmentIfc> getItemTextAttachmentSet();
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EvaluationMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EvaluationMessages.properties
@@ -118,6 +118,7 @@ no_submission=No Submission
 submitted=Submitted
 download_all=Download All
 no_answer=No Answer
+none_above=None of the Above
 paging_status=Viewing {0} - {1} of {2} items
 search_find=Find
 search_clear=Clear

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/MatchItemBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/MatchItemBean.java
@@ -28,7 +28,7 @@ public class MatchItemBean implements Serializable {
 
   private static final long serialVersionUID = 7526471155622776147L;
   public static final String CONTROLLING_SEQUENCE_DEFAULT = "*new*";
-  public static final String CONTROLLING_SEQUENCE_DISTRACTOR = "*distractor*";
+  public static final String CONTROLLING_SEQUENCE_DISTRACTOR = "*None of the Above*";
 //  private String text;
   private Long sequence;
 //  private String corrfeedback;

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/MatchingBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/MatchingBean.java
@@ -203,25 +203,15 @@ public class AnswerLabelWithCorrectStatus {
     this.isCorrect = isCorrect;
   }
   
-  public Boolean getIsCorrect()
-  {
-      /*
-    if (data != null && data.getPublishedAnswerId() != null &&
-        answer.getIsCorrect() != null &&
-        answer.getIsCorrect().booleanValue())
-      return true;
-    return false;
-      */
-    if(this.getIsDistractor()){
-		  if(this.response==null) return false;
-		  if(Integer.parseInt(this.response)<0){
-			  return true;
-		  }else{
-			  return false;
-		  }
-	}else{
-		return isCorrect;
-	}
+  public Boolean getIsCorrect() {
+    if (this.getIsDistractor()) {
+      if (this.response == null) {
+        return false;
+      }
+      return Integer.parseInt(this.response) < 0;
+    } else {
+        return isCorrect;
+    }
   }
   
   public boolean getIsDistractor() {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/MatchingBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/MatchingBean.java
@@ -212,7 +212,16 @@ public class AnswerLabelWithCorrectStatus {
       return true;
     return false;
       */
-    return isCorrect;
+    if(this.getIsDistractor()){
+		  if(this.response==null) return false;
+		  if(Integer.parseInt(this.response)<0){
+			  return true;
+		  }else{
+			  return false;
+		  }
+	}else{
+		return isCorrect;
+	}
   }
   
   public boolean getIsDistractor() {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -24,7 +24,6 @@ package org.sakaiproject.tool.assessment.ui.bean.evaluation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -90,8 +89,6 @@ public class QuestionScoresBean
   private String totalPeople;
   private String typeId;
   private Map scoresByItem;
-
-  private String marker;
 
   //private String selectedSectionFilterValue = TotalScoresBean.ALL_SECTIONS_SELECT_VALUE;
   private String selectedSectionFilterValue = null;
@@ -263,15 +260,6 @@ public class QuestionScoresBean
   public String getAssessmentId()
   {
     return Validator.check(assessmentId, "0");
-  }
-
-  public String getMarker()
-  {
-    return marker;
-  }
-
-  public void setMarker(String s){
-    marker = s;
   }
 
   /**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -91,6 +91,8 @@ public class QuestionScoresBean
   private String typeId;
   private Map scoresByItem;
 
+  private String marker;
+
   //private String selectedSectionFilterValue = TotalScoresBean.ALL_SECTIONS_SELECT_VALUE;
   private String selectedSectionFilterValue = null;
   
@@ -261,6 +263,15 @@ public class QuestionScoresBean
   public String getAssessmentId()
   {
     return Validator.check(assessmentId, "0");
+  }
+
+  public String getMarker()
+  {
+    return marker;
+  }
+
+  public void setMarker(String s){
+    marker = s;
   }
 
   /**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -1609,6 +1609,49 @@ public class DeliveryActionListener
   	  key += " | ";
     }
 
+    if (item.getTypeId().equals(TypeIfc.MATCHING)){
+        Iterator itemTexts = itemBean.getItemData().getItemTextArray().iterator();
+        StringBuffer distractorKeys = new StringBuffer();
+        while(itemTexts.hasNext()){
+            ItemTextIfc thisItemText = (ItemTextIfc) itemTexts.next();
+            Iterator thisItemAnswersIterator = thisItemText.getAnswerArray().iterator();
+            boolean hasCorrectAnswer = false;
+            while(thisItemAnswersIterator.hasNext()){
+                AnswerIfc thisItemAnswer = (AnswerIfc) thisItemAnswersIterator.next();
+                if(thisItemAnswer.getIsCorrect())hasCorrectAnswer=true;
+            }
+            if(!hasCorrectAnswer){
+                distractorKeys.append(", ");
+                distractorKeys.append(thisItemText.getSequence());
+
+                String noneOfTheAboveOption = Character.toString(alphabet.charAt(myanswers.size()));
+    //				distractorKeys.append(":N/A ");
+                distractorKeys.append(":"+noneOfTheAboveOption);
+            }
+        }
+        if(distractorKeys.length()>0){
+            key = key+distractorKeys.toString();
+        }
+		String individualKeys[] = key.split(",");
+		for(int k = 0;k<individualKeys.length;k++){
+			String thisIndividualKey = individualKeys[k].trim();
+			individualKeys[k] = thisIndividualKey;
+		}
+		Arrays.sort(individualKeys);
+		StringBuffer sortedKeysBuffer = new StringBuffer();
+		for(int k = 0;k<individualKeys.length;k++){
+			if(k==(individualKeys.length-1)){
+				sortedKeysBuffer.append(" ");
+				sortedKeysBuffer.append(individualKeys[k]);
+			}else{
+				sortedKeysBuffer.append(" ");
+				sortedKeysBuffer.append(individualKeys[k]);
+				sortedKeysBuffer.append(",");
+			}
+		}
+		key = sortedKeysBuffer.toString();
+    }
+
     itemBean.setKey(key);
 
     // Delete this
@@ -1899,9 +1942,15 @@ public class DeliveryActionListener
       
       GradingService gs = new GradingService();
       if (gs.hasDistractors(item)) {
+          String noneOfTheAboveOption = Character.toString(alphabet.charAt(i++));
+    	  newAnswers.add(noneOfTheAboveOption + "." + " None of the Above");
+//    	  choices.add(new SelectItem(NONE_OF_THE_ABOVE.toString(),
+//    			  					"None of the Above",
+//    			  					""));
+
     	  choices.add(new SelectItem(NONE_OF_THE_ABOVE.toString(),
-    			  					"None of the Above",
-    			  					""));
+    			  					noneOfTheAboveOption,
+					""));
       }
 
       mbean.setChoices(choices); // Set the A/B/C... pulldown

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -45,14 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.math3.util.Precision;
 
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.event.api.Event;
-import org.sakaiproject.event.api.LearningResourceStoreService;
-import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Actor;
-import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Object;
-import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Statement;
-import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb;
-import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Verb.SAKAI_VERB;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.cover.NotificationService;
 import org.sakaiproject.samigo.util.SamigoConstants;
@@ -1609,47 +1602,37 @@ public class DeliveryActionListener
   	  key += " | ";
     }
 
-    if (item.getTypeId().equals(TypeIfc.MATCHING)){
-        Iterator itemTexts = itemBean.getItemData().getItemTextArray().iterator();
-        StringBuffer distractorKeys = new StringBuffer();
-        while(itemTexts.hasNext()){
-            ItemTextIfc thisItemText = (ItemTextIfc) itemTexts.next();
-            Iterator thisItemAnswersIterator = thisItemText.getAnswerArray().iterator();
-            boolean hasCorrectAnswer = false;
-            while(thisItemAnswersIterator.hasNext()){
-                AnswerIfc thisItemAnswer = (AnswerIfc) thisItemAnswersIterator.next();
-                if(thisItemAnswer.getIsCorrect())hasCorrectAnswer=true;
-            }
-            if(!hasCorrectAnswer){
-                distractorKeys.append(", ");
-                distractorKeys.append(thisItemText.getSequence());
-
-                String noneOfTheAboveOption = Character.toString(alphabet.charAt(myanswers.size()));
-    //				distractorKeys.append(":N/A ");
-                distractorKeys.append(":"+noneOfTheAboveOption);
-            }
+    if (item.getTypeId().equals(TypeIfc.MATCHING)) {
+      StringBuilder distractorKeys = new StringBuilder();
+      for (ItemTextIfc thisItemText : itemBean.getItemData().getItemTextArray()) {
+        boolean hasCorrectAnswer = false;
+        for (AnswerIfc thisItemAnswer : thisItemText.getAnswerArray()) {
+          if (thisItemAnswer.getIsCorrect()) {
+            hasCorrectAnswer = true;
+          }
         }
-        if(distractorKeys.length()>0){
-            key = key+distractorKeys.toString();
+        if (!hasCorrectAnswer) {
+          distractorKeys.append(", ").append(thisItemText.getSequence()).append(":").append(Character.toString(alphabet.charAt(myanswers.size())));
         }
-		String individualKeys[] = key.split(",");
-		for(int k = 0;k<individualKeys.length;k++){
-			String thisIndividualKey = individualKeys[k].trim();
-			individualKeys[k] = thisIndividualKey;
-		}
-		Arrays.sort(individualKeys);
-		StringBuffer sortedKeysBuffer = new StringBuffer();
-		for(int k = 0;k<individualKeys.length;k++){
-			if(k==(individualKeys.length-1)){
-				sortedKeysBuffer.append(" ");
-				sortedKeysBuffer.append(individualKeys[k]);
-			}else{
-				sortedKeysBuffer.append(" ");
-				sortedKeysBuffer.append(individualKeys[k]);
-				sortedKeysBuffer.append(",");
-			}
-		}
-		key = sortedKeysBuffer.toString();
+      }
+      if (distractorKeys.length() > 0) {
+          key = key + distractorKeys.toString();
+      }
+      String individualKeys[] = key.split(",");
+      for (int k = 0; k < individualKeys.length; k++) {
+        String thisIndividualKey = individualKeys[k].trim();
+        individualKeys[k] = thisIndividualKey;
+      }
+      Arrays.sort(individualKeys);
+      StringBuilder sortedKeysBuffer = new StringBuilder();
+      for (int k = 0; k < individualKeys.length; k++) {
+        if (k == individualKeys.length - 1) {
+          sortedKeysBuffer.append(" ").append(individualKeys[k]);
+        } else {
+          sortedKeysBuffer.append(" ").append(individualKeys[k]).append(",");
+        }
+      }
+      key = sortedKeysBuffer.toString();
     }
 
     itemBean.setKey(key);
@@ -1942,15 +1925,9 @@ public class DeliveryActionListener
       
       GradingService gs = new GradingService();
       if (gs.hasDistractors(item)) {
-          String noneOfTheAboveOption = Character.toString(alphabet.charAt(i++));
-    	  newAnswers.add(noneOfTheAboveOption + "." + " None of the Above");
-//    	  choices.add(new SelectItem(NONE_OF_THE_ABOVE.toString(),
-//    			  					"None of the Above",
-//    			  					""));
-
-    	  choices.add(new SelectItem(NONE_OF_THE_ABOVE.toString(),
-    			  					noneOfTheAboveOption,
-					""));
+        String noneOfTheAboveOption = Character.toString(alphabet.charAt(i++));
+        newAnswers.add(noneOfTheAboveOption + "." + " None of the Above");
+        choices.add(new SelectItem(NONE_OF_THE_ABOVE.toString(), noneOfTheAboveOption, ""));
       }
 
       mbean.setChoices(choices); // Set the A/B/C... pulldown

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.tool.assessment.ui.listener.evaluation;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -31,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import javax.faces.event.AbortProcessingException;
 import javax.faces.event.ActionEvent;
@@ -101,6 +103,11 @@ import org.sakaiproject.util.ResourceLoader;
 			.getLocalizedString(
 					"org.sakaiproject.tool.assessment.bundle.EvaluationMessages",
 					"no_answer");
+
+	private static final String noneOfTheAbove = (String) ContextUtil
+			.getLocalizedString(
+					"org.sakaiproject.tool.assessment.bundle.EvaluationMessages",
+					"none_above");
 
 	/**
 	 * Standard process action method.
@@ -197,6 +204,7 @@ import org.sakaiproject.util.ResourceLoader;
 	public boolean questionScores(String publishedId, QuestionScoresBean bean,
 			boolean isValueChange) {
 		log.debug("questionScores()");
+		HashSet sortedAgentResults = new HashSet();
 		try {
 			PublishedAssessmentService pubService = new PublishedAssessmentService();
 			PublishedItemService pubItemService = new PublishedItemService();
@@ -220,6 +228,39 @@ import org.sakaiproject.util.ResourceLoader;
 					.preparePublishedItemTextHash(publishedAssessment);
 			log.debug("questionScores(): publishedItemTextHash.size = "
 					+ publishedItemTextHash.size());
+            Set publishedItemTextIds = publishedItemTextHash.keySet();
+			Iterator keyIterator = publishedItemTextIds.iterator();
+			GradingService delegate = new GradingService();
+			HashMap allItemsHash = new HashMap();
+			while(keyIterator.hasNext()){
+					Object thisKey =  keyIterator.next();
+					ItemTextIfc thisItemTextIfc = (ItemTextIfc) publishedItemTextHash.get(thisKey);
+					ItemDataIfc thisItemDataIfc = thisItemTextIfc.getItem();
+					Set answers = thisItemTextIfc.getAnswerSet();
+					Iterator answerIterator = answers.iterator();
+					while(answerIterator.hasNext()){
+							AnswerIfc thisAnswerIfc = (AnswerIfc) answerIterator.next();
+							log.debug(""+thisAnswerIfc.getId());
+					}
+					if(delegate.isDistractor(thisItemTextIfc)){
+							log.debug("item is a distractor");
+					}
+
+				TreeMap thisItemOptions = (TreeMap) allItemsHash.get(thisItemTextIfc.getItem().getItemId());
+				if(thisItemOptions == null){
+					thisItemOptions = new TreeMap();
+					thisItemOptions.put(thisItemTextIfc.getSequence(), thisItemTextIfc);
+					allItemsHash.put(thisItemTextIfc.getItem().getItemId(), thisItemOptions);
+				}else{
+					thisItemOptions.put(thisItemTextIfc.getSequence(), thisItemTextIfc);
+					allItemsHash.put(thisItemTextIfc.getItem().getItemId(), thisItemOptions);
+				}
+				log.debug("item = "+thisItemTextIfc.getSequence()+":"+thisItemTextIfc.getText()+"-"+thisItemTextIfc.getItem().getItemId());
+
+			}
+			log.debug("item -----------------------------------");
+//                     questionBean.setMarker("marker 1");
+			questionBean.setMarker("");
 			Map publishedAnswerHash = pubService
 					.preparePublishedAnswerHash(publishedAssessment);
 			// re-attach session and load all lazy loaded parent/child stuff
@@ -237,7 +278,7 @@ import org.sakaiproject.util.ResourceLoader;
 					+ publishedAnswerHash.size());
 			Map agentResultsByItemGradingIdMap = new HashMap();
 
-			GradingService delegate = new GradingService();
+			//GradingService delegate = new GradingService();
 
 			TotalScoresBean totalBean = (TotalScoresBean) ContextUtil
 					.lookupBean("totalScores");
@@ -692,6 +733,7 @@ import org.sakaiproject.util.ResourceLoader;
 						answerTextLength = 35;
 					}
 
+					log.debug("answerText="+answerText);
 					// Fix for SAK-6932: Strip out all HTML tags except image tags
  					if (answerText.length() > answerTextLength) {
 						String noHTMLAnswerText;
@@ -717,9 +759,9 @@ import org.sakaiproject.util.ResourceLoader;
 					 */
 
 					//SAM-755-"checkmark" indicates right, add "X" to indicate wrong
+					String checkmarkGif = "<img src='/samigo-app/images/delivery/checkmark.gif'>";
+					String crossmarkGif = "<img src='/samigo-app/images/crossmark.gif'>";
 					if (gdataAnswer != null) {
-						String checkmarkGif = "<img src='/samigo-app/images/delivery/checkmark.gif'>";
-						String crossmarkGif = "<img src='/samigo-app/images/crossmark.gif'>";
 						answerText = FormattedText.escapeHtml(answerText, true);
 						if (bean.getTypeId().equals("8") || bean.getTypeId().equals("11")) {
 							if (gdata.getIsCorrect() == null) {
@@ -770,12 +812,89 @@ import org.sakaiproject.util.ResourceLoader;
 								answerText = crossmarkGif + answerText;
 							}
 						}
+						}else if(bean.getTypeId().equals("9")){
+						log.debug("scoring a type 9 - matching");
+						boolean itemHasCorrectAnswers = hasCorrectAnswers(gdataPubItemText.getAnswerSet());
+						ItemGradingData thisItemGradingData = null;
+						Iterator allScoreIterator = allscores.iterator();
+						while(allScoreIterator.hasNext()){
+							thisItemGradingData = (ItemGradingData) allScoreIterator.next();
+							log.debug("thisItemGradingData.getItemGradingId().intValue()="+thisItemGradingData.getItemGradingId().intValue());
+							log.debug("gdata.getItemGradingId().intValue()="+gdata.getItemGradingId().intValue());
+							log.debug("thisItemGradingData.getAnswerText()="+thisItemGradingData.getAnswerText());
+							if(thisItemGradingData.getItemGradingId().intValue()==gdata.getItemGradingId().intValue())break;
+						}
+						if(thisItemGradingData!=null) log.debug("thisItemGradingData was found");
+						if(answerText.contains(noAnswer)&&fullAnswerText.contains(noAnswer)){
+							log.debug("check point A");
+							if(thisItemGradingData.getPublishedAnswerId()==null){
+									log.debug("null anwser id:thisItemGradingData.getAnswerText()="+thisItemGradingData.getAnswerText());
+                                    //                                    answerText = crossmarkGif+gdataPubItemText.getSequence() + ":" + noneOfTheAbove;
+									if(answerList.size()==1){
+										TreeMap thisItemOptions = (TreeMap) allItemsHash.get(item.getItemId());
+										Set itemKeys = thisItemOptions.keySet();
+										Iterator k = itemKeys.iterator();
+										StringBuffer optionsBuffer = new StringBuffer();
+										while(k.hasNext()){
+											Long thisItemKey = (Long) k.next();
+											ItemTextIfc thisItemOptionText = (ItemTextIfc) thisItemOptions.get(thisItemKey);
+											optionsBuffer.append(crossmarkGif+" "+thisItemOptionText.getSequence().toString()+":No Response <br/>");
+										}
+										answerText = optionsBuffer.toString();
+
+									}else{
+										answerText = crossmarkGif+gdataPubItemText.getSequence() + ":" + "No Response";
+									}
+                            }else if(itemHasCorrectAnswers && thisItemGradingData.getPublishedAnswerId().intValue()<0){
+								answerText = crossmarkGif+gdataPubItemText.getSequence() + ":" + noneOfTheAbove;
+							}else{
+								answerText = checkmarkGif+gdataPubItemText.getSequence() + ":" + noneOfTheAbove;
+							}
+							log.debug("answerText="+answerText);
+							String thisAgentId = gdata.getAgentId();
+							Iterator agentIterator = bean.getAgents().iterator();
+							boolean agentFound=false;
+							AgentResults thisAgentResult = null;
+							while(agentIterator.hasNext()){
+								thisAgentResult = (AgentResults) agentIterator.next();
+								if(thisAgentResult.getIdString().compareTo(thisAgentId)==0){
+									agentFound=true;
+									break;
+								}
+							}
+/*
+							if(agentFound){
+								String thisItemOptions[] = thisAgentResult.getAnswer().split("<br/>");
+								for(int s=0;s<thisItemOptions.length;s++){
+									int endOfCheckmark = thisItemOptions[s].indexOf(">");
+									int colonAt = thisItemOptions[s].indexOf(":");
+									String thisSequence = thisItemOptions[s].substring(endOfCheckmark, colonAt);
+									StringBuffer editItemBuffer = new StringBuffer();
+									editItemBuffer.append(thisSequence);
+									editItemBuffer.append("|");
+									editItemBuffer.append(thisItemOptions[s]);
+									thisItemOptions[s] = editItemBuffer.toString();
+								}
+								Arrays.sort(thisItemOptions);
+								StringBuffer optionBuffer = new StringBuffer();
+								for(int s=0;s<thisItemOptions.length;s++){
+									int dlmIndex = thisItemOptions[s].indexOf('|');
+									optionBuffer.append(thisItemOptions[s].substring(dlmIndex+1));
+									optionBuffer.append("<br/>");
+								}
+								log.debug("sortedOptions"+optionBuffer.toString());
+								thisAgentResult.setAnswer(optionBuffer.toString());
+							}
+*/
+						}
 					}
 
+					log.debug("check point B answerText="+answerText);
 					// -- Got the answer text --
 					if (!answerList.get(0).equals(gdata)) { // We already have
 						// an agentResults
 						// for this one
+						log.debug("check point C1");
 						results.setAnswer(results.getAnswer() + "<br/>"
 								+ answerText);
 						if (gdata.getAutoScore() != null) {
@@ -792,6 +911,7 @@ import org.sakaiproject.util.ResourceLoader;
 							results.setAnswerKey(results.getAnswerKey()+ " <br/>" + answerKey);
 						}
 					} else {
+						log.debug("check point C2");
 						results.setItemGradingId(gdata.getItemGradingId());
 						results.setAssessmentGradingId(gdata
 								.getAssessmentGradingId());
@@ -846,6 +966,7 @@ import org.sakaiproject.util.ResourceLoader;
 			}
 
 			bs = new BeanSort(agents, bean.getSortType());
+			log.debug("check point D");
 			if ((bean.getSortType()).equals("assessmentGradingId")
 					|| (bean.getSortType()).equals("totalAutoScore")
 					|| (bean.getSortType()).equals("totalOverrideScore")
@@ -863,6 +984,9 @@ import org.sakaiproject.util.ResourceLoader;
 				agents = (List) bs.sortDesc();
 			}
 
+			if(bean.getTypeId().equals("9")){
+				agents = sortMatching(agents);
+			}
 			bean.setAgents(agents);
 			bean.setAllAgents(agents);
 			bean
@@ -877,6 +1001,37 @@ import org.sakaiproject.util.ResourceLoader;
 		}
 
 		return true;
+	}
+
+	private ArrayList sortMatching(List a){
+
+		ArrayList returnValues = new ArrayList();
+		Iterator agentIterator = a.iterator();
+		while(agentIterator.hasNext()){
+			AgentResults thisAgentResult = (AgentResults) agentIterator.next();
+			String thisItemOptions[] = thisAgentResult.getAnswer().split("<br/>");
+			for(int s=0;s<thisItemOptions.length;s++){
+				int endOfCheckmark = thisItemOptions[s].indexOf(">");
+				int colonAt = thisItemOptions[s].indexOf(":");
+				String thisSequence = thisItemOptions[s].substring(endOfCheckmark, colonAt);
+				StringBuffer editItemBuffer = new StringBuffer();
+				editItemBuffer.append(thisSequence);
+				editItemBuffer.append("|");
+				editItemBuffer.append(thisItemOptions[s]);
+				thisItemOptions[s] = editItemBuffer.toString();
+			}
+			Arrays.sort(thisItemOptions);
+			StringBuffer optionBuffer = new StringBuffer();
+			for(int s=0;s<thisItemOptions.length;s++){
+				int dlmIndex = thisItemOptions[s].indexOf('|');
+				optionBuffer.append(thisItemOptions[s].substring(dlmIndex+1));
+				optionBuffer.append("<br/>");
+			}
+			log.debug("sortedOptions"+optionBuffer.toString());
+			thisAgentResult.setAnswer(optionBuffer.toString());
+			returnValues.add(thisAgentResult);
+		}
+		return returnValues;
 	}
 
 	/**
@@ -937,6 +1092,20 @@ import org.sakaiproject.util.ResourceLoader;
 					+ e.getMessage());
 		}
 	}
+
+	private boolean hasCorrectAnswers(Set answerSet){
+		    ArrayList list = new ArrayList();
+		    Iterator iter = answerSet.iterator();
+		    while (iter.hasNext()){
+		      list.add(iter.next());
+		    }
+	    	Iterator answerIterator = list.iterator();
+	    	while(answerIterator.hasNext()){
+	    		PublishedAnswer thisPublishedAnswer = (PublishedAnswer) answerIterator.next();
+	    		if(thisPublishedAnswer.getIsCorrect().booleanValue()) return true;
+	    	}
+	    	return false;
+	  }
 
 	private void populateSections(PublishedAssessmentIfc publishedAssessment,
 			QuestionScoresBean bean, TotalScoresBean totalBean,

--- a/samigo/samigo-app/src/webapp/jsf/author/preview_item/Matching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/preview_item/Matching.jsp
@@ -26,11 +26,12 @@ should be included in file importing DeliveryMessages
   <!-- ATTACHMENTS -->
   <%@ include file="/jsf/author/preview_item/attachment.jsp" %>
 
+  <!-- <h2>preview_item=matching.jsp</h2> -->
   <h:outputText escape="false" value="#{question.instruction}" />
   <!-- 1. print out the matching choices -->
   <h:dataTable value="#{question.itemData.itemTextArraySorted}" var="itemText">
     <h:column>
-      <h:dataTable value="#{itemText.answerArraySorted}" var="answer"
+      <h:dataTable value="#{itemText.answerArrayWithDistractorSorted}" var="answer"
          rendered="#{itemText.sequence==1}">
         <h:column>
             <h:panelGrid columns="2">

--- a/samigo/samigo-app/src/webapp/jsf/author/preview_item/Matching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/preview_item/Matching.jsp
@@ -26,7 +26,6 @@ should be included in file importing DeliveryMessages
   <!-- ATTACHMENTS -->
   <%@ include file="/jsf/author/preview_item/attachment.jsp" %>
 
-  <!-- <h2>preview_item=matching.jsp</h2> -->
   <h:outputText escape="false" value="#{question.instruction}" />
   <!-- 1. print out the matching choices -->
   <h:dataTable value="#{question.itemData.itemTextArraySorted}" var="itemText">

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMatching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMatching.jsp
@@ -35,7 +35,6 @@ should be included in file importing DeliveryMessages
    </h:column>
   </h:dataTable>
 
-  <h2>Matching Items</h2>
   <h:dataTable value="#{question.matchingArray}" var="matching">
     <h:column rendered="#{delivery.feedback eq 'true' &&
        delivery.feedbackComponent.showCorrectResponse && !delivery.noFeedback=='true'}">

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMatching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMatching.jsp
@@ -35,15 +35,16 @@ should be included in file importing DeliveryMessages
    </h:column>
   </h:dataTable>
 
+  <h2>Matching Items</h2>
   <h:dataTable value="#{question.matchingArray}" var="matching">
     <h:column rendered="#{delivery.feedback eq 'true' &&
        delivery.feedbackComponent.showCorrectResponse && !delivery.noFeedback=='true'}">
       <h:panelGroup id="image"
-        rendered="#{matching.isCorrect || matching.isDistractor}"
+        rendered="#{matching.isCorrect}"
         styleClass="icon-sakai--check feedBackCheck" >
       </h:panelGroup>
       <h:panelGroup id="ximage"
-        rendered="#{!matching.isCorrect && !matching.isDistractor}"
+        rendered="#{!matching.isCorrect}"
         styleClass="icon-sakai--delete feedBackCross" >
       </h:panelGroup>
       <h:graphicImage id="image2"

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/item/displayMatching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/item/displayMatching.jsp
@@ -26,7 +26,6 @@ include file for displaying matching questions
 <h:outputText value="#{question.text}"  escape="false"/>
 <h:dataTable value="#{question.itemTextArraySorted}" var="itemText">
  <h:column>
-   <!--    <h2>displayMatching.jsp</h2> -->
    <h:outputText value="#{itemText.sequence}#{evaluationMessages.dot} #{itemText.text}" escape="false" />
    <h:dataTable value="#{itemText.answerArrayWithDistractorSorted}" var="answer">
      <h:column>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/item/displayMatching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/item/displayMatching.jsp
@@ -26,8 +26,9 @@ include file for displaying matching questions
 <h:outputText value="#{question.text}"  escape="false"/>
 <h:dataTable value="#{question.itemTextArraySorted}" var="itemText">
  <h:column>
+   <!--    <h2>displayMatching.jsp</h2> -->
    <h:outputText value="#{itemText.sequence}#{evaluationMessages.dot} #{itemText.text}" escape="false" />
-   <h:dataTable value="#{itemText.answerArraySorted}" var="answer">
+   <h:dataTable value="#{itemText.answerArrayWithDistractorSorted}" var="answer">
      <h:column>
       <h:graphicImage alt="#{evaluationMessages.alt_correct}" id="image4" rendered="#{answer.isCorrect}"
         url="/images/delivery/checkmark.gif" >

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
@@ -207,8 +207,6 @@ function hiddenLinkOnClick(){
     </h:column>
   </h:dataTable>
 
-  <h:outputText value="#{questionScores.marker} " />
-
   <t:dataList value="#{questionScores.deliveryItem}" var="question">
     <div class="page-header">
       <h2>
@@ -519,7 +517,6 @@ function hiddenLinkOnClick(){
 
 </div>
 
-<h2>Point 1</h2>
   <!-- STUDENT RESPONSES AND GRADING -->
   <!-- note that we will have to hook up with the back end to get N at a time -->
 <div class="table-responsive">

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
@@ -207,6 +207,8 @@ function hiddenLinkOnClick(){
     </h:column>
   </h:dataTable>
 
+  <h:outputText value="#{questionScores.marker} " />
+
   <t:dataList value="#{questionScores.deliveryItem}" var="question">
     <div class="page-header">
       <h2>
@@ -517,6 +519,7 @@ function hiddenLinkOnClick(){
 
 </div>
 
+<h2>Point 1</h2>
   <!-- STUDENT RESPONSES AND GRADING -->
   <!-- note that we will have to hook up with the back end to get N at a time -->
 <div class="table-responsive">

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
@@ -27,6 +27,8 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.shared.TypeD;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemAttachmentIfc;
@@ -720,9 +722,30 @@ public ItemData() {}
 		}
 		return answerKey;
 	}
-   
-   List<AnswerIfc> answerArray = itemTextArray.get(0).getAnswerArraySorted();
-   HashMap<String, String> h = new HashMap<String, String>();
+
+	else if (typeId.equals(TypeD.MATCHING)) {
+
+		List<String> answerKeys = new ArrayList<>(itemTextArray.size());
+		for (ItemTextIfc question : itemTextArray) {
+			boolean isDistractor = true;
+
+			List<AnswerIfc> answersSorted = question.getAnswerArraySorted();
+			for (AnswerIfc answer : answersSorted) {
+				if (!getPartialCreditFlag() && answer.getIsCorrect()) {
+					answerKeys.add(question.getSequence() + ":" + answer.getLabel());
+					isDistractor = false;
+					break;
+				}
+			}
+
+			if (isDistractor) {
+				answerKeys.add(question.getSequence() + ":" + Character.toString(SamigoConstants.ALPHABET.charAt(answersSorted.size())));
+			}
+		}
+
+		answerKey = StringUtils.join(answerKeys, ", ");
+		return answerKey;
+	}
 
    for (int i=0; i<itemTextArray.size();i++){
 	   ItemTextIfc text = itemTextArray.get(i);
@@ -730,7 +753,6 @@ public ItemData() {}
 	   for (int j=0; j<answers.size();j++){
 		   AnswerIfc a = answers.get(j);
 		   if (!this.getPartialCreditFlag() && (Boolean.TRUE).equals(a.getIsCorrect())){
-			   String pair = (String)h.get(a.getLabel());
 			   if((!this.getTypeId().equals(TypeD.MATCHING))&&(!this.getTypeId().equals(TypeD.IMAGEMAP_QUESTION)))
 			   {
 				   if(this.getTypeId().equals(TypeD.TRUE_FALSE))
@@ -747,17 +769,6 @@ public ItemData() {}
 					   {
 						   answerKey+=","+a.getLabel();
 					   }
-				   }
-			   }
-			   else if (this.getTypeId().equals(TypeD.MATCHING)){
-				   if (pair==null)
-				   {
-					   String s = a.getLabel() + ":" + text.getSequence();
-					   h.put(a.getLabel(), s);
-				   }
-				   else
-				   {
-					   h.put(a.getLabel(), pair+" "+text.getSequence());
 				   }
 			   }
 		   }
@@ -778,28 +789,8 @@ public ItemData() {}
 		   }
 	   }
    }
-   
-   if (this.getTypeId().equals(TypeD.MATCHING))
-   {
-	   List answerArrayWithDistractor = itemTextArray.get(0).getAnswerArrayWithDistractorSorted();
-	   for (int k=0; k<answerArrayWithDistractor.size();k++)
-	   {
-		   AnswerIfc a = (AnswerIfc)answerArrayWithDistractor.get(k);
-		   String pair = a.getSequence()+":"+a.getLabel();
-//		   String pair = a.getLabel()+":"+a.getSequence();
-
-		   if (k!=0)
-		       answerKey = answerKey+",  "+pair;
-		   else
-
-		       answerKey = pair;
-	   }
-   }
-
-
 
    return answerKey;
-
   }
 
   public int compareTo(ItemDataIfc o) {

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
@@ -781,13 +781,12 @@ public ItemData() {}
    
    if (this.getTypeId().equals(TypeD.MATCHING))
    {
-	   for (int k=0; k<answerArray.size();k++)
+	   List answerArrayWithDistractor = itemTextArray.get(0).getAnswerArrayWithDistractorSorted();
+	   for (int k=0; k<answerArrayWithDistractor.size();k++)
 	   {
-		   AnswerIfc a = (AnswerIfc)answerArray.get(k);
-		   String pair = (String)h.get(a.getLabel());
-		   //if answer is not a match to any text, just print answer label
-		   if (pair == null)
-		       pair = a.getLabel()+": ";
+		   AnswerIfc a = (AnswerIfc)answerArrayWithDistractor.get(k);
+		   String pair = a.getSequence()+":"+a.getLabel();
+//		   String pair = a.getLabel()+":"+a.getSequence();
 
 		   if (k!=0)
 		       answerKey = answerKey+",  "+pair;

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemText.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemText.java
@@ -42,6 +42,7 @@ public class ItemText
     implements Serializable, ItemTextIfc, Comparable<ItemTextIfc> {
 
   private static final long serialVersionUID = 7526471155622776147L;
+  static String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   private Long id;
   private ItemDataIfc item;
@@ -124,9 +125,62 @@ public class ItemText
 
   public List<AnswerIfc> getAnswerArraySorted() {
     List<AnswerIfc> list = getAnswerArray();
+	List questionItems = getItem().getItemTextArray();
     Collections.sort(list);
     return list;
   }
+
+  public List getAnswerArrayWithDistractorSorted() {
+	    List<AnswerIfc> list = getAnswerArray();
+	    List questionItems = getItem().getItemTextArray();
+	    if(list.size()!=questionItems.size()){
+	    	ArrayList newAnswerList = new ArrayList();
+	    	Iterator answerIterator = list.iterator();
+	    	int answerSequence = 1;
+	    	while(answerIterator.hasNext()){
+	    		AnswerIfc thisAnswer = (AnswerIfc) answerIterator.next();
+	    		if(thisAnswer.getSequence().intValue()!=answerSequence){
+	    			Answer distractorAnswer = new Answer();
+		    		distractorAnswer.setId(new Long(0));
+		    		distractorAnswer.setLabel(Character.toString(alphabet.charAt(answerSequence-1)));
+		    		ItemText distractorItem = (ItemText) questionItems.get(answerSequence-1);
+		    		distractorAnswer.setText("None of the Above");
+		    		distractorAnswer.setIsCorrect(false);
+		    		distractorAnswer.setScore(this.getItem().getScore());
+		    		distractorAnswer.setSequence(new Long(answerSequence));
+		    		newAnswerList.add(distractorAnswer);
+		    		answerSequence++;
+		    		newAnswerList.add(thisAnswer);
+		    		answerSequence++;
+	    		}else{
+		    		newAnswerList.add(thisAnswer);
+		    		answerSequence++;
+	    		}
+	    	}
+	    	Iterator lastItemLookIterator = questionItems.iterator();
+	    	while(lastItemLookIterator.hasNext()){
+	    		ItemText thisItemText = (ItemText) lastItemLookIterator.next();
+	    		if(thisItemText.getSequence().intValue()==answerSequence){
+	    			Answer distractorAnswer = new Answer();
+		    		distractorAnswer.setId(new Long(0));
+		    		distractorAnswer.setLabel(Character.toString(alphabet.charAt(answerSequence-1)));
+		    		ItemText distractorItem = (ItemText) questionItems.get(answerSequence-1);
+		    		distractorAnswer.setText("None of the Above");
+		    		distractorAnswer.setIsCorrect(false);
+		    		distractorAnswer.setScore(this.getItem().getScore());
+		    		distractorAnswer.setSequence(new Long(answerSequence));
+		    		newAnswerList.add(distractorAnswer);
+	    		}
+	    	}
+
+
+		    Collections.sort(newAnswerList);
+		    return newAnswerList;
+	    }else{
+		    Collections.sort(list);
+		    return list;
+	    }
+	  }
   
 	public Set<ItemTextAttachmentIfc> getItemTextAttachmentSet() {
 		return itemTextAttachmentSet;

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
@@ -108,12 +108,62 @@ public class PublishedItemText
     while (iter.hasNext()){
       list.add(iter.next());
     }
+	boolean itemHasDistractors = hasDistractors();
+    boolean itemHasCorrectAnswers = hasCorrectAnswers();
     return list;
   }
 
+  private boolean hasDistractors(){
+	  List thisItemElements = getItem().getItemTextArray();
+	  if(thisItemElements.size()!=answerSet.size()){
+		  return true;
+	  }else{
+		  return false;
+	  }
+  }
+
+  private boolean hasCorrectAnswers(){
+	    ArrayList list = new ArrayList();
+	    Iterator iter = answerSet.iterator();
+	    while (iter.hasNext()){
+	      list.add(iter.next());
+	    }
+    	Iterator answerIterator = list.iterator();
+    	while(answerIterator.hasNext()){
+    		PublishedAnswer thisPublishedAnswer = (PublishedAnswer) answerIterator.next();
+    		if(thisPublishedAnswer.getIsCorrect()) return true;
+    	}
+    	return false;
+  }
+
   public ArrayList getAnswerArraySorted() {
+	  ArrayList list = getAnswerArray();
+	    Collections.sort(list);
+	    return list;
+	  }
+
+  public ArrayList getAnswerArrayWithDistractorSorted() {
     ArrayList list = getAnswerArray();
     Collections.sort(list);
+	if(this.getItem().getTypeId().intValue()==9){
+	    if(hasDistractors()){
+	    	if(hasCorrectAnswers()){
+	    		PublishedAnswer distractorAnswer = new PublishedAnswer();
+	    		distractorAnswer.setId(new Long(0));
+	    		distractorAnswer.setText("None of the above");
+	    		distractorAnswer.setIsCorrect(false);
+	    		distractorAnswer.setScore(this.getItem().getScore());
+	    		list.add(distractorAnswer);
+	    	}else{
+	    		PublishedAnswer distractorAnswer = new PublishedAnswer();
+	    		distractorAnswer.setText("None of the above");
+	    		distractorAnswer.setIsCorrect(true);
+	    		distractorAnswer.setScore(this.getItem().getScore());
+	    		distractorAnswer.setId(new Long(0));
+	    		list.add(distractorAnswer);
+	    	}
+	    }
+    }
     return list;
   }
 

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
@@ -108,61 +108,50 @@ public class PublishedItemText
     while (iter.hasNext()){
       list.add(iter.next());
     }
-	boolean itemHasDistractors = hasDistractors();
-    boolean itemHasCorrectAnswers = hasCorrectAnswers();
     return list;
   }
 
   private boolean hasDistractors(){
-	  List thisItemElements = getItem().getItemTextArray();
-	  if(thisItemElements.size()!=answerSet.size()){
-		  return true;
-	  }else{
-		  return false;
-	  }
+    List thisItemElements = getItem().getItemTextArray();
+    return thisItemElements.size() != answerSet.size();
   }
 
   private boolean hasCorrectAnswers(){
-	    ArrayList list = new ArrayList();
-	    Iterator iter = answerSet.iterator();
-	    while (iter.hasNext()){
-	      list.add(iter.next());
-	    }
-    	Iterator answerIterator = list.iterator();
-    	while(answerIterator.hasNext()){
-    		PublishedAnswer thisPublishedAnswer = (PublishedAnswer) answerIterator.next();
-    		if(thisPublishedAnswer.getIsCorrect()) return true;
-    	}
-    	return false;
+    for (Object thisAnswer : answerSet) {
+      if (((PublishedAnswer) thisAnswer).getIsCorrect()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public ArrayList getAnswerArraySorted() {
-	  ArrayList list = getAnswerArray();
-	    Collections.sort(list);
-	    return list;
-	  }
+    ArrayList list = getAnswerArray();
+    Collections.sort(list);
+    return list;
+  }
 
   public ArrayList getAnswerArrayWithDistractorSorted() {
     ArrayList list = getAnswerArray();
     Collections.sort(list);
-	if(this.getItem().getTypeId().intValue()==9){
-	    if(hasDistractors()){
-	    	if(hasCorrectAnswers()){
-	    		PublishedAnswer distractorAnswer = new PublishedAnswer();
-	    		distractorAnswer.setId(new Long(0));
-	    		distractorAnswer.setText("None of the above");
-	    		distractorAnswer.setIsCorrect(false);
-	    		distractorAnswer.setScore(this.getItem().getScore());
-	    		list.add(distractorAnswer);
-	    	}else{
-	    		PublishedAnswer distractorAnswer = new PublishedAnswer();
-	    		distractorAnswer.setText("None of the above");
-	    		distractorAnswer.setIsCorrect(true);
-	    		distractorAnswer.setScore(this.getItem().getScore());
-	    		distractorAnswer.setId(new Long(0));
-	    		list.add(distractorAnswer);
-	    	}
-	    }
+    if (this.getItem().getTypeId() == 9) {
+      if (hasDistractors()) {
+        if (hasCorrectAnswers()) {
+          PublishedAnswer distractorAnswer = new PublishedAnswer();
+          distractorAnswer.setId(new Long(0));
+          distractorAnswer.setText(NONE_OF_THE_ABOVE);
+          distractorAnswer.setIsCorrect(false);
+          distractorAnswer.setScore(this.getItem().getScore());
+          list.add(distractorAnswer);
+        }else{
+          PublishedAnswer distractorAnswer = new PublishedAnswer();
+          distractorAnswer.setText(NONE_OF_THE_ABOVE);
+          distractorAnswer.setIsCorrect(true);
+          distractorAnswer.setScore(this.getItem().getScore());
+          distractorAnswer.setId(new Long(0));
+          list.add(distractorAnswer);
+        }
+      }
     }
     return list;
   }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -1334,22 +1334,12 @@ public class GradingService
               }
               break;
 
-      case 9: // Matching     
-              //              initScore = getAnswerScore(itemGrading, publishedAnswerHash);
-              if(!isThisItemDistractor(item, itemGrading)){
-            	  initScore = getAnswerScore(itemGrading, publishedAnswerHash);
-                  if (initScore > 0) {
-              	  		int numberOfChoices = 0;
-            	    	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
-            	    	while (itemIter.hasNext()) {
-            	    		ItemTextIfc curItem = itemIter.next();
-            	    		numberOfChoices++;
-            	    	}
-                      autoScore = initScore / numberOfChoices;
-                	}
-              }else{
-            	  initScore = getScoreDistractor(item, itemGrading);
-            	  autoScore = initScore;
+      case 9: // Matching
+              initScore = isThisItemDistractor(item, itemGrading) ? getScoreDistractor(item, itemGrading) : getAnswerScore(itemGrading, publishedAnswerHash);
+              if (initScore > 0) {
+                autoScore = initScore / item.getItemTextArraySorted().size();
+              } else {
+                autoScore = initScore;
               }
               //overridescore?
               if (itemGrading.getOverrideScore() != null)
@@ -1470,33 +1460,23 @@ public class GradingService
     return autoScore;
   }
 
-  private boolean isThisItemDistractor(ItemDataIfc item, ItemGradingData thisItemGradingData){
-   	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
-  	while (itemIter.hasNext()) {
-  		ItemTextIfc curItem = itemIter.next();
-  		if (isDistractor(curItem)) {
-  			if(curItem.getId().doubleValue()==thisItemGradingData.getPublishedItemTextId().doubleValue()) return true;
-  		}
-  	}
-	return false;
+  private boolean isThisItemDistractor(ItemDataIfc item, ItemGradingData thisItemGradingData) {
+    for (ItemTextIfc curItem : item.getItemTextArraySorted()) {
+      if (isDistractor(curItem) && curItem.getId().equals(thisItemGradingData.getPublishedItemTextId())) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  private double getScoreDistractor(ItemDataIfc item, ItemGradingData thisItemGradingData){
-	  double numItems = 0;
-	   	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
-	  	while (itemIter.hasNext()) {
-	  		ItemTextIfc curItem = itemIter.next();
-	  		numItems++;
-	  	}
-		if(thisItemGradingData.getPublishedAnswerId()==null){
-			return 0;
-		}else{
-		  	if(thisItemGradingData.getPublishedAnswerId() <0){
-		  		return item.getScore().doubleValue()/numItems;
-	  		}else{
-	  			return 0;
-	  		}
-		}
+  private double getScoreDistractor(ItemDataIfc item, ItemGradingData thisItemGradingData) {
+    if (thisItemGradingData.getPublishedAnswerId() == null) {
+      return 0;
+    } else if (thisItemGradingData.getPublishedAnswerId() < 0) {
+      return item.getScore();
+    } else {
+      return 0;
+    }
   }
 
 /**

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -1335,18 +1335,22 @@ public class GradingService
               break;
 
       case 9: // Matching     
-              initScore = getAnswerScore(itemGrading, publishedAnswerHash);
-              if (initScore > 0) {
-            	  	int nonDistractors = 0;
-          	    	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
-          	    	while (itemIter.hasNext()) {
-          	    		ItemTextIfc curItem = itemIter.next();
-          	    		if (!isDistractor(curItem)) {
-          	    			nonDistractors++;
-          	    		}
-          	    	}            	  
-                    autoScore = initScore / nonDistractors;
-              	}
+              //              initScore = getAnswerScore(itemGrading, publishedAnswerHash);
+              if(!isThisItemDistractor(item, itemGrading)){
+            	  initScore = getAnswerScore(itemGrading, publishedAnswerHash);
+                  if (initScore > 0) {
+              	  		int numberOfChoices = 0;
+            	    	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
+            	    	while (itemIter.hasNext()) {
+            	    		ItemTextIfc curItem = itemIter.next();
+            	    		numberOfChoices++;
+            	    	}
+                      autoScore = initScore / numberOfChoices;
+                	}
+              }else{
+            	  initScore = getScoreDistractor(item, itemGrading);
+            	  autoScore = initScore;
+              }
               //overridescore?
               if (itemGrading.getOverrideScore() != null)
                 autoScore += itemGrading.getOverrideScore();
@@ -1464,6 +1468,35 @@ public class GradingService
     }
     
     return autoScore;
+  }
+
+  private boolean isThisItemDistractor(ItemDataIfc item, ItemGradingData thisItemGradingData){
+   	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
+  	while (itemIter.hasNext()) {
+  		ItemTextIfc curItem = itemIter.next();
+  		if (isDistractor(curItem)) {
+  			if(curItem.getId().doubleValue()==thisItemGradingData.getPublishedItemTextId().doubleValue()) return true;
+  		}
+  	}
+	return false;
+  }
+
+  private double getScoreDistractor(ItemDataIfc item, ItemGradingData thisItemGradingData){
+	  double numItems = 0;
+	   	Iterator<ItemTextIfc> itemIter = item.getItemTextArraySorted().iterator();
+	  	while (itemIter.hasNext()) {
+	  		ItemTextIfc curItem = itemIter.next();
+	  		numItems++;
+	  	}
+		if(thisItemGradingData.getPublishedAnswerId()==null){
+			return 0;
+		}else{
+		  	if(thisItemGradingData.getPublishedAnswerId() <0){
+		  		return item.getScore().doubleValue()/numItems;
+	  		}else{
+	  			return 0;
+	  		}
+		}
   }
 
 /**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-1579

* No points taken off if distractors are incorrectly matched. The points are divided by the correct number of matches. ex:
** 6 matches plus 2 distractors = 6 points
** If the student got 3 correct matches, but got one of the distractors wrong, the student still receives 3 points.
* On the questions screen, if the student does not make an entry (left as 'Select'), there is nothing displayed under the student response unless there is a distractor, in which case the distractor alone shows.
* The answer keys for matching questions with distractors are not displayed consistently between the edit screens and the score screens
** If you create an assessment that allows Immediate Feedback (i.e. student can click a Show Feedback link while in process of taking the quiz to view feedback), the answer key for the distractor question inside the quiz has the answers out of numerical order. It looks weird, but the answers shown appear to be correct in each case.
** When the instructor views the individual question screen for a distractor question in Scores > Questions, and a student has NOT selected answer options for each of the parts of the question, the Answer Key is INCORRECT.
** Some minor typographical issues (spaces displaying inconsistently between letters and matches).
* The answer keys for matching questions with distractors are not displayed correctly on the instructor's "Edit" UI, when any choice has either 'Existing' as an answer, or if there are two consecutive distractors in any sequence, or if there is a single distractor in the middle of the sequence