### PR TITLE
SAK-40467: GradebookNG > Import > avoid NPE if user missing from site and 'Student Name' cell is empty

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
@@ -62,7 +62,7 @@ public class UsernameIdentifier implements Serializable
         }
         else
         {
-            user = GbUser.forDisplayOnly(userEID, row.getStudentName().trim());
+            user = GbUser.forDisplayOnly(userEID, row.getStudentName());
             report.addUnknownUser(user);
             log.debug("User {} is unknown to this gradebook", userEID);
         }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -287,7 +287,7 @@ public class ImportGradesHelper {
 					}
 					break;
 				case USER_NAME:
-					row.setStudentName(lineVal);
+					row.setStudentName(StringUtils.trimToEmpty(lineVal));
 					break;
 				case GB_ITEM_WITH_POINTS:
 					// fall into next case (same impl)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40467

When importing a spreadsheet in GradebookNG, if a row contains a user ID which is not a member of the site AND the row contains a null value for the "Student Name" cell, an NPE will be generated.

This is caused by the reporting algorithm which is responsible for telling the user which entries in the file belong to users who are not members of the site. This algorithm access the row's "Student Name" value and tries to call `.trim()` on it, which generates the NPE if the cell in the file has no value.

The solution is simple: when setting this value, call `StringUtils.trimToEmpty()`.