### PR TITLE
SAK-39930: BasicLTI > extend 'Allow'/'Do not allow' configuration options to the custom tool icon setting

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -25,10 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.sakaiproject.exception.IdUnusedException;
-import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
-import org.sakaiproject.site.api.Site;
 
 /**
  * <p>
@@ -105,6 +102,7 @@ public interface LTIService extends LTISubstitutionsFilter {
             "title:text:label=bl_title:required=true:maxlength=1024",
             "allowtitle:radio:label=bl_allowtitle:choices=disallow,allow",
             "fa_icon:text:label=bl_fa_icon:allowed=true:maxlength=1024",
+            "allowfa_icon:radio:label=bl_allowfa_icon:choices=disallow,allow",
             "pagetitle:text:label=bl_pagetitle:required=true:maxlength=1024",
             "allowpagetitle:radio:label=bl_allowpagetitle:choices=disallow,allow",
             "description:textarea:label=bl_description:maxlength=4096",
@@ -322,6 +320,13 @@ public interface LTIService extends LTISubstitutionsFilter {
     String[] getToolModel(String siteId);
 
     String[] getContentModel(Long tool_id, String siteId);
+
+    /**
+     * @param tool_id
+     * @param siteId
+     * @return If the form does not contain configuration, returns null; otherwise returns an array containing the result of getContentModel(tool_id, siteId)
+     */
+    public String[] getContentModelIfConfigurable(Long tool_id, String siteId);
 
     String[] getContentModel(Map<String, Object> tool, String siteId);
 

--- a/basiclti/basiclti-impl/src/bundle/ltiservice.properties
+++ b/basiclti/basiclti-impl/src/bundle/ltiservice.properties
@@ -82,6 +82,9 @@ bl_allowcustom=Allow additional custom parameters
 bl_custom=Custom Parameters (key=value on separate lines)
 bl_splash=Splash Screen (If this is non-blank it is shown before the tool is launched)
 bl_fa_icon=Choose a custom icon (leave empty to use the default icon)
+bl_allowfa_icon=Allow custom icon to be changed
+bl_allowfa_icon_allow=Allow
+bl_allowfa_icon_disallow=Do not allow
 bl_matchpattern=Launch URL Pattern to Match
 bl_launchurl=Actual Launch Url
 bl_resource_handler=Resource Handler

--- a/basiclti/web-ifp/src/bundle/iframe.properties
+++ b/basiclti/web-ifp/src/bundle/iframe.properties
@@ -11,12 +11,14 @@ gen.pagtit = Page Title
 gen.url = URL
 gen.save = Update Options
 gen.cancel = Cancel
+gen.back = Back
 gen.options = Options
 gen.description = Description
 gen.info.url = Site Info URL
 gen.info.url.msg = If specified, this URL will be shown instead of the Site description.
 gen.info.maximize = Launch Maximum Width
 get.info.notconfig = Not yet configured.
+gen.info.nocustom = There are no settings to customize.
 
 new.page.launch=Page opened in new window.
 new.page.relaunch=Press to re-launch page.

--- a/basiclti/web-ifp/src/bundle/vm/edit.vm
+++ b/basiclti/web-ifp/src/bundle/vm/edit.vm
@@ -18,11 +18,19 @@
 	<div class="clear"></div>
 	#end
 	<form action="$actionUrl" method="post" name="customizeForm" >
-		$formInput 
+		#if ($noCustomizations)
+			<span class="messageInformation">$noCustomizations</span>
+		#elseif ($formInput)
+			$formInput
+		#end
 
 		<p class="act">
-			<input type="submit" accesskey ="s" class="active" name="$doUpdate" value="$tlang.getString('gen.save')" />
-			<input type="submit" accesskey ="x" name="$doCancel" value="$tlang.getString('gen.cancel')" />
+			#if ($noCustomizations)
+				<input type="submit" accesskey ="x" class="active" name="$doCancel" value="$tlang.getString('gen.back')" />
+			#else
+				<input type="submit" accesskey ="s" class="active" name="$doUpdate" value="$tlang.getString('gen.save')" />
+				<input type="submit" accesskey ="x" name="$doCancel" value="$tlang.getString('gen.cancel')" />
+			#end
 		</p>
 	</form>
 <script type="text/javascript">$(document).ready(function () { fontawesome_icon_picker('#fa_icon'); });</script>

--- a/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -351,9 +351,14 @@ public class SakaiIFrame extends GenericPortlet {
 				return;
 			}
 
-			String[] contentToolModel=m_ltiService.getContentModel(Long.valueOf(foundLtiToolId), placement.getContext());
-			String formInput=m_ltiService.formInput(content, contentToolModel);
-			context.put("formInput", formInput);
+			String[] contentToolModel = m_ltiService.getContentModelIfConfigurable(Long.valueOf(foundLtiToolId), placement.getContext());
+			if (contentToolModel != null) {
+				String formInput = m_ltiService.formInput(content, contentToolModel);
+				context.put("formInput", formInput);
+			} else {
+				String noCustomizations = rb.getString("gen.info.nocustom");
+				context.put("noCustomizations", noCustomizations);
+			}
 			
 			vHelper.doTemplate(vengine, "/vm/edit.vm", context, out);
 		}

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-modifyENW.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-modifyENW.vm
@@ -32,11 +32,13 @@
 				#end
 				#set($ltiToolValues=$ltiTool.getValue())
 				#set($ltiToolFormInput=$ltiToolValues.get("formInput"))
-				<h4>
-					$ltiToolValues.get("title")
-				</h4>
-				$ltiToolFormInput<br/>
-<script type="text/javascript">jQuery(document).ready(function () { fontawesome_icon_picker('#${ltiToolId}_fa_icon'); });</script>
+				#if ($ltiToolValues.get("hasConfiguration"))
+					<h4>
+						$ltiToolValues.get("title")
+					</h4>
+					$!ltiToolFormInput<br/>
+					<script type="text/javascript">jQuery(document).ready(function () { fontawesome_icon_picker('#${ltiToolId}_fa_icon'); });</script>
+				#end
 
 			#end
 		#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39930

The LTI tool setup interface has settings to "Allow [setting] to be changed", with the options of "Do not allow" and "Allow". However the custom icon setting does not have these corresponding options. This PR implements these options for the custom icon setting, as well as the following changes:

* new behaviour to skip the tool configuration step (when adding the LTI tool to a site manually, through "Manage Tools") if all settings have been set to "Do not allow". This also overrides the behaviour of the "[Show/Bypass] configuration dialog" configuration setting, in that if "Show configuration dialog" is selected the end user will not be presented with the configuration dialog if no settings are able to be configured (all settings have been set to "Do not allow").
* in the 'Edit' interface, if no settings are able to be configured, display a message indicating this situation and a 'Back' button, rather than an empty form with 'Save' and 'Cancel' buttons
* the "Allow external tool to store setting data" option no longer causes the configuration page to be shown when adding a tool to a site, if all other options have been set to "Do not allow" (it's not a setting that can be configured by the user, and should not trigger the configuration page to be displayed if no other options are able to be configured by the user)