### PR TITLE
SAM-3396: Modification indicator missing from quiz title on student view

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/select/selectIndex_content.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/select/selectIndex_content.jsp
@@ -289,7 +289,7 @@
                                 </h:panelGroup>
                             </f:facet>
                             <h:outputText value="#{reviewable.assessmentTitle}" rendered="#{!reviewable.isRecordedAssessment}" styleClass="hidden" />
-                            <h:outputText styleClass="highlight fa fa-fw fa-exclamation-circle" rendered="#{reviewable.isRecordedAssessment && reviewable.feedback == 'show' && !reviewable.isAssessmentRetractForEdit && reviewable.hasAssessmentBeenModified && select.warnUserOfModification}" title="#{selectIndexMessages.has_been_modified}" />
+                            <h:outputText styleClass="highlight fa fa-fw fa-exclamation-circle" rendered="#{reviewable.isRecordedAssessment && !reviewable.isAssessmentRetractForEdit && reviewable.hasAssessmentBeenModified && select.warnUserOfModification}" title="#{selectIndexMessages.has_been_modified}" />
                             <h:outputText styleClass="highlight fa fa-fw fa-exclamation" rendered="#{reviewable.isRecordedAssessment && reviewable.isAssessmentRetractForEdit}" title="#{selectIndexMessages.currently_being_edited}" />
                             <h:outputText value="#{reviewable.assessmentTitle}" styleClass="currentSort"  rendered="#{reviewable.isRecordedAssessment}"  escape="false"/>
                         </t:column>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAM-3396

If you modify a published test, students will see this message at the bottom of the T&Q page:

    This assessment has been modified since you submitted it. Please consult your instructor if you find any discrepancies.

However, if the quiz does not provide feedback (the default), an indicator doesn't appear next to any of the quizzes, so if you have more than one in the list you don't know which one was modified.