### PR TITLE
SAK-40004 - Update Maven Plugins

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -2178,7 +2178,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.4.1</version>
         <executions>
           <execution>
             <id>enforce-versions</id>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -2223,7 +2223,7 @@
         <inherited>true</inherited>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.7.0</version>
         <configuration>
           <!-- <compilerArguments> <verbose /> </compilerArguments> -->
           <source>${sakai.jdk.version}</source>

--- a/rubrics/tool/pom.xml
+++ b/rubrics/tool/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <name>Sakai Rubrics - Manager Tool</name>
-    <groupId>org.sakaiproject.rubrics</groupId>
     <artifactId>rubrics-service</artifactId>
     <packaging>war</packaging>
 

--- a/rubrics/tool/pom.xml
+++ b/rubrics/tool/pom.xml
@@ -214,6 +214,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>


### PR DESCRIPTION
With this, the command `mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V` works with no error on JDK8, JDK9 and JDK10.

Tests fails at `sakai-assignment-impl` on JDK9 and JDK10 due an Hibernate incompatibility.