### PR TITLE
SAK-34054: GBNG > Import > fix front-end validation for comma decimal locales

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/GradeValidator.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/GradeValidator.java
@@ -24,7 +24,6 @@ import org.sakaiproject.gradebookng.business.model.ImportedCell;
 import org.sakaiproject.gradebookng.business.model.ImportedColumn;
 import org.sakaiproject.gradebookng.business.model.ImportedColumn.Type;
 import org.sakaiproject.gradebookng.business.model.ImportedRow;
-import org.sakaiproject.gradebookng.business.util.FormatHelper;
 
 /**
  * Used to validate grades in an imported file.
@@ -67,7 +66,9 @@ public class GradeValidator
                     if (cell != null)
                     {
                         String studentIdentifier = row.getStudentEid();
-                        validateGrade(columnTitle, studentIdentifier, cell.getScore());
+
+                        // Validation is locale-aware, so use the raw score that the user input in their own locale
+                        validateGrade( columnTitle, studentIdentifier, cell.getRawScore() );
                     }
                 }
             }
@@ -89,10 +90,6 @@ public class GradeValidator
         {
             return;
         }
-
-        // Convert back to user's locale for display/validation purposes
-        grade = FormatHelper.formatGradeForDisplay( grade );
-
         // TODO: when/if letter grades are introduce, determine if grade is numeric
         // or alphabetical here and call/write the appropriate business service method.
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/GradeValidator.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/GradeValidator.java
@@ -24,6 +24,7 @@ import org.sakaiproject.gradebookng.business.model.ImportedCell;
 import org.sakaiproject.gradebookng.business.model.ImportedColumn;
 import org.sakaiproject.gradebookng.business.model.ImportedColumn.Type;
 import org.sakaiproject.gradebookng.business.model.ImportedRow;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
 
 /**
  * Used to validate grades in an imported file.
@@ -88,6 +89,9 @@ public class GradeValidator
         {
             return;
         }
+
+        // Convert back to user's locale for display/validation purposes
+        grade = FormatHelper.formatGradeForDisplay( grade );
 
         // TODO: when/if letter grades are introduce, determine if grade is numeric
         // or alphabetical here and call/write the appropriate business service method.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedCell.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedCell.java
@@ -35,9 +35,15 @@ public class ImportedCell implements Serializable {
 
 	@Getter
 	@Setter
+	private String rawScore;
+
+	@Getter
+	@Setter
 	private String comment;
 
-	public ImportedCell() {
+	public ImportedCell()
+	{
+		rawScore = "";
 	}
 
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -90,11 +90,11 @@ public class FormatHelper {
 	public static String formatDoubleToMatch(final Double score, final String toMatch) {
 		int numberOfDecimalPlaces = 0;
 
-		if (toMatch.indexOf(".") >= 0) {
+		if (toMatch.contains(".")) {
 			numberOfDecimalPlaces = toMatch.split("\\.")[1].length();
 		}
 
-		if (toMatch.indexOf(",") >= 0) {
+		if (toMatch.contains(",")) {
 			numberOfDecimalPlaces = toMatch.split("\\,")[1].length();
 		}
 
@@ -168,7 +168,7 @@ public class FormatHelper {
 			return "";
 		}
 
-		String s = null;
+		String s;
 		try {
 			final DecimalFormat dfParse = (DecimalFormat) NumberFormat.getInstance(Locale.ROOT);
 			dfParse.setParseBigDecimal(true);
@@ -179,11 +179,8 @@ public class FormatHelper {
 			dfFormat.setMaximumFractionDigits(2);
 			dfFormat.setGroupingUsed(true);
 			s = dfFormat.format(d);
-		} catch (final NumberFormatException e) {
-			log.debug("Bad format, returning original string: " + grade);
-			s = grade;
-		} catch (final ParseException e) {
-			log.debug("Bad format, returning original string: " + grade);
+		} catch (final NumberFormatException | ParseException e) {
+			log.debug("Bad format, returning original string: {}", grade);
 			s = grade;
 		}
 
@@ -202,7 +199,7 @@ public class FormatHelper {
 			return "";
 		}
 
-		String s = null;
+		String s;
 		try {
 			final DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(locale);
 			final Double d = df.parse(grade).doubleValue();
@@ -211,11 +208,8 @@ public class FormatHelper {
 			df.setGroupingUsed(false);
 
 			s = df.format(d);
-		} catch (final NumberFormatException e) {
-			log.debug("Bad format, returning original string: " + grade);
-			s = grade;
-		} catch (final ParseException e) {
-			log.debug("Bad format, returning original string: " + grade);
+		} catch (final NumberFormatException | ParseException e) {
+			log.debug("Bad format, returning original string: {}", grade);
 			s = grade;
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -294,10 +294,8 @@ public class ImportGradesHelper {
 				case GB_ITEM_WITHOUT_POINTS:
 					// fix the separator for the comparison with the current values
 					if (StringUtils.isNotBlank(lineVal)) {
-						if (",".equals(userDecimalSeparator)) {
-							lineVal = lineVal.replace(userDecimalSeparator,".");
-						}
-						cell.setScore(lineVal);
+						cell.setRawScore(lineVal);
+						cell.setScore(",".equals(userDecimalSeparator) ? lineVal.replace(userDecimalSeparator, ".") : lineVal);
 					}
 					row.getCellMap().put(columnTitle, cell);
 					break;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -82,7 +82,7 @@ public class ImportGradesHelper {
 	public final static int USER_NAME_POS = 1;
 
 	// patterns for detecting column headers and their types
-	final static Pattern ASSIGNMENT_PATTERN= Pattern.compile("([^\\[]+)(\\[(\\d+([\\.,]\\d\\d?)?)\\])?");
+	final static Pattern ASSIGNMENT_PATTERN = Pattern.compile("([^\\[]+)(\\[(\\d+([\\.,]\\d+)?)\\])?");
 	final static Pattern COMMENT_PATTERN = Pattern.compile("\\* (.+)");
 	final static Pattern IGNORE_PATTERN = Pattern.compile("(\\#.+)");
 
@@ -118,22 +118,22 @@ public class ImportGradesHelper {
 	 * @param mimetype
 	 * @param filename
 	 * @param businessService
-	 * @param userCSVSeparator
+	 * @param userDecimalSeparator
 	 * @return
 	 * @throws GbImportExportInvalidFileTypeException
 	 * @throws IOException
 	 * @throws InvalidFormatException
 	 */
 	public static ImportedSpreadsheetWrapper parseImportedGradeFile(final InputStream is, final String mimetype, final String filename,
-			final GradebookNgBusinessService businessService, String userCSVSeparator) throws GbImportExportInvalidFileTypeException, IOException, InvalidFormatException {
+			final GradebookNgBusinessService businessService, String userDecimalSeparator) throws GbImportExportInvalidFileTypeException, IOException, InvalidFormatException {
 
 		ImportedSpreadsheetWrapper rval = null;
 
 		// It would be great if we could depend on the browser mimetype, but Windows + Excel will always send an Excel mimetype
 		if (StringUtils.endsWithAny(filename, CSV_FILE_EXTS) || ArrayUtils.contains(CSV_MIME_TYPES, mimetype)) {
-			rval = ImportGradesHelper.parseCsv(is, businessService, userCSVSeparator);
+			rval = ImportGradesHelper.parseCsv(is, businessService, userDecimalSeparator);
 		} else if (StringUtils.endsWithAny(filename, XLS_FILE_EXTS) || ArrayUtils.contains(XLS_MIME_TYPES, mimetype)) {
-			rval = ImportGradesHelper.parseXls(is, businessService, userCSVSeparator);
+			rval = ImportGradesHelper.parseXls(is, businessService, userDecimalSeparator);
 		} else {
 			throw new GbImportExportInvalidFileTypeException("Invalid file type for grade import: " + mimetype);
 		}
@@ -149,15 +149,15 @@ public class ImportGradesHelper {
 	 * @throws GbImportExportInvalidColumnException
 	 * @throws GbImportExportDuplicateColumnException
 	 */
-	private static ImportedSpreadsheetWrapper parseCsv(final InputStream is, final GradebookNgBusinessService businessService, String userCSVSeparator)
+	private static ImportedSpreadsheetWrapper parseCsv(final InputStream is, final GradebookNgBusinessService businessService, String userDecimalSeparator)
 			throws IOException {
 
 		// manually parse method so we can support arbitrary columns
 		CSVReader reader;
-		if(StringUtils.isEmpty(userCSVSeparator)){
+		if(StringUtils.isEmpty(userDecimalSeparator)){
 			reader = new CSVReader(new InputStreamReader(is));
 		}else{
-			reader = new CSVReader(new InputStreamReader(is), ".".equals(userCSVSeparator) ? CSVParser.DEFAULT_SEPARATOR : CSV_SEMICOLON_SEPARATOR);
+			reader = new CSVReader(new InputStreamReader(is), ".".equals(userDecimalSeparator) ? CSVParser.DEFAULT_SEPARATOR : CSV_SEMICOLON_SEPARATOR);
 		}
 		String[] nextLine;
 		int lineCount = 0;
@@ -174,7 +174,7 @@ public class ImportGradesHelper {
 					mapping = mapHeaderRow(nextLine, importedGradeWrapper.getHeadingReport());
 				} else {
 					// map the fields into the object
-					final ImportedRow importedRow = mapLine(nextLine, mapping, userEidMap, userCSVSeparator);
+					final ImportedRow importedRow = mapLine(nextLine, mapping, userEidMap, userDecimalSeparator);
 					if (importedRow != null) {
 						list.add(importedRow);
 					}
@@ -206,7 +206,7 @@ public class ImportGradesHelper {
 	 * @throws GbImportExportInvalidColumnException
 	 * @Throws GbImportExportDuplicateColumnException
 	 */
-	private static ImportedSpreadsheetWrapper parseXls(final InputStream is, final GradebookNgBusinessService businessService, String userCSVSeparator)
+	private static ImportedSpreadsheetWrapper parseXls(final InputStream is, final GradebookNgBusinessService businessService, String userDecimalSeparator)
 			throws InvalidFormatException, IOException {
 
 		int lineCount = 0;
@@ -226,7 +226,7 @@ public class ImportGradesHelper {
 				mapping = mapHeaderRow(r, importedGradeWrapper.getHeadingReport());
 			} else {
 				// map the fields into the object
-				final ImportedRow importedRow = mapLine(r, mapping, userEidMap, userCSVSeparator);
+				final ImportedRow importedRow = mapLine(r, mapping, userEidMap, userDecimalSeparator);
 				if (importedRow != null) {
 					list.add(importedRow);
 				}
@@ -247,7 +247,7 @@ public class ImportGradesHelper {
 	 * @param mapping
 	 * @return
 	 */
-	private static ImportedRow mapLine(final String[] line, final Map<Integer, ImportedColumn> mapping, final Map<String, GbUser> userMap, String userCSVSeparator) {
+	private static ImportedRow mapLine(final String[] line, final Map<Integer, ImportedColumn> mapping, final Map<String, GbUser> userMap, String userDecimalSeparator) {
 
 		final ImportedRow row = new ImportedRow();
 
@@ -294,8 +294,8 @@ public class ImportGradesHelper {
 				case GB_ITEM_WITHOUT_POINTS:
 					// fix the separator for the comparison with the current values
 					if (StringUtils.isNotBlank(lineVal)) {
-						if (",".equals(userCSVSeparator)) {
-							lineVal = lineVal.replace(",",".");
+						if (",".equals(userDecimalSeparator)) {
+							lineVal = lineVal.replace(userDecimalSeparator,".");
 						}
 						cell.setScore(lineVal);
 					}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/CreateGradeItemStep.java
@@ -38,6 +38,7 @@ import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.gradebookng.tool.panels.AddOrEditGradeItemPanelContent;
 import org.sakaiproject.gradebookng.tool.panels.BasePanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
+import org.sakaiproject.util.FormattedText;
 
 /**
  * Importer has detected that items need to be created so extract the data and wrap the 'AddOrEditGradeItemPanelContent' panel
@@ -75,8 +76,13 @@ public class CreateGradeItemStep extends BasePanel {
 		final Assignment assignment = assignmentFromModel == null ? new Assignment() : assignmentFromModel;
 		if (assignmentFromModel == null) {
 			assignment.setName(StringUtils.trim(processedGradeItem.getItemTitle()));
-			if(StringUtils.isNotBlank(processedGradeItem.getItemPointValue())) {
-				assignment.setPoints(Double.parseDouble(processedGradeItem.getItemPointValue()));
+			String itemPointValue = processedGradeItem.getItemPointValue();
+			if(StringUtils.isNotBlank(itemPointValue)) {
+				String decimalSeparator = FormattedText.getDecimalSeparator();
+				if (",".equals(decimalSeparator)) {
+					itemPointValue = itemPointValue.replace(decimalSeparator, ".");
+				}
+				assignment.setPoints(Double.parseDouble(itemPointValue));
 			}
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -293,9 +293,9 @@ public class ExportPanel extends BasePanel {
 
 				// build column header
 				assignments.forEach(assignment -> {
-					final String assignmentPoints = assignment.getPoints().toString();
+					final String assignmentPoints = FormatHelper.formatGradeForDisplay(assignment.getPoints().toString());
 					if (!isCustomExport || this.includeGradeItemScores) {
-						header.add(assignment.getName() + " [" + StringUtils.removeEnd(assignmentPoints, ".0") + "]");
+						header.add(assignment.getName() + " [" + StringUtils.removeEnd(assignmentPoints, FormattedText.getDecimalSeparator() + "0") + "]");
 					}
 					if (!isCustomExport || this.includeGradeItemComments) {
 						header.add(String.join(" ", COMMENTS_COLUMN_PREFIX, assignment.getName()));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -237,7 +237,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 					for (ProcessedGradeItemDetail processedGradeItemDetail : processedGradeItemDetails) {
 						GradeDefinition gradeDef = new GradeDefinition();
 						gradeDef.setStudentUid(processedGradeItemDetail.getUser().getUserUuid());
-						gradeDef.setGrade(processedGradeItemDetail.getGrade());
+						gradeDef.setGrade(FormatHelper.formatGradeForDisplay(processedGradeItemDetail.getGrade()));
 						gradeDef.setGradeComment(processedGradeItemDetail.getComment());
 						gradeDefList.add(gradeDef);
 					}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportUploadStep.java
@@ -40,6 +40,7 @@ import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.gradebookng.tool.panels.BasePanel;
+import org.sakaiproject.util.FormattedText;
 
 /**
  * Upload/Download page
@@ -136,7 +137,8 @@ public class GradeImportUploadStep extends BasePanel {
 				// turn file into list
 				ImportedSpreadsheetWrapper spreadsheetWrapper;
 				try {
-					spreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(upload.getInputStream(), upload.getContentType(), upload.getClientFileName(), businessService);
+					spreadsheetWrapper = ImportGradesHelper.parseImportedGradeFile(upload.getInputStream(), upload.getContentType(), 
+																					upload.getClientFileName(), businessService, FormattedText.getDecimalSeparator());
 				} catch (final GbImportExportInvalidFileTypeException | InvalidFormatException e) {
 					log.debug("incorrect type", e);
 					error(getString("importExport.error.incorrecttype"));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.java
@@ -29,6 +29,7 @@ import org.apache.wicket.model.StringResourceModel;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItem;
 import org.sakaiproject.gradebookng.business.model.ProcessedGradeItemDetail;
+import org.sakaiproject.gradebookng.business.util.FormatHelper;
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 
 /**
@@ -87,7 +88,10 @@ public class PreviewImportedGradesPanel extends Panel
                 final GbUser user = details.getUser();
                 item.add( new Label( "studentID", user.getDisplayId() ) );
                 item.add( new Label( "studentName", user.getDisplayName() ) );
-                item.add( new Label( "studentGrade", details.getGrade() ) );
+
+                // Convert back to user's locale for display/validation purposes
+                String grade = FormatHelper.formatGradeForDisplay( details.getGrade() );
+                item.add( new Label( "studentGrade", grade ) );
             }
         };
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34054

Currently if you try to import a file in a locale that uses comma as the decimal separator, the import will fail.

The front-end validation routines need some touch ups to be compatible with the comma decimal locales.