### PR TITLE
SAK-40578 - Update and join all versions of Hibernate to latest v4.X

### DIFF
--- a/cmprovider/pom.xml
+++ b/cmprovider/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>5.1.0.Final</version>
     </dependency>
   </dependencies>
 

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -34,9 +34,6 @@
     <sakai.ehcache.artifactId>ehcache-core</sakai.ehcache.artifactId>
     <sakai.ehcache.version>2.6.11</sakai.ehcache.version>
     <sakai.elasticsearch.version>1.7.6</sakai.elasticsearch.version>
-    <sakai.hibernate.groupId>org.hibernate</sakai.hibernate.groupId>
-    <sakai.hibernate.artifactId>hibernate-core</sakai.hibernate.artifactId>
-    <sakai.hibernate.version>4.3.11.Final</sakai.hibernate.version>
     <sakai.httpclient.version>4.5.5</sakai.httpclient.version>
     <sakai.httpcore.version>4.4.9</sakai.httpcore.version>
     <sakai.httpmime.version>4.5.5</sakai.httpmime.version>
@@ -744,7 +741,7 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>${sakai.hibernate.version}</version>
+        <version>4.3.11.Final</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -756,13 +753,13 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-entitymanager</artifactId>
-        <version>${sakai.hibernate.version}</version>
+        <version>4.3.11.Final</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>5.3.5.Final</version>
+        <version>5.3.6.Final</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -816,7 +813,7 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-ehcache</artifactId>
-        <version>${sakai.hibernate.version}</version>
+        <version>4.3.11.Final</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This update will help to track deprecations done before 5.X making more easy to port all sakai to 5.X and join versions of hibernate from diferent modules