### PR TITLE
SAK-40646: SiteStats no longer tracks Gradebook events

### DIFF
--- a/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
+++ b/sitestats/sitestats-api/src/config/org/sakaiproject/sitestats/config/toolEventsDef.xml
@@ -90,18 +90,29 @@
 
 	<!-- gradebook (available in sakai 2.4+) -->
 	<!-- (see SAK-6207 and SAK-10802) -->
-	<tool 
-		toolId="sakai.gradebook.tool"
+	<tool
+		toolId="sakai.gradebookng"
+		additionalToolIds="sakai.gradebook.tool"
 		selected="true">
 		<event eventId="gradebook.newItem" selected="true"/>
+		<event eventId="gradebook.updateAssignment" selected="true"/>
 		<event eventId="gradebook.deleteItem" selected="true"/>
+		<event eventId="gradebook.updateItemScore" selected="true"/>
+		<event eventId="gradebook.updateUngradedScores" selected="true"/>
+		<event eventId="gradebook.comment" selected="true"/>
+		<event eventId="gradebook.studentView" selected="true"/>
+		<event eventId="gradebook.export" selected="true"/>
+		<event eventId="gradebook.importBegin" selected="true"/>
+		<event eventId="gradebook.importCompleted" selected="true"/>
+		<event eventId="gradebook.overrideCourseGrade" selected="true"/>
+		<event eventId="gradebook.updateSettings" selected="true"/>
+		<!-- legacy Gradebook Classic events, included here to retain historical statistics -->
 		<event eventId="gradebook.updateItemScores" selected="true"/>
 		<event eventId="gradebook.updateCourseGrades" selected="true"/>
-		<event eventId="gradebook.comment" selected="true"/>
 		<event eventId="gradebook.downloadRoster" selected="true"/>
 		<event eventId="gradebook.downloadCourseGrade " selected="true"/>
 		<event eventId="gradebook.importEntire" selected="true"/>
-        <event eventId="gradebook.importItem" selected="true"/>
+		<event eventId="gradebook.importItem" selected="true"/>
 		<eventParserTip for="contextId" separator="/" index="2"/>
 	</tool>
 

--- a/sitestats/sitestats-bundle/src/resources/Events.properties
+++ b/sitestats/sitestats-bundle/src/resources/Events.properties
@@ -45,16 +45,25 @@ disc.delete.any=Discussion topic/message delete (other)
 disc.delete.own=Discussion topic/message delete (own)
 disc.delete.category=Discussion category delete
 
-# gradebook
+# gradebook / gradebookng
+gradebook.updateItemScores=Gradebook Classic item scores update
+gradebook.updateCourseGrades=Gradebook Classic course scores update
+gradebook.downloadRoster=Gradebook Classic roster download
+gradebook.downloadCourseGrade=Gradebook Classic course grade download
+gradebook.importEntire=Gradebook Classic course grades import
+gradebook.importItem=Gradebook Classic item import
 gradebook.newItem=Gradebook item new
 gradebook.deleteItem=Gradebook item delete
-gradebook.updateItemScores=Gradebook item scores update
-gradebook.updateCourseGrades=Gradebook course scores update
 gradebook.comment=Gradebook comment
-gradebook.downloadRoster=Gradebook roster download
-gradebook.downloadCourseGrade=Gradebook course grade
-gradebook.importEntire=Gradebook course grades import
-gradebook.importItem=Gradebook item import
+gradebook.updateAssignment=Gradebook item update
+gradebook.updateItemScore=Gradebook item update score
+gradebook.updateUngradedScores=Gradebook update ungraded scores
+gradebook.studentView=Gradebook student view
+gradebook.export=Gradebook export
+gradebook.importBegin=Gradebook begin import
+gradebook.importCompleted=Gradebook import complete
+gradebook.overrideCourseGrade=Gradebook override course grade
+gradebook.updateSettings=Gradebook update settings
 
 # mail
 mail.new=Mail new

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
@@ -438,6 +438,8 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
 					try{
 						// parse from stored preferences
 						prefsdata = parseSitePrefs(new ByteArrayInputStream(prefs.getPrefs().getBytes()));
+						// preferences doesn't store additionalToolIds, add them back
+						EventUtil.addMissingAdditionalToolIds(prefsdata.getToolEventsDef(), M_ers.getEventRegistry());
 					}catch(Exception e){
 						// something failed, use default
 						log.warn("Exception in parseSitePrefs() ",e);

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/EventUtil.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/EventUtil.java
@@ -21,6 +21,7 @@ package org.sakaiproject.sitestats.impl.event;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.commons.collections4.ListUtils;
 
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.site.api.Site;
@@ -77,8 +78,7 @@ public class EventUtil {
 			ToolInfo t = iTED.next();
 			Iterator<ToolConfiguration> iST = siteTools.iterator();
 			while (iST.hasNext()){
-				ToolConfiguration tc = iST.next();
-				if(tc.getToolId().equals(t.getToolId())){
+				if(intersects(iST.next().getToolId(), t)){
 					intersected.add(t);
 					break;
 				}
@@ -107,8 +107,7 @@ public class EventUtil {
 			ToolInfo t = iTED.next();
 			Iterator<org.sakaiproject.tool.api.Tool> iST = sakaiTools.iterator();
 			while (iST.hasNext()){
-				org.sakaiproject.tool.api.Tool tc = iST.next();
-				if(tc.getId().equals(t.getToolId())){
+				if(intersects(iST.next().getId(), t)) {
 					intersected.add(t);
 					break;
 				}
@@ -116,6 +115,11 @@ public class EventUtil {
 		}
 	
 		return intersected;
+	}
+
+	private static boolean intersects(String siteToolId, ToolInfo regTool) {
+		List<String> aliasIds = ListUtils.emptyIfNull(regTool.getAdditionalToolIds());
+		return siteToolId.equals(regTool.getToolId()) || aliasIds.contains(siteToolId);
 	}
 
 	/**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40646

SiteStats was never updated to track the events from GradebookNG. This patch adds support for GradebookNG events while retaining the ability to view historical data for Gradebook Classic events.

To facilitate this, the GradebookNG tool id "sakai.gradebookng" becomes the primary id for the Gradebook in SiteStats, with the Gradebook Classic tool id "sakai.gradebook.tool" being an alternate id, which allows it to be displayed even in sites that only have Gradebook Classic.

As a minor side effect of improving the alternate id handling, the following will now occur:
-    Sites using Overview will have Web Content listed as a tool in SiteStats event if they have no explicit Web Content instances in the tool menu, Overview utilizes a variation of Web Content
-    Sites using Dropbox without also using Resources will have Resources appear as a tool in SiteStats, as Dropbox is an alternate id for Resources and shares the same events