### PR TITLE
SAK-40361: Assignments > visually distinguish sections of the students view of returned submission

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_feedback_attachments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_feedback_attachments.vm
@@ -5,29 +5,31 @@
 		<h4>
 			$tlang.getString("gen.addinstatts")
 		</h4>
-		<ul class="attachList indnt1">
-			#foreach ($attachmentReference in $feedbackAttachments)
-				#set ($reference = $submissionFeedbackAttachmentReferences.get($attachmentReference))
-				#if ($reference)
-					#set ($props = false)
-					#set ($props = $reference.Properties)
-					#if ($!props)
-						<li>
-							#if ($props.getBooleanProperty($props.NamePropIsCollection))
-								<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />
-							#else
-								<img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
-							#end
-							#if ($decoratedUrlMap)
-								<a href="$decoratedUrlMap.get($reference.Url)" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
-							#else
-								<a href="$reference.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
-							#end
-							#propertyDetails($props)
-						</li>
+		<div class="textPanel borderPanel">
+			<ul class="attachList indnt1">
+				#foreach ($attachmentReference in $feedbackAttachments)
+					#set ($reference = $submissionFeedbackAttachmentReferences.get($attachmentReference))
+					#if ($reference)
+						#set ($props = false)
+						#set ($props = $reference.Properties)
+						#if ($!props)
+							<li>
+								#if ($props.getBooleanProperty($props.NamePropIsCollection))
+									<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />
+								#else
+									<img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
+								#end
+								#if ($decoratedUrlMap)
+									<a href="$decoratedUrlMap.get($reference.Url)" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
+								#else
+									<a href="$reference.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
+								#end
+								#propertyDetails($props)
+							</li>
+						#end
 					#end
 				#end
-			#end
-		</ul>
+			</ul>
+		</div>
 	#end
 #end

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -248,7 +248,7 @@
     </h4>
 
     #if ($!assignment.Instructions.length() > 0)
-        <div class="textPanel">$validator.escapeHtmlFormattedText($!assignment.Instructions)</div>
+        <div class="textPanel borderPanel">$validator.escapeHtmlFormattedText($!assignment.Instructions)</div>
     #end
 
     ## Assignment Attachments
@@ -393,19 +393,19 @@
         ## show feedback text when submission is released or returned
         #if ($!submission.FeedbackText && ($submission.FeedbackText.length() > 0))
             <h5>$tlang.getString("gen.orisub2")</h5>
-            <div class="textPanel">$cheffeedbackhelper.escapeAssignmentFeedback($submission.FeedbackText)</div>
+            <div class="textPanel borderPanel">$cheffeedbackhelper.escapeAssignmentFeedback($submission.FeedbackText)</div>
         #else
             #set ($text = $submission.SubmittedText)
             #if ($!text && $text.length() > 0)
                 <h4>$tlang.getString("gen.orisub")</h4>
-                <div class="textPanel">$submission.SubmittedText</div>
+                <div class="textPanel borderPanel">$submission.SubmittedText</div>
             #end
         #end
     #else
         #set ($text = $submission.SubmittedText)
         #if ($!text && $text.length() > 0)
             <h4>$tlang.getString("gen.orisub")</h4>
-            <div class="textPanel">$submission.SubmittedText</div>
+            <div class="textPanel borderPanel">$submission.SubmittedText</div>
         #end
     #end
 
@@ -423,30 +423,32 @@
                     $tlang.getString("gen.stuatt")
                 #end
             </h4>
-            <ul class="attachList indnt1">
-                #foreach ($attachmentReference in $attachments)
-                    #set ($reference = $submissionAttachmentReferences.get($attachmentReference))
-                    #if ($reference)
-                        #set ($props = false)
-                        #set ($props = $reference.Properties)
-                        #if ($!props)
-                            <li>
-                                #if ($props.getBooleanProperty($props.NamePropIsCollection))
-                                    <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />
-                                #else
-                                    <img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
-                                #end
-                                #if ($decoratedUrlMap)
-                                    <a href="$decoratedUrlMap.get($reference.Url)" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
-                                #else
-                                    <a href="$reference.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
-                                #end
-                                #propertyDetails($props)
-                            </li>
+            <div class="textPanel borderPanel">
+                <ul class="attachList indnt1">
+                    #foreach ($attachmentReference in $attachments)
+                        #set ($reference = $submissionAttachmentReferences.get($attachmentReference))
+                        #if ($reference)
+                            #set ($props = false)
+                            #set ($props = $reference.Properties)
+                            #if ($!props)
+                                <li>
+                                    #if ($props.getBooleanProperty($props.NamePropIsCollection))
+                                        <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />
+                                    #else
+                                        <img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
+                                    #end
+                                    #if ($decoratedUrlMap)
+                                        <a href="$decoratedUrlMap.get($reference.Url)" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
+                                    #else
+                                        <a href="$reference.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
+                                    #end
+                                    #propertyDetails($props)
+                                </li>
+                            #end
                         #end
                     #end
-                #end
-            </ul>
+                </ul>
+            </div>
         #end
     #end
 
@@ -461,7 +463,7 @@
     ## show feedback comment and feedback comment when submission is released or returned
         #if (($!submission.FeedbackComment) && ($submission.FeedbackComment.length() > 0))
             <h5>$tlang.getString("gen.addinst")</h5>
-            <div class="textPanel">$validator.escapeHtmlFormattedText($submission.FeedbackComment)</div>
+            <div class="textPanel borderPanel">$validator.escapeHtmlFormattedText($submission.FeedbackComment)</div>
         #end
 
         ## Feedback Attachments
@@ -478,7 +480,7 @@
                         <br/>
                         #if($!review.getComment() && $review.getComment().length()>0)
                             <b>$tlang.getString("gen.comments")</b>
-                            <div class="textPanel">$validator.escapeHtmlFormattedText($review.getComment())</div>
+                            <div class="textPanel borderPanel">$validator.escapeHtmlFormattedText($review.getComment())</div>
                         #end
                         <ul class="attachList">
                             <lh><strong>$tlang.getString("gen.attachments")</strong></lh>

--- a/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
+++ b/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
@@ -482,4 +482,8 @@
 		}
 	}
 
+	.borderPanel {
+		border: 1px solid #aaa;
+		padding: 0.6em;
+	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40361

The current state of the student's view grade/submission/feedback UI can become cluttered if all possible sections are present (assignment instructions, assignment attachments, original submission text, original submission attachments, instructor feedback, instructor feedback attachments).

This PR visually distinguishes these sections by giving each "panel" a border. See before and after screenshots on the JIRA.