### PR TITLE
SAK-34181: Statistics / part dropdown list concatenates..

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/HistogramScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/HistogramScoresBean.java
@@ -1057,7 +1057,7 @@ publishedId = ppublishedId;
         String poolStr = ", " + ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.EvaluationMessages","pool") + ": ";
         for(PublishedSectionData section: assesmentParts){
             StringBuilder text = new StringBuilder();
-        	text.append(partStr + String.valueOf(section.getSequence()));
+            text.append(partStr + String.valueOf(section.getSequence()));
             if(!defaultStr.equals(section.getTitle())){
                 text.append(": " + section.getTitle());
             }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/HistogramScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/HistogramScoresBean.java
@@ -1055,9 +1055,9 @@ publishedId = ppublishedId;
         String defaultStr = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.CommonMessages","default");
         String partStr = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.EvaluationMessages","part") + " ";
         String poolStr = ", " + ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.EvaluationMessages","pool") + ": ";
-        StringBuilder text = new StringBuilder();
         for(PublishedSectionData section: assesmentParts){
-            text.append(partStr + String.valueOf(section.getSequence()));
+            StringBuilder text = new StringBuilder();
+        	text.append(partStr + String.valueOf(section.getSequence()));
             if(!defaultStr.equals(section.getTitle())){
                 text.append(": " + section.getTitle());
             }


### PR DESCRIPTION
..the current and previous item progressively


Fixed by clearing the stringbuilder before creating the next item's display string.

I originally wanted to fix this in 11.4/11.x because that's what we use; but it looks like the file hasn't been altered since at least 11.4, so it should be possible to cherry-pick it 1:1 into older branches.