### PR TITLE
SAK-40111 Fixed the width of the group membership select menus in Site Info

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -1,7 +1,8 @@
-.#{$namespace}sakai-siteinfo{
+.#{$namespace}sakai-siteinfo
+{
 	.groups-site{
 		list-style: none;
-		
+
 		li {
 			min-height: 4em;
 			&:nth-child(odd){
@@ -22,6 +23,13 @@
 	}
 	#groupfile {
 		vertical-align: top;
+	}
+
+	#siteMembers-selection, #groupMembers-selection
+	{
+		min-width: 100%;
+		padding-right: 0.5em;
+		background-image: none;
 	}
 }
 


### PR DESCRIPTION
On the create or edit pages for groups in Site Info, there are two multi-select menus for moving participants in and out of a group. If either select menu has participants with short names or no participants at all, the menus collapse to a thin tall box.

![01-before-fullpage](https://user-images.githubusercontent.com/12685096/41256985-4b4dafda-6d99-11e8-926d-fec81c99be43.png)

My fix changes the width of the menus to take up the full width available in their columns, so they are equal and uniform. I also removed the drop-down arrow used by standard select menus:

![03-after-groupmembership](https://user-images.githubusercontent.com/12685096/41256998-53bbfc12-6d99-11e8-8ece-7066b3d34b8c.png)

It also looks better in the narrow mobile view:

![04-after-groupmembership-mobile](https://user-images.githubusercontent.com/12685096/41257020-619cb0d8-6d99-11e8-8d47-43fc22db914e.png)

