### PR TITLE
SAK-33385 GBNG include selected group filter in export file name

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -196,6 +196,8 @@ importExport.instructions.1 = Student ID and Student Name are the first two colu
 importExport.instructions.2 = Gradebook Items may include points by wrapping the points in [ ] after the title, e.g. "Assignment 1 [50]".
 importExport.instructions.3 = Comments can be imported by prefixing the column with a *, e.g. "* Assignment 1".
 importExport.instructions.4 = Columns that cannot be re-imported are prefixed with #.
+importExport.download.filenameprefix = gradebook_export
+importExport.download.filenameallsuffix = ALL
 
 importExport.import.heading = Import
 importExport.import.description = Selectively import new grades or gradebook items by uploading a spreadsheet (.csv, .xls, and .xlsx formats) below.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -47,6 +47,7 @@ import org.sakaiproject.gradebookng.tool.panels.BasePanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.util.FormattedText;
+import org.sakaiproject.util.Validator;
 
 public class ExportPanel extends BasePanel {
 
@@ -437,10 +438,11 @@ public class ExportPanel extends BasePanel {
 
 		// If group/section filter is selected, add group title to filename
 		} else if (this.group != null && this.group.getId() != null && StringUtils.isNotBlank(this.group.getTitle())) {
-			final String sanitizedGroupName = this.group.getTitle().replaceAll("[^A-Za-z0-9]", "_");
-			fileNameComponents.add(sanitizedGroupName);
+			fileNameComponents.add(this.group.getTitle());
 		}
 
-		return String.format("%s.%s", fileNameComponents.stream().collect(Collectors.joining("-")), extension);
+		final String cleanFilename = Validator.cleanFilename(fileNameComponents.stream().collect(Collectors.joining("-")));
+
+		return String.format("%s.%s", cleanFilename, extension);
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -76,7 +76,7 @@ public class ExportPanel extends BasePanel {
 	boolean includeGradeOverride = false;
 	GbGroup group;
 
-	Component customDownloadLink;
+	private Component customDownloadLink;
 
 	public ExportPanel(final String id) {
 		super(id);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -22,8 +22,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
@@ -72,6 +74,8 @@ public class ExportPanel extends BasePanel {
 	boolean includeCalculatedGrade = false;
 	boolean includeGradeOverride = false;
 	GbGroup group;
+
+	Component customDownloadLink;
 
 	public ExportPanel(final String id) {
 		super(id);
@@ -224,6 +228,11 @@ public class ExportPanel extends BasePanel {
 				} else {
 					ExportPanel.this.group = (GbGroup) ((DropDownChoice) getComponent()).getDefaultModelObject();
 				}
+				// Rebuild the custom download link so it has a filename including the selected group
+				Component updatedCustomDownloadLink = buildCustomDownloadLink();
+				ExportPanel.this.customDownloadLink.replaceWith(updatedCustomDownloadLink);
+				ExportPanel.this.customDownloadLink = updatedCustomDownloadLink;
+				target.add(ExportPanel.this.customDownloadLink);
 			}
 		}));
 
@@ -235,9 +244,15 @@ public class ExportPanel extends BasePanel {
 				return buildFile(false);
 			}
 
-		}, buildFileName()).setCacheDuration(Duration.NONE).setDeleteAfterDownload(true));
+		}, buildFileName(false)).setCacheDuration(Duration.NONE).setDeleteAfterDownload(true));
 
-		add(new DownloadLink("downloadCustomGradebook", new LoadableDetachableModel<File>() {
+
+		this.customDownloadLink = buildCustomDownloadLink();
+		add(this.customDownloadLink);
+	}
+
+	private Component buildCustomDownloadLink() {
+		return new DownloadLink("downloadCustomGradebook", new LoadableDetachableModel<File>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -245,7 +260,7 @@ public class ExportPanel extends BasePanel {
 				return buildFile(true);
 			}
 
-		}, buildFileName()).setCacheDuration(Duration.NONE).setDeleteAfterDownload(true));
+		}, buildFileName(true)).setCacheDuration(Duration.NONE).setDeleteAfterDownload(true).setOutputMarkupId(true);
 	}
 
 	private File buildFile(final boolean isCustomExport) {
@@ -401,16 +416,31 @@ public class ExportPanel extends BasePanel {
 		return tempFile;
 	}
 
-	private String buildFileName() {
-		final String prefix = "gradebook_export";
-		final String extension = this.exportFormat.toString().toLowerCase();
-		String gradebookName = this.businessService.getGradebook().getName();
 
-		if (StringUtils.trimToNull(gradebookName) == null) {
-			return String.format("%s.%s", gradebookName, extension);
-		} else {
-			gradebookName = gradebookName.replaceAll("\\s", "_");
-			return String.format("%s-%s.%s", prefix, gradebookName, extension);
+	private String buildFileName(final boolean customDownload) {
+		final String prefix = getString("importExport.download.filenameprefix");
+		final String extension = this.exportFormat.toString().toLowerCase();
+		final String gradebookName = this.businessService.getGradebook().getName();
+
+		// File name contains the prefix
+		final List<String> fileNameComponents = new ArrayList<>();
+		fileNameComponents.add(prefix);
+
+		// Add gradebook name/site id to filename
+		if (StringUtils.trimToNull(gradebookName) != null) {
+			fileNameComponents.add(gradebookName.replaceAll("\\s", "_"));
 		}
+
+		// If custom download for all sections, append 'ALL' to filename
+		if (customDownload && (this.group == null || this.group.getId() == null)) {
+			fileNameComponents.add(getString("importExport.download.filenameallsuffix"));
+
+		// If group/section filter is selected, add group title to filename
+		} else if (this.group != null && this.group.getId() != null && StringUtils.isNotBlank(this.group.getTitle())) {
+			final String sanitizedGroupName = this.group.getTitle().replaceAll("[^A-Za-z0-9]", "_");
+			fileNameComponents.add(sanitizedGroupName);
+		}
+
+		return String.format("%s.%s", fileNameComponents.stream().collect(Collectors.joining("-")), extension);
 	}
 }

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/Validator.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/Validator.java
@@ -96,6 +96,8 @@ public class Validator
 	/** Valid special email local id characters (- those that are invalid resource ids) */
 	protected static final String VALID_EMAIL = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ!#$&'*+-=?^_`{|}~.";
 
+	protected static final String INVALID_CHARS_IN_FILENAME = "[\\/:\"*?<>|]+";
+
 	/**
 	 * Escape a plaintext string so that it can be output as part of an HTML document. Amperstand, greater-than, less-than, newlines, etc, will be escaped so that they display (instead of being interpreted as formatting).
 	 * 
@@ -922,5 +924,31 @@ public class Validator
 		}
 		if ( sb.length() < 1 ) return null;
 		return sb.substring(0, sb.length()-1);
+	}
+
+	/**
+	 * Return a safe filename by replacing all whitespace and invalid characters
+	 *
+	 * @param filename
+	 *        The string to clean
+	 * @return safe filename string
+	 */
+	public static String cleanFilename(String filename) {
+		// replace all whitespace
+		String cleanFilename = filename.replaceAll("\\s", "_");
+
+		// replace all invalid characters
+		final int len = cleanFilename.length();
+		StringBuilder buf = new StringBuilder();
+		for (int i = 0; i < len; i++) {
+			char c = cleanFilename.charAt(i);
+			if (INVALID_CHARS_IN_FILENAME.indexOf(c) != -1) {
+				buf.append("_");
+			} else {
+				buf.append(c);
+			}
+		}
+
+		return buf.toString();
 	}
 }


### PR DESCRIPTION
Reworks the generation of the filename for GBNG Custom Export CSVs based on the requests in https://jira.sakaiproject.org/browse/SAK-33385.  Namely, when "All Sections/Groups" is selected, the file will now be `<prefix>-<site id>-ALL.csv` and `<prefix>-<site id>-<group name>.csv` when a filter is applied.

Also, the prefix  and "ALL" used in the filename are now added to the translations so they can be more easily tweaked.