### PR TITLE
SAK-40249: Kernel > allow more flexibility in defining sakai.properties loaded with getPatternList() or getStringList()

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/BasicConfigurationService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/component/impl/BasicConfigurationService.java
@@ -31,8 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -648,9 +646,9 @@ public class BasicConfigurationService implements ServerConfigurationService, Ap
      */
     public List<String> getStringList(String name, List<String> dflt) {
 
-        String value = getString(name, null);
-        if (StringUtils.isNotBlank(value)) {
-            return Stream.of(StringUtils.split(value, ",")).collect(Collectors.toList());
+        String[] values = getStrings(name);
+        if (ArrayUtils.isNotEmpty(values)) {
+            return Arrays.asList(values);
         } else {
             return dflt != null ? dflt : new ArrayList<>();
         }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40249

Currently if you want to load some sakai.properties with either getStringList() or getPatternList(), the sakai.property must be defined as a single property with comma separated values:

```
propertyName=value1,value2,value3
```

If your list of values is really long (long text values, long or numerous regex patterns, etc.), the resulting property can be difficult to read and manage. Although the .count style of defining sakai.properties is "old", it can be really beneficial for situations like these to clean things up:

```
propertyName.count=3
propertyName.1=reallyLongValueWithOrWithoutRegex
propertyName.2=reallyLongValueWithOrWithoutRegex
propertyName.3=reallyLongValueWithOrWithoutRegex
```

It's a relatively minor change to getStringList() (which is also used by getPatternList()) to support both styles of defining sakai.properties by simply using the existing getStrings() method rather than getString().