### PR TITLE
SAK-40351 Only add Precedence: bulk to emails being sent to multiple users

### DIFF
--- a/emailtemplateservice/impl/logic/src/java/org/sakaiproject/emailtemplateservice/service/impl/EmailTemplateServiceImpl.java
+++ b/emailtemplateservice/impl/logic/src/java/org/sakaiproject/emailtemplateservice/service/impl/EmailTemplateServiceImpl.java
@@ -447,7 +447,10 @@ public void sendRenderedMessages(String key, List<String> userReferences,
 		headers.add("Subject: " + rt.getRenderedSubject());
 		headers.add("Content-Type: multipart/alternative; boundary=\"" + MULTIPART_BOUNDARY + "\"");
 		headers.add("Mime-Version: 1.0");
-		headers.add("Precedence: bulk");
+
+		if (toAddress.size() > 1) {
+			headers.add("Precedence: bulk");
+		}
 
 		String body = message.toString();
 		log.debug("message body " + body);


### PR DESCRIPTION
Email template service always adds Precedence: bulk which is inappropriate for single-user emails (e.g. password reset links). This can affect how email clients filter the email (e.g. to a non-default folder)

We should only add this if the email is actually being sent to multiple users.
