### PR TITLE
SAK-40063: You can't deactivate "Assign Grade Overrides" in a "Group Submission - One submission per group" assignment 

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5738,7 +5738,7 @@ public class AssignmentAction extends PagedResourceActionII {
             if (withGrade && a.getIsGroup()) {
                 for (AssignmentSubmissionSubmitter submitter : submission.getSubmitters()) {
                     String g = (String) state.getAttribute(GRADE_SUBMISSION_GRADE + "_" + submitter.getSubmitter());
-                    if (StringUtils.isNotBlank(g)) submitter.setGrade(g);
+                    if (g != submitter.getGrade()) submitter.setGrade(g);
                 }
             }
 


### PR DESCRIPTION
SAK-40063: You can't deactivate "Assign Grade Overrides" in a "Group Submission - One submission per group" assignment 

If the new grade is different to the old grade you have to set the new grade. It doesn't matter is g is NULL. 