### PR TITLE
SAK-34014: 'Copy Content from My Other Sites' link still disappears at smallest breakpoint

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -776,7 +776,7 @@
 					#end ## foreach $root in $other_sites
 	
 				#else
-					<tr class="hidden-xs">
+					<tr>
 						<th colspan="10">
 						<h3>
 							<a href="#" onclick="document.getElementById('sakai_action').value='doShowOtherSites';document.getElementById('showForm').submit();"


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34014

Steps to reproduce:

    1) Start with browser window at max width
    2) Start shrinking
    3) Notice there seems to be two breakpoints for the 'mobile' width
        3a) The first one retains the link, then shrink the browser a little more
        3b) Notice the link disappears, along with the 'Transfer Files' tab at the top

This link should never be hidden; there's no way for a user to access this functionality at small browser widths.