### PR TITLE
SAK-40563 - Problems with decimal separator character in Gradebook

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -293,8 +293,9 @@ public class FormatHelper {
 	 * @return true if the value is valid
 	 */
 	public static boolean isValidDouble(final String value) {
-		final DoubleValidator dv = new DoubleValidator();
-		return dv.isValid(value, rl.getLocale());
+		final DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(rl.getLocale());
+		final String doublePattern = "\\d+\\" + df.getDecimalFormatSymbols().getDecimalSeparator() + "\\d+|\\d+";
+		return value.matches(doublePattern);
 	}
 
 	/**


### PR DESCRIPTION
`DoubleValidator` and `NumberFormat` have known problems (https://www.ibm.com/developerworks/java/library/j-numberformat/index.html) converting and checking number not in the server locale. 

They pass as valid doubles that shouldn't be as "3,5" or ",2" on an english site because they assume and convert the double to 35 and 2 respectively, it should return a validation or parse error but `NumberFormat` and `DoubleValidator` don't work that way.

"3,5" is converted to 35
"3.5" is converted to 3.5
",2" is converted to 2

I've modified this method because is used just in two places, both of them used by grades check sent by ajax post calls.