### PR TITLE
SAK-40861 use the browser visibility state to avoid fetches when hidden and to fetch as soon as we are visible again

### DIFF
--- a/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatMessageEntityProvider.java
+++ b/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatMessageEntityProvider.java
@@ -318,14 +318,13 @@ public class ChatMessageEntityProvider implements CoreEntityProvider,
 			log.debug("No siteId specified");
 			throw new SecurityException("You must be specify the site ID");
 		}
-		log.debug("siteId: {}", siteId);
 		
 		String channelId = (String) params.get("channelId");
 		if (StringUtils.isBlank(channelId)) {
 			log.debug("No channelId specified");
 			throw new SecurityException("You must be specify the channel ID");
 		}
-		log.debug("channelId: {}", channelId);
+		log.debug("channelId: {}, siteId: {}, sessionKey: {}", channelId, siteId, chatManager.getSessionKey());
 		
 		ChatChannel channel = chatManager.getChatChannel(channelId);
 		if (!chatManager.getCanReadMessage(channel)) {

--- a/chat/chat-tool/tool/src/webapp/js/chatscript.js
+++ b/chat/chat-tool/tool/src/webapp/js/chatscript.js
@@ -18,13 +18,22 @@
  * limitations under the License.
  *
  **********************************************************************************/
+ 
+// When user goes between tabs or back from home screen, we monitor and updateChatData
+document.addEventListener('visibilitychange', function() {
+  if (document.visibilityState == 'hidden' || document.visibilityState == 'visible') {
+    chatscript.changePageVisibility(document.visibilityState);
+  }
+});
+
 var chatscript = {
 	url_submit : "/direct/chat-message/",
 	keycode_enter : 13,
 	pollInterval : 5000,
 	currentChatChannelId : null,
 	timeoutVar : null,
-	
+	pageVisibility : 'visible',
+
 	init : function(){
 		var me = this;
 		
@@ -101,6 +110,12 @@ var chatscript = {
 			});
 		});
 	},
+  changePageVisibility : function(newVisibility) {
+    this.pageVisibility = newVisibility;
+    if (newVisibility == 'visible') {
+      this.updateChatData();
+    }
+  },
 	sendMessage : function(params, textarea, submitButton) {
 		var me = this;
 		var errorSubmit = $("#errorSubmit");
@@ -143,9 +158,12 @@ var chatscript = {
 		if(this.timeoutVar != null) {
 			clearTimeout(this.timeoutVar);
 		}
-		this.timeoutVar = setTimeout(function() {
-			me.updateChatData();
-		}, this.pollInterval);
+		// If the tab is hidden, no use in firing AJAX requests for new chat data
+		if(this.pageVisibility != 'hidden') {
+			this.timeoutVar = setTimeout(function() {
+				me.updateChatData();
+			}, this.pollInterval);
+		}
 	},
 	doUpdateChatData : function() {
 		var me = this;


### PR DESCRIPTION
Also crucial to this change is not remove users from the `heartbeatMap` if we don't hear from them in 10 seconds. Instead, keep them in the map to make sure messages can be delivered when they reconnect!