### PR TITLE
SAK-34095: Improve the styling of the fieldset legend

### DIFF
--- a/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/library/src/morpheus-master/sass/base/_defaults.scss
@@ -183,9 +183,13 @@ video, embed, object, iframe {
 	max-width: 100%;
 }
 
-legend{
-	padding: 0.5em 0 0.1em 0;
+legend {
+	// override the Bootstrap defaults
+	display: inline-block;
+	width: auto;
 	margin-bottom: 0;
+	padding: 0.5em;
+	border: 0 none;
 }
 
 input[type="submit"][disabled="disabled"],


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34095

Currently has some styling issues:

* there's a weird underline underneath the title
* the "group box" border doesn't go all the way to the right side of the title

See before/after screenshots on the JIRA ticket.