### PR TITLE
SAK-40211: resources > improve accuracy of new/updated resources email notification

### DIFF
--- a/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/siteemacon/siteemacon.properties
+++ b/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/siteemacon/siteemacon.properties
@@ -2,9 +2,13 @@ anewres = A new resource has been added to
 
 anewres2 = A resource has been updated in
 
-anewresDnD = Several new resources have been added to
+anewresDnD = A new resource has been added to
 
-anewres2DnD = Several resources have been updated in
+anewresDnD.plural = {0} new resources have been added to
+
+anewres2DnD = A resource has been updated in
+
+anewres2DnD.plural = {0} resources have been updated in
 
 chan = Changed
 

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/SiteEmailNotificationDragAndDrop.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/SiteEmailNotificationDragAndDrop.java
@@ -475,14 +475,32 @@ public class SiteEmailNotificationDragAndDrop extends SiteEmailNotification
 			buf.append("<p>");
 		}
 
-		if ((contentHostingService.EVENT_RESOURCE_AVAILABLE.equals(function))||(contentHostingService.EVENT_RESOURCE_ADD.equals(function)))
+		boolean plural = this.fileList.size() > 1;
+		Object[] replacementValues = new Object[] {this.fileList.size()};
+		String numResourcesMsg;
+		if (ContentHostingService.EVENT_RESOURCE_AVAILABLE.equals(function) || ContentHostingService.EVENT_RESOURCE_ADD.equals(function))
 		{
-			buf.append(rb.getString("anewresDnD"));
+			if (plural)
+			{
+				numResourcesMsg = rb.getFormattedMessage("anewresDnD.plural", replacementValues);
+			}
+			else
+			{
+				numResourcesMsg = rb.getString("anewresDnD");
+			}
 		}
 		else
 		{
-			buf.append(rb.getString("anewres2DnD"));
+			if (plural)
+			{
+				numResourcesMsg = rb.getFormattedMessage("anewres2DnD.plural", replacementValues);
+			}
+			else
+			{
+				numResourcesMsg = rb.getString("anewres2DnD");
+			}
 		}
+		buf.append(numResourcesMsg);
 		buf.append(" ");
 		buf.append(rb.getString("tothe"));
 		buf.append(" \"");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40211

The opening line of the current emails sent (when new resources are added or existing resources are updated) is always plural regardless of how many resources were added or updated:

```
Several new resources have been added to ...
```

```
Several resources have been updated in ...
```

This PR changes the behaviour to be plural or singular based on how many resources were added/updated:

```
anewresDnD = A new resource has been added to

anewresDnD.plural = {0} new resources have been added to

anewres2DnD = A resource has been updated in

anewres2DnD.plural = {0} resources have been updated in
```