### PR TITLE
SAK-40665 PA System pop up does not dim the background

### DIFF
--- a/pasystem/pasystem-tool/tool/src/webapp/scripts/pasystem.js
+++ b/pasystem/pasystem-tool/tool/src/webapp/scripts/pasystem.js
@@ -163,6 +163,7 @@ PASystemPopup.prototype.showPopup = function() {
                    afterClose : function (event) {
                      var acknowledgement = self.permanentlyAcknowledged ? 'permanent' : 'temporary';
                      self.acknowledge(acknowledgement);
+                     $("#pasystem-popup-wrapper").remove();
                    },
                    afterContent : function (event) {
                      $('#popup-acknowledged-button').on('click', function () {
@@ -182,6 +183,10 @@ PASystemPopup.prototype.showPopup = function() {
                      this.$instance.find(".featherlight-content").focus();
                    }
                  });
+
+  $(".featherlight").after($('<div/>', {id:"pasystem-popup-wrapper"}));
+  $("#pasystem-popup-wrapper").append($(".featherlight"));
+
 };
 
 


### PR DESCRIPTION
This is a bit of a hack, but it's one of the suggestions in 

https://github.com/noelboss/featherlight/issues/231

That issue is still open but they haven't agreed on the best way to fix it yet.  there was a mention of configuring the 'root' and adding a <modals> tag to the end of the body, but someone else disagreed because <modals> may not be cross browser compatible.

So until featherlight gets updated with a fix (or we change pasystem to use some other lightbox lib), will this hack suffice in the meantime?