### PR TITLE
SAK-40230: Email Archive > clarify email alias can be one or many

### DIFF
--- a/mailarchive/mailarchive-tool/tool/src/bundle/email.properties
+++ b/mailarchive/mailarchive-tool/tool/src/bundle/email.properties
@@ -43,8 +43,8 @@ gen.sub2   = Subject
 
 hidehead = Hide Headers
 
-lis.emasen    = Email sent to the following addresses will be archived and sent to participants:
-lis.emasen2   = Email sent to the following addresses will be archived:
+lis.emasen    = Email sent to the following address(es) will be archived and sent to participants:
+lis.emasen2   = Email sent to the following address(es) will be archived:
 lis.searchnotif= Searching...
 lis.noema     = No archived email yet...
 lis.nosearchresults=Search returned no results.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40230

The current message shown in Email Archive implies there will always be multiple aliases:

```
lis.emasen    = Email sent to the following addresses will be archived and sent to participants:
lis.emasen2   = Email sent to the following addresses will be archived:
```

Let's clarify that there could be one, or many:

```
lis.emasen    = Email sent to the following address(es) will be archived and sent to participants:
lis.emasen2   = Email sent to the following address(es) will be archived:
```