### PR TITLE
SAK-40366: Roster > improve format of group membership in export file

### DIFF
--- a/roster2/src/i18n/org/sakaiproject/roster/i18n/ui.properties
+++ b/roster2/src/i18n/org/sakaiproject/roster/i18n/ui.properties
@@ -70,6 +70,7 @@ facet_role = Role
 facet_status = Status
 facet_credits = Credits
 facet_groups = Groups
+facet_roster = Roster
 # Page title messages
 title_msg = To add or remove participants from the site, visit the Site Info tool.
 title_msg_groups = To add or remove participants from groups, visit the Site Info tool.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40366

This PR alters the format of the export file in the following ways:

* removes the 'Group' column from sheet 1
* renames 'sheet1' to 'Roster'
* if groups are present and user has permission to view groups, a second worksheet is added titled 'Groups'
* 'Groups' sheet is a list of memberships per group, and include the same fields that would be included in the 'Roster' sheet (varies depending on selected tab, "Overview" vs. "Enrollment Status")

See screenshots on the JIRA for examples.

Test plan uses separate sites to avoid the caching issue reported in https://jira.sakaiproject.org/browse/SAK-40365.