### PR TITLE
SAK-34090: Worksite Setup > New > 'Build your own site' radio button conditional regression

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -584,13 +584,14 @@ sitediinf.editurl  = Site URL
 sitetype.acater    = Academic term:
 sitetype.alert     = Alert:
 sitetype.can       = Cancel
+sitetype.chothetyp.different.ways = A site can be created in a number of different ways:
 sitetype.chothetyp.withtemplate.build.own.info = This is for experienced users and lets site owners add individual site tools.
 sitetype.chothetyp.withtemplate.use.template.info = This gives a pre-configured site which already contains a selection of hand-picked tools.
 sitetype.template.copy.users.info = <strong>Copy Users:</strong> users specified in the template will be copied to your new site. This usually consist of support staff from your school.
 sitetype.template.copy.content.info = <strong>Copy Content:</strong> content included in the template will be copied to your site. This may consist of material selected by your campus, school or department.
 sitetype.template.publish.now = <strong>Publish Site:</strong> site will be published immediately. Leave unchecked to keep as a private draft.
 
-sitetype.chothetyp.withouttemplate = A site can be created in a number of different ways:
+sitetype.chothetyp.withouttemplate = Choose the type of site you want to create.
 sitetype.chothetyp.toolinfo=You can add or remove tools from either type of site at any time.
 sitetype.course.template.info=(select from templates for common <u>class</u> types)
 sitetype.project.template.info=(select from templates for common <u>project</u> types)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-type.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-type.vm
@@ -12,6 +12,8 @@
 
 *#
 
+#set($multipleTypes = ($templateSites.size() > 0) || ($canImportArchive))
+
 <script type="text/javascript" language="JavaScript">
     $(document).ready(function(){
         sakai.siteTypeSetup()
@@ -27,17 +29,25 @@
         <input type="text" id="courseSiteTypes" style="display:none" value="$courseSiteTypeStrings">
         
     #if ($alertMessage)<div class="alertMessage">$tlang.getString("sitetype.alert") $alertMessage</div>  #end
-    <p class="instruction">
-        $tlang.getString("sitetype.chothetyp.withouttemplate")
-    </p>
-    <form name="typeform" id="typeform" action="#toolForm("$action")&special=upload" method="post">
-        <p class="checkbox indnt1">
-            ## only show the radio button when there is any template site defined
-            <input type="radio" name="createMode" id="buildOwn" value="buildOwn" checked="checked"/>    
-            <label for="buildOwn">$tlang.getString("sitetype.buildown")</label>
+    #if ($multipleTypes)
+        <p class="instruction">
+            $tlang.getString("sitetype.chothetyp.different.ways")
         </p>
-        <p class="indnt4 textPanelFooter" style="margin-bottom:5px;">$tlang.getString("sitetype.chothetyp.withtemplate.build.own.info")</p>
-   
+    #end
+    <form name="typeform" id="typeform" action="#toolForm("$action")&special=upload" method="post">
+        #if ($multipleTypes)
+            <p class="checkbox indnt1">
+                ## only show the radio button when there is any template site defined
+                <input type="radio" name="createMode" id="buildOwn" value="buildOwn" checked="checked"/>
+                <label for="buildOwn">$tlang.getString("sitetype.buildown")</label>
+            </p>
+            <p class="indnt4 textPanelFooter" style="margin-bottom:5px;">$tlang.getString("sitetype.chothetyp.withtemplate.build.own.info")</p>
+        #else
+            ## otherwise, default to the choice
+            <input type="hidden" name="createMode" id="buildOwn" value="buildOwn" />
+            <p>$tlang.getString("sitetype.chothetyp.withouttemplate")</p>
+        #end
+
         ## NOTE: end if create from template enabled
         #* following block should show if "build own" has been selected,
          a site type has been picked, and then the user (from the next screen) hits "back"  - the "Build own" radio
@@ -285,9 +295,11 @@
 
         ## end create site from archive
 
-        <p class="instruction">
-             $tlang.getString("sitetype.chothetyp.toolinfo")
-        </p>
+        #if ($multipleTypes)
+            <p class="instruction">
+                 $tlang.getString("sitetype.chothetyp.toolinfo")
+            </p>
+        #end
 
         <input type="hidden" name="back" value="$!backIndex" />
         <input type="hidden" name="templateIndex" value="$!templateIndex" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34090

In 'Worksite Setup' > 'New', there is a radio button labeled "Build your own site". The intention is that you can choose to create a site from a pre-built template.

In 10.3, this radio button was surrounded by a conditional:

```
#if ($templates.size > 0)
...
#end
```

This conditional was removed in the 11 code base (SAK-25867), causing a regression whereby the radio button will always be displayed, even if there are no templates to build a site from.