### PR TITLE
SAM-2024: Samigo > print assessments with survey questions doesn't display answer options properly

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -72,6 +72,7 @@ import com.lowagie.text.pdf.BaseFont;
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
+import org.sakaiproject.tool.assessment.jsf.convert.AnswerSurveyConverter;
 
 /**
  * 
@@ -617,7 +618,8 @@ public class PDFAssessmentBean implements Serializable {
 					contentBuffer.append(". ");
 				}
 				
-				contentBuffer.append(convertFormattedText(answer.getText()));
+				AnswerSurveyConverter conv = new AnswerSurveyConverter();
+				contentBuffer.append(convertFormattedText(conv.getAsString(null, null, answer.getText())));
 				contentBuffer.append("</td>");
 			}
 			contentBuffer.append("</td>");

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/MultipleChoiceSurvey.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/MultipleChoiceSurvey.jsp
@@ -40,7 +40,9 @@ should be included in file importing DeliveryMessages
         <h:column>
           <%-- Show answer text --%>
 		  <h:graphicImage id="image1" url="/images/radiounchecked.gif"/>
-          <h:outputText escape="false" value="#{answer.text}" />
+          <h:outputText escape="false" value="#{answer.text}" >
+           <f:converter converterId="org.sakaiproject.tool.assessment.jsf.convert.AnswerSurveyConverter" />
+         </h:outputText>
 	    </h:column>
 	    <h:column>
 	       <%-- Show feedback answer --%>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-2024

The answer options to some Survey type questions do not display correctly, e.g. the option *Strongly Agree* shows up as *st_strongly_agree*.

See screenshots in the JIRA