### PR TITLE
SAM-3210: new sakai.property to control visibility of the 'Delete' column for submissions in the 'Scores' UI

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3360,6 +3360,12 @@
 # Set to true to show the filter in the Assessments List view
 # samigo.group.filter.enabled=true
 
+# Control visibility of the 'Delete' column for submissions in the 'Scores' UI globally.
+# Can also be set on a per site basis via site properties, using the same property string.
+# See SAM-3210 for more details.
+# DEFAULT: false
+# samigo.removeSubmission.restricted=true
+
 #########################################
 # MEMBERSHIP TOOL
 #########################################

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
@@ -36,10 +36,14 @@ import javax.faces.model.SelectItem;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.entity.api.ResourceProperties;
 
 import org.sakaiproject.jsf.model.PhaseAware;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.tool.assessment.business.entity.RecordingData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentAccessControl;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAccessControl;
@@ -57,6 +61,7 @@ import org.sakaiproject.tool.assessment.ui.bean.util.Validator;
 import org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreListener;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.util.AttachmentUtil;
+import org.sakaiproject.tool.cover.ToolManager;
 
 /**
  * <p>Description: class form for evaluating total scores</p>
@@ -84,6 +89,11 @@ public class TotalScoresBean
   public static final int CALLED_FROM_HISTOGRAM_LISTENER_STUDENT = 5;
   public static final int CALLED_FROM_EXPORT_LISTENER = 6;
   public static final int CALLED_FROM_NOTIFICATION_LISTENER = 7;
+
+  private static final String DELETE_RESTRICTED = "samigo.removeSubmission.restricted";
+  private ResourceProperties siteProperties = null;
+  private boolean sitePropertyExists = false;
+  private boolean delete_is_restricted = false;
  
     /** Use serialVersionUID for interoperability. */
   private final static long serialVersionUID = 5517587781720762296L;
@@ -155,6 +165,43 @@ public class TotalScoresBean
 
 	protected void init() {
         defaultSearchString = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.EvaluationMessages", "search_default_student_search_string");
+
+                try {
+                    Site site = SiteService.getSite(ToolManager.getCurrentPlacement().getContext());
+
+                    if (site != null) {
+                        siteProperties = site.getProperties();
+                        if (siteProperties != null) {
+                            String prop = siteProperties.getProperty(DELETE_RESTRICTED);
+                            if (prop != null) {
+                                sitePropertyExists = true;
+                                if (prop.toLowerCase().equals("true")) {
+                                   // Submission deletion is restricted
+                                   delete_is_restricted = true;
+                                } else {
+                                   // Submission deletion is not restricted
+                                   delete_is_restricted = false;
+                                }
+                            }
+                        } else {
+                            sitePropertyExists = false;
+                        }
+                    }
+
+                    if (!sitePropertyExists) {
+                        String s = ServerConfigurationService.getString(DELETE_RESTRICTED);
+                        if (s != null && s.toLowerCase().equals("true")) {
+                            // Submission deletion is restricted
+                            delete_is_restricted = true;
+                        } else {
+                            // Submission deletion is not restricted
+                            delete_is_restricted = false;
+                        }
+                    }
+
+                } catch (Exception ex) {
+                    log.warn(ex.getMessage(), ex);
+                }
 
 		if (searchString == null) {
 			searchString = defaultSearchString;
@@ -1193,4 +1240,8 @@ public class TotalScoresBean
 	{
 		this.isAnyAssessmentGradingAttachmentListModified = isAnyAssessmentGradingAttachmentListModified;
 	}
+
+        public boolean getRestrictedDelete() {
+            return delete_is_restricted;
+        }
 }

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -303,7 +303,7 @@ $(document).ready(function(){
   <h:dataTable id="totalScoreTable" value="#{totalScores.agents}" var="description" styleClass="table table-striped table-bordered" columnClasses="textTable">
 
 	<!-- Add Submission Attempt Deleter-->
-	<h:column rendered="true">
+	<h:column rendered="#{person.isAdmin || !totalScores.restrictedDelete}">
      <f:facet name="header">
        <h:outputText value="#{commonMessages.delete}" rendered="true" />
      </f:facet>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3210

New sakai.property to control the visibility of the 'Delete' column for submissions in the 'Scores' UI. If set to true, all sites will by default have the column hidden. This can be overridden on a site by site basis by adding a site property of the same name (samigo.removeSubmission.restricted).

See the JIRA for more information.