### PR TITLE
SAK-40728 Bullhorn update count prevents portal timeout

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
@@ -237,6 +237,9 @@
             $PBJQ.ajax({
                 url: '/direct/portal/bullhornCounts.json',
                 cache: false,
+                data: {
+                    auto: true // indicates that this request is not a user action
+                }
                 }).done(function (data) {
 
                     portal.failedBullhornCounts = 0;


### PR DESCRIPTION
Indicate that update count ajax request is "auto" meaning it is
not a user request and should not prevent the user's session from
timing out.