### PR TITLE
SAK-39970: samigo > published copies > edit > inconsistent display of answer keys and distractors for matching questions

### DIFF
--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
@@ -23,6 +23,7 @@ package org.sakaiproject.tool.assessment.data.dao.assessment;
 
 import java.io.*;
 import java.util.*;
+import org.sakaiproject.samigo.util.SamigoConstants;
 
 import org.sakaiproject.tool.assessment.data.dao.shared.TypeD;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
@@ -142,6 +143,7 @@ public class PublishedItemText
           distractorAnswer.setText(NONE_OF_THE_ABOVE);
           distractorAnswer.setIsCorrect(false);
           distractorAnswer.setScore(this.getItem().getScore());
+          distractorAnswer.setLabel(Character.toString(SamigoConstants.ALPHABET.charAt(list.size())));
           list.add(distractorAnswer);
         }else{
           PublishedAnswer distractorAnswer = new PublishedAnswer();
@@ -149,6 +151,7 @@ public class PublishedItemText
           distractorAnswer.setIsCorrect(true);
           distractorAnswer.setScore(this.getItem().getScore());
           distractorAnswer.setId(new Long(0));
+          distractorAnswer.setLabel(Character.toString(SamigoConstants.ALPHABET.charAt(list.size())));
           list.add(distractorAnswer);
         }
       }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39970

The following issues/inconsistencies occur in the Published Copies edit screens:

1) The letters are shown before the numbers, e.g. A:1, B:2, etc. instead of vice versa (numbers ought to come before letters)
2) The None of the Above answers are missing a letter in front of them in the question text, and in the answer key, they show nothing.
3) If there's more than one None of the Above answer, the answer key doesn't show them at all.

Screenshots in the JIRA.