### PR TITLE
SAK-40312 Rubrics: solving double 0 issue

### DIFF
--- a/rubrics/tool/src/main/frontend/imports/sakai-rubric-criterion-student.html
+++ b/rubrics/tool/src/main/frontend/imports/sakai-rubric-criterion-student.html
@@ -42,11 +42,9 @@
               <strong class$="points-display {{isOverridden(criterionitem.pointoverride)}}">
                 &nbsp;
                 {{criterionitem.selectedvalue}}
-                <template is="dom-if" if="[[!criterionitem.selectedvalue]]">0</template>
+                <template is="dom-if" if="[[!criterionitem.selectedRadingId]]">0</template>
                 &nbsp;
               </strong>
-
-              
               
               <template is="dom-if" if="[[options.fineTunePoints]]">
                 <strong class="points-display">[[criterionitem.pointoverride]]</strong>


### PR DESCRIPTION
An empty selectedValue was being considered as a 0, so it appeared twice. It's better to use a different variable that will match the same cases.