### PR TITLE
SAK-40240: Velocity > fix IndexOutOfBoundsException possibilities in PagedResourceActionII

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/javax/PagingPosition.java
+++ b/kernel/api/src/main/java/org/sakaiproject/javax/PagingPosition.java
@@ -167,6 +167,7 @@ public class PagingPosition implements Cloneable
 	{
 		if (m_first < 0) m_first = 1;
 		if (m_last > biggestLast) m_last = biggestLast;
+		if (m_first > biggestLast) m_first = biggestLast;
 		if (m_last < m_first) m_last = m_first;
 	}
 }

--- a/velocity/tool/src/java/org/sakaiproject/cheftool/PagedResourceActionII.java
+++ b/velocity/tool/src/java/org/sakaiproject/cheftool/PagedResourceActionII.java
@@ -39,6 +39,7 @@ import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.util.ResourceLoader;
 
 import javax.servlet.http.HttpServletRequest;
+import org.sakaiproject.javax.PagingPosition;
 
 /**
  * <p>
@@ -370,7 +371,17 @@ public abstract class PagedResourceActionII extends VelocityPortletPaneledAction
 
 		// compute the end to a page size, adjusted for the number of messages available
 		int posEnd = posStart + (pageSize - 1);
-		if (posEnd >= numMessages) posEnd = numMessages - 1;
+		PagingPosition page = new PagingPosition(posStart, posEnd);
+		page.validate(numMessages);
+		if (page.getFirst() >= numMessages)
+		{
+			posStart = 0;
+		}
+		else
+		{
+			posStart = page.getFirst();
+		}
+		posEnd = page.getLast();
 
 		// select the messages on this page
 		List messagePage = readResourcesPage(state, posStart + 1, posEnd + 1);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40240

All Velocity tools using PagedResourceActionII which have a table of data, a paginator component and one or more filter components (search, group/section filter, etc.) are susceptible to generating IndexOutOfBoundsExceptions. The logic to validate page number and page size is slightly flawed.

An example can be seen in Assignments:

1. Ensure you have 6 or more students/access users in your site
2. Create a group with only one student/access user
3. In Assignments, create a few bare bones assignments
4. Go to 'Grade Report' (warning, this UI takes a long time to load if you have a lot of users and/or assignments and/or submissions)
5. Use the paginator to scroll to the 2nd page of results (change page size if necessary)
6. Use the filter drop down to select the group you created in step 2
7. Notice bug report is shown in the UI, and a stacktrace is thrown in the logs for an IndexOutOfBoundsException:

```
Caused by: java.lang.IndexOutOfBoundsException: toIndex = 201
        at java.util.ArrayList.subListRangeCheck(ArrayList.java:1012)
        at java.util.ArrayList.subList(ArrayList.java:1004)
        at org.sakaiproject.assignment.tool.AssignmentAction.readResourcesPage(AssignmentAction.java:11946)
        at org.sakaiproject.cheftool.PagedResourceActionII.prepPage(PagedResourceActionII.java:376)
        at org.sakaiproject.assignment.tool.AssignmentAction.build_instructor_report_submissions(AssignmentAction.java:4796)
        at org.sakaiproject.assignment.tool.AssignmentAction.buildMainPanelContext(AssignmentAction.java:1267)
        ... 54 more
```

This bug has been long standing, and is reproducible as far back as 2.9.1 (probably earlier). If the requested (current) page number is out of range of the list size due to a filter being applied, the validation logic should reset to the first page in the list.