### PR TITLE
SAK-41016 Lessons: standardized the capitalization and punctuation of the Add Content menu options

### DIFF
--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -286,7 +286,7 @@ simplepage.edit=Update Item
 simplepage.description_label=Item Description
 simplepage.name_label=Item Name
 simplepage.edititem_header=Edit Item
-simplepage.multimedia=Embed content on page
+simplepage.multimedia=Embed Content on the Page
 simplepage.multimedia.tooltip=Add an image, video, Flash file, web page, etc. Use this to embed the item on this page. Use Add Content Links instead if you want a link to an item rather than showing it on the page.
 simplepage.multimedia-descrip=Add an image, video, Flash file, web page, etc. Use this to embed the item on this page. Use Add Content Links instead if you want a link to an item rather than showing it on the page.
 simplepage.expert_toggle=Show details
@@ -548,7 +548,7 @@ simplepage.anonymous=Anonymous
 simplepage.student-missing-prereqs=There is an area for student content, but you must complete all required items above before you can see it.
 simplepage.student-fake-missing-prereqs=If you were a student, you wouldn't be able to see student content, because you haven't completed all required items above.
 
-simplepage.website=Upload content in ZIP file
+simplepage.website=Upload Content from a ZIP File
 simplepage.website.noextension=For this operation to work, the ZIP file must have an extension, typically .zip.
 simplepage.website.tooltip=There is specific support for Camtasia, Wimba Create and Articulate, but any ZIP file may be uploaded. See the help in the dialog for more information.
 simplepage.addwebsite-descrip=There is specific support for Camtasia, Wimba Create and Articulate, but any ZIP file may be uploaded. See the help in the dialog for more information.
@@ -588,8 +588,8 @@ simplepage.format.page=New page: in a separate page with "next" and "back" butto
 simplepage.format.item_removed=<p style='font-family:arial, helvetica; padding:4px; font-size:80%; border:2px solid black'><span style='color:#c00'>ERROR:</span> The item that should have been displayed here has been removed. Please use the "Edit" button next to this item and pick "Change External Tool" to recreate the item or choose a new one.</p>
 
 simplepage.more-tools=More Tools
-simplepage.forum-descrip=Link to a forum or topic.
-simplepage.blti-descrip=Link to a web service that uses the IMS LTI standard to integrate with this system.
+simplepage.forum-descrip=Link to a Forum or Topic
+simplepage.blti-descrip=Link to a web service that uses the IMS LTI standard to integrate with this system
 simplepage.comments-descrip=Add a section allows students to enter comments.
 simplepage.student-descrip=Add a section where students may create their own pages.
 simplepage.title-student-descrip=Edit page title
@@ -607,8 +607,8 @@ simplepage.add-content=Add Content
 simplepage.addtext-descrip=Add an item using rich text editor
 simplepage.subpage-descrip=Create a new page on which you can create content, or link to an existing one
 simplepage.question-descrip=Create simple multiple-choice or short-answer question, can show results as poll
-simplepage.assignment-descrip=Link to an assignment
-simplepage.quiz-descrip=Link to a test or quiz
+simplepage.assignment-descrip=Link to an Assignment
+simplepage.quiz-descrip=Link to a Test or Quiz
 
 simplepage.broken-css=The customized CSS file could not be found.
 simplepage.css-dropdown-label=Custom CSS File:

--- a/lessonbuilder/tool/src/webapp/templates/instructions/website.html
+++ b/lessonbuilder/tool/src/webapp/templates/instructions/website.html
@@ -25,7 +25,7 @@ margin-right:345px;
 <h3> ADDING CONTENT FROM PACKAGES SUCH AS CAMTASIA, WIMBA CREATE AND ARTICULATE</h3>
 
 <p>
-The "Upload Content in ZIP File" dialog allows you to add content from a file.
+The "Upload Content from ZIP File" dialog allows you to add content from a file.
 There is specific support for Camtasia, Wimba Create, and Articulate, but
 any ZIP file containing resources may be uploaded. Content will be uploaded into a folder
 in Resources. Where possible a link will be added in the Lesson to the content.</p>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41016

I removed the period from the one option that was referenced in the Jira issue and uppercased the words to match the other options. Added a few article words in some options to also match the other options' phrasing.

See before and after screenshots in SAK-41016.