### PR TITLE
SAK-40004 - Delete javax.jcr

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -975,12 +975,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.jcr</groupId>
-        <artifactId>jcr</artifactId>
-        <version>1.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>javax.portlet</groupId>
         <artifactId>portlet-api</artifactId>
         <version>1.0</version>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -45,7 +45,6 @@
     <sakai.woodstox.version>5.0.3</sakai.woodstox.version>
     <sakai.stax2.version>3.1.4</sakai.stax2.version>
     <sakai.java.jwt.version>3.1.0</sakai.java.jwt.version>
-    <sakai.jcr.version>1.0</sakai.jcr.version>
     <sakai.jstl.version>1.2</sakai.jstl.version>
     <sakai.lombok.version>1.18.0</sakai.lombok.version>
     <sakai.lucene.version>4.10.4</sakai.lucene.version>
@@ -978,7 +977,7 @@
       <dependency>
         <groupId>javax.jcr</groupId>
         <artifactId>jcr</artifactId>
-        <version>${sakai.jcr.version}</version>
+        <version>1.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Seems like this library is not required, so better we delete it.