### PR TITLE
SAM-1384: remove restriction that 'View' dropdown should only be shown if quiz allows multiple submissions

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
@@ -551,21 +551,6 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
     List allscores = bean.getAssessmentGradingList();
     if (allscores == null || allscores.size()==0){
       PublishedAccessControl ac = (PublishedAccessControl) p.getAssessmentAccessControl();
-      if (ac.getUnlimitedSubmissions()!=null && !ac.getUnlimitedSubmissions().booleanValue()){
-        if (ac.getSubmissionsAllowed().intValue() == 1) {
-          // although the assessment is currently set to allow one submission, multiple submissions may still exist. Set
-          // the bean to display either the latest or the highest score, as defined in the assessment settings.
-          Integer scoringType = p.getEvaluationModel().getScoringType();
-          String scoringTypeStr = scoringType != null ? scoringType.toString() : TotalScoresBean.LAST_SUBMISSION;
-          if (TotalScoresBean.LAST_SUBMISSION.equals(scoringTypeStr) || TotalScoresBean.HIGHEST_SUBMISSION.equals(scoringTypeStr))
-          {
-            bean.setAllSubmissions(scoringTypeStr);
-            ((QuestionScoresBean) ContextUtil.lookupBean("questionScores")).setAllSubmissions(scoringTypeStr);
-            ((HistogramScoresBean) ContextUtil.lookupBean("histogramScores")).setAllSubmissions(scoringTypeStr);
-          }
-        }
-      }
-      
       EvaluationModelIfc model = p.getEvaluationModel();
       // If the assessment is set to anonymous grading, we don't want to get assessmentGrading records which has not
       // submitted by students but has been updated by grader (ie, forGrade != true, lastGradedBy and lastGradedDate is not null) 

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -205,7 +205,7 @@ $(document).ready(function(){
     <h:panelGroup styleClass="all-submissions form-group row" layout="block">
       <h:outputLabel styleClass="col-md-2" value="#{evaluationMessages.view}"/>
       <h:selectOneMenu value="#{totalScores.allSubmissions}" id="allSubmissionsA1"
-        required="true" onchange="document.forms[0].submit();" rendered="#{totalScores.scoringOption eq '4' && totalScores.multipleSubmissionsAllowed eq 'true' }">
+        required="true" onchange="document.forms[0].submit();" rendered="#{totalScores.scoringOption eq '4'}">
       <f:selectItem itemValue="3" itemLabel="#{evaluationMessages.all_sub}" />
       <f:selectItem itemValue="4" itemLabel="#{evaluationMessages.average_sub}" />
       <f:valueChangeListener
@@ -213,7 +213,7 @@ $(document).ready(function(){
      </h:selectOneMenu>
 
      <h:selectOneMenu value="#{totalScores.allSubmissions}" id="allSubmissionsL1"
-        required="true" onchange="document.forms[0].submit();" rendered="#{totalScores.scoringOption eq '2' && totalScores.multipleSubmissionsAllowed eq 'true' }">
+        required="true" onchange="document.forms[0].submit();" rendered="#{totalScores.scoringOption eq '2'}">
       <f:selectItem itemValue="3" itemLabel="#{evaluationMessages.all_sub}" />
       <f:selectItem itemValue="2" itemLabel="#{evaluationMessages.last_sub}" />
       <f:valueChangeListener
@@ -221,7 +221,7 @@ $(document).ready(function(){
      </h:selectOneMenu>
 
      <h:selectOneMenu value="#{totalScores.allSubmissions}" id="allSubmissionsH1"
-        required="true" onchange="document.forms[0].submit();" rendered="#{totalScores.scoringOption eq '1' && totalScores.multipleSubmissionsAllowed eq 'true' }">
+        required="true" onchange="document.forms[0].submit();" rendered="#{totalScores.scoringOption eq '1'}">
       <f:selectItem itemValue="3" itemLabel="#{evaluationMessages.all_sub}" />
       <f:selectItem itemValue="1" itemLabel="#{evaluationMessages.highest_sub}" />
       <f:valueChangeListener


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-1384

For multiple submission assessments, there's a _View_ drop-down menu available in the _Scores_ screens to select either *All Submissions* or the *[Recorded Submission/Score]* (the latter button's name depends on the setting for _Recorded Score If Multiple Submissions per User_).  However, if an assessment ONLY allows *1 submission* (as do most assessments), the drop-down menu is not present.  If the instructor chooses *Allow Retake* for a student, the student's second submission cannot be viewed side-by-side with their original submission UNLESS the instructor changes the test settings to allow at least *2 submissions* for ALL students.  Absence of the drop-down for the instructor when a retake has been submitted can be a greater problem for the student as follows:

1.  Test is configured to accept *Highest Score* (DEFAULT).
2.  Student scores higher on FIRST submission.  This would be the case if there are manually-graded questions, and some grades were entered for those questions by the instructor before the retake was allowed.
3.  Instructor doesn't realize they're not seeing the new submission, and the final grade for the assessment is based on the first submission.

*Solution:* The drop-down menu to _View_ *All Submissions* should be available for all assessments, because changing the selection on the drop-down would have no effect if there's only one submission per student.