### PR TITLE
SAK-40777: Polls > 'poll.add' event is never fired due to logic error

### DIFF
--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -169,7 +169,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
         	throw new SecurityException();
         }
         
-        if (t.getId() == null) {
+        if (t.getPollId() == null) {
             newPoll = true;
             t.setId(idManager.createUuid());
         }

--- a/polls/impl/src/test/org/sakaiproject/poll/logic/test/PollListManagerTest.java
+++ b/polls/impl/src/test/org/sakaiproject/poll/logic/test/PollListManagerTest.java
@@ -27,10 +27,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import org.sakaiproject.id.api.IdManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 
 import org.sakaiproject.poll.dao.PollDao;
@@ -69,6 +70,7 @@ public class PollListManagerTest extends AbstractTransactionalJUnit4SpringContex
 		pollListManager.setExternalLogic(externalLogicStubb);
 		pollVoteManager.setExternalLogic(externalLogicStubb);
 		pollListManager.setPollVoteManager(pollVoteManager);
+		pollListManager.setIdManager(mock(IdManager.class));
 		
 		// preload testData
 		tdp.preloadTestData(dao);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40777

The event "poll.add" is never fired due to a logic error:

```
        if (t.getId() == null) {
            newPoll = true;
            t.setId(idManager.createUuid());
        }

...
...
...

        if (newPoll)
        	externalLogic.postEvent("poll.add", "poll/site/"
                    + t.getSiteId() + "/poll/" + t.getId(), true);
        else
        	externalLogic.postEvent("poll.update", "poll/site/"
                    + t.getSiteId() + " /poll/" + t.getId(), true);
```

Where `Poll.getId()` is:

```
    public String getId() {
        if (entityID == null) {
            entityID = id + "";
        }
        return entityID;
    }
```

In this situation, `t.getId()` returns a string of `"null"`, and thus never satisfies the condition to flip the `newPoll` boolean to true. The code should be checking for the absence/null value of the actual ID of the poll, not the entity ID:

```
if (t.getPollId() == null)
```