### PR TITLE
SAK-40345: Announcements > sort order problems

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -3886,11 +3886,13 @@ public class AnnouncementAction extends PagedResourceActionII
 		}
 		else
 		{
-			// if the messages are not already sorted by subject, set the sort sequence to be descending
+			// if the messages are not already sorted by field, reset the sort sequence to be ascending
 			state.setCurrentSortedBy(field);
 			state.setCurrentSortAsc(true);
-			sstate.setAttribute(STATE_CURRENT_SORT_ASC, Boolean.FALSE);
+			sstate.setAttribute(STATE_CURRENT_SORT_ASC, Boolean.TRUE);
 		}
+
+		resetPaging(sstate);
 	} // setupSort
 
 	/**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40345

This patch fixes two issues with announcement sorting, one bug and one usability feature:
1.  a bug where the first time clicking on a sorting header, the sort will take any 'overflow' (based on the number of items being viewed) from the top of the list first, making the 'first x items' of a list actually be the _last_ X items, though sorted correctly on-screen
* example: in a list of items named 1-250 (created in ascending order), viewing 200 items, the first click of "modified by" would show items 50-250, correctly sorted by date, while items 1-49 (which should be the earliest and thus on the initial screen) are pushed off to first overflow page.
2. if you were looking at a subset in the middle of the list (say, announcments 21-40 out of 60), doing a re-sort by clicking a column header would leave you looking at 21-40 of the new sort order, rather than re-sorting then showing you the first 20 of whatever you wanted.