### PR TITLE
SAK-32761 Help: Restored panels to the introductory tutorial and updated the tutorial to match recent updates to Sakai's interface

### DIFF
--- a/help/help-component/src/bundle/TutorialMessages.properties
+++ b/help/help-component/src/bundle/TutorialMessages.properties
@@ -15,7 +15,7 @@ next=Next
 previous=Back
 
 #End Tutorial text:
-endTutorial=OK, Got it
+endTutorial=Okay, got it!
 
 
 
@@ -30,6 +30,12 @@ introToSakai_sitenav.title=Site Navigation
 introToSakai_sitenav.body=Your sites are displayed as links across the top, starting with your own private Home <span class="no-wrap">( <i class="fa fa-home tut-icon-home"></i> ).</span>\
 <br/><br/>\
 Home gives you an overview of the activity in your sites and allows you to personalize your {0} experience.
+
+#Current Site panel (narrow view only)
+introToSakai_currentSite.title=The Current Site
+introToSakai_currentSite.body=The title of the site you currently are visiting is displayed here.\
+<br/><br/>\
+Click or tap it to return to the main page of that site.
 
 #Sites panel (narrow view only)
 introToSakai_allsites.title=Sites
@@ -55,12 +61,17 @@ introToSakai_toolMenuNarrowView.body=Tools for the current site appear in the To
 <br/><br/>\
 Each site maintainer, such as the instructor, controls which tools appear in the site and how they appear.
 
-#Breadcrumbs panal
-#formerly the Refresh Tool panel
-introToSakai_refreshTool.title=Breadcrumbs
-introToSakai_refreshTool.body=The breadcrumbs across the top indicate which site you are in and which tool you are using.\
+#Refresh Tool panel (for desktop view)
+introToSakai_refreshTool.title=Tool Name
+introToSakai_refreshTool.body=The tool name at the top indicates which tool you are using.\
 <br /><br />\
-Click or tap the tool name to return to the main page of that tool. To return to the site&#39;s home page, click or tap the site name.
+Click or tap it to return to the main page of that tool.
+
+#Refresh Tool panel (for narrow view)
+introToSakai_refreshToolNarrowView.title=Tool Name
+introToSakai_refreshToolNarrowView.body=The tool name at the top indicates which tool you are using.\
+<br /><br />\
+Click or tap it to return to the main page of that tool.
 
 #Help Icon panel
 introToSakai_helpIcon.title=Help
@@ -71,7 +82,7 @@ Each tool&#39;s Help button <span class="no-wrap">( <i class="fa fa-question tut
 #Account Menu panel
 #formerly the Profile Tool panel
 introToSakai_profileTool.title=Account Menu
-introToSakai_profileTool.body=The Account Menu contains quick links to personal tasks, such as managing your account, creating new sites, and logging out of {0}.\
+introToSakai_profileTool.body=The Account Menu contains quick links to personal tasks, such as managing your account and logging out of {0}.\
 <br/><br/>\
 That&#39;s it! If you&#39;d like to review this tutorial, you can restart it by choosing it from the Account Menu.
 

--- a/help/help-component/src/tutorial/Tutorial.config
+++ b/help/help-component/src/tutorial/Tutorial.config
@@ -33,17 +33,26 @@ introToSakai_p1.positionTarget=
 introToSakai_p1.fadeout=
 
 #Site Navigation panel
-introToSakai_sitenav.selection=#linkNav:visible ul#topnav li:first i
+introToSakai_sitenav.selection=#linkNav:visible ul#topnav li:first .fa-home
 introToSakai_sitenav.previousUrl=/direct/tutorial/introToSakai_p1.json
-introToSakai_sitenav.nextUrl=/direct/tutorial/introToSakai_allsites.json
+introToSakai_sitenav.nextUrl=/direct/tutorial/introToSakai_currentSite.json
 introToSakai_sitenav.dialog=
 introToSakai_sitenav.positionTooltip=topLeft
 introToSakai_sitenav.positionTarget=bottomMiddle
 introToSakai_sitenav.fadeout=
 
+#Current Site Panel (narrow view only)
+introToSakai_currentSite.selection=.Mrphs-hierarchy--siteName-label:visible
+introToSakai_currentSite.previousUrl=/direct/tutorial/introToSakai_sitenav.json
+introToSakai_currentSite.nextUrl=/direct/tutorial/introToSakai_allsites.json
+introToSakai_currentSite.dialog=
+introToSakai_currentSite.positionTooltip=topLeft
+introToSakai_currentSite.positionTarget=bottomMiddle
+introToSakai_currentSite.fadeout=
+
 #Sites panel (narrow view only)
 introToSakai_allsites.selection=.Mrphs-skipNav__menu:visible .Mrphs-skipNav__menuitem--worksite a
-introToSakai_allsites.previousUrl=/direct/tutorial/introToSakai_sitenav.json
+introToSakai_allsites.previousUrl=/direct/tutorial/introToSakai_currentSite.json
 introToSakai_allsites.nextUrl=/direct/tutorial/introToSakai_moreButton.json
 introToSakai_allsites.dialog=
 introToSakai_allsites.positionTooltip=topRight
@@ -59,8 +68,8 @@ introToSakai_moreButton.positionTooltip=topRight
 introToSakai_moreButton.positionTarget=bottomMiddle
 introToSakai_moreButton.fadeout=
 
-#Tool Menu panel
-introToSakai_toolMenu.selection=#toolMenu ul:first:has(li.js-toggle-nav:visible)
+#Tool Menu panel (for desktop view)
+introToSakai_toolMenu.selection=#toolMenu ul:first:has(li > .js-toggle-nav:visible)
 introToSakai_toolMenu.previousUrl=/direct/tutorial/introToSakai_moreButton.json
 introToSakai_toolMenu.nextUrl=/direct/tutorial/introToSakai_toolMenuNarrowView.json
 introToSakai_toolMenu.dialog=
@@ -68,7 +77,7 @@ introToSakai_toolMenu.positionTooltip=leftMiddle
 introToSakai_toolMenu.positionTarget=rightMiddle
 introToSakai_toolMenu.fadeout=
 
-#Tool Menu panel (for narrow view)
+#Tool Menu panel (for narrow view only)
 introToSakai_toolMenuNarrowView.selection=.Mrphs-skipNav__menu:visible .Mrphs-skipNav__menuitem--tools a
 introToSakai_toolMenuNarrowView.previousUrl=/direct/tutorial/introToSakai_toolMenu.json
 introToSakai_toolMenuNarrowView.nextUrl=/direct/tutorial/introToSakai_refreshTool.json
@@ -77,19 +86,27 @@ introToSakai_toolMenuNarrowView.positionTooltip=topLeft
 introToSakai_toolMenuNarrowView.positionTarget=bottomMiddle
 introToSakai_toolMenuNarrowView.fadeout=
 
-#Breadcrumbs panel
-#formerly the Refresh Tool panel
-introToSakai_refreshTool.selection=.Mrphs-hierarchy--toolName
+#Refresh Tool panel (for desktop view)
+introToSakai_refreshTool.selection=.Mrphs-hierarchy--toolName:visible
 introToSakai_refreshTool.previousUrl=/direct/tutorial/introToSakai_toolMenuNarrowView.json
-introToSakai_refreshTool.nextUrl=/direct/tutorial/introToSakai_helpIcon.json
+introToSakai_refreshTool.nextUrl=/direct/tutorial/introToSakai_refreshToolNarrowView.json
 introToSakai_refreshTool.dialog=
 introToSakai_refreshTool.positionTooltip=topLeft
 introToSakai_refreshTool.positionTarget=bottomMiddle
 introToSakai_refreshTool.fadeout=
 
+#Refresh Tool panel (for narrow view)
+introToSakai_refreshToolNarrowView.selection=.Mrphs-skipNav--toolName:visible
+introToSakai_refreshToolNarrowView.previousUrl=/direct/tutorial/introToSakai_refreshTool.json
+introToSakai_refreshToolNarrowView.nextUrl=/direct/tutorial/introToSakai_helpIcon.json
+introToSakai_refreshToolNarrowView.dialog=
+introToSakai_refreshToolNarrowView.positionTooltip=topLeft
+introToSakai_refreshToolNarrowView.positionTarget=bottomMiddle
+introToSakai_refreshToolNarrowView.fadeout=
+
 #Help Icon panel
 introToSakai_helpIcon.selection=.Mrphs-toolTitleNav__link--help-popup
-introToSakai_helpIcon.previousUrl=/direct/tutorial/introToSakai_refreshTool.json
+introToSakai_helpIcon.previousUrl=/direct/tutorial/introToSakai_refreshToolNarrowView.json
 introToSakai_helpIcon.nextUrl=/direct/tutorial/introToSakai_profileTool.json
 introToSakai_helpIcon.dialog=
 introToSakai_helpIcon.positionTooltip=topRight
@@ -112,5 +129,5 @@ introToSakai_pTutorialLocation.previousUrl=
 introToSakai_pTutorialLocation.nextUrl=
 introToSakai_pTutorialLocation.dialog=
 introToSakai_pTutorialLocation.positionTooltip=topRight
-introToSakai_pTutorialLocation.positionTarget=center
-introToSakai_pTutorialLocation.fadeout=true
+introToSakai_pTutorialLocation.positionTarget=bottomMiddle
+introToSakai_pTutorialLocation.fadeout=


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-32761

I have restored some of the panels of Sakai's introductory tutorial by updating the tutorial's selectors to reflect changes to Sakai's interface for Sakai 12. 

I also updated some of the wording on some of the tutorial panels to reflect the recent interface updates.