### PR TITLE
SAK-40521 copy sort order to export

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -2598,7 +2598,51 @@ public class GradebookNgBusinessService {
 
 		return rval;
 	}
-	
+
+	/**
+	 * Build map of a user's section membership
+	 *
+	 */
+	public Map<String, List<String>> getUserSections() {
+		final String siteId = getCurrentSiteId();
+
+		Site site;
+		try {
+			site = this.siteService.getSite(siteId);
+		} catch (final IdUnusedException e) {
+			log.error("Error looking up site: " + siteId, e);
+			return null;
+		}
+
+		// filtered for the user
+		final List<GbGroup> viewableGroups = getSiteSectionsAndGroups();
+
+		final Map<String, List<String>> rval = new HashMap<>();
+
+		for (final GbGroup gbGroup : viewableGroups) {
+			final String groupReference = gbGroup.getReference();
+			final Group group = site.getGroup(groupReference);
+
+			// Only want to add provider groups
+			if (group != null && group.getProviderGroupId() != null) {
+				final Set<Member> members = group.getMembers();
+
+				for (final Member m : members) {
+					String userId = m.getUserId();
+
+					List<String> groups = rval.get(userId);
+					if (groups == null) {
+						groups = new ArrayList<>();
+					}
+					groups.add(group.getTitle());
+					rval.put(userId, groups);
+				}
+			}
+		}
+
+		return rval;
+	}
+
 	/**
 	 * Have categories been enabled for the gradebook?
 	 *

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ExportTempFile.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ExportTempFile.java
@@ -1,0 +1,32 @@
+package org.sakaiproject.gradebookng.business.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+public class ExportTempFile {
+    private static File tempDir= new File(System.getProperty("java.io.tmpdir"));
+
+
+    public static File createTempFile(String prefix, String suffix){
+        return createTempFile(prefix, suffix, tempDir);
+    }
+
+    public static File createTempFile(final String prefix, String suffix, File directory){
+        if(StringUtils.isEmpty(suffix)){
+            suffix = ".csv"; //for export we are always wanting a csv file
+        }
+
+        if(directory == null){
+            directory = tempDir;
+        }
+
+        String[] files = directory.list(new FilenameFilter(){
+            public boolean accept(File dir, String name){
+                return name.startsWith(prefix);
+            }
+        });
+            return new File(directory, prefix + suffix);
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -81,6 +81,8 @@ public class ImportGradesHelper {
 	public final static int USER_ID_POS = 0;
 	public final static int USER_NAME_POS = 1;
 
+    public final static int SECTION_POS = 2;
+
 	// patterns for detecting column headers and their types
 	final static Pattern ASSIGNMENT_PATTERN = Pattern.compile("([^\\[]+)(\\[(\\d+([\\.,]\\d+)?)\\])?");
 	final static Pattern COMMENT_PATTERN = Pattern.compile("\\* (.+)");
@@ -743,6 +745,9 @@ public class ImportGradesHelper {
 			} else if (i == USER_NAME_POS) {
 				column = new ImportedColumn();
 				column.setType(ImportedColumn.Type.USER_NAME);
+			} else if(i == SECTION_POS) {
+				column = new ImportedColumn();
+				column.setType(ImportedColumn.Type.IGNORE);
 			} else {
 				column = parseHeaderToColumn(StringUtils.trimToNull(line[i]), headingReport);
 			}


### PR DESCRIPTION
When Categories are enabled exported excel files match the sort order
of categories and assignments

SAKAI-3183 Compare strings with string utils

SAKAI-3955 add back gradebook export sort

minor changes to comply with SAKAI 12.

SAKAI-3955 add back gradebook export sort

minor changes to comply with SAKAI 12, fix file names for export.

SAKAI-3955 gradebook export sort

minor change in import helper to stop NPE from happening on Section column.

SAK-40521 add missing constant.

SAKAI-3955 add gradebook export sort

implemented createTempFile method locally to avoid random hash being added to file name.

SAK-40521