### PR TITLE
SAK-40857: DelegatedAccess doesn't work for provided LDAP users

### DIFF
--- a/delegatedaccess/impl/src/java/org/sakaiproject/delegatedaccess/logic/SakaiProxyImpl.java
+++ b/delegatedaccess/impl/src/java/org/sakaiproject/delegatedaccess/logic/SakaiProxyImpl.java
@@ -237,7 +237,7 @@ public class SakaiProxyImpl implements SakaiProxy {
 	 */
 	public List<User> searchUsers(String search) {
 		List<User> returnList = new ArrayList<User>();
-		returnList.addAll(userDirectoryService.searchExternalUsers(search, -1, -1));
+		returnList.addAll(userDirectoryService.searchExternalUsers(search, 1, Integer.MAX_VALUE));
 		returnList.addAll(userDirectoryService.searchUsers(search, 1, Integer.MAX_VALUE));
 		return returnList;
 	}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40857

The delegated access tool, out of the box, does not work for provided LDAP users.