### PR TITLE
SAK-39983 add sonarcloud reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ cache:
 before_cache:
  - find $HOME/.m2/repository/org/sakaiproject -name \*-SNAPSHOT.\*  -delete
 
+# connect SonarCloud
 addons:
   sonarcloud:
     organization: "sakai-sandbox"
     token:
       secure: "x59elKsea0HAOMrRnxSkP3hAVG+d5eZaxjm/s9Q9tKXxZMeUo+bsxuxmbt+yGeyyj8sMeN3Wce1i0lNbnGlyBFZF7gSefimHvOM72pCv9oqBwm+MAyGqd+bBMX+ctWq9jAkz7uxRVbRnt0tHqow/ZJa4C4UXoRnNOV1SFq1sG0vJV5aSX6CAsYn42rGt0PxPT71FFl+T7XTlFcQClPJ/z92OwcykKtVq1RYL9c/jjTXoj43/KXCRhMUZixHnuko1/NBBUWlrDJjkW09QE0GnDEeHbq0gnt2A0Mvu5Qb6GNeX4XkovV2mqbpR8s84XjdFgdg3iUtDDfL12M6wuGaTDOH1x/PEx3m/Oz47FQ2o7bADGnJ4cTPzJPmqvwm6Y+iSACXNhr1lh8EKt5+F2iJ5wROuNlONOfTOrJrYKWPqiczPE0DMsAiZUagG+WfMNgXOlNJc0NklsTGN9OI5w/LKcn25UoMd+MwpWvCWtfm169i8SliI+tbYcB7JerV56XU76xn9fGWBqovOx/RIvENGgTQ5A1LkonfCvE50R/r8BshYZouBCFn6/t1SImgae7Xnpx9vsYh7wdLXJSL7B/+iAa8+MWoKFmz4+SGlqmTLVpxXhZi3lVJR2vzMrQZmXXsK1IPp4ox8zDLgjIzImJlW7bHqsuT5uTq0wLUynxiG6mc="
 script:
+  # this is what we want Travis to do
   - mvn clean install org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,11 @@ cache:
 # This makes the cache smaller and helps highlight problems with a clean build
 before_cache:
  - find $HOME/.m2/repository/org/sakaiproject -name \*-SNAPSHOT.\*  -delete
+
+addons:
+  sonarcloud:
+    organization: "sakai-sandbox"
+    token:
+      secure: "x59elKsea0HAOMrRnxSkP3hAVG+d5eZaxjm/s9Q9tKXxZMeUo+bsxuxmbt+yGeyyj8sMeN3Wce1i0lNbnGlyBFZF7gSefimHvOM72pCv9oqBwm+MAyGqd+bBMX+ctWq9jAkz7uxRVbRnt0tHqow/ZJa4C4UXoRnNOV1SFq1sG0vJV5aSX6CAsYn42rGt0PxPT71FFl+T7XTlFcQClPJ/z92OwcykKtVq1RYL9c/jjTXoj43/KXCRhMUZixHnuko1/NBBUWlrDJjkW09QE0GnDEeHbq0gnt2A0Mvu5Qb6GNeX4XkovV2mqbpR8s84XjdFgdg3iUtDDfL12M6wuGaTDOH1x/PEx3m/Oz47FQ2o7bADGnJ4cTPzJPmqvwm6Y+iSACXNhr1lh8EKt5+F2iJ5wROuNlONOfTOrJrYKWPqiczPE0DMsAiZUagG+WfMNgXOlNJc0NklsTGN9OI5w/LKcn25UoMd+MwpWvCWtfm169i8SliI+tbYcB7JerV56XU76xn9fGWBqovOx/RIvENGgTQ5A1LkonfCvE50R/r8BshYZouBCFn6/t1SImgae7Xnpx9vsYh7wdLXJSL7B/+iAa8+MWoKFmz4+SGlqmTLVpxXhZi3lVJR2vzMrQZmXXsK1IPp4ox8zDLgjIzImJlW7bHqsuT5uTq0wLUynxiG6mc="
+script:
+  - mvn clean install org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar


### PR DESCRIPTION
See https://jira.sakaiproject.org/browse/SAK-39983

This adds the sakai code to sonarcloud via the sakai-sandbox org. Unfortunately I need this in master in order to troubleshoot anything as it must have a master analysis before it can do it on branches.

Once this is finalised I will switch it over to the main sakai org in sonarcloud.