### PR TITLE
SAK-40886: Samigo > retract date check can be bypassed

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -190,6 +190,7 @@ public class AssessmentSettingsBean
   private boolean isValidDueDate = true;
   private boolean isValidRetractDate = true;
   private boolean isValidFeedbackDate = true;
+  private boolean isRetractAfterDue = true;
   
   private String originalStartDateString;
   private String originalDueDateString;
@@ -1177,12 +1178,15 @@ public class AssessmentSettingsBean
     if (retractDateString == null || retractDateString.trim().equals("")) {
       this.isValidRetractDate = true;
       this.retractDate = null;
+      this.isRetractAfterDue = true;
     }
     else {
 
       Date tempDate = tu.parseISO8601String(ContextUtil.lookupParam(HIDDEN_RETRACT_DATE_FIELD));
+      Date tempDueDate = tu.parseISO8601String(ContextUtil.lookupParam(HIDDEN_END_DATE_FIELD));
 
       if (tempDate != null) {
+        this.isRetractAfterDue = !(tempDueDate == null || tempDate.before(tempDueDate));
         this.isValidRetractDate = true;
         this.retractDate = tempDate;
       } else {
@@ -1454,6 +1458,11 @@ public class AssessmentSettingsBean
   public boolean getIsValidRetractDate()
   {
 	  return this.isValidRetractDate;
+  }
+
+  public boolean getIsRetractAfterDue()
+  {
+	  return this.isRetractAfterDue;
   }
   
   public boolean getIsValidFeedbackDate()

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
@@ -22,7 +22,6 @@
 package org.sakaiproject.tool.assessment.ui.listener.author;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -104,6 +103,11 @@ public class SaveAssessmentSettingsListener
     	error=true;
     }
 
+    // check if RetractDate needs to be nulled
+    if ("2".equals(assessmentSettings.getLateHandling())){
+        assessmentSettings.setRetractDateString(null);
+    }
+
     if(assessmentSettings.getDueDate() == null && assessmentSettings.getRetractDate() != null && AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString().equals(assessmentSettings.getLateHandling())){
         String dueDateErr = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "due_null_with_retract_date");
         context.addMessage(null,new FacesMessage(dueDateErr));
@@ -116,7 +120,14 @@ public class SaveAssessmentSettingsListener
     	context.addMessage(null,new FacesMessage(retractDateErr));
     	error=true;
     }
-    
+
+    // check that retract is after due and due is not null
+    if (!assessmentSettings.getIsRetractAfterDue()) {
+    	String retractDateErr = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "retract_earlier_than_due");
+    	context.addMessage(null, new FacesMessage(retractDateErr));
+    	error = true;
+    }
+
     if (assessmentSettings.getReleaseTo().equals(AssessmentAccessControl.RELEASE_TO_SELECTED_GROUPS)) {
     	String[] groupsAuthorized = assessmentSettings.getGroupsAuthorizedToSave(); //getGroupsAuthorized();
     	if (groupsAuthorized == null || groupsAuthorized.length == 0) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40886

The retract date check can be bypassed by editing from the Republish UI, resulting in retract earlier than due date.

 If you attempt to edit an assessment's settings after clicking *Save Settings and Publish* in _Working Copies_, then you click *Save*, you can bypass the date check where Samigo confirms that the *Late Submission* (aka *Retract*) date is set *after* the *Due Date* for an assessment.  Because autosubmit triggers off the late submission date, this can result in unexpected behavior in the case of an autosubmit test.

This issue was found because an instructor managed to set the *Late Submission* date before the due date; this resulted in an exam being autosubmitted out from under a number of students who were in the process of taking it.

Steps to reproduce in the JIRA.