### PR TITLE
SAK-31290 prevent loop in threaded view logic

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -1269,9 +1269,16 @@ public void processChangeSelectView(ValueChangeEvent eve)
 	  if(msgsList != null)
 	  {
 		  List tempMsgsList = new ArrayList();
+		  // Using this HashMap to ensure that each message is only processed once
+		  // preventing a logic loop that can cause a memory leak. 
+		  HashMap messageIds = new HashMap<Long,Boolean>();
 		  for(int i=0; i<msgsList.size(); i++)
 		  {
-			  tempMsgsList.add((PrivateMessageDecoratedBean)msgsList.get(i));
+			  long msgId = ((PrivateMessageDecoratedBean)msgsList.get(i)).getMsg().getId();
+			  if (messageIds.get(msgId) == null) {
+				  messageIds.put(msgId, true);
+				  tempMsgsList.add((PrivateMessageDecoratedBean)msgsList.get(i));
+			  }
 		  }
 		  Iterator iter = tempMsgsList.iterator();
 		  while(iter.hasNext())


### PR DESCRIPTION
I tried a couple approaches, starting with hibernate, but the query will always return the duplicate ID because the value from user_index_col in MFR_PVT_MSG_USR_T will make the "copy" of the message a unique entity. This approach seemed simple and efficient enough for the purpose. 