### PR TITLE
SAK-34056 - NPEs in Forums' Statistics UIs

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/WEB-INF/faces-config.xml
+++ b/msgcntr/messageforums-app/src/webapp/WEB-INF/faces-config.xml
@@ -785,6 +785,11 @@
             <value>#{Components["org.sakaiproject.api.app.messageforums.AnonymousManager"]}</value>
         </managed-property>
         <managed-property>
+            <description>Site Service</description>
+            <property-name>siteService</property-name>
+            <value>#{Components["org.sakaiproject.site.api.SiteService"]}</value>
+        </managed-property>
+        <managed-property>
             <description>Tool Manager</description>
             <property-name>toolManager</property-name>
             <value>#{Components["org.sakaiproject.tool.api.ToolManager"]}</value>
@@ -803,6 +808,11 @@
             <description>Event Tracking Service</description>
             <property-name>eventTrackingService</property-name>
             <value>#{Components["org.sakaiproject.event.api.EventTrackingService"]}</value>
+        </managed-property>
+        <managed-property>
+            <description>Session Manager</description>
+            <property-name>sessionManager</property-name>
+            <value>#{Components["org.sakaiproject.tool.api.SessionManager"]}</value>
         </managed-property>
  	</managed-bean>
  


### PR DESCRIPTION
When browsing through the statistics UIs in Forums, you'll get a few NPEs resulting from bean properties that haven't been injected. This patch isn't comprehensive, just fixing a few I've encountered while poking around; it may be advisable for someone to go through some of these forums beans and ensure all their properties are injected in faces-config.xml