### PR TITLE
SAK-40459: Library > JavaScript spin+clone tweak to retain visible checked state of checkboxes and radios

### DIFF
--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -309,7 +309,6 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
     newElement.setAttribute( "value", element.getAttribute( "value" ) );
     newElement.setAttribute( "disabled", "true" );
     newElement.style.display = origDisplay;
-    newElement.className = activateSpinner ? "spinButton formButtonDisabled" : "formButtonDisabled";
 
     if( element.type === "checkbox" || element.type === "radio" )
     {
@@ -318,6 +317,7 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
     else
     {
         newElement.textContent = element.getAttribute( "value" );
+        newElement.className = activateSpinner ? "spinButton formButtonDisabled" : "formButtonDisabled";
     }
 
     if( "" !== divID )


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40459

In 12 and 19 the JavaScript spin and clone routine is applying a class to inputs of type radio and checkboxes which in effect makes the "checked" state of the cloned elements no longer visible. This can be confusing for the user, as it may look as though their selection(s) have been lost.

This is a regression compared to 11.x.