### PR TITLE
SAK-40817 Assignments regression from SAK-40742

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/AssignmentSubmission.java
@@ -72,7 +72,7 @@ public class AssignmentSubmission {
     @GenericGenerator(name = "uuid", strategy = "uuid2")
     private String id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ASSIGNMENT_ID")
     private Assignment assignment;
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.assignment.impl;
 
 import static org.sakaiproject.assignment.api.AssignmentServiceConstants.*;
+import static org.sakaiproject.assignment.api.model.Assignment.Access.*;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -421,7 +422,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                         if (reference.getId() != null) {
                             Assignment a = getAssignment(reference);
                             if (a != null) {
-                                grouped = Assignment.Access.GROUP == a.getTypeOfAccess();
+                                grouped = GROUP == a.getTypeOfAccess();
                                 groups = a.getGroups();
                             }
                         }
@@ -631,7 +632,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         String assignmentId = AssignmentReferenceReckoner.reckoner().reference(assignmentReference).reckon().getId();
         try {
             Assignment a = getAssignment(assignmentId);
-            if (a.getTypeOfAccess() == Assignment.Access.GROUP) {
+            if (a.getTypeOfAccess() == GROUP) {
                 // for grouped assignment, need to include those users that with "all.groups" and "grade assignment" permissions on the site level
                 try {
                     AuthzGroup group = authzGroupService.getAuthzGroup(siteService.siteReference(a.getContext()));
@@ -793,7 +794,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 assignment.setAllowPeerAssessment(existingAssignment.getAllowPeerAssessment());
                 if (!existingAssignment.getGroups().isEmpty()) {
                 	assignment.setGroups(new HashSet<>(existingAssignment.getGroups()));
-                	assignment.setTypeOfAccess(Assignment.Access.GROUP);
+                	assignment.setTypeOfAccess(GROUP);
                 }
 
                 // peer properties
@@ -1001,7 +1002,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         if (assignment != null) {
             String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
             // check permissions first
-            if (assignment.getTypeOfAccess() == Assignment.Access.GROUP) {
+            if (assignment.getTypeOfAccess() == GROUP) {
                 if (!permissionCheckWithGroups(SECURE_ADD_ASSIGNMENT_SUBMISSION, assignment)) {
                     throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_ADD_ASSIGNMENT_SUBMISSION, assignmentReference);
                 }
@@ -1171,7 +1172,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         }
         eventTrackingService.post(eventTrackingService.newEvent(AssignmentConstants.EVENT_UPDATE_ASSIGNMENT_SUBMISSION, reference, true));
 
-        submission.setDateModified(Instant.now());
         assignmentRepository.updateSubmission(submission);
 
         // Assignment Submission Notifications
@@ -1303,7 +1303,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     // only those who can see a draft assignment
                     assignments.add(assignment);
                 }
-            } else if (assignment.getTypeOfAccess() == Assignment.Access.GROUP) {
+            } else if (assignment.getTypeOfAccess() == GROUP) {
                 if (permissionCheckWithGroups(AssignmentServiceConstants.SECURE_ACCESS_ASSIGNMENT, assignment)) {
                     assignments.add(assignment);
                 }
@@ -1352,7 +1352,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             Collection<Assignment> assignments = getAssignmentsForContext(context);
             for (Assignment assignment : assignments) {
                 Set<String> userIds = new HashSet<>();
-                if (assignment.getTypeOfAccess() == Assignment.Access.GROUP) {
+                if (assignment.getTypeOfAccess() == GROUP) {
                     for (String groupRef : assignment.getGroups()) {
                         if (groupIdUserIds.containsKey(groupRef)) {
                             userIds.addAll(groupIdUserIds.get(groupRef));
@@ -1417,55 +1417,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             }
         }
         return null;
-    }
-
-    private Map<User, AssignmentSubmission> getUserSubmissionMap(Assignment assignment) {
-        Map<User, AssignmentSubmission> userSubmissionMap = new HashMap<>();
-        if (assignment != null) {
-            if (assignment.getIsGroup()) {
-                // All this block does is some verification of members in the group and the submissions submitters
-                try {
-                    Site site = siteService.getSite(assignment.getContext());
-                    for (AssignmentSubmission submission : assignment.getSubmissions()) {
-                        String gid = submission.getGroupId();
-                        if (StringUtils.isNotBlank(gid)) {
-                            Group group = site.getGroup(gid);
-                            if (group != null) {
-                                Set<String> members = group.getMembers().stream().map(Member::getUserId).collect(Collectors.toSet());
-                                Set<String> submitters = submission.getSubmitters().stream().map(AssignmentSubmissionSubmitter::getSubmitter).collect(Collectors.toSet());
-                                log.debug("Checking for consistency of group members [{}] to submitters [{}]", members.size(), submitters.size());
-                                if (Collections.disjoint(members, submitters)) {
-                                    log.warn("DISJOINT group members and submitters detected");
-                                    List<String> submittersNotMembers = submitters.stream().filter(s -> !members.contains(s)).collect(Collectors.toList());
-                                    log.warn("DISJOINT there are {} submitters that are not a member of a group: {}", submittersNotMembers.size(), submittersNotMembers);
-                                    List<String> membersNotSubmitters = members.stream().filter(s -> !submitters.contains(s)).collect(Collectors.toList());
-                                    log.warn("DISJOINT there are {} members that are not a submitter: {}", membersNotSubmitters.size(), membersNotSubmitters);
-                                } else {
-                                    log.debug("All members of group: {}::{} are submitters", gid, group.getTitle());
-                                }
-                            } else {
-                                log.warn("Submission contains a group that doesn't exist in the site, submission: {}, group: {}", submission.getId(), gid);
-                                break;
-                            }
-                        }
-                    }
-                } catch (IdUnusedException e) {
-                    log.warn("Could not fetch site for assignment: {} with a context of: {}");
-                }
-            }
-            // Simply we add every AssignmentSubmissionSubmitter to the Map, this works equally well for group submissions
-            for (AssignmentSubmission submission : assignment.getSubmissions()) {
-                for (AssignmentSubmissionSubmitter submitter : submission.getSubmitters()) {
-                    try {
-                        User user = userDirectoryService.getUser(submitter.getSubmitter());
-                        userSubmissionMap.put(user, submission);
-                    } catch (UserNotDefinedException e) {
-                        log.warn("Could not find user: {}, that is a submitter for submission: {}", submitter.getSubmitter(), submission.getId());
-                    }
-                }
-            }
-        }
-        return userSubmissionMap;
     }
 
     @Override
@@ -1941,11 +1892,9 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if (a != null) {
                 Site st = siteService.getSite(contextString);
                 if (StringUtils.equals(allOrOneGroup, AssignmentConstants.ALL) || StringUtils.isEmpty(allOrOneGroup)) {
-                    if (a.getTypeOfAccess().equals(Assignment.Access.SITE)) {
+                    if (a.getTypeOfAccess().equals(SITE)) {
                         for (Group group : st.getGroups()) {
-                            //if (_gg.getProperties().get(GROUP_SECTION_PROPERTY) == null) {		// NO SECTIONS (this might not be valid test for manually created sections)
                             rv.add(group);
-                            //}
                         }
                     } else {
                         for (String groupRef : a.getGroups()) {
@@ -1978,7 +1927,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                     AssignmentSubmission s = addSubmission(a.getId(), g.getId());
                                     s.setSubmitted(true);
                                     s.setUserSubmission(false);
-                                    s.setDateModified(Instant.now());
 
                                     // set the resubmission properties
                                     // get the assignment setting for resubmitting
@@ -2035,21 +1983,26 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Transactional
     public Map<User, AssignmentSubmission> getSubmitterMap(String searchFilterOnly, String allOrOneGroup, String searchString, String aRef, String contextString) {
         Map<User, AssignmentSubmission> rv = new HashMap<>();
-        if (StringUtils.isBlank(aRef)) return rv;
 
-        List<User> rvUsers;
-        allOrOneGroup = StringUtils.trimToNull(allOrOneGroup);
-        searchString = StringUtils.trimToNull(searchString);
-        boolean bSearchFilterOnly = "true".equalsIgnoreCase(searchFilterOnly);
-
-        try {
+        Assignment assignment = null;
+        if (StringUtils.isNotBlank(aRef)) {
             String id = AssignmentReferenceReckoner.reckoner().reference(aRef).reckon().getId();
-            Assignment a = getAssignment(id);
+            try {
+                assignment = getAssignment(id);
+            } catch (IdUnusedException iue) {
+                log.warn("Assignment could not be found with id: {}, {}", id, iue.getMessage());
+            } catch (PermissionException pe) {
+                log.warn("You do not have permissions to access assignment {}, {}", id, pe.getMessage());
+            }
+        }
 
-            if (a == null) return rv;
+        if (assignment != null) {
+            List<User> rvUsers;
+            allOrOneGroup = StringUtils.trimToNull(allOrOneGroup);
+            searchString = StringUtils.trimToNull(searchString);
+            boolean bSearchFilterOnly = "true".equalsIgnoreCase(searchFilterOnly);
 
-            // SAK-27824
-            if (assignmentUsesAnonymousGrading(a)) {
+            if (assignmentUsesAnonymousGrading(assignment)) {
                 bSearchFilterOnly = false;
                 searchString = "";
             }
@@ -2066,7 +2019,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                         rvUsers = getSearchedUsers(searchString, allowAddSubmissionUsers, false);
                     } else {
                         // group filter first
-                        rvUsers = getSelectedGroupUsers(allOrOneGroup, contextString, a, allowAddSubmissionUsers);
+                        rvUsers = getSelectedGroupUsers(allOrOneGroup, contextString, assignment, allowAddSubmissionUsers);
                         if (searchString != null) {
                             // then search
                             rvUsers = getSearchedUsers(searchString, rvUsers, true);
@@ -2077,7 +2030,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 List<User> allowAddSubmissionUsers = allowAddSubmissionUsers(aRef);
 
                 // SAK-28055 need to take away those users who have the permissions defined in sakai.properties
-                String resourceString = AssignmentReferenceReckoner.reckoner().context(a.getContext()).reckon().getReference();
+                String resourceString = AssignmentReferenceReckoner.reckoner().context(assignment.getContext()).reckon().getReference();
                 String[] permissions = serverConfigurationService.getStrings("assignment.submitter.remove.permission");
                 if (permissions != null) {
                     for (String permission : permissions) {
@@ -2088,89 +2041,97 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 }
 
                 // Step 1: get group if any that is selected
-                rvUsers = getSelectedGroupUsers(allOrOneGroup, contextString, a, allowAddSubmissionUsers);
+                rvUsers = getSelectedGroupUsers(allOrOneGroup, contextString, assignment, allowAddSubmissionUsers);
 
                 // Step 2: get all student that meets the search criteria based on previous group users. If search is null or empty string, return all users.
                 rvUsers = getSearchedUsers(searchString, rvUsers, true);
             }
 
             if (!rvUsers.isEmpty()) {
-                List<String> groupRefs = new ArrayList<String>();
-                Map<User, AssignmentSubmission> userSubmissionMap = getUserSubmissionMap(a);
-                for (User u : rvUsers) {
-                    AssignmentSubmission uSubmission = userSubmissionMap.get(u);
+                for (User user : rvUsers) {
+                    AssignmentSubmission submission = assignmentRepository.findSubmissionForUser(assignment.getId(), user.getId());
 
-                    if (uSubmission != null) {
-                        rv.put(u, uSubmission);
+                    if (submission != null) {
+                        rv.put(user, submission);
                     } else {
-                        // add those users who haven't made any submissions and with submission rights
-                        //only initiate the group list once
-                        if (groupRefs.isEmpty()) {
-                            if (a.getTypeOfAccess() == Assignment.Access.SITE) {
-                                // for site range assignment, add the site reference first
-                                groupRefs.add(siteService.siteReference(contextString));
-                            }
-                            // add all groups inside the site
-                            Collection<Group> groups = getGroupsAllowGradeAssignment(AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference());
-                            for (Group g : groups) {
-                                groupRefs.add(g.getReference());
-                            }
-                        }
-                        // construct fake submissions for grading purpose if the user has right for grading
-                        if (allowGradeSubmission(AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference())) {
-                            SecurityAdvisor securityAdvisor = new MySecurityAdvisor(
-                                    sessionManager.getCurrentSessionUserId(),
-                                    new ArrayList<>(Arrays.asList(SECURE_ADD_ASSIGNMENT_SUBMISSION, SECURE_UPDATE_ASSIGNMENT_SUBMISSION)),
-                                    groupRefs/* no submission id yet, pass the empty string to advisor*/);
-                            try {
-                                // temporarily allow the user to read and write from assignments (asn.revise permission)
-                                securityService.pushAdvisor(securityAdvisor);
+                        String submitter = null;
+                        switch (assignment.getTypeOfAccess()) {
+                            case SITE:
+                                // access is for the entire site and submitter is a user
+                                submitter = user.getId();
+                                break;
+                            case GROUP:
+                                // access is restricted to groups
+                                Site site;
+                                try {
+                                    site = siteService.getSite(assignment.getContext());
+                                } catch (IdUnusedException iue) {
+                                    log.warn("Could not get the site {} for assignment {} while determining the submitter of the submission", assignment.getContext(), assignment.getId());
+                                    break;
+                                }
+                                Set<String> assignmentGroups = assignment.getGroups();
+                                Collection<Group> userGroups = site.getGroupsWithMember(user.getId());
+                                Set<String> groupIdsMatchingAssignmentForUser = userGroups.stream().filter(g -> assignmentGroups.contains(g.getReference())).map(Group::getId).collect(Collectors.toSet());
 
-                                AssignmentSubmission s = addSubmission(a.getId(), u.getId());
-                                if (s != null) {
+                                if (groupIdsMatchingAssignmentForUser.size() < 1) {
+                                    log.debug("User {} is not a member of any groups for this assignment {}", user.getId(), assignment.getId());
+                                } else if (groupIdsMatchingAssignmentForUser.size() == 1) {
+                                    if (assignment.getIsGroup()) {
+                                        submitter = groupIdsMatchingAssignmentForUser.toArray(new String[]{})[0];
+                                    } else {
+                                        submitter = user.getId();
+                                    }
+                                    break;
+                                } else if (groupIdsMatchingAssignmentForUser.size() > 1) {
+                                    log.warn("User {} is on more than one group for this assignment {}, please remove the user from a group so that they are only a member of a single group",
+                                            user.getId(), assignment.getId());
+                                }
+                            default:
+                                log.warn("Can't determine the type of submission to create for user {} in assignment {}", user.getId(), assignment.getId());
+                                continue;
+                        }
+                        if (submitter != null) {
+                            try {
+                                submission = addSubmission(assignment.getId(), submitter);
+                                if (submission != null) {
                                     // Note: If we had s.setSubmitted(false);, this would put it in 'draft mode'
-                                    s.setSubmitted(true);
+                                    submission.setSubmitted(true);
                                     /*
                                      * SAK-29314 - Since setSubmitted represents whether the submission is in draft mode state, we need another property. So we created isUserSubmission.
-									 * This represents whether the submission was geenrated by a user.
-									 * We set it to false because these submissions are generated so that the instructor has something to grade;
-									 * the user did not in fact submit anything.
-									 */
-                                    s.setUserSubmission(false);
-                                    s.setDateModified(Instant.now());
+                                     * This represents whether the submission was geenrated by a user.
+                                     * We set it to false because these submissions are generated so that the instructor has something to grade;
+                                     * the user did not in fact submit anything.
+                                     */
+                                    submission.setUserSubmission(false);
 
                                     // set the resubmission properties
                                     // get the assignment setting for resubmitting
-                                    Map<String, String> assignmentProperties = a.getProperties();
+                                    Map<String, String> assignmentProperties = assignment.getProperties();
                                     String assignmentAllowResubmitNumber = assignmentProperties.get(AssignmentConstants.ALLOW_RESUBMIT_NUMBER);
-                                    if (assignmentAllowResubmitNumber != null) {
-                                        s.getProperties().put(AssignmentConstants.ALLOW_RESUBMIT_NUMBER, assignmentAllowResubmitNumber);
+                                    if (StringUtils.isNotBlank(assignmentAllowResubmitNumber)) {
+                                        Map<String, String> submissionProperties = submission.getProperties();
+                                        submissionProperties.put(AssignmentConstants.ALLOW_RESUBMIT_NUMBER, assignmentAllowResubmitNumber);
 
                                         String assignmentAllowResubmitCloseDate = assignmentProperties.get(AssignmentConstants.ALLOW_RESUBMIT_CLOSETIME);
                                         // if assignment's setting of resubmit close time is null, use assignment close time as the close time for resubmit
-                                        s.getProperties().put(AssignmentConstants.ALLOW_RESUBMIT_CLOSETIME,
-                                                assignmentAllowResubmitCloseDate != null ? assignmentAllowResubmitCloseDate : String.valueOf(a.getCloseDate().toEpochMilli()));
+                                        submissionProperties.put(AssignmentConstants.ALLOW_RESUBMIT_CLOSETIME,
+                                                StringUtils.isNotBlank(assignmentAllowResubmitCloseDate)
+                                                        ? assignmentAllowResubmitCloseDate
+                                                        : String.valueOf(assignment.getCloseDate().toEpochMilli()));
                                     }
-
-                                    assignmentRepository.updateSubmission(s);
-                                    rv.put(u, s);
+                                    assignmentRepository.updateSubmission(submission);
+                                    rv.put(user, submission);
+                                } else {
+                                    log.warn("No submission was found/created for user {} in assignment {}, this should never happen", user.getId(), assignment.getId());
                                 }
                             } catch (Exception e) {
-                                log.warn("Exception thrown while creating empty submission for student who has not submitted, {}", e.getMessage());
-                            } finally {
-                                // clear the permission
-                                securityService.popAdvisor(securityAdvisor);
+                                log.warn("Exception thrown while creating empty submission for student who has not submitted, {}", e.getMessage(), e);
                             }
                         }
                     }
                 }
             }
-        } catch (IdUnusedException aIdException) {
-            log.warn("Assignment id not used: {}, {}", aRef, aIdException.getMessage());
-        } catch (PermissionException aPerException) {
-            log.warn("Not allowed to get assignment {}, {}", aRef, aPerException.getMessage());
         }
-
         return rv;
     }
 
@@ -2558,7 +2519,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
     private Assignment checkAssignmentAccessibleForUser(Assignment assignment, String currentUserId) throws PermissionException {
 
-        if (assignment.getTypeOfAccess() == Assignment.Access.GROUP) {
+        if (assignment.getTypeOfAccess() == GROUP) {
             String context = assignment.getContext();
             Collection<String> asgGroups = assignment.getGroups();
             Collection<Group> allowedGroups = getGroupsAllowFunction(SECURE_ACCESS_ASSIGNMENT, context, currentUserId);
@@ -3510,8 +3471,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     nAssignment.setReleaseGrades(oAssignment.getReleaseGrades());
 
                     // group assignment
-                    if (oAssignment.getTypeOfAccess() == Assignment.Access.GROUP) {
-                        nAssignment.setTypeOfAccess(Assignment.Access.GROUP);
+                    if (oAssignment.getTypeOfAccess() == GROUP) {
+                        nAssignment.setTypeOfAccess(GROUP);
                         Site oSite = siteService.getSite(oAssignment.getContext());
                         Site nSite = siteService.getSite(nAssignment.getContext());
 


### PR DESCRIPTION
This change cleans up getSubmitterMap and instead of locking the table
it locks the Assignment until it has added all submissions. This change
is a bit smarter since it will only lock the assignment if a submission
is to be added.