### PR TITLE
SAM-3212: allow retract date to be null

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -93,7 +93,7 @@
               input: '#assessmentSettingsAction\\:retractDate',
               useTime: 1,
               parseFormat: 'YYYY-MM-DD HH:mm:ss',
-              allowEmptyDate: false,
+              allowEmptyDate: true,
               val: '<h:outputText value="#{assessmentSettings.retractDate}"><f:convertDateTime pattern="yyyy-MM-dd HH:mm:ss"/></h:outputText>',
               ashidden: { iso8601: 'retractDateISO8601' }
           });


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3212

There is a use case described in the JIRA ticket that requires the retract date to be null/nullable.