### PR TITLE
SAK-40535 Add User API methods for ContextualUserDisplayService

### DIFF
--- a/admin-tools/src/java/org/sakaiproject/user/tool/PasswordPolicyHelper.java
+++ b/admin-tools/src/java/org/sakaiproject/user/tool/PasswordPolicyHelper.java
@@ -135,7 +135,9 @@ public class PasswordPolicyHelper {
         @Override public boolean 			checkPassword(String arg0) 					{ return false; }
         @Override public String 			getId() 									{ return null; }
         @Override public String 			getDisplayId() 								{ return null; }
+        @Override public String 			getDisplayId(String arg0) 						{ return null; }
         @Override public String 			getDisplayName() 							{ return null; }
+        @Override public String 			getDisplayName(String arg0) 						{ return null; }
         @Override public String 			getEid() 									{ return null; }
         @Override public String 			getFirstName() 								{ return null; }
         @Override public String 			getLastName() 								{ return null; }

--- a/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatManagerImpl.java
+++ b/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatManagerImpl.java
@@ -995,7 +995,7 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
         ZonedDateTime ldt = ZonedDateTime.ofInstant(item.getMessageDate().toInstant(), ZoneId.of(getUserTimeZone()));
         Locale locale = rl.getLocale();
         
-        String newText = body + ", " + user.getDisplayName() + ", " + ldt.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT).withLocale(locale));
+        String newText = body + ", " + user.getDisplayName(item.getChatChannel().getContext()) + ", " + ldt.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT).withLocale(locale));
         return newText;
     }
 
@@ -1109,11 +1109,11 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
                     String displayName = us.getUserDisplayId();
                     String userId = us.getUserId();
                     try {
-                        displayName = userDirectoryService.getUser(us.getUserId()).getDisplayName();
+                        displayName = userDirectoryService.getUser(us.getUserId()).getDisplayName(siteId);
                         //if user stored in heartbeat is different to the presence one
                         if(!userId.equals(sessionUserId)) {
                             userId += ":"+sessionUserId;
-                            displayName += " (" + userDirectoryService.getUser(sessionUserId).getDisplayName() + ")";
+                            displayName += " (" + userDirectoryService.getUser(sessionUserId).getDisplayName(siteId) + ")";
                         }
                     }catch(Exception e){
                         log.error("Error getting user "+sessionUserId, e);

--- a/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatMessageEntityProvider.java
+++ b/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatMessageEntityProvider.java
@@ -97,8 +97,8 @@ public class ChatMessageEntityProvider implements CoreEntityProvider,
 			
 			try {
 				User msgowner = userDirectoryService.getUser(this.owner);
-				this.ownerDisplayId = msgowner.getDisplayId();
-				this.ownerDisplayName = msgowner.getDisplayName();
+				this.ownerDisplayId = msgowner.getDisplayId(this.context);
+				this.ownerDisplayName = msgowner.getDisplayName(this.context);
 			} catch (UserNotDefinedException e) {
 				// user not found - ignore
 			}

--- a/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
+++ b/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
@@ -1242,7 +1242,7 @@ public class ChatTool {
          log.debug("Failed to find user for ID: "+ message.getOwner(), e);
          return message.getOwner();
       }
-      return sender.getDisplayName();
+      return sender.getDisplayName(message.getChatChannel().getContext());
    }
 
    protected String getPastXDaysText(int x) {

--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/model/EntityUser.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/model/EntityUser.java
@@ -175,6 +175,10 @@ public class EntityUser implements User {
         return displayName;
     }
 
+    public String getDisplayName(String context) {
+        return displayName;
+    }
+
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
@@ -231,6 +235,10 @@ public class EntityUser implements User {
     }
 
     public String getDisplayId() {
+        return displayId;
+    }
+
+    public String getDisplayId(String context) {
         return displayId;
     }
 

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/User.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/User.java
@@ -72,6 +72,16 @@ public interface User extends Entity, Comparable
 	String getDisplayName();
 
 	/**
+	 * Access the user's name for display purposes in the given context.
+	 *
+	 * @param context
+	 *        The display context, typically a site id.
+	 *
+	 * @return The user's name for display purposes.
+	 */
+	String getDisplayName(String context);
+
+	/**
 	 * Access the user's name for sorting purposes.
 	 * 
 	 * @return The user's name for sorting purposes, never <code>null</code>
@@ -124,4 +134,15 @@ public interface User extends Entity, Comparable
 	 * @return The user's display id string.
 	 */
 	String getDisplayId();
+
+	/**
+	 * Access a string portraying the user's enterprise identity, for display purposes in the given context.<br />
+	 * Use this, not getEid(), when displaying the user's id, probably along with the user's sort or display name, for disambiguating purposes.
+	 *
+	 * @param context
+	 *        The display context, typically a site id.
+	 *
+	 * @return The user's display id string.
+	 */
+	String getDisplayId(String context);
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -2529,13 +2529,17 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		/**
 		 * @inheritDoc
 		 */
-		public String getDisplayName()
+		public String getDisplayName(String context)
 		{
 			String rv = null;
 
 			// If a contextual aliasing service exists, let it have the first try.
 			if (m_contextualUserDisplayService != null) {
-				rv = m_contextualUserDisplayService.getUserDisplayName(this);
+				if (context != null) {
+					rv = m_contextualUserDisplayService.getUserDisplayName(this, context);
+				} else {
+					rv = m_contextualUserDisplayService.getUserDisplayName(this);
+				}
 				if (rv != null) {
 					return rv;
 				}
@@ -2575,13 +2579,24 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		/**
 		 * @inheritDoc
 		 */
-		public String getDisplayId()
+		public String getDisplayName() {
+			return getDisplayName(null);
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public String getDisplayId(String context)
 		{
 			String rv = null;
 			
 			// If a contextual aliasing service exists, let it have the first try.
 			if (m_contextualUserDisplayService != null) {
-				rv = m_contextualUserDisplayService.getUserDisplayId(this);
+				if (context != null) {
+					rv = m_contextualUserDisplayService.getUserDisplayId(this, context);
+				} else {
+					rv = m_contextualUserDisplayService.getUserDisplayId(this);
+				}
 				if (rv != null) {
 					return rv;
 				}
@@ -2600,6 +2615,13 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 			}
 
 			return rv;
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public String getDisplayId() {
+			return getDisplayId(null);
 		}
 
 		/**

--- a/providers/jldap-mock/src/java/edu/amc/sakai/user/UserEditStub.java
+++ b/providers/jldap-mock/src/java/edu/amc/sakai/user/UserEditStub.java
@@ -153,11 +153,15 @@ class UserEditStub implements UserEdit {
 		return this.id;
 	}
     
-    public String getDisplayId() {
-        return this.eid;
-    }
-         
-    public String getDisplayName() {
+	public String getDisplayId() {
+		return this.eid;
+	}
+
+	public String getDisplayId(String context) {
+		return this.eid;
+	}
+
+	public String getDisplayName() {
 
 		// This was copied from BaseUserDirectoryService
 
@@ -176,7 +180,10 @@ class UserEditStub implements UserEdit {
 		}
 
 	}
-    
+
+	public String getDisplayName(String context) {
+		return getDisplayName();
+	}
 
 	public ResourceProperties getProperties() {
 		return this.properties;


### PR DESCRIPTION
SAK-10868 and SAK-39642 added support for context-specific user aliases, that is a display name for a user that can be different in a specific site context.

This supports the "role play" or "user alias" use case, for example for simulation games (. There is a contrib implementation for this (https://confluence.sakaiproject.org/display/RPLAY/Home) in use by UCT and possibly others.

When implemented, it was sufficient to resolve the site context from the tool context, but as more tools have moved to using /direct/ or other REST endpoints for tool data, this no longer works as the tool placement is not available, specifically for chatData in the Chat Tool.

This task adds methods to the User API so that tool- and service endpoints can get a display name for a user for a specific site context explicitly.

This also allows us to remove explicit use of ContextualUserDisplayService in various tool code.

This PR adds the User API methods, updates implementations and mocks of User and adds support in the Chat tool code.