### PR TITLE
SAK-40285 Show more than 20 Rubric entries

### DIFF
--- a/rubrics/tool/src/main/frontend/imports/sakai-rubric-association.html
+++ b/rubrics/tool/src/main/frontend/imports/sakai-rubric-association.html
@@ -152,6 +152,11 @@
       },
       listresponse: function(request) {
         this.rubricslist = request.detail.response._embedded.rubrics;
+        if(request.detail.response.page.size <= this.rubricslist.length){
+          this.$.getRubrics.params = {"size": this.rubricslist.length+25};
+          this.$.getRubrics.generateRequest();
+          return;
+        }
         if (this.rubricslist.length) {
           this.rubricsAvailable = true;
           this.buildOptions();

--- a/rubrics/tool/src/main/frontend/imports/sakai-rubrics-list.html
+++ b/rubrics/tool/src/main/frontend/imports/sakai-rubrics-list.html
@@ -78,6 +78,10 @@
       },
       listresponse: function(request) {
         this.rubricslist = request.detail.response._embedded.rubrics;
+        if(request.detail.response.page.size <= this.rubricslist.length){
+          this.$.getRubrics.params = {"size": this.rubricslist.length+25};
+          this.$.getRubrics.generateRequest();
+        }
       },
       activate: function(e, aid) {
         var rubrics = Polymer.dom(this.root).querySelectorAll('sakai-rubric');


### PR DESCRIPTION
Solving the bug both for Rubrics and the selector that appears on other
tools. Iron-ajax has 20 as its default size param value.