### PR TITLE
SAK-40028: Duplicated assignments always have 'Access: Display to Sit…

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -788,6 +788,10 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 assignment.setPosition(existingAssignment.getPosition());
                 assignment.setIsGroup(existingAssignment.getIsGroup());
                 assignment.setAllowPeerAssessment(existingAssignment.getAllowPeerAssessment());
+                if (!existingAssignment.getGroups().isEmpty()) {
+                	assignment.setGroups(new HashSet<>(existingAssignment.getGroups()));
+                	assignment.setTypeOfAccess(Assignment.Access.GROUP);
+                }
 
                 // peer properties
                 assignment.setPeerAssessmentInstructions(existingAssignment.getPeerAssessmentInstructions());


### PR DESCRIPTION
…e' even if the original had groups