### PR TITLE
SAK-34075: Remove title truncation for assignments

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
@@ -50,7 +50,7 @@
 							<tr>
 								<td headers="title" scope="row">
 											<strong>
-												$validator.escapeHtml($validator.limit($!assignment.title, 64))
+												$validator.escapeHtml($!assignment.title)
 												#if ($assignment.getContentReview())
 													<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" />
 												#end

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
@@ -90,11 +90,11 @@
 					<input type="text" size="3" value="$count" id="index$count"/>
 					<input type="hidden"  size="3" id="holder$count"  value="$count" tabindex="-2"/>
 				</span>
-				<span class="title col-md-6 col-sm-6 col-xs-12" title="$validator.escapeHtml($!assignment.Title)">
+				<span class="col-md-6 col-sm-6 col-xs-12" title="$validator.escapeHtml($!assignment.Title)">
 					#if ($!assignment.Draft)
 						<em class="highlight" style="font-style:normal">$tlang.getString("gen.dra2")</em>
 					#end
-					$validator.escapeHtml($validator.limit($!assignment.Title, 45))
+					$validator.escapeHtml($!assignment.Title)
 				</span>
 				<span class="col-md-3 col-sm-3 col-xs-12">
 					$!service.getUsersLocalDateTimeString($!assignment.OpenDate)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -182,7 +182,7 @@
 							</td>
 							<td headers="assignment">
 								#assignmentTitleIcon($assignment)
-								$validator.escapeHtml($validator.limit($!assignment.Title, 40))
+								$validator.escapeHtml($!assignment.Title)
 							</td>
 							#if($!isAdditionalNotesEnabled)
 							<td headers="notes">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -146,7 +146,7 @@
 										<td headers="assignment">
 											#if (!$isAnon)
 											<h5>
-												<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$validator.escapeUrl($assignmentReference)&submissionId=$validator.escapeUrl($submissionReference)&option=lisofass2")" title="$validator.escapeHtml($assignment.Title)">$validator.limit($validator.escapeHtml($assignment.Title), 40)</a>
+												<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$validator.escapeUrl($assignmentReference)&submissionId=$validator.escapeUrl($submissionReference)&option=lisofass2")" title="$validator.escapeHtml($assignment.Title)">$validator.escapeHtml($assignment.Title)</a>
 												#if ($allowAddAssignment && $allowSubmitByInstructor)
 												#set( $submitSpinnerID = "submitFor_" + $member.Id + "_" + $validator.escapeUrl($assignmentReference) )
 												<div class="itemAction spinnerBesideContainer">
@@ -157,7 +157,7 @@
 												</div>
 												#end
 											#else
-												$validator.limit($validator.escapeHtml($assignment.Title), 40) ($tlang.getString("grading.anonymous.title"))
+												$validator.escapeHtml($assignment.Title) ($tlang.getString("grading.anonymous.title"))
 											#end
 											</h5>
 										</td>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -267,7 +267,7 @@
 											#if ($!assignment.draft)
 												<span class="highlight">$tlang.getString("gen.dra2")</span>
 											#end
-												$validator.escapeHtml($validator.limit($!assignment.title, 64))
+												$validator.escapeHtml($!assignment.Title)
 
 											#if ($assignment.getContentReview())
 												<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" />
@@ -319,14 +319,14 @@
 												#else
 													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submissionReference)")" title="$validator.escapeHtml($!assignment.Title)">
 												#end
-												$validator.escapeHtml($validator.limit($assignment.Title, 40))</a>
+												$validator.escapeHtml($assignment.Title)</a>
 											#else
 												#assignmentTitleIcon($assignment)
-												$validator.escapeHtml($validator.limit($assignment.Title, 40))
+												$validator.escapeHtml($assignment.Title)
 												#if ($!allowSubmit)
 													<div class="itemAction">
 														<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignmentReference)&submitterIdInstructor=instructor")" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'subAsStudentSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)' );" title="$validator.escapeHtml($!assignment.Title)">
-															$tlang.getString("subasstudent")<span class="skip">: $validator.escapeHtml($validator.limit($assignment.Title, 40))</span>
+															$tlang.getString("subasstudent")<span class="skip">: $validator.escapeHtml($assignment.Title)</span>
 														</a>
 														<div id="subAsStudentSpinnerPlaceholder_$validator.escapeUrl($assignmentReference)" class="allocatedSpinPlaceholder"></div>
 													</div>
@@ -362,16 +362,16 @@
 													#if ($service.canSubmit($assignment.Context, $assignment))
 														## go to view submission page when (1) submission has been returned and allow for resubmit;(2)submission has not been posted yet.
 														<strong>#assignmentTitleIcon($assignment)
-															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignmentReference)")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($validator.limit($assignment.Title, 40))</a>
+															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignmentReference)")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($assignment.Title)</a>
 														</strong>
 												#else
 														<strong>#assignmentTitleIcon($assignment)
-															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submissionReference)")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($validator.limit($assignment.Title, 40))</a>
+															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$validator.escapeUrl($submissionReference)")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($assignment.Title)</a>
 														</strong>
 													#end
 												#else
 												<strong>#assignmentTitleIcon($assignment)
-													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignmentReference)")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($validator.limit($assignment.Title, 40))</a>
+													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$validator.escapeUrl($assignmentReference)")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($assignment.Title)</a>
 												</strong>
 												#end
 												#if ($taggable && $allowAddAssignment)
@@ -406,7 +406,7 @@
 													</div>
 												#end
 											#else
-												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_as_student" "assignmentId=$assignmentReference")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($validator.limit($assignment.Title, 40))</a>
+												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_as_student" "assignmentId=$assignmentReference")" title="$validator.escapeHtml($!assignment.Title)">$validator.escapeHtml($assignment.Title)</a>
 											#end
 										#end
 										#set ($deleted = false)
@@ -540,7 +540,7 @@
 								<td></td>
 								<!-- title col -->
 								<td class="peer-header">
-									<strong title="$validator.escapeHtml($!assignment.Title)"><span class="fa fa-caret-square-o-right" aria-hidden="true"></span> $validator.escapeHtml($validator.limit($assignment.Title, 40))</strong>
+									<strong title="$validator.escapeHtml($!assignment.Title)"><span class="fa fa-caret-square-o-right" aria-hidden="true"></span> $validator.escapeHtml($assignment.Title)</strong>
 									<em>$tlang.getString("peerAssessmentName")</em>
 								</td>
 								#if ($!groups && $!allowGradeSubmission)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34075

Sometimes assignment titles are truncated after 40 or 64 characters, so the full title never makes it to the client. This can be problematic for longer assignment titles that have the same prefix.

The truncation that happens in the Velocity templates should be removed. In all cases I can see, the browser will wrap the longer titles just fine. If truncation is discovered to be needed later, it can and should be done with CSS.