### PR TITLE
SAK-40462: Sitestats no longer tracks News events

### DIFF
--- a/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
+++ b/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
@@ -129,7 +129,7 @@
 
 	<!-- news -->
 	<tool 
-		toolId="sakai.news"
+		toolId="sakai.simple.rss"
 		selected="true">
 		<event eventId="news.read" selected="true"/>
 		<event eventId="news.revise" selected="true"/>

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/EventRegistryServiceImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/EventRegistryServiceImpl.java
@@ -263,7 +263,7 @@ public class EventRegistryServiceImpl implements EventRegistry, EventRegistrySer
 			toolIdIconMap.put("sakai.messages", StatsManager.SILK_ICONS_DIR + "comment.png");
 			toolIdIconMap.put("sakai.metaobj", StatsManager.SILK_ICONS_DIR + "application_form.png");
 			toolIdIconMap.put("sakai.membership", StatsManager.SILK_ICONS_DIR + "group.png");
-			toolIdIconMap.put("sakai.news", StatsManager.SILK_ICONS_DIR + "rss.png");
+			toolIdIconMap.put("sakai.simple.rss", StatsManager.SILK_ICONS_DIR + "rss.png");
 			toolIdIconMap.put("sakai.podcasts", StatsManager.SILK_ICONS_DIR + "ipod_cast.png");
 			toolIdIconMap.put("sakai.postem", StatsManager.SILK_ICONS_DIR + "database_table.png");
 			toolIdIconMap.put("sakai.preferences", StatsManager.SILK_ICONS_DIR + "cog.png");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40462

News events no longer appear in SiteStats for two reasons:

    1. The new News tool introduced in Sakai 11 doesn't post events
    2. The new News tool has a different toolId and SiteStats wasn't updated to reflect this

This patch will address both issues.