### PR TITLE
SAK-40264 - Cannot delete item in lessons

### DIFF
--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -795,7 +795,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		try {
 			getHibernateTemplate().delete(o);
 			return true;
-		} catch (DataAccessException e) {
+		} catch (DataAccessException | IllegalArgumentException e) {
 			try {
 				
 				/* If we have multiple objects of the same item, you must merge them
@@ -804,8 +804,8 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 				getHibernateTemplate().delete(getHibernateTemplate().merge(o));
 				
 				return true;
-			}catch(DataAccessException ex) {
-				log.warn("Hibernate could not delete: " + e.toString());
+			}catch(DataAccessException | IllegalArgumentException ex) {
+				log.warn("Hibernate could not delete: " + ex.toString());
 				return false;
 			}
 		}


### PR DESCRIPTION
Seems like Lessons was already doing this 

https://stackoverflow.com/a/17027553/3708872

Just not catching this new exception? Maybe this pattern will need to be used more often? I'll defer to the JPA experts. I tested and this is working though to allow for deletion again.