### PR TITLE
SAK-34097: Style the disabled checkboxes and radios (and their labels) to distinguish them from enabled ones

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -41,6 +41,7 @@ $secondary-color:  			 #F00 !default;
 $alt-colour: 				 #d36f00 !default;
 
 $text-color:				 #212121 !default;
+$text-color-disabled:		 #767676 !default;
 
 $body-background-color: #FAFAFA !default;
 

--- a/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/library/src/morpheus-master/sass/base/_defaults.scss
@@ -128,16 +128,17 @@ input[type="checkbox"], input[type="radio"]{
 
 	//SAK-30977
 	&[disabled],&[disabled="disabled"],&[disabled="true"]{
-		opacity: 0.8;
+		opacity: 0.5;
 		& + label{
-			color: lighten($text-color, 10%);
+			cursor: not-allowed;
+			color: $text-color-disabled;
 		}
 	}
 }
 
 label.disabled{
-	color: lighten($text-color, 10%);
 	cursor: not-allowed;
+	color: $text-color-disabled;
 }
 
 input[type="checkbox"]{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34097

Disabled checkboxes and radio buttons are currently indistinguishable from enabled ones, aside from the icon change when hovering over them. This isn't the most intuitive paradigm. The disabled controls should be visibly different from those that are enabled:

* apply a lighter shade of grey to the checkboxes, radio buttons, and their respective labels
* apply the no-selection icon to both the controls and their respective labels