### PR TITLE
SAK-39934 - Improvements wrt unpublishing sites with the Course Site Removal job

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4892,11 +4892,19 @@
 # the actions can be: remove or unpublish (by default)
 #course_site_removal_service.action=unpublish
 
+# When true, this bypasses the standard hooks of saving sites; this significantly boosts the job's performance
+# Set this to true only in conjuction with course_site_removal_service.action=unpublish
+#course_site_removal_service.silently.unpublish=false
+
 #The user that will execute the removal/unpublish job
 #course_site_removal_service.user=admin
 
 # The grace period after the term ends
 #course_site_removal_service.num_days_after_term_ends=14
+
+# It is possible for a course to be attached to multiple sections that fall in different terms
+# When this is true, a given site will only be unpublished if all of its associated sections' terms' end dates have elapsed before the grace period
+#course_site_removal_service.handle.crosslisting=false
 
 
 # Tool ID to use when adding users to a site.

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseSiteRemovalServiceImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseSiteRemovalServiceImpl.java
@@ -15,16 +15,26 @@
  */
 package org.sakaiproject.coursemanagement.impl;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.coursemanagement.api.AcademicSession;
 import org.sakaiproject.coursemanagement.api.CourseManagementService;
+import org.sakaiproject.coursemanagement.api.CourseOffering;
+import org.sakaiproject.coursemanagement.api.Section;
 import org.sakaiproject.coursemanagement.api.CourseSiteRemovalService;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.SiteService.SelectionType;
@@ -32,6 +42,8 @@ import org.sakaiproject.site.api.SiteService.SortType;
 import org.springframework.orm.hibernate4.support.HibernateDaoSupport;
 
 import lombok.extern.slf4j.Slf4j;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
@@ -43,10 +55,31 @@ public class CourseSiteRemovalServiceImpl extends HibernateDaoSupport implements
    // class members
    private static final long ONE_DAY_IN_MS = 1000L * 60L * 60L * 24L;    // one day in ms = 1000ms/s · 60s/m · 60m/h · 24h/day
 
+   // batch sizes to silently unpublish sites
+   private static final long SILENT_UNPUBLISH_BATCH_SIZE = 1000;
+
+   private static final String SAK_PROP_HANDLE_CROSSLISTING = "course_site_removal_service.handle.crosslisting";
+   private static final String SAK_PROP_SILENT_UNPUBLISH = "course_site_removal_service.silently.unpublish";
+   private static final boolean SAK_PROP_HANDLE_CROSSLISTING_DEFAULT = false;
+   private static final boolean SAK_PROP_SILENT_UNPUBLISH_DEFAULT = false;
+
+   private final int NUM_SITE_IDS_TO_LOG = 1000;
+
+   // Used to append "Additional " after the first time we log (so we initialize to "" and set its value afterwards)
+   private String additional = "";
+
    // sakai services
+   @Getter @Setter
+   private AuthzGroupService authzGroupService;
+   @Getter @Setter
    private CourseManagementService courseManagementService;
+   @Getter @Setter
    private FunctionManager functionManager;
+   @Getter @Setter
    private SecurityService securityService;
+   @Getter @Setter
+   private ServerConfigurationService serverConfigurationService;
+   @Getter @Setter
    private SiteService siteService;
 
    /**
@@ -69,77 +102,6 @@ public class CourseSiteRemovalServiceImpl extends HibernateDaoSupport implements
    }
 
    /**
-    * returns the instance of the CourseManagementService injected by the spring framework specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @return the instance of the CourseManagementService injected by the spring framework specified in the components.xml file via IoC.
-    */
-   public CourseManagementService getCourseManagementService() {
-      return courseManagementService;
-   }
-
-   /**
-    * called by the spring framework to initialize the courseManagementService data member specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @param courseManagementService   the implementation of the CourseManagementService interface provided by the spring framework.
-    */
-   public void setCourseManagementService(CourseManagementService courseManagementService) {
-      this.courseManagementService = courseManagementService;
-   }
-   /**
-    * returns the instance of the FunctionManager injected by the spring framework specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @return the instance of the FunctionManager injected by the spring framework specified in the components.xml file via IoC.
-    */
-   public FunctionManager getFunctionManager() {
-      return functionManager;
-   }
-
-   /**
-    * called by the spring framework to initialize the functionManager data member specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @param functionManager   the implementation of the FunctionManager interface provided by the spring framework.
-    */
-   public void setFunctionManager(FunctionManager functionManager) {
-      this.functionManager = functionManager;
-   }
-
-   /**
-    * returns the instance of the SecurityService injected by the spring framework specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @return the instance of the SecurityService injected by the spring framework specified in the components.xml file via IoC.
-    */
-   public SecurityService getSecurityService() {
-      return securityService;
-   }
-
-   /**
-    * called by the spring framework to initialize the securityService data member specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @param securityService   the implementation of the SecurityService interface provided by the spring framework.
-    */
-   public void setSecurityService(SecurityService securityService) {
-      this.securityService = securityService;
-   }
-
-   /**
-    * returns the instance of the SiteService injected by the spring framework specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @return the instance of the SiteService injected by the spring framework specified in the components.xml file via IoC.
-    */
-   public SiteService getSiteService() {
-      return siteService;
-   }
-
-   /**
-    * called by the spring framework to initialize the siteService data member specified in the components.xml file via IoC.
-    * <br/><br/>
-    * @param siteService   the implementation of the SiteService interface provided by the spring framework.
-    */
-   public void setSiteService(SiteService siteService) {
-      this.siteService = siteService;
-   }
-
-   /**
     * removes\\unpublishes course sites whose terms have ended and a specified number of days have passed.
     * Once a term has ended, the course sites for that term remain available for a specified number of days, whose duration is specified in sakai.properties
     * via the <i>course_site_removal_service.num_days_after_term_ends</i> property.  After the specified period has elapsed, this invoking this service will either
@@ -153,66 +115,183 @@ public class CourseSiteRemovalServiceImpl extends HibernateDaoSupport implements
 
     public int removeCourseSites(CourseSiteRemovalService.Action action, int numDaysAfterTermEnds) {
 
-       log.info("removeCourseSites(" + action + " course sites, " + numDaysAfterTermEnds + " days after the term ends)");
+       log.info("removeCourseSites({} course sites, {} days after the term ends)", action, numDaysAfterTermEnds);
        Date today           = new Date();
        Date expirationDate  = new Date(today.getTime() - numDaysAfterTermEnds * ONE_DAY_IN_MS);
-       int  numSitesRemoved = 0;
 
-       try {
-         // get the list of the academic term(s)
-         List<AcademicSession> academicSessions = courseManagementService.getAcademicSessions();
-
-         for(AcademicSession academicSession : academicSessions) {
-            // see if the academic session ended more than the specified number of days ago
-            if (academicSession.getEndDate().getTime() < expirationDate.getTime()) {
-               // get a list of all published course sites in ascending creation date order which are associated with the specified academic session
-               Hashtable<String, String> propertyCriteria = new Hashtable<String, String>();
-               propertyCriteria.put("term_eid", academicSession.getEid());
-                //We only will check COURSES with the right term_eid property. We will filter later if they are or not published
-                List<String> sites = (List<String>)siteService.getSiteIds(SelectionType.ANY, "course", null, propertyCriteria, SortType.CREATED_ON_ASC, null);
-
-                for(String siteId : sites) {
-                    // see if this service has already removed/unpublished this course site once before.
-                     // if it has, then someone has manually published the site, and wants the course to be published.
-                     // so don't switch it back to being unpublished - just leave it as published.
-                    Site site = siteService.getSite(siteId);
-                    //we only need to check published sites and not softlyDeleted.
-                    if (site.isPublished() && (!site.isSoftlyDeleted())) {
-                        ResourcePropertiesEdit siteProperties = site.getPropertiesEdit();
-                        String siteProperty = siteProperties.getProperty(SITE_PROPERTY_COURSE_SITE_REMOVAL);
-                        if (!"set".equals(siteProperty)) {
-                            // check permissions
-
-                            if (!checkPermission(PERMISSION_COURSE_SITE_REMOVAL, site.getId())) {
-                                log.error("You do not have permission to " + action + " the " + site.getTitle() + " course site (" + site.getId() + ").");
-                            } else if (action == CourseSiteRemovalService.Action.remove) {
-                                // remove the course site
-                                log.debug(action + "removing course site " + site.getTitle() + " (" + site.getId() + ").");
-                                siteService.removeSite(site);
-                            } else {
-                                // unpublish the course site
-                                log.debug("unpublishing course site " + site.getTitle() + " (" + site.getId() + ").");
-                                siteProperties.addProperty(SITE_PROPERTY_COURSE_SITE_REMOVAL, "set");
-                                site.setPublished(false);
-                                siteService.save(site);
-                            }
-                            numSitesRemoved++;
-
-                        }
-                    }
-               }
-            }
-         }
-       } catch (Exception ex) {
-         log.error(ex.getMessage(), ex);
+       boolean handleCrosslistedTerms = serverConfigurationService.getBoolean(SAK_PROP_HANDLE_CROSSLISTING, SAK_PROP_HANDLE_CROSSLISTING_DEFAULT);
+       if (handleCrosslistedTerms) {
+          return removeCourseSitesWithCriteria(action, null, expirationDate);
        }
+
+       // get the list of the academic term(s)
+       List<AcademicSession> academicSessions = courseManagementService.getAcademicSessions();
+
+       int numSitesRemoved = 0;
+       for (AcademicSession academicSession : academicSessions) {
+          // see if the academic session ended more than the specified number of days ago
+          if (academicSession.getEndDate().getTime() < expirationDate.getTime()) {
+             // get a list of all published course sites in ascending creation date order which are associated with the specified academic session
+             Map<String, String> propertyCriteria = new HashMap<>();
+             propertyCriteria.put("term_eid", academicSession.getEid());
+             numSitesRemoved += removeCourseSitesWithCriteria(action, propertyCriteria, expirationDate);
+          }
+       }
+
        return numSitesRemoved;
     }
 
+    /**
+     * Removes all sites matching the specified propertyCriteria except sites that:
+     * 1) have been touched by this job in the past, or that have academic sessions that are not yet expired
+     * 2) are attached to rosters that have academic sessions that are not yet expired (applies only if isHandleCrosslistedTerms())
+     * @param action action to perform: remove / unpublish (default: unpublish)
+     * @param propertyCriteria map of propertyCriteria for SiteService.getSites(...)
+     * @param expirationDate sessions are considered expired if they fall before this date
+     * @return the number of sites that were successfully removed
+     */
+    private int removeCourseSitesWithCriteria(CourseSiteRemovalService.Action action, Map<String, String> propertyCriteria, Date expirationDate) {
 
-    private boolean checkPermission(String lock, String reference)
-    {
+        int numSitesRemoved = 0;
+
+        // select published / non-deleted sites only:
+        // SelectionType: id=any, ignoreSpecial=false, ignoreUser=false, ignoreUnpublished=true, ignoreSoftlyDeleted=true
+        SelectionType publishedNonDeletedOnly = new SelectionType("any", false, false, true ,true);
+        // Also, in the case that an instructors has manaully re-published a site processed by this job, we shouldn't keep removing it on them, 
+        // so use the COURSE_SITE_REMOVAL property to skip sites stamped by this job in the past
+        Map<String, String> propertyRestrictions = Collections.singletonMap(SITE_PROPERTY_COURSE_SITE_REMOVAL, "set");
+        List<String> siteIds = siteService.getSiteIds(publishedNonDeletedOnly, "course", null, propertyCriteria, propertyRestrictions, SortType.CREATED_ON_ASC, null, null);
+
+        // A heartbeat log; log something for every 1000 sites determined to be unpublished
+        List<String> siteIdsToLog = new ArrayList<>(Math.min(NUM_SITE_IDS_TO_LOG, siteIds.size()));
+
+        /*
+         * Two ways to unpublish a site:
+         * 1) SiteService.save(Site site)
+         *     -triggers SiteAdvisors
+         *     -deletes all pages, tools, properties, etc associated with the site, then inserts them all back with any modifications
+         *     -handles authz group changes
+         *     -notifies all ContextObservers to do their own work related to the site modification
+         *     -triggers EventTrackingService
+         * 2) SiteService.silentlyUnpublish(List<String> siteIds)
+         *     -sets PUBLISHED flag to 0 on all SAKAI_SITE matches
+         *     -triggers EventTrackingService
+         */
+        boolean silentlyUnpublish = action == CourseSiteRemovalService.Action.unpublish && serverConfigurationService.getBoolean(SAK_PROP_SILENT_UNPUBLISH, SAK_PROP_SILENT_UNPUBLISH_DEFAULT);
+
+        // toUnpublish will collect siteIds to unpublish in bulk
+        // It is only used if we are silently unpublishing sites, otherwise we unpublish / remove sites one at a time
+        // Size will grow towards siteIds.size(), but it will not necessarily reach that size
+        List<String> toUnpublish = silentlyUnpublish ? new ArrayList<>(siteIds.size()) : Collections.EMPTY_LIST;
+
+        for (String siteId : siteIds) {
+            try {
+                if (isHandleCrosslistedTerms()) {
+                    if (isSiteCrosslistedWithEndDateAfterExpirationDate(siteId, expirationDate)) {
+                        // This site is attached to an academic session that has not yet expired; don't unpublish it
+                        continue;
+                    }
+                }
+
+                // check permissions
+                if (!checkPermission(PERMISSION_COURSE_SITE_REMOVAL, siteId)) {
+                    log.error("You do not have permission to {} the site with id {}", action, siteId);
+                } else if (action == CourseSiteRemovalService.Action.remove) {
+                    // remove the course site
+                    Site site = siteService.getSite(siteId);
+                    log.debug("{} removing course site {} ({}).", action, site.getTitle(), site.getId());
+                    siteService.removeSite(site);
+                    numSitesRemoved++;
+                } else {
+                    // unpublish the course site (default)
+                    log.debug("unpublishing course site {}", siteId);
+
+                    if (silentlyUnpublish) {
+                        toUnpublish.add(siteId);
+                    } else {
+                        Site site = siteService.getSite(siteId);
+
+                        // Add site property
+                        ResourcePropertiesEdit siteProperties = site.getPropertiesEdit();
+                        siteProperties.addProperty(SITE_PROPERTY_COURSE_SITE_REMOVAL, "set");
+
+                        // Unpublish the site and commit site property addition
+                        site.setPublished(false);
+                        siteService.save(site);
+                        numSitesRemoved++;
+                    }
+                }
+                
+                siteIdsToLog.add(siteId);
+                if (siteIdsToLog.size() == NUM_SITE_IDS_TO_LOG) {
+                    logProgress(siteIdsToLog, silentlyUnpublish);
+                    siteIdsToLog.clear();
+                }
+            }
+            catch (PermissionException | IdUnusedException ex) {
+                logger.error(ex.getMessage(), ex);
+            }
+        }
+
+        if (!siteIdsToLog.isEmpty()) {
+            logProgress(siteIdsToLog, silentlyUnpublish);
+        }
+
+        if (silentlyUnpublish) {
+            log.info("Unpublishing {} sites.", toUnpublish.size());
+
+            // bulk unpublish
+            siteService.silentlyUnpublish(toUnpublish);
+
+            // Add site property on sites
+            siteService.saveSitePropertyOnSites(SITE_PROPERTY_COURSE_SITE_REMOVAL, "set", toUnpublish.toArray(new String[toUnpublish.size()]));
+            numSitesRemoved += toUnpublish.size();
+            log.info("{} sites unpublished.", toUnpublish.size());
+        }
+
+        return numSitesRemoved;
+    }
+
+    /**
+     * For crosslisted sites, the sections may belong to multiple academic sessions which have differing end dates.
+     * If we find a date that isn't before the grace period, this site is not supposed to be removed / unpublished.
+     * @return true if this site has an academic session with an end date after the expiration date
+     */
+    private boolean isSiteCrosslistedWithEndDateAfterExpirationDate(String siteId, Date expirationDate) {
+        String siteReference = siteService.siteReference(siteId);
+        Set<String> providerIds = authzGroupService.getProviderIds(siteReference);
+        for (String providerId : providerIds) {
+            Section section = courseManagementService.getSection(providerId);
+            if (section != null) {
+                CourseOffering offering = courseManagementService.getCourseOffering(section.getCourseOfferingEid());
+                if (offering != null) {
+                    AcademicSession session = offering.getAcademicSession();
+                    if (session != null) {
+                        Date endDate = session.getEndDate();
+                        if (endDate != null && endDate.getTime() >= expirationDate.getTime()) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean checkPermission(String lock, String reference) {
         return securityService.unlock(lock, reference);
     }
 
+    private boolean isHandleCrosslistedTerms() {
+        return serverConfigurationService.getBoolean(SAK_PROP_HANDLE_CROSSLISTING, SAK_PROP_HANDLE_CROSSLISTING_DEFAULT);
+    }
+
+    private void logProgress(List<String> sitesToLog, boolean silentlyUnpublish) {
+        // when silentlyUnpublished is true, we find sites first, and the unpublishing is the final step
+        // Otherwise, we unpublish sites as we discover them
+        String logString = silentlyUnpublish ? " sites will be unpublished: " : " sites have been removed / unpublished: ";
+        log.info("{}{}{}{}", additional, sitesToLog.size(), logString, sitesToLog);
+        additional = "Additional ";
+    }
 }

--- a/edu-services/cm-service/cm-impl/hibernate-pack/src/webapp/WEB-INF/components.xml
+++ b/edu-services/cm-service/cm-impl/hibernate-pack/src/webapp/WEB-INF/components.xml
@@ -212,11 +212,13 @@
 		  class="org.sakaiproject.coursemanagement.impl.CourseSiteRemovalServiceImpl"
 		  destroy-method="destroy"
 		  init-method="init">
-		<property name="courseManagementService"><ref bean="org.sakaiproject.coursemanagement.api.CourseManagementService"      /></property>   <!-- used to get the start and end date of terms       -->
-		<property name="functionManager"        ><ref bean="org.sakaiproject.authz.api.FunctionManager"                         /></property>   <!-- used to register api permissions                  -->
-		<property name="securityService"        ><ref bean="org.sakaiproject.authz.api.SecurityService"                         /></property>   <!-- used to check for super user                      -->
-		<property name="sessionFactory"         ><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/></property>   <!-- global hibernate transaction manager              -->
-		<property name="siteService"            ><ref bean="org.sakaiproject.site.api.SiteService"                              /></property>   <!-- needed to retrieve course sites that have expired -->
+		<property name="authzGroupService"         ><ref bean="org.sakaiproject.authz.api.AuthzGroupService"                       /></property>   <!-- used to get providers from a site                 -->
+		<property name="courseManagementService"   ><ref bean="org.sakaiproject.coursemanagement.api.CourseManagementService"      /></property>   <!-- used to get the start and end date of terms       -->
+		<property name="functionManager"           ><ref bean="org.sakaiproject.authz.api.FunctionManager"                         /></property>   <!-- used to register api permissions                  -->
+		<property name="securityService"           ><ref bean="org.sakaiproject.authz.api.SecurityService"                         /></property>   <!-- used to check for super user                      -->
+		<property name="serverConfigurationService"><ref bean="org.sakaiproject.component.api.ServerConfigurationService"          /></property>   <!-- to get sakai.properties                           -->
+		<property name="sessionFactory"            ><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/></property>   <!-- global hibernate transaction manager              -->
+		<property name="siteService"               ><ref bean="org.sakaiproject.site.api.SiteService"                              /></property>   <!-- needed to retrieve course sites that have expired -->
 	</bean>
 
 	<!-- global hibernate transaction proxy bean -->

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/coursepublish/CourseSiteRemovalJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/coursepublish/CourseSiteRemovalJob.java
@@ -104,7 +104,7 @@ public class CourseSiteRemovalJob implements StatefulJob {
          user = userDirectoryService.getUser(userId);
       } catch (UserNotDefinedException ex) {
          user = null;
-         log.error("The user with eid " + userId + " was not found.  The course site publish job has been aborted.");
+         log.error("The user with eid {} was not found.  The course site publish job has been aborted.", userId);
       }
 
 
@@ -112,14 +112,14 @@ public class CourseSiteRemovalJob implements StatefulJob {
       String actionString = serverConfigurationService.getString(PROPERTY_COURSE_SITE_REMOVAL_ACTION);
       if (actionString == null || actionString.trim().length() == 0)
       {
-         log.warn("The property " + PROPERTY_COURSE_SITE_REMOVAL_ACTION + " was not specified in sakai.properties.  Using a default value of " + DEFAULT_VALUE_COURSE_SITE_REMOVAL_ACTION + ".");
+         log.warn("The property " + PROPERTY_COURSE_SITE_REMOVAL_ACTION + " was not specified in sakai.properties.  Using a default value of {}.", DEFAULT_VALUE_COURSE_SITE_REMOVAL_ACTION);
          action = DEFAULT_VALUE_COURSE_SITE_REMOVAL_ACTION;
       }
       else
       {
          action = getAction(actionString);
          if (action == null) {
-            log.error("The value specified for " + actionString + " in sakai.properties, " + PROPERTY_COURSE_SITE_REMOVAL_ACTION + ", is not valid.  A default value of " + DEFAULT_VALUE_COURSE_SITE_REMOVAL_ACTION + " will be used instead.");
+            log.error("The value specified for {} in sakai.properties, " + PROPERTY_COURSE_SITE_REMOVAL_ACTION + ", is not valid.  A default value of {} will be used instead.", actionString, DEFAULT_VALUE_COURSE_SITE_REMOVAL_ACTION);
             action = DEFAULT_VALUE_COURSE_SITE_REMOVAL_ACTION;
          }
       }
@@ -132,9 +132,10 @@ public class CourseSiteRemovalJob implements StatefulJob {
    public void execute(JobExecutionContext context) throws JobExecutionException {
       synchronized (this) {
          log.info("execute()");
+         String actionStr = CourseSiteRemovalService.Action.remove.equals(action) ? " course sites were removed." : " course sites were unpublished.";
 
          if (user == null) {
-            log.error("The scheduled job to remove course sites can not be run with an invalid user.  No courses were removed.");
+            log.error("The scheduled job to remove course sites can not be run with an invalid user.  No{}", actionStr);
          } else {
             try {
                // switch the current user to the one specified to run the quartz job
@@ -142,9 +143,9 @@ public class CourseSiteRemovalJob implements StatefulJob {
                sakaiSesson.setUserId(user.getId());
 
                int numSitesRemoved = courseSiteRemovalService.removeCourseSites(action, numDaysAfterTermEnds);
-               log.info(numSitesRemoved + " course sites were removed.");
+               log.info("{}{}", numSitesRemoved, actionStr);
             } catch (Exception ex) {
-               log.error(ex.getMessage());
+               log.error(ex.getMessage(), ex);
             }
          }
       }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/SiteServiceSql.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/SiteServiceSql.java
@@ -21,6 +21,8 @@
 
 package org.sakaiproject.site.impl;
 
+import org.sakaiproject.site.api.SiteService.SelectionType.PublishedFilter;
+
 /**
  * database methods.
  */
@@ -214,6 +216,11 @@ public interface SiteServiceSql
 	/**
 	 * returns the sql statement which is part of the where clause to retrieve sites.
 	 */
+	String getSitesWhere4Sql(PublishedFilter publishedFilter);
+
+	/**
+	 * returns the sql statement which is part of the where clause to retrieve sites.
+	 */
 	String getSitesWhere5Sql();
 
 	/**
@@ -255,6 +262,11 @@ public interface SiteServiceSql
 	 * returns the sql statement which is part of the where clause to retrieve sites.
 	 */
 	String getSitesWhere13Sql();
+
+	/**
+	 * Returns the sql statement which is part of the where clause to retrieve sites.
+	 */
+	String getSitesWhere13PrimeSql();
 
 	/**
 	 * returns the sql statement which is part of the where clause to retrieve sites.
@@ -372,4 +384,9 @@ public interface SiteServiceSql
 	 * returns part of the where clause to retrieve sites that are unpublished
 	 */
 	String getUnpublishedSitesOnlySql();
+
+	/**
+	 * returns the sql statement which unpublishes multiple sites in the sakai_site table
+	 */
+	String getUpdateSitesUnpublishSql(String table, int toUpdateCount);
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/SiteServiceSqlDefault.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/SiteServiceSqlDefault.java
@@ -21,6 +21,8 @@
 
 package org.sakaiproject.site.impl;
 
+import org.sakaiproject.site.api.SiteService.SelectionType.PublishedFilter;
+
 /**
  * methods for accessing site data in a database.
  */
@@ -322,6 +324,16 @@ public class SiteServiceSqlDefault implements SiteServiceSql
 		return "SAKAI_SITE.PUBLISHED = 1 and ";
 	}
 
+	public String getSitesWhere4Sql(PublishedFilter publishedFilter)
+	{
+		if (PublishedFilter.ALL == publishedFilter)
+		{
+			return "";
+		}
+		String filterValue = PublishedFilter.PUBLISHED_ONLY == publishedFilter ? "1 and " : "0 and ";
+		return "SAKAI_SITE.PUBLISHED = " + filterValue;
+	}
+
 	/**
 	 * returns the sql statement which is part of the where clause to retrieve sites.
 	 */
@@ -392,6 +404,11 @@ public class SiteServiceSqlDefault implements SiteServiceSql
 	public String getSitesWhere13Sql()
 	{
 		return "SAKAI_SITE.SITE_ID in (select SITE_ID from SAKAI_SITE_PROPERTY where NAME = ? and UPPER(VALUE) like UPPER(?)) and ";
+	}
+
+	public String getSitesWhere13PrimeSql()
+	{
+		return "SAKAI_SITE.SITE_ID not in (select SITE_ID from SAKAI_SITE_PROPERTY where NAME = ? and UPPER(VALUE) like UPPER(?)) and ";
 	}
 
 	/**
@@ -592,5 +609,27 @@ public class SiteServiceSqlDefault implements SiteServiceSql
 	 */
 	public String getUnpublishedSitesOnlySql() {
 		return "SAKAI_SITE.PUBLISHED = '0' and ";
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	@Override
+	public String getUpdateSitesUnpublishSql(String table, int toUpdateCount)
+	{
+		StringBuilder sb = new StringBuilder("update ")
+			.append(table)
+			.append(" set PUBLISHED = 0, MODIFIEDBY = ?, MODIFIEDON = ? where SITE_ID in (");
+
+		String delim = "";
+		for (int i = 0; i < toUpdateCount; i++)
+		{
+			sb.append(delim)
+				.append("?");
+			delim = ", ";
+		}
+
+		sb.append(")");
+		return sb.toString();
 	}
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
@@ -172,6 +172,12 @@ public class SiteServiceTest extends DbSiteService
 	}
 
 	@Override
+	public List<String> getSiteIds(SelectionType type, Object ofType, String criteria, Map<String,String> propertyCriteria, Map<String,String> propertyRestrictions, SortType sort, PagingPosition page, String userId)
+	{
+		return new ArrayList<String>(0);
+	}
+
+	@Override
 	public String getUserSpecificSiteTitle( Site site, String userID )
 	{
 		return null;

--- a/kernel/kernel-storage-util/src/main/java/org/sakaiproject/util/BaseDbFlatStorage.java
+++ b/kernel/kernel-storage-util/src/main/java/org/sakaiproject/util/BaseDbFlatStorage.java
@@ -1406,6 +1406,73 @@ public class BaseDbFlatStorage
 	}
 
 	/**
+	 * Insert a uniform property on multiple resources. NB: this will not check for duplicates; calling method must prevent unique constraint violations
+	 */
+	public void writePropertyOnResources(final String table, final String idField, final Object[] ids, final String extraIdField, final String[] extraIds,
+			final String propName, final String propValue)
+	{
+		if (extraIdField != null && ids.length != extraIds.length)
+		{
+			throw new IllegalArgumentException("writePropertyOnResources: extraIdField exists, but ids and extraIds arrays differ in length");
+		}
+		if (table == null || StringUtils.isBlank(propName) || StringUtils.isBlank(propValue))
+		{
+			return;
+		}
+
+		StringBuilder tagName = new StringBuilder("writePropertiesOnResource");
+		String delim = "";
+
+		Cache myCache = getCache(table);
+		if (myCache != null)
+		{
+			for (Object id : ids)
+			{
+				tagName.append(delim).append(id.toString());
+				String cacheKey = table + ":" + idField + ":" + id;
+				myCache.remove(cacheKey);
+
+				// optimized away by compiler
+				delim = ",";
+			}
+		}
+
+		// do it all in the same transaction
+		m_sql.transact(()->
+		{
+			for (int i = 0; i < ids.length; i++)
+			{
+				String extraId = extraIdField == null ? null : extraIds[i];
+				writePropertyTx(table, idField, ids[i], extraIdField, extraId, propName, propValue);
+			}
+		}, tagName.toString());
+	}
+
+	/**
+	 * The transaction code that writes the properties
+	 */
+	protected void writePropertyTx(String table, String idField, Object id, String extraIdField, String extraId, String propName, String propValue)
+	{
+		String statement = flatStorageSql.getInsertSql(table, idField, extraIdField);
+		boolean useExtraId = extraIdField != null;
+		Object fields[] = new Object[(useExtraId ? 4 : 3)];
+		fields[0] = id;
+
+		fields[1] = propName;
+		fields[2] = propValue;
+
+		if (useExtraId)
+		{
+			fields[3] = extraId;
+		}
+
+		if (propValue.length() > 0)
+		{
+			m_sql.dbWrite(statement, fields);
+		}
+	}
+
+	/**
 	 * The transaction code for writing properties.
 	 * 
 	 * @param r


### PR DESCRIPTION
The Course Site Removal job's default configuration is to unpublish sites.
In our seven years of working on Sakai at Western, it's safe to say that this piece has the... 'least optimal' performance. Once, we ran this in our QA environment and got sidetracked; it completed after 12 days of execution.

A big part of this is that it invokes siteService.save(site) has a lot of slow performing hooks (as once might expect, you're saving a whole site afterall!). These hooks include:
- triggering SiteAdvisors
- deleting all pages, tools, properties, etc., associated with the site, then inserting them all back with any modifications
- handling authz group changes
- notifying ContextObservers to do their own work related to the site modification
- triggering EventTrackingService
These are important hooks, but generally, all except the EventTrackingService are not necessary when the job's intention is to simply flip the "published" flag to 0.

So I introduced a sakai.property which allows all those hooked to be bypassed; default is false:
course_site_removal_service.silently.unpublish=false (default)

We also have a use case to handle sites that are crosslisted with sections in different terms.
For instance, consider a course that has two sections attached - CompSci101FW18A, and CompSci101FW18B. Those two sections can be in different terms.
If CompSci101FW18A is associated with an Academic Session whose end date is December, and CompSci101B is associated with an Academic Session whose end date is in May, the job currently only considers one of these end dates (the first one that was attached if I'm not mistaken). But we don't want to unpublish this site until both sections' academic sessions' end dates fall before the grace period, so the job needs to consider all the attached sections' Academic Session end dates before it can decide whether it can unpublish the site.
I've introduced a sakai.property for this too that is also off by default:
course_site_removal_service.handle.crosslisting=false