### PR TITLE
SAK-40081 - Allow to decide whether to use title site or short

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/SiteEmailNotificationAnnc.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/SiteEmailNotificationAnnc.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.announcement.api.AnnouncementMessage;
 import org.sakaiproject.announcement.api.AnnouncementMessageEdit;
 import org.sakaiproject.announcement.api.AnnouncementMessageHeader;
@@ -316,8 +317,13 @@ public class SiteEmailNotificationAnnc extends SiteEmailNotification
 		String title = siteId;
 		try
 		{
-			Site site = siteService.getSite(siteId);
+			final Site site = siteService.getSite(siteId);
+			boolean shortDescription = ServerConfigurationService.getBoolean("announcement.email.use.short.description", false);
+
 			title = site.getTitle();
+			if(shortDescription && StringUtils.isNotEmpty(site.getShortDescription())) {
+				title = site.getShortDescription();
+			}
 		}
 		catch (Exception ignore)
 		{

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2006,6 +2006,10 @@
 # ALTERNATELY, use the comma seperated list form
 # prevent.public.announcements=project,portfolio
 
+# Decide whether to use the site title or the short description in the subject when notifying an announcement by email.
+# DEFAULT: false
+# announcement.email.use.short.description=true
+
 ## BASICLTI PROVIDER
 # blti.producer prefix no longer used, should be basiclti.provider
 


### PR DESCRIPTION
description in subject when notifying an announcement via email