### PR TITLE
SAK-40212: web content > explain why pop-up behaviour changes for https vs http links

### DIFF
--- a/web/web-portlet/src/bundle/iframe.properties
+++ b/web/web-portlet/src/bundle/iframe.properties
@@ -38,7 +38,7 @@ gen.custheight = Custom height
 gen.pixels = pixels
 gen.pixelshid = (in pixels)
 gen.info.pop = Open in new window?
-gen.popup.info=Note: Applies only to secure (https://) URLs. A non-secure (http://) URL will always open in a new window.
+gen.popup.info=Note: Applies only to secure (https://) URLs that allow framing. Most major websites do not allow framing. A non-secure (http://) URL will always open in a new window.
 ### (moot) gen.info.yes = yes
 ### (moot) gen.info.no = no
 

--- a/web/web-portlet/src/bundle/iframe.properties
+++ b/web/web-portlet/src/bundle/iframe.properties
@@ -38,6 +38,7 @@ gen.custheight = Custom height
 gen.pixels = pixels
 gen.pixelshid = (in pixels)
 gen.info.pop = Open in new window?
+gen.popup.info=Note: Applies only to secure (https://) URLs. A non-secure (http://) URL will always open in a new window.
 ### (moot) gen.info.yes = yes
 ### (moot) gen.info.no = no
 

--- a/web/web-portlet/src/bundle/vm/edit.vm
+++ b/web/web-portlet/src/bundle/vm/edit.vm
@@ -82,12 +82,11 @@ ${includeLatestJQuery}
         #end
 
             #if ($showPopup)
-                        <div class="form-group">    
+                    <div class="form-group">    
                         <input type="checkbox" value="true" name="popup" id="opentrue" #if ($popup) checked="checked" #end  class="indnt1" />
                         <label for="opentrue" class="control-label form-control-label">$tlang.getString("gen.info.pop")</label>
-                        </div>
-                        <br />
-
+                        <div style="padding-left: 1.5em;"><i>$tlang.getString("gen.popup.info")</i></div>
+                    </div>
             #end
 
                 <p class="act">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40212

Due to mixed content rules in browsers, the behaviour of the "Open in new window?" option differs if the provided link is either https or http. Provide a brief explanation of this behaviour:

```
Note: Applies only to secure (https://) URLs. A non-secure (http://) URL will always open in a new window.
```
![screenshot_20180623_133712](https://user-images.githubusercontent.com/10403943/41812103-22e2022c-770c-11e8-9b47-4a4ba97e850c.png)
