### PR TITLE
SAK-37348 - Disable portal chat by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -757,8 +757,8 @@
 # portal.styleable.contentSummary
 
 # Controls the portal chat feature
-# DEFAULT: true
-# portal.neochat=false
+# DEFAULT: false
+# portal.neochat=true
 
 # Lookup page aliases. May cause performance issues when enabled. See SAK-15002
 # DEFAULT: false

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1680,7 +1680,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 			}
 
                         boolean neoChatAvailable
-                            = ServerConfigurationService.getBoolean("portal.neochat", true)
+                            = ServerConfigurationService.getBoolean("portal.neochat", false)
                                 && chatHelper.checkChatPermitted(thisUser);
 
                         rcontext.put("neoChat", neoChatAvailable);


### PR DESCRIPTION
I'm thinking we should disable this in all branches by default. 

It sounds like on the list this isn't working.

I always considered this an experimental feature, especially the video part which relies on either setting up our/your own STUN server or hoping the default (Google's) is working right. 

I can still leave this on the experimental properties.