### PR TITLE
SAK-34098: Portal > reinstate the quick tool dropdown for the 'Home' site

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -974,13 +974,12 @@ body.is-logged-out{
 			}
 
 			&.#{$namespace}sitesNav__menuitem--myworkspace{
-				.#{$namespace}sitesNav__drop{
-					display: none;
+
+				.link-container{
+					padding-left: 0.5em;
 				}
 
 				a{
-					padding: 0.5em;
-
 					i{
 						margin-top: 1px; /* to compensate for an issue with the icon */
 						margin-bottom: -1px; /* to compensate for an issue with the icon */

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
@@ -11,8 +11,8 @@
                         <a class="link-container" href="${site.siteUrl}" title="${rloader.sit_mywor}">
                             <span class="fa fa-home" aria-hidden="true"></span>
                             <span class="Mrphs-sitesNav__menuitem--myworkspace-label">${rloader.sit_mywor}</span>
-                            <span class="Mrphs-sitesNav__drop" tabindex="-1" data-site-id="${site.siteId}"></span>
                         </a>
+                        <a class="Mrphs-sitesNav__dropdown" href="#" data-site-id="${site.siteId}" role="separator"></a>
                     </li>           
                 #end ## END of IF (${site.isMyWorkspace})
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34098

For consistency, reinstate the quick tool dropdown for the 'Home' site. This feature was removed in Sakai 11, but I can't think of a good reason for why it was removed. 'Home' is still a site, which contains tools, and just like all other sites users may prefer jumping directly to a tool in the site rather than having to navigate to the site, wait for the site to load everything, and then pick the tool they want.