### PR TITLE
SAK-40027 (Assignments) Multi node caché issues

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
@@ -47,6 +47,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -162,7 +164,6 @@ public class Assignment {
     @Column(name = "POSITION")
     private Integer position;
 
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @OneToMany(mappedBy = "assignment", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<AssignmentSubmission> submissions = new HashSet<>();
 
@@ -172,17 +173,20 @@ public class Assignment {
     @Lob
     @Column(name = "VALUE", length = 65535)
     @CollectionTable(name = "ASN_ASSIGNMENT_PROPERTIES", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
+    @Fetch(FetchMode.SUBSELECT)
     private Map<String, String> properties = new HashMap<>();
 
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @CollectionTable(name = "ASN_ASSIGNMENT_GROUPS", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
+    @Fetch(FetchMode.SUBSELECT)
     @Column(name = "GROUP_ID")
     private Set<String> groups = new HashSet<>();
 
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @CollectionTable(name = "ASN_ASSIGNMENT_ATTACHMENTS", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
+    @Fetch(FetchMode.SUBSELECT)
     @Column(name = "ATTACHMENT", length = 1024)
     private Set<String> attachments = new HashSet<>();
 

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
@@ -40,7 +40,6 @@ import javax.persistence.Lob;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Version;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -48,8 +47,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -102,10 +99,6 @@ public class Assignment {
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "uuid2")
     private String id;
-
-    @Version
-    @Column(name = "VERSION")
-    private Integer version;
 
     @Column(name = "TITLE")
     private String title;
@@ -173,24 +166,24 @@ public class Assignment {
     @OneToMany(mappedBy = "assignment", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<AssignmentSubmission> submissions = new HashSet<>();
 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @MapKeyColumn(name = "NAME")
     @Lob
     @Column(name = "VALUE", length = 65535)
     @CollectionTable(name = "ASN_ASSIGNMENT_PROPERTIES", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
-    @Fetch(FetchMode.SUBSELECT)
     private Map<String, String> properties = new HashMap<>();
 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @CollectionTable(name = "ASN_ASSIGNMENT_GROUPS", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
     @Column(name = "GROUP_ID")
-    @Fetch(FetchMode.SUBSELECT)
     private Set<String> groups = new HashSet<>();
 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @CollectionTable(name = "ASN_ASSIGNMENT_ATTACHMENTS", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
     @Column(name = "ATTACHMENT", length = 1024)
-    @Fetch(FetchMode.SUBSELECT)
     private Set<String> attachments = new HashSet<>();
 
     @Enumerated(value = EnumType.STRING)

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
@@ -48,8 +48,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -98,16 +96,16 @@ public class AssignmentSubmission {
     @Column(name = "MODIFIED_DATE")
     private Instant dateModified;
 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @Column(name = "ATTACHMENT", length = 1024)
     @CollectionTable(name = "ASN_SUBMISSION_ATTACHMENTS", joinColumns = @JoinColumn(name = "SUBMISSION_ID"))
-    @Fetch(FetchMode.SUBSELECT)
     private Set<String> attachments = new HashSet<>();
 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @Column(name = "FEEDBACK_ATTACHMENT", length = 1024)
     @CollectionTable(name = "ASN_SUBMISSION_FEEDBACK_ATTACH", joinColumns = @JoinColumn(name = "SUBMISSION_ID"))
-    @Fetch(FetchMode.SUBSELECT)
     private Set<String> feedbackAttachments = new HashSet<>();
 
     @Lob
@@ -155,11 +153,11 @@ public class AssignmentSubmission {
     @Column(name = "GROUP_ID", length = 36)
     private String groupId;
 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @MapKeyColumn(name = "NAME")
     @Lob
     @Column(name = "VALUE", length = 65535)
     @CollectionTable(name = "ASN_SUBMISSION_PROPERTIES", joinColumns = @JoinColumn(name = "SUBMISSION_ID"))
-    @Fetch(FetchMode.SUBSELECT)
     private Map<String, String> properties = new HashMap<>();
 }

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
@@ -48,6 +48,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -100,12 +102,14 @@ public class AssignmentSubmission {
     @ElementCollection
     @Column(name = "ATTACHMENT", length = 1024)
     @CollectionTable(name = "ASN_SUBMISSION_ATTACHMENTS", joinColumns = @JoinColumn(name = "SUBMISSION_ID"))
+    @Fetch(FetchMode.SUBSELECT)
     private Set<String> attachments = new HashSet<>();
 
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @Column(name = "FEEDBACK_ATTACHMENT", length = 1024)
     @CollectionTable(name = "ASN_SUBMISSION_FEEDBACK_ATTACH", joinColumns = @JoinColumn(name = "SUBMISSION_ID"))
+    @Fetch(FetchMode.SUBSELECT)
     private Set<String> feedbackAttachments = new HashSet<>();
 
     @Lob

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
@@ -163,5 +163,6 @@ public class AssignmentSubmission {
     @Lob
     @Column(name = "VALUE", length = 65535)
     @CollectionTable(name = "ASN_SUBMISSION_PROPERTIES", joinColumns = @JoinColumn(name = "SUBMISSION_ID"))
+    @Fetch(FetchMode.SUBSELECT)
     private Map<String, String> properties = new HashMap<>();
 }


### PR DESCRIPTION
This PR reverts #5745 because we have tested on our multinode servers and Version wasn't been updated when submissions were created so there was still a race condition.

It was only necessary to remove the submissions cache on Assignment Hibernate object.

We were worried about the benchmarks being a lot worse but that's not been the case. I attach two documents for you to see the difference. These documents are in spanish but text is quite simple.

If there are any doubts about this maybe @adrianmticarum  or @juanjmerono can help to clarify them.

Our tester has been @jesusmmp , if you people need anything too

Bulk automatic tests (first column **with** cache, 2nd column **without** it):

![testtareas](https://user-images.githubusercontent.com/3238226/42805590-7be8dd8e-89ac-11e8-8735-2a1c8b671752.jpg)

Manual tests on some sites from 20 to 200 users (instructor and students)
[Pruebas caché Assignment - Hoja 1.pdf](https://github.com/sakaiproject/sakai/files/2200829/Pruebas.cache.Assignment.-.Hoja.1.pdf)
