### PR TITLE
SAK-38438 re-add auto=true to the GradebookNG AJAX polls 

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-connection-poll.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-connection-poll.js
@@ -25,6 +25,9 @@ ConnectionPoll.prototype.ping = function() {
   $.ajax({
     type: "GET",
     url: this.PING_URL,
+    data: {
+      auto: true // indicate that the request is automatic, not from a user action
+    },
     timeout: this.PING_TIMEOUT,
     cache: false,
     success: $.proxy(this.onSuccess, this),

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -3038,7 +3038,8 @@ GradebookAPI = {};
 GradebookAPI.isAnotherUserEditing = function(siteId, timestamp, onSuccess, onError) {
   var endpointURL = "/direct/gbng/isotheruserediting/" + siteId + ".json";
   var params = {
-    since: timestamp
+    since: timestamp,
+    auto: true // indicate that the request is automatic, not from a user action
   };
   GradebookAPI._GET(endpointURL, params, onSuccess, onError);
 };


### PR DESCRIPTION
(concurrent edits/server ping) so that the user session lastAccessedTime is not bumped (#3584)

SAK-38438 Moved previous changes to new file locations - David Bauer <dbauer1@udayton.edu>