### PR TITLE
SAK-37795 - Columns in Firefox show bottom section in its own section

### DIFF
--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -1470,7 +1470,7 @@ div.navIntraTool {
 }
 
 .edit-col {
-margin-top:5px;
+margin-top:4px;
 display:inline-block;
 position:absolute;
 background-color:#eee;


### PR DESCRIPTION
This fixes the issue for Firefox (wasn't an issue in Chrome). I'm not exactly sure why. Anything 5px and above breaks Firefox alignment for the edit when using multiple columns. I feel like a better fix would involve changing the HTML that Lessons is writing out or changing this use the bootstrap grid for multi column instead of these column hacks.