### PR TITLE
SAK-32655 Default property for signup email notification

### DIFF
--- a/signup/tool/src/bundle/signupConfig.properties
+++ b/signup/tool/src/bundle/signupConfig.properties
@@ -49,3 +49,7 @@ signup.csv.export.enabled=false
 
 #configure whether the Signup tool data in a site will be archived into xml file. (default is false)
 signup.isarchive.support=false
+
+# default property for signup email notification
+signup.default.email.selected=all
+


### PR DESCRIPTION
Add default value for signup.default.email.selected (all)

Avoids the WARN message in logs,

26-Nov-2017 23:27:44.522 WARN [http-nio-20013-exec-9] org.sakaiproject.util.ResourceLoader.getString bundle 'signupConfig'  missing key: 'signup.default.email.selected'  from: org.sakaiproject.signup.tool.util.Utilities.getSignupConfigParamVal(Utilities.java:499)


