### PR TITLE
SAK-40884: Forums > grading modal doesn't remember previously entered user data

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -6547,6 +6547,13 @@ public class DiscussionForumTool
         gradebookService.saveGradeAndCommentForStudent(gradebookUuid, gbItemId, studentUid, gradePoint, gradeComment);
         
         if(selectedMessage != null){
+
+            // Get fresh copy of current data, to prevent hibernate version discrepancy on
+            // intermediate update from "Select a Gradebook item" html select input.
+            selectedMessage = new DiscussionMessageBean(
+                messageManager.getMessageByIdWithAttachments(selectedMessage.getMessage().getId()),
+                messageManager);
+
         	Message msg = selectedMessage.getMessage();
         //SAK-30711
         	msg.setGradeAssignmentName(Long.toString(gbItemId));


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40884

Using the grading modal to grade a student's post (in a forum and topic that were not previously associated with a gradebook item), may appear to the user as having lost their data.

In fact, the user data is not actually lost; it is saved the the Gradebook properly behind the scenes. However, upon returning to the same user's post and clicking the 'Grade' button again does not load the previously selected gradebook item and grade/comment which was saved.

Steps to reproduce in the JIRA.