### PR TITLE
SAK-40749: Kernel > realms refresh queue uses a HashMap

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -248,7 +248,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
             refreshTaskInterval = initConfig(REFRESH_INTERVAL_PROPKEY, serverConfigurationService().getString(REFRESH_INTERVAL_PROPKEY), refreshTaskInterval);
             refreshMaxTime = initConfig(REFRESH_MAX_TIME_PROPKEY, serverConfigurationService().getString(REFRESH_MAX_TIME_PROPKEY), refreshMaxTime);
 
-            refreshQueue = Collections.synchronizedMap(new HashMap<String, AuthzGroup>());
+            refreshQueue = Collections.synchronizedMap(new LinkedHashMap<>());
 
             refreshScheduler = Executors.newSingleThreadScheduledExecutor();
             refreshScheduler.scheduleWithFixedDelay(


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40749

The queue that is used for scheduling realm refresh tasks is a `HashMap` that has it's values iterated over. The order of a `HashMap` is not intended to be defined, and as of Java 8 is no longer predictable. This causes jobs in the queue to be executed in "random" order. This should to be changed to a `LinkedHashMap`.