### PR TITLE
SAK-34076: Site Info > improve the 'Unjoin' joinable site process

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -632,9 +632,12 @@ sitinfimp.youcan.user1 = You can choose to import user(s) only from other
 sitinfimp.youcan.user2 = sites that you own. You can combine users from more than one site.
 sitinfimp.material.hidden.warn = Content imported from the Resources tool will be marked as hidden (indicated by grey text), meaning it will not be visible to site participants who do not have permission to access hidden content. <br/> By default, 'guest' and 'student' roles cannot view items marked as hidden, although a site administrator can modify this default setting.
 sitinfimp.material.visible.warn = Content imported from the Resources tool will be visible by default, meaning it will be accessible to site participants like 'guest' and 'student' roles, although a site administrator can modify this setting.
-sitinfimp.youhave = You are no longer a participant in site.
-sitinfimp.youhave2 = You are now a participant in site.
-sitinfimp.sitebeing = The site is being edited. Please try again later.
+
+# unjoin messages
+site.unjoin=You are no longer a member of this site. You may navigate to your <a href="{0}">Home</a> site.
+site.unjoin.inUseException=This site is currently being edited. Please try again later.
+site.unjoin.permissionException=You either do not have the necessary permissions to unjoin this site, or unjoining would leave this site without a maintainer.
+site.unjoin.error=An unexpected error has occurred. Please try again later. If the problem persists, please contact {0}.
 
 size.bytes			= {0} bytes
 size.gb				= {0} GB

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -102,6 +102,7 @@ import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.entity.cover.EntityManager;
+import org.sakaiproject.entitybroker.DeveloperHelperService;
 import org.sakaiproject.event.api.SessionState;
 import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.event.cover.EventTrackingService;
@@ -223,6 +224,8 @@ public class SiteAction extends PagedResourceActionII {
 	private static ShortenedUrlService shortenedUrlService = (ShortenedUrlService) ComponentManager.get(ShortenedUrlService.class);
 	
 	private PreferencesService preferencesService = (PreferencesService)ComponentManager.get(PreferencesService.class);
+
+	private static DeveloperHelperService devHelperService = (DeveloperHelperService) ComponentManager.get(DeveloperHelperService.class);
 
 	private static final String SITE_MODE_SITESETUP = "sitesetup";
 
@@ -15012,40 +15015,33 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 	
 	/**
 	 * Handle the eventSubmit_doUnjoin command to have the user un-join this site.
+	 * @param data
 	 */
 	public void doUnjoin(RunData data) {
 		
-		SessionState state = ((JetspeedRunData) data)
-			.getPortletSessionState(((JetspeedRunData) data).getJs_peid());
+		SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
 		final ParameterParser params = data.getParameters();
-
 		final String id = params.get("itemReference");
-		String siteTitle = null;
-		
-		if (id != null)	{
-			try	{
-				siteTitle = SiteService.getSite(id).getTitle();
+
+		if (id != null) {
+			try {
 				SiteService.unjoin(id);
-				String msg = rb.getString("sitinfimp.youhave") + " " + siteTitle;
-				addAlert(state, msg);
-				
-			} catch (IdUnusedException ignore) {
-				
-			} catch (PermissionException e)	{
-				// This could occur if the user's role is the maintain role for the site, and we don't let the user
-				// unjoin sites they are maintainers of
-			 	log.warn(e.getMessage());
-				//TODO can't access site so redirect to portal
-				
+				String userHomeURL = devHelperService.getUserHomeLocationURL(devHelperService.getCurrentUserReference());
+				addAlert(state, rb.getFormattedMessage("site.unjoin", new Object[] {userHomeURL}));
+			} catch (IdUnusedException e) {
+				// Something strange happened, log and notify the user
+				log.debug("Unexpected error: ", e);
+				addAlert(state, rb.getFormattedMessage("site.unjoin.error", new Object[] {ServerConfigurationService.getString("mail.support")}));
+			} catch (PermissionException e) {
+				// This could occur if the user's role is the maintain role for the site, and unjoining would leave the site without
+				// a user with the maintain role
+				log.warn(e.getMessage());
+				addAlert(state, rb.getString("site.unjoin.permissionException"));
 			} catch (InUseException e) {
-				addAlert(state, siteTitle + " "
-						+ rb.getString("sitinfimp.sitebeing") + " ");
+				log.debug("InUseException: ", e);
+				addAlert(state, rb.getString("site.unjoin.inUseException"));
 			}
 		}
-		
-		// refresh the whole page
-		scheduleTopRefresh();
-		
 	} // doUnjoin
 
 	


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34076

In it's current form, members of joinable sites will be presented with an "Unjoin" button when they visit the Site Info tool of the given site. When the user clicks the button, the page refreshes and the button is disabled. It's unclear what happened, as there is no messaging to the user. In actuality, there is a message that's supposed to be displayed, but it's not. This PR proposes the following changes:

* rename message bundle keys appropriately
* fix grammar of the message bundle values
* provide a link to the user's Home site in the "success" message
* provide messages for each of the error possibilities
* remove the refreshing behaviour so the messages are are actually seen by the user