### PR TITLE
SAK-40248: Begin the standardization of the toolbar for table controls (e.g. filtering and paging) across tools

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -43,7 +43,7 @@
 		
 
 
-	
+<script type="text/javascript" src="/library/js/spinner.js$!{portalCdnQuery}"></script>
 <div class="portletBody container-fluid">
 	#if ($isOnWorkspaceTab.equals("false"))
 		#if($menu && $EnabledMenuItemExists)
@@ -418,101 +418,29 @@
 			#if ($toolId == "sakai.announcements") ##In tool or admin MOTD...			
 
 				#if ($displayOptions.isShowAllColumns())
-					## <h3>$tlang.getString("gen.announcements")</h3>
-
 					<div class="page-header">
 					  <h3>$tlang.getString("gen.announcements") <br /><small>$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</small></h3>
 					</div>
 
 					#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
-					<div class="navPanel">
-						<div class="viewNav">
-							<form name="viewForm" class="inlineForm" method="post" action="#toolForm("$action")">
-								<input type="hidden" name="eventSubmit_doView" value="view" />
-								<label for="view">
-									$tlang.getString("view.label")
-								</label>
-								<span class="skip">$tlang.getString("gen.listnavselect")</span>
-								<select id="view" name="view" size="1" onchange="document.viewForm.submit();">
-									<option value="view.all" #if ($!view == "'view.all")selected="selected"#end >$!tlang.getString('view.all')</option>
-									<option value="view.public"  #if ($!view == "view.public")selected="selected"#end >$!tlang.getString('view.public')</option>
-									##if ($!groups)
-										<option value="view.bygroup" #if ($!view == "view.bygroup")selected="selected"#end >$!tlang.getString('view.bygroup')</option>
-										##end 
-								</select>
-								<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-							</form>
+
+					<div class="sakai-table-toolBar">
+						<div class="sakai-table-filterContainer">
+							#define($viewSelectOptions)
+							<option value="view.all" #if ($!view == "'view.all")selected="selected"#end >$!tlang.getString('view.all')</option>
+							<option value="view.public"  #if ($!view == "view.public")selected="selected"#end >$!tlang.getString('view.public')</option>
+							<option value="view.bygroup" #if ($!view == "view.bygroup")selected="selected"#end >$!tlang.getString('view.bygroup')</option>
+							#end
+							#viewFilterPanel("viewFilterForm", "view", $viewSelectOptions, "doView")
 						</div>
 						#if ($messageListVector.iterator().hasNext())
-							<div class="listNav">
-								<div class="instruction">
-									$tlang.getFormattedMessage("gen.viewing.phrase", $topMsgPos, $btmMsgPos, $allMsgNumber)
-								</div>
-								#if ($pagesize != 0)
-									#if ($goFPButton == "true")
-										<form name="firstpageForm" class="inlineForm"  method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#else
-										<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getString("gen.first")</legend><input type="submit" name="eventSubmit_doList_first" value="|&lt;" disabled="disabled" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#end
-									#if ($goPPButton == "true")
-										<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getFormattedMessage('gen.previous.pagesize', $pagesize)</legend><input type="submit" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getFormattedMessage('gen.previous.pagesize', $pagesize)"  accesskey="p" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#else
-										<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getFormattedMessage('gen.previous.pagesize', $pagesize)</legend><input type="submit" name="eventSubmit_doList_prev" value="&lt;" disabled="disabled" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#end
-								#end
-							
-								<form name="pagesizeForm" class="inlineForm" method="post" action="#toolForm("$action")">
-									<input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
-									<span class="skip">$tlang.getString("gen.listnavselect")</span>
-                                    <label for="selectPageSize" class="skip">$tlang.getString("gen.select.label")</label>
-									<select id="selectPageSize" name="selectPageSize" onchange="document.pagesizeForm.submit();">
-										<option value="5" #if($pagesize == 5) selected="selected" #end>$tlang.getFormattedMessage("gen.show", "5")</option>
-										<option value="10" #if($pagesize == 10) selected="selected" #end>$tlang.getFormattedMessage("gen.show", "10")</option>
-										<option value="20" #if($pagesize == 20) selected="selected" #end>$tlang.getFormattedMessage("gen.show", "20")</option>
-										<option value="50" #if($pagesize == 50) selected="selected" #end>$tlang.getFormattedMessage("gen.show", "50")</option>
-										<option value="100" #if($pagesize == 100) selected="selected" #end>$tlang.getFormattedMessage("gen.show", "100")</option>
-										<option value="200" #if($pagesize == 200) selected="selected" #end>$tlang.getFormattedMessage("gen.show", "200")</option>
-									</select>
-									<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-								</form>
-								#if ($pagesize != 0)
-									#if ($goNPButton == "true")
-										<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getFormattedMessage('gen.next.pagesize', $pagesize)</legend><input type="submit" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getFormattedMessage('gen.next.pagesize', $pagesize)"  accesskey="n" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#else
-										<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getFormattedMessage('gen.next.pagesize', $pagesize)</legend><input type="submit" name="eventSubmit_doList_next" value="&gt;" disabled="disabled" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#end
-									#if ($goLPButton == "true")
-										<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getString("gen.last")</legend><input type="submit" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString("gen.last")" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#else
-										<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-											<fieldset><legend>$tlang.getString("gen.last")</legend><input type="submit" name="eventSubmit_doList_last" value="&gt;|" disabled="disabled" /></fieldset>
-											<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-										</form>
-									#end
-								#end
-							</div>
-						</div> ##end navPanel
+						<div class="sakai-table-pagerContainer">
+							#pagerPanel("pager1")
+						</div>
+						#end
+					</div> ##end sakai-table-toolBar
+
+					#if ($messageListVector.iterator().hasNext())
 						<form name="announcementListForm" action="#toolForm("AnnouncementAction")" method="post">
 						<div class="table-responsive">
 							<table class="table table-hover table-striped table-bordered" summary="$tlang.getString('gen.tablecaptionsite')">
@@ -715,7 +643,6 @@
 						</table>
 						</div>
 						#else
-							</div> ##end navPanel
 							<div class="instruction clear">
 								#if ($!view == "view.public")
 									$tlang.getString("gen.therearepublic")
@@ -729,7 +656,7 @@
 								<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 							</form>
 						#end	
-						
+
 						#if ($messageListVector.iterator().hasNext())
 							#if ($isOnWorkspaceTab.equals("false"))
 								##if ($EnableItemCheckBoxes)  ## SAK-14021. This checks for new ann permission, which is not a requirement to have update and cancel buttons

--- a/assignment/bundles/resources/assignment.properties
+++ b/assignment/bundles/resources/assignment.properties
@@ -315,9 +315,8 @@ dateselectionwidget.ampm = Select AM or PM
 
 letter = Letter grade
 
-lisofass1 = Assignment List
-
-lisofass2 = Assignment List by Student
+lisofass1 = Assignments
+lisofass2 = Assignments by Student
 
 listassig.allgroups = All groups
 listassig.filterbygroup = Filter by group:
@@ -524,7 +523,7 @@ youmust8 = You must upload an attachment
 list.show = Show
 list.itemsper = items...
 update = Update
-removedAssignmentList = Removed Assignments List
+removedAssignmentList = Removed Assignments
 removeSelected = Remove Selected
 selectAssignments = Select Assignments
 restoreSelected = Restore Selected
@@ -1080,3 +1079,18 @@ option.hidepoints=Hide point values (feedback only)
 option.studentpreview=Hide Rubric preview from student
 grading_rubric=Grading Rubric
 asn.list.userubric=This assignment could be graded using a Rubric
+
+# table toolbar common messages
+view.label=View
+gen.viewing.phrase=Viewing {0} - {1} of {2} items
+gen.show=Show {0} items...
+# {0} is the pagesize
+gen.previous.pagesize = Previous {0}
+# {0} is the pagesize
+gen.next.pagesize = Next {0}
+gen.select.label = Choose page size
+gen.listnavselect = To operate the combo box, first press Alt+Down Arrow to open it, and then use the up and down arrow keys to scroll through the options.
+search.label=Search
+search.button=Search
+search.clear=Clear Search
+

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4764,6 +4764,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
         add2ndToolbarFields(data, context);
 
+        context.put("view", MODE_INSTRUCTOR_VIEW_STUDENTS_ASSIGNMENT);
+
         return getContext(data).get("template") + TEMPLATE_INSTRUCTOR_VIEW_STUDENTS_ASSIGNMENT;
 
     } // build_instructor_view_students_assignment_context
@@ -5267,13 +5269,7 @@ public class AssignmentAction extends PagedResourceActionII {
 
         ParameterParser params = data.getParameters();
         String option = params.getString("option");
-        if ("changeView".equals(option)) {
-            doChange_submission_list_option(data);
-        } else if ("search".equals(option)) {
-            state.setAttribute(VIEW_SUBMISSION_SEARCH, params.getString("search"));
-        } else if ("clearSearch".equals(option)) {
-            state.removeAttribute(VIEW_SUBMISSION_SEARCH);
-        } else if ("download".equals(option)) {
+        if ("download".equals(option)) {
             // go to download all page
             doPrep_download_all(data);
         } else if ("upload".equals(option)) {
@@ -5285,6 +5281,20 @@ public class AssignmentAction extends PagedResourceActionII {
         }
 
     } // doView_submission_list_option
+
+	public void doView_submission_list_search(RunData data)
+	{
+        SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
+
+        ParameterParser params = data.getParameters();
+        state.setAttribute(VIEW_SUBMISSION_SEARCH, params.getString("search"));
+	}
+
+	public void doView_submission_list_search_clear(RunData data)
+	{
+        SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
+        state.removeAttribute(VIEW_SUBMISSION_SEARCH);
+	}
 
     /**
      * Action is to view the content of one specific assignment submission

--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -111,6 +111,15 @@
                 <span class="current">$!tlang.getString( "lisofass1" )</span>
             #end
         </li>
+        <li>
+            #if( !$!view.equals( "lisofass2" ) )
+                <span>
+                    <a href="#toolLinkParam( "$action" "doView" "view=lisofass2" )" title="$!tlang.getString( "lisofass2" )">$!tlang.getString( "lisofass2" )</a>
+                </span>
+            #else
+                <span class="current">$!tlang.getString( "lisofass2" )</span>
+            #end
+        </li>
 
         #if( $withGrade && $!allowGradeSubmission )
             <li #if( $prevAction == false ) class="firstToolBarItem" #set( $prevAction = true ) #end>
@@ -212,6 +221,23 @@
         #else
             <li>
                 <span class="disabled">$!tlang.getString( "lisofass1" )</span>
+            </li>
+        #end
+        #if( !$!view.equals( "lisofass2" ) )
+            <li>
+                <span>
+                    <a href="javascript:void(0)" title="$!tlang.getString( "lisofass2" )" onclick="ASN.submitForm( '$formID', 'view', null, 'lisofass2' ); return false;">
+                        $!tlang.getString( "lisofass2" )
+                    </a>
+                </span>
+            </li>
+        #elseif( $current == "list" )
+            <li>
+                <span class="current">$!tlang.getString( "lisofass2" )</span>
+            </li>
+        #else
+            <li>
+                <span class="disabled">$!tlang.getString( "lisofass2" )</span>
             </li>
         #end
         #if( $withGrade && $!allowGradeSubmission )

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
@@ -14,11 +14,9 @@
 			$tlang.getString("gen.thearecur1")
 		</p>
 	#else
-		<div class="navPanel row">
-			<div class="col-sm-5 col-xs-12">
-			</div>
-			<div class="col-sm-7 col-xs-12">
-				#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
+		<div class="sakai-table-toolBar">
+			<div class="sakai-table-pagerContainer">
+				#pagerPanel("pager1")
 			</div>
 		</div>
 		<form name="listDeletedAssignmentsForm" action="#toolForm("$action")" method="post">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -70,49 +70,49 @@ function printView(url) {
 		</div>
 	#end
 
-	<div class="row">
-		<div class="col-xs-12">
-
+	<div class="sakai-asn-controlRow">
+		#set ($showMsg = false)
+		#set ($showMsg = $!allMsgNumber)
+		#if ($!showMsg || $showMsg != 0)
+		<div class="navPanel">
+			<div class="viewNav">
+			#set ($gradeType = $typeOfGrade)
+			#if(!$disableGrade)
+				<form id="defaultGradeForm" name="defaultGradeForm" class="inlineForm" method="post" action="#toolForm($action)">
+					<input type="hidden" name="$!form_action" value="setScore" />
+					<label for="defaultGrade_1" style="display:block" class="textPanelFooter">$!form_label</label>
+					##for non-point-based grading, choose the default grade from drop-down
+					#if ($!gradeType != 3)
+						<select id="defaultGrade_1" name="defaultGrade" size="1" >
+							<option value="">$tlang.getString("non.submission.grade.select")</option>
+							#if ($!gradeType == 1)
+								<option value="gen.nograd" #if($!defaultGrade && $!defaultGrade.equals("gen.nograd"))selected="selected"#end>$tlang.getString("gen.nograd")</option>
+							#elseif ($!gradeType == 2)
+								#foreach ($i in $letterGradeOptions)
+									<option value="$i" #if($!defaultGrade && $!defaultGrade.equals($i))selected="selected"#end>$i</option>
+								#end
+							#elseif ($!gradeType == 4)
+								#foreach ($i in ["Pass", "Fail"])
+									<option value="$i" #if($!defaultGrade && $!defaultGrade.equals($i))selected="selected"#end>#if ($i=="Pass") $tlang.getString("pass") #elseif ($i=="Fail") $tlang.getString("fail") #end</option>
+								#end
+							#elseif ($!gradeType == 5)
+								<option value="Checked" #if($!defaultGrade && $!defaultGrade.equals("Checked"))selected="selected"#end>$tlang.getString("gen.checked")</option>
+							#end
+						</select>
+					#else
+						## instructor needs to type in default points in point-based-grading
+						<input type="text" id="defaultGrade_2" name="defaultGrade" value="$!defaultGrade" size="5" />
+					#end
+					<input type="button" accesskey="a" class="active" name="apply" value="$tlang.getString('gen.applygrade')" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'defaultGradeForm', null, null, null );" title="$tlang.getString("gen.applygrade")" />
+					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+				</form>
+			#end
+			</div>
+		</div>
 		<form name="viewForm" id="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
 			<input type="hidden" name="assignmentId" id = "assignmentId" value=$validator.escapeUrl($!assignmentReference) />
 			<input type="hidden" name="option" id="option" value="x" />
 			<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
-			## show the view by group choice when there is at least one group defined
-			#if (!$assignment.IsGroup)
-				#if (!$value_CheckAnonymousGrading && $!groups.hasNext())
-					<div class="form-group spinnerBesideContainer">
-						<label class="col-md-2" for="view">
-							$tlang.getString("gen.view2")
-						</label>
-						<div class="col-md-10">
-							<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-							<select id="view" name="view" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, escapeList, null ); ASN.submitForm( 'viewForm', 'changeView', null, null ); return false;">
-								#if (!$showSubmissionByFilterSearchOnly)
-									<option value="all" #if($!view.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
-								#else
-									<option value="" >$tlang.getString('please_select_group')</option>
-								#end
-								#foreach($aGroup in $groups)
-									<option value="$!aGroup.Reference" #if($!view.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
-								#end
-							</select>
-						</div>
-					</div>
-				#end
-
-				#if (!$value_CheckAnonymousGrading)
-					<div class="form-group">
-						<label class="col-md-2" for="$form_search">$tlang.getString("search_students")</label>
-						<div class="col-md-10">
-							<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )" name="search" id="search" type="text" class="searchField" size="20" />
-							<input type="button" value="$tlang.getString('search')" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'viewForm', 'search', null, null ); return false;" />
-							#if (($!searchString) && (!$searchString.equals("")))
-								<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'viewForm', 'clearSearch', null, null ); return false;" />
-							#end
-						</div>
-					</div>
-				#end
-			#end
 			#set($disableGrade=false)
 			#if($assignment.AllowPeerAssessment && !$isPeerAssessmentClosed)
 				#set($disableGrade=true)
@@ -151,55 +151,9 @@ function printView(url) {
 			#end
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>
-
-		#set ($showMsg = false)
-		#set ($showMsg = $!allMsgNumber)
-		#if (!$!showMsg || $showMsg == 0)
-		#else
-		<div class="navPanel">
-			<div class="viewNav">
-			#set ($gradeType = $typeOfGrade)
-			#if(!$disableGrade)
-				<form id="defaultGradeForm" name="defaultGradeForm" class="inlineForm" method="post" action="#toolForm($action)">
-					<input type="hidden" name="$!form_action" value="setScore" />
-					<label for="defaultGrade_1" style="display:block" class="textPanelFooter">$!form_label</label>
-					##for non-point-based grading, choose the default grade from drop-down
-					#if ($!gradeType != 3)
-						<select id="defaultGrade_1" name="defaultGrade" size="1" >
-							<option value="">$tlang.getString("non.submission.grade.select")</option>
-							#if ($!gradeType == 1)
-								<option value="gen.nograd" #if($!defaultGrade && $!defaultGrade.equals("gen.nograd"))selected="selected"#end>$tlang.getString("gen.nograd")</option>
-							#elseif ($!gradeType == 2)
-								#foreach ($i in $letterGradeOptions)
-									<option value="$i" #if($!defaultGrade && $!defaultGrade.equals($i))selected="selected"#end>$i</option>
-								#end
-							#elseif ($!gradeType == 4)
-								#foreach ($i in ["Pass", "Fail"])
-									<option value="$i" #if($!defaultGrade && $!defaultGrade.equals($i))selected="selected"#end>#if ($i=="Pass") $tlang.getString("pass") #elseif ($i=="Fail") $tlang.getString("fail") #end</option>
-								#end
-							#elseif ($!gradeType == 5)
-								<option value="Checked" #if($!defaultGrade && $!defaultGrade.equals("Checked"))selected="selected"#end>$tlang.getString("gen.checked")</option>
-							#end
-						</select>
-					#else
-						## instructor needs to type in default points in point-based-grading
-						<input type="text" id="defaultGrade_2" name="defaultGrade" value="$!defaultGrade" size="5" />
-					#end
-					<input type="button" accesskey="a" class="active" name="apply" value="$tlang.getString('gen.applygrade')" onclick="SPNR.disableControlsAndSpin( this, escapeList ); ASN.submitForm( 'defaultGradeForm', null, null, null );" title="$tlang.getString("gen.applygrade")" />
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-			#end
-			</div>
-		</div>
-		</div>
-		<div class="col-lg-6 col-md-7 col-xs-12 pull-right">
-			#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
-		</div>
 	</div>
-
-		<form name= "listSubmissionsForm" action="#toolForm("AssignmentAction")" method="post">
+		<form id="listSubmissionForm" name= "listSubmissionsForm" action="#toolForm("AssignmentAction")" method="post">
 			<input type="hidden" name="assignmentId" value="$assignmentReference" />
-			
 			## model answer
 			#if($allowViewModelAnswer)
 			<h4  id="toggleModel" class="toggleAnchor specialLink"><img alt="expand" class="expand" src="/library/image/sakai/expand.gif" /><img alt="collapse" class="collapse" src="/library/image/sakai/collapse.gif" />$tlang.getString('modelAnswer')</h4>
@@ -402,15 +356,41 @@ function printView(url) {
 						</div> <!-- allowResubmissionPanelContent -->
 			</div>
 			#end
-			
+
 			#if ($!isAdditionalNotesEnabled && !$assignment.IsGroup)
 				<a href="#" onclick="window.open(printView('#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$validator.escapeUrl($assignmentReference)&grade_showStudentDetails=true")'));return false"><span alt="$tlang.getString("assignment.print")" class="fa fa-print"></span><span> $tlang.getString("assignment.print") $tlang.getString("assignment.additional.notes.export.title")</span></a>
 			#end
-			
-			
+
 			#if($disableGrade)
 				<div class="highlight">$tlang.getFormattedMessage("peerassessment.cantgradewithdate", $!service.getUsersLocalDateTimeString($assignment.PeerAssessmentPeriodDate))</div>
 			#end
+
+			<div class="sakai-table-toolBar">
+				<div class="sakai-table-filterContainer">
+					#if (!$assignment.IsGroup)
+						#if (!$value_CheckAnonymousGrading && $!groups.hasNext())
+							#define($viewSelectOptions)
+								#if (!$showSubmissionByFilterSearchOnly)
+									<option value="all" #if($!view.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
+								#else
+									<option value="" >$tlang.getString('please_select_group')</option>
+								#end
+								#foreach($aGroup in $groups)
+									<option value="$!aGroup.Reference" #if($!view.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
+								#end
+							#end
+							#viewFilterPanel("viewFilterForm", "view", $viewSelectOptions, "doChange_submission_list_option")
+						#end
+						#if (!$value_CheckAnonymousGrading)
+							#searchFilterPanel("$form_search", $searchString, "doView_submission_list_search", "doView_submission_list_search_clear")
+						#end
+					#end
+				</div>
+				<div class="sakai-table-pagerContainer">
+					#pagerPanel("pager1")
+				</div>
+			</div>
+
 			## show all submission
 			<table class="listHier lines nolines" id ="submissionList" cellpadding="0" cellspacing="0" summary="$tlang.getString("gen.viewassliststudentsummary")">
 				<tr>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -1,5 +1,5 @@
 <!-- start: chef_assignments_instructor_report_submissions.vm  -->
-<div class="portletBody">
+<div class="portletBody sakai-asn-grade-report">
 	#navBarHREF( $allowAddAssignment $withGrade $allowGradeSubmission $allowAddAssignment $allowRecoverAssignment $allowAllGroups $assignmentscheck $allowUpdateSite $enableViewOption $view "" )
 
 	#if ($alertMessage)<div class="alertMessage"><strong>$tlang.getString("gen.alert")</strong> $alertMessage</div><div class="clear"></div>#end
@@ -10,63 +10,37 @@
 		</h1>
 	</div>
 
-	<div class="navPanel row">
-		<div class="viewNav col-xs-12">
+	#if ($!submissions.size() == 0)
+		<p class="instruction">$tlang.getString("gen.theare2")</p>
+	#else
+		<div class="sakai-table-toolBar">
+			<div class="sakai-table-filterContainer">
 			#if (!$hasAtLeastOneAnonAssignment)
-			<form id="viewForm" name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
-			<input type="hidden" name="option" id="option" value="x" />
-			<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
-			<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-				#if( $!groups.hasNext() )
-				<div class="instruction">
-					$tlang.getString("view_instruction")
-				</div>
-				<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-
-				<div class="spinnerBesideContainer">
-					<select id="view" name="viewgroup" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null ); return false;">
-
-					#if (!$showSubmissionByFilterSearchOnly)
-						<option value="all" #if($!viewString.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
-					#else
-						<option value="" >$tlang.getString('please_select_group')</option>
+				#if ($!groups.hasNext())
+					#define($viewSelectOptions)
+						#if (!$showSubmissionByFilterSearchOnly)
+							<option value="all" #if($!viewString.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
+						#else
+							<option value="" >$tlang.getString('please_select_group')</option>
+						#end
+						#foreach($aGroup in $groups)
+							<option value="$!aGroup.Reference" #if($!viewString.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
+						#end
 					#end
-					#foreach($aGroup in $groups)
-						<option value="$!aGroup.Reference" #if($!viewString.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
-					#end
-					</select>
-				</div>
-				<p />
+					#viewFilterPanel("viewFilterForm", "viewgroup", $viewSelectOptions, "doChange_submission_list_option")
 				#end
 
-				<label for="$form_search" class="skip">$tlang.getString("search")</label>
-				<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )"
-					name="search" id="search" type="text" class="searchField" size="20" />
-				<input type="button" value="$tlang.getString('search')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'search', null, null ); return false;" />
-				#if (($!searchString) && (!$searchString.equals("")))
-					<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'clearSearch', null, null ); return false;" />
-				#end
-				<p />
-
-				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-			</form>
-
+				#searchFilterPanel("$form_search", $searchString, "doView_submission_list_search", "doView_submission_list_search_clear")
 			#end
-			#if ($!submissions.size() == 0)
-				<p class="instruction">
-					$tlang.getString("gen.theare2")
-				</p>
-			#else
-			<br />
-			<a href="$accessPointUrl" title="$!tlang.getString('downspr')" id="downloadAll">$!tlang.getString('downspr')</a>
-
-
+			</div>
+			<div class="sakai-table-toolBar-centre">
+				<a href="$accessPointUrl" title="$!tlang.getString('downspr')" id="downloadAll">$!tlang.getString('downspr')</a>
+			</div>
+			<div class="sakai-table-pagerContainer">
+				#pagerPanel("pager1")
+			</div>
 		</div>
-		<div class="col-lg-6 col-md-7 col-sm-9 col-xs-12">
-			#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
-		#if ($alertMessage)<div class="alertMessage"><strong>$tlang.getString("gen.alert")</strong> $alertMessage</div><div class="clear"></div>#end
-		</div>
-	</div>
+
 		<form name="reportForm" action="#toolForm("AssignmentAction")" method="post">
 			#if ($submissions.size()==0)
 				<p class="instruction">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -13,67 +13,27 @@
 				$tlang.getString("theisnostudent")
 			</p>
 		#else
-			<p class="instruction" style="clear:both">
-				$tlang.getString("stulistsunbm.chotri")
-			</p>
-		<div class="navPanel">
-			<div class="viewNav">
-				<form id="viewFormList" name="viewFormList" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
-					<input type="hidden" name="eventSubmit_doView" value="view" />
-					<div class="spinnerBesideContainer">
-						<label for="view">$tlang.getString("gen.view2")</label>
-						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-						<select name="view" id="view" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewFormList', null, null, null );">
-							<option value="lisofass1" >$!tlang.getString('lisofass1')</option>
-							<option value="lisofass2" selected="selected" >$!tlang.getString('lisofass2')</option>
-						</select>
-					</div>
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-
-				#if ($!groups.hasNext() || !$hasAtLeastOneAnonAssignment)
-					<form id="viewForm" name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
-						<input type="hidden" name="option" id="option" value="x" />
-						<input type="hidden" name="eventSubmit_doView_submission_list_option" value="x" />
-						#if( $!groups.hasNext() )
-						<div class="instruction">
-							$tlang.getString("view_instruction")
-						</div>
- 						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-
- 						<div class="spinnerBesideContainer">
-							<select id="viewgroup" name="viewgroup" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null ); return false;">ASN.disableControls( null, 'studentLink' );ASN.showSpinner( 'groupSpinner' );blur();document.getElementById('option').value='changeView';document.viewForm.submit();return false;">
-
-							#if (!$showSubmissionByFilterSearchOnly)
-								<option value="all" #if($!viewGroup.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
-							#else
-								<option value="" >$tlang.getString('please_select_group')</option>
-							#end
- 							#foreach($aGroup in $groups)
- 								<option value="$!aGroup.Reference" #if($!viewGroup.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
- 							#end
- 							</select>
-						</div>
-						#end
- 						<p />
-
-					#if( !$hasAtLeastOneAnonAssignment )
-					<label for="$form_search" class="skip">$tlang.getString("search")</label>
-					<input value="$validator.escapeHtml($searchString)" placeholder="$tlang.getString( "search_student_instruction" )"
-						name="search" id="search" type="text" class="searchField" size="20" />
-					<input type="button" value="$tlang.getString('search')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'search', null, null ); return false;" />
-					#if (($!searchString) && (!$searchString.equals("")))
-						<input type="button" class="button" value="$tlang.getString("search_clear")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'viewForm', 'clearSearch', null, null ); return false;" />
+		<div class="sakai-table-toolBar">
+			<div class="sakai-table-filterContainer">
+			#if ($!groups.hasNext() || !$hasAtLeastOneAnonAssignment)
+				#define($viewSelectOptions)
+					#if (!$showSubmissionByFilterSearchOnly)
+						<option value="all" #if($!viewGroup.equals("all"))selected="selected"#end >$tlang.getString('gen.viewallgroupssections')</option>
+					#else
+						<option value="" >$tlang.getString('please_select_group')</option>
 					#end
+					#foreach($aGroup in $groups)
+						<option value="$!aGroup.Reference" #if($!viewGroup.equals($!aGroup.Reference))selected="selected"#end >$validator.escapeHtml($aGroup.Title)</option>
 					#end
-
-					#end
-
-
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
+				#end
+				#viewFilterPanel("viewFilterForm", "viewgroup", $viewSelectOptions, "doChange_submission_list_option")
+			#end
+			#if( !$hasAtLeastOneAnonAssignment )
+				#searchFilterPanel("$form_search", $searchString, "doView_submission_list_search", "doView_submission_list_search_clear")
+			#end
 			</div>
 		</div>
+
 		<form name="studentAssignmentForm" action="#toolForm("AssignmentAction")" method="post">
 			#if ($assignments.size()==0)
 				<p class="instruction">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -44,67 +44,44 @@
 		</h1>
 	</div>
 
-	#if($!groupFilterEnabled && $!filterGroupIterator.hasNext())
-		<div class="row" id="filterByGroupDiv">
-			<div class="col-md-12">
-			<form id="groupFilterForm" name="groupFilterForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
-				<input type="hidden" name="eventSubmit_doFilterByGroup" value="filterByGroup" />
-					<div class="spinnerBesideContainer">
-						<label for="groupFilter">
-							$!tlang.getString("listassig.filterbygroup")
-						</label>
-						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-						<select id="filterByGroup" name="filterByGroup" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'groupFilterForm', null, null, null ); return false;">
-							<option value="all" #if($!filterByGroup.equals('all'))selected="selected"#end>$!tlang.getString("listassig.allgroups")</option>
-							#foreach($group in $!filterGroupIterator)
-								<option value="$group.getId()" #if($!filterByGroup.equals($group.getId()))selected="selected"#end>$group.getTitle()</option>
-							#end
-						</select>
-					</div>
-				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-			</form>
-			</div>
-		</div>
-	#end
-
 	#if (!$!assignments.hasNext())
 		<p class="instruction">
 			$tlang.getString("gen.thearecur1")
 		</p>
 	#else
-	<div class="navPanel row">
-		#if ($allowAddAssignment)
-			#if (!$!view.equals('stuvie'))
-			<div class="col-sm-5 col-xs-12">
-				<form id="viewForm" name="viewForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
-					<input type="hidden" name="eventSubmit_doView" value="view" />
-					<div class="spinnerBesideContainer">
-						<label for="view">
-							$tlang.getString("gen.view2")
-						</label>
-						<span class="skip">$tlang.getString("newassig.selectmessage")</span>
-						<select id="view" name="view" size="1" tabindex="3" onchange="SPNR.insertSpinnerAfter( this, null, null ); ASN.submitForm( 'viewForm', 'changeView', null, null ); return false;">
-							<option value="lisofass1" #if($!view.equals('lisofass1'))selected="selected"#end >$!tlang.getString('lisofass1')</option>
-							<option value="lisofass2" #if($!view.equals('lisofass2'))selected="selected"#end >$!tlang.getString('lisofass2')</option>
-						</select>
-					</div>
+	#if ($allowAddAssignment)
+		#if ($!view.equals('stuvie'))
+			<div class="messageInformation">$tlang.getString("stulistassig.selanass1")</div>
+		#end
+	#else
+		<div>$tlang.getString("stulistassig.selanass")</div>
+	#end
+
+	<div class="sakai-table-toolBar">
+		#if($!groupFilterEnabled && $!filterGroupIterator.hasNext())
+		<div class="sakai-table-filterContainer">
+			<div class="row" id="filterByGroupDiv">
+				<div class="col-md-12">
+				<form id="groupFilterForm" name="groupFilterForm" class="inlineForm" method="post" action="#toolForm("AssignmentAction")">
+					<input type="hidden" name="eventSubmit_doFilterByGroup" value="filterByGroup" />
+					<label for="groupFilter">
+						$!tlang.getString("listassig.filterbygroup")
+					</label>
+					<span class="skip">$tlang.getString("newassig.selectmessage")</span>
+					<select id="filterByGroup" name="filterByGroup" onchange="SPNR.disableControlsAndSpin(this, null); ASN.submitForm( 'groupFilterForm', null, null, null ); return false;">
+						<option value="all" #if($!filterByGroup.equals('all'))selected="selected"#end>$!tlang.getString("listassig.allgroups")</option>
+						#foreach($group in $!filterGroupIterator)
+							<option value="$group.getId()" #if($!filterByGroup.equals($group.getId()))selected="selected"#end>$group.getTitle()</option>
+						#end
+					</select>
 					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 				</form>
+				</div>
 			</div>
-			<div class="col-sm-7 col-xs-12">
-			#else
-				<div class="col-md-12">
-				<div class="instruction">	$tlang.getString("stulistassig.selanass1")</div>
-			</div>
-			<div class="col-lg-6 col-md-7 col-sm-9 col-xs-12">
-			#end
-		#else
-			<div class="col-md-12">
-				<div class="instruction">$tlang.getString("stulistassig.selanass")</div>
-			</div>
-			<div class="col-lg-6 col-md-7 col-sm-9 col-xs-12">
+		</div>
 		#end
-			#paginator( $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
+		<div class="sakai-table-pagerContainer">
+			#pagerPanel("pager1")
 		</div>
 	</div>
 

--- a/library/src/morpheus-master/sass/base/_compass.scss
+++ b/library/src/morpheus-master/sass/base/_compass.scss
@@ -22,6 +22,10 @@
     -webkit-flex-basis: $p;
     flex-basis: $p;
 }
+@mixin flex-wrap($p: wrap) {
+    -webkit-flex-wrap: $p;
+    flex-wrap: $p;
+}
 @mixin appearance($p: none) {
 	-moz-appearance: $p;
 	-webkit-appearance: $p;

--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -266,11 +266,11 @@ a.noPointers, input.noPointers {
 	to {transform: rotate(360deg);}
 }
 
-.spinButton {
+.spinButton, .spinSelect {
 	position: relative;
 }
 
-.spinButton:after, .spinPlaceholder:after {
+.spinButton:after, .spinPlaceholder:after, .spinSelect:after {
 	content: "";
 	background: url("images/ring58.png") center center no-repeat;
 	-moz-animation-name: rotate;
@@ -294,6 +294,12 @@ a.noPointers, input.noPointers {
 	height: 100%;
 }
 
+.spinSelect:after {
+	left: initial;
+	right: 4px;
+	width: 16px;
+}
+
 .spinPlaceholder, .allocatedSpinPlaceholder {
 	position: relative;
 	display: inline-block;
@@ -312,6 +318,7 @@ a.noPointers, input.noPointers {
 		margin-bottom: 0px;
 	}
 }
+
 /*** End button spinner overlay ***/
 .ui-dialog.ui-widget {
 	@media #{$phone}{

--- a/library/src/morpheus-master/sass/modules/tool/_table.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_table.scss
@@ -176,6 +176,7 @@ table{
 		}
 	}
 
+	/* specific breakpoint based on width of pager controls, allows them to stack when there isn't enough room */
 	@media all and (max-width: 400px)
 	{
 		.sakai-table-pagerControls

--- a/library/src/morpheus-master/sass/modules/tool/_table.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_table.scss
@@ -36,3 +36,180 @@ table{
 		}
 	}
 }
+
+.sakai-table-toolBar
+{
+	@include display-flex();
+	@include align-items(flex-end);
+	margin: 0;
+
+	&+table
+	{
+		margin-top: 0;
+		padding-top: 0;
+	}
+
+	.sakai-table-filterContainer
+	{
+		@include display-flex();
+		@include flex-direction(column);
+		margin: 0 auto 10px 0;
+		padding-right: 10px;
+
+		label
+		{
+			margin: 0 4px 0 0;
+		}
+	}
+	.sakai-table-viewFilter, .sakai-table-searchFilter
+	{
+		@include display-flex();
+		@include align-items(center);
+	}
+	.sakai-table-viewFilter ~ .sakai-table-searchFilter
+	{
+		margin-top: 10px;
+	}
+	.sakai-table-searchFilter
+	{
+		@include flex-grow(1);
+
+		.sakai-table-searchFilter-searchField
+		{
+			margin-right: 4px;
+			width: 200px;
+			@include flex-grow(1);
+		}
+
+		input[type=button],	input[type=submit],
+		input[type=button]:disabled, input[type=submit]:disabled,
+		button,	button:disabled
+		{
+			margin: 0 4px 0 0;
+		}
+	}
+
+	.sakai-table-pagerContainer
+	{
+		margin-bottom: 10px;
+		text-align: center;
+		margin-left: auto;
+		padding-left: 10px;
+	}
+	.sakai-table-pagerLabel
+	{
+		padding: 0 5px 3px 5px;
+		font-size: 12px;
+		color: #505050;
+		text-align: center;
+	}
+	.sakai-table-pagerControls
+	{
+		@include justify-content(center);
+		padding: 0;
+
+		label
+		{
+			display: none;
+		}
+
+		input, button
+		{
+			font-size: 12px;
+			line-height: 1;
+
+			&:first-of-type
+			{
+				margin-left: 0;
+			}
+		}
+
+		input, select, button
+		{
+			margin: 0 0 0 10px;
+		}
+
+	}
+
+	.sakai-table-toolBar-centre
+	{
+		margin-bottom: 10px;
+	}
+
+	.sakai-table-viewFilter select
+	{
+		width: 100%;
+	}
+
+	.sakai-table-searchFilterControls
+	{
+		@include display-flex();
+		width: 100%;
+
+		input:last-of-type
+		{
+			margin-right: 0;
+		}
+	}
+
+	@media #{$tablet}
+	{
+		@include flex-direction(column);
+		@include justify-content(flex-start);
+		@include align-items(center);
+
+		.sakai-table-filterContainer, .sakai-table-viewFilter
+		{
+			margin-right: 0;
+			padding-right: 0;
+		}
+
+		.sakai-table-pagerContainer
+		{
+			margin-left: 0;
+			padding-left: 0;
+		}
+
+		.sakai-table-searchFilter .sakai-table-searchFilter-searchField
+		{
+			width: 150px;
+		}
+	}
+
+	@media all and (max-width: 400px)
+	{
+		.sakai-table-pagerControls
+		{
+			@include flex-wrap(wrap);
+			@include justify-content(center);
+
+			.sakai-table-pagerPageSize
+			{
+				order: -1;
+				width: 100%;
+				margin-bottom: 10px;
+			}
+
+			button, input
+			{
+				line-height: 1.5;
+			}
+
+			select
+			{
+				margin-left: 0;
+			}
+		}
+
+		.sakai-table-searchFilter, .sakai-table-viewFilter
+		{
+			@include flex-direction(column);
+			@include align-items(flex-start);
+		}
+
+		.sakai-table-searchFilter .sakai-table-searchFilter-searchField
+		{
+			width: 100px;
+		}
+	}
+}

--- a/library/src/morpheus-master/sass/modules/tool/announcements/_announcements.scss
+++ b/library/src/morpheus-master/sass/modules/tool/announcements/_announcements.scss
@@ -40,5 +40,5 @@
 		margin-bottom: 20px;
 		border: 1px solid darken( $tool-background-color, 10% );
 		border-radius: 4px;		
-	}	
+	}
 }

--- a/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
+++ b/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
@@ -486,4 +486,11 @@
 		border: 1px solid #aaa;
 		padding: 0.6em;
 	}
+
+	.sakai-asn-controlRow {
+		@include justify-content(space-between);
+		@include align-items(flex-end);
+		-webkit-flex-wrap: wrap;
+		flex-wrap: wrap;
+	}
 }

--- a/library/src/morpheus-master/sass/modules/tool/sitemanage/_sitemanage.scss
+++ b/library/src/morpheus-master/sass/modules/tool/sitemanage/_sitemanage.scss
@@ -527,4 +527,44 @@
       padding: 0.5em 0;
     }
   }
+
+  .siteinfo-tableHeading
+  {
+    @include justify-content(space-between);
+    @include align-items(center);
+    margin-bottom: 10px;
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
+    margin-top: 0.75em;
+
+    a
+    {
+      margin: 0 0 0.5em 0;
+    }
+  
+    h4
+    {
+      margin: 0 10px 0.5em 0;
+    }
+  }
+
+  .siteinfo-tableFooter
+  {
+    @include justify-content(space-between);
+    @include align-items(flex-end);
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
+
+    .act
+    {
+      padding: 0;
+      margin-bottom: 10px;
+
+      input
+      {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+    }
+  }
 }

--- a/library/src/webapp/js/sakai-table-toolbar/pagerPanelMacro.js
+++ b/library/src/webapp/js/sakai-table-toolbar/pagerPanelMacro.js
@@ -1,0 +1,23 @@
+// scripts for the #pagerPanel velocity macro (see VM_chef_library.vm in the velocity project)
+// will use SPNR (spinner.js) if it is already loaded
+var VM_PP = VM_PP || {};
+
+VM_PP.doChangePageSize = function (url, selectElement)
+{
+    if (typeof SPNR !== "undefined") // if SPNR is available, use it
+    {
+        SPNR.disableControlsAndSpin(selectElement, null);
+    }
+	var selectedPageSizeValue = selectElement.options[selectElement.selectedIndex].value;
+	location = url + "&selectPageSize=" + selectedPageSizeValue;
+	return true;
+};
+VM_PP.doPageNav = function (url, buttonElement)
+{
+    if (typeof SPNR !== "undefined") // if SPNR is available, use it
+    {
+        SPNR.disableControlsAndSpin(buttonElement, null);
+    }
+	location = url;
+	return true;
+};

--- a/library/src/webapp/js/sakai-table-toolbar/searchFilterPanelMacro.js
+++ b/library/src/webapp/js/sakai-table-toolbar/searchFilterPanelMacro.js
@@ -1,0 +1,44 @@
+// scripts for the #searchFilterPanel velocity macro (see VM_chef_library.vm in the velocity project)
+// will use SPNR (spinner.js) if it is already loaded
+var VM_SFP = VM_SFP || {};
+
+VM_SFP.spinButton = function(buttonElement)
+{
+    // if SPNR is available, use it
+    if (typeof SPNR !== "undefined")
+    {
+        // if variable "escapeList" is defined on the page, use it
+        var escape = typeof escapeList === "undefined" ? null : escapeList;
+        SPNR.disableControlsAndSpin(buttonElement, escape);
+    }
+};
+
+VM_SFP.keyupListener = function(event)
+{
+    if (event.keyCode === 13) // Enter
+    {
+        // immediate nextSibling is an empty text node 
+        event.currentTarget.nextSibling.nextSibling.click();
+    }
+};
+
+var searchFields = document.getElementsByClassName("sakai-table-searchFilter-searchField");
+Array.prototype.forEach.call(searchFields, function(field) {
+    field.addEventListener("keyup", VM_SFP.keyupListener);
+});
+
+VM_SFP.doSearch = function (url, buttonElementId, textElementId)
+{
+	var buttonElement = document.getElementById(buttonElementId);
+	VM_SFP.spinButton(buttonElement);
+	var searchText = document.getElementById(textElementId).value;
+	location = url + "&search=" + searchText;
+	return true;
+};
+
+VM_SFP.doClearSearch = function(url, buttonElement)
+{
+    VM_SFP.spinButton(buttonElement);
+    location = url;
+    return false;
+};

--- a/library/src/webapp/js/sakai-table-toolbar/viewFilterPanelMacro.js
+++ b/library/src/webapp/js/sakai-table-toolbar/viewFilterPanelMacro.js
@@ -1,0 +1,14 @@
+// scripts for the #viewFilterPanel velocity macro (see VM_chef_library.vm in the velocity project)
+// will use SPNR (spinner.js) if it is already loaded
+var VM_VFP = VM_VFP || {};
+
+VM_VFP.doChangeView = function (url, selectElement)
+{
+	if (typeof SPNR !== "undefined")
+	{
+		SPNR.disableControlsAndSpin(selectElement, null);
+	}
+	var selectedView = selectElement.options[selectElement.selectedIndex].value;
+	location = url + "&" + selectElement.name + "=" + selectedView;
+	return true;
+};

--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -123,7 +123,7 @@ SPNR.disableControlsAndSpin = function( clickedElement, escapeList )
 
     SPNR.disableInputs( clickedElement, escapeList );
     SPNR.disableLinkPointers( escapeList );
-    SPNR.disableSelects( escapeList );
+    SPNR.disableSelects( clickedElement, escapeList );
     SPNR.disableTextAreas( escapeList );
 };
 
@@ -191,9 +191,10 @@ SPNR.disableInputs = function( clickedElement, escapeList )
 /**
  * This function clones and disables all 'select' elements on the page.
  * 
+ * @param {DOM Element} clickedElement - the element being interacted with
  * @param {Array[String]} escapeList - array of IDs you do not wish to be disabled
  */
-SPNR.disableSelects = function( escapeList )
+SPNR.disableSelects = function( clickedElement, escapeList )
 {
     // Clone and disable all drop downs (disable the clone, hide the original)
     var dropDowns = SPNR.nodeListToArray( document.getElementsByTagName( "select" ) );
@@ -217,9 +218,23 @@ SPNR.disableSelects = function( escapeList )
             newSelect.innerHTML = select.innerHTML;
             newSelect.selectedIndex = select.selectedIndex;
 
-            // Add the clone to the DOM where the original was
-            var parent = select.parentNode;
-            parent.insertBefore( newSelect, select );
+            if (select === clickedElement)
+            {
+                // wrap it
+                var wrapper = document.createElement("span");
+                wrapper.className = "spinSelect";
+                wrapper.appendChild(newSelect);
+                // transfer any margins from the original select to the wrapper
+                wrapper.style.margin = select.style.margin;
+
+                // insert it
+                select.parentNode.insertBefore(wrapper, select);
+            }
+            else
+            {
+                // Add the clone to the DOM where the original was
+                select.parentNode.insertBefore( newSelect, select );
+            }
         }
     }
 };
@@ -316,3 +331,4 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
         parent.insertBefore( newElement, element );
     }
 };
+

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1274,3 +1274,15 @@ sinfo.portalneochat.name=Portal Chat
 sinfo.portalneochat.allowForSite=Enable <strong>Portal Chat</strong> in this site.
 sinfo.portalneochat.confirmDisabled=You have disabled the Portal Chat for this site
 sinfo.portalneochat.disabled=Disabled
+
+# table toolbar common messages
+view.label=View
+gen.viewing.phrase=Viewing {0} - {1} of {2} items
+gen.show=Show {0} items...
+# {0} is the pagesize
+gen.previous.pagesize = Previous {0}
+# {0} is the pagesize
+gen.next.pagesize = Next {0}
+gen.select.label = Choose page size
+gen.listnavselect = To operate the combo box, first press Alt+Down Arrow to open it, and then use the up and down arrow keys to scroll through the options.
+

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -1,96 +1,5 @@
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm,v 1.6 2005/05/28 03:04:36 ggolden.umich.edu Exp $ -->
 
-## This macro has been defined in order to reuse the paging panel once at the top of the participant group table and once at the bottom of the participant group table. JIRA Ref -WL3736
-#macro(pagingPanel $pagesizeFormName)
-<div class="navPanel">
-	<div class="viewNav">
-		<h4>
-			$validator.escapeHtml($!siteTitle) $tlang.getString("sitegen.siteinfolist.part") ($tlang.getFormattedMessage("sinfo.list.participantListSize", $!participantListSize))
-		</h4>
-	</div>
-	<div class="listNav">
-		<div >
-			$tlang.getString("sitegen.siteinfolist.view") $topMsgPos - $btmMsgPos $tlang.getString("sitegen.siteinfolist.of") $allMsgNumber $tlang.getString("sitegen.siteinfolist.items")
-			<div id="pagerSpinner" class="allocatedSpinPlaceholder"></div>
-		</div>
-			#if ($pagesize != 0)
-				#if ($goFPButton == "true")
-					<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString("gen.first")</legend>
-							<input type="submit" name="eventSubmit_doList_first" value="|&lt;" title="$tlang.getString("gen.first")" onclick="SPNR.disableControlsAndSpin( this, null );" />
-						</fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#else
-					<form name="firstpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString("gen.first")</legend>
-							<input type="submit" name="eventSubmit_doList_first" value="|&lt;" disabled="disabled" />
-						</fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#end
-				#if ($goPPButton == "true")
-					<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend>
-							<input type="submit" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getString('gen.previous') $pagesize" onclick="SPNR.disableControlsAndSpin( this, null );" />
-						</fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#else
-					<form name="prevpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-						<fieldset><legend>$tlang.getString('gen.previous') $pagesize</legend>
-							<input type="submit" name="eventSubmit_doList_prev" value="&lt;" disabled="disabled" />
-						</fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-					</form>
-				#end
-			#end
-			<form id="$pagesizeFormName" name="$pagesizeFormName" class="inlineForm" method="post" action="#toolForm("$action")">
-				<input type="hidden" name="eventSubmit_doChange_pagesize" value="changepagesize" />
-				<label for="size_$pagesizeFormName" class="skip">$tlang.getString("sitegen.siteinfolist.view.pagesize")</label>
-				<select id="size_$pagesizeFormName" name="selectPageSize" onchange="SPNR.insertSpinnerInPreallocated( this, null, 'pagerSpinner' );document.getElementById('$pagesizeFormName').submit()">
-					#foreach ($i in $!pagesizes)
-						<option value="$i" #if($pagesize == $i) selected="selected" #end>$tlang.getString("sitegen.siteinfolist.show") $i $tlang.getString("sitegen.siteinfolist.itemspage")</option>
-					#end
-				</select>
-				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-			</form>
-		#if ($pagesize != 0)
-			#if($goNPButton == "true")
-				<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-					<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend>
-						<input type="submit" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getString('gen.next') $pagesize" onclick="SPNR.disableControlsAndSpin( this, null );" />
-					</fieldset>
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-			#else
-				<form name="nextpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-					<fieldset><legend>$tlang.getString('gen.next') $pagesize</legend>
-						<input type="submit" name="eventSubmit_doList_next" value="&gt;" disabled="disabled" />
-					</fieldset>
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-			#end
-			#if ($goLPButton == "true")
-				<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-					<fieldset><legend>$tlang.getString('gen.last')</legend>
-						<input type="submit" name="eventSubmit_doList_last" value="&gt;|" title="$tlang.getString('gen.last')" onclick="SPNR.disableControlsAndSpin( this, null );" />
-					</fieldset>
-					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-			#else
-				<form name="lastpageForm" class="inlineForm" method="post" action="#toolForm("$action")">
-					<fieldset><legend>$tlang.getString('gen.last')</legend>
-						<input type="submit" name="eventSubmit_doList_last" value="&gt;|" disabled="disabled" />
-					</fieldset>
-					 <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-				</form>
-			#end
-		#end
-	</div>
-</div>
-#end
-
 <div id="dialog">
 </div>
 <script type="text/javascript">
@@ -554,12 +463,22 @@
 
 	#if ($!viewRoster)
 		#if ($participantList.size() > 0)
-			#set($pagesizeFormName="pagesizeFormTop")
-			#pagingPanel($pagesizeFormName)
+			##set($pagesizeFormName="pagesizeFormTop")
+			##pagingPanel($pagesizeFormName)
+			<div class="siteinfo-tableHeading">
+				<h4>$validator.escapeHtml($!siteTitle) $tlang.getString("sitegen.siteinfolist.part") ($tlang.getFormattedMessage("sinfo.list.participantListSize", $!participantListSize))</h4>
+				## download link for print out participant list
+				<a href="$printParticipantUrl" title="$!tlang.getString('print')" target="_blank" rel="noreferrer"><span class="icon-sakai--pdf" aria-hidden="true"></span> $!tlang.getString('print')</a>
+			</div>
+			<div class="sakai-table-toolBar sakai-table-toolBar-pagerOnly">
+				#if (!$participantList.isEmpty())
+				<div class="sakai-table-pagerContainer">
+					#pagerPanel("pager1")
+				</div>
+				#end
+			</div>
 		#end
-		## download link for print out participant list
-		<a href="$printParticipantUrl" title="$!tlang.getString('print')" target="_blank" rel="noreferrer"><span class="icon-sakai--pdf" aria-hidden="true"></span> $!tlang.getString('print')</a>
-		<hr />
+
 		<form name="participantForm" id="participantForm" action="#toolForm("SiteAction")" method="post">
 			<div class="table-responsive">
 			<table class ="table table-responsive table-bordered table-striped table-hover" summary ="$tlang.getString("sitegen.siteinfolist.partlist.summary")" id="siteMembers">
@@ -764,19 +683,23 @@
 					</tr>
 				#end
 			</table></div>
-			<hr />
-			<div class="act" style="padding: 0 0">
-				<input type="submit" accesskey="s" class="active" name="eventSubmit_doUpdate_participant" value="$tlang.getString("sitegen.siteinfolist.update")" onclick="SPNR.disableControlsAndSpin( this, null );" />
-				#if ($fromWSetup)
-					<input type="submit" accesskey="x" name="eventSubmit_doBack_to_site_list" value="$tlang.getString("sitegen.siteinfolist.cancel")" onclick="SPNR.disableControlsAndSpin( this, null );" />
-				#end
-				<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-            </div>
+			<div class="siteinfo-tableFooter">
+				<div class="act">
+					<input type="submit" accesskey="s" class="active" name="eventSubmit_doUpdate_participant" value="$tlang.getString("sitegen.siteinfolist.update")" onclick="SPNR.disableControlsAndSpin( this, null );" />
+					#if ($fromWSetup)
+						<input type="submit" accesskey="x" name="eventSubmit_doBack_to_site_list" value="$tlang.getString("sitegen.siteinfolist.cancel")" onclick="SPNR.disableControlsAndSpin( this, null );" />
+					#end
+					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+				</div>
+				<div class="sakai-table-toolBar sakai-table-toolBar-pagerOnly">
+					#if (!$participantList.isEmpty() && $participantList.size() > 10)
+					<div class="sakai-table-pagerContainer">
+						#pagerPanel("pager2")
+					</div>
+					#end
+				</div>
+			</div>
 		</form>
-		#if ($participantList.size() > 10)
-			#set($pagesizeFormName="pagesizeFormBottom")
-			#pagingPanel($pagesizeFormName)
-		#end
 		<div style="padding-left: 0.3em;"><em>$tlang.getString("sitegen.siteinfolist.lastupdated") $realmModifiedTime</em></span></div>
 		#chef_flashnotif()
 		<h4>$tlang.getString("sitegen.siteinfolist.roledes")</h4>

--- a/velocity/tool/src/templates/VM_chef_library.vm
+++ b/velocity/tool/src/templates/VM_chef_library.vm
@@ -645,3 +645,77 @@ scheduleUpdate();
 
 #macro (siteLink $siteId)${config.getPortalUrl()}/site/${siteId}#end
 
+#* -----------------------------------------------------------------------------------
+#  Adds a view filter dropdown to the page. Intended for use in a sakai-table-toolbar.
+#  Requires spinner.js to be loaded on the page.
+#  -----------------------------------------------------------------------------------
+*#
+#macro (viewFilterPanel $panelName $selectName $selectOptions $actionKey)
+#set($libLink="#libraryLink('js/sakai-table-toolbar/viewFilterPanelMacro.js')")
+<script type='text/javascript' src='$libLink' defer></script>
+<div class="sakai-table-viewFilter">
+	<label for="viewFilter_$panelName">$tlang.getString("view.label")</label>
+	<span class="skip">$tlang.getString("gen.listnavselect")</span>
+	<select id="viewFilter_$panelName" name="$selectName" onchange="VM_VFP.doChangeView('#toolLink("$action", "$actionKey")', this);">
+		$selectOptions
+	</select>
+</div>
+#end ## viewFilterPanel
+
+#* -----------------------------------------------------------------------------------
+#  Adds a table pager to the page. Intended for use in a sakai-table-toolbar.
+#  Requires spinner.js to be loaded on the page.
+#  -----------------------------------------------------------------------------------
+*#
+#macro (pagerPanel $panelName)
+#set($libLink="#libraryLink('js/sakai-table-toolbar/pagerPanelMacro.js')")
+<script type='text/javascript' src='$libLink' defer></script>
+<div class="sakai-table-pagerLabel">$tlang.getFormattedMessage("gen.viewing.phrase", $topMsgPos, $btmMsgPos, $allMsgNumber)</div>
+<div class="sakai-table-pagerControls">
+	<span class="skip">$tlang.getString("gen.first")</span>
+	<input type="button" name="eventSubmit_doList_first" value="&#124;&lt;" title="$tlang.getString("gen.first")"
+		onclick="VM_PP.doPageNav('#toolLink("$action", "doList_first")', this);" #if ($goFPButton != "true") disabled="disabled" #end />
+
+	<span class="skip">$tlang.getFormattedMessage('gen.previous.pagesize', $pagesize)</span>
+	<input type="button" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getFormattedMessage('gen.previous.pagesize', $pagesize)"
+		onclick="VM_PP.doPageNav('#toolLink("$action", "doList_prev")', this);" #if ($goPPButton != "true") disabled="disabled" #end />
+
+	<label for="selectPageSize_$panelName">$tlang.getString("gen.select.label")</label>
+	<span class="skip">$tlang.getString("gen.listnavselect")</span>
+	<div class="sakai-table-pagerPageSize">
+		<select id="selectPageSize_$panelName" name="selectPageSize_$panelName" onchange="VM_PP.doChangePageSize('#toolLink("$action", "doChange_pagesize")', this);">
+		#foreach ($i in $!pagesizes)
+			<option value="$i" #if($pagesize == $i) selected="selected" #end>$tlang.getFormattedMessage("gen.show", $i)</option>
+		#end
+		</select>
+	</div>
+
+	<span class="skip">$tlang.getFormattedMessage('gen.next.pagesize', $pagesize)</span>
+	<input type="button" name="eventSubmit_doList_next" value="&gt;" title="$tlang.getFormattedMessage('gen.next.pagesize', $pagesize)"
+		onclick="VM_PP.doPageNav('#toolLink("$action", "doList_next")', this);" #if($goNPButton != "true") disabled="disabled" #end />
+
+	<span class="skip">$tlang.getString('gen.last')</span>
+	<input type="button" name="eventSubmit_doList_last" value="&gt;&#124;" title="$tlang.getString('gen.last')"
+		onclick="VM_PP.doPageNav('#toolLink("$action", "doList_last")', this);" #if ($goLPButton != "true") disabled="disabled" #end />
+</div>
+#end ## pagerPanel
+
+#* -----------------------------------------------------------------------------------
+#  Adds a search filter to the page. Intended for use in a sakai-table-toolbar.
+#  Requires spinner.js to be loaded on the page.
+#  -----------------------------------------------------------------------------------
+*#
+#macro (searchFilterPanel $panelName $userSearchTerm $searchActionKey $clearSearchActionKey)
+<div class="sakai-table-searchFilter">
+	<label for="$panelName">$tlang.getString("search.label")</label>
+	<div class="sakai-table-searchFilterControls">
+		<input type="text" name="$panelName" id="$panelName" value="$validator.escapeHtml($!userSearchTerm)" class="sakai-table-searchFilter-searchField" />
+		<input type="button" id="btnSearch_$panelName" value="$tlang.getString('search.button')" onclick="VM_SFP.doSearch('#toolLink("$action" "$searchActionKey")', 'btnSearch_$panelName', '$panelName');" />
+		#if($!userSearchTerm && !$userSearchTerm.isEmpty())
+			<input type="button" value="$tlang.getString("search.clear")" onclick="VM_SFP.doClearSearch('#toolLink("$action" "$clearSearchActionKey")', this);" />
+		#end
+	</div>
+</div>
+#set($libLink="#libraryLink('js/sakai-table-toolbar/searchFilterPanelMacro.js')")
+<script type='text/javascript' src='$libLink' defer></script>
+#end ## searchFilterPanel


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40248

As a small step of the standardization project known as SWITCH, standardize the view and paging controls found at the top of most tools. Start with a few tools, such as Assignments, Announcements, and Site Info.

Goals of this change:

-    Create standard components, styles, design, and layout for these controls
-    Ensure the layout of these components work across varying screen sizes and toolbar
-    Make the controls easy for developers to use in future table pages
-    Create reusable Velocity components that can be applied to other tools

Scope:

-    Announcements - main page
-    Assignments - all pages with tables
-    Site Info - main page