### PR TITLE
SAK-40670 - Calendar doesn't check daylight saving time on subscribing events

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.sakaiproject.calendar.impl.GenericCalendarImporter;
 import org.sakaiproject.exception.ImportException;
@@ -238,6 +239,10 @@ public class IcalendarReader extends Reader
 			// Raw + calendar/owner TZ's offset
 			ZonedDateTime srcZonedDateTime = startInstant.atZone(srcZoneId);
 			long millis = startInstant.plusMillis(srcZonedDateTime.getOffset().getTotalSeconds() * 1000).toEpochMilli();
+			TimeZone tz = TimeZone.getTimeZone(tzid);
+			if( tz.inDaylightTime(startDate) ) {
+				millis = millis - tz.getDSTSavings();
+			}
 			
 			// Duration of event
 			Duration gapMinutes = Duration.ofMinutes(durationInMinutes);


### PR DESCRIPTION
Calendar doesn't check if timezone has summer or winter time on external subscribing events