### PR TITLE
SAM-3374: document samigo.eventlog.ipaddress.enabled in default.sakai.properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4960,6 +4960,9 @@
 #Allow the display of tags in the grading part (default is false)
 #samigo.evaluation.usetags=false
 
+# Enable/disable displaying IP addresses in the Samigo Event Log
+# DEFAULT: false
+# samigo.eventlog.ipaddress.enabled=true
 
 #MULTI-TAGS PROPERTIES
 #If true, the tags will be updated in all the questions identical to the one edited (same hash). (default is false)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3374

As requested.