### PR TITLE
SAK-40643 Library: updated the styles and positioning of the Manage Overview button

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -1290,33 +1290,17 @@ body.is-logged-out{
     }
 }
 
-@media only screen and (min-width: 801px) {
-	.manage-overview-link {
-		border: 1px solid #ccc;
-		color: #333 !important;
-		cursor: pointer;
-		display: inline-block;
-		font-family: "Open Sans", sans-serif;
-		font-size: 12px;
-		text-decoration: none !important;
-		-moz-appearance: none;
-		-webkit-appearance: none;
-		-moz-border-radius: 3px;
-		-webkit-border-radius: 3px;
-		border-radius: 3px;
-		padding: 5px !important; /* important needed for these two--otherwise gets overridden by hierarchy.*/
-		margin: 5px 30px !important;
-		position: absolute;
-		right: 0px;
-
-		span {
-			padding-right: 5px;
-		}
+.#{$namespace}siteHierarchy .manage-overview-link {
+	@include sakai_secondary_button();
+	position: absolute;
+	right: $standard-spacing;
+	margin-top: -4px;
+	
+	> span {
+		margin-right: $standard-space;
 	}
-}
-
-@media only screen and (max-width: 800px){
-	.manage-overview-link {
+	
+	@media #{$phone} {
 		visibility: hidden;
 	}
 }

--- a/library/src/morpheus-master/sass/modules/navigation/_skipnav.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_skipnav.scss
@@ -72,6 +72,7 @@
 
 			// Tool row
 			&.#{$namespace}skipNav__menuitem.#{$namespace}skipNav__menuitem--tools {
+				@include display-flex;
 				background: $portal-background-color;
 				box-shadow: $divider-shadow;
 
@@ -95,17 +96,16 @@
 					color: $link-color;
 				}
 				a.manage-overview-link-mobile {
-					color: $link-color;
-					cursor: pointer;
 					display: inline-block;
-					font-family: "Open Sans", sans-serif;
+					margin-left: auto; 			// push this link to the far right
+					color: $link-color;
 
 					span {
-						padding-right: 5px;
+						padding-right: $standard-space;
 					}
 
-					&::after {
-						border-right: 0px none;
+					&:after {
+						border-right: 0 none;
 					}
 				}
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40643

The new Manage Overview button introduced in SAK-40520 was not designed and positioned to match similar buttons, like the Link and Help buttons in the top of most pages. 

My fix simplifies the implementation and standardizes the look to be consistent with the related buttons. 

Unfortunately, I wasn't able to restructure the markup to be more semantic, so I just focused on the styles.

See https://jira.sakaiproject.org/browse/SAK-40643 for before and after screenshots.