### PR TITLE
SAK-34091 code from the TII-157 patch that didnt seem to make the ContentReview re-org

### DIFF
--- a/content-review/impl/turnitin/src/main/resources/turnitin.properties
+++ b/content-review/impl/turnitin/src/main/resources/turnitin.properties
@@ -10,3 +10,22 @@
 302= MD5 not authenticated - the MD5 in the URL does not match the MD5 calculated
 208= An error occurred enrolling the student in the Turnitin class. Please contact the helpdesk
 1000=The due date for this assignment has passed. Please see your instructor to request a late submission.
+
+file.type.doc = Word 97-2003
+file.type.docx = Word 2007+
+file.type.xls = Excel
+file.type.xlsx = Excel
+file.type.ppt = PowerPoint
+file.type.pptx = PowerPoint
+file.type.pps = PowerPoint
+file.type.ppsx = PowerPoint
+file.type.pdf = PDF
+file.type.ps = PostScript
+file.type.eps = PostScript
+file.type.txt = plain text
+file.type.html = HTML
+file.type.htm = HTML
+file.type.wpd = WordPerfect
+file.type.odt = OpenOffice
+file.type.rtf = rich text
+file.type.hwp = Hangul


### PR DESCRIPTION
I believe this is older @bbailla2 code from TII-157 that didn't make the re-org in 12.0 for some reason.

