### PR TITLE
SAK-34015 remove bootstrap rule that removes outline on focus

### DIFF
--- a/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -22,11 +22,6 @@
   position: relative;
 }
 
-// Prevent the focus on the dropdown toggle when closing dropdowns
-.dropdown-toggle:focus {
-  outline: 0;
-}
-
 // The dropdown menu (ul)
 .dropdown-menu {
   position: absolute;


### PR DESCRIPTION
Yes, I'm doing this straight against Bootstrap files, but a) this rule is not in Bootstrap 4 and b) I bet our next move will be to Bootstrap 4 and not another Bootstrap 3 revision