### PR TITLE
SAK-34106 - In resources, warning message shows as success

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -94,7 +94,7 @@
 		</ul>
 		</ul>
 	#if ($alertMessage)
-                 <br /><div class="messageValidation">$alertMessage</div><div class="clear"></div>
+                 <br /><div class="messageWarning">$alertMessage</div><div class="clear"></div>
 	#end
 	## display print success message
 	#if ($content_print_status_success)


### PR DESCRIPTION
This would be the change

Before:
![capturaresourcesgreen](https://user-images.githubusercontent.com/38246606/38862237-b28767d0-4234-11e8-8bc5-94a895ad6aea.PNG)

After:
![capturaresourceswarning](https://user-images.githubusercontent.com/38246606/38862238-b2a3743e-4234-11e8-8310-7b4e69138835.PNG)
