### PR TITLE
SAK-40483 Don’t log error when gradebook missing.

### DIFF
--- a/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
+++ b/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
@@ -558,28 +558,26 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 	 * 
 	 * @param data
 	 *            Map containing Site/Assignment IDs
-	 * @return Associated gradebook item
+	 * @return Associated gradebook item or null if not found
 	 */
 	public Assignment getAssociatedGbItem(Map data) {
-		Assignment assignment = null;
 		String taskId = data.get("taskId").toString();
 		String siteId = data.get("siteId").toString();
 		String taskTitle = data.get("taskTitle").toString();
+		Assignment assignment = null;
 
-		pushAdvisor();
+		SecurityAdvisor advisor = pushAdvisor();
 		try {
 			List<Assignment> allGbItems = gradebookService.getAssignments(siteId);
 			for (Assignment assign : allGbItems) {
 				// Match based on External ID / Assignment title
 				if (taskId.equals(assign.getExternalId()) || assign.getName().equals(taskTitle)) {
 					assignment = assign;
-					break;
 				}
 			}
-		} catch (Exception e) {
-			log.error("(allGbItems)" + e.toString());
+		} catch (GradebookNotFoundException ignore) {
 		} finally {
-			popAdvisor();
+			popAdvisor(advisor);
 		}
 		return assignment;
 	}
@@ -595,11 +593,12 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 		Session sess = sessionManager.getCurrentSession();
 		boolean runOnce = gradesChecked(sess, data.get("taskId").toString());
 		boolean isStudent = isUserStudent(data.get("siteId").toString(), sess.getUserId());
+		String siteId = data.get("siteId").toString();
 
-		if (turnitinConn.getUseGradeMark() && runOnce == false && isStudent == false) {
+		if (turnitinConn.getUseGradeMark() && gradebookService.isGradebookDefined(siteId)
+				&& !runOnce && !isStudent) {
 			log.info("Syncing Grades with Turnitin");
 
-			String siteId = data.get("siteId").toString();
 			String taskId = data.get("taskId").toString();
 
 			HashMap<String, Integer> reportTable = new HashMap<String, Integer>();
@@ -619,54 +618,58 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 			// Get students enrolled on class in Turnitin
 			Map<String, Object> enrollmentInfo = getAllEnrollmentInfo(siteId);
 
-			// Get Associated GB item
-			Assignment assignment = getAssociatedGbItem(data);
-
-			// List submissions call
-			Map params = new HashMap();
-			params = TurnitinAPIUtil.packMap(turnitinConn.getBaseTIIOptions(), "fid", "10", "fcmd", "2", "tem",
-					getTEM(siteId), "assign", assign, "assignid", taskId, "cid", siteId, "ctl", siteId, "utp", "2");
-			params.putAll(getInstructorInfo(siteId));
-
-			Document document = null;
 			try {
+				// Get Associated GB item
+				Assignment assignment = getAssociatedGbItem(data);
+				if (assignment == null) {
+					log.warn("Failed to find assignment when syncing site: "+ siteId);
+					return;
+				}
+
+				// List submissions call
+				Map params = new HashMap();
+				params = TurnitinAPIUtil.packMap(turnitinConn.getBaseTIIOptions(), "fid", "10", "fcmd", "2", "tem",
+						getTEM(siteId), "assign", assign, "assignid", taskId, "cid", siteId, "ctl", siteId, "utp", "2");
+				params.putAll(getInstructorInfo(siteId));
+
+				Document document = null;
 				document = turnitinConn.callTurnitinReturnDocument(params);
+				Element root = document.getDocumentElement();
+				if (((CharacterData) (root.getElementsByTagName("rcode").item(0).getFirstChild())).getData().trim()
+						.compareTo("72") == 0) {
+					NodeList objects = root.getElementsByTagName("object");
+					String grade = "";
+					log.debug(objects.getLength() + " objects in the returned list");
+
+					for (int i = 0; i < objects.getLength(); i++) {
+						tiiUserId = ((CharacterData) (((Element) (objects.item(i))).getElementsByTagName("userid").item(0)
+								.getFirstChild())).getData().trim();
+						additionalData.put("tiiUserId", tiiUserId);
+						// Get GradeMark Grade
+						try {
+							grade = ((CharacterData) (((Element) (objects.item(i))).getElementsByTagName("score").item(0)
+									.getFirstChild())).getData().trim();
+							reportTable.put("grade" + tiiUserId, Integer.valueOf(grade));
+						} catch (Exception e) {
+							// No score returned
+							grade = "";
+						}
+
+						if (!grade.equals("")) {
+							// Update Grade ----------------
+							writeGrade(assignment, data, reportTable, additionalData, enrollmentInfo);
+						}
+					}
+				} else {
+					log.debug("Report list request not successful");
+					log.debug(document.getTextContent());
+				}
+			} catch (GradebookNotFoundException e) {
+				log.warn("Failed to find gradebook for site: "+ e.getMessage());
 			} catch (TransientSubmissionException e) {
 				log.error(e.getMessage());
 			} catch (SubmissionException e) {
 				log.warn("SubmissionException error. " + e.getMessage());
-			}
-			Element root = document.getDocumentElement();
-			if (((CharacterData) (root.getElementsByTagName("rcode").item(0).getFirstChild())).getData().trim()
-					.compareTo("72") == 0) {
-				NodeList objects = root.getElementsByTagName("object");
-				String grade = "";
-				log.debug(objects.getLength() + " objects in the returned list");
-
-				for (int i = 0; i < objects.getLength(); i++) {
-					tiiUserId = ((CharacterData) (((Element) (objects.item(i))).getElementsByTagName("userid").item(0)
-							.getFirstChild())).getData().trim();
-					additionalData.put("tiiUserId", tiiUserId);
-					// Get GradeMark Grade
-					try {
-						grade = ((CharacterData) (((Element) (objects.item(i))).getElementsByTagName("score").item(0)
-								.getFirstChild())).getData().trim();
-						reportTable.put("grade" + tiiUserId, Integer.valueOf(grade));
-					} catch (Exception e) {
-						// No score returned
-						grade = "";
-					}
-
-					if (!grade.equals("")) {
-						// Update Grade ----------------
-						if (gradebookService.isGradebookDefined(siteId)) {
-							writeGrade(assignment, data, reportTable, additionalData, enrollmentInfo);
-						}
-					}
-				}
-			} else {
-				log.debug("Report list request not successful");
-				log.debug(document.getTextContent());
 			}
 		}
 	}
@@ -732,7 +735,7 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 		// If so then set to the maximum grade
 		grade = processGrade(reportTable.get("grade" + currentStudentUserId).toString(), assignment);
 
-		pushAdvisor();
+		SecurityAdvisor advisor = pushAdvisor();
 		try {
 			if (grade != null) {
 				try {
@@ -755,7 +758,7 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 		} catch (Exception e) {
 			log.error("Error setting grade " + e.toString());
 		} finally {
-			popAdvisor();
+			popAdvisor(advisor);
 		}
 		return success;
 	}
@@ -804,17 +807,14 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 		return enrollmentInfo;
 	}
 
-	public void pushAdvisor() {
-		securityService.pushAdvisor(new SecurityAdvisor() {
-
-			public SecurityAdvisor.SecurityAdvice isAllowed(String userId, String function, String reference) {
-				return SecurityAdvisor.SecurityAdvice.ALLOWED;
-			}
-		});
+	private SecurityAdvisor pushAdvisor() {
+		SecurityAdvisor advisor = (userId, function, reference) -> SecurityAdvisor.SecurityAdvice.ALLOWED;
+		securityService.pushAdvisor(advisor);
+		return advisor;
 	}
 
-	public void popAdvisor() {
-		securityService.popAdvisor();
+	private void popAdvisor(SecurityAdvisor advisor) {
+		securityService.popAdvisor(advisor);
 	}
 
 	/**


### PR DESCRIPTION
If there isn’t a gradebook in the current site don’t log a failure to find the gradebook when attempting to sync grades, instead just don’t attempt to do the sync.

Also improved security advisor handling to use correct push/pop.