### PR TITLE
SAK-28966: Announcements > Reorder option not persistent on update

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1345,7 +1345,14 @@ public class AnnouncementAction extends PagedResourceActionII
 
 			context.put("announcementItemRangeArray", viewValues);
 		}
-		// context.put("jsfutil", JsfUtil.this);
+
+		if (sstate.getAttribute("updating_sort") == Boolean.TRUE) {
+			state.setCurrentSortedBy(SORT_MESSAGE_ORDER);
+			state.setCurrentSortAsc(false);
+			sstate.setAttribute(STATE_CURRENT_SORTED_BY, SORT_MESSAGE_ORDER);
+			sstate.setAttribute(STATE_CURRENT_SORT_ASC, Boolean.FALSE);
+			sstate.setAttribute("updating_sort", Boolean.FALSE);
+		}
 
 	} // buildSortedContext
 
@@ -4321,6 +4328,9 @@ public class AnnouncementAction extends PagedResourceActionII
 
 		String peid = ((JetspeedRunData) rundata).getJs_peid();
 		SessionState sstate = ((JetspeedRunData) rundata).getPortletSessionState(peid);
+
+		// set updating_sort state so state.getCurrentSortedBy() and state.getCurrentSortAsc() can be reset after buildSortedContext() finishes
+		sstate.setAttribute("updating_sort", Boolean.TRUE);
 
 		// Storing the re-ordered sequence of the announcements
 		if (state.getIsListVM())


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-28966

The Reorder Option in Announcements doesn't work properly with drag&drop, if previously it has been another ordering. 
Steps: 
- Create three announcements, for example: 
01 warning
02 warning
03 warning

1- Go to Reorder option.
2- Sort by subject
3- Then, sort by drag&drop
4- Click Update: ERROR, It doesn't keep the last ordering done by drag&drop. 
- If you refresh de page, the ordering appears ok. 
It doesn't happen if you omit the second step, directly going to drag&drop it'll result ok. 