### PR TITLE
SAK-38337 explain role switch to assisted users

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
@@ -35,8 +35,8 @@ $PBJQ(document).ready(function(){
     };
 
     // Setup the initial ARIA attributes
-    $PBJQ('#roleSwitchDropDownToggle').attr('aria-hidden', 'false');
-    $PBJQ('#roleSwitchDropDown').attr('aria-hidden', 'true').attr('aria-label', 'submenu');
+    $PBJQ('#roleSwitchDropDownToggle').attr('aria-hidden', 'false').attr('aria-haspopup', 'true');
+    $PBJQ('#roleSwitchDropDown').attr('aria-hidden', 'true');
 
     $PBJQ('#roleSwitchDropDownToggle').click( function(){
       $PBJQ('#roleSwitchDropDown').css('right', $PBJQ(window).width() - 20 - ($PBJQ('#roleSwitchDropDownToggle').offset().left + $PBJQ('#roleSwitchDropDownToggle').width()));
@@ -62,7 +62,7 @@ $PBJQ(document).ready(function(){
 
   $PBJQ('#roleSwitchSelect').on("change", function(){
     if( $PBJQ('option:selected', this ).text() !== '' ){
-      document.location = $PBJQ('option:selected', this ).val();
+      document.location = $PBJQ('option:selected', this ).val() + '#roleSwitch';
     }else{
       $PBJQ(this)[0].selectedIndex = 0;
     }

--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -83,6 +83,7 @@ rs_exitRoleSwapWithRole = Exit View
 rs_viewSiteAs = View Site As:
 rs_selectRole = - Select Role -
 rs_menuTooltip = Show View options
+rs_menuExplanation = Visit site as a different role. Role selection will reload page as new role. Use 'Exit View' link to return to normal role.
 
 bread_separator = >
 

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/roleSwitch-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/roleSwitch-snippet.vm
@@ -6,14 +6,14 @@
             <span class="Mrphs-toolsNav__menuitem--title">$rloader.getFormattedMessage("rs_exitRoleSwapWithRole", $roleUrlValue)</span>
         </a>
     #else
-        <a id="roleSwitchDropDownToggle" href="javascript:void('0')" aria-hidden='true' aria-haspopup="true" title='${rloader.rs_menuTooltip}'>
+        <a id="roleSwitchDropDownToggle" href="javascript:void('0')" aria-hidden="true" aria-haspopup="false" title="${rloader.rs_menuTooltip}" aria-label="${rloader.rs_menuTooltip}">
             <i class="fa fa-user-secret" aria-hidden="true"></i>
         </a>
         <div id="roleSwitchDropDown">
             <i class="fa fa-user-secret" aria-hidden="true"></i>
             #if ($roleswapdropdown)
             <div class="Mrphs-roleSwitch__anchor">
-                <select id="roleSwitchSelect" class="Mrphs-roleSwitch__dropdown">
+                <select id="roleSwitchSelect" class="Mrphs-roleSwitch__dropdown" aria-label="${rloader.rs_menuExplanation}">
                     <option value="" selected="selected">${rloader.rs_viewSiteAs}</option>
                 #foreach ( $role in $siteRoles )
                     <option value="$switchRoleUrl$role$panelString">$role</option>


### PR DESCRIPTION
A few explanations:

1) aria-label: submenu isn't descriptive so remove
2) aria-haspopup: only set if we are in mobile mode
3) Try to return focus back to #roleSwitch 
4) aria-label: explain the select box 