### PR TITLE
SAK-40778: Polls > creation date is never populated

### DIFF
--- a/polls/tool/src/java/org/sakaiproject/poll/tool/params/PollToolBean.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/params/PollToolBean.java
@@ -143,7 +143,7 @@ public class PollToolBean {
 			Poll existingPoll = manager.getPollById(poll.getPollId(), false);
 			isNew = false;
 			//check for possible unchanged values
-			log.debug(" newPoll is " + poll.getText()+ " while poll text is " + existingPoll.getText());
+			log.debug("newPoll is {} while poll text is {}", poll.getText(), existingPoll.getText());
 			
 
 			if (poll.getCreationDate() == null) {

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/params/PollToolBean.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/params/PollToolBean.java
@@ -24,6 +24,7 @@ package org.sakaiproject.poll.tool.params;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -139,16 +140,17 @@ public class PollToolBean {
 		boolean isNew = true;
 		if (poll.getPollId()!=null) {
 			log.debug("Actualy updating poll " + poll.getPollId());
+			Poll existingPoll = manager.getPollById(poll.getPollId(), false);
 			isNew = false;
 			//check for possible unchanged values
-			log.debug(" newPoll is " + poll.getText()+ " while poll text is " + poll.getText());
+			log.debug(" newPoll is " + poll.getText()+ " while poll text is " + existingPoll.getText());
 			
 
-			if (poll.getText().equals("") && poll.getText()!=null)
-				poll.setText(poll.getText());
-
-			if (poll.getDetails().equals("") && poll.getDetails() != null)
-				poll.setDetails(poll.getDetails());
+			if (poll.getCreationDate() == null) {
+				poll.setCreationDate(existingPoll.getCreationDate());
+			}
+		} else {
+			poll.setCreationDate(new Date());
 		}
 
 		


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40778

Went to do a SQL query ordered by poll_creation_date of the poll_poll table, realized every poll in every database we have (both MySQL and Oracle) has null values for this field...