### PR TITLE
SAK-31988 removed scrolling when expanding a syllabus item

### DIFF
--- a/syllabus/syllabus-app/src/webapp/js/syllabus.js
+++ b/syllabus/syllabus-app/src/webapp/js/syllabus.js
@@ -50,17 +50,6 @@ function setupAccordion(iframId, isInstructor, msgs, openDataId){
 		autoHeight: false,
 		collapsible: true,
 		heightStyle: "content",
-		activate: function( event, ui ) {
-			if(ui.newHeader[0]){
-				if($("#" + iframId, window.parent.document).parents('html, body').size() > 0){
-					//we are in the portal, grab parent
-					$("#" + iframId, window.parent.document).parents('html, body').animate({scrollTop: $(ui.newHeader[0]).offset().top});
-				}else{
-					//we are in tool view w/o portal, grab html/body
-					$('html, body').animate({scrollTop: $(ui.newHeader[0]).offset().top});
-				}
-			}
-		}
 	});
 	if(isInstructor){
 		$( "#accordion span" ).sortable({


### PR DESCRIPTION
This change was already made in 0249d876 but got (probably accidentally)
reintroduced in 7a8ef643

It removes the scrolling when clicking on the header of a syllabus item
to expand it. This resulted in a determined scrolling to the bottom of
the page when the "expand all" button was used.