### PR TITLE
SAK-34439: Samigo > erroneous bold styling on answers to MC, MS and T/F questions

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -32,6 +32,9 @@
 			input[type="checkbox"], input[type="radio"] {
 				margin-right: 0.25em;
 			}
+			label {
+				font-weight: normal;
+			}
 	}
 
 	.listNav {

--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -547,7 +547,6 @@ a.hideDivision {
 .mcAnswerText {
 	display:inline;
 	float:unset;
-	font-weight: bold;
 }
 .mcAnswerText label {
 	font-weight: normal;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34439

If your quiz includes a *Multiple Choice, Multiple Selection* or *True False* type question, students see the answer options (in *Multiple Choice, Multiple Selection*, this includes the letters for answer options, e.g. *A.*) in *bold* when they take the test and view feedback, even if the instructor did NOT select to make these bold. Answer text should NOT be bold unless specified by instructor.