### PR TITLE
SAK-40239: Velocity > #toolbar macro needs updating for active tab styling

### DIFF
--- a/velocity/tool/src/templates/VM_chef_library.vm
+++ b/velocity/tool/src/templates/VM_chef_library.vm
@@ -57,20 +57,20 @@
 								#if($item.IsChecked)
 									#set( $toolbaritemCount=$toolbaritemCount + 1)
 									<li #if ($toolbaritemCount ==1) class="firstToolBarItem" #end>
-										<span class="chefToolBarToggle $prevItemWasField $current"><a href="#" title="$item.AccessibilityLabel" onclick="location = '$base'#if($item.Form)+buildQueryString('$item.Form')#end;return false;">$item.Title</a></span>
+										<span class="chefToolBarToggle $prevItemWasField $current">#if(!$item.IsCurrent)<a href="#" title="$item.AccessibilityLabel" onclick="location = '$base'#if($item.Form)+buildQueryString('$item.Form')#end;return false;">#end$item.Title#if(!$item.IsCurrent)</a>#end</span>
 									</li>
 								## unchecked item support
 								#else
 									#set( $toolbaritemCount=$toolbaritemCount + 1)
 									<li #if ($toolbaritemCount ==1) class="firstToolBarItem" #end>
-										<span class="$prevItemWasField $current"><a href="#" title="$item.AccessibilityLabel" onclick="location = '$base'#if($item.Form)+buildQueryString('$item.Form')#end;return false;">$item.Title</a></span>
+										<span class="$prevItemWasField $current">#if(!$item.IsCurrent)<a href="#" title="$item.AccessibilityLabel" onclick="location = '$base'#if($item.Form)+buildQueryString('$item.Form')#end;return false;">#end$item.Title#if(!$item.IsCurrent)</a>#end</span>
 									</li>
 								#end
 							## url support (i.e. to another place, another window)
 							#else
 								#set( $toolbaritemCount=$toolbaritemCount + 1)
 								<li #if ($toolbaritemCount ==1) class="firstToolBarItem" #end>
-									<span class="externalLink $prevItemWasField $current"><a href="$item.Url" title="$item.AccessibilityLabel" target="_blank">$item.Title</a></span>
+									<span class="externalLink $prevItemWasField $current">#if(!$item.IsCurrent)<a href="$item.Url" title="$item.AccessibilityLabel" target="_blank">#end$item.Title#if(!$item.IsCurrent)</a>#end</span>
 								</li>	
 							#end
 							#set ($formItem=0)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40239

All Velocity tools that make use of the #toolbar macro to display the top menu bar have a styling problem with the "active" tab. See attached screenshot; notice active tab has grey inner background (bug), is clickable (bug), and has hover state styles (bug).

![screenshot_20180627_151453](https://user-images.githubusercontent.com/10403943/41994952-a182f894-7a3f-11e8-980e-2755b7ae2218.png)
