### PR TITLE
SAK-39994: assignments > assign grade to participants without a grade, decimals multiplied by 100 (display issue)

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -12613,9 +12613,9 @@ public class AssignmentAction extends PagedResourceActionII {
 
                 // Only record the default grade setting for no-submission if there were no errors produced
                 if (state.getAttribute(STATE_MESSAGE) == null) {
-                    grade = scalePointGrade(state, grade, a.getScaleFactor());
 
                     try {
+                        // Save value as input by user, not scaled
                         a.getProperties().put(GRADE_NO_SUBMISSION_DEFAULT_GRADE, grade);
                         assignmentService.updateAssignment(a);
                     } catch (PermissionException e) {
@@ -12626,6 +12626,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
 
             if (grade != null && state.getAttribute(STATE_MESSAGE) == null) {
+                grade = scalePointGrade(state, grade, a.getScaleFactor());
+
                 // get the user list
                 String aRef = AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference();
                 List<AssignmentSubmission> submissions = getFilteredSubmitters(state, aRef);
@@ -12692,9 +12694,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
                 // Only record the default grade setting for no-submission if there were no errors produced
                 if (state.getAttribute(STATE_MESSAGE) == null) {
-                    grade = scalePointGrade(state, grade, a.getScaleFactor());
-
                     try {
+                        // Save value as input by user, not scaled
                         a.getProperties().put(GRADE_NO_SUBMISSION_DEFAULT_GRADE, grade);
                         assignmentService.updateAssignment(a);
                     } catch (PermissionException e) {
@@ -12705,6 +12706,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
 
             if (grade != null && state.getAttribute(STATE_MESSAGE) == null) {
+                grade = scalePointGrade(state, grade, a.getScaleFactor());
+
                 // get the submission list
                 String aRef = AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference();
                 List<AssignmentSubmission> submissions = getFilteredSubmitters(state, aRef);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39994

In assignments, when you use the "Assign this grade to participants without a grade" feature and assign a decimal value, the grades are applied correctly, but the "Assign this grade..." text field is re-populated with the input value multiplied by 100.