### PR TITLE
SAK-40756 Gradebook: fixed missing icons for due date on GB item add or edit modal

### DIFF
--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -292,6 +292,15 @@ div.wicket-modal div.w_content_container > div > form > h2:first-child {
   margin: 0 0 20px;
   border-bottom: 1px solid #EEE;
 }
+/* override Bootstrap for the date picker */
+div.wicket-modal div.w_content_container .input-group-btn button {
+  font-size: 12px;
+  height: 30px;
+}
+div.wicket-modal div.w_content_container .input-group-btn button > .glyphicon {
+  top: -1px;
+}
+
 div.wicket-modal .w_topLeft,
 div.wicket-modal .w_top,
 div.wicket-modal .w_topRight,


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40756

Fixed the missing icons on the due date form field controls in the Gradebook item add/edit modal by specifying a font-size on the group to override Bootstrap in conjunction with the glyphicon.

Before:

![01-gb-before](https://user-images.githubusercontent.com/12685096/47050439-61aaee80-d16e-11e8-86a5-72546043bbfd.png)

After:

![02-gb-after](https://user-images.githubusercontent.com/12685096/47050438-61aaee80-d16e-11e8-9543-07e1e1315b1a.png)


