### PR TITLE
SAK-40682: EntityBroker > fix wrong return type for membership

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
@@ -240,7 +240,7 @@ RESTful, ActionsExecutable {
 
         List<EntityData> l = getEntities(new EntityReference(PREFIX, ""), new Search(
                 CollectionResolvable.SEARCH_LOCATION_REFERENCE, locationReference));
-        ActionReturn actionReturn = new ActionReturn(l, Formats.JSON);
+        ActionReturn actionReturn = new ActionReturn(l, view.getFormat());
         if ((extraResponseHeaders != null) && !extraResponseHeaders.isEmpty()) {
             actionReturn.setHeaders(extraResponseHeaders);
         }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40682

Currently, a call to /direct/membership/site/<siteId>.xml improperly returns JSON instead of XML. It in fact returns JSON regardless of the requested return type.