### PR TITLE
SAK-40316 Cleaned up the top bar, including spacing and alignment, accessibility and usability

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -139,16 +139,17 @@ $header-gradient-d: $header-gradient-a !default;
 
 /* topNav Main Menu */
 $header-size: 50px !default;
-$topNav-text-color:                         #fff !default; /* used for links and text in the topNav */
-$topNav-text-alt-color:                     #ccc !default;
+$topNav-text-color:                         #fff !default; 		// used for links and text in the topNav
+$topNav-alt-color:                     		#9c9c9c !default;	// used for topNav spacers
 
 /* Favorites */
+$sites-nav-menu-item-border-thickness:		1px !default;
 /* Favorites - item */
 $sites-nav-menu-item-background:            #FFFFFF !default;
 $sites-nav-menu-item-color:                 #4C4C4C !default;
 $sites-nav-menu-item-icon-color:            #666666 !default;
 $sites-nav-menu-item-border-color:          #E5E5E5 !default;
-$sites-nav-menu-item-border-top:            1px solid $sites-nav-menu-item-border-color !default;
+$sites-nav-menu-item-border-top:            $sites-nav-menu-item-border-thickness solid $sites-nav-menu-item-border-color !default;
 $sites-nav-menu-item-border-right:          $sites-nav-menu-item-border-top !default;
 $sites-nav-menu-item-border-bottom:         $sites-nav-menu-item-border-top !default;
 $sites-nav-menu-item-border-left:           $sites-nav-menu-item-border-top !default;
@@ -157,7 +158,7 @@ $sites-nav-menu-item-hover-background:      #FFFFFF !default;
 $sites-nav-menu-item-hover-color:           #191919 !default;
 $sites-nav-menu-item-hover-icon-color:      #424242 !default;
 $sites-nav-menu-item-hover-border-color:    #7F7F7F !default;
-$sites-nav-menu-item-hover-border-top:      1px solid $sites-nav-menu-item-hover-border-color !default;
+$sites-nav-menu-item-hover-border-top:      $sites-nav-menu-item-border-thickness solid $sites-nav-menu-item-hover-border-color !default;
 $sites-nav-menu-item-hover-border-right:    $sites-nav-menu-item-hover-border-top !default;
 $sites-nav-menu-item-hover-border-bottom:   $sites-nav-menu-item-hover-border-top !default;
 $sites-nav-menu-item-hover-border-left:     $sites-nav-menu-item-hover-border-top !default;
@@ -166,33 +167,33 @@ $sites-nav-menu-item-selected-background:   #15597e !default;
 $sites-nav-menu-item-selected-color:        #FFFFFF !default;
 $sites-nav-menu-item-selected-icon-color:   #FFFFFF !default;
 $sites-nav-menu-item-selected-border-color: #326B97 !default;
-$sites-nav-menu-item-selected-border-top:   1px solid $sites-nav-menu-item-selected-border-color !default;
+$sites-nav-menu-item-selected-border-top:   $sites-nav-menu-item-border-thickness solid $sites-nav-menu-item-selected-border-color !default;
 $sites-nav-menu-item-selected-border-right: $sites-nav-menu-item-selected-border-top !default;
 $sites-nav-menu-item-selected-border-bottom:$sites-nav-menu-item-selected-border-top !default;
 $sites-nav-menu-item-selected-border-left:  $sites-nav-menu-item-selected-border-top !default;
 /* Favorites - item selected and hovered */
-$sites-nav-menu-item-selected-hover-background:   #15597e !default;
+$sites-nav-menu-item-selected-hover-background:   lighten($sites-nav-menu-item-selected-background, 5%) !default;
 $sites-nav-menu-item-selected-hover-color:        #FFFFFF !default;
 $sites-nav-menu-item-selected-hover-icon-color:   #FFFFFF !default;
-$sites-nav-menu-item-selected-hover-border-color: #326B97 !default;
-$sites-nav-menu-item-selected-hover-border-top:   1px solid $sites-nav-menu-item-selected-hover-border-color !default;
+$sites-nav-menu-item-selected-hover-border-color: $sites-nav-menu-item-selected-border-color !default;
+$sites-nav-menu-item-selected-hover-border-top:   $sites-nav-menu-item-border-thickness solid $sites-nav-menu-item-selected-hover-border-color !default;
 $sites-nav-menu-item-selected-hover-border-right: $sites-nav-menu-item-selected-hover-border-top !default;
 $sites-nav-menu-item-selected-hover-border-bottom:$sites-nav-menu-item-selected-hover-border-top !default;
 $sites-nav-menu-item-selected-hover-border-left:  $sites-nav-menu-item-selected-hover-border-top !default;
 /* Favorites - tool submenu */
-$sites-nav-submenu-background:              #FFFFFF !default;
-$sites-nav-submenu-topleft-border-color:    $sites-nav-menu-item-background !default;
+$sites-nav-submenu-background:              $sites-nav-menu-item-hover-background !default;
+$sites-nav-submenu-topleft-border-color:    $sites-nav-menu-item-hover-background !default;
 $sites-nav-submenu-border-color:            $sites-nav-menu-item-hover-border-color !default;
 /* Favorites - tool selected submenu */
 $sites-nav-selected-submenu-border-color: $sites-nav-menu-item-selected-hover-border-color !default;
-$sites-nav-selected-submenu-topleft-border-color: $sites-nav-menu-item-selected-background !default;
+$sites-nav-selected-submenu-topleft-border-color: $sites-nav-menu-item-selected-hover-background !default;
 /* Favorites - tool submenu items */
 $sites-nav-submenu-item-text-size:          13px !default;
-$sites-nav-submenu-item-background:         #FFFFFF !default;
+$sites-nav-submenu-item-background:          $sites-nav-menu-item-hover-background !default;
 $sites-nav-submenu-item-color:              #4C4C4C !default;
 $sites-nav-submenu-item-icon-color:         #666666 !default;
 $sites-nav-submenu-item-divider-color:      #E5E5E5 !default;
-$sites-nav-submenu-item-left-border-color:  #FFFFFF !default;
+$sites-nav-submenu-item-left-border-color:  transparent !default;
 /* Favorites - tool submenu items hovered */
 $sites-nav-submenu-item-hover-background:   #ECECEC !default;
 $sites-nav-submenu-item-hover-color:        #191919 !default;
@@ -336,6 +337,7 @@ $measure: 960px !default;
 
 /* The standard spacing for items in Sakai */
 $standard-spacing: 10px !default;
+$standard-space: 4px !default; 		// the width of a keyboard space
 
 $banner-height: 52px !default;
 

--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -1,11 +1,5 @@
 //.#{$namespace}
 body.is-logged-out{
-	#toolMenuWrap{
-		//top: 0;
-		@media #{$phone}{
-			//top: $header-size;
-		}
-	}
 	.#{$namespace}mainHeader.is-maximized ~ #container #toolMenuWrap{
 		top: $header-size;
 	}

--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -22,7 +22,7 @@ body.is-logged-out{
 	.#{$namespace}headerLogo{
 		width: 100%;
 		overflow: hidden;
-		padding: 0 1em;
+		padding: 0 $standard-spacing;
 		height: $banner-height;
 		background: $top-header-background;
 
@@ -143,7 +143,7 @@ body.is-logged-out{
     			color: $primary-color-highContrast;
 			}
 			.toolMenuIcon{
-				@extend .fa-fw;
+				@extend .fa-fw;			// standardize the width of all icons for proper text alignment
 				vertical-align: sub;
 				margin: 0 0.5em 0 0;
 			}
@@ -234,9 +234,11 @@ body.is-logged-out{
 		@include justify-content( flex-end );
 
 		#roleSwitch {
-			padding-right: 1em;
-			margin-right: 1em;
-			border-right: 1px solid #F0F0F0;
+			@include display-flex;
+			@include align-items( center );
+			padding-right: $standard-spacing;
+			margin-right: $standard-spacing;
+			border-right: 1px solid $topNav-alt-color;
 			white-space: nowrap;
 
 				@media #{$phone} {
@@ -271,7 +273,7 @@ body.is-logged-out{
 			#roleSwitchDropDown {
 				@media #{$phone} {
 					position: absolute;
-					left: -100000000;
+					left: -100000000px;
 					height: 1px;
 					width: 1px;
 					overflow: hidden;
@@ -296,6 +298,7 @@ body.is-logged-out{
 
 				@media #{$phone} {
 					&.open {
+						top: calc((#{$banner-height} / 2) + #{$default-font-size} + 4px); 	// half of the height of the banner plus the height of the line plus half the height of the arrow tip border (because it is a triangle)
 						left: auto;
 						height: auto;
 						width: auto;
@@ -304,8 +307,6 @@ body.is-logged-out{
 						padding: 1em;
 						z-index: 50;
 						overflow: visible;
-						min-width: 180px;
-						margin-top: 4px;
 
 						&:after {
 							bottom: 100%;
@@ -553,7 +554,7 @@ body.is-logged-out{
 				}
 			}
 		}
-		.#{$namespace}userNav__submenuitem--username, .#{$namespace}userNav__submenuitem--userid{
+		.#{$namespace}userNav__submenuitem--username span.textlink, .#{$namespace}userNav__submenuitem--userid span.textlink {
 			@media #{$phone}{
 				display: none;
 			}
@@ -589,9 +590,9 @@ body.is-logged-out{
 
 	#loginLinks{
 		font-family: $header-font-family;
-		margin: 0 1em 0 0;
+		margin: 0;
 		list-style: none;
-		padding: 0 0 0 1em;
+		padding: 0 0 0 $standard-spacing;
 
 		@media #{$phone}
 		{
@@ -694,7 +695,7 @@ body.is-logged-out{
 /* because #loginLinks appears on the Gateway page when two log-in links are available (e.g. for CAS), the following applies only when you are logged in: */
 .is-maximized #loginLinks
 {
-	border-left: 1px solid $tool-border-color;
+	border-left: 1px solid $topNav-alt-color;
 }
 
 .#{$namespace}sitesNav__menu{
@@ -706,8 +707,8 @@ body.is-logged-out{
 .portal-bullhorns-buttons{
 	position: relative;
 	display: inline-block;
-	padding-right: 1em;
-	border-right: 1px solid $tool-border-color;
+	padding-right: $standard-spacing;
+	border-right: 1px solid $topNav-alt-color;
     white-space: nowrap;
 }
 
@@ -726,7 +727,7 @@ body.is-logged-out{
 .view-all-sites-btn{
 	position: relative;
 	display: inline-block;
-	padding: 0 1em;
+	padding: 0 $standard-spacing;
 
 	@media #{$phone}{
 		display: none;
@@ -763,15 +764,15 @@ body.is-logged-out{
 		fontawesome.css which adjusts the size of our icon unless
 		we override it. */
 	font-size: 16pt !important;
-	padding-right: 4px;
+	padding-right: $standard-space;
 }
 #topnav_container
 {
 	@include display-flex;
-	padding-left: 0.5em;
+	@include align-items(center);
 	background-color: $sites-nav-background;
-	min-height: 52px;
-	padding: 4px 8px;
+	min-height: $banner-height;
+	padding: 0 $standard-spacing;		// space on the sides; top and bottom spacing will be determined by children
 }
 
 #linkNav{
@@ -779,28 +780,47 @@ body.is-logged-out{
 		@include display-flex;
 		@include flex-wrap( wrap );
 		font-family: $header-font-family;
-		margin: 0.5em 0 0 0;
+		margin: $standard-spacing 0 0 0;
 		padding: 0;
+		
 		li.#{$namespace}sitesNav__menuitem{
-			margin: 0 0.5em 0.5em 0;
+			@include display-flex;
+			@include align-items(center);
+			margin: 0 $standard-spacing $standard-spacing 0;	// space the items apart, and space vertically if wrapped
 			padding: 0;
 			position: relative;
-			border-top: $sites-nav-menu-item-border-top;
-			border-right: $sites-nav-menu-item-border-right;
-			border-bottom: $sites-nav-menu-item-border-bottom;
-			border-left: $sites-nav-menu-item-border-left;
-			background: $sites-nav-menu-item-background;
 
 			> a.link-container{
 				@include display-flex;
 				@include align-items( center );
 
-				padding: 0.5em 36px 0.5em 0.5em;
+				border-top: $sites-nav-menu-item-border-top;
+				border-right: $sites-nav-menu-item-border-right;
+				border-bottom: $sites-nav-menu-item-border-bottom;
+				border-left: $sites-nav-menu-item-border-left;
+				background: $sites-nav-menu-item-background;
+				padding: ($standard-space * 2);
 				color: $sites-nav-menu-item-color;
 				text-decoration: none;
 
 				i.fa {
 					color: $sites-nav-menu-item-icon-color;
+				}
+				
+				&:hover {
+					border-top: $sites-nav-menu-item-hover-border-top;
+					border-right: $sites-nav-menu-item-hover-border-right;
+					border-bottom: $sites-nav-menu-item-hover-border-bottom;
+					border-left: $sites-nav-menu-item-hover-border-left;
+					background: $sites-nav-menu-item-hover-background;
+					
+					~ .#{$namespace}sitesNav__drop, ~ .#{$namespace}sitesNav__dropdown {
+						border-left: $sites-nav-menu-item-hover-border-left; 		// so the right border of the .link-container will show through the overlapping box
+					}
+				}
+				
+				&:active {
+					outline: 0 none;	// hiding on click
 				}
 			}
 
@@ -816,23 +836,24 @@ body.is-logged-out{
 				}
 			}
 
-			&.dropdown-is-visible, &:hover {
-				border-top: $sites-nav-menu-item-hover-border-top;
-				border-right: $sites-nav-menu-item-hover-border-right;
-				border-bottom: $sites-nav-menu-item-hover-border-bottom;
-				border-left: $sites-nav-menu-item-hover-border-left;
-				background: $sites-nav-menu-item-hover-background;
-			}
-
 			&.dropdown-is-visible {
 				&:after {
-					border-bottom: 1px solid $sites-nav-submenu-topleft-border-color;
 					content: "";
-					width: 100%;
+					border-bottom: $sites-nav-menu-item-border-thickness solid $sites-nav-submenu-topleft-border-color;
+					width: 100%; // fallback for browsers who don't calculate nested equations
+					width: calc(100% - (2 * #{$sites-nav-menu-item-border-thickness}));	// width minus the left and right border widths
 					position: absolute;
-					bottom: -1px;
-					left: 0;
+					bottom: 0;
+					left: $sites-nav-menu-item-border-thickness;					// left border width
 					z-index: 100;
+				}
+				
+				.link-container{
+					border-top: $sites-nav-menu-item-hover-border-top;
+					border-right: $sites-nav-menu-item-hover-border-right;
+					border-bottom: $sites-nav-menu-item-hover-border-bottom;
+					border-left: $sites-nav-menu-item-hover-border-left;
+					background: $sites-nav-menu-item-hover-background;
 				}
 			}
 
@@ -842,14 +863,18 @@ body.is-logged-out{
 			}
 			.#{$namespace}sitesNav__drop, .#{$namespace}sitesNav__dropdown{
 				text-align: center;
-				margin-left: 0.2em;
-				position: absolute;
-				right: 8px;
-				top: 50%;
-				transform: translate(0%,-50%);
 				text-decoration: none;
 				color: $sites-nav-menu-item-icon-color;
-				border: none;
+				margin-left: -#{$sites-nav-menu-item-border-thickness}; 					// to overlap the left border with the site title's border, so border thickness will remain 1px and hover will still work
+				padding: ($standard-space * 2);
+				width: $default-font-size; 			// to match the height
+				height: $default-font-size;			// to match the link text size
+				box-sizing: content-box;			// to allow width and height control the size to match the site title link text
+				border-top: $sites-nav-menu-item-border-top;
+				border-right: $sites-nav-menu-item-border-right;
+				border-bottom: $sites-nav-menu-item-border-bottom;
+				border-left: $sites-nav-menu-item-border-left;
+				background: $sites-nav-menu-item-background;
 
 				@extend .fa-angle-down;
 				@extend .fa;
@@ -859,10 +884,23 @@ body.is-logged-out{
 				&.is-clicked{
 					@include transform( rotate(180deg) );
 					top: 40%;
+					border-right: $sites-nav-menu-item-hover-border-left;	// using the left variable because of the item rotation (right is left)
+					border-bottom: $sites-nav-menu-item-hover-border-top;	// using top variable because of the item rotation (bottom is top)
+					border-left: $sites-nav-menu-item-hover-border-right;	// using the right variable because of the item rotation (left is right)
+					background: $sites-nav-menu-item-hover-background;
 				}
 
 				&:hover {
+					border-top: $sites-nav-menu-item-hover-border-top;
+					border-right: $sites-nav-menu-item-hover-border-right;
+					border-bottom: $sites-nav-menu-item-hover-border-bottom;
+					border-left: $sites-nav-menu-item-hover-border-left;
+					background: $sites-nav-menu-item-hover-background;
 					color: $sites-nav-menu-item-hover-icon-color;
+				}
+				
+				&:active {
+					outline: 0 none;	// hiding on click
 				}
 			}
 			ul{
@@ -870,9 +908,9 @@ body.is-logged-out{
 				display: none;
 				font-family: $header-font-family;
 				position: absolute;
-				border: 1px solid $sites-nav-submenu-border-color;
-				margin-top: 0;
-				margin-left: -1px;
+				border: $sites-nav-menu-item-border-thickness solid $sites-nav-submenu-border-color;
+				top: calc( #{$default-font-size} + ( #{$standard-space} * 2) - #{$sites-nav-menu-item-border-thickness});	// 1px for item border
+				left: 0;
 				width: 17em;
 				z-index: 99;
 				box-shadow: 0 3px 2px rgba( $text-color, 0.35);
@@ -885,8 +923,9 @@ body.is-logged-out{
 					min-height: 15px;
 
 					a{
-						display: block;
-						padding: 0.5em 0.65em;
+						@include display-flex;
+						@include align-items(center);
+						padding: $standard-spacing;
 						text-decoration: none;
 						color: $sites-nav-submenu-item-color;
 						font-size: $sites-nav-submenu-item-text-size;
@@ -896,6 +935,7 @@ body.is-logged-out{
 							color: $sites-nav-submenu-item-color; /* to override default link hover color */
 						}
 						.toolMenuIcon{
+							@extend .fa-fw;
 							vertical-align: sub;
 							margin: 0;
 						}
@@ -903,12 +943,10 @@ body.is-logged-out{
 					.#{$namespace}sitesNav__submenuitem-icon {
 						display: inline-block;
 						vertical-align: middle;
-						padding: 0 10px;
+						padding: 0 $standard-spacing 0 0;
 					}
 					.#{$namespace}sitesNav__submenuitem-title {
-						margin-bottom: 2px;
 						display: inline-block;
-						width: 80%;
 					}
 				}
 				&.is-visible{
@@ -920,16 +958,29 @@ body.is-logged-out{
 
 			}
 			&.is-selected{
-				background: $sites-nav-menu-item-selected-background;
-				border-top: $sites-nav-menu-item-selected-border-top;
-				border-right: $sites-nav-menu-item-selected-border-right;
-				border-bottom: $sites-nav-menu-item-selected-border-bottom;
-				border-left: $sites-nav-menu-item-selected-border-left;
-
+				
 				a.link-container{
+					background: $sites-nav-menu-item-selected-background;
+					border-top: $sites-nav-menu-item-selected-border-top;
+					border-right: $sites-nav-menu-item-selected-border-right;
+					border-bottom: $sites-nav-menu-item-selected-border-bottom;
+					border-left: $sites-nav-menu-item-selected-border-left;
 					color: $sites-nav-menu-item-selected-color;
+					
 					i.fa {
 						color: $sites-nav-menu-item-selected-icon-color;
+					}
+					
+					&:hover {
+						border-top: $sites-nav-menu-item-selected-hover-border-top;
+						border-right: $sites-nav-menu-item-selected-hover-border-right;
+						border-bottom: $sites-nav-menu-item-selected-hover-border-bottom;
+						border-left: $sites-nav-menu-item-selected-hover-border-left;
+						background: $sites-nav-menu-item-selected-hover-background;
+						
+						~ .#{$namespace}sitesNav__drop, ~ .#{$namespace}sitesNav__dropdown {
+							border-left: $sites-nav-menu-item-selected-hover-border-left; 		// so the right border of the .link-container will show through the overlapping box
+						}
 					}
 				}
 				/* hover for sites when tool quick-menu isn't open */
@@ -944,29 +995,35 @@ body.is-logged-out{
 					}
 				}
 
-				&.dropdown-is-visible, &:hover {
-					border-top: $sites-nav-menu-item-selected-hover-border-top;
-					border-right: $sites-nav-menu-item-selected-hover-border-right;
-					border-bottom: $sites-nav-menu-item-selected-hover-border-bottom;
-					border-left: $sites-nav-menu-item-selected-hover-border-left;
-					background: $sites-nav-menu-item-selected-hover-background;
-				}
-
 				&.dropdown-is-visible {
-					&:after {
-						border-bottom: 1px solid $sites-nav-selected-submenu-topleft-border-color;
+					&:after {	// the rest of the properties will inherit from the default case above
 						content: "";
-						width: 100%;
-						position: absolute;
-						bottom: -1px;
-						left: 0;
-						z-index: 100;
+						border-bottom: $sites-nav-menu-item-border-thickness solid $sites-nav-selected-submenu-topleft-border-color;
+					}
+					
+					.link-container, .#{$namespace}sitesNav__drop, .#{$namespace}sitesNav__dropdown{
+						border-top: $sites-nav-menu-item-selected-hover-border-top;
+						border-right: $sites-nav-menu-item-selected-hover-border-right;
+						border-bottom: $sites-nav-menu-item-selected-hover-border-bottom;
+						border-left: $sites-nav-menu-item-selected-hover-border-left;
+						background: $sites-nav-menu-item-selected-hover-background;
 					}
 				}
 
 				.#{$namespace}sitesNav__drop, .#{$namespace}sitesNav__dropdown{
-					color: $sites-nav-menu-item-selected-hover-icon-color;
+					background: $sites-nav-menu-item-selected-background;
+					border-top: $sites-nav-menu-item-selected-border-top;
+					border-right: $sites-nav-menu-item-selected-border-right;
+					border-bottom: $sites-nav-menu-item-selected-border-bottom;
+					border-left: $sites-nav-menu-item-selected-border-left;
+					color: $sites-nav-menu-item-selected-icon-color;
+					
 					&:hover {
+						border-top: $sites-nav-menu-item-selected-hover-border-top;
+						border-right: $sites-nav-menu-item-selected-hover-border-right;
+						border-bottom: $sites-nav-menu-item-selected-hover-border-bottom;
+						border-left: $sites-nav-menu-item-selected-hover-border-left;
+						background: $sites-nav-menu-item-selected-hover-background;
 						color: $sites-nav-menu-item-selected-hover-icon-color;
 					}
 				}
@@ -976,33 +1033,23 @@ body.is-logged-out{
 				}
 			}
 
-			&.#{$namespace}sitesNav__menuitem--myworkspace{
-
-				.link-container{
-					padding-left: 0.5em;
-				}
-
-				a{
-					i{
-						margin-top: 1px; /* to compensate for an issue with the icon */
-						margin-bottom: -1px; /* to compensate for an issue with the icon */
-						margin-right:0.35em;
-						font-size: 1em;
-					}
-				}
+			&.#{$namespace}sitesNav__menuitem--myworkspace .fa-home{
+				margin-top: -1px; // to compensate for an issue with the icon
+				margin-bottom: 1px; // to compensate for an issue with the icon
+				margin-right: $standard-space;
 			}
 
 			ul.#{$namespace}sitesNav__submenu{
 				background: $sites-nav-submenu-background;
 				li.#{$namespace}sitesNav__submenuitem{
 					a {
+						position: relative;
 						background: $sites-nav-submenu-item-background;
 						color: $sites-nav-submenu-item-color;
+						
 						.toolMenuIcon {
 							color: $sites-nav-submenu-item-icon-color;
 						}
-
-						position: relative;
 
 						&:before{
 							border-left: 4px solid $sites-nav-submenu-item-left-border-color;
@@ -1014,10 +1061,10 @@ body.is-logged-out{
 							left: 0;
 						}
 
-						&:hover, &:active
-						{
+						&:hover, &:active, &:focus {
 							background: $sites-nav-submenu-item-hover-background;
 							color: $sites-nav-submenu-item-hover-color;
+							
 							.toolMenuIcon {
 								color: $sites-nav-submenu-item-hover-icon-color;
 							}

--- a/library/src/morpheus-master/sass/modules/quicklinks/_base.scss
+++ b/library/src/morpheus-master/sass/modules/quicklinks/_base.scss
@@ -1,6 +1,6 @@
 .#{$namespace}quickLinksNav__popup {
   @extend .view-all-sites-btn;
-  border-right: 1px solid $tool-border-color;
+  border-right: 1px solid $topNav-alt-color;
   @media #{$phone}{
     display: inline-block;
   }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40316

Cleaned up Sakai's top bar that contains the account link and the favourited sites. Fixed the following:

- fixed the alignment and spacing of the house icon beside "Home" for the Home site (desktop view)
- improved the hit area of the favourite sites' quick drop-down menu beside a site title (desktop view)
- set a fixed width on the tool icons under the favourite sites' quick dropdown menus (desktop view)
- fixed the alignment and spacing of the favourite sites' quick dropdown menus (desktop view)
- reviewed the colour customization options in SASS to ensure the favourite sites list can be modified properly (desktop view)
- added additional hover and focus states to the favourite sites list and dropdown menus (desktop view)
- aligned the Role Switch panel (particularly in mobile view)
- restored the account menu in mobile view, so users can access their account tools and be able to log out (mobile view)

*Before:*
![01-before](https://user-images.githubusercontent.com/12685096/42784720-13e3e262-891e-11e8-9bac-77580285f9ae.png)

*After:*
![02-after](https://user-images.githubusercontent.com/12685096/42784727-195a136a-891e-11e8-9c51-7cb1788db52c.png)



