### PR TITLE
SAK-40208 Tightened up default page header spacing around page title

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -333,6 +333,9 @@ $hierarchy-size: 3.5em !default;
 /* Golden Ratio width for 16px font http://www.pearsonified.com/typography/ */
 $measure: 960px !default;
 
+/* The standard spacing for items in Sakai */
+$standard-spacing: 10px !default;
+
 $banner-height: 52px !default;
 
 /* Logo location */

--- a/library/src/morpheus-master/sass/modules/tool/_base.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_base.scss
@@ -170,7 +170,8 @@
 	}
 }
 
-.portletBody{
+.portletBody
+{
 	background: $tool-background-color;
 	padding: $default-font-size $default-font-size 40px $default-font-size;
 	@media #{$phone}{
@@ -182,6 +183,19 @@
 	}
 	> .modal {
 		position: fixed;
+	}
+	.page-header
+	{
+		margin: calc(#{$standard-spacing} + 5px) 0; // additional 5px for equallying the header text descenders
+		padding: 0 0 $standard-spacing 0;
+		border-bottom: 1px solid $tool-border-color;
+
+		h1, h2, h3
+		{
+			margin: $standard-spacing 0 0 0; // vertical margins will collapse into one
+			padding: 0;
+			line-height: 1;
+		}
 	}
 }
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40208

Some tools use .page-header containing a h1 (or h3) tag for displaying the title of the page at the top of the page (below the tools' page tabs).

The spacing of this page header and header texts needs to be tightened up, so the content appears on the screen sooner and so more content can appear on the screen.

Not all tools use the same markup structure, so won't all benefit from this change. However, as tool consistency is rolled out in other tickets, they too will benefit from this change.
