### PR TITLE
SAK-40286 Library: Updated the SASS files to fix minor styling and usage issues with the mixins

### DIFF
--- a/library/src/morpheus-master/sass/base/_compass.scss
+++ b/library/src/morpheus-master/sass/base/_compass.scss
@@ -1,14 +1,14 @@
 @mixin align-items($p: center) {
+    -webkit-align-items: $p;
     align-items: $p;
-    -webkit-align-items: $p; /* safari */
 }
-@mixin display-flex($p: flex) {
-    display: $p;
-    display: -webkit-flex; /* safari */
+@mixin display-flex() {
+    display: -webkit-flex;
+    display: flex;
 }
 @mixin flex-direction($p: row) {
+    -webkit-flex-direction: $p;
     flex-direction: $p;
-    -webkit-flex-direction: $p; /* safari */
 }
 @mixin flex-shrink($p: 0) {
     -webkit-flex-shrink: $p;
@@ -32,16 +32,15 @@
     border-radius: $p;
 }
 @mixin justify-content($p: flex-start) {
-	@include display-flex(flex);
 	-webkit-justify-content: $p;
 	justify-content: $p;
 }
 @mixin align-self($p: auto) {
-    -webkit-align-self: $p; /* safari */
+    -webkit-align-self: $p;
     align-self: $p;
 }
 @mixin filter($p: none) {
-	-webkit-filter: $p; /* Chrome, Safari, Opera */
+	-webkit-filter: $p;
 	filter: $p;
 }
 @mixin transition($property: all, $duration: 0s, $timing: ease, $delay: 0s) {

--- a/library/src/morpheus-master/sass/modules/_main.scss
+++ b/library/src/morpheus-master/sass/modules/_main.scss
@@ -18,7 +18,7 @@
 
 #pageBody{
 	@include align-items(stretch);
-	@include display-flex(flex);
+	@include display-flex;
 	@include flex-direction(row);
 	> .#{$namespace}pagebody{
 		width: 100%;

--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -38,7 +38,7 @@ body.is-logged-out{
 	}
 
 	.#{$namespace}loginUser{
-		@include display-flex( inline-flex );
+		display: inline-flex;
 		li{
 			display: inline-block;
 			margin: 0 0.8em 0 0;
@@ -211,7 +211,7 @@ body.is-logged-out{
 
 	a
 	{
-		@include display-flex( flex );
+		@include display-flex;
 		@include align-items( center );
 
 		color: $topNav-text-color;
@@ -229,7 +229,7 @@ body.is-logged-out{
 		float: right;
 		height: $banner-height;
 		@include flex-shrink( 0 );
-		@include display-flex( flex );
+		@include display-flex;
 		@include align-items( center );
 		@include justify-content( flex-end );
 
@@ -355,7 +355,7 @@ body.is-logged-out{
 	}
 
 	@media #{$phone}{
-		@include display-flex( flex );
+		@include display-flex;
 		position: fixed;
 		width: 100%;
 		top: 0;
@@ -400,7 +400,7 @@ body.is-logged-out{
 
 	#loginForm{
 
-		@include display-flex( flex );
+		@include display-flex;
 		@include align-items( center );
 		@include justify-content( flex-end );
 
@@ -442,7 +442,7 @@ body.is-logged-out{
 	}
 
 	#loginUser{
-		@include display-flex( flex );
+		@include display-flex;
 		@include align-items( center );
 
 		&.has-avatar:hover .#{$namespace}userNav__submenuitem--profilepicture,
@@ -767,7 +767,7 @@ body.is-logged-out{
 }
 #topnav_container
 {
-	@include display-flex(flex);
+	@include display-flex;
 	padding-left: 0.5em;
 	background-color: $sites-nav-background;
 	min-height: 52px;
@@ -776,7 +776,7 @@ body.is-logged-out{
 
 #linkNav{
 	ul{
-		@include display-flex(flex);
+		@include display-flex;
 		@include flex-wrap( wrap );
 		font-family: $header-font-family;
 		margin: 0.5em 0 0 0;
@@ -792,7 +792,7 @@ body.is-logged-out{
 			background: $sites-nav-menu-item-background;
 
 			> a.link-container{
-				@include display-flex( flex );
+				@include display-flex;
 				@include align-items( center );
 
 				padding: 0.5em 36px 0.5em 0.5em;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40286

In our SASS files in the Library project, Sakai has a _compass.scss file containing a number of SASS mixins for short-handing CSS properties, particularly browser prefixes.

There are a few issues with some of these mixins:

- vendor prefixes should appear first, so they can be overridden by non-prefixed styles
- the justify-content mixin contains an include for display-flex, while none of the other flex-related mixins have an include (this either causes duplication in the output or improper usage)
- the display-flex mixin requires a parameter to be passed in, but it is not used for the webkit-prefixed style inside the rule

I fixed these issues to improve the output and usage of these mixins.
