### PR TITLE
SAK-33957: GBNG > make display of stack traces configurable

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
@@ -22,9 +22,9 @@ import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.cycle.AbstractRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.resource.PackageResourceReference;
-import org.apache.wicket.settings.IExceptionSettings;
 import org.apache.wicket.settings.IRequestCycleSettings.RenderStrategy;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
+
 import org.sakaiproject.gradebookng.framework.GradebookNgStringResourceLoader;
 import org.sakaiproject.gradebookng.tool.pages.ErrorPage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
@@ -74,10 +74,6 @@ public class GradebookNgApplication extends WebApplication {
 		// On Wicket session timeout, redirect to main page
 		// getApplicationSettings().setPageExpiredErrorPage(getHomePage());
 
-		// show internal error page rather than default developer page
-		// for production, set to SHOW_NO_EXCEPTION_PAGE
-		getExceptionSettings().setUnexpectedExceptionDisplay(IExceptionSettings.SHOW_EXCEPTION_PAGE);
-
 		// Intercept any unexpected error stacktrace and take to our page
 		getRequestCycleListeners().add(new AbstractRequestCycleListener() {
 			@Override
@@ -93,12 +89,12 @@ public class GradebookNgApplication extends WebApplication {
 		getMarkupSettings().setStripWicketTags(true);
 		getMarkupSettings().setStripComments(true);
 		getMarkupSettings().setCompressWhitespace(true);
-
 	}
 
 	/**
 	 * The main page for our app
 	 *
+	 * @return
 	 * @see org.apache.wicket.Application#getHomePage()
 	 */
 	@Override
@@ -109,7 +105,5 @@ public class GradebookNgApplication extends WebApplication {
 	/**
 	 * Constructor
 	 */
-	public GradebookNgApplication() {
-	}
-
+	public GradebookNgApplication() {}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ErrorPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ErrorPage.html
@@ -5,11 +5,12 @@
 <wicket:extend>
 	
 	<h2><wicket:message key="errorpage.heading" /></h2>
-	
+
 	<p wicket:id="error">Error code: C123K4F</p>
-	
-	<pre><wicket:container wicket:id="stacktrace" /></pre>
-			
+
+	<wicket:enclosure>
+		<pre><wicket:container wicket:id="stacktrace" /></pre>
+	</wicket:enclosure>
 </wicket:extend>
 </body>
 </html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ErrorPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ErrorPage.java
@@ -15,12 +15,14 @@
  */
 package org.sakaiproject.gradebookng.tool.pages;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.StringResourceModel;
 
-import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.component.cover.ServerConfigurationService;
 
 /**
  * Page displayed when an internal error occurred.
@@ -30,6 +32,9 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class ErrorPage extends BasePage {
+
+	private static final String SAK_PROP_PORTAL_SHOW_ERROR = "portal.error.showdetail";
+	private static final boolean SAK_PROP_PORTAL_SHOW_ERROR_DEFAULT = true;
 
 	private static final long serialVersionUID = 1L;
 
@@ -43,14 +48,18 @@ public class ErrorPage extends BasePage {
 		// generate an error code so we can log the exception with it without giving the user the stacktrace
 		// note that wicket will already have logged the stacktrace so we aren't going to bother logging it again
 		final String code = RandomStringUtils.randomAlphanumeric(10);
-		log.error("User supplied error code for the above stacktrace: " + code);
+		log.error("User supplied error code for the above stacktrace: {}", code);
 
 		final Label error = new Label("error", new StringResourceModel("errorpage.text", null, new Object[] { code }));
 		error.setEscapeModelStrings(false);
 		add(error);
 
-		// show the stacktrace. This should be configurable at some point
-		add(new Label("stacktrace", stacktrace));
-
+		// Display the stack trace only if the application is configured to do so
+		boolean showStackTraces = ServerConfigurationService.getBoolean(SAK_PROP_PORTAL_SHOW_ERROR, SAK_PROP_PORTAL_SHOW_ERROR_DEFAULT);
+		Label trace = new Label("stacktrace", stacktrace);
+		if (!showStackTraces && !businessService.isSuperUser()) {
+			trace.setVisible(false);
+		}
+		add(trace);
 	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33957

Stack traces are currently shown by default in GBNG. There is a comment in GradebookNgApplication.java that implies this behaviour can be changed:

```
// show internal error page rather than default developer page
// for production, set to SHOW_NO_EXCEPTION_PAGE
getExceptionSettings().setUnexpectedExceptionDisplay(IExceptionSettings.SHOW_EXCEPTION_PAGE);
```

However, flipping this value has no effect because ErrorPage.java does not check which value is being used, and dumps the stacktrace into a Wicket label regardless (it also has a comment that this should be configurable "at some point"):

```
// show the stacktrace. This should be configurable at some point
add(new Label("stacktrace", stacktrace));
```

This PR proposes the following changes:

* make the default value correspond to the `sakai.property` "portal.error.showdetails"
* make ErrorPage.java determine which value is being used, and display the stack trace as appropriate (but admins should always see the stack trace)