### PR TITLE
SAK-40980 - Add LTI 1.1 launch type field for future use

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -167,6 +167,7 @@ public interface LTIService extends LTISubstitutionsFilter {
 
             // SHA256 Support (See SAK-33898)
             "sha256:radio:label=bl_sha256:hidden=true:role=admin:choices=off,on,content",
+            "lti11_launch_type:radio:label=bl_lti11_launch_type:hidden=true:role=admin:choices=off,on",
             "xmlimport:textarea:hidden=true:maxlength=1M",
             "created_at:autodate",
             "updated_at:autodate"};


### PR DESCRIPTION
This is like the lti13_settings and sha256 fields - there for future use.  I just want it there before Sakai-19.