### PR TITLE
SAK-40252: Site Info > Improve location and language of 'Unjoin' button

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -869,7 +869,7 @@ sinfo.list.joinable.unjoin=Unjoin
 ### (moot) sitegen.addpart.continue = Continue
 ### (moot) sitegen.addpart.cancel = Cancel
 
-sitegen.siteinfolist.siteunjoin = Unjoin
+sitegen.siteinfolist.siteunjoin = Unjoin this site
 
 
 ### (moot) alert.apubsit = A published site is viewable to all participants. Unpublished sites are only viewable to those with permission to set up the site. 	If you choose to leave the site unpublished for now, you can publish it later at any time using the Site Info tool, which is visible in the menu bar of each project or course site.

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -282,8 +282,16 @@
 					#end
 				</td>
 			</tr>
- 			<tr>
- 				<th>
+			<tr>
+				<th>
+					$tlang.getString("sitegen.siteinfolist.crea")
+				</th>
+				<td>
+					$!siteCreationDate
+				</td>
+			</tr>
+			<tr>
+				<th>
 					$tlang.getString("sitegen.siteinfolist.modify")
 				</th>
 				<td>
@@ -291,37 +299,7 @@
 				</td>
 			</tr>
 		#end
-		
-		#if ($siteJoinable)
-			
-			<tr>
-				<th>
-					&nbsp;
-				</th>
-				<td>
-					
-			#if ($allowUnjoin)
-                    
-					<form name="unjoinSiteForm" class="inlineForm" method="post" action="#toolForm("SiteAction")">
-						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-						<input type="hidden" name="itemReference" value="$siteId"/>
-						<input type="submit" class="active" name="eventSubmit_doUnjoin" value="$tlang.getString("sitegen.siteinfolist.siteunjoin")" onclick="SPNR.disableControlsAndSpin( this, null );" />
-					</form>
-                    
-			#else
-                    
-            		<form name="unjoinSiteForm" class="inlineForm" method="post" action="#toolForm("SiteAction")">
-						<input type="hidden" name="itemReference" value="$siteId"/>
-						<input type="submit" disabled="disabled" name="eventSubmit_doUnjoin" value="$tlang.getString("sitegen.siteinfolist.siteunjoin")" onclick="SPNR.disableControlsAndSpin( this, null );" />
-					</form>
-                    
-			#end
-					
-				</td>
-			</tr>
-				
-		#end
-            
+
 		#if ($!allowUpdate)
 		
 			<tr>
@@ -346,15 +324,7 @@
 					<span class="instruction textPanelFooter" id="displayPublicInfoText" style="display:none">$tlang.getString("ediacc.dismysit.h")</span>
 				</td>
 			</tr>
-			<tr>
-				<th>
-					$tlang.getString("sitegen.siteinfolist.crea")
-				</th>
-				<td>
-					$!siteCreationDate
-				</td>
-			</tr> 
-		
+
 		#if ($!isCourseSite)
 			<tr>
 				<th>
@@ -399,6 +369,21 @@
 				</th>
 				<td>
 					$tlang.getString("sinfo.lessonbuildersubnav.enabled")
+				</td>
+			</tr>
+		#end
+
+		#if ($siteJoinable && $allowUnjoin)
+			<tr>
+				<th>
+					&nbsp;
+				</th>
+				<td>
+					<form name="unjoinSiteForm" class="inlineForm" method="post" action="#toolForm("SiteAction")">
+						<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+						<input type="hidden" name="itemReference" value="$siteId"/>
+						<input type="submit" class="active" name="eventSubmit_doUnjoin" value="$tlang.getString("sitegen.siteinfolist.siteunjoin")" onclick="SPNR.disableControlsAndSpin( this, null );" />
+					</form>
 				</td>
 			</tr>
 		#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40252

SAK-29342 introduced an 'Unjoin' button for joinable sites, but its location is unfortunate. It's located between the 'Modification date' and 'Modified by' fields which should appear together as they are closely related.

The linked PR makes the following changes:

* Move the 'Unjoin' button to the bottom row of the table on the 'Site Info' landing page
* Change the button text from 'Unjoin' to 'Unjoin this site'
![screenshot_20180629_101946](https://user-images.githubusercontent.com/10403943/42097478-bffa3bde-7ba7-11e8-894e-0c1709a53ced.png)
