### PR TITLE
SAK-34057: roster > new sakai.property to control visibility of 'Permissions' widget

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2874,6 +2874,10 @@
 # DEFAULT: null (none)
 # roster2.visibleroles=instructor,student
 
+# SAK-34057: show 'Permissions' widget to site maintainers (otherwise only admins)
+# DEFAULT: true
+# roster.showPermsToMaintainers=false
+
 ## SEARCH
 # Elastic search is the default search as of Sakai 10
 # For more information please see this confluence page

--- a/roster2/src/java/org/sakaiproject/roster/api/SakaiProxy.java
+++ b/roster2/src/java/org/sakaiproject/roster/api/SakaiProxy.java
@@ -250,12 +250,15 @@ public interface SakaiProxy {
 	//public String getSakaiSkin();
 
 	/**
-	 * Returns whether or not the current user is a super user.
+	 * Returns whether or not the current user can access the 'Permissions' tab.
+	 * Takes into account sakai.property 'roster.showPermsToMaintainers' (default true).
+	 * If property is true and user is site maintainer, they can access the tab.
+	 * If property is false, only admins can access the tab.
 	 * 
-	 * @return <code>true</code> if the current user is a super user, else
-	 *         returns <code>false</code>.
+	 * @return <code>true</code> if property is true and user is site maintainer or if user is admin,
+	 * returns <code>false</code> if property is false and user is not site maintainer or user is not admin.
 	 */
-	public boolean isSuperUser();
+	public boolean showPermsToMaintainers();
 	
 	/**
 	 * Checks if the user has site.upd in the given site

--- a/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -108,6 +108,9 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 	private ToolManager toolManager;
 	private UserDirectoryService userDirectoryService;
     private RosterMemberComparator memberComparator;
+
+    private static final String SAK_PROP_SHOW_PERMS_TO_MAINTAINERS = "roster.showPermsToMaintainers";
+    private static final boolean SAK_PROP_SHOW_PERMS_TO_MAINTAINERS_DEFAULT = true;
 	
 	public void init() {
 		
@@ -161,8 +164,9 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 	/**
 	 * {@inheritDoc}
 	 */
-	public boolean isSuperUser() {
-		return securityService.isSuperUser();
+	public boolean showPermsToMaintainers() {
+		boolean showToMaintainers = serverConfigurationService.getBoolean(SAK_PROP_SHOW_PERMS_TO_MAINTAINERS, SAK_PROP_SHOW_PERMS_TO_MAINTAINERS_DEFAULT);
+		return (showToMaintainers && isSiteMaintainer(getCurrentSiteId())) || securityService.isSuperUser();
 	}
 	
 	public Site getSite(String siteId) {

--- a/roster2/src/java/org/sakaiproject/roster/tool/RosterTool.java
+++ b/roster2/src/java/org/sakaiproject/roster/tool/RosterTool.java
@@ -129,7 +129,7 @@ public class RosterTool extends HttpServlet {
         request.setAttribute("viewUserProperty", sakaiProxy.getViewUserProperty());
         request.setAttribute("officialPicturesByDefault", sakaiProxy.getOfficialPicturesByDefault());
         request.setAttribute("viewEmail", sakaiProxy.getViewEmail());
-		request.setAttribute("superUser", sakaiProxy.isSuperUser());
+		request.setAttribute("showPermsToMaintainers", sakaiProxy.showPermsToMaintainers());
 		request.setAttribute("siteMaintainer", sakaiProxy.isSiteMaintainer(sakaiProxy.getCurrentSiteId()));
         request.setAttribute("viewConnections", sakaiProxy.getViewConnections());
         request.setAttribute("showVisits", sakaiProxy.getShowVisits());

--- a/roster2/src/webapp/WEB-INF/bootstrap.jsp
+++ b/roster2/src/webapp/WEB-INF/bootstrap.jsp
@@ -41,7 +41,7 @@
                 officialPictureMode: ${officialPicturesByDefault},
                 viewEmail: ${viewEmail},
                 viewConnections: ${viewConnections},
-                superUser: ${superUser},
+                showPermsToMaintainers: ${showPermsToMaintainers},
                 siteMaintainer: ${siteMaintainer},
                 i18n: {},
                 showVisits: ${showVisits}

--- a/roster2/src/webapp/js/roster.js
+++ b/roster2/src/webapp/js/roster.js
@@ -103,7 +103,7 @@
         }
         
         // permissions
-        if (roster.siteMaintainer) {
+        if (roster.showPermsToMaintainers) {
             $('#navbar_permissions_link').show();
         } else {
             $('#navbar_permissions_link').hide();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34057

For those institutions that have policy around what information students and/or faculty have access to, this proposed sakai.property allows locking down the "Permissions" widget in Roster to admin users only.

In this way, the administration team can set desired permissions in course/project/etc. site templates, set the sakai.property to false, and be assured that maintainers will not be able to change the default permissions via the widget in the tool.

The sakai.property introduced here is "roster.showPermsToMaintainers", which defaults to "true" to preserve OOTB functionality.