### PR TITLE
SAK-40560: SiteStats allows mutation of cached event registry data

### DIFF
--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/event/EventInfo.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/event/EventInfo.java
@@ -30,6 +30,12 @@ public class EventInfo implements Serializable {
 		this.eventId = eventId.trim();
 	}
 
+	public EventInfo(EventInfo info) {
+		eventId = info.eventId;
+		selected = info.selected;
+		anonymous = info.anonymous;
+	}
+
 	public String getEventId() {
 		return eventId;
 	}

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/event/ToolInfo.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/event/ToolInfo.java
@@ -44,6 +44,17 @@ public class ToolInfo implements Serializable {
 		eventInfos = new ArrayList<EventInfo>();
 	}
 
+	public ToolInfo(ToolInfo tool) {
+		toolId = tool.toolId;
+		additionalToolIds = tool.additionalToolIds != null ? new ArrayList<>(tool.additionalToolIds) : null;
+		eventInfos = new ArrayList<>(tool.eventInfos.size());
+		for (EventInfo info : tool.eventInfos) {
+			eventInfos.add(new EventInfo(info));
+		}
+		selected = tool.selected;
+		eventParserTip = tool.eventParserTip != null ? new EventParserTip(tool.eventParserTip) : null;
+	}
+
 	public List<EventInfo> getEvents() {
 		return eventInfos;
 	}
@@ -132,5 +143,4 @@ public class ToolInfo implements Serializable {
 		}
 		return buff.toString();
 	}
-	
 }

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/parser/EventParserTip.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/parser/EventParserTip.java
@@ -37,6 +37,12 @@ public class EventParserTip implements Serializable {
 		this.index = index;
 	}
 
+	public EventParserTip(EventParserTip tip) {
+		forWhat = tip.forWhat;
+		separator = tip.separator;
+		index = tip.index;
+	}
+
 	public String getFor() {
 		return forWhat;
 	}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/EventRegistryServiceImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/EventRegistryServiceImpl.java
@@ -402,9 +402,17 @@ public class EventRegistryServiceImpl implements EventRegistry, EventRegistrySer
 		}
 		// STAT-380 ensure we do not return a null from this method
 		if (eventRegistry == null) {
-			eventRegistry = new ArrayList<ToolInfo>(0);
+			return new ArrayList<>(0);
 		}
-		return eventRegistry;
+
+		// defensively deep copy the event registry before returning it, this prevents outside code from
+		// mutating the cached registry entries
+		List<ToolInfo> cloneRegistry = new ArrayList<>(eventRegistry.size());
+		for (ToolInfo t : eventRegistry) {
+			cloneRegistry.add(new ToolInfo(t));
+		}
+
+		return cloneRegistry;
 	}
 	
 	/** Process event registry expired notifications */


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40560

SiteStats maintains a list of all the events it is aware of, known as the event registry. Individual sites can store their own copies of the registry in their preferences, and choose to ignore certain events, or include certain events that are ignored by default. However, when sites have not yet saved their own copy of the registry, they are given direct access to the cached copy of the master event registry, which is then by default modified to exclude events from tools not in the site.

This modified registry is then given out to other sites, when those sites really want the master registry instead. As a result, if a site with only a few tools accesses the master registry first, the cached master registry will now be set to ignore any events from tools not in the original site. When a different site needs to use the cached registry, events for tools it has that the original site does not have, would be silently ignored (at the presentation level, events are always counted regardless of display preferences).

To avoid this problem, a deep copy of the registry can be given out in place of direct access to the cached registry. Sites are then free to modify the copy without their changes making it back into the cached version and affecting other sites.