### PR TITLE
SAK-22701 Library: Made the Role Swap capitalization consistent

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -333,6 +333,7 @@ body.is-logged-out{
 
 			#roleSwitchAnchor {
 				text-decoration: none;
+				text-transform: capitalize; 	// standardizes the capitalization of the first letter of each word, regardless of role name (e.g. "access" becomes "Access")
 				@media #{$phone} {
 					color: $primary-color;
 				}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-22701

Text-transformed the role swap words to capitalize the first letter of each word to make the phrase consistent separate of role styling, so "View access Role" is now "View Access Role" and it doesn't matter the capitalization of the role's name.