### PR TITLE
SAK-40286 Library: Fixed an extra case of display-flex taking a parameter added in #5705

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/calendar/_calendarSynoptic.scss
+++ b/library/src/morpheus-master/sass/modules/tool/calendar/_calendarSynoptic.scss
@@ -11,14 +11,14 @@
 	{
 		tr
 		{
-			@include display-flex(flex);
+			@include display-flex;
 			@include justify-content(space-between);
 			@include flex-wrap(wrap);
 		}
 
 		td
 		{
-			@include display-flex(flex);
+			@include display-flex;
 			@include align-items(center);
 		}
 	}
@@ -32,6 +32,7 @@
 
 	.calRight
 	{
+		@include display-flex;
 		@include justify-content(flex-end);
 		vertical-align: middle;
 		text-align: right;
@@ -89,7 +90,7 @@
 		> span
 		{
 			position: relative;
-			@include display-flex(flex);
+			@include display-flex;
 			@include justify-content(center);
 			@include align-items(center);
 			width: 100%;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40286

The main work for SAK-40286 was already merged in #5771, but when #5705 was merged today, it introduced another instance of the display-flex mixin using a parameter, which breaks the build now that both have been merged.

This fixes that extra case.