### PR TITLE
SAK-40513 - Content : Missing extension when a folder is zipped

### DIFF
--- a/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -152,7 +152,7 @@ public class ZipContentUtil {
 					newResourceId += ZIP_EXTENSION;
 					newResourceName += ZIP_EXTENSION;
 					ContentCollectionEdit currentEdit;
-					if(reference.getId().split(Entity.SEPARATOR).length>3 && ContentHostingService.isInDropbox(reference.getId())) {
+					if(reference.getId().split(Entity.SEPARATOR).length>3) {
 						currentEdit = (ContentCollectionEdit) ContentHostingService.getCollection(resourceId + Entity.SEPARATOR);
 						displayName = currentEdit.getProperties().getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
 						if (displayName != null && displayName.length() > 0) {


### PR DESCRIPTION
I've removed Dropbox condition because it was failing on content tool on sites and My Workspace and, instead of adding the extension, zip file display name was always just the folder name.