### PR TITLE
SAK-40334 Samigo > more display issues with Matching questions

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -144,8 +144,6 @@ public final class SamigoConstants {
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_TO_ADDRESS  = "samigo.email.autoSubmit.errorNotification.toAddress";
     public static final     String      SAK_PROP_SUPPORT_EMAIL_ADDRESS                      = "mail.support";
 
-    public static final     String      ALPHABET                                            = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
     /*
      * Message Bundles
      */

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
@@ -62,7 +62,6 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemText;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerFeedbackIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
-import org.sakaiproject.tool.assessment.data.ifc.assessment.AttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemAttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemFeedbackIfc;
@@ -95,14 +94,12 @@ import org.sakaiproject.tool.assessment.ui.bean.author.ItemAuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.ItemBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.MatchItemBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.CalculatedQuestionBean;
-import org.sakaiproject.tool.assessment.ui.bean.author.PublishedAssessmentSettingsBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.bean.questionpool.QuestionPoolBean;
 import org.sakaiproject.tool.assessment.ui.bean.questionpool.QuestionPoolDataBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.util.ParameterUtil;
 import org.sakaiproject.tool.assessment.util.TextFormat;
-import org.sakaiproject.tool.assessment.ws.Item;
 import org.sakaiproject.util.FormattedText;
 
 /**
@@ -1209,26 +1206,23 @@ public class ItemAddListener
 	  choicetext.setText(stripPtags(choicebean.getChoice()));
 
 	  // loop through matches for in validAnswers list and add all to this choice
-	  Iterator<MatchItemBean>answeriter = validAnswers.iterator();	  
 	  Set<AnswerIfc> answerSet = new HashSet<AnswerIfc>();
-	  while (answeriter.hasNext()) {
+	  for (int i = 0; i < validAnswers.size(); i++) {
 		  Answer answer = null;
-		  MatchItemBean answerbean = (MatchItemBean) answeriter.next();
+		  MatchItemBean answerbean = validAnswers.get(i);
 		  if (answerbean.getSequence().equals(choicebean.getSequence()) ||
 				  answerbean.getSequenceStr().equals(choicebean.getControllingSequence())) {
 			  // correct answers
 			  answer = new Answer(choicetext, stripPtags(answerbean
 					  .getMatch()), answerbean.getSequence(), AnswerBean
-					  .getChoiceLabels()[answerbean.getSequence()
-					                     .intValue() - 1], Boolean.TRUE, null, Double.valueOf(
+					  .getChoiceLabels()[i], Boolean.TRUE, null, Double.valueOf(
 					                    		 bean.getItemScore()), Double.valueOf(0d), Double.valueOf(bean.getItemDiscount()));
 
 		  } else {
 			  // incorrect answers
 			  answer = new Answer(choicetext, stripPtags(answerbean
 					  .getMatch()), answerbean.getSequence(), AnswerBean
-					  .getChoiceLabels()[answerbean.getSequence()
-					                     .intValue() - 1], Boolean.FALSE, null,  Double.valueOf(
+					  .getChoiceLabels()[i], Boolean.FALSE, null,  Double.valueOf(
 					                    		 bean.getItemScore()), Double.valueOf(0d), Double.valueOf(bean.getItemDiscount()));
 		  }
 

--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -539,6 +539,10 @@ a.hideDivision {
     margin: 0 0 1em 0;
 }
 
+span.author_mcLabelText {
+    padding-right: 0.2em;
+}
+
 .mcColumn1 {
   	width: 40px;
 }

--- a/samigo/samigo-app/src/webapp/jsf/author/preview_item/Matching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/preview_item/Matching.jsp
@@ -34,7 +34,7 @@ should be included in file importing DeliveryMessages
          rendered="#{itemText.sequence==1}">
         <h:column>
             <h:panelGrid columns="2">
-              <h:outputText escape="false" value="#{answer.label}. "/>
+              <h:outputText escape="false" value="#{answer.label}." styleClass="author_mcLabelText" />
               <h:outputText escape="false" value="#{answer.text}" />
             </h:panelGrid>
         </h:column>

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/bundle/Messages.properties
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/bundle/Messages.properties
@@ -1,1 +1,2 @@
 correct=Correct
+choice_labels=A:B:C:D:E:F:G:H:I:J:K:L:M:N:O:P:Q:R:S:T:U:V:W:X:Y:Z

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.shared.TypeD;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemAttachmentIfc;
@@ -739,7 +738,7 @@ public ItemData() {}
 			}
 
 			if (isDistractor) {
-				answerKeys.add(question.getSequence() + ":" + Character.toString(SamigoConstants.ALPHABET.charAt(answersSorted.size())));
+				answerKeys.add(question.getSequence() + ":" + rb.getString("choice_labels").split(":")[answersSorted.size()]);
 			}
 		}
 

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemText.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemText.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
-import org.sakaiproject.samigo.util.SamigoConstants;
+import java.util.ResourceBundle;
 
 import org.sakaiproject.tool.assessment.data.dao.shared.TypeD;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
@@ -41,6 +41,9 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
 
 public class ItemText
     implements Serializable, ItemTextIfc, Comparable<ItemTextIfc> {
+
+  static ResourceBundle rb =
+    ResourceBundle.getBundle("org.sakaiproject.tool.assessment.bundle.Messages");
 
   private static final long serialVersionUID = 7526471155622776147L;
 
@@ -158,7 +161,7 @@ public class ItemText
         if (isDistractor) {
           Answer distractor = new Answer();
           distractor.setId(new Long(0));
-          distractor.setLabel(Character.toString(SamigoConstants.ALPHABET.charAt(answers.size())));
+          distractor.setLabel(rb.getString("choice_labels").split(":")[answersSorted.size()]);
           distractor.setText(NONE_OF_THE_ABOVE);
           distractor.setIsCorrect(false);
           distractor.setScore(this.getItem().getScore());

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
@@ -34,7 +34,6 @@ import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.dao.shared.TypeD;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
@@ -703,7 +702,7 @@ public class PublishedItemData
 					answerKeys.add(
 						question.getSequence()
 							+ ":"
-							+ Character.toString(SamigoConstants.ALPHABET.charAt(answersSorted.size())));
+							+ rb.getString("choice_labels").split(":")[answersSorted.size()]);
 				}
 			}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40334

PR addresses the following issues:

1. Distractor choice displayed for questions that do not include a distractor (Published Copies > Edit UI only)
2. No space between the choice label and choice text, ex: A.Choice1 (both Published Copies and Working Copies > Edit UIs)
3. Incorrect choice labels for any Matching question which has two or more consequitive options which use the same choice, which are not at the very end of all options

See screenshots on the JIRA.