### PR TITLE
SAK-26580 Ignore cache creation attempt if it already exists

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/memory/impl/EhcacheMemoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/memory/impl/EhcacheMemoryService.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.ObjectExistsException;
 import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.config.Configuration;
 
@@ -130,7 +131,12 @@ public class EhcacheMemoryService implements MemoryService {
 
     @Override
     public Cache getCache(String cacheName) {
-        return new EhcacheCache(makeEhcache(cacheName, null));
+	try {
+		return new EhcacheCache(makeEhcache(cacheName, null));
+	} catch (ObjectExistsException ex) {
+		log.debug("Cache {} already exists; possibly created by another thread", cacheName);
+		return null;
+	}
     }
 
     @Override


### PR DESCRIPTION
This addresses a race condition where a number of request threads are handled just after startup. Several threads try to create the cache at the same time.

It's harmless to return null here because that is checked for in the calling code. The cache has been created by another thread, and will be used by all subsequent threads.
