### PR TITLE
SAK-40914 allow samigo via lessons or url

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -3452,7 +3452,11 @@ public class DeliveryBean
   }
   
   public String checkBeforeProceed(boolean isSubmitForGrade, boolean isFromTimer){
-	  return checkBeforeProceed(isSubmitForGrade, isFromTimer, false);
+	  boolean isViaUrlLogin = false;
+	  if(AgentFacade.getCurrentSiteId() == null){
+	    isViaUrlLogin = true;
+	  }
+	  return checkBeforeProceed(isSubmitForGrade, isFromTimer, isViaUrlLogin);
   }
 
   private boolean getHasSubmissionLeft(int numberRetake){


### PR DESCRIPTION
The changes included in this PR  https://github.com/sakaiproject/sakai/pull/6113 force us to check if it's a lessons/url submission, instead of just checking it the first time as it was before.