### PR TITLE
SAK-38440: edu-services > implement site property to override 'gradebook.externalAssessments.updateSameScore' sakai.property

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
@@ -35,7 +35,6 @@ import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.hibernate.HibernateCriterionUtils;
 import org.sakaiproject.service.gradebook.shared.AssessmentNotFoundException;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
@@ -49,6 +48,8 @@ import org.sakaiproject.service.gradebook.shared.GradebookHelper;
 import org.sakaiproject.service.gradebook.shared.GradebookNotFoundException;
 import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.service.gradebook.shared.InvalidCategoryException;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.tool.gradebook.GradebookAssignment;
 import org.sakaiproject.tool.gradebook.AssignmentGradeRecord;
 import org.sakaiproject.tool.gradebook.Category;
@@ -58,12 +59,24 @@ import org.springframework.orm.hibernate4.HibernateCallback;
 import org.springframework.orm.hibernate4.HibernateTemplate;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.site.api.Site;
 
 @Slf4j
 public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager implements GradebookExternalAssessmentService {
 
+    private ToolManager toolManager;
+    private SiteService siteService;
+
     public GradebookService getGradebookService() {
         return (GradebookService) ComponentManager.get("org.sakaiproject.service.gradebook.GradebookService");
+    }
+
+    public void setToolManager(ToolManager toolManager) {
+        this.toolManager = toolManager;
+    }
+
+    public void setSiteService(SiteService siteService) {
+        this.siteService = siteService;
     }
 
 	private ConcurrentHashMap<String, ExternalAssignmentProvider> externalProviders =
@@ -144,6 +157,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
      * score is different than what is currently in the db.
      */
     public static final String UPDATE_SAME_SCORE_PROP = "gradebook.externalAssessments.updateSameScore";
+    public static final boolean UPDATE_SAME_SCORE_PROP_DEFAULT = false;
 
 	@Override
 	public synchronized void addExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl,
@@ -322,7 +336,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 
                 // Try to reduce data contention by only updating when a score
                 // has changed or property has been set forcing a db update every time.
-                boolean alwaysUpdate = ServerConfigurationService.getBoolean(UPDATE_SAME_SCORE_PROP, false);
+                boolean alwaysUpdate = isUpdateSameScore();
 
                 CommentDefinition gradeComment = getAssignmentScoreComment(gradebookUid, asn.getId(), studentUid);
                 String oldComment = gradeComment != null ? gradeComment.getCommentText() : null;
@@ -373,7 +387,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 
                 // Try to reduce data contention by only updating when a score
                 // has changed or property has been set forcing a db update every time.
-                boolean alwaysUpdate = ServerConfigurationService.getBoolean(UPDATE_SAME_SCORE_PROP, false);
+                boolean alwaysUpdate = isUpdateSameScore();
 
                 Double oldPointsEarned = agr.getPointsEarned();
                 Double newPointsEarned = studentUidsToScores.get(studentUid);
@@ -439,7 +453,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 
                 // Try to reduce data contention by only updating when a score
                 // has changed or property has been set forcing a db update every time.
-                boolean alwaysUpdate = ServerConfigurationService.getBoolean(UPDATE_SAME_SCORE_PROP, false);
+                boolean alwaysUpdate = isUpdateSameScore();
 
                 //TODO: for ungraded items, needs to set ungraded-grades later...
                 Double oldPointsEarned = agr.getPointsEarned();
@@ -817,7 +831,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 		HibernateCallback<?> hc = session -> {
             // Try to reduce data contention by only updating when the
             // score has actually changed or property has been set forcing a db update every time.
-            boolean alwaysUpdate = ServerConfigurationService.getBoolean(UPDATE_SAME_SCORE_PROP, false);
+            boolean alwaysUpdate = isUpdateSameScore();
 
             CommentDefinition gradeComment = getAssignmentScoreComment(gradebookUid, asn.getId(), studentUid);
             String oldComment = gradeComment != null ? gradeComment.getCommentText() : null;
@@ -828,6 +842,9 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
                     setAssignmentScoreComment(gradebookUid, asn.getId(), studentUid, comment);
                 else
                     setAssignmentScoreComment(gradebookUid, asn.getId(), studentUid, null);
+                log.debug("updateExternalAssessmentComment: grade record saved");
+            } else {
+                log.debug("Ignoring updateExternalAssessmentComment, since the new comment is the same as the old");
             }
             return null;
         };
@@ -855,7 +872,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 
 			// Try to reduce data contention by only updating when the
 			// score has actually changed or property has been set forcing a db update every time.
-			boolean alwaysUpdate = ServerConfigurationService.getBoolean(UPDATE_SAME_SCORE_PROP, false);
+			boolean alwaysUpdate = isUpdateSameScore();
 
 			//TODO: for ungraded items, needs to set ungraded-grades later...
 			Double oldPointsEarned = (agr == null) ? null : agr.getPointsEarned();
@@ -943,4 +960,27 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 		return categoryId;
 	}
 
+	/**
+	 * Determines whether to update a grade record when there have been no changes.
+	 * This is useful when we need to update only gb_grade_record_t's 'DATE_RECORDED' field for instance.
+	 * Generally uses the sakai.property 'gradebook.externalAssessments.updateSameScore', but a site property by the same name can override it.
+	 * That is to say, the site property is checked first, and if it is not present, the sakai.property is used.
+	 */
+	private boolean isUpdateSameScore() {
+		String siteProperty = null;
+		try {
+			String siteId = toolManager.getCurrentPlacement().getContext();
+			Site site = siteService.getSite(siteId);
+			siteProperty = site.getProperties().getProperty(UPDATE_SAME_SCORE_PROP);
+		} catch (Exception e) {
+			// Can't access site property. Leave it set to null
+		}
+
+		// Site property override not set. Use setting in sakai.properties
+		if (siteProperty == null) {
+			return serverConfigurationService.getBoolean(UPDATE_SAME_SCORE_PROP, UPDATE_SAME_SCORE_PROP_DEFAULT);
+		}
+
+		return Boolean.TRUE.toString().equals(siteProperty);
+	}
 }

--- a/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
+++ b/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
@@ -65,6 +65,8 @@
 			<ref bean="org_sakaiproject_tool_gradebook_facades_Authn" />
 		</property>
 		<property name="eventTrackingService" ref="org_sakaiproject_tool_gradebook_facades_EventTrackingService" />
+		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
+		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 		<!-- This would be a circular dependency, so for now, we get it from the ComponentManager. -->
 		<!-- <property name="gradebookService" ref="org_sakaiproject_service_gradebook_GradebookService" /> -->
 	</bean>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-38440

Currently if a quiz is linked to the Gradebook, and the "Last" option is enabled to send the latest grade to the gradebook (as opposed to "Highest"), if the grade achieved on new attempts is the same as the grade already recorded in the gradebook, the record is not updated. This presents a problem in certain situations where the quiz is a requirement to obtain certification, because the date of completion is not updated in the Gradebook. The result is that users retaking the quiz don't receive an updated certificate with a new expiry date.

There is a related sakai.property (gradebook.externalAssessments.updateSameScore), which when set to true forces the Gradebook record to be updated even if the scores are the same. This resolves the issue described above, but it may not be the desired behaviour globally.

In consultation with Longsight, it was determined that new behaviour in edu-services should be developed to allow a site property of the same name to override the functionality defined by the global sakai.property. In this way, institutions with a low number of sites requiring this behaviour could use the site property, while institutions with many sites requiring this behaviour could elect to use the global sakai.property.
