### PR TITLE
SAK-40943 Always include current user memberships

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/MembershipEntityProvider.java
@@ -705,18 +705,22 @@ RESTful, ActionsExecutable {
                 throw new IllegalArgumentException("unable to find user with id ("+userId+")");
             }
 
-            boolean userCurrent = userId.equals(currentUserId);
 
             // Is there a faster way to do this? I really truly hope so -AZ
             // Only if you don't care about getMember details -MJ
             List<Site> allUserSites = siteService.getUserSites(false, userId);
+            List<Site> sites = new ArrayList<>();
 
-            // Filter out sites where the logged in user of EB does not have view roster status.
-            List<Site> sites = new ArrayList<Site>();
-            for (Site site: allUserSites) {
-                if (siteService.allowViewRoster(site.getId())) {
-                    sites.add(site);
+            boolean userCurrent = userId.equals(currentUserId);
+            if (!userCurrent) {
+                // Filter out sites where the logged in user of EB does not have view roster status.
+                for (Site site : allUserSites) {
+                    if (siteService.allowViewRoster(site.getId())) {
+                        sites.add(site);
+                    }
                 }
+            } else {
+                sites = allUserSites;
             }
 
             if (includeMemberDetails) {


### PR DESCRIPTION
When getting memberships for the current user the list of sites to return the results for were incorrectly getting filtered so that only the entries where the current user was allowed to view the roster in the site. That should have only been happening when the a non-admin user was looking for the memberships of a different user.