### PR TITLE
SAK-40883: Wiki > fix link macro for relative links

### DIFF
--- a/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/macros/SakaiLinkMacro.java
+++ b/rwiki/rwiki-impl/impl/src/java/uk/ac/cam/caret/sakai/rwiki/component/macros/SakaiLinkMacro.java
@@ -118,7 +118,7 @@ public class SakaiLinkMacro extends BaseLocaleMacro
 
 			// SAK-20449 XSS protection
 			if (!url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith("ftp://") &&
-				!url.startsWith("mailto:")) {
+				!url.startsWith("mailto:") && !url.startsWith("/")) {
 				log.warn("RWiki URL (" + url + ") looks invalid so we're removing it from the display.");
 				url = "";
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40883

In it's current form, the link macro aborts processing any relative URLs when clicked by the user:

> 04-Nov-2018 11:27:25.370 WARN [https-jsse-nio-8452-exec-5] uk.ac.cam.caret.sakai.rwiki.component.macros.SakaiLinkMacro.execute RWiki URL (//dev.thlib.org) looks invalid so we're removing it from the display.

This PR extends the `link` macro to allow relative URLs.