### PR TITLE
SAK-40090 - Textarea appears when grading a submission without text and/or unsubmitted

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -429,7 +429,7 @@
             <p class="text-warning">$tlang.getString("nonelec_instruction2")</p>
         #else
             #if($submissionType == 1 || $submissionType == 3)
-                #if (($submission.Submitted || !$alertGradeDraft) && !$!value_feedback_text.isEmpty())
+                #if (($submission.Submitted || !$alertGradeDraft) && $!value_feedback_text && !$!value_feedback_text.isEmpty())
                     <p class="text-info">$tlang.getString("gradingsub.belisthe")</p>
                     <div class="textarea-holder">
                         <textarea name="$name_feedback_text" id="$name_feedback_text" rows="30" wrap="virtual" cols="80">


### PR DESCRIPTION
This is caused because  `value_feedback_text` is null