### PR TITLE
SAK-40294 Library: Removed magic number from calculation

### DIFF
--- a/library/src/morpheus-master/sass/base/_responsive.scss
+++ b/library/src/morpheus-master/sass/base/_responsive.scss
@@ -206,7 +206,7 @@ body {
     .phone, .tablet, .desktop {
       display: none;
 
-      height: 1px;
+      height: 0;			// removed in SAK-40294 because it caused an extra pixel of unnecessary page height
       width: 1px;
       overflow: hidden;
       position: absolute;

--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -177,7 +177,7 @@ body.is-logged-out{
 	min-width: $tool-menu-width;
 	width: $tool-menu-width;
 	min-height: 100vh;											// alternative for browswers who cannot do calculations
-	min-height: calc(100vh - (#{$banner-height} * 2) - 1px);	// viewport minus the two top banners; "- 1px" for extra pixel somewhere
+	min-height: calc(100vh - (#{$banner-height} * 2));	// viewport minus the two top banners
 	@include flex-basis( $tool-menu-width );
 	padding: 5px 0 0 0;
 	text-align: center;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40294

When working on the fix for SAK-40287, I had to add a magic number of 1px to the height calculation because I couldn't find where the 1px was coming from. This bothered me. I have finally found it: it was coming from the height of the #Mrphs-viewport-helpers children.

I've removed the 1px height from these children and removed the magic number from my #toolMenuWrap calculation.
