### PR TITLE
SAK-40691 - WebJars: Upgrade codemirror from 5.6.0 to 5.40.2

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>codemirror</artifactId>
-			<version>5.6</version>
+			<version>5.40.2</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/library/src/webapp/editor/elfinder/sakai/js/src/editors.js
+++ b/library/src/webapp/editor/elfinder/sakai/js/src/editors.js
@@ -63,7 +63,7 @@ var ckeditor = (function() {
 
 // Codemirror (code editor)
 var codemirror = (function() {
-  var url = '/library/webjars/codemirror/5.6/';
+  var url = '/library/webjars/codemirror/5.40.2/';
   var codemirrorjs = url + 'lib/codemirror.js';
   var scripts = []; // keeps track of loaded codemirror js files
   var instance;     // one reference to the editor instance


### PR DESCRIPTION
This PR should be broken because the webjar libraries need to be populated to sonatype.