### PR TITLE
SAK-34145 Clarify autosubmit implications for student

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -502,10 +502,8 @@ begin_assessment_msg_num_submission_2=time(s).
 begin_assessment_msg_highest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your highest score will be recorded.
 begin_assessment_msg_latest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your latest score will be recorded.
 begin_assessment_msg_average=Your average score will be recorded.
-begin_assessment_msg_attempt_autosubmit_warn_1=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be
-begin_assessment_msg_attempt_autosubmit_warn_average=averaged with all previous attempts to determine your overall assessment score.
-begin_assessment_msg_attempt_autosubmit_warn_last=recorded as your overall score for this assessment.
-begin_assessment_msg_attempt_autosubmit_warn_2=Do you want to begin a new attempt of this assessment?
+begin_assessment_msg_attempt_autosubmit_warn_average=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be averaged with all previous attempts to determine your overall assessment score.  Do you want to begin a new attempt of this assessment?
+begin_assessment_msg_attempt_autosubmit_warn_last=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be recorded as your overall score for this assessment.  Do you want to begin a new attempt of this assessment?
 
 submission_allowed_1=You can submit this assessment {0} time(s).
 submission_allowed_2=You can submit this assessment {0} more time(s).

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -502,6 +502,10 @@ begin_assessment_msg_num_submission_2=time(s).
 begin_assessment_msg_highest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your highest score will be recorded.
 begin_assessment_msg_latest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your latest score will be recorded.
 begin_assessment_msg_average=Your average score will be recorded.
+begin_assessment_msg_attempt_autosubmit_warn_1=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be
+begin_assessment_msg_attempt_autosubmit_warn_average=averaged with all previous attempts to determine your overall assessment score.
+begin_assessment_msg_attempt_autosubmit_warn_last=recorded as your overall score for this assessment.
+begin_assessment_msg_attempt_autosubmit_warn_2=Do you want to begin a new attempt of this assessment?
 
 submission_allowed_1=You can submit this assessment {0} time(s).
 submission_allowed_2=You can submit this assessment {0} more time(s).

--- a/samigo/samigo-app/src/webapp/jsf/delivery/beginTakingAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/beginTakingAssessment.jsp
@@ -203,8 +203,7 @@
     action="#{delivery.validate}" type="submit" styleClass="active" 
     rendered="#{(delivery.actionString=='takeAssessment'
              || delivery.actionString=='takeAssessmentViaUrl')
-	     && delivery.navigation != 1 && delivery.firstTimeTaking}"
-	     onclick="return checkIfHonorPledgeIsChecked()">
+	     && delivery.navigation != 1 && delivery.firstTimeTaking}">
 	<f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryActionListener" />
   </h:commandButton>
   
@@ -212,8 +211,7 @@
     action="#{delivery.validate}" type="submit" styleClass="active" 
     rendered="#{(delivery.actionString=='takeAssessment'
              || delivery.actionString=='takeAssessmentViaUrl')
-	     && delivery.navigation == 1 && delivery.firstTimeTaking}"
-	     onclick="return checkIfHonorPledgeIsChecked()">
+	     && delivery.navigation == 1 && delivery.firstTimeTaking}">
 	<f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.LinearAccessDeliveryActionListener" />
   </h:commandButton>
   
@@ -237,7 +235,7 @@
   </h:commandButton>
   
 
- <h:commandButton id="beginAssessment3" value="#{deliveryMessages.begin_assessment_}" action="#{delivery.pvalidate}" type="submit" styleClass="active" rendered="#{delivery.actionString=='previewAssessment'}" onclick="return checkIfHonorPledgeIsChecked()">
+ <h:commandButton id="beginAssessment3" value="#{deliveryMessages.begin_assessment_}" action="#{delivery.pvalidate}" type="submit" styleClass="active" rendered="#{delivery.actionString=='previewAssessment'}" >
     <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryActionListener" />
   </h:commandButton>
 

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
@@ -26,6 +26,7 @@
      var honorPledgeIsChecked = true;
      var scoringType = <h:outputText value="#{delivery.scoringType}"/>;
      var autoSubmit = <h:outputText value="#{delivery.settings.autoSubmit}"/>;
+     var totalSubmissions = <h:outputText value="#{delivery.totalSubmissions}"/>;
      var button_ok = "<h:outputText value="#{deliveryMessages.button_ok} "/>";
      var please_wait = "<h:outputText value="#{deliveryMessages.please_wait} "/>";
 
@@ -58,7 +59,7 @@
 					$('#takeAssessmentForm\\:honorPledgeRequired').show();
 					return false;
 				}
-				if (autoSubmit && (scoringType === 2 || scoringType === 4)) {
+				if (totalSubmissions > 0 && autoSubmit && (scoringType === 2 || scoringType === 4)) {
 					if (!confirm(newAttemptAutoSubmitWarning)) {
 						return false;
 					}

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
@@ -31,7 +31,7 @@
 
      var time_30_warning = "<h:outputText value="#{deliveryMessages.time_30_warning} "/><h:outputText value="#{deliveryMessages.time_30_warning_2} " />";
      var time_due_warning = "<h:outputText value="#{deliveryMessages.time_due_warning_1} "/><h:outputText value="#{deliveryMessages.time_due_warning_2} " />";     
-     var newAttemptAutoSubmitWarning = "<h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_1} "/><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_average} " rendered="#{delivery.scoringType == 4}" /><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_last} " rendered="#{delivery.scoringType == 2}" /><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_2} "/>";
+     var newAttemptAutoSubmitWarning = "<h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_average}" rendered="#{delivery.scoringType == 4}" /><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_last} " rendered="#{delivery.scoringType == 2}" />";
      
      $(document).ready(function(){
 

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliveryjQuery.jsp
@@ -24,11 +24,14 @@
 
 <script type="text/javascript">
      var honorPledgeIsChecked = true;
+     var scoringType = <h:outputText value="#{delivery.scoringType}"/>;
+     var autoSubmit = <h:outputText value="#{delivery.settings.autoSubmit}"/>;
      var button_ok = "<h:outputText value="#{deliveryMessages.button_ok} "/>";
      var please_wait = "<h:outputText value="#{deliveryMessages.please_wait} "/>";
 
      var time_30_warning = "<h:outputText value="#{deliveryMessages.time_30_warning} "/><h:outputText value="#{deliveryMessages.time_30_warning_2} " />";
      var time_due_warning = "<h:outputText value="#{deliveryMessages.time_due_warning_1} "/><h:outputText value="#{deliveryMessages.time_due_warning_2} " />";     
+     var newAttemptAutoSubmitWarning = "<h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_1} "/><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_average} " rendered="#{delivery.scoringType == 4}" /><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_last} " rendered="#{delivery.scoringType == 2}" /><h:outputText value="#{deliveryMessages.begin_assessment_msg_attempt_autosubmit_warn_2} "/>";
      
      $(document).ready(function(){
 
@@ -46,10 +49,22 @@
 			);
 		}
 
-		// Block the UI to avoid user double-clicks
+		// Check honor code checkbox, warn about autosubmitting empty attempts, lock the UI to avoid user double-clicks
 		$("input[type='submit'][class!='noActionButton']").click(function() { 
-			if (!honorPledgeIsChecked) return false;
-                        if (!timerSave) $.blockUI({ message: '<h3>' + please_wait + ' <img src="/library/image/sakai/spinner.gif" /></h3>', overlayCSS: { backgroundColor: '#ccc', opacity: 0.25} });
+			var beginButtonIds = ["takeAssessmentForm:beginAssessment1", "takeAssessmentForm:beginAssessment2", "takeAssessmentForm:beginAssessment3"];
+			if (beginButtonIds.includes($(this).attr('id'))) {
+				if (!honorPledgeIsChecked) {
+					alert("<h:outputText value='#{deliveryMessages.honor_pledge_select}'/>");
+					$('#takeAssessmentForm\\:honorPledgeRequired').show();
+					return false;
+				}
+				if (autoSubmit && (scoringType === 2 || scoringType === 4)) {
+					if (!confirm(newAttemptAutoSubmitWarning)) {
+						return false;
+					}
+				}
+			}
+			if (!timerSave) $.blockUI({ message: '<h3>' + please_wait + ' <img src="/library/image/sakai/spinner.gif" /></h3>', overlayCSS: { backgroundColor: '#ccc', opacity: 0.25} });
 		}); 
 		//Disable the back button
 		disableBackButton("<h:outputText value="#{deliveryMessages.use_form_navigation}"/>");
@@ -58,14 +73,5 @@
 			showTimerExpiredWarning(function() { ($('#timer-expired-warning').parent()).css('display', 'none');});
 		}
 	});
-
-        function checkIfHonorPledgeIsChecked() {
-          if(!honorPledgeIsChecked){
-            alert("<h:outputText value='#{deliveryMessages.honor_pledge_select}'/>");
-            $('#takeAssessmentForm\\:honorPledgeRequired').show();
-            return false;
-          }
-          return true;
-        }
 
 </script>


### PR DESCRIPTION
Add pop-up warning for assessement takers that starting a new attempt will impact their grade.  (Especially if they don't answer any questions.)  Warning only appears if autosubmit is on, and grading is set to "last score" or "average score".  The warning only appears after they've taken the assessment at least once.  Warning explains how their grade will be affected, and offers them a chance to cancel starting a new attempt.  

Warning doesn't apply if autosubmit is off, or if "highest score" is in effect so it doesn't appear.

https://jira.sakaiproject.org/browse/SAK-34145#