### PR TITLE
SAK-37654 Lessons: fixed some capitalization for components when they appear on the Lessons  Reorder page

### DIFF
--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -790,10 +790,10 @@ simplepage.edit-title.announcements=Edit Announcements
 simplepage.announcements-no-message=There are currently no announcements
 simplepage.announcements-error-message=Error in adding announcements:
 simplepage.announcements-header-title=Announcements
-simplepage.announcements-snippet=latest announcements
-simplepage.forums-snippet=latest forum conversations
-simplepage.twitter-snippet=twitter timeline
-simplepage.resources-snippet=resources folder
-simplepage.calendar-snippet=calendar
+simplepage.announcements-snippet=Latest Announcements
+simplepage.forums-snippet=Latest forum conversations
+simplepage.twitter-snippet=Twitter timeline
+simplepage.resources-snippet=Resources folder
+simplepage.calendar-snippet=Calendar
 
 simplepage.printall.continuation=continuation


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-37654

Fixed some capitalization for components when they appear on the Lessons  Reorder page. 

See SAK-37654 for before and after screenshots.