### PR TITLE
SAK-34007 - SOAP no longer compatible for login methods

### DIFF
--- a/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiLogin.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiLogin.java
@@ -78,15 +78,17 @@ public class SakaiLogin extends AbstractWebService {
      * @param pw password for the user
      * @return session string
      */
-    @WebMethod
+    @WebMethod(operationName="login")
     @Path("/login")
     @Produces(MediaType.TEXT_PLAIN)
     //Can't get MediaType.MULTIPART_FORM_DATA to work
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
     @POST
     public java.lang.String loginPOST(
+            @WebParam(partName = "id", name = "id")
             @FormParam("id")
             java.lang.String id,
+            @WebParam(partName = "pw", name = "pw")
             @FormParam("pw")
             java.lang.String pw) {
     	return login (id,pw);
@@ -167,7 +169,7 @@ public class SakaiLogin extends AbstractWebService {
      * @return
      * @throws InterruptedException
      */
-    @WebMethod
+    @WebMethod(operationName="logout")
     @Produces(MediaType.TEXT_PLAIN)
     //Can't get MediaType.MULTIPART_FORM_DATA to work
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
@@ -175,6 +177,7 @@ public class SakaiLogin extends AbstractWebService {
     @Path("/logout")
     public boolean logoutPOST(
             @FormParam("sessionid")
+            @WebParam(partName = "sessionid", name = "sessionid")
             java.lang.String sessionid) {
     	return logout (sessionid);
     }
@@ -214,15 +217,17 @@ public class SakaiLogin extends AbstractWebService {
     }
 
 
-    @WebMethod
+    @WebMethod(operationName="loginToServer")
     @Produces(MediaType.TEXT_PLAIN)
     //Can't get MediaType.MULTIPART_FORM_DATA to work
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
     @POST
     @Path("/loginToServer")
     public java.lang.String loginToServerPOST(
+            @WebParam(partName = "id", name = "id")
             @FormParam("id")
             java.lang.String id,
+            @WebParam(partName = "pw", name = "pw")
             @FormParam("pw")
             java.lang.String pw) {
         return login(id, pw) + "," + serverConfigurationService.getString("webservices.directurl", serverConfigurationService.getString("serverUrl"));

--- a/webservices/cxf/src/test/java/org/sakaiproject/webservices/SakaiLoginLoginTest.java
+++ b/webservices/cxf/src/test/java/org/sakaiproject/webservices/SakaiLoginLoginTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.eq;
 
 import org.apache.cxf.jaxrs.client.WebClient;
+import javax.ws.rs.core.Form;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -80,11 +82,11 @@ public class SakaiLoginLoginTest extends AbstractCXFTest {
 		// client call
 		client.accept("text/plain");
 		client.path("/" + getOperation());
-		client.query("id", "admin");
-		client.query("pw", "admin");
+		Form form = new Form();
+		form.param("id", "admin").param("pw", "admin"); 
 
 		// client result
-		String result = client.get(String.class);
+		String result = client.post(form, String.class);
 
 		// test verifications
 		assertNotNull(result);
@@ -100,11 +102,11 @@ public class SakaiLoginLoginTest extends AbstractCXFTest {
 		// client call
 		client.accept("text/plain");
 		client.path("/" + getOperation());
-		client.query("id", "admin");
-		client.query("pw", "fail");
+		Form form = new Form();
+		form.param("id", "admin").param("pw", "fail"); 
 
 		// client result
 		thrown.expect(RuntimeException.class);
-		client.get(String.class);
+		client.post(form, String.class);
 	}
 }


### PR DESCRIPTION
This looks like it's restores the WSDL to be compatible. Were you previously using a POST with these tasks? I'm not sure if it will take a GET anymore or not. 

There should be methods available, loginGET/logoutGET that are the respective GET methods until/unless we deprecate them. 