### PR TITLE
SAK-38431: Add role checks and redirects to all gradebook pages

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.java
@@ -26,6 +26,7 @@ import org.apache.wicket.settings.IRequestCycleSettings.RenderStrategy;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 
 import org.sakaiproject.gradebookng.framework.GradebookNgStringResourceLoader;
+import org.sakaiproject.gradebookng.tool.pages.AccessDeniedPage;
 import org.sakaiproject.gradebookng.tool.pages.ErrorPage;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
@@ -51,6 +52,8 @@ public class GradebookNgApplication extends WebApplication {
 		mountPage("/importexport", ImportExportPage.class);
 		mountPage("/permissions", PermissionsPage.class);
 		mountPage("/gradebook", StudentPage.class);
+		mountPage("/accessdenied", AccessDeniedPage.class);
+		mountPage("/error", ErrorPage.class);
 
 		// remove the version number from the URL so that browser refreshes re-render the page
 		getRequestCycleSettings().setRenderStrategy(RenderStrategy.ONE_PASS_RENDER);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -316,8 +316,6 @@ importExport.export.csv.headers.example.ignore = This column will be ignored
 # Student ID and Student Name are not here because they are a special string. 
 # To i18n these, the import helper would need to be made to look for columns by position instead of by column title
 
-role.none=You do not have permission to view the gradebook.
-
 assignment.option.edit = Edit Item Details
 assignment.option.viewgradestatistics = View Grade Statistics
 assignment.option.moveleft = Move Left

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -119,7 +119,7 @@ public class GradebookPage extends BasePage {
 	public GradebookPage() {
 		disableLink(this.gradebookPageLink);
 
-		if (this.role == null) {
+		if (this.role == GbRole.NONE) {
 			sendToAccessDeniedPage(getString("error.role"));
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/ImportExportPage.java
@@ -15,7 +15,6 @@
  */
 package org.sakaiproject.gradebookng.tool.pages;
 
-import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.ExactLevelFeedbackMessageFilter;
 import org.apache.wicket.feedback.FeedbackMessage;
@@ -24,10 +23,8 @@ import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import org.sakaiproject.component.cover.ServerConfigurationService;
-import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.tool.component.GbFeedbackPanel;
 import org.sakaiproject.gradebookng.tool.panels.importExport.GradeImportUploadStep;
 
@@ -56,18 +53,10 @@ public class ImportExportPage extends BasePage {
 	public final GbFeedbackPanel errorFeedbackPanel = (GbFeedbackPanel) new GbFeedbackPanel("errorFeedbackPanel").setFilter(new ExactLevelFeedbackMessageFilter(FeedbackMessage.ERROR));
 
 	public ImportExportPage() {
+
+		defaultRoleChecksForInstructorOnlyPage();
+
 		disableLink(this.importExportPageLink);
-
-		if (role == GbRole.NONE) {
-			final PageParameters params = new PageParameters();
-			params.add("message", getString("role.none"));
-			throw new RestartResponseException(AccessDeniedPage.class, params);
-		}
-
-		// students cannot access this page; redirect to the StudentPage
-		if (this.role == GbRole.STUDENT) {
-			throw new RestartResponseException(StudentPage.class);
-		}
 
 		container = new WebMarkupContainer("gradebookImportExportContainer");
 		container.setOutputMarkupId(true);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/PermissionsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/PermissionsPage.java
@@ -72,6 +72,9 @@ public class PermissionsPage extends BasePage {
 	private final Long ALL_CATEGORIES = new Long(-1);
 
 	public PermissionsPage() {
+
+		defaultRoleChecksForInstructorOnlyPage();
+
 		disableLink(this.permissionsPageLink);
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -66,18 +66,22 @@ public class SettingsPage extends BasePage {
 	SettingsGradingSchemaPanel gradingSchemaPanel;
 
 	public SettingsPage() {
+
+		defaultRoleChecksForInstructorOnlyPage();
+
 		disableLink(this.settingsPageLink);
 		setShowGradeEntryToNonAdmins();
 	}
 
 	public SettingsPage(final boolean gradeEntryExpanded, final boolean gradeReleaseExpanded,
 			final boolean categoryExpanded, final boolean gradingSchemaExpanded) {
-		disableLink(this.settingsPageLink);
+
+		this();
+
 		this.gradeEntryExpanded = gradeEntryExpanded;
 		this.gradeReleaseExpanded = gradeReleaseExpanded;
 		this.categoryExpanded = categoryExpanded;
 		this.gradingSchemaExpanded = gradingSchemaExpanded;
-		setShowGradeEntryToNonAdmins();
 	}
 
 	private void setShowGradeEntryToNonAdmins() {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.java
@@ -25,6 +25,7 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.tool.panels.StudentGradeSummaryGradesPanel;
 import org.sakaiproject.user.api.User;
 
@@ -40,6 +41,10 @@ public class StudentPage extends BasePage {
 	private static final long serialVersionUID = 1L;
 
 	public StudentPage() {
+
+		if (role == GbRole.NONE) {
+			sendToAccessDeniedPage(getString("error.role"));
+		}
 
 		final User u = this.businessService.getCurrentUser();
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-38431



Some gradebook pages check the user's role and redirect them appropriately if they attempt to visit a page they aren't allowed to access. However, not all pages have these checks, which leads to error messages in some cases. Add checks to all remaining pages that are missing them.

In general:

    users with no gradebook permissions are redirected to the access denied page
    students are redirected to the student page
    TAs are redirected to the grades page