### PR TITLE
SAK-40485: Clean up wiki read events

### DIFF
--- a/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/bean/RenderBean.java
+++ b/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/bean/RenderBean.java
@@ -189,14 +189,6 @@ public class RenderBean
 	 */
 	public String getRenderedPage()
 	{
-	    // SAK-23566 capture the view wiki page events
-	    if (rwo != null && rwo.getName() != null) {
-	        // KNOWN ISSUE: getRenderedPage is also called when editing, there doesn't seem to be a way to tell the difference
-	        EventTrackingService ets = (EventTrackingService) ComponentManager.get(EventTrackingService.class);
-	        if (ets != null) {
-	            ets.post(ets.newEvent("wiki.read", StringUtils.abbreviate(rwo.getName(), 250), false));
-	        }
-	    }
 		return toolRenderService.renderPage(rwo);
 	}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40485

SAK-23566 added read events for the wiki, but there appear to be several problems with the way it was done:

    - clicking the Edit tab fires a read event when it should not (this was indicated in code comments as a known issue)
    - if the page has any comments, a separate read event is fired for each comment, which is unnecessary since the comments are not being viewed in isolation but rather automatically as part of rendering the parent page
    - the event references from SAK-23566 do not match the pattern used by the other event code in the tool

It turns out also that read events were already tracked by the wiki, just disabled by default. As of Sakai 12 (see SAK-21039), it is enabled by default, so we now have duplication of read events.

At this point, I think the code introduced in SAK-23566 can just be removed.