### PR TITLE
SAK-40210 Updated default Sakai Project feed address for the News tool

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2279,7 +2279,7 @@
 # wsetup.config.tool.title_sakai.news=CNN Top Stories
 
 # RSS feed to set for the default (10-)
-# DEFAULT: http://sakaiproject.org/feed
+# DEFAULT: https://www.sakaiproject.org/feed
 # wsetup.config.tool.attribute.default_sakai.news=http://rss.cnn.com/rss/cnn_topstories.rss
 
 
@@ -2292,7 +2292,7 @@
 # wsetup.config.tool.title_sakai.simple.rss=CNN Top Stories 
 
 # RSS feed to set for the default (11+)
-# DEFAULT: http://sakaiproject.org/feed
+# DEFAULT: https://www.sakaiproject.org/feed
 # wsetup.config.tool.attribute.default_sakai.simple.rss=http://rss.cnn.com/rss/cnn_topstories.rss
 
 

--- a/simple-rss-portlet/src/main/webapp/WEB-INF/sakai/simple-rss-portlet.xml
+++ b/simple-rss-portlet/src/main/webapp/WEB-INF/sakai/simple-rss-portlet.xml
@@ -10,7 +10,7 @@
 		<configuration name="functions.require" /> 
 		<configuration name="reset.button" value="true"/>
 		<configuration name="allowMultipleInstances" value="true" />
-		<configuration name="feed_url" value="http://sakaiproject.org/feed" />
+		<configuration name="feed_url" value="https://www.sakaiproject.org/feed" />
 
 	</tool>
 

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -745,7 +745,7 @@ public class SiteAction extends PagedResourceActionII {
 	/** the news tool **/
 	private final static String NEWS_TOOL_ID = "sakai.simple.rss";
 	private final static String NEWS_TOOL_CHANNEL_CONFIG = "javax.portlet-feed_url";
-	private final static String NEWS_TOOL_CHANNEL_CONFIG_VALUE = "http://sakaiproject.org/feed";
+	private final static String NEWS_TOOL_CHANNEL_CONFIG_VALUE = "https://www.sakaiproject.org/feed";
 	
    	private final static String LESSONS_TOOL_ID = "sakai.lessonbuildertool";
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40210

When you add the News tool to a site, it has a default "URL Channel" of "http://sakaiproject.org/feed". If you leave this default as the link for the feed and go to the News tool (after adding it), you'll get the following error:

>     An error has occurred
>     No data was returned from the remote server. Please ensure the URL added is correct.

as seen in the following screenshot:

![01-before-newserror](https://user-images.githubusercontent.com/12685096/41795083-8dc8e322-762f-11e8-9f95-e1b56bc34245.png)

This is bad for a default.

The problem seems to be that "http://sakaiproject.org/feed" redirects in a web browser to "https://www.sakaiproject.org/feed" (note the "s" in "https" and the "www." part have been added).

I grepped the Sakai codebase for "http://sakaiproject.org/feed" and replaced it with "https://www.sakaiproject.org/feed" so the defaults would resolve to the correct new address.