### PR TITLE
SAK-40286 Library: Fixed an extra case of display-flex taking a parameter added in #5773

### DIFF
--- a/library/src/morpheus-master/sass/modules/_main.scss
+++ b/library/src/morpheus-master/sass/modules/_main.scss
@@ -22,7 +22,7 @@
 	@include flex-direction(row);
 	
 	> .#{$namespace}pagebody{
-		@include display-flex(flex);
+		@include display-flex;
 		@include flex-direction(column);
 		width: 100%;
 	}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40286

The main work for SAK-40286 was already merged in #5771, but after #5773 introduced another instance of the display-flex mixin using a parameter, which breaks the build now that both have been merged.

This fixes that extra case.