### PR TITLE
SAK-40362: Assignments > instructor feedback not visible in resubmission scenario

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -937,7 +937,7 @@ $(document).ready(function(){
 				#end
 			#end
 
-				#if ($returned && $dateReturned && ($dateSubmitted && $dateReturned && $dateReturned.isAfter($dateSubmitted) || !$dateSubmitted))
+				#if ($returned && $dateReturned && ($dateSubmitted && $dateReturned && $dateReturned.isAfter($dateSubmitted) || !$dateSubmitted || !$!submitted))
 					#if (($!submission.FeedbackComment) && ($submission.FeedbackComment.trim().length()>0))
 						#if ($submissionType==2)
 							<h3>$tlang.getString("gen.addinst2")</h3>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40362

When grading an Assignment, Instructors can provide any/all of the following:

1) inline feedback
2) summary comments
3) upload an attachment to return with a grade.

Once the item has been saved and released to the student, the student can view all 3 of these items provided by the Instructor. However - if the student presses Save Draft while working on their Resubmission attempt - when they resume work again on this Resubmission (after previously saving), the screen changes and most of the Instructor feedback information is missing from the page.