### PR TITLE
SAK-34074: Site Info > Participants List > Improve printable PDF formatting

### DIFF
--- a/site-manage/site-manage-tool/tool/src/config/participants-all-attrs.xsl
+++ b/site-manage/site-manage-tool/tool/src/config/participants-all-attrs.xsl
@@ -3,15 +3,15 @@
   
   <!-- Isolate locale-specific content -->
   <xsl:variable name="lang.name" select="'NAME'"/>
-  <xsl:variable name="lang.section" select="'SECTION'"/>
   <xsl:variable name="lang.id" select="'ID'"/>
+  <xsl:variable name="lang.section" select="'SECTION'"/>
   <xsl:variable name="lang.cr" select="'CR'"/>
   <xsl:variable name="lang.role" select="'ROLE'"/>
   <xsl:variable name="lang.status" select="'STATUS'"/>
 
 	<xsl:param name="titleName"/>
-	<xsl:param name="titleSection"/>
 	<xsl:param name="titleId"/>
+	<xsl:param name="titleSection"/>
 	<xsl:param name="titleCredit"/>
 	<xsl:param name="titleRole"/>
 	<xsl:param name="titleStatus"/>
@@ -31,14 +31,14 @@
 			<!-- actual layout -->
 			<fo:page-sequence master-reference="roster">
 				<fo:static-content flow-name="xsl-region-before">
-					<fo:block font-size="12pt" line-height="1cm" space-after.optimum="1pt" color="black" text-align="right" padding-top="0pt">
-						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - <fo:page-number />
+					<fo:block font-size="12pt" line-height="1cm" space-after.optimum="1pt" color="black" text-align="center" padding-top="0pt">
+						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - Page <fo:page-number />
 					</fo:block>
 				</fo:static-content>
 				<fo:static-content flow-name="xsl-region-after"> </fo:static-content>
 				<fo:flow flow-name="xsl-region-body" font-size="9pt">
-					<fo:table table-layout="fixed" width="6in">
-						<fo:table-column column-width="2in" />
+					<fo:table table-layout="fixed" width="7.5in">
+						<fo:table-column column-width="2.5in" />
 						<fo:table-column column-width="4in" />
 						<fo:table-body>
 							<fo:table-row>
@@ -50,6 +50,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//ROLE[not(.=following::ROLE)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -57,7 +58,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//ROLE[text()=$this])" />
 															</fo:block>
@@ -69,7 +70,7 @@
 														<fo:block font-weight="bold"> </fo:block>
 													</fo:table-cell>
 													<fo:table-cell  padding="4pt" border-top="1pt solid #ccc">
-														<fo:block font-weight="bold">
+														<fo:block font-weight="bold" text-align="right">
 															<xsl:value-of select="count(//ROLE)" />
 														</fo:block>
 													</fo:table-cell>
@@ -86,6 +87,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//SECTION[not(.=following::SECTION)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -93,7 +95,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//SECTION[text()=$this])" />
 															</fo:block>
@@ -109,16 +111,16 @@
 					</fo:table>
 					<fo:table table-layout="fixed" width="100%"  text-align="left">
 						<!-- name col  -->
-						<fo:table-column   column-width="2in"/> 
+						<fo:table-column column-width="2in" />
+						<!-- id col -->
+						<fo:table-column column-width="1.15in" />
 						<!-- section col -->
 						<fo:table-column column-width="2.2in" />
-						<!-- id col -->						
-						<fo:table-column column-width="1.15in" />
 						<!-- credits col -->
 						<fo:table-column column-width=".5in" />
 						<!-- role col -->
-						<fo:table-column column-width=".5in" />
-						<!-- status col -->						
+						<fo:table-column column-width="1.15in" />
+						<!-- status col -->
 						<fo:table-column column-width=".5in" />
 						<fo:table-body>
 							<fo:table-row line-height="9pt" background-color="#cccccc" font-weight="bold" display-align="center">
@@ -129,12 +131,12 @@
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$titleSection"/>
+										<xsl:value-of select="$titleId"/>
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$titleId"/>
+										<xsl:value-of select="$titleSection"/>
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
@@ -186,21 +188,21 @@
 		<fo:table-cell  padding="2pt" white-space="nowrap">
 			<xsl:choose>
 				<xsl:when test="../ROLE='Instructor'">
-					<fo:block font-weight="bold" white-space="nowrap">
+					<fo:block font-weight="bold" white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:when>
 				<xsl:otherwise>
-					<fo:block white-space="nowrap">
+					<fo:block white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:otherwise>
 			</xsl:choose>
 		</fo:table-cell>
 	</xsl:template>
-	<xsl:template match="ROLE | STATUS | ID | CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:table-cell  padding="2pt" >
-			<fo:block font-size="70%">
+	<xsl:template match="ROLE | STATUS | ID" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt" white-space="nowrap">
+			<fo:block white-space="nowrap" wrap-option="wrap">
 				<xsl:value-of select="." />
 			</fo:block>
 		</fo:table-cell>
@@ -213,16 +215,20 @@
 		</fo:table-cell>
 	</xsl:template>
 	<xsl:template match="SECTION" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:inline font-size="70%" padding-right="3em">
-			<xsl:choose>
-				<xsl:when test="position() = last()">
-					<xsl:value-of select="." />
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="." />
-					<xsl:text>, </xsl:text>
-				</xsl:otherwise>
-			</xsl:choose>
-		</fo:inline>
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
+	</xsl:template>
+	<xsl:template match="CREDITS" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt">
+			<fo:block>
+				<xsl:apply-templates select="CREDIT" />
+			</fo:block>
+		</fo:table-cell>
+	</xsl:template>
+	<xsl:template match="CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
 	</xsl:template>
 </xsl:stylesheet>

--- a/site-manage/site-manage-tool/tool/src/config/participants-all-attrs_ca_ES.xsl
+++ b/site-manage/site-manage-tool/tool/src/config/participants-all-attrs_ca_ES.xsl
@@ -3,8 +3,8 @@
   
   <!-- Isolate locale-specific content -->
   <xsl:variable name="lang.name" select="'NOM'"/>
-  <xsl:variable name="lang.section" select="'GRUP'"/>
   <xsl:variable name="lang.id" select="'ID'"/>
+  <xsl:variable name="lang.section" select="'GRUP'"/>
   <xsl:variable name="lang.cr" select="'CR'"/>
   <xsl:variable name="lang.role" select="'ROL'"/>
   <xsl:variable name="lang.status" select="'ESTAT'"/>
@@ -24,14 +24,14 @@
 			<!-- actual layout -->
 			<fo:page-sequence master-reference="roster">
 				<fo:static-content flow-name="xsl-region-before">
-					<fo:block font-size="12pt" font-family="sans-serif" line-height="1cm" space-after.optimum="1pt" color="black" text-align="right" padding-top="0pt">
-						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - <fo:page-number />
+					<fo:block font-size="12pt" font-family="sans-serif" line-height="1cm" space-after.optimum="1pt" color="black" text-align="center" padding-top="0pt">
+						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - Pàgina <fo:page-number />
 					</fo:block>
 				</fo:static-content>
 				<fo:static-content flow-name="xsl-region-after"> </fo:static-content>
 				<fo:flow flow-name="xsl-region-body" font-size="9pt">
-					<fo:table table-layout="fixed" width="6in">
-						<fo:table-column column-width="2in" />
+					<fo:table table-layout="fixed" width="7.5in">
+						<fo:table-column column-width="2.5in" />
 						<fo:table-column column-width="4in" />
 						<fo:table-body>
 							<fo:table-row>
@@ -43,6 +43,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//ROLE[not(.=following::ROLE)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -50,7 +51,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//ROLE[text()=$this])" />
 															</fo:block>
@@ -62,7 +63,7 @@
 														<fo:block font-weight="bold"> </fo:block>
 													</fo:table-cell>
 													<fo:table-cell  padding="4pt" border-top="1pt solid #ccc">
-														<fo:block font-weight="bold">
+														<fo:block font-weight="bold" text-align="right">
 															<xsl:value-of select="count(//ROLE)" />
 														</fo:block>
 													</fo:table-cell>
@@ -79,6 +80,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//SECTION[not(.=following::SECTION)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -86,7 +88,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//SECTION[text()=$this])" />
 															</fo:block>
@@ -102,16 +104,16 @@
 					</fo:table>
 					<fo:table table-layout="fixed" width="100%"  text-align="left">
 						<!-- name col  -->
-						<fo:table-column   column-width="2in"/> 
+						<fo:table-column column-width="2in" />
+						<!-- id col -->
+						<fo:table-column column-width="1.15in" />
 						<!-- section col -->
 						<fo:table-column column-width="2.2in" />
-						<!-- id col -->						
-						<fo:table-column column-width="1.15in" />
 						<!-- credits col -->
 						<fo:table-column column-width=".25in" />
 						<!-- role col -->
-						<fo:table-column column-width=".5in" />
-						<!-- status col -->						
+						<fo:table-column column-width="1.15in" />
+						<!-- status col -->
 						<fo:table-column column-width=".5in" />
 						<fo:table-body>
 							<fo:table-row line-height="9pt" background-color="#cccccc" font-weight="bold" display-align="center">
@@ -122,12 +124,12 @@
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$lang.section" />
+										<xsl:value-of select="$lang.id" />
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$lang.id" />
+										<xsl:value-of select="$lang.section" />
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
@@ -179,21 +181,21 @@
 		<fo:table-cell  padding="2pt" white-space="nowrap">
 			<xsl:choose>
 				<xsl:when test="../ROLE='Instructor'">
-					<fo:block font-weight="bold" white-space="nowrap">
+					<fo:block font-weight="bold" white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:when>
 				<xsl:otherwise>
-					<fo:block white-space="nowrap">
+					<fo:block white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:otherwise>
 			</xsl:choose>
 		</fo:table-cell>
 	</xsl:template>
-	<xsl:template match="ROLE | STATUS | ID | CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:table-cell  padding="2pt" >
-			<fo:block font-size="70%">
+	<xsl:template match="ROLE | STATUS | ID" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt" white-space="nowrap">
+			<fo:block white-space="nowrap" wrap-option="wrap">
 				<xsl:value-of select="." />
 			</fo:block>
 		</fo:table-cell>
@@ -206,16 +208,20 @@
 		</fo:table-cell>
 	</xsl:template>
 	<xsl:template match="SECTION" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:inline font-size="70%" padding-right="3em">
-			<xsl:choose>
-				<xsl:when test="position() = last()">
-					<xsl:value-of select="." />
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="." />
-					<xsl:text>, </xsl:text>
-				</xsl:otherwise>
-			</xsl:choose>
-		</fo:inline>
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
+	</xsl:template>
+	<xsl:template match="CREDITS" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt">
+			<fo:block>
+				<xsl:apply-templates select="CREDIT" />
+			</fo:block>
+		</fo:table-cell>
+	</xsl:template>
+	<xsl:template match="CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
 	</xsl:template>
 </xsl:stylesheet>

--- a/site-manage/site-manage-tool/tool/src/config/participants-all-attrs_es_ES.xsl
+++ b/site-manage/site-manage-tool/tool/src/config/participants-all-attrs_es_ES.xsl
@@ -3,8 +3,8 @@
   
   <!-- Isolate locale-specific content -->
   <xsl:variable name="lang.name" select="'NOMBRE'"/>
-  <xsl:variable name="lang.section" select="'GRUPO'"/>
   <xsl:variable name="lang.id" select="'ID'"/>
+  <xsl:variable name="lang.section" select="'GRUPO'"/>
   <xsl:variable name="lang.cr" select="'CR'"/>
   <xsl:variable name="lang.role" select="'ROL'"/>
   <xsl:variable name="lang.status" select="'ESTADO'"/>
@@ -24,14 +24,14 @@
 			<!-- actual layout -->
 			<fo:page-sequence master-reference="roster">
 				<fo:static-content flow-name="xsl-region-before">
-					<fo:block font-size="12pt" font-family="sans-serif" line-height="1cm" space-after.optimum="1pt" color="black" text-align="right" padding-top="0pt">
-						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - <fo:page-number />
+					<fo:block font-size="12pt" font-family="sans-serif" line-height="1cm" space-after.optimum="1pt" color="black" text-align="center" padding-top="0pt">
+						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - Pàgina <fo:page-number />
 					</fo:block>
 				</fo:static-content>
 				<fo:static-content flow-name="xsl-region-after"> </fo:static-content>
 				<fo:flow flow-name="xsl-region-body" font-size="9pt">
-					<fo:table table-layout="fixed" width="6in">
-						<fo:table-column column-width="2in" />
+					<fo:table table-layout="fixed" width="7.5in">
+						<fo:table-column column-width="2.5in" />
 						<fo:table-column column-width="4in" />
 						<fo:table-body>
 							<fo:table-row>
@@ -43,6 +43,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//ROLE[not(.=following::ROLE)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -50,7 +51,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//ROLE[text()=$this])" />
 															</fo:block>
@@ -62,7 +63,7 @@
 														<fo:block font-weight="bold"> </fo:block>
 													</fo:table-cell>
 													<fo:table-cell  padding="4pt" border-top="1pt solid #ccc">
-														<fo:block font-weight="bold">
+														<fo:block font-weight="bold" text-align="right">
 															<xsl:value-of select="count(//ROLE)" />
 														</fo:block>
 													</fo:table-cell>
@@ -79,6 +80,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//SECTION[not(.=following::SECTION)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -86,7 +88,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//SECTION[text()=$this])" />
 															</fo:block>
@@ -102,16 +104,16 @@
 					</fo:table>
 					<fo:table table-layout="fixed" width="100%"  text-align="left">
 						<!-- name col  -->
-						<fo:table-column   column-width="2in"/> 
+						<fo:table-column column-width="2in" />
+						<!-- id col -->
+						<fo:table-column column-width="1.15in" />
 						<!-- section col -->
 						<fo:table-column column-width="2.2in" />
-						<!-- id col -->						
-						<fo:table-column column-width="1.15in" />
 						<!-- credits col -->
 						<fo:table-column column-width=".25in" />
 						<!-- role col -->
-						<fo:table-column column-width=".5in" />
-						<!-- status col -->						
+						<fo:table-column column-width="1.15in" />
+						<!-- status col -->
 						<fo:table-column column-width=".5in" />
 						<fo:table-body>
 							<fo:table-row line-height="9pt" background-color="#cccccc" font-weight="bold" display-align="center">
@@ -122,12 +124,12 @@
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$lang.section" />
+										<xsl:value-of select="$lang.id" />
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$lang.id" />
+										<xsl:value-of select="$lang.section" />
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
@@ -179,21 +181,21 @@
 		<fo:table-cell  padding="2pt" white-space="nowrap">
 			<xsl:choose>
 				<xsl:when test="../ROLE='Instructor'">
-					<fo:block font-weight="bold" white-space="nowrap">
+					<fo:block font-weight="bold" white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:when>
 				<xsl:otherwise>
-					<fo:block white-space="nowrap">
+					<fo:block white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:otherwise>
 			</xsl:choose>
 		</fo:table-cell>
 	</xsl:template>
-	<xsl:template match="ROLE | STATUS | ID | CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:table-cell  padding="2pt" >
-			<fo:block font-size="70%">
+	<xsl:template match="ROLE | STATUS | ID" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt" white-space="nowrap">
+			<fo:block white-space="nowrap" wrap-option="wrap">
 				<xsl:value-of select="." />
 			</fo:block>
 		</fo:table-cell>
@@ -206,16 +208,20 @@
 		</fo:table-cell>
 	</xsl:template>
 	<xsl:template match="SECTION" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:inline font-size="70%" padding-right="3em">
-			<xsl:choose>
-				<xsl:when test="position() = last()">
-					<xsl:value-of select="." />
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="." />
-					<xsl:text>, </xsl:text>
-				</xsl:otherwise>
-			</xsl:choose>
-		</fo:inline>
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
+	</xsl:template>
+	<xsl:template match="CREDITS" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt">
+			<fo:block>
+				<xsl:apply-templates select="CREDIT" />
+			</fo:block>
+		</fo:table-cell>
+	</xsl:template>
+	<xsl:template match="CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
 	</xsl:template>
 </xsl:stylesheet>

--- a/site-manage/site-manage-tool/tool/src/config/participants-all-attrs_ja_JP.xsl
+++ b/site-manage/site-manage-tool/tool/src/config/participants-all-attrs_ja_JP.xsl
@@ -3,8 +3,8 @@
   
   <!-- Isolate locale-specific content -->
   <xsl:variable name="lang.name" select="'&#x540D;&#x524D;'"/>
-  <xsl:variable name="lang.section" select="'&#x30BB;&#x30AF;&#x30B7;&#x30E7;&#x30F3;'"/>
   <xsl:variable name="lang.id" select="'ID'"/>
+  <xsl:variable name="lang.section" select="'&#x30BB;&#x30AF;&#x30B7;&#x30E7;&#x30F3;'"/>
   <xsl:variable name="lang.cr" select="'&#x30AF;&#x30EC;&#x30B8;&#x30C3;&#x30C8;'"/>
   <xsl:variable name="lang.role" select="'&#x30ED;&#x30FC;&#x30EB;'"/>
   <xsl:variable name="lang.status" select="'&#x72B6;&#x614B;'"/>
@@ -24,14 +24,14 @@
 			<!-- actual layout -->
 			<fo:page-sequence master-reference="roster">
 				<fo:static-content flow-name="xsl-region-before">
-					<fo:block font-size="12pt" font-family="sans-serif" line-height="1cm" space-after.optimum="1pt" color="black" text-align="right" padding-top="0pt">
+					<fo:block font-size="12pt" font-family="sans-serif" line-height="1cm" space-after.optimum="1pt" color="black" text-align="center" padding-top="0pt">
 						<xsl:value-of select="PARTICIPANTS/SITE_TITLE" /> - <fo:page-number />
 					</fo:block>
 				</fo:static-content>
 				<fo:static-content flow-name="xsl-region-after"> </fo:static-content>
 				<fo:flow flow-name="xsl-region-body" font-size="9pt">
-					<fo:table table-layout="fixed" width="6in">
-						<fo:table-column column-width="2in" />
+					<fo:table table-layout="fixed" width="7.5in">
+						<fo:table-column column-width="2.5in" />
 						<fo:table-column column-width="4in" />
 						<fo:table-body>
 							<fo:table-row>
@@ -43,6 +43,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//ROLE[not(.=following::ROLE)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -50,7 +51,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//ROLE[text()=$this])" />
 															</fo:block>
@@ -62,7 +63,7 @@
 														<fo:block font-weight="bold"> </fo:block>
 													</fo:table-cell>
 													<fo:table-cell  padding="4pt" border-top="1pt solid #ccc">
-														<fo:block font-weight="bold">
+														<fo:block font-weight="bold" text-align="right">
 															<xsl:value-of select="count(//ROLE)" />
 														</fo:block>
 													</fo:table-cell>
@@ -79,6 +80,7 @@
 											<fo:table-body>
 												<xsl:variable name="unique-list" select="//SECTION[not(.=following::SECTION)]" />
 												<xsl:for-each select="$unique-list">
+													<xsl:sort select="." />
 													<fo:table-row>
 														<fo:table-cell  padding="4pt">
 															<fo:block>
@@ -86,7 +88,7 @@
 															</fo:block>
 														</fo:table-cell>
 														<fo:table-cell  padding="4pt">
-															<fo:block>
+															<fo:block text-align="right">
 																<xsl:variable name="this" select="." />
 																<xsl:value-of select="count(//SECTION[text()=$this])" />
 															</fo:block>
@@ -102,16 +104,16 @@
 					</fo:table>
 					<fo:table table-layout="fixed" width="100%"  text-align="left">
 						<!-- name col  -->
-						<fo:table-column   column-width="2in"/> 
+						<fo:table-column column-width="2in" />
+						<!-- id col -->
+						<fo:table-column column-width="1.15in" />
 						<!-- section col -->
 						<fo:table-column column-width="2.2in" />
-						<!-- id col -->						
-						<fo:table-column column-width="1.15in" />
 						<!-- credits col -->
 						<fo:table-column column-width=".25in" />
 						<!-- role col -->
-						<fo:table-column column-width=".5in" />
-						<!-- status col -->						
+						<fo:table-column column-width="1.15in" />
+						<!-- status col -->
 						<fo:table-column column-width=".5in" />
 						<fo:table-body>
 							<fo:table-row line-height="9pt" background-color="#cccccc" font-weight="bold" display-align="center">
@@ -122,12 +124,12 @@
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$lang.section" />
+										<xsl:value-of select="$lang.id" />
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
 									<fo:block>
-										<xsl:value-of select="$lang.id" />
+										<xsl:value-of select="$lang.section" />
 									</fo:block>
 								</fo:table-cell>
 								<fo:table-cell  padding="2pt">
@@ -179,21 +181,21 @@
 		<fo:table-cell  padding="2pt" white-space="nowrap">
 			<xsl:choose>
 				<xsl:when test="../ROLE='Instructor'">
-					<fo:block font-weight="bold" white-space="nowrap">
+					<fo:block font-weight="bold" white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:when>
 				<xsl:otherwise>
-					<fo:block white-space="nowrap">
+					<fo:block white-space="nowrap" wrap-option="wrap">
 						<xsl:value-of select="." />
 					</fo:block>
 				</xsl:otherwise>
 			</xsl:choose>
 		</fo:table-cell>
 	</xsl:template>
-	<xsl:template match="ROLE | STATUS | ID | CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:table-cell  padding="2pt" >
-			<fo:block font-size="70%">
+	<xsl:template match="ROLE | STATUS | ID" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt" white-space="nowrap">
+			<fo:block white-space="nowrap" wrap-option="wrap">
 				<xsl:value-of select="." />
 			</fo:block>
 		</fo:table-cell>
@@ -206,16 +208,20 @@
 		</fo:table-cell>
 	</xsl:template>
 	<xsl:template match="SECTION" xmlns:fo="http://www.w3.org/1999/XSL/Format">
-		<fo:inline font-size="70%" padding-right="3em">
-			<xsl:choose>
-				<xsl:when test="position() = last()">
-					<xsl:value-of select="." />
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="." />
-					<xsl:text>, </xsl:text>
-				</xsl:otherwise>
-			</xsl:choose>
-		</fo:inline>
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
+	</xsl:template>
+	<xsl:template match="CREDITS" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:table-cell padding="2pt">
+			<fo:block>
+				<xsl:apply-templates select="CREDIT" />
+			</fo:block>
+		</fo:table-cell>
+	</xsl:template>
+	<xsl:template match="CREDIT" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+		<fo:block white-space="nowrap" wrap-option="wrap">
+			<xsl:value-of select="." />
+		</fo:block>
 	</xsl:template>
 </xsl:stylesheet>

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteInfoToolServlet.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteInfoToolServlet.java
@@ -97,6 +97,7 @@ public class SiteInfoToolServlet extends HttpServlet
 	protected static final String PARTICIPANT_SECTIONS_NODE_NAME = "SECTIONS";
 	protected static final String PARTICIPANT_SECTION_NODE_NAME = "SECTION";
 	protected static final String PARTICIPANT_ID_NODE_NAME = "ID";
+	protected static final String PARTICIPANT_CREDITS_NODE_NAME = "CREDITS";
 	protected static final String PARTICIPANT_CREDIT_NODE_NAME = "CREDIT";
 	protected static final String PARTICIPANT_ROLE_NODE_NAME = "ROLE";
 	protected static final String PARTICIPANT_STATUS_NODE_NAME = "STATUS";
@@ -296,20 +297,17 @@ public class SiteInfoToolServlet extends HttpServlet
 		if (participants != null)
 		{
 		
-			// Go through all the time ranges (days)
-			for (Iterator<Participant> iParticipants = participants.iterator(); iParticipants.hasNext();)
+			// Go through all the participants
+			for (Participant participant : participants)
 			{
-				Participant participant = iParticipants.next();
 				// Create Participant Element
 				Element participantNode = doc.createElement(PARTICIPANT_NODE_NAME);
 				
 				// participant name
-				String participantName= participant.getName();
-				if (participant.getDisplayId() != null)
-				{
-					participantName +="( " +  participant.getDisplayId() + " )";
-				}
-				writeStringNodeToDom(doc, participantNode, PARTICIPANT_NAME_NODE_NAME, StringUtils.trimToEmpty(participantName));
+				writeStringNodeToDom(doc, participantNode, PARTICIPANT_NAME_NODE_NAME, StringUtils.trimToEmpty(participant.getName()));
+
+				// display id
+				writeStringNodeToDom(doc, participantNode, PARTICIPANT_ID_NODE_NAME, StringUtils.trimToEmpty(participant.getDisplayId()));
 
 				// sections
 				Element sectionsNode = doc.createElement(PARTICIPANT_SECTIONS_NODE_NAME);
@@ -319,12 +317,15 @@ public class SiteInfoToolServlet extends HttpServlet
 					writeStringNodeToDom(doc, sectionsNode, PARTICIPANT_SECTION_NODE_NAME, StringUtils.trimToEmpty(section));
 				}
 				participantNode.appendChild(sectionsNode);
-
-				// registration id
-				writeStringNodeToDom(doc, participantNode, PARTICIPANT_ID_NODE_NAME, StringUtils.trimToEmpty(participant.getRegId()));
 				
-				// credit
-				writeStringNodeToDom(doc, participantNode, PARTICIPANT_CREDIT_NODE_NAME, StringUtils.trimToEmpty(participant.getCredits()));
+				// credits
+				String[] credits = StringUtils.trimToEmpty(participant.getCredits()).replaceAll("<br />", "").split(",");
+				Element creditsNode = doc.createElement(PARTICIPANT_CREDITS_NODE_NAME);
+				for (String credit : credits)
+				{
+					writeStringNodeToDom(doc, creditsNode, PARTICIPANT_CREDIT_NODE_NAME, credit.trim());
+				}
+				participantNode.appendChild(creditsNode);
 
 				// role id
 				writeStringNodeToDom(doc, participantNode, PARTICIPANT_ROLE_NODE_NAME, StringUtils.trimToEmpty(participant.getRole()));
@@ -407,8 +408,8 @@ public class SiteInfoToolServlet extends HttpServlet
 			InputStream in = getClass().getClassLoader().getResourceAsStream(xslFileName);
 			Transformer transformer = transformerFactory.newTransformer(new StreamSource(in));
 			transformer.setParameter("titleName", rb.getString("sitegen.siteinfolist.title.name"));
-			transformer.setParameter("titleSection", rb.getString("sitegen.siteinfolist.title.section"));
 			transformer.setParameter("titleId", rb.getString("sitegen.siteinfolist.title.id"));
+			transformer.setParameter("titleSection", rb.getString("sitegen.siteinfolist.title.section"));
 			transformer.setParameter("titleCredit", rb.getString("sitegen.siteinfolist.title.credit"));
 			transformer.setParameter("titleRole", rb.getString("sitegen.siteinfolist.title.role"));
 			transformer.setParameter("titleStatus", rb.getString("sitegen.siteinfolist.title.status"));

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteInfoToolServlet.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteInfoToolServlet.java
@@ -109,6 +109,7 @@ public class SiteInfoToolServlet extends HttpServlet
 
 	/**
 	 * Initialize this servlet.
+	 * @throws javax.servlet.ServletException
 	 */
 	public void init() throws ServletException
 	{
@@ -124,11 +125,11 @@ public class SiteInfoToolServlet extends HttpServlet
     		}
     		catch (ParserConfigurationException e)
     		{
-    			log.warn(this + " cannot get DocumentBuilder " + e.getMessage());
+    			log.warn("{} cannot get DocumentBuilder {}", this, e.getMessage());
     		}
 
         } catch (Exception e) {
-            log.warn(this + "init " + e.getMessage());
+            log.warn("{}init {}", this, e.getMessage());
         }
 	}
 	
@@ -183,7 +184,7 @@ public class SiteInfoToolServlet extends HttpServlet
 		if (userId == null)
 		{
 			// fail the request, user not logged in yet.
-			log.warn(this + " HttpAccess for printing participant of site id =" + siteId + " without user loggin. ");
+			log.warn("{} HttpAccess for printing participant of site id ={} without user loggin. ", this, siteId);
 		}
 		else
 		{
@@ -195,14 +196,14 @@ public class SiteInfoToolServlet extends HttpServlet
 			}
 			else
 			{
-				log.warn(this + " HttpAccess for printing participant of site id =" + siteId + " with user id = " + userId + ": user does not have permission to view roster. " );
+				log.warn("{} HttpAccess for printing participant of site id ={} with user id = {}: user does not have permission to view roster. ", this, siteId, userId);
 			}
 		}
 	}
 	
 	/**
 	 * generate PDF file containing all site participant
-	 * @param data
+	 * @param siteId
 	 */
 	public void print_participant(String siteId)
 	{
@@ -272,7 +273,7 @@ public class SiteInfoToolServlet extends HttpServlet
 		// Create Root Element
 		Element root = doc.createElement(PARTICIPANTS_NODE_NAME);
 
-		String siteTitle = "";
+		String siteTitle;
 		
 		if (siteId != null)
 		{
@@ -282,11 +283,11 @@ public class SiteInfoToolServlet extends HttpServlet
 				siteTitle = site.getTitle();
 	    		
 				// site title
-				writeStringNodeToDom(doc, root, SITE_TITLE_NODE_NAME, rb.getFormattedMessage("participant_pdf_title", new String[] {siteTitle}));
+				writeStringNodeToDom(doc, root, SITE_TITLE_NODE_NAME, rb.getFormattedMessage("participant_pdf_title", new Object[] {siteTitle}));
 			}
 			catch (Exception e)
 			{
-				log.warn(this + ":generateParticipantXMLDocument: Cannot find site with id =" + siteId);
+				log.warn("{}:generateParticipantXMLDocument: Cannot find site with id ={}", this, siteId);
 			}
 		}
 
@@ -341,6 +342,11 @@ public class SiteInfoToolServlet extends HttpServlet
 	
 	/**
 	 * Utility routine to write a string node to the DOM.
+	 * @param doc
+	 * @param parent
+	 * @param nodeName
+	 * @param nodeValue
+	 * @return
 	 */
 	protected Element writeStringNodeToDom(Document doc, Element parent, String nodeName, String nodeValue)
 	{
@@ -359,8 +365,7 @@ public class SiteInfoToolServlet extends HttpServlet
 	 * 
 	 * @param doc
 	 *        DOM structure
-	 * @param xslFileName
-	 *        XSL file to use to translate the DOM document to FOP
+	 * @param streamOut
 	 */
 	@SuppressWarnings("unchecked")
 	protected void generatePDF(Document doc, OutputStream streamOut)
@@ -419,13 +424,11 @@ public class SiteInfoToolServlet extends HttpServlet
 		}
 		catch (Exception e)
 		{
-			log.warn(this+".generatePDF(): " + e);
-			return;
+			log.warn("{}.generatePDF(): {}", this, e.toString());
 		}
 		finally
 		{
 			IOUtils.closeQuietly(configInputStream);
 		}
 	}
-	
 }

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -562,7 +562,7 @@
 			#pagingPanel($pagesizeFormName)
 		#end
 		## download link for print out participant list
-		<a href="$printParticipantUrl" title="$!tlang.getString('print')">$!tlang.getString('print')</a><i class="icon-sakai--pdf"></i>
+		<a href="$printParticipantUrl" title="$!tlang.getString('print')" target="_blank" rel="noreferrer">$!tlang.getString('print')</a><i class="icon-sakai--pdf"></i>
 		<hr />
 		<form name="participantForm" id="participantForm" action="#toolForm("SiteAction")" method="post">
 			<div class="table-responsive">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34074 (before and after screenshots in the JIRA ticket)

This PR changes the following with regards to the printable PDF of the participants list:

* ID column is always empty (the ID is actually being concatenated into the 'Name' field)
** Extract ID into it's proper column, use 'Name' column for names only
* Re-order column order:
** Name
** ID
** Section
** CR
** Role
** Status
* Add text wrapping to several columns to avoid data being cut-off
** Currently, long user names are cut off (they bleed underneath the next column)
* Alphabetize the role list panel at the top
* Alphabetize the section list panel at the top
* Remove 3em right padding after each section listed per row (causing large gaps between sections for individual users)
* Removed plaintext `<br />`'s after each credit per row (it's not an HTML document, the tag appears in the output of the PDF)
* Make the link to generate the PDF target="_blank" to open in a new tab (with rel="noreferrer")
* Change comma separated sections per user to one section per line within the row (makes formatting cleaner and more consistent)
* Chagne comma separated credits to one credit per line within the row (makes formatting cleaner and more consistent)
* Centre the title on the page (was hanging off to one side a bit)
* Add 'Page ' text to title to better indicate the page numbering
* Standardize the font size in the main table (some columns used bigger font text than others, which looks strange and inconsistent)
* Increase size of the "Role" column so the table is full page width (7.5")
* Centred the section list panel in the available whitespace
* Right align role and section totals in the top panels