### PR TITLE
SAK-33281: Site Info > import from site shows multiples of each tool

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
@@ -70,7 +70,6 @@
 						<tr>					
 							<td>
 									#set($toolTitle = "")
-									#set($alternateToolTitles = "")
 								
 									#foreach($t in $toolRegistrationList)
 										#if ($t.getId() == $toolId)
@@ -81,13 +80,7 @@
 										#set($toolTitle = $siteInfoToolTitle)
 									#end
 								
-									#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
-								
 									<h5>$toolTitle
-									
-										#if ($alternateToolTitles != "")
-											<span class="instruction">($alternateToolTitles)</span>
-										#end
 								
     									#if ($addMissingTools)
     										## if the tool doesnt exist in the selected site, output icon

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
@@ -38,7 +38,6 @@
 						<tr>
 							<td>
 								#set($toolTitle = "")
-								#set($alternateToolTitles = "")
 
 								#foreach($t in $toolRegistrationList)
 									#if ($t.getId() == $toolId)
@@ -49,13 +48,7 @@
 									#set($toolTitle = $siteInfoToolTitle)
 								#end
 							
-								#set($alternateToolTitles = $!alternateToolTitlesMap.get($toolId))
-							
 								<h5>$toolTitle
-								
-									#if ($alternateToolTitles != "")
-										<span class="instruction">($alternateToolTitles)</span>
-									#end
 								
 									#if ($addMissingTools)
 										## if the tool doesnt exist in the selected site, output icon


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33281

If you elect to import from site (merge data), and select multiple sites to import from, you'll end up with a list of multiple instances of each tool. For example, if you select three sites to import from and all three have the Assignments tool, you'll end up with three entries for Assignments in the list.

This list was also changed to display the custom configured tool title, if any was configured. This can make it difficult for people to understand what they're importing, as they may not be aware which tools correspond to the custom titles.

These two issues are both regressions compared to 10.x behaviour. Steps to reproduce and screenshots in the JIRA.