### PR TITLE
SAM-3113: when a late test is auto-submitted, Scores screen only shows LATE flag

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -657,10 +657,21 @@ $(document).ready(function(){
         </h:outputText>
 		<h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
                     && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
+                    && (description.isAutoSubmitted == 'false')
 					&& !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false')}">
 			<f:verbatim><br/></f:verbatim>
 			<h:outputText style="color:red" value="#{evaluationMessages.late}"/>
 		</h:panelGroup>
+               <h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
+                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
+                    && (description.isAutoSubmitted == 'true')
+                    && (totalScores.acceptLateSubmission eq 'true')
+                                       && !(totalScores.isTimedAssessment eq 'true')}">
+                       <f:verbatim><br/></f:verbatim>
+                       <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
+                       <f:verbatim><br/></f:verbatim>
+                       <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
+               </h:panelGroup>
 
 		<h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && description.isLate == 'false' && description.attemptDate != null
                     && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
@@ -688,10 +699,22 @@ $(document).ready(function(){
         </h:outputText>
 		<h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
                     && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
+                    && (description.isAutoSubmitted == 'false')
 					&& !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false')}">
 			<f:verbatim><br/></f:verbatim>
 			<h:outputText style="color:red" value="#{evaluationMessages.late}"/>
 		</h:panelGroup>
+               <h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
+                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
+                    && (description.isAutoSubmitted == 'true')
+                    && (totalScores.acceptLateSubmission eq 'true')
+                                       && !(totalScores.isTimedAssessment eq 'true' )}">
+                       <f:verbatim><br/></f:verbatim>
+                       <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
+                       <f:verbatim><br/></f:verbatim>
+                       <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
+
+               </h:panelGroup>
 
 		<h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && description.isLate == 'false' && description.attemptDate != null
                     && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
@@ -720,10 +743,21 @@ $(document).ready(function(){
         </h:outputText>
 		<h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
                     && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
+                    && (description.isAutoSubmitted == 'false')
 					&& !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false')}">
 			<f:verbatim><br/></f:verbatim>
 			<h:outputText style="color:red" value="#{evaluationMessages.late}"/>
 		</h:panelGroup>
+               <h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
+                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
+                    && (description.isAutoSubmitted == 'true')
+                    && (totalScores.acceptLateSubmission eq 'true')
+                                       && !(totalScores.isTimedAssessment eq 'true' )}">
+                       <f:verbatim><br/></f:verbatim>
+                       <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
+                       <f:verbatim><br/></f:verbatim>
+                       <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
+               </h:panelGroup>
 
 		<h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && description.isLate == 'false' && description.attemptDate != null
                     && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -655,31 +655,18 @@ $(document).ready(function(){
         <h:outputText value="#{description.submittedDate}" rendered="#{description.attemptDate != null && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')}" >
           <f:convertDateTime pattern="#{generalMessages.output_data_picker_w_sec}"/>
         </h:outputText>
-		<h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-                    && (description.isAutoSubmitted == 'false')
-					&& !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false')}">
-			<f:verbatim><br/></f:verbatim>
-			<h:outputText style="color:red" value="#{evaluationMessages.late}"/>
-		</h:panelGroup>
-               <h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-                    && (description.isAutoSubmitted == 'true')
-                    && (totalScores.acceptLateSubmission eq 'true')
-                                       && !(totalScores.isTimedAssessment eq 'true')}">
-                       <f:verbatim><br/></f:verbatim>
-                       <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
-                       <f:verbatim><br/></f:verbatim>
-                       <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
-               </h:panelGroup>
+        <h:panelGroup rendered="#{description.attemptDate != null && (totalScores.anonymous eq 'false' || description.assessmentGradingId ne '-1')}">
+          <h:panelGroup rendered="#{description.isLate == 'true' && ((description.isAutoSubmitted == 'false' && !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false'))
+                                      || (description.isAutoSubmitted == 'true' && totalScores.acceptLateSubmission eq 'true' && totalScores.isTimedAssessment ne 'true'))}">
+            <f:verbatim><br/></f:verbatim>
+            <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
+          </h:panelGroup>
+          <h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && totalScores.isTimedAssessment ne 'true' && (description.isLate == 'false' || totalScores.acceptLateSubmission eq 'true')}">
+            <f:verbatim><br/></f:verbatim>
+            <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
+          </h:panelGroup>
+        </h:panelGroup>
 
-		<h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && description.isLate == 'false' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-					&& !totalScores.isTimedAssessment eq 'true'}">
-			<f:verbatim><br/></f:verbatim>
-			<h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
-		</h:panelGroup>
-		
       <h:outputText value="#{evaluationMessages.no_submission}"
          rendered="#{description.attemptDate == null && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')}"/>
     </h:column>
@@ -697,31 +684,17 @@ $(document).ready(function(){
         <h:outputText value="#{description.submittedDate}" rendered="#{description.attemptDate != null && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')}" >
           <f:convertDateTime pattern="#{generalMessages.output_data_picker_w_sec}"/>
         </h:outputText>
-		<h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-                    && (description.isAutoSubmitted == 'false')
-					&& !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false')}">
-			<f:verbatim><br/></f:verbatim>
-			<h:outputText style="color:red" value="#{evaluationMessages.late}"/>
-		</h:panelGroup>
-               <h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-                    && (description.isAutoSubmitted == 'true')
-                    && (totalScores.acceptLateSubmission eq 'true')
-                                       && !(totalScores.isTimedAssessment eq 'true' )}">
-                       <f:verbatim><br/></f:verbatim>
-                       <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
-                       <f:verbatim><br/></f:verbatim>
-                       <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
-
-               </h:panelGroup>
-
-		<h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && description.isLate == 'false' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-					&& !totalScores.isTimedAssessment eq 'true'}">
-			<f:verbatim><br/></f:verbatim>
-			<h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
-		</h:panelGroup>
+        <h:panelGroup rendered="#{description.attemptDate != null && (totalScores.anonymous eq 'false' || description.assessmentGradingId ne '-1')}">
+          <h:panelGroup rendered="#{description.isLate == 'true' && ((description.isAutoSubmitted == 'false' && !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false'))
+                                      || (description.isAutoSubmitted == 'true' && totalScores.acceptLateSubmission eq 'true' && totalScores.isTimedAssessment ne 'true'))}">
+            <f:verbatim><br/></f:verbatim>
+            <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
+          </h:panelGroup>
+          <h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && totalScores.isTimedAssessment ne 'true' && (description.isLate == 'false' || totalScores.acceptLateSubmission eq 'true')}">
+            <f:verbatim><br/></f:verbatim>
+            <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
+          </h:panelGroup>
+        </h:panelGroup>
 
         <h:outputText value="#{evaluationMessages.no_submission}"
          rendered="#{description.attemptDate == null && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')}"/>
@@ -741,31 +714,18 @@ $(document).ready(function(){
         <h:outputText value="#{description.submittedDate}" rendered="#{description.attemptDate != null && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')}" >
           <f:convertDateTime pattern="#{generalMessages.output_data_picker_w_sec}"/>
         </h:outputText>
-		<h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-                    && (description.isAutoSubmitted == 'false')
-					&& !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false')}">
-			<f:verbatim><br/></f:verbatim>
-			<h:outputText style="color:red" value="#{evaluationMessages.late}"/>
-		</h:panelGroup>
-               <h:panelGroup rendered="#{description.isLate == 'true' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-                    && (description.isAutoSubmitted == 'true')
-                    && (totalScores.acceptLateSubmission eq 'true')
-                                       && !(totalScores.isTimedAssessment eq 'true' )}">
-                       <f:verbatim><br/></f:verbatim>
-                       <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
-                       <f:verbatim><br/></f:verbatim>
-                       <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
-               </h:panelGroup>
+        <h:panelGroup rendered="#{description.attemptDate != null && (totalScores.anonymous eq 'false' || description.assessmentGradingId ne '-1')}">
+          <h:panelGroup rendered="#{description.isLate == 'true' && ((description.isAutoSubmitted == 'false' && !(totalScores.isTimedAssessment eq 'true' && totalScores.acceptLateSubmission eq 'false'))
+                                      || (description.isAutoSubmitted == 'true' && totalScores.acceptLateSubmission eq 'true' && totalScores.isTimedAssessment ne 'true'))}">
+            <f:verbatim><br/></f:verbatim>
+            <h:outputText style="color:red" value="#{evaluationMessages.late}"/>
+          </h:panelGroup>
+          <h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && totalScores.isTimedAssessment ne 'true' && (description.isLate == 'false' || totalScores.acceptLateSubmission eq 'true')}">
+            <f:verbatim><br/></f:verbatim>
+            <h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
+          </h:panelGroup>
+        </h:panelGroup>
 
-		<h:panelGroup rendered="#{description.isAutoSubmitted == 'true' && description.isLate == 'false' && description.attemptDate != null
-                    && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')
-					&& !totalScores.isTimedAssessment eq 'true'}">
-			<f:verbatim><br/></f:verbatim>
-			<h:outputText style="color:red" value="#{evaluationMessages.auto_submit}"/>
-		</h:panelGroup>
-		
         <h:outputText value="#{evaluationMessages.no_submission}"
          rendered="#{description.attemptDate == null && (totalScores.anonymous eq 'false'  || description.assessmentGradingId ne '-1')}"/>
     </h:column>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3113

If a test has both a late acceptance date and auto-submit enabled in its Settings, and a student saves but does not submit the test after the due date, but before the late acceptance date, the Scores screen only displays one flag under the student's submission date: "LATE". To be more accurate, it should display both flags: "LATE", and "AUTO-SUBMIT".

More info in the JIRA ticket.