### PR TITLE
SAK-38304 Consolidate isolateContainingId()/isolateName() methods

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
@@ -112,6 +112,8 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.StringUtil;
 import org.sakaiproject.util.Validator;
 
+import static org.sakaiproject.content.util.IdUtil.isolateName;
+
 /**
  * The FilePickerAction drives the FilePicker helper.<br />
  * This works with the ResourcesTool to show a file picker / attachment editor that can be used by any Sakai tools as a helper.<br />
@@ -2559,24 +2561,6 @@ public class FilePickerAction extends PagedResourceHelperAction
 		}
 		return true;
 	}
-
-	/**
-	 * Find the resource name of a given resource id or filepath.
-	 * 
-	 * @param id
-	 *        The resource id.
-	 * @return the resource name.
-	 */
-	protected static String isolateName(String id)
-	{
-		if (id == null) return null;
-		if (id.length() == 0) return null;
-
-		// take after the last resource path separator, not counting one at the very end if there
-		boolean lastIsSeparator = id.charAt(id.length() - 1) == '/';
-		return id.substring(id.lastIndexOf('/', id.length() - 2) + 1, (lastIsSeparator ? id.length() - 1 : id.length()));
-
-	} // isolateName
 
 	/**
 	 * @param url

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -64,6 +64,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang.StringUtils;
 
+import org.sakaiproject.content.util.IdUtil;
 import org.w3c.dom.Element;
 
 import org.quartz.Scheduler;
@@ -156,6 +157,9 @@ import org.sakaiproject.util.Resource;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.FileItem;
+
+import static org.sakaiproject.content.util.IdUtil.isolateContainingId;
+import static org.sakaiproject.content.util.IdUtil.isolateName;
 
 /**
 * <p>ResourceAction is a ContentHosting application</p>
@@ -3273,42 +3277,9 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		state.setAttribute (STATE_MOVE_FLAG, Boolean.FALSE.toString());
 
 	}	// initCopyContent
-	
+
 
 	/**
-	 * Find the containing collection id of a given resource id.
-	 * 
-	 * @param id
-	 *        The resource id.
-	 * @return the containing collection id.
-	 */
-	protected String isolateContainingId(String id)
-	{
-		// take up to including the last resource path separator, not counting one at the very end if there
-		return id.substring(0, id.lastIndexOf('/', id.length() - 2) + 1);
-
-	} // isolateContainingId
-
-	/**
-	 * Find the resource name of a given resource id or filepath.
-	 * 
-	 * @param id
-	 *        The resource id.
-	 * @return the resource name.
-	 */
-	protected static String isolateName(String id)
-	{
-		log.debug("ResourcesAction.isolateName()");
-		if (id == null) {return null;}
-		if (id.length() == 0) {return null;}
-
-		// take after the last resource path separator, not counting one at the very end if there
-		boolean lastIsSeparator = id.charAt(id.length() - 1) == '/';
-		return id.substring(id.lastIndexOf('/', id.length() - 2) + 1, (lastIsSeparator ? id.length() - 1 : id.length()));
-
-	} // isolateName
-
-/**
 	 * Returns true if the suspended operations stack contains no elements.
 	 * @param state The current session state, including the STATE_SUSPENDED_OPERATIONS_STACK attribute.
 	 * @return true if the suspended operations stack contains no elements

--- a/dav/dav/src/java/org/sakaiproject/dav/DavServlet.java
+++ b/dav/dav/src/java/org/sakaiproject/dav/DavServlet.java
@@ -177,6 +177,8 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.StringUtil;
 import org.sakaiproject.util.Validator;
 
+import static org.sakaiproject.content.util.IdUtil.isolateContainingId;
+
 /**
  * Servlet which adds support for WebDAV level 2. All the basic HTTP requests are handled by the DefaultServlet.
  */
@@ -2491,21 +2493,6 @@ public class DavServlet extends HttpServlet
 			return str;
 		}
 	}
-
-	/**
-	 * Find the containing collection id of a given resource id. Copied from BaseContentService.
-	 * 
-	 * @param id
-	 *        The resource id.
-	 * @return the containing collection id.
-	 */
-	private String isolateContainingId(String id)
-	{
-		// take up to including the last resource path separator, not counting one at the very end if there
-		return id.substring(0, id.lastIndexOf('/', id.length() - 2) + 1);
-
-	} // isolateContainingId
-
 
 	/**
 	 * MKCOL Method.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -181,6 +181,9 @@ import org.sakaiproject.util.Web;
 import org.sakaiproject.util.Xml;
 import org.sakaiproject.util.api.LinkMigrationHelper;
 
+import static org.sakaiproject.content.util.IdUtil.isolateContainingId;
+import static org.sakaiproject.content.util.IdUtil.isolateName;
+
 /**
  * <p>
  * BaseContentService is an abstract base implementation of the Sakai ContentHostingService.
@@ -5918,7 +5921,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					throw new IdUniquenessException(new_folder_id);
 				}
 			}
-			String containerId = this.isolateContainingId(new_folder_id);
+			String containerId = isolateContainingId(new_folder_id);
 			ContentCollection containingCollection = findCollection(containerId);
 			SortedSet<String> siblings = new TreeSet<String>();
 			siblings.addAll(containingCollection.getMembers());
@@ -9184,38 +9187,6 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		return edit;
 
 	} // mergeResource
-
-	/**
-	 * Find the containing collection id of a given resource id.
-	 * 
-	 * @param id
-	 *        The resource id.
-	 * @return the containing collection id.
-	 */
-	protected String isolateContainingId(String id)
-	{
-		// take up to including the last resource path separator, not counting one at the very end if there
-		return id.substring(0, id.lastIndexOf('/', id.length() - 2) + 1);
-
-	} // isolateContainingId
-
-	/**
-	 * Find the resource name of a given resource id.
-	 * 
-	 * @param id
-	 *        The resource id.
-	 * @return the resource name.
-	 */
-	protected String isolateName(String id)
-	{
-		if (id == null) return null;
-		if (id.length() == 0) return null;
-
-		// take after the last resource path separator, not counting one at the very end if there
-		boolean lastIsSeparator = id.charAt(id.length() - 1) == '/';
-		return id.substring(id.lastIndexOf('/', id.length() - 2) + 1, (lastIsSeparator ? id.length() - 1 : id.length()));
-
-	} // isolateName
 
 	/**
 	 * Check the fixed type and id infomation: The same or better content type based on the known type for this id's extension, if any. The same or added extension id based on the know MIME type, if any Only if the type is the unknown type already.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -90,6 +90,8 @@ import org.sakaiproject.util.EntityReaderAdapter;
 import org.sakaiproject.util.SingleStorageUser;
 import org.sakaiproject.util.Xml;
 
+import static org.sakaiproject.content.util.IdUtil.isolateContainingId;
+
 /**
  * <p>
  * DbContentService is an extension of the BaseContentService with a database implementation.

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/IdUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/IdUtil.java
@@ -1,0 +1,36 @@
+package org.sakaiproject.content.util;
+
+public class IdUtil {
+
+    /**
+     * Find the containing collection id of a given resource id.
+     *
+     * @param id
+     *        The resource id.
+     * @return the containing collection id.
+     */
+    public static String isolateContainingId(String id)
+    {
+        // take up to including the last resource path separator, not counting one at the very end if there
+        return id.substring(0, id.lastIndexOf('/', id.length() - 2) + 1);
+
+    } // isolateContainingId
+
+    /**
+     * Find the resource name of a given resource id or filepath.
+     *
+     * @param id
+     *        The resource id.
+     * @return the resource name.
+     */
+    public static String isolateName(String id)
+    {
+        if (id == null) {return null;}
+        if (id.length() == 0) {return null;}
+
+        // take after the last resource path separator, not counting one at the very end if there
+        boolean lastIsSeparator = id.charAt(id.length() - 1) == '/';
+        return id.substring(id.lastIndexOf('/', id.length() - 2) + 1, (lastIsSeparator ? id.length() - 1 : id.length()));
+
+    } // isolateName
+}


### PR DESCRIPTION
There were multiple copies of the same method across multiple files in the codebase, although this method is small putting them all the kernel utilities project means new uses can call them and all the existing copies can be removed.