### PR TITLE
SAK-40874 - Velocity null errors on assignment log

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_preview_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_preview_submission.vm
@@ -101,7 +101,7 @@
     <h4>
         $tlang.getString("gen.submission")
     </h4>
-    #if ($!text.length() > 0)
+    #if ($text && $!text.length() > 0)
         <div class="textPanel">
             $validator.escapeHtmlFormattedText($text)
         </div>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -243,7 +243,7 @@
         $tlang.getString("gen.instr")
     </h4>
 
-    #if ($!assignment.Instructions.length() > 0)
+    #if ($assignment.Instructions && $!assignment.Instructions.length() > 0)
         <div class="textPanel borderPanel">$validator.escapeHtmlFormattedText($!assignment.Instructions)</div>
     #end
 


### PR DESCRIPTION
This is a small backward compatibility issue, there are assignments that still don't have all mandatory properties because are too old.

There are similar issues on other tools and I'm going to try to check all nulls on the having log error.