### PR TITLE
SAK-40466: SiteStats doesn't track read events from Announcements

### DIFF
--- a/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
+++ b/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
@@ -23,6 +23,7 @@
 	<tool 
 		toolId="sakai.announcements"
 		selected="true">
+		<event eventId="annc.read" selected="true"/>
 		<event eventId="annc.new" selected="true"/>
 		<event eventId="annc.revise.own" selected="true"/>
 		<event eventId="annc.revise.any" selected="true"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40466

The "annc.read" event is missing from the event definition file in SiteStats, even though there is localization support for the event in the message bundles.