### PR TITLE
SAK-40492: Add calendar read events to sitestats

### DIFF
--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -2524,7 +2524,7 @@ extends VelocityPortletStateAction
 		        // need to cleanup the cal references which look like /calendar/calendar/4ea74c4d-3f9e-4c32-b03f-15e7915e6051/main
 		        String eventRef = StringUtils.replace(calendarRef, "/main", "/"+stateName);
 		        String calendarEventId = state.getCalendarEventId();
-		        if (StringUtils.isNotBlank(calendarEventId)) {
+		        if (StringUtils.isNotBlank(calendarEventId) && stateName.equals("description")) {
 		            eventRef += "/"+calendarEventId;
 		        }
 		        ets.post(ets.newEvent("calendar.read", eventRef, false));

--- a/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
+++ b/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
@@ -386,7 +386,7 @@
 		selected="true">
 		<event eventId="calendar.new" selected="true"/>
 		<event eventId="calendar.revise" selected="true"/>
-		<!--<event eventId="calendar.read" selected="true"/>-->
+		<event eventId="calendar.read" selected="true"/>
 		<eventParserTip for="contextId" separator="/" index="3"/>
 	</tool>
 	

--- a/sitestats/sitestats-bundle/src/resources/Events.properties
+++ b/sitestats/sitestats-bundle/src/resources/Events.properties
@@ -205,6 +205,7 @@ search.query = Search performed
 # scheduler
 calendar.new=Calendar event new
 calendar.revise=Calendar event revise
+calendar.read=View calendar
 
 # section
 section.student.join=Section student join


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40492

Calendar read events are commented out in the SiteStats event definition file. This patch uncomments them so they can be counted.

It also slightly changes the calendar.read event reference to remove the id of the most recently viewed calendar item, which was being added to subsequent events where it was not appropriate. For example, if you visit the calendar with the weekly default view, the calendar.read reference looks like "<site_id>/week". If you view a calendar event, the calendar.read reference looks like this: "<site_id>/description/<cal_event_id>". If you then go back to the weekly view, the reference looks like "<site_id>/week/<cal_event_id>", which makes little sense as the id references a particular event, not a particular week.