### PR TITLE
SAK-40432 Modify GradebookNG to handle negative scores

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -381,6 +381,7 @@ grade.notifications.concurrentedit = A concurrent edit has been detected. Please
 grade.notifications.concurrentedituser = Edited by:
 grade.notifications.concurrentedittime = At time:
 grade.notifications.isexternal = Go to {0} tool to edit scores for this item.
+grade.notifications.externalinvalid = External tool has provided an invalid score which may affect the student's final grade.
 grade.notifications.invalid = Item score must be a non-negative number with a maximum of 10 digits before and 2 digits after the decimal.
 grade.notifications.readonly = Item score is read only
 grade.notifications.privileges = Insufficient privileges to edit this Gradebook item score

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -385,6 +385,10 @@
                                             </dl>
                                         {/if}
                                     </li>
+                                {elseif notification.type == 'external-invalid'}
+                                    <li>
+                                        <span class="gb-flag-save-invalid"></span> <wicket:message key="grade.notifications.externalinvalid"/>
+                                    </li>
                                 {elseif notification.type == 'external'}
                                     <li class="gb-external-app-wrapper">
                                         <span class="gb-flag-external"></span> <wicket:message key="grade.notifications.isexternal"/>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -260,7 +260,7 @@ public class GbGradebookData {
 	}
 
 	private String serializeGrades(final List<Score> gradeList) {
-		if (gradeList.stream().anyMatch(score -> score.isLarge())) {
+		if (gradeList.stream().anyMatch(score -> !score.isPackable())) {
 			return "json:" + serializeLargeGrades(gradeList);
 		} else {
 			return "packed:" + serializeSmallGrades(gradeList);
@@ -268,7 +268,7 @@ public class GbGradebookData {
 	}
 
 	private String serializeLargeGrades(final List<Score> gradeList) {
-		final List<Double> scores = gradeList.stream().map(score -> score.isNull() ? -1 : score.getScore()).collect(Collectors.toList());
+		final List<Double> scores = gradeList.stream().map(score -> score.isNull() ? null : score.getScore()).collect(Collectors.toList());
 
 		try {
 			final ObjectMapper mapper = new ObjectMapper();
@@ -310,6 +310,11 @@ public class GbGradebookData {
 			}
 
 			final double grade = score.getScore();
+
+			if (grade < 0) {
+			    throw new IllegalStateException("serializeSmallGrades doesn't support negative scores");
+			}
+
 
 			final boolean hasFraction = ((int) grade != grade);
 
@@ -619,8 +624,8 @@ public class GbGradebookData {
 			return score == null;
 		}
 
-		public boolean isLarge() {
-			return score != null && Double.valueOf(score) >= 16384;
+		public boolean isPackable() {
+			return isNull() || (Double.valueOf(score) >= 0 && Double.valueOf(score) < 16384);
 		}
 
         public boolean isExcused() {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -375,6 +375,13 @@ GbGradeTable.cellRenderer = function (instance, td, row, col, prop, value, cellP
       externalId: column.externalId,
       externalAppName: column.externalAppName,
     });
+    // Mark negative scores as invalid
+    if (typeof value == 'string' && value[0] == '-') {
+      $cellDiv.addClass('gb-external-invalid');
+      notifications.push({
+        type: 'external-invalid'
+      });
+    }
   } else if (isReadOnly) {
     $cellDiv.addClass("gb-read-only");
     notifications.push({

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -23,7 +23,7 @@ GbGradeTable.unpackJsonScores = function (s, rowCount, columnCount) {
             currentRow = []
         }
 
-        currentRow.push(parsedArray[i] < 0 ? "" : GbGradeTable.localizeNumber(parsedArray[i]));
+        currentRow.push(parsedArray[i] == null ? "" : GbGradeTable.localizeNumber(parsedArray[i]));
     }
 
     result.push(currentRow);

--- a/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
@@ -339,11 +339,13 @@
   content: "\f06a" !important;
   color: rgb(204,0,0) !important;
 }
-#gradeTableWrapper .gb-save-invalid {
+#gradeTableWrapper .gb-save-invalid,
+#gradeTableWrapper .gb-external-invalid {
   background-color: #FCF8E3 !important;
 }
 #gradeTableWrapper .gb-save-invalid .gb-notification:before,
-.gb-flag-save-invalid:before {
+.gb-flag-save-invalid:before,
+#gradeTableWrapper .gb-external-invalid .gb-notification:before {
   font-family: "gradebook-icons";
   content: "\f071" !important;
   color: rgb(200,144,0) !important;


### PR DESCRIPTION
Although GradebookNG won't let you enter a negative grade, they can find their way in via external tools (like Samigo) in the form of grade overrides.  Gradebook Classic shows these scores, whereas GradebookNG would throw a JS exception.  Modify GradebookNG to handle this case.

When this happens, the negative cell will be highlighted with a warning message, as it's quite likely that the negative score wasn't really intended to be there.