### PR TITLE
SAK-40242 Sign-up: Changed article in message from a to an

### DIFF
--- a/signup/api/src/java/org/sakaiproject/signup/model/SignupTimeslot.java
+++ b/signup/api/src/java/org/sakaiproject/signup/model/SignupTimeslot.java
@@ -123,7 +123,7 @@ public class SignupTimeslot implements Comparable{
 	 * get the SignupAttendee object according to the attendee's Id
 	 * 
 	 * @param attendeeId
-	 *            a attendee's Id
+	 *            an attendee's Id
 	 * @return a SignupAttendee object
 	 */
 	public SignupAttendee getAttendee(String attendeeId) {

--- a/signup/tool/src/bundle/messages.properties
+++ b/signup/tool/src/bundle/messages.properties
@@ -704,7 +704,7 @@ organizer_instruction_mailto_all_image = &nbsp;to email all participants.
 
 organizer_instruction_mailto_image = &nbsp;to email a participant.
 
-organizer_instruction_comment_image=&nbsp;to view/edit a attendee's comment.
+organizer_instruction_comment_image=&nbsp;to view/edit an attendee's comment.
 
 organizer_instruction_max_capacity = - Meeting organizers can add participants even if the time slot is full.
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40242

In Sign-up, I changed "a" to "an" as reported in the ticket. Here is the result:

![sak-40242-after](https://user-images.githubusercontent.com/12685096/42531506-24935db6-8452-11e8-98d6-bd74bf07d305.png)

