### PR TITLE
SAK-40380 Check for pages with no tools

### DIFF
--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
@@ -161,7 +161,7 @@ public class SiteManageServiceImpl implements SiteManageService {
         if (pageList != null) {
             for (SitePage page : pageList) {
                 List<ToolConfiguration> pageToolList = page.getTools();
-                if (pageToolList != null) {
+                if ((pageToolList != null) && !pageToolList.isEmpty()) {
                     Tool tool = pageToolList.get(0).getTool();
                     String toolId = tool != null ? tool.getId() : "";
                     if (toolId.equalsIgnoreCase("sakai.resources")) {


### PR DESCRIPTION
Avoids an ArrayIndexOutOfBoundsException when duplicating a site
