### PR TITLE
SAK-33103: Users with TA role cannot grade students by default in Gradebook - against master - based on PR 4378

### DIFF
--- a/edu-services/gradebook-service/api/pom.xml
+++ b/edu-services/gradebook-service/api/pom.xml
@@ -24,5 +24,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.sakaiproject.edu-services.sections</groupId>
+      <artifactId>sections-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookPermissionService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookPermissionService.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.sakaiproject.section.api.facade.Role;
 
 public interface GradebookPermissionService
 {
@@ -269,6 +270,18 @@ public interface GradebookPermissionService
 	  * @return
 	  */
 	 public void updatePermissionsForUser(final String gradebookUid, final String userId, List<PermissionDefinition> permissionDefinitions);
-
 	 
+	 /**
+	  * Get a list of permissions defined for the given user based on section and role or all sections if allowed. 
+	  * This method checks realms permissions for role/section and is independent of the 
+	  * gb_permissions_t permissions.
+	  * 
+	  * note: If user has the grade privilege, they are given the GraderPermission.VIEW_COURSE_GRADE permission to match
+	  * GB classic functionality. This needs to be reviewed.
+	  *
+	  * @param userUuid
+	  * @param siteId
+	  * @return list of {@link org.sakaiproject.service.gradebook.shared.PermissionDefinition PermissionDefinitions} or empty list if none
+	  */	
+	 public List<PermissionDefinition> getRealmsPermissionsForUser(String userUuid,String siteId, Role role);
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookPermissionServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookPermissionServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.section.api.SectionAwareness;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
@@ -43,6 +44,7 @@ import org.springframework.orm.hibernate4.HibernateCallback;
 public class GradebookPermissionServiceImpl extends BaseHibernateManager implements GradebookPermissionService
 {
 	private SectionAwareness sectionAwareness;
+	private GradebookService gradebookService;
 	
 	public List<Long> getCategoriesForUser(Long gradebookId, String userId, List<Long> categoryIdList) throws IllegalArgumentException
 	{
@@ -1193,6 +1195,59 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 		
 	}
 
+	/**
+	 * Get a list of permissions defined for the given user based on section and role or all sections if allowed. 
+	 * This method checks realms permissions for role/section and is independent of the 
+	 * gb_permissions_t permissions.
+	 *
+	 * note: If user has the grade privilege, they are given the GraderPermission.VIEW_COURSE_GRADE permission to match
+	 * GB classic functionality. This needs to be reviewed.
+	 *
+	 * @param userUuid
+	 * @param siteId
+	 * @param role user Role
+	 * @return list of {@link org.sakaiproject.service.gradebook.shared.PermissionDefinition PermissionDefinitions} or empty list if none
+	 */
+	public List<PermissionDefinition> getRealmsPermissionsForUser(String userUuid,String siteId, Role role){
+
+		List<PermissionDefinition> permissions = new ArrayList<PermissionDefinition>();
+
+		if( this.getGradebookService().isUserAllowedToGrade(siteId,userUuid)){
+			//FIXME:giving them view course grade (this needs to be reviewed!!), 
+			//it appears in GB classic, User can view course grades if they have the ability to grade in realms
+			PermissionDefinition permDef = new PermissionDefinition();
+			permDef.setFunction(GraderPermission.VIEW_COURSE_GRADE.toString());
+			permDef.setUserId(userUuid);
+			permissions.add(permDef);
+
+			if(this.getGradebookService().isUserAllowedToGradeAll(siteId,userUuid)){
+				permDef = new PermissionDefinition();
+				permDef.setFunction(GraderPermission.GRADE.toString());
+				permDef.setUserId(userUuid);
+				permissions.add(permDef);
+			}else{
+				//get list of sections belonging to user and set a PermissionDefinition for each one
+				//Didn't find a method that returned gradeable sections for a TA, only for the logged in user.
+				//grabbing list of sections for the site, if User is a member of the section and has privilege to
+				//grade their sections, they are given the grade permission. Seems straight forward??
+				List<CourseSection> sections = this.getSectionAwareness().getSections(siteId);
+
+				for(CourseSection section: sections){
+					if(this.getSectionAwareness().isSectionMemberInRole(section.getUuid(), userUuid,role)){
+						//realms have no categories defined for grading, just perms and group id
+						permDef = new PermissionDefinition();
+						permDef.setFunction(GraderPermission.GRADE.toString());
+						permDef.setUserId(userUuid);
+						permDef.setGroupReference(section.getUuid());
+						permissions.add(permDef);
+					}
+				}
+			}
+		}
+
+		return permissions;
+	}
+
 	public SectionAwareness getSectionAwareness()
 	{
 		return sectionAwareness;
@@ -1201,6 +1256,16 @@ public class GradebookPermissionServiceImpl extends BaseHibernateManager impleme
 	public void setSectionAwareness(SectionAwareness sectionAwareness)
 	{
 		this.sectionAwareness = sectionAwareness;
+	}
+
+	public GradebookService getGradebookService()
+	{
+		return (GradebookService) ComponentManager.get("org.sakaiproject.service.gradebook.GradebookService");
+	}
+
+	public void setGradebookService(GradebookService gradebookService)
+	{
+		this.gradebookService = gradebookService;
 	}
 	
 	private Map<String, List<String>> getSectionIdStudentIdsMap(Collection courseSections, Collection studentIds) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -15,6 +15,10 @@
  */
 package org.sakaiproject.gradebookng.business;
 
+import java.math.RoundingMode;
+import java.security.Permission;
+import java.text.Format;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,6 +44,9 @@ import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.coursemanagement.api.Membership;
+import org.sakaiproject.section.api.coursemanagement.CourseSection;
+import org.sakaiproject.section.api.facade.Role;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.gradebookng.business.exception.GbAccessDeniedException;
@@ -219,13 +226,28 @@ public class GradebookNgBusinessService {
 					final Gradebook gradebook = this.getGradebook(givenSiteId);
 
 					// get list of sections and groups this TA has access to
-					final List courseSections = this.gradebookService.getViewableSections(gradebook.getUid());
+					final List<CourseSection> courseSections = this.gradebookService.getViewableSections(gradebook.getUid());
 
-					// get viewable students.
-					final List<String> viewableStudents = this.gradebookPermissionService.getViewableStudentsForUser(
-							gradebook.getUid(), user.getId(), new ArrayList<>(userUuids), courseSections);
+					//for each section TA has access to, grab student Id's
+					List<String> viewableStudents = new ArrayList();
 
-					if (viewableStudents != null) {
+					Map<String, Set<Member>> groupMembers = getGroupMembers();
+					
+					//iterate through sections available to the TA and build a list of the student members of each section
+					if(courseSections != null && !courseSections.isEmpty() && groupMembers!=null){
+						for(CourseSection section:courseSections){
+							if(groupMembers.containsKey(section.getUuid())) {
+								Set<Member> members = groupMembers.get(section.getUuid());
+								for(Member member:members){
+									if(givenSiteId!=null && member.getUserId()!=null && securityService.unlock(member.getUserId(), GbPortalPermission.VIEW_OWN_GRADES.getValue(), siteService.siteReference(givenSiteId))/*member.getRole().equals("S")*/){
+											viewableStudents.add(member.getUserId());
+									}
+								}
+							}
+						}
+					}
+
+					if (!viewableStudents.isEmpty()) {
 						userUuids.retainAll(viewableStudents); // retain only
 																// those that
 																// are visible
@@ -465,8 +487,16 @@ public class GradebookNgBusinessService {
 			}
 
 			// get a list of category ids the user can actually view
-			final List<Long> viewableCategoryIds = this.gradebookPermissionService
+			List<Long> viewableCategoryIds = this.gradebookPermissionService
 					.getCategoriesForUser(gradebook.getId(), user.getId(), allCategoryIds);
+
+			//FIXME: this is a hack to implement the old style realms checks. The above method only checks the gb_permission_t table and not realms
+			//if categories is empty (no fine grain permissions enabled), Check permissions, if they are not empty then realms perms exist 
+			//and they don't filter to category level so allow all.
+			//This should still allow the gb_permission_t perms to override if the TA is restricted to certain categories
+			if(viewableCategoryIds.isEmpty() && !this.getPermissionsForUser(user.getId()).isEmpty()){
+				viewableCategoryIds = allCategoryIds;
+			}
 
 			// remove the ones that the user can't view
 			final Iterator<CategoryDefinition> iter = rval.iterator();
@@ -1437,8 +1467,21 @@ public class GradebookNgBusinessService {
 
 			// get the ones the TA can actually view
 			// note that if a group is empty, it will not be included.
-			final List<String> viewableGroupIds = this.gradebookPermissionService
+			List<String> viewableGroupIds = this.gradebookPermissionService
 					.getViewableGroupsForUser(gradebook.getId(), user.getId(), allGroupIds);
+
+			//FIXME: Another realms hack. The above method only returns groups from gb_permission_t. If this list is empty,
+			//need to check realms to see if user has privilege to grade any groups. This is already done in 
+			if(viewableGroupIds.isEmpty()){
+				List<PermissionDefinition> realmsPerms = this.getPermissionsForUser(user.getId());
+				if(!realmsPerms.isEmpty()){
+					for(PermissionDefinition permDef : realmsPerms){
+						if(permDef.getGroupReference()!=null){
+							viewableGroupIds.add(permDef.getGroupReference());
+						}
+					}
+				}
+			}
 
 			// remove the ones that the user can't view
 			final Iterator<GbGroup> iter = rval.iterator();
@@ -2140,10 +2183,13 @@ public class GradebookNgBusinessService {
 		final String siteId = getCurrentSiteId();
 		final Gradebook gradebook = getGradebook(siteId);
 
-		final List<PermissionDefinition> permissions = this.gradebookPermissionService
+		List<PermissionDefinition> permissions = this.gradebookPermissionService
 				.getPermissionsForUser(gradebook.getUid(), userUuid);
-		if (permissions == null) {
-			return new ArrayList<>();
+
+		//if db permissions are null, check realms permissions.
+		if (permissions == null || permissions.isEmpty()) {
+			//This method should return empty arraylist if they have no realms perms
+			permissions = this.gradebookPermissionService.getRealmsPermissionsForUser(userUuid, siteId, Role.TA);
 		}
 		return permissions;
 	}
@@ -2291,6 +2337,40 @@ public class GradebookNgBusinessService {
 		return rval;
 	}
 
+	/**
+	 * Build a list of group references to site membership (as Member) for the groups that are viewable for the current user.
+	 *
+	 * @return
+	 */
+	public Map<String, Set<Member>> getGroupMembers() {
+
+		final String siteId = getCurrentSiteId();
+
+		Site site;
+		try {
+			site = this.siteService.getSite(siteId);
+		} catch (final IdUnusedException e) {
+			log.error("Error looking up site: {}", siteId, e);
+			return null;
+		}
+
+		// filtered for the user
+		final List<GbGroup> viewableGroups = getSiteSectionsAndGroups();
+
+		final Map<String, Set<Member>> rval = new HashMap<>();
+
+				
+		for (final GbGroup gbGroup : viewableGroups) {
+			final String groupReference = gbGroup.getReference();
+			final Group group = site.getGroup(groupReference);
+			if (group != null) {
+				rval.put(groupReference, group.getMembers());
+			}
+		}
+
+		return rval;
+	}
+	
 	/**
 	 * Have categories been enabled for the gradebook?
 	 *

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -123,6 +123,9 @@ public class GradebookPage extends BasePage {
 			sendToAccessDeniedPage(getString("error.role"));
 		}
 
+		// get Gradebook to save additional calls later
+		final Gradebook gradebook = this.businessService.getGradebook();
+
 		// students cannot access this page, they have their own
 		if (this.role == GbRole.STUDENT) {
 			throw new RestartResponseException(StudentPage.class);
@@ -220,9 +223,6 @@ public class GradebookPage extends BasePage {
 			sortBy = SortType.SORT_BY_CATEGORY;
 			this.form.add(new AttributeAppender("class", "gb-grouped-by-category"));
 		}
-
-		// get Gradebook to save additional calls later
-		final Gradebook gradebook = this.businessService.getGradebook();
 
 		final List<Assignment> assignments = this.businessService.getGradebookAssignments(sortBy);
 		final List<String> students = this.businessService.getGradeableUsers();


### PR DESCRIPTION
PR done against trunk (based on previous PR #4396). Fully tested on local and qa server 
(13-SNAPSHOT - https://sakai-trunk.atica.um.es/portal). It works as expected: 'ta' is able to grade. The students and instructors work ok.