### PR TITLE
KNL-1585: corrected wrong return type of method (collection type erasure)

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/event/api/UsageSessionService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/api/UsageSessionService.java
@@ -154,7 +154,7 @@ public interface UsageSessionService
 	 * 
 	 * @return a Map (server id -> List (UsageSession)) of all open sessions, ordered by server, then by start (asc)
 	 */
-	Map<String, UsageSession> getOpenSessionsByServer();
+	Map<String, List<UsageSession>> getOpenSessionsByServer();
 	
 	/**
 	 * Start a usage session and do any other book-keeping needed to login a user who has already been authenticated.


### PR DESCRIPTION
Stumbled across an API interface method with a wrongly paramterized return type.
Looks like this method isn't used anywhere at the moment, everyone seems to still use the unparameterized static cover instead.

https://jira.sakaiproject.org/browse/KNL-1585