### PR TITLE
SAK-34084: Improve formatting of attachment list in assignment submission email receipt

### DIFF
--- a/assignment/bundles/resources/assignment.properties
+++ b/assignment/bundles/resources/assignment.properties
@@ -765,6 +765,7 @@ noti.site.url=Site URL:
 noti.assignment.duedate=Assignment Due Date:
 noti.student=Student:
 noti.submit.time=Submitted on:
+noti.archive.empty=Archive is empty.
 
 ## navigation labels
 nav.prev=< Previous


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34084

The attachment listing in the email receipt for an assignment with multiple attachments can be difficult to read. It is missing line breaks, and zip file contents are not distinguished in any way from other files.

PR adds line breaks and indents files that are part of a zip archive under the archive's name.

Empty archives are also detected and reported as such.