### PR TITLE
SAK-33934 reduce assignment count when person is removed from course

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
@@ -77,7 +77,7 @@ public interface AssignmentRepository extends SerializableRepository<Assignment,
      * @param userSubmission if not null adds the requirement that the submission's userSubmission field matches this value
      * @return
      */
-    long countAssignmentSubmissions(String assignmentId, Boolean graded, Boolean hasSubmissionDate, Boolean userSubmission);
+    long countAssignmentSubmissions(String assignmentId, Boolean graded, Boolean hasSubmissionDate, Boolean userSubmission, List<String> userIds);
 
     void resetAssignment(Assignment assignment);
 }

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1567,8 +1567,27 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if (assignment.getTypeOfSubmission() == Assignment.SubmissionType.NON_ELECTRONIC_ASSIGNMENT_SUBMISSION) {
                 isNonElectronic = true;
             }
+
+            List<User> allowAddSubmissionUsers = allowAddSubmissionUsers(assignmentReference);
+            List<String> userIds = new ArrayList<>();
+
+            // SAK-28055 need to take away those users who have the permissions defined in sakai.properties
+            String resourceString = AssignmentReferenceReckoner.reckoner().context(assignment.getContext()).reckon().getReference();
+            String[] permissions = serverConfigurationService.getStrings("assignment.submitter.remove.permission");
+            if (permissions != null) {
+                for (String permission : permissions) {
+                    allowAddSubmissionUsers.removeAll(securityService.unlockUsers(permission, resourceString));
+                }
+            } else {
+                allowAddSubmissionUsers.removeAll(securityService.unlockUsers(SECURE_ADD_ASSIGNMENT, resourceString));
+            }
+
+            for(User user : allowAddSubmissionUsers){
+                userIds.add(user.getId());
+            }
+
             // if the assignment is non-electronic don't include submission date or is user submission
-            return (int) assignmentRepository.countAssignmentSubmissions(assignmentId, graded, !isNonElectronic, !isNonElectronic);
+            return (int) assignmentRepository.countAssignmentSubmissions(assignmentId, graded, !isNonElectronic, !isNonElectronic, userIds);
         } catch (Exception e) {
             log.warn("Couldn't count submissions for assignment reference {}, {}", assignmentReference, e.getMessage());
         }

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1567,10 +1567,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if (assignment.getTypeOfSubmission() == Assignment.SubmissionType.NON_ELECTRONIC_ASSIGNMENT_SUBMISSION) {
                 isNonElectronic = true;
             }
-
             List<User> allowAddSubmissionUsers = allowAddSubmissionUsers(assignmentReference);
             List<String> userIds = new ArrayList<>();
-
             // SAK-28055 need to take away those users who have the permissions defined in sakai.properties
             String resourceString = AssignmentReferenceReckoner.reckoner().context(assignment.getContext()).reckon().getReference();
             String[] permissions = serverConfigurationService.getStrings("assignment.submitter.remove.permission");
@@ -1581,11 +1579,9 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             } else {
                 allowAddSubmissionUsers.removeAll(securityService.unlockUsers(SECURE_ADD_ASSIGNMENT, resourceString));
             }
-
             for(User user : allowAddSubmissionUsers){
                 userIds.add(user.getId());
             }
-
             // if the assignment is non-electronic don't include submission date or is user submission
             return (int) assignmentRepository.countAssignmentSubmissions(assignmentId, graded, !isNonElectronic, !isNonElectronic, userIds);
         } catch (Exception e) {

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
@@ -20,7 +20,6 @@ import java.util.*;
 
 import org.hibernate.Criteria;
 import org.hibernate.Session;
-import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.sakaiproject.assignment.api.model.Assignment;

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
@@ -193,7 +193,9 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
         if (userSubmission != null) {
             criteria.add(Restrictions.eq("userSubmission", userSubmission));
         }
-        criteria.add(HibernateCriterionUtils.CriterionInRestrictionSplitter("s.submitter", userIds));
+        if (userIds != null) {
+            criteria.add(HibernateCriterionUtils.CriterionInRestrictionSplitter("s.submitter", userIds));
+        }
         return ((Number) criteria.uniqueResult()).longValue();
     }
 


### PR DESCRIPTION
added check in the count submissions list to get just the count of the submission for the students active in the course

added checking to do the queries in multiple portions if there are more than 1000 people in the course. Oracle can only handle up to 1000 items in the "IN" clause at a time.