### PR TITLE
SAK-34030 Only have a single setter for RSF

### DIFF
--- a/mailsender/api/src/java/org/sakaiproject/mailsender/model/EmailEntry.java
+++ b/mailsender/api/src/java/org/sakaiproject/mailsender/model/EmailEntry.java
@@ -127,7 +127,8 @@ public class EmailEntry
 		return config;
 	}
 
-	public void setOtherRecipients(List<String> otherRecipients)
+	// RSF Has a problem with overloaded setters so we force it to use the String one.
+	public void setOtherRecipientsList(List<String> otherRecipients)
 	{
 		this.otherRecipients = otherRecipients;
 	}

--- a/mailsender/api/src/test/org/sakaiproject/mailsender/model/EmailEntryTest.java
+++ b/mailsender/api/src/test/org/sakaiproject/mailsender/model/EmailEntryTest.java
@@ -132,7 +132,7 @@ public class EmailEntryTest {
 		otherRecipients.add("someone@example.com");
 		otherRecipients.add("whatever@example.com");
 
-		entry.setOtherRecipients(otherRecipients);
+		entry.setOtherRecipientsList(otherRecipients);
 		assertFalse(entry.getOtherRecipients().isEmpty());
 		assertEquals(3, entry.getOtherRecipients().size());
 		assertEquals("nobody@example.com", entry.getOtherRecipients().get(0));


### PR DESCRIPTION
When binding parameters from a request to a bean RSF isn’t predictable in which setter will get used, this results in the binding failing 50% of the time. By renaming one of the methods we force RSF to use the one we want all the time.