### PR TITLE
SAK-40222: resources > add accompanying text to the 'Paste' icons

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -490,7 +490,12 @@
 							#set ($itemsOnLine = 0)
 							#foreach($action in $item.pasteActions)
 								#if($itemsOnLine > 0)|#end
-								<a href="#" class=" highlightlink" title="$labeler.getLabel($action) $tlang.getString("paste.here")" onclick="document.getElementById('selectedItemId').value='$qid';document.getElementById('rt_action').value='${action.typeId}${ACTION_DELIMITER}$action.id';document.getElementById('sakai_action').value='doDispatchAction';submitform('showForm');"><span class="fa fa-clipboard" aria-hidden="true"></span><span class="sr-only">$labeler.getLabel($action)</span></a> 
+								<a href="#" class="highlightlink" title="$labeler.getLabel($action) $tlang.getString("paste.here")"
+										onclick="document.getElementById('selectedItemId').value='$qid';document.getElementById('rt_action').value='${action.typeId}${ACTION_DELIMITER}$action.id';document.getElementById('sakai_action').value='doDispatchAction';submitform('showForm');">
+									<span class="iconText" aria-hidden="true">$tlang.getString("action.paste")</span>
+									<span class="fa fa-clipboard" aria-hidden="true"></span>
+									<span class="sr-only">$labeler.getLabel($action)</span>
+								</a>
 								#set ($itemsOnLine = $itemsOnLine + 1)
 							#end
 						#end

--- a/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -282,4 +282,12 @@
 			}
 		}
 	}
+
+	a.highlightlink {
+		text-decoration: none;
+
+		span.iconText {
+			margin-right: 0.1em;
+		}
+	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40222

It can be easy for users to miss the 'Paste' icon when they're not familiar with the UI. Let's add some accompanying text to the icon to help draw attention to it, and also to clarify it's function.

![screenshot_20180625_181824](https://user-images.githubusercontent.com/10403943/41878753-fa99da04-78c5-11e8-9a46-1d5b55193e04.png)
