### PR TITLE
SAK-40563 - Problems with decimal separator character in Gradebook

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -287,17 +287,6 @@ public class FormatHelper {
 	}
 
 	/**
-	 * Validate if a string is a valid Double using the specified Locale.
-	 *
-	 * @param value - The value validation is being performed on.
-	 * @return true if the value is valid
-	 */
-	public static boolean isValidDouble(final String value) {
-		final DoubleValidator dv = new DoubleValidator();
-		return dv.isValid(value, rl.getLocale());
-	}
-
-	/**
 	 * Validate/convert a Double using the user's Locale.
 	 *
 	 * @param value - The value validation is being performed on.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
@@ -38,6 +38,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.service.gradebook.shared.CategoryScoreData;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.tool.gradebook.Gradebook;
+import org.sakaiproject.util.NumberUtil;
 
 public class GradeUpdateAction extends InjectableAction implements Serializable {
 
@@ -134,7 +135,7 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 		final String rawNewGrade = params.get("newScore").textValue();
 
 		if (StringUtils.isNotBlank(rawNewGrade)
-				&& (!FormatHelper.isValidDouble(rawNewGrade) || FormatHelper.validateDouble(rawNewGrade) < 0)) {
+				&& (!NumberUtil.isValidLocaleDouble(rawNewGrade) || FormatHelper.validateDouble(rawNewGrade) < 0)) {
 			target.add(page.updateLiveGradingMessage(page.getString("feedback.error")));
 
 			return new ArgumentErrorResponse("Grade not valid");

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.java
@@ -46,6 +46,7 @@ import org.sakaiproject.service.gradebook.shared.GraderPermission;
 import org.sakaiproject.service.gradebook.shared.GradingType;
 import org.sakaiproject.service.gradebook.shared.PermissionDefinition;
 import org.sakaiproject.util.FormattedText;
+import org.sakaiproject.util.NumberUtil;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -99,7 +100,7 @@ public class UpdateUngradedItemsPanel extends BasePanel {
 				final Assignment assignment = UpdateUngradedItemsPanel.this.businessService.getAssignment(assignmentId);
 
 				try {
-					if(!FormatHelper.isValidDouble(override.getGrade())){
+					if(!NumberUtil.isValidLocaleDouble(override.getGrade())){
 						throw new NumberFormatException();
 					}
 					final Double overrideValue = FormatHelper.validateDouble(override.getGrade());

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/NumberUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/NumberUtil.java
@@ -1,0 +1,59 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2018 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+ 
+package org.sakaiproject.util;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * Utilities based on double and integers such as validation formats.
+ */
+public class NumberUtil {
+	
+	/**
+	 * @param origin number that is needed to validate
+	 * @param locale specific geographic location to validate format on origin param  
+	 * @return true if number format is valid for that locale
+	 */
+	public static boolean isValidLocaleDouble(final String origin, Locale locale) {
+		final DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(locale);
+		final DecimalFormatSymbols fs = df.getDecimalFormatSymbols();
+		final String doublePattern =
+			"\\d+\\" + fs.getGroupingSeparator() 
+			+ "\\d\\d\\d\\" + fs.getDecimalSeparator()
+			+ "\\d+|\\d+\\" + fs.getDecimalSeparator()
+			+ "\\d+|\\d+\\" + fs.getGroupingSeparator() 
+			+ "\\d\\d\\d|\\d+";
+		return origin.matches(doublePattern);
+	}
+
+	/**
+	 * @param origin origin number that is needed to validate on the default user's locale
+	 * @return true if number format is valid for user's locale
+	 */
+	public static boolean isValidLocaleDouble(final String origin) {
+		return isValidLocaleDouble(origin, new ResourceLoader().getLocale());
+	}
+
+}

--- a/kernel/kernel-util/src/test/java/org/sakaiproject/util/NumberUtilTest.java
+++ b/kernel/kernel-util/src/test/java/org/sakaiproject/util/NumberUtilTest.java
@@ -1,0 +1,114 @@
+/**********************************************************************************
+ * $URL:$
+ * $Id:$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2017 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.util;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Testing the NumberUtilTest class
+ * 
+ */
+@Slf4j
+public class NumberUtilTest {
+	
+	@Test
+	public void testIsValidLocaleDouble() {
+		/* 
+		 * There are 4 different ways to use decimal and group separator
+		 * https://en.wikipedia.org/wiki/Decimal_separator
+		 * comma, dot, both (Canada but are en-CA, fr-CA so it belongs to dot and comma), Arabic format 
+		 * 
+		 */
+		
+		// Group 1 : comma on decimal separator, dot on group separator.
+		final Locale commaGroupLocale = new Locale("es", "ES");
+		
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("1.234,00", commaGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("3,00", commaGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("456457546", commaGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("3524,055", commaGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("2.300", commaGroupLocale));
+		
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("2.00", commaGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("3,520.55", commaGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("3.4561,00", commaGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble(",01", commaGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble(".02", commaGroupLocale));
+		
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("A4FC9", commaGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("0x42", commaGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("1.2345678E7", commaGroupLocale));
+		
+		// Group 2 : dot on decimal separator, comma on group separator.
+		final Locale dotGroupLocale = new Locale("en", "EN");
+		
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("1,234.00", dotGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("3.00", dotGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("456457546", dotGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("3524.055", dotGroupLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("2,300", dotGroupLocale));
+		
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("2,00", dotGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("3.520,55", dotGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("3,4561.00", dotGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble(".01", dotGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble(",02", dotGroupLocale));
+		
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("A4FC9", dotGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("0x42", dotGroupLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("1.2345678E7", dotGroupLocale));
+		
+		// Group 3 : arabic
+		final Locale arabicLocale = new Locale("ar", "DZ");
+		// Arabic separators are special unicode chars so we get it from locale NumberFormat configuration.
+		final DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(arabicLocale);
+		final char arabicGroup = df.getDecimalFormatSymbols().getGroupingSeparator();
+		final char arabicDecimal = df.getDecimalFormatSymbols().getDecimalSeparator();
+		
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("1" + arabicGroup + "234" + arabicDecimal + "00", arabicLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("3" + arabicDecimal + "00", arabicLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("456457546", arabicLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("3524" + arabicDecimal + "055", arabicLocale));
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("2" + arabicGroup + "300", arabicLocale));
+		
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("3" + arabicDecimal + "520" + arabicGroup + "55", arabicLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("3" + arabicDecimal + "4561" + arabicGroup + "00", arabicLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble( arabicGroup + "01", arabicLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble( arabicDecimal + "02", arabicLocale));
+		
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("A4FC9", arabicLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("0x42", arabicLocale));
+		Assert.assertFalse(NumberUtil.isValidLocaleDouble("1.2345678E7", arabicLocale));
+				
+		
+		// Just tests function call
+		Assert.assertTrue(NumberUtil.isValidLocaleDouble("123"));
+	}
+	
+}


### PR DESCRIPTION
`DoubleValidator` and `NumberFormat` have known problems (https://www.ibm.com/developerworks/java/library/j-numberformat/index.html) converting and checking number not in the server locale. 

They pass as valid doubles that shouldn't be as "3,5" or ",2" on an english site because they assume and convert the double to 35 and 2 respectively, it should return a validation or parse error but `NumberFormat` and `DoubleValidator` don't work that way.

"3,5" is converted to 35
"3.5" is converted to 3.5
",2" is converted to 2

So we have modified the way gradebookng checks its valid Double on a common class for all sakai that can be improved