### PR TITLE
SAK-40012 Remove the longDataSource

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/db/impl/BasicSqlService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/db/impl/BasicSqlService.java
@@ -75,9 +75,6 @@ public abstract class BasicSqlService implements SqlService
 	/** The "shared", "common" database connection pool */
 	protected DataSource defaultDataSource;
 
-	/** The "slow" connection pool for file uploads/downloads */
-	protected DataSource longDataSource;
-
 	/** Should we do a commit after a single statement read? */
 	protected boolean m_commitAfterRead = false;
 
@@ -2451,20 +2448,6 @@ public abstract class BasicSqlService implements SqlService
 		}
 
 		this.defaultDataSource = defaultDataSource;
-	}
-
-	/**
-	 * @param slowDataSource
-	 *        The slowDataSource to set.
-	 */
-	public void setLongDataSource(DataSource slowDataSource)
-	{
-		if (log.isDebugEnabled())
-		{
-			log.debug("setLongDataSource(DataSource " + slowDataSource + ")");
-		}
-
-		this.longDataSource = slowDataSource;
 	}
 
 	/**

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
@@ -19,11 +19,7 @@
 		<property name="defaultDataSource">
 			<ref bean="javax.sql.DataSource" />
 		</property>
-		
-		<property name="longDataSource">
-			<ref bean="javax.sql.LongDataSource" />
-		</property>
-		
+
 		<property name="autoDdl">
 			<value>${auto.ddl}</value>
 		</property>
@@ -420,11 +416,6 @@
        because it keeps the connection from being opened and held if it is not needed -->
     <bean id="javax.sql.LazyDataSource" class="org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy">
        <property name="targetDataSource"><ref bean="javax.sql.DataSource" /></property>
-    </bean>
-
-    <!-- The "slow" connection pool for streaming downloads from db -->
-    <bean id="javax.sql.LongDataSource"
-            parent="javax.sql.BaseDataSource">
     </bean>
 
 	<!--  The "Global" Hibernate Session Factory -->


### PR DESCRIPTION
This used to be used to separate file uploads/downloads from using all the connections in the pool, but it isn’t used any more and can be removed.