### PR TITLE
SAK-40784 fix for NoClassDefFound

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.math3.util.Precision;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.service.gradebook.shared.GradebookExternalAssessmentService;


### PR DESCRIPTION
  java.lang.NoClassDefFoundError: org/apache/commons/text/StringEscapeUtils
    at org.sakaiproject.tool.assessment.integration.helper.integrated.GradebookServiceHelperImpl.addToGradebook(GradebookServiceHelperImpl.java:191)