### PR TITLE
SAK-40959 Changed assessment id parameter to publishedId

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java
@@ -586,7 +586,7 @@ public class SamigoEntity implements LessonEntity, QuizEntity {
 	}
 
 	if (samigo_linked)
-	    return ServerConfigurationService.getToolUrl() + "/" + tool + "/jsf/author/editLink?publishedAssessmentId=" + id;
+	    return ServerConfigurationService.getToolUrl() + "/" + tool + "/jsf/author/editLink?publishedId=" + id;
 	else
 	    return ServerConfigurationService.getToolUrl() + "/" + tool + "/jsf/index/mainIndex";
     }
@@ -600,7 +600,7 @@ public class SamigoEntity implements LessonEntity, QuizEntity {
 	    return null;
     
 	if (samigo_linked)
-	    return ServerConfigurationService.getToolUrl() + "/" + tool + "/jsf/author/editLink?publishedAssessmentId=" + id + "&settings=true";
+	    return ServerConfigurationService.getToolUrl() + "/" + tool + "/jsf/author/editLink?publishedId=" + id + "&settings=true";
 	else
 	    return ServerConfigurationService.getToolUrl() + "/" + tool + "/jsf/index/mainIndex";
 


### PR DESCRIPTION
This was a regression caused by SAK-34820. The assessment id changed
from publishedAssessmentId to publishedId in that ticket.