### PR TITLE
SAK-40879: CKEditor > allow tools to override default toolbar config

### DIFF
--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -218,6 +218,10 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
 	ckconfig.baseFloatZIndex = config.baseFloatZIndex;
     }
 
+    if (config && config.toolbarSet && ckconfig['toolbar_' + config.toolbarSet]) {
+        ckconfig.toolbar = config.toolbarSet;
+    }
+
     //To add extra plugins outside the plugins directory, add them here! (And in the variable)
     (function() {
         // SAK-30370 present a nice and simple editor without plugins to the user on a tiny screen.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40879

The `#chef_setupformattedtextareaparams` velocity macro allows passing a named toolbar configuration, like this:
`#chef_setupformattedtextareaparams("contenttext" "" "" "FullNoKaltura")`

However, the code in `ckeditor.launch.js` omitted the code that allowed this parameter to function. It needs to be added back; this is a regression from SAK-30370.