### PR TITLE
SAK-39943 fix external app icons in gradbookng summary view

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -142,8 +142,6 @@ public class GradebookNgBusinessService {
 	public static final String ASSIGNMENT_ORDER_PROP = "gbng_assignment_order";
 	public static final String ICON_SAKAI = "icon-sakai--";
 
-	public static final ResourceLoader externalAppLoader = new ResourceLoader("org.sakaiproject.localization.bundle.tool.tools");
-
 	/**
 	 * Get a list of all users in the current site that can have grades
 	 *
@@ -2710,11 +2708,12 @@ public class GradebookNgBusinessService {
 		final String externalAppName = assignment.getExternalAppName();
 
 		String iconClass = getDefaultIconClass();
-		if (StringUtils.equals(externalAppName, externalAppLoader.getString("sakai.assignment.title"))) {
+		if (StringUtils.equals(externalAppName, this.toolManager.getLocalizedToolProperty("sakai.assignment", "title"))) {
 			iconClass = getAssignmentsIconClass();
-		} else if (StringUtils.equals(externalAppName, externalAppLoader.getString("sakai.samigo.title"))) {
+		} else if (StringUtils.equals(externalAppName, this.toolManager.getLocalizedToolProperty("sakai.samigo", "title"))) {
 			iconClass = getSamigoIconClass();
-		} else if (StringUtils.equals(externalAppName, externalAppLoader.getString("sakai.lessonbuildertool.title"))) {
+		// "Lesson Builder" is currently hardcoded in SimplePageBean.java (no localization required)
+		} else if (StringUtils.equals(externalAppName, "Lesson Builder")) {
 			iconClass = getLessonBuilderIconClass();
 		}
 		return iconClass;
@@ -2728,16 +2727,8 @@ public class GradebookNgBusinessService {
 	public Map<String, String> getIconClassMap() {
 		final Map<String, String> mapping = new HashMap<>();
 
-		final Tool assignment = this.toolManager.getTool("sakai.assignment.grades");
-		if (assignment != null) {
-			mapping.put(assignment.getTitle(), getAssignmentsIconClass());
-		}
-
-		final Tool samigo = this.toolManager.getTool("sakai.samigo");
-		if (samigo != null) {
-			mapping.put(samigo.getTitle(), getSamigoIconClass());
-		}
-
+		mapping.put(this.toolManager.getLocalizedToolProperty("sakai.assignment", "title"), getAssignmentsIconClass());
+		mapping.put(this.toolManager.getLocalizedToolProperty("sakai.samigo", "title"), getSamigoIconClass());
 		mapping.put("Lesson Builder", getLessonBuilderIconClass());
 
 		return mapping;


### PR DESCRIPTION
The issue seems to be due to the `externalAppLoader.getString("sakai.lessonbuildertool.title")` returning `[missing key (mre): org.sakaiproject.localization.bundle.tool.tools sakai.lessonbuildertool.title]`. Perhaps something has changed in that space?

This patch changes the `externalAppLoader.getString` to `this.toolManager.getLocalizedToolProperty`.  This seems to return the localized string most likely to have been used in the externalAppName field. Note, "Lesson Builder" is the hardcoded externalAppName in SimplePageBean.java, so doesn't need any special treatment.

