### PR TITLE
SAK-34096: Preferences > missing active primary button for 'Sites' and 'Editor' tabs

### DIFF
--- a/user/user-tool-prefs/tool/src/webapp/css/prefs.css
+++ b/user/user-tool-prefs/tool/src/webapp/css/prefs.css
@@ -316,7 +316,6 @@
 }
 
 .submit-buttons {
-    margin-top: 1em;
     width: 100%;
     clear: both;
 }

--- a/user/user-tool-prefs/tool/src/webapp/prefs/editor.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/editor.jsp
@@ -44,7 +44,7 @@
                                                 <f:selectItem itemValue="full" itemLabel="#{msgs.editor_full}"/>
                         </h:selectOneRadio>
                         
-                        <div class="submit-buttons">
+                        <div class="submit-buttons act">
                                 <h:commandButton accesskey="s" id="submit" styleClass="active formButton" value="#{msgs.update_pref}" action="#{UserPrefsTool.processActionEditorSave}" onclick="SPNR.disableControlsAndSpin( this, null );" />
                                 <h:commandButton accesskey="x" id="cancel" styleClass="formButton" value="#{msgs.cancel_pref}" action="#{UserPrefsTool.processActionEditorFrmEdit}" onclick="SPNR.disableControlsAndSpin( this, null );" />
                         </div>

--- a/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/hidden.jsp
@@ -112,7 +112,7 @@
 
                         <script src="/sakai-user-tool-prefs/js/manage-hidden-sites.js"></script>
 
-                        <div class="submit-buttons">
+                        <div class="submit-buttons act">
                                 <h:commandButton accesskey="s" id="submit" styleClass="active formButton" value="#{msgs.update_pref}" action="#{UserPrefsTool.processHiddenSites}" onclick="SPNR.disableControlsAndSpin( this, null );" />
                                 <h:commandButton accesskey="x" id="cancel" styleClass="formButton" value="#{msgs.cancel_pref}" action="#{UserPrefsTool.processActionHiddenFrmEdit}" onclick="SPNR.disableControlsAndSpin( this, null );" />
                         </div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34096

In SAK-28975, work was done to standardize the buttons on the various UIs. However, the "Sites" UI was introduced as a replacement for the "Customize Tabs" UI, and a new UI was introduced: "Editor". These two new UIs are missing the primary active buttons.