### PR TITLE
SAK-40877: Kernel > inappropriate sort option causes kernel code to create broken SQL statement

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
@@ -1196,7 +1196,14 @@ public abstract class DbSiteService extends BaseSiteService
 			LinkedHashMap<String, Site> siteMap = getOrderedSiteMap(siteIds, requireDescription);
 
 			SqlReader reader = requireDescription ? fullSiteReader : lightSiteReader;
-			String order = getSitesOrder(sort);
+			String order = null;
+			if ((sort != SortType.CREATED_BY_ASC)
+					&& (sort != SortType.CREATED_BY_DESC)
+					&& (sort != SortType.MODIFIED_BY_ASC)
+					&& (sort != SortType.MODIFIED_BY_DESC))
+			{
+				order = getSitesOrder(sort);
+			}
 
 			// Account for limitations in the number of IN parameters we can use by batching
 			// Load just the sites that weren't found in cache


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40877

Log errors result from SQL statement errors when `ORDER BY` states a column whose table is not part of the `SELECT`. The sort order results from user choices in the UI.

Stacktrace and steps to reproduce in the JIRA.