### PR TITLE
SAK-40575 - Problems decimal characters between Assignment and Gradebook

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -2312,7 +2312,8 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		}
 
 	  	// avoid scientific notation on large scores by using a formatter
-	  	final DecimalFormat df = new DecimalFormat();
+	  	final NumberFormat numberFormat = NumberFormat.getInstance(new ResourceLoader().getLocale());
+	  	final DecimalFormat df = (DecimalFormat) numberFormat;
 	  	df.setGroupingUsed(false);
 
 	  	return df.format(assignmentScore);


### PR DESCRIPTION
Solved problem with wrong locale when a instructor set a grade to a
student in an assignment linked with a Gradebook item.