### PR TITLE
SAK-40004 - Update javax.activation

### DIFF
--- a/common/import-handlers/content-handlers/pom.xml
+++ b/common/import-handlers/content-handlers/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
+      <artifactId>javax.activation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.common</groupId>

--- a/common/import-impl/pom.xml
+++ b/common/import-impl/pom.xml
@@ -25,7 +25,7 @@
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
+      <artifactId>javax.activation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>

--- a/common/import-util/pom.xml
+++ b/common/import-util/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
+      <artifactId>javax.activation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.common</groupId>

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -586,7 +586,7 @@
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <artifactId>javax.activation-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -99,7 +99,7 @@
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <artifactId>javax.activation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -205,7 +205,7 @@
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
+      <artifactId>javax.activation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -554,6 +554,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>javax.activation-api</artifactId>
+        <version>1.2.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>antlr</groupId>
         <artifactId>antlr</artifactId>
         <version>2.7.7</version>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -549,12 +549,6 @@
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>javax.activation</groupId>
         <artifactId>javax.activation-api</artifactId>
         <version>1.2.0</version>
         <scope>provided</scope>

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -163,7 +163,7 @@
         </dependency>
 		<dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <artifactId>javax.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/samigo/samigo-qti/pom.xml
+++ b/samigo/samigo-qti/pom.xml
@@ -82,8 +82,8 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.0.2</version>
+			<artifactId>javax.activation-api</artifactId>
+			<version>1.2.0</version>
 			<!--properties:  war.bundle: standalone -->
 		</dependency>
         <dependency>

--- a/samigo/samigo-services/pom.xml
+++ b/samigo/samigo-services/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <artifactId>javax.activation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
One of the hard requirements to port to newer JDKs will be update Hibernate.
So, one of its sub depencencies is javax.activation-api.
https://mvnrepository.com/artifact/org.hibernate/hibernate-core/5.3.3.Final

So, I have deleted the old package of activation and update it to the required in the near future