### PR TITLE
SAK-39928: samigo > minimize redundant UPDATE queries on SAM_ITEMGRADING_T

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -423,11 +423,8 @@ public class SubmitToGradingActionListener implements ActionListener {
 			// 2. add any modified SAQ/TF/FIB/Matching/MCMR/FIN
 			// 3. save any modified Mark for Review in FileUplaod/Audio
 
-			Map<Long, ItemDataIfc> fibMap = getFIBMap(publishedAssessment);
-			Map<Long, ItemDataIfc> finMap = getFINMap(publishedAssessment);
 			Map<Long, ItemDataIfc> calcQuestionMap = getCalcQuestionMap(publishedAssessment); // CALCULATED_QUESTION
 			Map<Long, ItemDataIfc> imagQuestionMap = getImagQuestionMap(publishedAssessment); // IMAGEMAP_QUESTION
-			Map<Long, ItemDataIfc> mcmrMap = getMCMRMap(publishedAssessment);
 			Map<Long, ItemDataIfc> emiMap = getEMIMap(publishedAssessment);
 			Set<ItemGradingData> itemGradingSet = adata.getItemGradingSet();
 			log.debug("*** 2a. before removal & addition " + (new Date()));
@@ -459,7 +456,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 						+ adds.size());
 
 				HashSet<ItemGradingData> updateItemGradingSet = getUpdateItemGradingSet(
-						itemGradingSet, adds, fibMap, finMap, calcQuestionMap,imagQuestionMap,mcmrMap, emiMap, adata);
+						itemGradingSet, adds, calcQuestionMap,imagQuestionMap, emiMap, adata);
 				adata.setItemGradingSet(updateItemGradingSet);
 			}
 		}
@@ -508,15 +505,6 @@ public class SubmitToGradingActionListener implements ActionListener {
 		return adata;
 	}
 
-	private Map<Long, ItemDataIfc> getFIBMap(PublishedAssessmentIfc publishedAssessment) {
-		return publishedAssesmentService.prepareFIBItemHash(publishedAssessment);
-	}
-
-  
-  	private Map<Long, ItemDataIfc> getFINMap(PublishedAssessmentIfc publishedAssessment){
-	    return publishedAssesmentService.prepareFINItemHash(publishedAssessment);
-	}
-  	
   	/**
   	 * CALCULATED_QUESTION
   	 * @param publishedAssessment
@@ -533,10 +521,6 @@ public class SubmitToGradingActionListener implements ActionListener {
   	 */
   	private Map<Long, ItemDataIfc> getImagQuestionMap(PublishedAssessmentIfc publishedAssessment){
 	    return (Map<Long, ItemDataIfc>) publishedAssesmentService.prepareImagQuestionItemHash(publishedAssessment);
-	}  
-
-	private Map<Long, ItemDataIfc> getMCMRMap(PublishedAssessmentIfc publishedAssessment) {
-		return publishedAssesmentService.prepareMCMRItemHash(publishedAssessment);
 	}
 
 	private Map<Long, ItemDataIfc> getEMIMap(PublishedAssessmentIfc publishedAssessment) {
@@ -545,9 +529,8 @@ public class SubmitToGradingActionListener implements ActionListener {
 	}
 
 	private HashSet<ItemGradingData> getUpdateItemGradingSet(Set oldItemGradingSet, Set<ItemGradingData> newItemGradingSet,
-															 Map<Long, ItemDataIfc> fibMap, Map<Long, ItemDataIfc> finMap,
 															 Map<Long, ItemDataIfc> calcQuestionMap, Map<Long, ItemDataIfc> imagQuestionMap,
-															 Map<Long, ItemDataIfc> mcmrMap, Map<Long, ItemDataIfc> emiMap, AssessmentGradingData adata) {
+															 Map<Long, ItemDataIfc> emiMap, AssessmentGradingData adata) {
 		log.debug("Submitforgrading: oldItemGradingSet.size = "
 				+ oldItemGradingSet.size());
 		log.debug("Submitforgrading: newItemGradingSet.size = "
@@ -568,13 +551,12 @@ public class SubmitToGradingActionListener implements ActionListener {
 					.getItemGradingId());
 			if (oldItem != null) {
 			    if (!oldItem.equals(newItem) || 
-			    //Now Check all the maps
-			            fibMap.get(oldItem.getPublishedItemId()) != null
-			            || emiMap.get(oldItem.getPublishedItemId()) != null 
-			            || finMap.get(oldItem.getPublishedItemId())!=null
+			    // Check for presence of old data in the EMI, calcQuestion and imagQuestion maps.
+			    // FIB, NR, and MCMR maps are not checked; checking them for previous data can cause updates when only the date has changed.
+			    // The above check (!oldItem.equals(newItem) suffices for checking new data against these question types. See SAK-39928 for more details.
+			            emiMap.get(oldItem.getPublishedItemId()) != null
 			            || calcQuestionMap.get(oldItem.getPublishedItemId())!=null
-						|| imagQuestionMap.get(oldItem.getPublishedItemId())!=null
-			            || mcmrMap.get(oldItem.getPublishedItemId()) != null) {
+						|| imagQuestionMap.get(oldItem.getPublishedItemId()) != null) {
 			        String newAnswerText = newItem.getAnswerText();
 			        oldItem.setReview(newItem.getReview());
 			        oldItem.setPublishedAnswerId(newItem.getPublishedAnswerId());


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39928

When students navigate over questions without making changes, there are certain question types that update `SAM_ITEMGRADING_T` entries with nothing more than a new date stamp. In situations where there are a lot of questions in a quiz, with a lot of students taking the quiz at the same time, this can lead to poor performance at the database level. We found that in at least one case this code was responsible for putting full table locks on `SAM_ITEMGRADING_T` in high succession, which resulted in blocking hundreds of connections to the database. These blocking connections had to be killed manually by our DBA for the process to recover.

We identified three specific question types with high usage that exhibit this behaviour: fill in the blank, multiple choice multiple correct, and numeric response.

For FIB and NR, `oldAnswerText` and `newAnswerText` differ when the student changes their actual response. For MCMR, `oldAnswerId` and `newAnswerId` differ. So the `fibMap.get(itemId) != null`, `finMap.get(itemId) != null` and `mcmrMap.get(itemId) != null` checks aren't determining if there were changes to the question: they only allowed the code to enter the `if` block and as a result it adds unchanged FIB/MCMR/NR responses to the update set.

We've had this code running in our production instance for over 2 years now, with multiple rounds of internal QA, and no reports of lost/missing updates of data.