### PR TITLE
SAK-40004 - Javax.servlet api

### DIFF
--- a/access/access-impl/impl/pom.xml
+++ b/access/access-impl/impl/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/admin-tools/pom.xml
+++ b/admin-tools/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/announcement/announcement-impl/impl/pom.xml
+++ b/announcement/announcement-impl/impl/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>

--- a/announcement/announcement-tool/tool/pom.xml
+++ b/announcement/announcement-tool/tool/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/assignment/impl/pom.xml
+++ b/assignment/impl/pom.xml
@@ -94,7 +94,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/assignment/tool/pom.xml
+++ b/assignment/tool/pom.xml
@@ -111,7 +111,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/basiclti/basiclti-blis/pom.xml
+++ b/basiclti/basiclti-blis/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.portlet</groupId>

--- a/basiclti/basiclti-common/pom.xml
+++ b/basiclti/basiclti-common/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/basiclti/basiclti-impl/pom.xml
+++ b/basiclti/basiclti-impl/pom.xml
@@ -70,7 +70,7 @@
 		</dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>

--- a/basiclti/basiclti-portlet/pom.xml
+++ b/basiclti/basiclti-portlet/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.portlet</groupId>

--- a/basiclti/basiclti-tool/pom.xml
+++ b/basiclti/basiclti-tool/pom.xml
@@ -37,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/basiclti/portlet-util/pom.xml
+++ b/basiclti/portlet-util/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/basiclti/tsugi-util/pom-tsugi.xml
+++ b/basiclti/tsugi-util/pom-tsugi.xml
@@ -20,8 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.4</version>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
       <dependency>

--- a/basiclti/tsugi-util/pom.xml
+++ b/basiclti/tsugi-util/pom.xml
@@ -23,7 +23,7 @@
             Sakai-specific code needs to be placed in the basiclti-common folder -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/basiclti/web-ifp/pom.xml
+++ b/basiclti/web-ifp/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     <dependency>
       <groupId>javax.portlet</groupId>

--- a/calendar/calendar-impl/impl/pom.xml
+++ b/calendar/calendar-impl/impl/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/calendar/calendar-tool/tool/pom.xml
+++ b/calendar/calendar-tool/tool/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/calendar/calendar-util/util/pom.xml
+++ b/calendar/calendar-util/util/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat/chat-impl/impl/pom.xml
+++ b/chat/chat-impl/impl/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/chat/chat-tool/tool/pom.xml
+++ b/chat/chat-tool/tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/citations/citations-api/api/pom.xml
+++ b/citations/citations-api/api/pom.xml
@@ -36,7 +36,7 @@
 <!--org.sakaiprojectsakai-util-api${sakai.version}-->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>OKI</groupId>

--- a/citations/citations-impl/impl/pom.xml
+++ b/citations/citations-impl/impl/pom.xml
@@ -22,7 +22,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/citations/citations-impl/impl/pom.xml
+++ b/citations/citations-impl/impl/pom.xml
@@ -114,11 +114,6 @@
      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
      <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/citations/citations-impl/impl/pom.xml
+++ b/citations/citations-impl/impl/pom.xml
@@ -116,7 +116,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/citations/citations-osid/web2bridge/pom.xml
+++ b/citations/citations-osid/web2bridge/pom.xml
@@ -24,7 +24,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/citations/citations-servlet/servlet/pom.xml
+++ b/citations/citations-servlet/servlet/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/citations/citations-tool/tool/pom.xml
+++ b/citations/citations-tool/tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/commons/impl/pom.xml
+++ b/commons/impl/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/commons/tool/pom.xml
+++ b/commons/tool/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/content-review/api/pom.xml
+++ b/content-review/api/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
 	        <groupId>javax.servlet</groupId>
-	        <artifactId>servlet-api</artifactId>
+	        <artifactId>javax.servlet-api</artifactId>
 	    </dependency>
     </dependencies>
 </project>

--- a/content-review/impl/compilatio/pom.xml
+++ b/content-review/impl/compilatio/pom.xml
@@ -50,7 +50,7 @@
 		</dependency>
 		<dependency>
 	        <groupId>javax.servlet</groupId>
-	        <artifactId>servlet-api</artifactId>
+	        <artifactId>javax.servlet-api</artifactId>
 	    </dependency>
 		<!-- Apache commons dependencies -->
 		<dependency>

--- a/content-review/impl/service/pom.xml
+++ b/content-review/impl/service/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
 	        <groupId>javax.servlet</groupId>
-	        <artifactId>servlet-api</artifactId>
+	        <artifactId>javax.servlet-api</artifactId>
 	    </dependency>
 	</dependencies>
 </project>

--- a/content-review/impl/turnitin-oc/pom.xml
+++ b/content-review/impl/turnitin-oc/pom.xml
@@ -71,7 +71,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/content-review/impl/turnitin/pom.xml
+++ b/content-review/impl/turnitin/pom.xml
@@ -134,7 +134,7 @@
         </dependency>
         <dependency>
 	        <groupId>javax.servlet</groupId>
-	        <artifactId>servlet-api</artifactId>
+	        <artifactId>javax.servlet-api</artifactId>
 	    </dependency>
 	</dependencies>
 </project>

--- a/content-review/impl/urkund/pom.xml
+++ b/content-review/impl/urkund/pom.xml
@@ -94,7 +94,7 @@
 		</dependency>
 		<dependency>
 	        <groupId>javax.servlet</groupId>
-	        <artifactId>servlet-api</artifactId>
+	        <artifactId>javax.servlet-api</artifactId>
 	    </dependency>
 
 		<!-- Spring and Hibernate dependencies. -->

--- a/content-review/impl/vericite/pom.xml
+++ b/content-review/impl/vericite/pom.xml
@@ -61,7 +61,7 @@
                 </dependency>
         <dependency>
 	        <groupId>javax.servlet</groupId>
-	        <artifactId>servlet-api</artifactId>
+	        <artifactId>javax.servlet-api</artifactId>
 	    </dependency>
 		<!-- HTTP client: jersey-client -->
                 <dependency>

--- a/content-review/tool/pom.xml
+++ b/content-review/tool/pom.xml
@@ -25,7 +25,7 @@
     <!-- we are running a webapp in a servlet container so we need the servlet API -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <!-- third party dependencies -->

--- a/content/content-tool/tool/pom.xml
+++ b/content/content-tool/tool/pom.xml
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/courier/courier-tool/tool/pom.xml
+++ b/courier/courier-tool/tool/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
     

--- a/dav/dav/pom.xml
+++ b/dav/dav/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/edu-services/gradebook-service/impl/pom.xml
+++ b/edu-services/gradebook-service/impl/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/entitybroker/api/pom.xml
+++ b/entitybroker/api/pom.xml
@@ -23,7 +23,7 @@
 <!-- external dependencies -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/entitybroker/core-providers/pom.xml
+++ b/entitybroker/core-providers/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
          <dependency>
             <groupId>com.sun.mail</groupId>

--- a/entitybroker/impl/pom.xml
+++ b/entitybroker/impl/pom.xml
@@ -35,7 +35,7 @@
         <!-- external dependencies -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/entitybroker/mocks/pom.xml
+++ b/entitybroker/mocks/pom.xml
@@ -40,7 +40,7 @@
 <!-- external dependencies -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/entitybroker/rest/pom.xml
+++ b/entitybroker/rest/pom.xml
@@ -45,8 +45,10 @@
         </dependency>
         <!-- external dependencies -->
         <dependency>
+            <!--TODO Move to javax.servlet-api version of master-->
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/entitybroker/rest/pom.xml
+++ b/entitybroker/rest/pom.xml
@@ -47,8 +47,8 @@
         <dependency>
             <!--TODO Move to javax.servlet-api version of master-->
             <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <artifactId>servlet-api</artifactId>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/entitybroker/rest/pom.xml
+++ b/entitybroker/rest/pom.xml
@@ -46,7 +46,7 @@
         <!-- external dependencies -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/entitybroker/tool/pom.xml
+++ b/entitybroker/tool/pom.xml
@@ -36,7 +36,7 @@
         <!-- external dependencies -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <!-- oAuth dependency -->
         <dependency>

--- a/entitybroker/utils/pom.xml
+++ b/entitybroker/utils/pom.xml
@@ -67,8 +67,11 @@
             <version>3.1</version>
         </dependency>
         <dependency>
+            <!--TODO Move to javax.servlet-api version of master-->
             <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/entitybroker/utils/pom.xml
+++ b/entitybroker/utils/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -40,7 +40,7 @@
   	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/gradebook/app/business/pom.xml
+++ b/gradebook/app/business/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/gradebook/app/ui/pom.xml
+++ b/gradebook/app/ui/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/gradebook/grades-rest/pom.xml
+++ b/gradebook/grades-rest/pom.xml
@@ -65,7 +65,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
         <!-- utility libs -->

--- a/gradebookng/tool/pom.xml
+++ b/gradebookng/tool/pom.xml
@@ -36,7 +36,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>

--- a/help/help-component/pom.xml
+++ b/help/help-component/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/help/help-tool/pom.xml
+++ b/help/help-tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/jobscheduler/scheduler-tool/pom.xml
+++ b/jobscheduler/scheduler-tool/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/jsf/jsf-app/pom.xml
+++ b/jsf/jsf-app/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/jsf/jsf-spreadsheet/pom.xml
+++ b/jsf/jsf-spreadsheet/pom.xml
@@ -23,7 +23,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>

--- a/jsf/jsf-tool-sun/pom.xml
+++ b/jsf/jsf-tool-sun/pom.xml
@@ -29,7 +29,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <!-- Generic JSF Dependencies Below -->
         <dependency>

--- a/jsf/jsf-tool/pom.xml
+++ b/jsf/jsf-tool/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jsf/jsf-widgets-sun/pom.xml
+++ b/jsf/jsf-widgets-sun/pom.xml
@@ -26,7 +26,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.faces</groupId>

--- a/jsf/jsf-widgets/pom.xml
+++ b/jsf/jsf-widgets/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/jsf/myfaces-tool/pom.xml
+++ b/jsf/myfaces-tool/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.faces</groupId>

--- a/jsf/myfaces-widgets/pom.xml
+++ b/jsf/myfaces-widgets/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>

--- a/jsf2/jsf2-app/pom.xml
+++ b/jsf2/jsf2-app/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/jsf2/jsf2-tool-sun/pom.xml
+++ b/jsf2/jsf2-tool-sun/pom.xml
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.faces</groupId>

--- a/jsf2/jsf2-tool/pom.xml
+++ b/jsf2/jsf2-tool/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jsf2/jsf2-widgets-sun/pom.xml
+++ b/jsf2/jsf2-widgets-sun/pom.xml
@@ -21,7 +21,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
         <groupId>javax.faces</groupId>

--- a/jsf2/jsf2-widgets/pom.xml
+++ b/jsf2/jsf2-widgets/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -23,7 +23,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>

--- a/kernel/component-manager/pom.xml
+++ b/kernel/component-manager/pom.xml
@@ -25,7 +25,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -146,7 +146,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jvnet.opendmk</groupId>

--- a/kernel/kernel-util/pom.xml
+++ b/kernel/kernel-util/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>

--- a/kernel/kernel-util/pom.xml
+++ b/kernel/kernel-util/pom.xml
@@ -95,7 +95,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/kernel/kernel-util/pom.xml
+++ b/kernel/kernel-util/pom.xml
@@ -92,11 +92,5 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 </project>

--- a/lessonbuilder/api/pom.xml
+++ b/lessonbuilder/api/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -104,7 +104,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jdom</groupId>

--- a/login/login-api/api/pom.xml
+++ b/login/login-api/api/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/login/login-authn-tool/tool/pom.xml
+++ b/login/login-authn-tool/tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/login/login-impl/impl/pom.xml
+++ b/login/login-impl/impl/pom.xml
@@ -38,7 +38,7 @@
      </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>

--- a/login/login-render-engine-impl/impl/pom.xml
+++ b/login/login-render-engine-impl/impl/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>

--- a/login/login-tool/tool/pom.xml
+++ b/login/login-tool/tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/mailarchive/mailarchive-impl/impl/pom.xml
+++ b/mailarchive/mailarchive-impl/impl/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>

--- a/mailarchive/mailarchive-subetha/pom.xml
+++ b/mailarchive/mailarchive-subetha/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/mailarchive/mailarchive-tool/tool/pom.xml
+++ b/mailarchive/mailarchive-tool/tool/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/mailsender/impl/pom.xml
+++ b/mailsender/impl/pom.xml
@@ -99,8 +99,7 @@
         </dependency>
         <dependency>
         	<groupId>javax.servlet</groupId>
-        	<artifactId>servlet-api</artifactId>
-        	<version>2.4</version>
+        	<artifactId>javax.servlet-api</artifactId>
         	<scope>test</scope>
         </dependency>
     </dependencies>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -306,7 +306,7 @@
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
-        <version>3.0.1</version>
+        <version>4.0.1</version>
         <scope>provided</scope>
       </dependency>
       <!-- parser API inconsistancies -->

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -309,6 +309,12 @@
         <version>2.4</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>4.0.1</version>
+        <scope>provided</scope>
+      </dependency>
       <!-- parser API inconsistancies -->
       <!-- force this version where used -->
       <dependency>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -305,12 +305,6 @@
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.4</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>4.0.1</version>
         <scope>provided</scope>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -306,7 +306,7 @@
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
-        <version>4.0.1</version>
+        <version>3.0.1</version>
         <scope>provided</scope>
       </dependency>
       <!-- parser API inconsistancies -->

--- a/message/message-tool/tool/pom.xml
+++ b/message/message-tool/tool/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/message/message-util/util/pom.xml
+++ b/message/message-util/util/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -22,7 +22,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>

--- a/mycalendar/pom.xml
+++ b/mycalendar/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/myconnections/pom.xml
+++ b/myconnections/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/oauth/api/pom.xml
+++ b/oauth/api/pom.xml
@@ -23,7 +23,7 @@
         <!-- For filter declaration -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/oauth/impl/pom.xml
+++ b/oauth/impl/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/oauth/tool/pom.xml
+++ b/oauth/tool/pom.xml
@@ -35,7 +35,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pasystem/pom.xml
+++ b/pasystem/pom.xml
@@ -26,7 +26,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/podcasts/podcasts-app/pom.xml
+++ b/podcasts/podcasts-app/pom.xml
@@ -56,7 +56,7 @@
     </dependency> 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.entitybroker</groupId>

--- a/podcasts/podcasts/pom.xml
+++ b/podcasts/podcasts/pom.xml
@@ -22,7 +22,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/polls/tool/pom.xml
+++ b/polls/tool/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
 		<dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 		<dependency>
 			<groupId>commons-beanutils</groupId>

--- a/portal/editor-tool/tool/pom.xml
+++ b/portal/editor-tool/tool/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/portal/portal-api/api/pom.xml
+++ b/portal/portal-api/api/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/portal/portal-chat/tool/pom.xml
+++ b/portal/portal-chat/tool/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -101,7 +101,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jtidy</groupId>

--- a/portal/portal-render-api/api/pom.xml
+++ b/portal/portal-render-api/api/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
   </dependencies>
   

--- a/portal/portal-render-engine-impl/impl/pom.xml
+++ b/portal/portal-render-engine-impl/impl/pom.xml
@@ -46,8 +46,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!--TODO Move to javax.servlet-api version of master-->
             <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/portal/portal-render-engine-impl/impl/pom.xml
+++ b/portal/portal-render-engine-impl/impl/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/portal/portal-render-engine-impl/pack/pom.xml
+++ b/portal/portal-render-engine-impl/pack/pom.xml
@@ -52,7 +52,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/portal/portal-render-impl/impl/pom.xml
+++ b/portal/portal-render-impl/impl/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.pluto</groupId>

--- a/portal/portal-service-impl/impl/pom.xml
+++ b/portal/portal-service-impl/impl/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/portal/portal-tool/tool/pom.xml
+++ b/portal/portal-tool/tool/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/portal/portal-util/util/pom.xml
+++ b/portal/portal-util/util/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/portal/portal-util/util/pom.xml
+++ b/portal/portal-util/util/pom.xml
@@ -41,8 +41,10 @@
             <artifactId>sakai-portal-api</artifactId>
         </dependency>
         <dependency>
+            <!--TODO Move to javax.servlet-api version of master-->
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/postem/postem-app/pom.xml
+++ b/postem/postem-app/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/presence/presence-tool/tool/pom.xml
+++ b/presence/presence-tool/tool/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
     

--- a/profile2/impl/pom.xml
+++ b/profile2/impl/pom.xml
@@ -60,7 +60,7 @@
 		</dependency>
 		<dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>

--- a/profile2/tool/pom.xml
+++ b/profile2/tool/pom.xml
@@ -43,7 +43,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
       		<groupId>commons-io</groupId>

--- a/reset-pass/account-validator-tool/pom.xml
+++ b/reset-pass/account-validator-tool/pom.xml
@@ -82,7 +82,7 @@
       </dependency>
       <dependency>
       	<groupId>javax.servlet</groupId>
-      	<artifactId>servlet-api</artifactId>
+      	<artifactId>javax.servlet-api</artifactId>
       </dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/roster2/pom.xml
+++ b/roster2/pom.xml
@@ -116,7 +116,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/rsf/sakai-rsf-core/pom.xml
+++ b/rsf/sakai-rsf-core/pom.xml
@@ -87,7 +87,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/rubrics/tool/pom.xml
+++ b/rubrics/tool/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>

--- a/rwiki/rwiki-access-tool/pom.xml
+++ b/rwiki/rwiki-access-tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/rwiki/rwiki-api/api/pom.xml
+++ b/rwiki/rwiki-api/api/pom.xml
@@ -49,7 +49,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/rwiki/rwiki-impl/impl/pom.xml
+++ b/rwiki/rwiki-impl/impl/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/rwiki/rwiki-tool/tool/pom.xml
+++ b/rwiki/rwiki-tool/tool/pom.xml
@@ -54,7 +54,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/samigo/samigo-api/pom.xml
+++ b/samigo/samigo-api/pom.xml
@@ -29,7 +29,7 @@
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
+        <artifactId>javax.servlet-api</artifactId>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -182,7 +182,7 @@
         </dependency>
 		<dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jdom</groupId>

--- a/samigo/samigo-cp/pom.xml
+++ b/samigo/samigo-cp/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>

--- a/samigo/samigo-impl/pom.xml
+++ b/samigo/samigo-impl/pom.xml
@@ -93,7 +93,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>

--- a/samigo/samigo-qti/pom.xml
+++ b/samigo/samigo-qti/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/samigo/samigo-services/pom.xml
+++ b/samigo/samigo-services/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>

--- a/search/elasticsearch/impl/pom.xml
+++ b/search/elasticsearch/impl/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/search/search-impl/impl/pom.xml
+++ b/search/search-impl/impl/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/search/search-tool/tool/pom.xml
+++ b/search/search-tool/tool/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/sections/sections-app/pom.xml
+++ b/sections/sections-app/pom.xml
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/shortenedurl/impl/pom.xml
+++ b/shortenedurl/impl/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
         
         <!-- kernel dependencies -->

--- a/shortenedurl/tool/pom.xml
+++ b/shortenedurl/tool/pom.xml
@@ -26,7 +26,7 @@
 		<!--  external dependencies -->
 	    <dependency>
 	      	<groupId>javax.servlet</groupId>
-	      	<artifactId>servlet-api</artifactId>
+	      	<artifactId>javax.servlet-api</artifactId>
 	    </dependency>
 	    <dependency>
       		<groupId>commons-lang</groupId>

--- a/signup/tool/pom.xml
+++ b/signup/tool/pom.xml
@@ -101,7 +101,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.myfaces.tomahawk</groupId>

--- a/simple-rss-portlet/pom.xml
+++ b/simple-rss-portlet/pom.xml
@@ -105,8 +105,7 @@
     	</dependency>
     	<dependency>
       		<groupId>javax.servlet</groupId>
-      		<artifactId>servlet-api</artifactId>
-      		<version>2.4</version>
+      		<artifactId>javax.servlet-api</artifactId>
       		<scope>provided</scope>
     	</dependency>
 		<dependency>

--- a/site-manage/site-manage-group-section-role-helper/tool/pom.xml
+++ b/site-manage/site-manage-group-section-role-helper/tool/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-fileupload</groupId>

--- a/site-manage/site-manage-link-helper/pom.xml
+++ b/site-manage/site-manage-link-helper/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/site-manage/site-manage-tool/tool/pom.xml
+++ b/site-manage/site-manage-tool/tool/pom.xml
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/site/admin-perms-tool/pom.xml
+++ b/site/admin-perms-tool/pom.xml
@@ -27,7 +27,7 @@
     <!-- we are running a webapp in a servlet container so we need the servlet API -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <!-- We need this special package to run the jsps in Sakai -->
     <dependency>

--- a/site/sakai-message-bundle-manager-tool/pom.xml
+++ b/site/sakai-message-bundle-manager-tool/pom.xml
@@ -70,7 +70,7 @@
         <!-- we are running a webapp in a servlet container so we need the servlet API -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
         </dependency>
 

--- a/sitedescription/pom.xml
+++ b/sitedescription/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>

--- a/sitemembers/pom.xml
+++ b/sitemembers/pom.xml
@@ -31,7 +31,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>

--- a/sitestats/sitestats-impl/pom.xml
+++ b/sitestats/sitestats-impl/pom.xml
@@ -218,7 +218,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sitestats/sitestats-tool/pom.xml
+++ b/sitestats/sitestats-tool/pom.xml
@@ -114,7 +114,7 @@
     <!-- Servlet -->  
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet.jsp</groupId>

--- a/syllabus/syllabus-app/pom.xml
+++ b/syllabus/syllabus-app/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/tags/pom.xml
+++ b/tags/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/textarea/FCKeditor/connector/pom.xml
+++ b/textarea/FCKeditor/connector/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/textarea/calendar/pom.xml
+++ b/textarea/calendar/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/textarea/elfinder-sakai/pom.xml
+++ b/textarea/elfinder-sakai/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/user/user-tool-prefs/tool/pom.xml
+++ b/user/user-tool-prefs/tool/pom.xml
@@ -95,7 +95,7 @@
       </dependency>
     <dependency>
        <groupId>javax.servlet</groupId>
-       <artifactId>servlet-api</artifactId>
+       <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
 	<dependency>

--- a/userauditservice/tool/pom.xml
+++ b/userauditservice/tool/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/userauditservice/util/pom.xml
+++ b/userauditservice/util/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/usermembership/tool/pom.xml
+++ b/usermembership/tool/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/velocity/tool/pom.xml
+++ b/velocity/tool/pom.xml
@@ -51,7 +51,7 @@
 	
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.velocity</groupId>

--- a/velocity/util/pom.xml
+++ b/velocity/util/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/web/web-portlet/pom.xml
+++ b/web/web-portlet/pom.xml
@@ -49,7 +49,7 @@
          </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     <dependency>
       <groupId>javax.portlet</groupId>

--- a/web/web-tool/tool/pom.xml
+++ b/web/web-tool/tool/pom.xml
@@ -25,7 +25,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sakaiproject.kernel</groupId>

--- a/webservices/cxf/pom.xml
+++ b/webservices/cxf/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
         <!--  Sakai dependencies -->

--- a/webservices/cxf/pom.xml
+++ b/webservices/cxf/pom.xml
@@ -195,7 +195,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/webservices/cxf/pom.xml
+++ b/webservices/cxf/pom.xml
@@ -192,11 +192,6 @@
             <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This sets the servlet api to its latest by default.
Some modules could not be upgraded directly so I have added a `<!--TODO Move to javax.servlet-api version of master-->`. Some of the modules have the old artifactId (v2.5) and others could be set to v3.0.1

So we can track this future work.