### PR TITLE
SAK-40468: Roster > fix NPE on 'Enrollment Status' UI

### DIFF
--- a/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -539,10 +539,14 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 		}
 
 		Map<String, User> userMap = getUserMap(membership);
+
+		// Audio URL for how to pronunce each name
+		Map<String, String> pronunceMap = getPronunciationMap(userMap);
+
 		Collection<Group> groups = site.getGroups();
 		for (Member member : membership) {
 			try {
-				RosterMember rosterMember = getRosterMember(userMap, groups, member, site, null);
+				RosterMember rosterMember = getRosterMember(userMap, groups, member, site, pronunceMap);
 				rosterMembers.put(rosterMember.getEid(), rosterMember);
 			} catch (UserNotDefinedException e) {
 				log.warn("user not found: " + e.getId());

--- a/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -717,8 +717,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 		rosterMember.setSortName(user.getSortName());
 
 		// See if there is a pronunciation available for the user
-		String pronunceEmbed = pronunceMap.containsKey(user.getEmail()) ? pronunceMap.get(user.getEmail()) : null;
-		rosterMember.setPronunciation(pronunceEmbed);
+		rosterMember.setPronunciation(pronunceMap.get(user.getEmail()));
 
 		Map<String, String> userPropertiesMap = new HashMap<>();
 		ResourceProperties props = user.getProperties();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40468

Going to the "Enrollment Status" tab results in an NPE and the loading gif animating indefinitely. This is a regression from SAK-40451. Stacktrace in the JIRA.