### PR TITLE
SAK-40674 solve wrongly considered concurrent edit in GB

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -15,6 +15,7 @@
  */
 package org.sakaiproject.gradebookng.business;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -763,7 +764,9 @@ public class GradebookNgBusinessService {
 		// concurrency check, if stored grade != old grade that was passed in,
 		// someone else has edited.
 		// if oldGrade == null, ignore concurrency check
-		if (oldGrade != null && !StringUtils.equals(storedGradeAdjusted, oldGradeAdjusted)) {
+		BigDecimal storedBig = storedGradeAdjusted == null ? BigDecimal.ZERO : new BigDecimal(storedGradeAdjusted).setScale(2, BigDecimal.ROUND_HALF_UP);
+		BigDecimal oldBig = oldGradeAdjusted == null ? BigDecimal.ZERO : new BigDecimal(oldGradeAdjusted).setScale(2, BigDecimal.ROUND_HALF_UP);
+		if (oldGrade != null && (storedBig.compareTo(oldBig) != 0)) {
 			return GradeSaveResponse.CONCURRENT_EDIT;
 		}
 


### PR DESCRIPTION
Dealing with percentages and precision via String objects is a bad idea and a nightmare (even more if we're adding i18n to the mix), but at least if we are comparing two values I believe we should do it with actual numbers.

I'd rather just add this verification than modifying more logic, but I'm open to suggestions.