### PR TITLE
SAK-40434 Fix off-by-one error in isLarge check

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -611,7 +611,7 @@ public class GbGradebookData {
 		}
 
 		public boolean isLarge() {
-			return score != null && Double.valueOf(score) > 16384;
+			return score != null && Double.valueOf(score) >= 16384;
 		}
 	}
 


### PR DESCRIPTION
Gradebook uses two different serialization schemes, depending on the size of the maximum grade that needs to be represented.  The boundary between these schemes (16384) wasn't properly handled: it would attempt to use packed serialization but then throw an error because the value couldn't be represented.