### PR TITLE
SAK-39978: Develop an empty state for Gradebook to better orientate and guide user

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -497,7 +497,7 @@ permissionspage.update.dupes=Note: One or more duplicate permissions were detect
 
 
 no-assignments.label = There are no Gradebook items
-no-students.label = There are no students with Gradebook items
+no-students.label = There are no students to display
 
 gradebookpage.uncategorised = Uncategorized
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -5,8 +5,6 @@
 
 <wicket:extend>
   <form wicket:id="form" id="gradebookSpreadsheet">
-    <div wicket:id="noAssignments" class="messageInformation"><wicket:message key="no-assignments.label" /></div>
-    <div wicket:id="noStudents" class="messageInformation"><wicket:message key="no-students.label" /></div>
     <div id="gbConnectionTimeoutFeedback" class="messageWarning" style="display:none;">
         <wicket:message key="feedback.connectiontimeout" />
     </div>
@@ -14,79 +12,92 @@
         <wicket:message key="feedback.reordercolumnsfailed" />
     </div>
 
-    <div class="row">
-        <div class="col-sm-12">
-            <div class="col-sm-6">
-                <button wicket:id="addGradeItem" class="button_color gb-add-gradebook-item-button">
-                    <wicket:message key="button.addgradeitem" />
-                </button>
-
-                <div wicket:id="liveGradingFeedback" class="gb-live-feedback"></div>
-            </div>
-            <div class="col-sm-6 text-right">
-                <wicket:enclosure>
-                    <label for="filterByGroup" class="sr-only"><wicket:message key="filter.groups" /></label>
-                    <select id="filterByGroup" wicket:id="groupFilter">
-                        <option value="1">Section 1</option>
-                        <option value="2">Section 2</option>
-                    </select>
-                </wicket:enclosure>
-                <a wicket:id="captionToggle" href="javascript:void(0);" id="captionToggle" aria-popup="true" aria-controls="gradeTableCaption">
-                    <span class="sr-only">
-                        <wicket:message key="label.toolbar.togglehelp"/>
-                    </span>
-                </a>
-            </div>
-        </div>
-    </div>
-
     <div wicket:id="addOrEditGradeItemWindow" />
     <div wicket:id="studentGradeSummaryWindow" />
     <div wicket:id="updateUngradedItemsWindow" />
-	<div wicket:id="gradeLogWindow" />
-	<div wicket:id="gradeCommentWindow" />
-	<div wicket:id="deleteItemWindow" />
-	<div wicket:id="gradeStatisticsWindow" />
-	<div wicket:id="updateCourseGradeDisplayWindow" />
-	<div wicket:id="sortGradeItemsWindow" />
-	<div wicket:id="courseGradeStatisticsWindow" />
+    <div wicket:id="gradeLogWindow" />
+    <div wicket:id="gradeCommentWindow" />
+    <div wicket:id="deleteItemWindow" />
+    <div wicket:id="gradeStatisticsWindow" />
+    <div wicket:id="updateCourseGradeDisplayWindow" />
+    <div wicket:id="sortGradeItemsWindow" />
+    <div wicket:id="courseGradeStatisticsWindow" />
 
-    <div wicket:id="toolbar" id="gradebookGradesToolbar" class="btn-toolbar">
-      <ul class="gb-toolbar-left">
-        <wicket:enclosure>
-            <li>
-                <div class="gb-student-filter">
-                    <label for="studentFilterInput" class="sr-only"><wicket:message key="filter.students"/></label>
-                    <input type="text" id="studentFilterInput" class="form-control" aria-controls="gradeTable" wicket:id="studentFilter" wicket:message="placeholder:filter.students" accesskey="f">
-                    <a class="gb-student-filter-clear-button" wicket:message="title:filter.studentsclear" href="javascript:void(0)">
-                        <i class="fa fa-times-circle" aria-hidden="true"></i>
+    <div wicket:id="gradeTableArea">
+        <div wicket:id="noAssignments" class="gb-noGbItems">
+            <i class="fa fa-fw fa-table" aria-hidden="true"></i>
+            <wicket:message key="no-assignments.label" />
+            <div class="act">
+                <button wicket:id="addGradeItem2" class="active gb-add-gradebook-item-button">
+                    <wicket:message key="button.addgradeitem" />
+                </button>
+            </div>
+        </div>
+
+        <div class="row gradesToolbar1">
+            <div class="col-sm-12">
+                <div class="col-sm-6">
+                    <button wicket:id="addGradeItem" class="button_color gb-add-gradebook-item-button">
+                        <wicket:message key="button.addgradeitem" />
+                    </button>
+                    <div wicket:id="liveGradingFeedback" class="gb-live-feedback"></div>
+                </div>
+                <div class="col-sm-6 text-right">
+                    <wicket:enclosure>
+                        <label for="filterByGroup" class="sr-only"><wicket:message key="filter.groups" /></label>
+                        <select id="filterByGroup" wicket:id="groupFilter">
+                            <option value="1">Section 1</option>
+                            <option value="2">Section 2</option>
+                        </select>
+                    </wicket:enclosure>
+                    <a wicket:id="captionToggle" href="javascript:void(0);" id="captionToggle" aria-popup="true" aria-controls="gradeTableCaption">
+                        <span class="sr-only">
+                            <wicket:message key="label.toolbar.togglehelp"/>
+                        </span>
                     </a>
                 </div>
-            </li>
-        </wicket:enclosure>
-        <wicket:enclosure>
-            <li><span wicket:id="groupFilterOnlyOne" class="gb-group-title" role="status">Section 001</span></li>
-        </wicket:enclosure>
-        <li class="gb-student-summary"><!-- Populated by JavaScript --></li>
-      </ul>
-      <ul class="gb-toolbar-right">
-        <li class="gb-grade-item-summary"><!-- Populated by JavaScript --></li>
-        <li>
-          <button wicket:id="toggleGradeItemsToolbarItem" id="toggleGradeItemsToolbarItem" class="button" aria-popup="true" aria-controls="gradeItemsTogglePanel"><wicket:message key="label.toolbar.toggleitems"/></button>
-        </li>
-        <li>
-          <button wicket:id="sortGradeItemsToolbarItem" id="sortGradeItemsToolbarItem" class="button" aria-popup="true"><wicket:message key="label.toolbar.sortgradeitems"/></button>
-        </li>
-        <wicket:enclosure>
-            <li>
-              <button wicket:id="toggleCategoriesToolbarItem" id="toggleCategoriesToolbarItem" class="button" aria-controls="gradeTable"><wicket:message key="label.toolbar.togglecategories"/></button>
-            </li>
-        </wicket:enclosure>
-      </ul>
-    </div>
+            </div>
+        </div>
 
-    <!-- Here we go... -->
-    <div wicket:id="gradeTable" />
+        <div wicket:id="toolbar" id="gradebookGradesToolbar" class="btn-toolbar gradesToolbar2">
+            <ul class="gb-toolbar-left">
+                <wicket:enclosure>
+                <li>
+                    <div class="gb-student-filter">
+                        <label for="studentFilterInput" class="sr-only"><wicket:message key="filter.students"/></label>
+                        <input type="text" id="studentFilterInput" class="form-control" aria-controls="gradeTable" wicket:id="studentFilter" wicket:message="placeholder:filter.students" accesskey="f">
+                        <a class="gb-student-filter-clear-button" wicket:message="title:filter.studentsclear" href="javascript:void(0)">
+                            <i class="fa fa-times-circle" aria-hidden="true"></i>
+                        </a>
+                    </div>
+                </li>
+                </wicket:enclosure>
+                <wicket:enclosure>
+                <li><span wicket:id="groupFilterOnlyOne" class="gb-group-title" role="status">Section 001</span></li>
+                </wicket:enclosure>
+                <li class="gb-student-summary"><!-- Populated by JavaScript --></li>
+            </ul>
+            <ul wicket:id="gbToolbarColumnTools" class="gb-toolbar-right">
+                <li class="gb-grade-item-summary"><!-- Populated by JavaScript --></li>
+                <li>
+                    <button wicket:id="toggleGradeItemsToolbarItem" id="toggleGradeItemsToolbarItem" class="button" aria-popup="true" aria-controls="gradeItemsTogglePanel"><wicket:message key="label.toolbar.toggleitems"/></button>
+                </li>
+                <li>
+                    <button wicket:id="sortGradeItemsToolbarItem" id="sortGradeItemsToolbarItem" class="button" aria-popup="true"><wicket:message key="label.toolbar.sortgradeitems"/></button>
+                </li>
+                <wicket:enclosure>
+                <li>
+                    <button wicket:id="toggleCategoriesToolbarItem" id="toggleCategoriesToolbarItem" class="button" aria-controls="gradeTable"><wicket:message key="label.toolbar.togglecategories"/></button>
+                </li>
+                </wicket:enclosure>
+            </ul>
+        </div>
+
+        <div class="gradeTableOuterWrapper">
+            <div wicket:id="gradeTable" />
+            <div wicket:id="noStudents" class="gb-noStudents"><wicket:message key="no-students.label" /></div>
+        </div>
+    </div>
 
   </form>
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -106,7 +106,7 @@ public class GradebookPage extends BasePage {
 	GbModalWindow courseGradeStatisticsWindow;
 
 	Label liveGradingFeedback;
-	boolean hasAssignmentsAndGrades;
+	boolean hasGradebookItems, hasStudents;
 	private static final AttributeModifier DISPLAY_NONE = new AttributeModifier("style", "display: none");
 
 	Form<Void> form;
@@ -114,6 +114,8 @@ public class GradebookPage extends BasePage {
 	List<PermissionDefinition> permissions = new ArrayList<>();
 	boolean showGroupFilter = true;
 	private GbGradeTable gradeTable;
+
+	private final WebMarkupContainer tableArea;
 
 	@SuppressWarnings({ "rawtypes", "unchecked", "serial" })
 	public GradebookPage() {
@@ -195,25 +197,6 @@ public class GradebookPage extends BasePage {
 		this.courseGradeStatisticsWindow.setPositionAtTop(true);
 		this.form.add(this.courseGradeStatisticsWindow);
 
-		final GbAjaxButton addGradeItem = new GbAjaxButton("addGradeItem") {
-			@Override
-			public void onSubmit(final AjaxRequestTarget target, final Form form) {
-				final GbModalWindow window = getAddOrEditGradeItemWindow();
-				window.setTitle(getString("heading.addgradeitem"));
-				window.setComponentToReturnFocusTo(this);
-				window.setContent(new AddOrEditGradeItemPanel(window.getContentId(), window, null));
-				window.show(target);
-			}
-
-			@Override
-			public boolean isVisible() {
-				return (businessService.isUserAbleToEditAssessments());
-			}
-		};
-		addGradeItem.setDefaultFormProcessing(false);
-		addGradeItem.setOutputMarkupId(true);
-		this.form.add(addGradeItem);
-
 		// first get any settings data from the session
 		final GradebookUiSettings settings = getUiSettings();
 
@@ -227,28 +210,52 @@ public class GradebookPage extends BasePage {
 		final List<Assignment> assignments = this.businessService.getGradebookAssignments(sortBy);
 		final List<String> students = this.businessService.getGradeableUsers();
 
-		this.hasAssignmentsAndGrades = !assignments.isEmpty() && !students.isEmpty();
-
+		hasGradebookItems = !assignments.isEmpty();
+		hasStudents = !students.isEmpty();
 		// categories enabled?
 		final boolean categoriesEnabled = this.businessService.categoriesAreEnabled();
 
 		// grading type?
 		final GradingType gradingType = GradingType.valueOf(gradebook.getGrade_type());
 
+		tableArea = new WebMarkupContainer("gradeTableArea");
+		if (!hasGradebookItems) {
+			tableArea.add(AttributeAppender.append("class", "gradeTableArea"));
+		}
+		form.add(tableArea);
+
+		final GbAddButton addGradeItem = new GbAddButton("addGradeItem");
+		addGradeItem.setDefaultFormProcessing(false);
+		addGradeItem.setOutputMarkupId(true);
+		tableArea.add(addGradeItem);
+
 		final WebMarkupContainer noAssignments = new WebMarkupContainer("noAssignments");
 		noAssignments.setVisible(assignments.isEmpty());
-		this.form.add(noAssignments);
+		tableArea.add(noAssignments);
+		final GbAddButton addGradeItem2 = new GbAddButton("addGradeItem2") {
+			@Override
+			public boolean isVisible() {
+				return GradebookPage.this.role == GbRole.INSTRUCTOR;
+			}
+		};
+		addGradeItem2.setDefaultFormProcessing(false);
+		addGradeItem2.setOutputMarkupId(true);
+		noAssignments.add(addGradeItem2);
 
 		final WebMarkupContainer noStudents = new WebMarkupContainer("noStudents");
 		noStudents.setVisible(students.isEmpty());
-		this.form.add(noStudents);
+		tableArea.add(noStudents);
 
 		// Populate the toolbar
 		final WebMarkupContainer toolbar = new WebMarkupContainer("toolbar");
-		this.form.add(toolbar);
+		tableArea.add(toolbar);
+
+		final WebMarkupContainer toolbarColumnTools = new WebMarkupContainer("gbToolbarColumnTools");
+		toolbarColumnTools.setVisible(hasGradebookItems);
+		toolbar.add(toolbarColumnTools);
 
 		final WebMarkupContainer toggleGradeItemsToolbarItem = new WebMarkupContainer("toggleGradeItemsToolbarItem");
-		toolbar.add(toggleGradeItemsToolbarItem);
+		toolbarColumnTools.add(toggleGradeItemsToolbarItem);
 
 		this.gradeTable = new GbGradeTable("gradeTable",
 				new LoadableDetachableModel() {
@@ -276,7 +283,7 @@ public class GradebookPage extends BasePage {
 		this.gradeTable.addEventListener("viewCourseGradeStatistics", new ViewCourseGradeStatisticsAction());
 
 
-		this.form.add(this.gradeTable);
+		tableArea.add(this.gradeTable);
 
 		final Button toggleCategoriesToolbarItem = new Button("toggleCategoriesToolbarItem") {
 			@Override
@@ -302,7 +309,7 @@ public class GradebookPage extends BasePage {
 				return categoriesEnabled;
 			}
 		};
-		toolbar.add(toggleCategoriesToolbarItem);
+		toolbarColumnTools.add(toggleCategoriesToolbarItem);
 
 		final GbAjaxLink sortGradeItemsToolbarItem = new GbAjaxLink("sortGradeItemsToolbarItem") {
 			@Override
@@ -324,7 +331,7 @@ public class GradebookPage extends BasePage {
 				return (businessService.isUserAbleToEditAssessments());
 			}
 		};
-		toolbar.add(sortGradeItemsToolbarItem);
+		toolbarColumnTools.add(sortGradeItemsToolbarItem);
 
 		// section and group dropdown
 		final List<GbGroup> groups = this.businessService.getSiteSectionsAndGroups();
@@ -405,15 +412,13 @@ public class GradebookPage extends BasePage {
 		groupFilter.setNullValid(false);
 
 		// if only one item, hide the dropdown
-		if (groups.size() == 1 || !this.hasAssignmentsAndGrades) {
-			groupFilter.setVisible(false);
-		}
+		groupFilter.setVisible(groups.size() > 1 && hasStudents);
 
 		final WebMarkupContainer studentFilter = new WebMarkupContainer("studentFilter");
-		studentFilter.setVisible(this.hasAssignmentsAndGrades);
+		studentFilter.setVisible(hasStudents);
 		toolbar.add(studentFilter);
 
-		this.form.add(groupFilter);
+		tableArea.add(groupFilter);
 
 		final Map<String, Object> togglePanelModel = new HashMap<>();
 		togglePanelModel.put("assignments", this.businessService.getGradebookAssignments(sortBy));
@@ -424,17 +429,9 @@ public class GradebookPage extends BasePage {
 			new ToggleGradeItemsToolbarPanel("gradeItemsTogglePanel", Model.ofMap(togglePanelModel));
 		add(gradeItemsTogglePanel);
 
-		this.form.add(new WebMarkupContainer("captionToggle").setVisible(this.hasAssignmentsAndGrades));
+		tableArea.add(new WebMarkupContainer("captionToggle").setVisible(hasStudents));
 
-		//
-		// hide/show components
-		//
-
-		// Only show the toolbar if there are students and grade items
-		toolbar.setVisible(!assignments.isEmpty());
-
-		// Show the table if there are grade items
-		this.gradeTable.setVisible(!assignments.isEmpty());
+		toolbar.setVisible(hasStudents || hasGradebookItems);
 
 		stopwatch.time("Gradebook page done", stopwatch.getTime());
 	}
@@ -560,7 +557,7 @@ public class GradebookPage extends BasePage {
 		// add simple feedback nofication to sit above the table
 		// which is reset every time the page renders
 		this.liveGradingFeedback = new Label("liveGradingFeedback", getString("feedback.saved"));
-		this.liveGradingFeedback.setVisible(this.hasAssignmentsAndGrades);
+		this.liveGradingFeedback.setVisible(hasGradebookItems && hasStudents);
 		this.liveGradingFeedback.setOutputMarkupId(true);
 		this.liveGradingFeedback.add(DISPLAY_NONE);
 
@@ -568,7 +565,7 @@ public class GradebookPage extends BasePage {
 		// need to be the one that displays this message (Wicket will handle
 		// the 'saved' and 'error' messages when a grade is changed
 		this.liveGradingFeedback.add(new AttributeModifier("data-saving-message", getString("feedback.saving")));
-		this.form.addOrReplace(this.liveGradingFeedback);
+		tableArea.addOrReplace(this.liveGradingFeedback);
 	}
 
 	public Component updateLiveGradingMessage(final String message) {
@@ -577,5 +574,30 @@ public class GradebookPage extends BasePage {
 			this.liveGradingFeedback.remove(DISPLAY_NONE);
 		}
 		return this.liveGradingFeedback;
+	}
+
+	private class GbAddButton extends GbAjaxButton	{
+
+		public GbAddButton(String id) {
+			super(id);
+		}
+
+		public GbAddButton(String id, Form<?> form) {
+			super(id, form);
+		}
+
+		@Override
+		public void onSubmit(final AjaxRequestTarget target, final Form form) {
+			final GbModalWindow window = getAddOrEditGradeItemWindow();
+			window.setTitle(getString("heading.addgradeitem"));
+			window.setComponentToReturnFocusTo(this);
+			window.setContent(new AddOrEditGradeItemPanel(window.getContentId(), window, null));
+			window.show(target);
+		}
+
+		@Override
+		public boolean isVisible() {
+			return GradebookPage.this.role == GbRole.INSTRUCTOR && hasGradebookItems;
+		}
 	}
 }

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -629,7 +629,12 @@ GbGradeTable.renderTable = function (elementId, tableData) {
   };
 
   GbGradeTable.calculateIdealWidth = function() {
-    return MorpheusViewportHelper.isPhone() ? $("#pageBody").width() - 40 : $("#pageBody").width() - $("#toolMenuWrap").width() - 60;
+    if (GbGradeTable.columns.length > 0) {
+        return MorpheusViewportHelper.isPhone() ? $("#pageBody").width() - 40 : $("#pageBody").width() - $("#toolMenuWrap").width() - 60;
+    }
+
+    var scrollbarWidth = GbGradeTable.students.length > 0 ? 16 : 0;
+    return GbGradeTable.getColumnWidths().reduce(function (acc, cur) { return acc + cur; }, 0) + scrollbarWidth;
   };
 
   GbGradeTable.instance = new Handsontable(document.getElementById(elementId), {
@@ -735,7 +740,7 @@ GbGradeTable.renderTable = function (elementId, tableData) {
       // show visual cue that columns are hidden
       // check for last of the fixed columns
       if (col == GbGradeTable.FIXED_COLUMN_OFFSET - 1) { //GbGradeTable.instance.getSettings().fixedColumnsLeft - 1) {
-        if (GbGradeTable.columns[0].hidden &&
+        if (GbGradeTable.columns[0] && GbGradeTable.columns[0].hidden &&
             $th.find(".gb-hidden-column-visual-cue").length == 0) {
           $th.find(".relative").append("<a href='javascript:void(0);' class='gb-hidden-column-visual-cue'></a>");
         }

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -565,3 +565,125 @@ div.wicket-modal div.w_right > div {
   margin: 0;
 }
 
+.gb-noGbItems
+{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  padding: 1em;
+  font-size: 20px;
+  text-align: center;
+  color: #666;
+  background-color: #eee;
+  -ms-grid-row: 3;
+  -ms-grid-row-span: 1;
+  -ms-grid-column: 2;
+  -ms-grid-column-span: 1;
+  grid-area: empty;
+}
+.gb-noGbItems > i
+{
+  display: block;
+  font-size: 3em;
+}
+
+.gradeTableOuterWrapper
+{
+  -ms-grid-row: 3;
+  -ms-grid-row-span: 1;
+  -ms-grid-column: 1;
+  -ms-grid-column-span: 1;
+  grid-area: grades;
+}
+
+.gradesToolbar1
+{
+  -ms-grid-row: 1;
+  -ms-grid-row-span: 1;
+  -ms-grid-column: 1;
+  -ms-grid-column-span: 2;
+  grid-area: toolbar1;
+}
+
+.gradesToolbar2
+{
+  -ms-grid-row: 2;
+  -ms-grid-row-span: 1;
+  -ms-grid-column: 1;
+  -ms-grid-column-span: 2;
+  grid-area: toolbar2;
+}
+
+.gradeTableArea
+{
+  display: -ms-grid;
+  display: grid;
+  -ms-grid-columns: auto 1fr;
+  grid-template-columns: auto 1fr;
+  -ms-grid-rows: auto auto auto;
+  grid-template-areas:
+    "toolbar1 toolbar1"
+    "toolbar2 toolbar2"
+    "grades empty";
+}
+
+#gradeTableWrapper
+{
+  background-color: #eee;
+}
+
+@media all and (max-width: 1024px)
+{
+  .gradeTableArea
+  {
+    display: block;
+  }
+
+  .gradeTableArea #gradebookGradesToolbar
+  {
+    margin-top: 0;
+  }
+
+  .gb-noGbItems div.act
+  {
+    padding-bottom: 0;
+  }
+
+  .gradeTableArea .gradeTableOuterWrapper
+  {
+    border-right: none;
+  }
+}
+
+@media all and (max-width: 640px)
+{
+  .gb-noGbItems
+  {
+    font-size: 1em;
+  }
+}
+
+.gb-noStudents
+{
+  position: absolute;
+  top: calc(30vh + 58px - 0.5em);
+  z-index: 100;
+  width: 100%;
+  text-align: center;
+  line-height: 1em;
+  font-size: 16px;
+  color: #666;
+}
+
+.gradeTableOuterWrapper
+{
+  border-right: 1px solid #ddd;
+  position: relative;
+}
+
+.gb-noGbItems button
+{
+	margin: 0;
+}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-39978

Most Sakai tools could benefit from having a welcoming empty state that establishes the tool and suggests next steps for site maintainers. Gradebook, Announcements, Syllabus, Resources, Assignments, Tests & Quizzes, Email Archive, Polls, PostEm, Search, and Sign-up are all good examples of tools needing a default empty state.

When we upgraded to Sakai 11, we created an empty state for our local GBNG because early user feedback showed that the lack of the student listings caused people to think that there were no students enrolled in the site.