### PR TITLE
SAK-40743 Library: standardized the focus outlines in Sakai, including buttons, links, and form elements

### DIFF
--- a/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_tab-focus.scss
+++ b/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/mixins/_tab-focus.scss
@@ -1,8 +1,6 @@
 // WebKit-style focus
 
 @mixin tab-focus() {
-  // SAK-32484 Bootstrap 3 default for tab-focus totally ignores Firefox
-  outline: 5px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }

--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -396,9 +396,9 @@ $overview-portlet-title-background-color: $tool-tab-background-color !default;
 $instruction-color: #5c5c5c !default;
 $instruction-background-color: #fff !default;
 
-// Accessibility
-// This should be visible based on your button colors and is based on webkit's default
-
+/* focus styles for all control elements (e.g. buttons, form controls, links, etc) */
 $focus-outline-width: 3px;
+$focus-outline-style: solid;
 $focus-outline-color: #5b9dd9;
+$sakai-focus-outline: $focus-outline-width $focus-outline-style $focus-outline-color;
 $focus-outline-offset: 2px;

--- a/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/library/src/morpheus-master/sass/base/_defaults.scss
@@ -22,8 +22,9 @@ a{
 	}
 	&[href]{  // This means a[href]
 		color: $link-color;
-		&:focus, &::-moz-focus-inner{ // This would compile to -> a[href]:focus, a[href]::moz-focus-inner
-			outline-color: invert;
+		&:focus{
+			outline: $sakai-focus-outline;
+			outline-offset: $focus-outline-offset;
 		}
 		&:hover{
 			color: $link-hover-color;
@@ -33,6 +34,7 @@ a{
 		&:active{
 			color: $link-active-color;
 			background-color: $link-active-background-color;
+			outline: 0;		// no focus outline on click
 		}
 		&.btn{
 			text-decoration: none;
@@ -117,7 +119,7 @@ input[type="checkbox"], input[type="radio"]{
 	@include appearance(none);
 	&:focus
 	{
-		box-shadow: 0px 0px 1px 4px Highlight;
+		box-shadow: 0px 0px $focus-outline-width $focus-outline-width $focus-outline-color;
 		outline: 0 none; // to override Bootstrap
 		outline-offset: 0; // to override Bootstrap
 	}

--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -110,6 +110,10 @@
 		background-image: none;
 	}
 	
+	&:focus {
+		box-shadow: 0px 0px $focus-outline-width $focus-outline-width $focus-outline-color;
+	}
+	
 	&[disabled="disabled"],&[disabled],&[disabled="true"] {
 		opacity: 0.7;
 		background-color: #f3f3f3;
@@ -174,7 +178,7 @@
 	}
 
 	&:focus {
-		outline: $focus-outline-width solid $focus-outline-color;
+		outline: $sakai-focus-outline;
 		outline-offset: $focus-outline-offset;
 	}
 

--- a/library/src/morpheus-master/sass/modules/_footer.scss
+++ b/library/src/morpheus-master/sass/modules/_footer.scss
@@ -33,10 +33,6 @@
 				border-right: 0 none;
 			}
 		}
-		
-		a:focus {
-			outline-offset: 2px;	// allow you to read the link text without the outline obstructing
-		}
 	}
 	
 	##{$namespace}footer--poweredBy {

--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -364,6 +364,11 @@ nav#subSites{
 					{
 						color: $tool-menu-collapse-icon-color;
 					}
+					
+					&:focus 
+					{
+						outline-offset: -#{$focus-outline-width};	// to match the width of the default link focus to fit in the link container
+					}
 				}
 
 				span.fa-angle-double-left

--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -812,7 +812,7 @@ body.is-logged-out{
 					color: $sites-nav-menu-item-icon-color;
 				}
 				
-				&:hover {
+				&:hover, &:focus {
 					border-top: $sites-nav-menu-item-hover-border-top;
 					border-right: $sites-nav-menu-item-hover-border-right;
 					border-bottom: $sites-nav-menu-item-hover-border-bottom;
@@ -822,6 +822,10 @@ body.is-logged-out{
 					~ .#{$namespace}sitesNav__drop, ~ .#{$namespace}sitesNav__dropdown {
 						border-left: $sites-nav-menu-item-hover-border-left; 		// so the right border of the .link-container will show through the overlapping box
 					}
+				}
+				
+				&:focus {
+					outline-offset: -#{$focus-outline-width};	// to match the width of the default link focus to fit in the link container
 				}
 				
 				&:active {
@@ -895,13 +899,17 @@ body.is-logged-out{
 					background: $sites-nav-menu-item-hover-background;
 				}
 
-				&:hover {
+				&:hover, &:focus {
 					border-top: $sites-nav-menu-item-hover-border-top;
 					border-right: $sites-nav-menu-item-hover-border-right;
 					border-bottom: $sites-nav-menu-item-hover-border-bottom;
 					border-left: $sites-nav-menu-item-hover-border-left;
 					background: $sites-nav-menu-item-hover-background;
 					color: $sites-nav-menu-item-hover-icon-color;
+				}
+				
+				&:focus {
+					outline-offset: -#{$focus-outline-width};	// to match the width of the default link focus to fit in the link container
 				}
 				
 				&:active {
@@ -1074,6 +1082,10 @@ body.is-logged-out{
 							&:before{
 								border-left-color: $sites-nav-submenu-item-hover-left-border-color;
 							}
+						}
+						
+						&:focus {
+							outline-offset: -#{$focus-outline-width};	// to match the width of the default link focus to fit in the tool's link container
 						}
 					}
 					&.#{$namespace}sitesNav__submenuitem__gotosite {

--- a/library/src/morpheus-master/sass/modules/tool/_menu.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_menu.scss
@@ -32,7 +32,7 @@
 				text-transform: $tool-tab-text-transform;
 				letter-spacing: $tool-tab-text-letter-spacing;
 
-				&:hover{
+				&:hover, &:focus {
 					color: $tool-tab-hover-text-color;
 					background: $tool-tab-hover-background-color;
 					text-decoration: none;
@@ -47,7 +47,12 @@
 						right: -1px;
 						top: -1px;
 					}
-			  }
+				}
+				
+				&:focus {
+					position: relative;		// so the outline doesn't get hidden by adjacent tabs
+					outline-offset: -#{$focus-outline-width};	// to match the width of the default link focus to fit in the tool's link container
+				}
 			}
 			&.current{
 				color: $tool-tab-active-text-color;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40743

The focus outline in Sakai varies from component to component. The design and colour of the outline is different for buttons than it is for links than it is for radio buttons.

SAK-38356 introduced a Sakai default outline colour for links. SAK-32484 defined a separate design for Bootstrap buttons. SAK-40146 used a different style and colour for the focus of radio buttons and checkmarks.

This fix standardizes all of these cases with central variables. It undoes the Bootstrap override added in SAK-32484 by overriding the behaviour in Sakai's SASS files. My fix also tweaks some of the overlap issues for portal controls, such as the site links and the intra-tool tabs.
