### PR TITLE
SAK-40507 Fixed missing arrow from some dropdown select elements

### DIFF
--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -107,7 +107,7 @@
 	    display: none;
 	}
 	
-	&[multiple], &[size] {
+	&[multiple], &[size]:not([size='1']) {
 		background-image: none;
 	}
 	


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40507

As a result of SAK-40461, the select dropdown elements (<select>) with a size of "1" specified in the markup will not display the necessary down arrow.

In this PR, I have made the CSS rule more specific to still avoid multi-size selects without removing them from the applicable dropdowns.