### PR TITLE
SAK-32104 - Sitestats - Lessons: number of pages is incorrectly calculated

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
@@ -108,6 +108,7 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
 	private Boolean						visitsInfoAvailable						= null;
 	private boolean						enableServerWideStats					= true;
 	private boolean						countFilesUsingCHS						= true;
+	private boolean						countPagesUsingLBS						= true;
 	private String						chartBackgroundColor					= "white";
 	private boolean						chartIn3D								= true;
 	private float						chartTransparency						= 0.80f;
@@ -203,6 +204,10 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
 	
 	public void setCountFilesUsingCHS(boolean countFilesUsingCHS) {
 		this.countFilesUsingCHS = countFilesUsingCHS;
+	}
+	
+	public void setCountPagesUsingLBS(boolean countPagesUsingLBS) {
+		this.countPagesUsingLBS = countPagesUsingLBS;
 	}
 	
 	public void setChartBackgroundColor(String color) {
@@ -870,6 +875,8 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
 
 		if (siteId == null){
 			throw new IllegalArgumentException("Null siteId");
+		} if(countPagesUsingLBS){
+			return lessonBuilderService.getSitePages(siteId).size();
 		} else {
 			// Use SiteStats tables (very fast, relies on resource events)
 			// Build common HQL

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/EventAggregatorTestPerf.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/EventAggregatorTestPerf.java
@@ -161,6 +161,7 @@ public class EventAggregatorTestPerf extends AbstractJUnit4SpringContextTests {
 		((StatsManagerImpl)M_sm).setContentTypeImageService(M_ctis);
 		((StatsManagerImpl)M_sm).setResourceLoader(msgs);
 		((StatsManagerImpl)M_sm).setCountFilesUsingCHS(false);
+		((StatsManagerImpl)M_sm).setCountPagesUsingLBS(false);
 		((StatsUpdateManagerImpl)M_sum).setSiteService(M_ss);
 		((StatsUpdateManagerImpl)M_sum).setStatsManager(M_sm);
 	}

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
@@ -183,6 +183,7 @@ public class StatsManagerTest extends AbstractTransactionalJUnit4SpringContextTe
 		((StatsManagerImpl)M_sm).setContentTypeImageService(M_ctis);
 		((StatsManagerImpl)M_sm).setResourceLoader(msgs);
 		((StatsManagerImpl)M_sm).setCountFilesUsingCHS(false);
+		((StatsManagerImpl)M_sm).setCountPagesUsingLBS(false);
 		((StatsUpdateManagerImpl)M_sum).setSiteService(M_ss);
 		((StatsUpdateManagerImpl)M_sum).setStatsManager(M_sm);
 		// This is needed to make the tests deterministic, otherwise on occasion the collect thread will run


### PR DESCRIPTION
@adrianfish Would you mind to take a look?

I admit this solution is very radical but correct, use the Lessons API instead of events, events are incorrect in duplicated courses because there are no "create" events.