### PR TITLE
SAK-40750: Resources > disable email notification options when uploading hidden files

### DIFF
--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -174,6 +174,7 @@ gen.email1      		 = Email Notification
 gen.email2      		 = High - All participants
 gen.email3      		 = Low - Not received by those who have opted out
 gen.email4      		 = None - No notification
+gen.email.disabled = Notifications are disabled for hidden resources
 gen.location		 = Location:
 
 instr.access.fldr	 = Folders and their contents can be scheduled to be visible between certain dates only. Site administrators will always be able to see hidden items, even when they are hidden from other users.

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
@@ -108,7 +108,7 @@
                         #end
                         <div class="form-group">
                             <h4><label for="notify">$tlang.getString("gen.email1")</label></h4>
-                            <select name="notify" id="notify">
+                            <select name="notify" id="notify" #if($upload_visibility_hidden) title="$tlang.getString('gen.email.disabled')" disabled #end>
                                 #if ($noti)
                                     <option value="r" #if($noti=="r") selected="selected" #end>$tlang.getString("gen.email2")</option>
                                     <option value="o" #if($noti=="o") selected="selected" #end>$tlang.getString("gen.email3")</option>

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -155,8 +155,26 @@
 				tag.onclick = handleRetractDatePopupRequest;
 			}
 		}
+
+		jQuery("#hidden_false").click(function() { toggleEmailNotification(true); });
+		jQuery("#hidden_true").click(function() { toggleEmailNotification(false); });
+
 	  return false;
 	}
+
+	function toggleEmailNotification(enable)
+	{
+		var select = jQuery("#notify");
+		var notificationsDisabledMsg = "$tlang.getString('gen.email.disabled')";
+		select.prop("disabled", !enable);
+		select.prop("title", enable ? "" : notificationsDisabledMsg);
+
+		if(!enable)
+		{
+			select.val('n');
+		}
+	}
+
 	function handleEnterKey(evt) 
 	{
 		evt = (typeof(evt)!= 'undefined') ? evt : ((typeof(event) != 'undefined') ? event : null);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40750

Sakai 11 introduced a new feature in which file uploaders can choose for files to be hidden when they are uploaded. However, it is still possible to select email notifications for files uploaded as hidden, meaning that site members could receive notifications for files that they are not permitted to access.

The email notifications dropdown menu should probably be disabled if the option to upload files as hidden is selected.

Screenshots in the JIRA.