### PR TITLE
SAK-40004 Updated Mockito Libs

### DIFF
--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -97,7 +97,7 @@
 
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -82,25 +82,25 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
-    <!-- So we can mock static cover -->
+
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.6</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.6</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -58,12 +58,6 @@
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
     </dependency>
-    <!-- UNUSED
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>
       <artifactId>sakai-component-manager</artifactId>
@@ -82,25 +76,21 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.sakaiproject.component.api.ServerConfigurationService;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.*;
  * Created by buckett on 30/09/2014.
  */
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.security.auth.*")
 @PrepareForTest(ComponentManager.class)
 public class RequestFilterTest {
 

--- a/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.*;
  * Created by buckett on 30/09/2014.
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.security.auth.*")
+@PowerMockIgnore("javax.security.auth.Subject")
 @PrepareForTest(ComponentManager.class)
 public class RequestFilterTest {
 

--- a/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
@@ -38,9 +38,6 @@ import java.security.Principal;
 
 import static org.mockito.Mockito.*;
 
-/**
- * Created by buckett on 30/09/2014.
- */
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.security.auth.Subject")
 @PrepareForTest(ComponentManager.class)

--- a/kernel/api/src/test/java/org/sakaiproject/util/ToolListenerTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/ToolListenerTest.java
@@ -70,7 +70,7 @@ public class ToolListenerTest {
         sakaiHome = Files.createTempDirectory("ToolListenerTest");
         toolsFolder = Files.createDirectories(sakaiHome.resolve("tools"));
         when(serverConfigurationService.getSakaiHomePath()).thenReturn(sakaiHome.toString());
-        doAnswer(invocation -> "/webapp"+ invocation.getArgumentAt(0, String.class))
+        doAnswer(invocation -> "/webapp"+ invocation.getArgument(0))
                 .when(context).getRealPath(anyString());
     }
 

--- a/kernel/api/src/test/java/org/sakaiproject/util/ToolListenerTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/ToolListenerTest.java
@@ -120,7 +120,6 @@ public class ToolListenerTest {
     public void testIgnoreFiles() {
         when(context.getResourcePaths("/WEB-INF/tools/")).thenReturn(Stream.of("/WEB-INF/tools/", "/WEB-INF/tools/sakai-tool.ignored", "/WEB-INF/tools/folder/").collect(Collectors.toSet()));
         InputStream inputStream = mock(InputStream.class);
-        when(context.getResourceAsStream(anyString())).thenReturn(inputStream);
         listener.contextInitialized(event);
         verify(activeToolManager, never()).register(inputStream, context);
     }

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -74,7 +74,7 @@
     <sakai.slf4j.version>1.7.25</sakai.slf4j.version>
     <sakai.poi.version>3.17</sakai.poi.version>
     <sakai.mockito.version>2.18.3</sakai.mockito.version>
-    <sakai.powermock.version>1.7.4</sakai.powermock.version>
+    <sakai.powermock.version>2.0.0-beta.5</sakai.powermock.version>
     <sakai.okiosid.version>2.0</sakai.okiosid.version>
     <joda.time.version>2.9.9</joda.time.version>
     <jayway.jsonpath.version>2.4.0</jayway.jsonpath.version>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -73,8 +73,8 @@
     <sakai.log4j.version>1.2.17</sakai.log4j.version>
     <sakai.slf4j.version>1.7.25</sakai.slf4j.version>
     <sakai.poi.version>3.17</sakai.poi.version>
-    <sakai.mockito.version>2.7.22</sakai.mockito.version>
-    <sakai.powermock.version>1.7.3</sakai.powermock.version>
+    <sakai.mockito.version>2.18.3</sakai.mockito.version>
+    <sakai.powermock.version>1.7.4</sakai.powermock.version>
     <sakai.okiosid.version>2.0</sakai.okiosid.version>
     <joda.time.version>2.9.9</joda.time.version>
     <jayway.jsonpath.version>2.4.0</jayway.jsonpath.version>
@@ -1658,6 +1658,8 @@
         <version>4.12</version>
         <scope>test</scope>
       </dependency>
+
+      <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
@@ -1665,18 +1667,23 @@
         <scope>test</scope>
       </dependency>
       <!-- So we can mock static cover -->
+
+      <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
       <dependency>
           <groupId>org.powermock</groupId>
           <artifactId>powermock-module-junit4</artifactId>
           <version>${sakai.powermock.version}</version>
           <scope>test</scope>
       </dependency>
+
+      <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
       <dependency>
           <groupId>org.powermock</groupId>
           <artifactId>powermock-api-mockito2</artifactId>
           <version>${sakai.powermock.version}</version>
           <scope>test</scope>
       </dependency>
+
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1658,32 +1658,24 @@
         <version>4.12</version>
         <scope>test</scope>
       </dependency>
-
-      <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${sakai.mockito.version}</version>
         <scope>test</scope>
       </dependency>
-      <!-- So we can mock static cover -->
-
-      <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
       <dependency>
           <groupId>org.powermock</groupId>
           <artifactId>powermock-module-junit4</artifactId>
           <version>${sakai.powermock.version}</version>
           <scope>test</scope>
       </dependency>
-
-      <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
       <dependency>
           <groupId>org.powermock</groupId>
           <artifactId>powermock-api-mockito2</artifactId>
           <version>${sakai.powermock.version}</version>
           <scope>test</scope>
       </dependency>
-
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>


### PR DESCRIPTION
Please, note that org.powermockito is in BETA. This is due cause there is no stable version that support JDK9 or more.

Also, one unnecesary stubbing has been deleted.

So now, kernel/api tests pass on JDK9