### PR TITLE
SAK-40885: Forums > mobile view post UI's action buttons squished

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -278,7 +278,11 @@ table.messageActions td{
 	background: #fff;
 	padding: 2px 5px;
 	vertical-align: middle;
-	margin: 0 .3em 0 0;
+	margin: 0 .3em .3em 0;
+	display: inline-block;
+}
+.messageActions a span{
+	white-space: nowrap;
 }
 .messageActions a:hover{
 	border: 1px solid #555  !important;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40885

When on a mobile device, viewing a post and trying to click on any of the action buttons is extremely difficult due to how they're squished together and overlapping. For example, it's very easy to erroneously click on 'Delete' when meaning to click on 'Reply...'.

Screenshots in the JIRA.