### PR TITLE
SAM-3392: ArrayIndexOutOfBoundsException protection in HistogramListener.doAnswerStatistics()

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/HistogramListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/HistogramListener.java
@@ -876,8 +876,10 @@ public class HistogramListener
     }
     else if (!qbean.getQuestionType().equals(TypeIfc.MATCHING.toString())) // matching
     {
-      ItemTextIfc firstText = (ItemTextIfc) publishedItemTextHash.get(((ItemTextIfc) text.toArray()[0]).getId());
-      answers = firstText.getAnswerArraySorted();
+      if (text.size() > 0) {
+        ItemTextIfc firstText = (ItemTextIfc) publishedItemTextHash.get(((ItemTextIfc) text.toArray()[0]).getId());
+        answers = firstText.getAnswerArraySorted();
+      }
     }
    
     if (qbean.getQuestionType().equals(TypeIfc.MULTIPLE_CHOICE.toString())) // mcsc


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3392

We ran into an issue recently in our production environment where a user was not able to access the Statistics or Export pages of a published quiz. The failure was caused by an uncaught ArrayIndexOutOfBoundsException in HistogramListener.doAnswerStatistics() (stack trace in the JIRA).

After investigation, we found that the cause of this was a specific question in a question pool the quiz was drawing from. The offending question had no type, no question text, and had no answers (or really any information at all); it was a 'shell' of a question.

We were unable to reproduce any situation that would allow us to create such an erroneous question. So we're not sure *how* the question came into existence, but putting in a simple size check allows the code to complete without exploding.