### PR TITLE
 SAM-3180: incorrect behavior of Multiple Choice, Partial Credit in question edit UI

### DIFF
--- a/samigo/samigo-app/src/webapp/js/authoring.js
+++ b/samigo/samigo-app/src/webapp/js/authoring.js
@@ -328,6 +328,25 @@ $( document ).ready( function() {
 
     });
 
+    // Fix the input value and display for the correct answer in Multiple Choice
+    // when entering with partial credit enabled.
+    $('[id$="mcradiobtn"]').click(function(e){
+        $('[id$="partialCredit"]').removeAttr('disabled');
+        $('[id$="partialCredit"]').attr('type', 'text');
+        $('#correctAnswerPC').remove();
+        pcBox = $('#'+this.id.replace(/:/g,'\\:').replace('mcradiobtn','partialCredit'));
+        pcBox.after('<span id="correctAnswerPC">100%</span>');
+        pcBox.attr('disabled',true);
+        pcBox.attr('type', 'hidden');
+        pcBox.val("0");
+    });
+    // Apply the above when the form loads.
+    $('[id$="mcradiobtn"]').each(function() {
+        if( $("input", this).attr("checked") ) {
+            $("input", this).click();
+        }
+    })
+
 });
 
 function validationWarningSetDefault(element, value) {

--- a/samigo/samigo-app/src/webapp/js/authoring.js
+++ b/samigo/samigo-app/src/webapp/js/authoring.js
@@ -328,25 +328,28 @@ $( document ).ready( function() {
 
     });
 
-    // Fix the input value and display for the correct answer in Multiple Choice
-    // when entering with partial credit enabled.
-    $('[id$="mcradiobtn"]').click(function(e){
+    // Fix the input value and display for the correct answer in Multiple Choice when entering with partial credit enabled.
+    $('[id$="mcradiobtn"]').click( function(e) {
+
+        // Transform the previous full credit label into an empty text field
         $('[id$="partialCredit"]').removeAttr('disabled');
         $('[id$="partialCredit"]').attr('type', 'text');
         $('#correctAnswerPC').remove();
-        pcBox = $('#'+this.id.replace(/:/g,'\\:').replace('mcradiobtn','partialCredit'));
+
+        // For the choice that was marked as correct, replace the editable point value field with a static value/label of 100%
+        pcBox = $('#'+this.id.replace(/:/g, '\\:').replace('mcradiobtn', 'partialCredit'));
         pcBox.after('<span id="correctAnswerPC">100%</span>');
-        pcBox.attr('disabled',true);
+        pcBox.attr('disabled', true);
         pcBox.attr('type', 'hidden');
         pcBox.val("0");
     });
+
     // Apply the above when the form loads.
     $('[id$="mcradiobtn"]').each(function() {
         if( $("input", this).attr("checked") ) {
             $("input", this).click();
         }
-    })
-
+    });
 });
 
 function validationWarningSetDefault(element, value) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3180

When you author or edit a Multiple Choice question with Partial Credit enabled, the correct answer's % Value field is not being disabled or set to 100. However, if you save the question with any value other than 100 in the correct answer's % Value field, the question saves ok and, as it should, forces the correct answer's % value to be 100.

More details and steps to reproduce in the JIRA.