### PR TITLE
SAK-34061: GBNG > Import > Omissions panels > missing students list should display student names from import file as well as IDs

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UserIdentificationReport.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UserIdentificationReport.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import lombok.Getter;
 
-import org.apache.commons.lang.StringUtils;
-
 import org.sakaiproject.gradebookng.business.model.GbUser;
 
 /**
@@ -40,7 +38,7 @@ public class UserIdentificationReport implements Serializable
     private final SortedSet<GbUser> missingUsers; // users that could have been matched against an id but weren't
 
     @Getter
-    private final SortedSet<String> unknownUsers; // ids that couldn't be matched against a user
+    private final SortedSet<GbUser> unknownUsers; // ids that couldn't be matched against a user
 
     @Getter
     private final SortedSet<GbUser> duplicateUsers; // users that have more than one entry in the sheet
@@ -69,9 +67,9 @@ public class UserIdentificationReport implements Serializable
         }
     }
 
-    public void addUnknownUser(String user)
+    public void addUnknownUser(GbUser user)
     {
-        if (StringUtils.isNotBlank(user))
+        if (user != null)
         {
             unknownUsers.add(user);
         }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
@@ -48,11 +48,12 @@ public class UsernameIdentifier implements Serializable
 
     /**
      * Finds the user by the given identifier
-     * @param userID a string that uniquely identifies a user
+     * @param row - the row data 
      * @return the user
      */
-    private GbUser getUser(String userEID)
+    private GbUser getUser(ImportedRow row)
     {
+        String userEID = row.getStudentEid();
         GbUser user = userEidMap.get(userEID);
         if (user != null)
         {
@@ -61,8 +62,8 @@ public class UsernameIdentifier implements Serializable
         }
         else
         {
-            user = GbUser.forDisplayOnly(userEID, "");
-            report.addUnknownUser(userEID);
+            user = GbUser.forDisplayOnly(userEID, row.getStudentName().trim());
+            report.addUnknownUser(user);
             log.debug("User {} is unknown to this gradebook", userEID);
         }
 
@@ -80,7 +81,7 @@ public class UsernameIdentifier implements Serializable
     {
         for (ImportedRow row : rows)
         {
-            GbUser user = getUser(row.getStudentEid());
+            GbUser user = getUser(row);
             if (user != null)
             {
                 row.setUser(user);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.java
@@ -18,6 +18,7 @@ package org.sakaiproject.gradebookng.tool.panels.importExport;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxEventBehavior;
@@ -120,7 +121,7 @@ public class GradeItemImportOmissionsPanel extends Panel
 
         // Sort the omission lists alphabetically
         List<GbUser> missingUsersSorted = new ArrayList<>( report.getMissingUsers() );
-        List<String> unknownUsersSorted = new ArrayList<>( report.getUnknownUsers() );
+        List<GbUser> unknownUsersSorted = new ArrayList<>( report.getUnknownUsers() );
         Collections.sort( missingUsersSorted );
         Collections.sort( unknownUsersSorted );
 
@@ -136,13 +137,19 @@ public class GradeItemImportOmissionsPanel extends Panel
         };
 
         // Create and populate the list of unknown users
-        final ListView<String> unknownUsers = new ListView<String>( "unknownUsers", unknownUsersSorted )
+        final ListView<GbUser> unknownUsers = new ListView<GbUser>( "unknownUsers", unknownUsersSorted )
         {
             @Override
-            protected void populateItem( final ListItem<String> item )
+            protected void populateItem( final ListItem<GbUser> item )
             {
-                final String user = item.getModelObject();
-                item.add( new Label( "unknownUser", user ) );
+                final GbUser user = item.getModelObject();
+                String userDisplay = user.getDisplayId();
+                String displayName = user.getDisplayName().trim();
+                if( StringUtils.isNotBlank( displayName ))
+                {
+                    userDisplay += " (" + displayName + ")";
+                }
+                item.add( new Label( "unknownUser", userDisplay ) );
             }
         };
 

--- a/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestImportGradesHelper.java
+++ b/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestImportGradesHelper.java
@@ -440,11 +440,11 @@ public class TestImportGradesHelper {
 	private Map<String, GbUser> mockUserMap() {
 		final Map<String, GbUser> userMap = new HashMap<>();
 		final GbUser user1 = Mockito.mock(GbUser.class);
-		Mockito.when(user1.getUserUuid()).thenReturn("student name 1");
-		Mockito.when(user1.getDisplayId()).thenReturn("student1");
+		Mockito.when(user1.getDisplayId()).thenReturn("student name 1");
+		Mockito.when(user1.getUserUuid()).thenReturn("student1");
 		final GbUser user2 = Mockito.mock(GbUser.class);
-		Mockito.when(user2.getUserUuid()).thenReturn("student name 2");
-		Mockito.when(user2.getDisplayId()).thenReturn("student2");
+		Mockito.when(user2.getDisplayId()).thenReturn("student name 2");
+		Mockito.when(user2.getUserUuid()).thenReturn("student2");
 		userMap.put("student1", user1);
 		userMap.put("student2", user2);
 		return userMap;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34061

For consistency, the missing students panel should display both the IDs and the names of the students found in the file who are not members of the site.