### PR TITLE
SAK-40889 Ignore a null event

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -543,6 +543,12 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 	// Event process methods
 	// ################################################################	
 	private void preProcessEvent(Event event) {
+
+		if (event == null) {
+			log.debug("Ignoring null event");
+			return;
+		}
+
 		totalEventsProcessed++;
 		String userId = event.getUserId();
 		Event e = fixMalFormedEvents(event);


### PR DESCRIPTION
It's not clear why we should ever get a null event passed here, but it has happened in testing conditions, and so it seems better to just check and ignore it rather than allow the stats update thread to die, requiring it to be re-started.
