### PR TITLE
SAK-33108: Provide visual indicators for dropped scores in categories

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/CategoryScoreData.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/CategoryScoreData.java
@@ -1,0 +1,20 @@
+package org.sakaiproject.service.gradebook.shared;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable category score and list of gradebook items dropped (highest/lowest) from the score calculation
+ * @author plukasew
+ */
+public final class CategoryScoreData
+{
+	public final double score;
+	public final List<Long> droppedItems;
+
+	public CategoryScoreData(double score, List<Long> droppedItems)
+	{
+		this.score = score;
+		this.droppedItems = Collections.unmodifiableList(droppedItems);
+	}
+}

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -804,10 +805,10 @@ public interface GradebookService {
 	 * @param gradebookId Id of the gradebook
 	 * @param studentUuid uuid of the student
 	 * @param categoryId id of category
-	 * @return percentage or null if no calculations were made
+	 * @return percentage and dropped items, or empty if no calculations were made
 	 *
 	 */
-	Double calculateCategoryScore(Long gradebookId, String studentUuid, Long categoryId);
+	Optional<CategoryScoreData> calculateCategoryScore(Long gradebookId, String studentUuid, Long categoryId);
 
 	/**
 	 * Calculate the category score for the given gradebook, category, assignments in the category and grade map. This doesn't do any
@@ -816,12 +817,12 @@ public interface GradebookService {
 	 * @param gradebook the gradebook. As this method is called for every student at once, this is passed in to save additional lookups by
 	 *            id.
 	 * @param studentUuid uuid of the student
-	 * @param categoryId id of category
+	 * @param category the category
 	 * @param categoryAssignments list of assignments the student can view, and are in the category
 	 * @param gradeMap map of assignmentId to grade, to use for the calculations
-	 * @return percentage or null if no calculations were made
+	 * @return percentage and dropped items, or empty if no calculations were made
 	 */
-	Double calculateCategoryScore(Object gradebook, String studentUuid, CategoryDefinition category,
+	Optional<CategoryScoreData> calculateCategoryScore(Object gradebook, String studentUuid, CategoryDefinition category,
 			final List<Assignment> categoryAssignments, Map<Long, String> gradeMap);
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -29,6 +29,11 @@ label.noduedate=-
 label.percentage.valued={0}%
 label.percentage.plain=%
 
+label.category.drophighest=Drop Highest: {0}
+label.category.droplowest=Drop Lowest: {0}
+label.category.keephighest=Keep Highest: {0}
+label.category.dropSeparator=&
+
 label.coursegrade.released=Course grade has been released to students.
 label.coursegrade.notreleased=Course grade has not been released to students.
 label.coursegrade.nopermission=-

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -42,6 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 
 import org.sakaiproject.authz.api.Member;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityAdvisor.SecurityAdvice;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.coursemanagement.api.Membership;
@@ -67,6 +69,7 @@ import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.service.gradebook.shared.AssessmentNotFoundException;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
+import org.sakaiproject.service.gradebook.shared.CategoryScoreData;
 import org.sakaiproject.service.gradebook.shared.CommentDefinition;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.service.gradebook.shared.GradeDefinition;
@@ -513,6 +516,38 @@ public class GradebookNgBusinessService {
 		Collections.sort(rval, CategoryDefinition.orderComparator);
 
 		return rval;
+	}
+
+	/**
+	* Retrieve the categories visible to the given student.
+	*
+	* This should only be called if you are wanting to view the categories that a student would see (ie if you ARE a student, or if you
+	* are an instructor using the student review mode)
+	*
+	* @param studentUuid
+	* @return list of visible categories
+	*/
+	public List<CategoryDefinition> getGradebookCategoriesForStudent(String studentUuid) {
+		// find the categories that this student's visible assignments belong to
+		List<Assignment> viewableAssignments = getGradebookAssignmentsForStudent(studentUuid);
+		final List<Long> catIds = new ArrayList<>();
+		for (Assignment a : viewableAssignments) {
+			Long catId = a.getCategoryId();
+			if (catId != null && !catIds.contains(catId)) {
+				catIds.add(a.getCategoryId());
+			}
+		}
+
+		// get all the categories in the gradebook, use a security advisor in case the current user is the student
+		SecurityAdvisor gbAdvisor = (String userId, String function, String reference)
+						-> "gradebook.gradeAll".equals(function) ? SecurityAdvice.ALLOWED : SecurityAdvice.PASS;
+		securityService.pushAdvisor(gbAdvisor);
+		List<CategoryDefinition> catDefs = gradebookService.getCategoryDefinitions(getGradebook().getUid());
+		securityService.popAdvisor(gbAdvisor);
+
+		// filter out the categories that don't match the categories of the viewable assignments
+		return catDefs.stream().filter(def -> catIds.contains(def.getId())).collect(Collectors.toList());
+
 	}
 
 	/**
@@ -1110,10 +1145,17 @@ public class GradebookNgBusinessService {
 						}
 					}
 
-					final Double categoryScore = this.gradebookService.calculateCategoryScore(gradebook, student.getUserUuid(), category, category.getAssignmentList(), gradeMap);
-
-					// add to GbStudentGradeInfo
-					sg.addCategoryAverage(category.getId(), categoryScore);
+					final Optional<CategoryScoreData> categoryScore = gradebookService.calculateCategoryScore(gradebook,
+							student.getUserUuid(), category, category.getAssignmentList(), gradeMap);
+					categoryScore.ifPresent(data -> {
+						for (Long item : gradeMap.keySet())	{
+							if (data.droppedItems.contains(item)) {
+								grades.get(item).setDroppedFromCategoryScore(true);
+							}
+						}
+						// add to GbStudentGradeInfo
+						sg.addCategoryAverage(category.getId(), data.score);
+					});
 
 					// TODO the TA permission check could reuse this iteration... check performance.
 				}
@@ -2094,14 +2136,14 @@ public class GradebookNgBusinessService {
 	 * @param studentUuid uuid of student
 	 * @return
 	 */
-	public Double getCategoryScoreForStudent(final Long categoryId, final String studentUuid) {
+	public Optional<CategoryScoreData> getCategoryScoreForStudent(final Long categoryId, final String studentUuid) {
 
 		final Gradebook gradebook = getGradebook();
 
-		final Double score = this.gradebookService.calculateCategoryScore(gradebook.getId(), studentUuid, categoryId);
-		log.info("Category score for category: {}, student: {}:{}", categoryId, studentUuid, score);
+		final Optional<CategoryScoreData> result = gradebookService.calculateCategoryScore(gradebook.getId(), studentUuid, categoryId);
+		log.info("Category score for category: {}, student: {}:{}", categoryId, studentUuid, result.map(r -> r.score).orElse(null));
 
-		return score;
+		return result;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbGradeInfo.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbGradeInfo.java
@@ -48,6 +48,13 @@ public class GbGradeInfo implements Serializable, Comparable<GbGradeInfo> {
 	private boolean gradeable;
 
 	/**
+	* Whether this grade has been dropped from the category score calculation
+	*/
+	@Getter
+	@Setter
+	private boolean droppedFromCategoryScore = false;
+
+	/**
 	 * Constructor. Takes a GradeDefinition or null. If null, a stub is created.
 	 *
 	 * @param gd GradeDefinition object. May be null

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -24,7 +24,10 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.lang.StringUtils;
@@ -32,6 +35,7 @@ import org.apache.commons.validator.routines.DoubleValidator;
 import org.sakaiproject.util.ResourceLoader;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 
 @Slf4j
 public class FormatHelper {
@@ -321,5 +325,38 @@ public class FormatHelper {
 		} catch (final UnsupportedEncodingException e) {
 			throw new AssertionError("UTF-8 not supported");
 		}
+	}
+
+	/**
+	 * Returns a list of drop highest/lowest labels based on the settings of the given category.
+	 * @param category the category
+	 * @return a list of 1 or 2 labels indicating that drop highest/lowest is in use, or an empty list if not in use.
+	 */
+	public static List<String> formatCategoryDropInfo(CategoryDefinition category) {
+
+		if (category == null) {
+			return Collections.emptyList();
+		}
+
+		int dropHighest = category.getDropHighest() == null ? 0 : category.getDropHighest();
+		int dropLowest = category.getDropLowest() == null ? 0 : category.getDropLowest();
+		int keepHighest = category.getKeepHighest() == null ? 0 : category.getKeepHighest();
+
+		if (dropHighest == 0 && dropLowest == 0 && keepHighest == 0) {
+			return Collections.emptyList();
+		}
+
+		List<String> info = new ArrayList<>(2);
+		if (dropHighest > 0) {
+			info.add(MessageHelper.getString("label.category.drophighest", dropHighest));
+		}
+		if (dropLowest > 0) {
+			info.add(MessageHelper.getString("label.category.droplowest", dropLowest));
+		}
+		if (keepHighest > 0) {
+			info.add(MessageHelper.getString("label.category.keephighest", keepHighest));
+		}
+
+		return info;
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -166,6 +166,9 @@
                         {/if}
                     </span>
                 </a>
+                {for info in dropInfo}
+                <div class="gb-drop-info">${info}</div>
+                {/for}
                 <div class="btn-group">
                     <a class="btn btn-sm btn-default dropdown-toggle"
                        data-toggle="dropdown" href="#" role="button" aria-haspopup="true"

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
@@ -18,9 +18,9 @@
 					<th class="col-md-4" scope="col"><wicket:message key="column.header.studentsummary.gradebookitem" /></th>
 					<th class="col-md-2" scope="col"><wicket:message key="column.header.studentsummary.grade" /></th>
 					<th class="col-md-1" scope="col" wicket:id="weightColumnHeader"><wicket:message key="column.header.studentsummary.weight" /></th>
-					<th class="col-md-2" scope="col"><wicket:message key="column.header.studentsummary.duedate" /></th>
+					<th class="date-col" scope="col" wicket:id="dateColumnHeader"><wicket:message key="column.header.studentsummary.duedate" /></th>
 					<th class="col-md-3" scope="col"><wicket:message key="column.header.studentsummary.comments" /></th>
-					<th class="col-md-1 category-col" scope="col" wicket:id="categoryColumnHeader"><wicket:message key="column.header.studentsummary.category" /></th>
+					<th class="col-md-2 category-col" scope="col" wicket:id="categoryColumnHeader"><wicket:message key="column.header.studentsummary.category" /></th>
 				</tr>
 			</thead>
 			<wicket:container wicket:id="categoriesList">
@@ -28,8 +28,10 @@
 					<tbody class="gb-summary-category-tbody">
 						<tr wicket:id="categoryRow" class="gb-summary-category-row" wicket:message="aria-label:studentsummary.categoryrow">
 							<th scope="rowgroup">
-								<span wicket:id="category" class="gb-summary-category-name"></span>
-								<a href="javascript:void(0);" class="gb-summary-category-toggle" wicket:message="title:studentsummary.categorytoggle"></a>
+								<a href="javascript:void(0);" class="gb-summary-category-toggle" wicket:message="title:studentsummary.categorytoggle"><span wicket:id="category" class="gb-summary-category-name"></span></a>
+								<p wicket:id="categoryDropInfo" class="gb-summary-grade-category-dropInfo">
+									<span wicket:id="categoryDropInfo1">Drop Highest: 1 & </span><wbr><span wicket:id="categoryDropInfo2">Drop Lowest: 1</span>
+								</p>
 							</th>
 							<td class="gb-summary-category-grade" wicket:id="categoryGrade" wicket:message="aria-label:studentsummary.categoryaverage"></td>
 							<td class="gb-summary-category-weight weight-col" wicket:id="categoryWeight" wicket:message="aria-label:studentsummary.categoryweight"></td>
@@ -49,14 +51,18 @@
 								<span wicket:id="isExternal"></span>
 							</span>
 						</th>
-						<td class="gb-summary-grade-score">
+						<td class="gb-summary-grade-score" wicket:id="gradeScore">
 							<span class="gb-summary-grade-score-raw" wicket:id="grade" wicket:message="aria-label:studentsummary.gradebookitem.score"></span>
 							<span class="gb-summary-grade-score-outof" wicket:id="outOf" wicket:message="aria-label:studentsummary.gradebookitem.outof"></span>
 						</td>
 						<td wicket:id="weight"><!-- empty --></td>
 						<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
 						<td class="gb-summary-grade-comments"><div wicket:id="comments"></div></td>
-						<td class="gb-summary-grade-category" wicket:id="category"></td>
+						<td class="gb-summary-grade-category" wicket:id="category">
+							<div wicket:id="categoryName"></div>
+							<p wicket:id="categoryDropInfo" class="gb-summary-grade-category-col-dropInfo">Drop Highest: 1</p>
+							<p wicket:id="categoryDropInfo2" class="gb-summary-grade-category-col-dropInfo">Drop Lowest: 1</p>
+						</td>
 					</tr>
 				</tbody>
 			</wicket:container>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
@@ -34,6 +35,7 @@ import org.sakaiproject.gradebookng.business.model.GbStudentGradeInfo;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
+import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.service.gradebook.shared.GradingType;
 import org.sakaiproject.tool.gradebook.Gradebook;
@@ -103,8 +105,8 @@ public class InstructorGradeSummaryGradesPanel extends BasePanel {
 		final Map<Long, GbGradeInfo> grades = studentGradeInfo.getGrades();
 
 		// setup
-		final List<String> categoryNames = new ArrayList<String>();
-		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<String, List<Assignment>>();
+		final List<String> categoryNames = new ArrayList<>();
+		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<>();
 
 		// iterate over assignments and build map of categoryname to list of assignments
 		for (final Assignment assignment : assignments) {
@@ -113,11 +115,13 @@ public class InstructorGradeSummaryGradesPanel extends BasePanel {
 
 			if (!categoryNamesToAssignments.containsKey(categoryName)) {
 				categoryNames.add(categoryName);
-				categoryNamesToAssignments.put(categoryName, new ArrayList<Assignment>());
+				categoryNamesToAssignments.put(categoryName, new ArrayList<>());
 			}
 
 			categoryNamesToAssignments.get(categoryName).add(assignment);
 		}
+		Map<String, CategoryDefinition> categoriesMap = businessService.getGradebookCategories().stream()
+				.collect(Collectors.toMap(cat -> cat.getName(), cat -> cat));
 		Collections.sort(categoryNames);
 
 		// build the model for table
@@ -131,6 +135,7 @@ public class InstructorGradeSummaryGradesPanel extends BasePanel {
 		tableModel.put("isGroupedByCategory", this.isGroupedByCategory);
 		tableModel.put("showingStudentView", false);
 		tableModel.put("gradingType", GradingType.valueOf(gradebook.getGrade_type()));
+		tableModel.put("categoriesMap", categoriesMap);
 
 		addOrReplace(new GradeSummaryTablePanel("gradeSummaryTable", new LoadableDetachableModel<Map<String, Object>>() {
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.AttributeModifier;
@@ -33,6 +34,8 @@ import org.sakaiproject.gradebookng.business.model.GbGradeInfo;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.service.gradebook.shared.Assignment;
+import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
+import org.sakaiproject.service.gradebook.shared.CategoryScoreData;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.service.gradebook.shared.GradingType;
 import org.sakaiproject.tool.gradebook.Gradebook;
@@ -93,9 +96,10 @@ public class StudentGradeSummaryGradesPanel extends BasePanel {
 		final Map<Long, GbGradeInfo> grades = this.businessService.getGradesForStudent(userId);
 		final List<Assignment> assignments = this.businessService.getGradebookAssignmentsForStudent(userId);
 
-		final List<String> categoryNames = new ArrayList<String>();
-		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<String, List<Assignment>>();
+		final List<String> categoryNames = new ArrayList<>();
+		final Map<String, List<Assignment>> categoryNamesToAssignments = new HashMap<>();
 		final Map<Long, Double> categoryAverages = new HashMap<>();
+		Map<String, CategoryDefinition> categoriesMap = Collections.emptyMap();
 
 		// if gradebook release setting disabled, no work to do
 		if (this.isAssignmentsDisplayed) {
@@ -109,20 +113,29 @@ public class StudentGradeSummaryGradesPanel extends BasePanel {
 
 					if (!categoryNamesToAssignments.containsKey(categoryName)) {
 						categoryNames.add(categoryName);
-						categoryNamesToAssignments.put(categoryName, new ArrayList<Assignment>());
-
-						if (assignment.getCategoryId() != null) {
-							final Double categoryAverage = this.businessService.getCategoryScoreForStudent(assignment.getCategoryId(),
-									userId);
-							if (categoryAverage != null) {
-								categoryAverages.put(assignment.getCategoryId(), categoryAverage);
-							}
-						}
+						categoryNamesToAssignments.put(categoryName, new ArrayList<>());
 					}
 
 					categoryNamesToAssignments.get(categoryName).add(assignment);
 				}
 			}
+			// get the category scores and mark any dropped items
+			for (String catName : categoryNamesToAssignments.keySet()) {
+				if (catName.equals(getString(GradebookPage.UNCATEGORISED))) {
+					continue;
+				}
+
+				List<Assignment> catItems = categoryNamesToAssignments.get(catName);
+				if (!catItems.isEmpty()) {
+					Long catId = catItems.get(0).getCategoryId();
+					if (catId != null) {
+						businessService.getCategoryScoreForStudent(catId, userId)
+							.ifPresent(avg -> storeAvgAndMarkIfDropped(avg, catId, categoryAverages, grades));
+					}
+				}
+			}
+			categoriesMap = businessService.getGradebookCategoriesForStudent(userId).stream()
+				.collect(Collectors.toMap(cat -> cat.getName(), cat -> cat));
 			Collections.sort(categoryNames);
 		}
 
@@ -137,6 +150,7 @@ public class StudentGradeSummaryGradesPanel extends BasePanel {
 		tableModel.put("isGroupedByCategory", this.isGroupedByCategory);
 		tableModel.put("showingStudentView", true);
 		tableModel.put("gradingType", GradingType.valueOf(gradebook.getGrade_type()));
+		tableModel.put("categoriesMap", categoriesMap);
 
 		addOrReplace(new GradeSummaryTablePanel("gradeSummaryTable", new LoadableDetachableModel<Map<String, Object>>() {
 			@Override
@@ -183,6 +197,15 @@ public class StudentGradeSummaryGradesPanel extends BasePanel {
 	 * @return
 	 */
 	private boolean isCategoryWeightEnabled() {
-		return (this.configuredCategoryType == GbCategoryType.WEIGHTED_CATEGORY) ? true : false;
+		return configuredCategoryType == GbCategoryType.WEIGHTED_CATEGORY;
+	}
+
+	private void storeAvgAndMarkIfDropped(CategoryScoreData avg, Long catId, Map<Long, Double> categoryAverages,
+		Map<Long, GbGradeInfo> grades) {
+
+		categoryAverages.put(catId, avg.score);
+
+		grades.entrySet().stream().filter(e -> avg.droppedItems.contains(e.getKey()))
+			.forEach(entry -> entry.getValue().setDroppedFromCategoryScore(true));
 	}
 }

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -255,10 +255,11 @@ GbGradeTable.cellRenderer = function (instance, td, row, col, prop, value, cellP
   // key needs to contain all values the cell requires for render
   // otherwise it won't rerender when those values change
   var hasComment = column.type === "assignment" ? GbGradeTable.hasComment(student, column.assignmentId) : false;
+  var isDropped = column.type === "assignment" ? student.hasDroppedScores[index] === '1' : false;
   var scoreState = GbGradeTable.getCellState(row, col, instance);
   var isReadOnly = column.type === "assignment" ? GbGradeTable.isReadOnly(student, column.assignmentId) : false;
   var hasConcurrentEdit = column.type === "assignment" ? GbGradeTable.hasConcurrentEdit(student, column.assignmentId) : false;
-  var keyValues = [row, index, value, student.eid, hasComment, isReadOnly, hasConcurrentEdit, column.type, scoreState];
+  var keyValues = [row, index, value, student.eid, hasComment, isReadOnly, hasConcurrentEdit, column.type, scoreState, isDropped];
   var cellKey = GbGradeTable.cleanKey(keyValues.join("_"));
 
   var wasInitialised = $.data(td, 'cell-initialised');
@@ -419,6 +420,8 @@ GbGradeTable.cellRenderer = function (instance, td, row, col, prop, value, cellP
     $(gbNotification).removeClass("gb-flag-extra-credit");
     $cellDiv.removeClass("gb-extra-credit");
   }
+
+  $cellDiv.toggleClass("gb-dropped-grade-cell", isDropped && scoreState !== "error" && scoreState !== "invalid");
 
   if (column.type == 'category') {
     $cellDiv.addClass('gb-category-average');
@@ -1242,6 +1245,29 @@ GbGradeTable.colModelForAssignment = function(assignmentId) {
   }
   
   throw "colModelForAssignment: column not found for " + assignmentId;
+};
+
+// returns the gradebook items included in this category, as AssignmentColumn objects
+GbGradeTable.itemsInCategory = function(categoryId) {
+    return GbGradeTable.columns.filter(function(col) {
+        return col.categoryId === categoryId && col.type === "assignment";
+    });
+};
+
+GbGradeTable.updateHasDroppedScores = function(student, assignmentIndex, dropped) {
+    var hasDroppedScores = student.hasDroppedScores;
+    var flag = dropped ? '1' : '0';
+    student.hasDroppedScores = hasDroppedScores.substr(0, assignmentIndex) + flag + hasDroppedScores.substr(assignmentIndex + 1);
+};
+
+GbGradeTable.moveItemFlag = function(flagString, fromIndex, toIndex) {
+    if (fromIndex === toIndex)
+    {
+        return flagString;
+    }
+    var tmp = flagString[fromIndex];
+    var removed = flagString.substr(0, fromIndex) + flagString.substr(fromIndex + 1);
+    return removed.substr(0, toIndex) + tmp + removed.substr(toIndex);
 };
 
 GbGradeTable.hasComment = function(student, assignmentId) {
@@ -2210,9 +2236,19 @@ GbGradeTable.setupDragAndDrop = function () {
           moveColumn(GbGradeTable.grades, sourceColIndex, targetColIndex);
 
           /* And the header columns */
-          moveColumn([GbGradeTable.columns],
-                     (sourceColIndex - numberOfFixedColumns),
-                     (targetColIndex - numberOfFixedColumns));
+          var adjustedSource = sourceColIndex - numberOfFixedColumns;
+          var adjustedTarget = targetColIndex - numberOfFixedColumns;
+          moveColumn([GbGradeTable.columns], adjustedSource, adjustedTarget);
+
+          /* And the comment/concurrent/dropped flag strings in the student objects */
+          var hasCategories = GbGradeTable.settings.isCategoriesEnabled;
+          GbGradeTable.students.forEach(function(student) {
+              if (hasCategories) {
+                  student.hasDroppedScores = GbGradeTable.moveItemFlag(student.hasDroppedScores, adjustedSource, adjustedTarget);
+              }
+              student.hasComments = GbGradeTable.moveItemFlag(student.hasComments, adjustedSource, adjustedTarget);
+              student.hasConcurrentEdit = GbGradeTable.moveItemFlag(student.hasConcurrentEdit, adjustedSource, adjustedTarget);
+          });
 
           GbGradeTable.redrawTable(true);
         };
@@ -2836,7 +2872,7 @@ GbGradeTable.syncCourseGrade = function(studentId, courseGradeData) {
 };
 
 
-GbGradeTable.syncCategoryAverage = function(studentId, categoryId, categoryScore) {
+GbGradeTable.syncCategoryAverage = function(studentId, categoryId, categoryScore, droppedItems) {
     var categoryScoreAsLocaleString = GbGradeTable.localizeNumber(categoryScore);
 
     // update table
@@ -2851,6 +2887,16 @@ GbGradeTable.syncCategoryAverage = function(studentId, categoryId, categoryScore
     var modelRow = GbGradeTable.modelIndexForStudent(studentId);
     var modelCol = $.inArray(GbGradeTable.colModelForCategoryId(categoryId), GbGradeTable.columns);
     GbGradeTable.grades[modelRow][modelCol + GbGradeTable.FIXED_COLUMN_OFFSET] = categoryScore;
+
+    // update dropped status of all items in this category
+    var categoryItems = GbGradeTable.itemsInCategory(categoryId);
+    categoryItems.forEach(function(col) {
+        var dropped = droppedItems.indexOf(col.assignmentId) > -1;
+        var columnIndex = GbGradeTable.colForAssignment(col.assignmentId);
+        var student = GbGradeTable.modelForStudent(studentId);
+        GbGradeTable.updateHasDroppedScores(student, columnIndex - GbGradeTable.FIXED_COLUMN_OFFSET, dropped);
+        GbGradeTable.redrawCell(tableRow, columnIndex);
+    });
 };
 
 
@@ -2901,7 +2947,7 @@ GbGradeTable.setScore = function(studentId, assignmentId, oldScore, newScore) {
 
         // update the category average cell
         if (assignment.categoryId) {
-          GbGradeTable.syncCategoryAverage(studentId, assignment.categoryId, data.categoryScore);
+          GbGradeTable.syncCategoryAverage(studentId, assignment.categoryId, data.categoryScore, data.categoryDroppedItems);
         }
 
         GbGradeTable.syncScore(studentId, assignmentId, newScore);

--- a/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
@@ -164,7 +164,8 @@
 }
 #gradeTableWrapper .gb-grade-section,
 #gradeTableWrapper .gb-due-date,
-#gradeTableWrapper .gb-category {
+#gradeTableWrapper .gb-category,
+#gradeTableWrapper .gb-drop-info {
   text-align: left;
   font-size: 0.9em;
   line-height: 1.3em;
@@ -359,6 +360,15 @@
   font-family: "gradebook-icons";
   content: '\f040';
   color: rgb(204,0,0);
+}
+#gradeTableWrapper .handsontable tbody tr td .gb-dropped-grade-cell,
+#gradeTableWrapper .handsontable tbody tr:nth-child(2n) td .gb-dropped-grade-cell,
+#gradeTableWrapper .handsontable tbody tr:nth-child(2n) td .relative .gb-dropped-grade-cell {
+  background-image: repeating-linear-gradient(135deg, #eee, #eee 5px, #fff 5px, #fff 10px);
+  background-clip: padding-box;
+}
+#gradeTableWrapper .handsontable tbody tr td .gb-dropped-grade-cell .gb-value {
+  text-decoration: line-through;
 }
 
 /* Cell Metadata Summary */

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -418,7 +418,7 @@ div.wicket-modal div.w_right > div {
 .gb-summary-grade-panel .gb-summary-category-toggle:hover,
 .gb-summary-grade-panel .gb-summary-category-toggle:active {
   text-decoration: none;
-  float: left;
+  display: flex;
 }
 .gb-summary-grade-title {
   font-weight: normal;
@@ -426,7 +426,9 @@ div.wicket-modal div.w_right > div {
 .gb-summary-grade-panel .gb-summary-category-toggle:before {
   font-family: 'gradebook-icons';
   content: '\f078';
-  padding-right: 4px;
+  padding-right: 5px;
+  width: 24px;
+  text-align: center;
 }
 .gb-summary-grade-panel .gb-summary-category-toggle.collapsed:before {
   content: '\f054';
@@ -520,3 +522,36 @@ div.wicket-modal div.w_right > div {
 {
   text-align: left;
 }
+
+.gb-summary-grade-score-dropped
+{
+  background-image: repeating-linear-gradient(135deg, #eee, #eee 5px, #fff 5px, #fff 10px);
+  position: relative;
+}
+
+.gb-summary-grade-score-dropped .gb-summary-grade-score-raw
+{
+  text-decoration: line-through;
+}
+
+.gb-summary-grade-category-dropInfo
+{
+  font-size: 0.9em;
+  color: #999999;
+  font-weight: normal;
+  margin: 0 0 0 24px;
+}
+
+.gb-summary-grade-category-dropInfo span
+{
+  white-space: nowrap;
+}
+
+.gb-summary-grade-category-col-dropInfo
+{
+  font-size: 0.9em;
+  color: #999999;
+  font-weight: normal;
+  margin: 0;
+}
+


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33108

Basic implementation overview:

The student data sent to the client now has a string of flags to
indicate which cells are marked as dropped (this mirrors the string of
flags used to indicate which cells have comments).

Retrieving the category score now also retrieves a list of gradebook
  items that were dropped from the calculation because of the
  category's drop highest/lowest settings. This list is used to set the
  flags on the student.

When a cell is rendered on the client, it checks the flags and if it
finds the cell was dropped, it is given a particular css class.

When a cell is updated and the category score is recalculated, the drop
state for each cell in that category (for this student only) is
re-evaluated and the cells are redrawn to reflect the new state.

This PR also incorporates a fix for an issue with drag and drop column re-ordering
where the comment indicators would not move along with their respective
cell contents after the drag and drop.