### PR TITLE
SAK-40072: Assignments - First instruction box for student submission…

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -125,7 +125,7 @@ $(document).ready(function(){
 			<p class="instruction">
 				#if (($submissionType==1) || ($submissionType==3))
 					 $tlang.getString("stuviewsubm.asshasnot")
-				#elseif ($submissionType==2)
+				#elseif (($submissionType==2) || ($submissionType==5))
 				 	$tlang.getString("stuviewsubm.assattonly")
 				#end
 				#if($assignment.AllowPeerAssessment)


### PR DESCRIPTION
In the meantime of having a distinct message for the Submission Type of "Single Uploaded File only" for all supported languages, I propose using the same message for "Attachments only".

For those universities that use Turnitin where "Single Uploaded File only" is also enforced to be the Submission Type, the blank message will appear to students more frequently and look confusing (like an empty text field).