### PR TITLE
SAK-40220 Removed the h4 and h5 tags from the Assignment List by Students table in Assignments

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -109,7 +109,6 @@
 							#end
 						<tr>
 							<td headers="studentname" class="specialLink">
-								<h4>
 									<div class="spinnerBesideContainer">
 								#set( $userSpinnerID = "userSpinner_" + $member.Id )
 								#if (!$studentListShowSet.contains($member.Id))
@@ -125,7 +124,6 @@
 										</a>
 										<div id="$userSpinnerID" class="allocatedSpinPlaceholder"></div>
 									</div>
-								</h4>
 							</td>
 							<td colspan="4">
 							</td>
@@ -145,7 +143,6 @@
 										<td headers="studentname"/>
 										<td headers="assignment">
 											#if (!$isAnon)
-											<h5>
 												<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$validator.escapeUrl($assignmentReference)&submissionId=$validator.escapeUrl($submissionReference)&option=lisofass2")" title="$validator.escapeHtml($assignment.Title)">$validator.escapeHtml($assignment.Title)</a>
 												#if ($allowAddAssignment && $allowSubmitByInstructor)
 												#set( $submitSpinnerID = "submitFor_" + $member.Id + "_" + $validator.escapeUrl($assignmentReference) )
@@ -163,7 +160,6 @@
 											#else
 												$validator.escapeHtml($assignment.Title) ($tlang.getString("grading.anonymous.title"))
 											#end
-											</h5>
 										</td>
 										<td headers="submitted">
 											#if ($!submission.submitted)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40220

In the table found on the "Assignment List by Student" page in Assignments, there are h4 and h5 tags used inside of the table. It looks like they've been added to help divide up the table of students based on the expanding student assignment list functionality that the table uses.

These section header tags are wrong for two reasons:

1. the content page has an h1 tag, but no h2 or h3 - [header tags should be sequential and form a hierarchy](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Defining_sections)

2. [the markup is invalid](https://stackoverflow.com/questions/11859671/are-h1-html-heading-allowed-inside-a-table-th-or-td-tag)

I have removed the h4 and h5 tags from the markup.
