### PR TITLE
SAK-40748: Help > fix bug with docId

### DIFF
--- a/help/help-tool/src/java/org/sakaiproject/tool/help/HelpJsfTool.java
+++ b/help/help-tool/src/java/org/sakaiproject/tool/help/HelpJsfTool.java
@@ -77,8 +77,8 @@ public class HelpJsfTool extends JsfTool
 	       }
 	       String extUrl = EXTERNAL_WEBAPP_URL;
 	       
-	       if (docId != null && ! "".equals("docId")) {
-	    	   extUrl += docId;
+	       if (docId != null && !"".equals(docId)) {
+	    	   extUrl += "/tags?tag=" + docId; // format to use if EXTERNAL_WEBAPP_URL = associated ScreenSteps home
 	       }
 	    	
 	       res.sendRedirect(extUrl);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40748

addressed 2 issues with the help system:

1. conditional anded with an expression which is always true; replace the expression with what appears to be intended
2. add param to ScreenSteps URL to convey doc tag
