### PR TITLE
SAK-40832: Samigo > fix contrast of bar graph totals (a11y)

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -17,6 +17,24 @@ div#questionProgressPanel>div.tier1>table>tbody>tr {
 div#questionProgressPanel>div.tier1>table>tbody>tr:hover {
   background: #bcd8ff;
 }
+table.table.stat-table {
+  margin-bottom: 0;
+}
+span.progress-num {
+  padding-left: 2px;
+  color: #000;
+  font-weight: bold;
+}
+.progress {
+  margin-bottom: 0;
+}
+.progress-bar {
+  background-color: #70A7D7;
+  border-right: 1px solid #000;
+}
+.progress-bar-success {
+  background-color: #5cb85c;
+}
 .samigo-subheading {
   font-weight: 400;
   border-bottom: 1px solid #999;

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/histogramScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/histogramScores.jsp
@@ -158,7 +158,7 @@ $Id$
         <strong><h:outputText value="#{evaluationMessages.tot}" /></strong>
       </div>
       <div class="table-reponsive">
-        <h:dataTable styleClass="table table-condensed" value="#{histogramScores.histogramBars}" var="bar" headerClass="navView">
+        <h:dataTable styleClass="table table-condensed stat-table" value="#{histogramScores.histogramBars}" var="bar" headerClass="navView">
           <h:column>
             <f:facet name="header">
               <h:outputText escape="false" value="#{evaluationMessages.num_points}" /> 
@@ -172,7 +172,9 @@ $Id$
             <h:panelGroup>
               <div class="progress">
                 <h:outputText value="<div class=\"progress-bar\" role=\"progressbar\" aria-valuenow=\"#{bar.columnHeight}\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width: #{bar.columnHeight}%;\">" escape="false" />
-                  <h:outputText value="#{bar.numStudents}" />
+                <span class="progress-num">
+                    <h:outputText value="#{bar.numStudents}" />
+                </span>
                 </div>
               </div>
             </h:panelGroup>
@@ -286,7 +288,9 @@ $Id$
                 <div class="progress">
                   <h:outputText rendered="#{bar.isCorrect}" value="<div class=\"progress-bar progress-bar-success\" role=\"progressbar\" aria-valuenow=\"#{bar.columnHeight}\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width: #{bar.columnHeight}%;\">" escape="false" />
                   <h:outputText rendered="#{!bar.isCorrect}" value="<div class=\"progress-bar\" role=\"progressbar\" aria-valuenow=\"#{bar.columnHeight}\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width: #{bar.columnHeight}%;\">" escape="false" />
-                    <h:outputText value="#{bar.numStudentsText}" />
+                    <span class="progress-num">
+                      <h:outputText value="#{bar.numStudentsText}" />
+                    </span>
                   </div>
                 </div>
                 <div class="num-students-text hide">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40832

When few or no students fall into a certain category for the final grade statistics, the total number is over-layed on the grey bar in grey text and is almost impossible to see. Before and after screenshots in the JIRA.