### PR TITLE
SAK-40882: PostEm > incorrect error message when uploading wrong file type

### DIFF
--- a/postem/postem-app/src/bundle/org/sakaiproject/tool/postem/bundle/Messages.properties
+++ b/postem/postem-app/src/bundle/org/sakaiproject/tool/postem/bundle/Messages.properties
@@ -23,11 +23,11 @@ no=No
 #email_notification=Email Notification
 #template_instructions=Click Browse, double-click your display template file. To remove the template, upload an empty file.
 released=Released
-missing_title=Alert: A title is required.
-missing_csv=Alert: Please choose a file to post.
-invalid_ext=Alert: The file "{0}" that you uploaded is not a valid file type. Please make sure your file is saved as a *.csv file and try again.
-duplicate_title=Alert: That title is already in use.
-title_too_long=Alert: The title contains {0} characters. Your title may not exceed {1} characters.
+missing_title=A title is required.
+missing_csv=Please choose a file to post.
+invalid_ext=The file "{0}" that you uploaded is not a valid file type. Please make sure your file is saved as a *.csv file and try again.
+duplicate_title=That title is already in use.
+title_too_long=The title contains {0} characters. Your title may not exceed {1} characters.
 #Unused
 #ok=OK
 choose_username= Select a Participant:
@@ -182,19 +182,19 @@ cancel=Cancel
 upload=Upload File
 
 select_participant=No participant is selected.
-missing_single_username=Alert: The following field does not contain a username: 
-missing_mult_usernames=Alert: The following fields do not contain a username: 
+missing_single_username=The following field does not contain a username:
+missing_mult_usernames=The following fields do not contain a username:
 missing_location=Column 1, Row {0}
 missing_username_dir=To continue, you must first provide a username for all participants in the file.
 
-single_invalid_username=Alert: The following username is not associated with a participant in this site: 
-mult_invalid_usernames=Alert: The following usernames are not associated with participants in this site: 
+single_invalid_username=The following username is not associated with a participant in this site:
+mult_invalid_usernames=The following usernames are not associated with participants in this site:
 mult_invalid_usernames_dir=To continue, you must first add these participants to the site or remove the participants from the file. 
 single_invalid_username_dir=To continue, you must first add this participant to the site or remove the participant from the file. 
 invalid_username={0}
 
-single_duplicate_username=Alert: The following username appears more than once in the uploaded file:
-mult_duplicate_usernames=Alert: The following usernames appear more than once in the uploaded file:
+single_duplicate_username=The following username appears more than once in the uploaded file:
+mult_duplicate_usernames=The following usernames appear more than once in the uploaded file:
 duplicate_username={0}
 duplicate_username_dir=To continue, you must ensure there are no duplicate usernames in the file.
 
@@ -202,8 +202,8 @@ no_gradebooks=There are currently no items at this location.
 no_gradebook_selected=Sorry, no gradebook currently selected.
 no_grades_for_user=No grades for current user in gradebook {0}.
 no_grades_in_gradebook=No grades exist in gradebook {0}.
-blank_headings=Alert: The first row of your file must contain headings. The heading cannot be left blank.
-heading_too_long=Alert: Each column heading in your uploaded file may not exceed {0} characters.
+blank_headings=Your file must be in CSV format with the first row containing headings. The headings cannot be left blank.
+heading_too_long=Each column heading in your uploaded file may not exceed {0} characters.
 data_truncated_warning=Some data in your uploaded file exceeded the {0} character limit and was truncated.
 
 title_label=Title:
@@ -215,8 +215,8 @@ blank=
 #comma_delim=Comma
 #tab_delim=Tab
 #delimiter=Delimiter
-invalid_delim=Alert: Please select a valid delimiter for your file.  
-template_too_long=Alert: The uploaded template file contains {0} characters. Your template file may not exceed {1} characters.
+invalid_delim=Please select a valid delimiter for your file.
+template_too_long=The uploaded template file contains {0} characters. Your template file may not exceed {1} characters.
 
 #sorting
 sort_title_asc=Sort by Title ascending

--- a/postem/postem-app/src/java/org/sakaiproject/tool/postem/PostemTool.java
+++ b/postem/postem-app/src/java/org/sakaiproject/tool/postem/PostemTool.java
@@ -33,8 +33,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.zip.DataFormatException;
 
-import javax.faces.FactoryFinder;
-import javax.faces.application.ApplicationFactory;
 import javax.faces.application.FacesMessage;
 import javax.faces.component.UIData;
 import javax.faces.context.ExternalContext;
@@ -580,6 +578,12 @@ public class PostemTool {
 					}
 				}
 				else {
+					// check that file is actually a CSV file
+					if (!cr.getContentType().equalsIgnoreCase("text/csv")) {
+						PostemTool.populateMessage(FacesMessage.SEVERITY_ERROR, "invalid_ext", new Object[] {getAttachmentTitle()});
+						return "create_gradebook";
+					}
+
 					csv = new String(cr.getContent());
 					if (log.isDebugEnabled()) {
 						log.debug(csv);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40882

When uploading a feedback file in PostEm, the instructions clearly state:

> Your feedback file must be saved in .csv format.
> The first column of your file must contain individual usernames.
> The first row of your file must contain headings. 

However, when you upload or link to a file in resources which is not a CSV, the error message is not appropriate:

> Some data in your uploaded file exceeded the 2,000 character limit and was truncated.
> Alert: Each column heading in your uploaded file may not exceed 500 characters.

These errors may not be accurate, as the data in the file may be completely valid. The problem here is that the file type is invalid, and the error message should indicate this to the user to help them resolve the problem. There is already an error message present in the code designed to report this issue, but it's not being populated in this scenario:

> The file "fileName.ext" that you uploaded is not a valid file type. Please make sure your file is saved as a *.csv file and try again.

This PR ensures that this error message is displayed to the user in the appropriate situation. It also removes the "Alert: " prefix on several error messages, as it's redundant and unnecessary.