### PR TITLE
SAK-40004 - JDK9 Fixes

### DIFF
--- a/kernel/kernel-util/pom.xml
+++ b/kernel/kernel-util/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>4.0.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/DateFormatterUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/DateFormatterUtil.java
@@ -94,18 +94,17 @@ public final class DateFormatterUtil {
 	 * 			If throws a parse exception then returns the SHORT format by default (MM/dd/yyyy hh:mm a)
 	 */
 	public static String format(Date inputDate, String format, Locale locale) {
-		SimpleDateFormat formatter = null;
-
 		if(inputDate == null){
 			return null;
 		}
 
 		try {
-			formatter = new SimpleDateFormat(format, locale);
-			return formatter.format(inputDate);
+			return new SimpleDateFormat(format, locale)
+					.format(inputDate);
 		} catch(Exception ex) {
-			formatter = (SimpleDateFormat) DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.US);
-			return formatter.format(inputDate);
+			return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.US)
+					.format(inputDate)
+					.replace(",",""); // FIX JDK8 -> JDK9
 		}
 	}
 }


### PR DESCRIPTION
DateFormatterUtil.format() has some little changes.

The bug fix is at `.replace(",",""); // FIX JDK8 -> JDK9`

Also `javax.servelet-api` updated to latest version