### PR TITLE
SAK-34081: Assignments refactor regression: resubmission modification check doesn't work

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -1608,7 +1608,7 @@ public class AssignmentAction extends PagedResourceActionII {
      *
      * @return true if currentAttachments isn't equal to oldAttachments
      */
-    private boolean areAttachmentsModified(Set<String> oldAttachments, List currentAttachments) {
+    private boolean areAttachmentsModified(Set<String> oldAttachments, List<Reference> currentAttachments) {
         boolean hasCurrent = CollectionUtils.isNotEmpty(currentAttachments);
         boolean hasOld = CollectionUtils.isNotEmpty(oldAttachments);
 
@@ -1621,8 +1621,9 @@ public class AssignmentAction extends PagedResourceActionII {
             return true;
         }
 
+        Set<String> currentSet = currentAttachments.stream().map(Reference::getReference).collect(Collectors.toSet());
         //.equals on Sets of Strings will compare .equals on the contained Strings
-        return !oldAttachments.equals(currentAttachments);
+        return !oldAttachments.equals(currentSet);
     }
 
     /**

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -33,6 +33,7 @@ $(document).ready(function(){
 	#set($dateSubmitted=$submission.DateSubmitted)
 	#set($submitted=false)
 	#set($submitted=$submission.Submitted)
+	#set($isUserSubmission=$submission.UserSubmission)
 	#set($returned=false)
 	#set($returned=$submission.Returned)
 	#set($closeDate = false)
@@ -1031,7 +1032,7 @@ $(document).ready(function(){
 									onclick="ASN_SVS.confirmDiscardOrSubmit( '$name_submission_text', $!new_attachments ); return false;" />
 							#end
 
-                            #if ($submitted && ($submissionType == 2 || $submissionType == 5) && !$!new_attachments)
+                            #if ($submitted && $!isUserSubmission && ($submissionType == 2 || $submissionType == 5) && !$!new_attachments)
                                 <span class="messageInformation">$tlang.getString("stuviewsubm.modifytoresubmit")</span>
                             #elseif ($submissionType == 5)
                                 <span class="messageInformation">$tlang.getString("stuviewsubm.reminder")</span>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34081

For Attachments Only and Single File Upload assignment types, there is a check on modification of the attachments when a student hits the submission page for a resubmission. It presents a message and disables the Submit button until the attachment list is modified. This check was broken by the assignments refactor, and will always allow resubmission even if there are no changes.