### PR TITLE
SAK-40702 wicket tools don't work if site id has a blank space

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1460,6 +1460,8 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				} else {
 					toolContextPath = toolContextPath.replace("/~","/%7E");
 				}
+			} else if ( toolContextPath.indexOf(" ") > 0 && reqUrl.indexOf(" ") < 1 ) {
+				toolContextPath = toolContextPath.replace(" ","%20");
 			}
 		}
 		log.debug("forwardtool call {} toolPathInfo {} ctx {}", req.getRequestURL(), toolPathInfo, toolContextPath);


### PR DESCRIPTION
This is only interesting for legacy purposes, as new sites can't be created with spaces on the id.