### PR TITLE
SAK-40542: enable JSONP for a few entities

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
@@ -240,7 +240,7 @@ RESTful, ActionsExecutable {
 
         List<EntityData> l = getEntities(new EntityReference(PREFIX, ""), new Search(
                 CollectionResolvable.SEARCH_LOCATION_REFERENCE, locationReference));
-        ActionReturn actionReturn = new ActionReturn(l, Formats.JSON);
+        ActionReturn actionReturn = new ActionReturn(l, view.getFormat());
         if ((extraResponseHeaders != null) && !extraResponseHeaders.isEmpty()) {
             actionReturn.setHeaders(extraResponseHeaders);
         }
@@ -991,11 +991,11 @@ RESTful, ActionsExecutable {
     }
 
     public String[] getHandledOutputFormats() {
-        return new String[] { Formats.HTML, Formats.XML, Formats.JSON, Formats.FORM };
+        return new String[] { Formats.HTML, Formats.XML, Formats.JSON, Formats.JSONP, Formats.FORM };
     }
 
     public String[] getHandledInputFormats() {
-        return new String[] { Formats.HTML, Formats.XML, Formats.JSON };
+        return new String[] { Formats.HTML, Formats.XML, Formats.JSON, Formats.JSONP };
     }
 
     public EntityMember getMember(String userId, String locationReference) {

--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/SiteEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/SiteEntityProvider.java
@@ -1156,11 +1156,11 @@ RESTful, ActionsExecutable, Redirectable, RequestStorable, DepthLimitable {
     }
 
     public String[] getHandledInputFormats() {
-        return new String[] { Formats.HTML, Formats.XML, Formats.JSON };
+        return new String[] { Formats.HTML, Formats.XML, Formats.JSON, Formats.JSONP };
     }
 
     public String[] getHandledOutputFormats() {
-        return new String[] { Formats.XML, Formats.JSON, Formats.HTML, Formats.FORM };
+        return new String[] { Formats.XML, Formats.JSON, Formats.JSONP, Formats.HTML, Formats.FORM };
     }
 
     private Site getSiteById(String siteId) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/entity/impl/PublishedItemEntityProviderImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/entity/impl/PublishedItemEntityProviderImpl.java
@@ -227,11 +227,11 @@ public class PublishedItemEntityProviderImpl implements PublishedItemEntityProvi
     }
 
     public String[] getHandledOutputFormats() {
-        return new String[]{Formats.JSON};
+        return new String[]{Formats.JSON, Formats.JSONP};
     }
 
     public String[] getHandledInputFormats() {
-        return new String[]{Formats.JSON};
+        return new String[]{Formats.JSON, Formats.JSONP};
     }
 
     public String createEntity(EntityReference ref, Object entity, Map<String, Object> params) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40542

We control the server and the script, so there should be no harm in enabling JSONP for these entities.

Also adds first and last name to the membership entity provider, and fixes a bug when a call to /direct/membership/site/<siteId>.xml improperly returns JSON instead of XML.