### PR TITLE
SAK-34085: Dropdowns lose styling after organizing topics

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -358,8 +358,7 @@ td div.title{
 .selChanged{
 	/*flag an item as changed in organize view*/
 	border: 1px solid #aaa;
-	background: #fc6;
-	padding: 1px;
+	background-color: #fc6;
 }
 .attachPanel{
 /*panel listing attachmetns when in edit mode for forum/topic/message*/


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34085

After using the dropdowns to organize topics, styling is applied that makes them render incorrectly.