### PR TITLE
SAK-41026: Site Info > Improve performance when displaying roster lists

### DIFF
--- a/edu-services/cm-service/cm-api/api/src/java/org/sakaiproject/coursemanagement/api/CourseManagementService.java
+++ b/edu-services/cm-service/cm-api/api/src/java/org/sakaiproject/coursemanagement/api/CourseManagementService.java
@@ -445,6 +445,16 @@ public interface CourseManagementService {
 	public Map<String, String> findSectionRoles(String userEid);
 
 	/**
+	 * Finds the Sections (and roles) for which a user is a member and which are part of a
+	 * CourseOffering in a given AcademicSession.
+	 *
+	 * @param userEid
+	 * @param academicSessionEid
+	 * @return A Map of Section EIDs to roles for the user
+	 */
+	public Map<String, String> findSectionRoles(String userEid, String academicSessionEid);
+
+	/**
 	 * Finds the CourseOfferings (and roles) for which a user is a member.
 	 * 
 	 * @param userEid

--- a/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/hibernate/org/sakaiproject/coursemanagement/impl/SectionCmImpl.hbm.xml
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/hibernate/src/hibernate/org/sakaiproject/coursemanagement/impl/SectionCmImpl.hbm.xml
@@ -54,6 +54,15 @@
         ]]>
     </query>
 
+    <query name="findSectionRolesByAcademicSession">
+        <![CDATA[
+        select section.eid, mbr.role from SectionCmImpl as section, MembershipCmImpl as mbr
+            where mbr.userId=:userEid and
+            mbr.memberContainer=section and
+            section.courseOffering.academicSession.eid=:academicSessionEid
+        ]]>
+    </query>
+
 	<query name="findInstructingSections">
         <![CDATA[
         select sec from SectionCmImpl as sec, EnrollmentSetCmImpl as es join es.officialInstructors as instructor

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseManagementServiceFederatedImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseManagementServiceFederatedImpl.java
@@ -96,6 +96,7 @@ public class CourseManagementServiceFederatedImpl implements
 			try {
 				set = cm.findCourseOfferings(courseSetEid, academicSessionEid);
 				if(set != null) {
+					log.debug("{} found course set {}", cm, courseSetEid);
 					resultSet.addAll(set);
 				}
 			} catch (IdNotFoundException ide) {
@@ -184,6 +185,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<Section> set = null;
 			try {
+				log.debug("{} found find academic session {}", cm, academicSessionEid);
 				set = cm.findInstructingSections(userId, academicSessionEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -204,6 +206,7 @@ public class CourseManagementServiceFederatedImpl implements
 		for(Iterator implIter = implList.iterator(); implIter.hasNext();) {
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			try {
+				log.debug("{} found academic session {}", cm, eid);
 				return cm.getAcademicSession(eid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate academic session " + eid);
@@ -230,6 +233,7 @@ public class CourseManagementServiceFederatedImpl implements
 		for(Iterator implIter = implList.iterator(); implIter.hasNext();) {
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			try {
+				log.debug("{} found canonical course {}", cm, canonicalCourseEid);
 				return cm.getCanonicalCourse(canonicalCourseEid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate canonical course " + canonicalCourseEid);
@@ -245,6 +249,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<CanonicalCourse> set = null;
 			try {
+				log.debug("{} founnd course set {}", cm, courseSetEid);
 				set = cm.getCanonicalCourses(courseSetEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -268,6 +273,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<CourseSet> set = null;
 			try {
+				log.debug("{} found parent course set {}", cm, parentCourseSetEid);
 				set = cm.getChildCourseSets(parentCourseSetEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -291,6 +297,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<Section> set = null;
 			try {
+				log.debug("{} found parent section {}", cm, parentSectionEid);
 				set = cm.getChildSections(parentSectionEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -311,6 +318,7 @@ public class CourseManagementServiceFederatedImpl implements
 		for(Iterator implIter = implList.iterator(); implIter.hasNext();) {
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			try {
+				log.debug("{} found course offering {}", cm, courseOfferingEid);
 				return cm.getCourseOffering(courseOfferingEid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate course offering " + courseOfferingEid);
@@ -349,6 +357,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<CourseOffering> set = null;
 			try {
+				log.debug("{} found locate course set {}", cm, courseSetEid);
 				set = cm.getCourseOfferingsInCourseSet(courseSetEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -369,6 +378,7 @@ public class CourseManagementServiceFederatedImpl implements
 		for(Iterator implIter = implList.iterator(); implIter.hasNext();) {
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			try {
+				log.debug("{} found course set {}", cm, eid);
 				return cm.getCourseSet(eid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate course set " + eid);
@@ -384,6 +394,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<Membership> set = null;
 			try {
+				log.debug("{} found course set {}", cm, courseSetEid);
 				set = cm.getCourseSetMemberships(courseSetEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -429,6 +440,7 @@ public class CourseManagementServiceFederatedImpl implements
 		for(Iterator implIter = implList.iterator(); implIter.hasNext();) {
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			try {
+				log.debug("{} found enrollmentSet {}", cm, enrollmentSetEid);
 				return cm.getEnrollmentSet(enrollmentSetEid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate enrollmentSet " + enrollmentSetEid);
@@ -444,6 +456,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<EnrollmentSet> set = null;
 			try {
+				log.debug("{} found course offering {}", cm, courseOfferingEid);
 				set = cm.getEnrollmentSets(courseOfferingEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -467,6 +480,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<Enrollment> set = null;
 			try {
+				log.debug("{} found enrollment set {}", cm, enrollmentSetEid);
 				set = cm.getEnrollments(enrollmentSetEid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate enrollment set " + enrollmentSetEid);
@@ -489,6 +503,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<CanonicalCourse> set = null;
 			try {
+				log.debug("{} found locate canonical course {}", cm, canonicalCourseEid);
 				set = cm.getEquivalentCanonicalCourses(canonicalCourseEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -512,6 +527,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<CourseOffering> set = null;
 			try {
+				log.debug("{} found course offering {}", cm, courseOfferingEid);
 				set = cm.getEquivalentCourseOfferings(courseOfferingEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -535,6 +551,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<String> set = null;
 			try {
+				log.debug("{} found enrollment set {}", cm, enrollmentSetEid);
 				set = cm.getInstructorsOfRecordIds(enrollmentSetEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -555,6 +572,7 @@ public class CourseManagementServiceFederatedImpl implements
 		for(Iterator implIter = implList.iterator(); implIter.hasNext();) {
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			try {
+				log.debug("{} found section {}", cm, sectionEid);
 				return cm.getSection(sectionEid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not locate section " + sectionEid);
@@ -593,6 +611,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<Section> set = null;
 			try {
+				log.debug("{} found course offering {}", cm, courseOfferingEid);
 				set = cm.getSections(courseOfferingEid);
 			} catch (IdNotFoundException ide) {
 				exceptions++;
@@ -729,6 +748,26 @@ public class CourseManagementServiceFederatedImpl implements
 		return sectionRoleMap;
 	}
 
+	public Map<String, String> findSectionRoles(String userEid, String academicSessionEid) {
+		Map<String, String> sectionRoleMap = new HashMap<>();
+		for (CourseManagementService cm : implList) {
+			Map<String, String> map = cm.findSectionRoles(userEid, academicSessionEid);
+			if (map == null) {
+				continue;
+			}
+			for (String sectionEid : map.keySet()) {
+				String role = (String) map.get(sectionEid);
+
+				// Earlier impls take precedence, so don't overwrite what's in the map
+				if (!sectionRoleMap.containsKey(sectionEid)) {
+					sectionRoleMap.put(sectionEid, role);
+				}
+			}
+		}
+
+		return sectionRoleMap;
+	}
+
 	public Set<CourseOffering> getCourseOfferingsInCanonicalCourse(String canonicalCourseEid) throws IdNotFoundException {
 		Set<CourseOffering> resultSet = new HashSet<CourseOffering>();
 		int exceptions = 0;
@@ -736,6 +775,7 @@ public class CourseManagementServiceFederatedImpl implements
 			CourseManagementService cm = (CourseManagementService)implIter.next();
 			Set<CourseOffering> set = null;
 			try {
+				log.debug("{} found canonical course {}", cm, canonicalCourseEid);
 				set = cm.getCourseOfferingsInCanonicalCourse(canonicalCourseEid);
 			} catch (IdNotFoundException ide) {
 				if(log.isDebugEnabled()) log.debug(cm + " could not find canonical course " + canonicalCourseEid);

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseManagementServiceHibernateImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseManagementServiceHibernateImpl.java
@@ -397,6 +397,22 @@ public class CourseManagementServiceHibernateImpl extends HibernateDaoSupport im
 		return sectionRoleMap;
 	}
 
+	public Map<String, String> findSectionRoles(final String userEid, final String academicSessionEid) {
+		HibernateCallback hc = session -> {
+			Query q = session.getNamedQuery("findSectionRolesByAcademicSession");
+			q.setParameter("userEid", userEid);
+			q.setParameter("academicSessionEid", academicSessionEid);
+			return q.list();
+		};
+
+		List<Object[]> results = new ArrayList<>((List<Object[]>) getHibernateTemplate().execute(hc));
+		Map<String, String> sectionRoleMap = new HashMap<>();
+		for(Object[] oa : results) {
+			sectionRoleMap.put((String) oa[0], (String) oa[1]);
+		}
+
+		return sectionRoleMap;
+	}
 
 	public Set<CourseOffering> getCourseOfferingsInCanonicalCourse(final String canonicalCourseEid) throws IdNotFoundException {
 		if(!isCanonicalCourseDefined(canonicalCourseEid)) {

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseManagementServiceSampleChainImpl.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/CourseManagementServiceSampleChainImpl.java
@@ -191,6 +191,10 @@ public class CourseManagementServiceSampleChainImpl implements CourseManagementS
 		return null;
 	}
 
+	public Map findSectionRoles(String userEid, String academicSessionEid) {
+		return null;
+	}
+
 	public Set getCourseOfferingsInCanonicalCourse(String canonicalCourseEid) throws IdNotFoundException {
 		throw new IdNotFoundException(canonicalCourseEid, CanonicalCourse.class.getName());
 	}

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/GroupProvider.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/GroupProvider.java
@@ -63,6 +63,17 @@ public interface GroupProvider
 	Map<String, String> getGroupRolesForUser(String userId);
 
 	/**
+	 * Access the external group id - role name map for this user in the given acadEid.
+	 *
+	 * @param userId
+	 *        The user id.
+	 * @param acadEid
+	 *        The acad EID
+	 * @return the the external group id - role name map for this users in the given acadEid. (may be empty).
+	 */
+	Map<String, String> getGroupRolesForUser(String userId, String acadEid);
+
+	/**
 	 * Packs any number of simple ids into a compound id.
 	 * @param ids
 	 * 		The external group ids

--- a/providers/allhands/src/java/org/sakaiproject/provider/authzGroup/AllHandsGroupProvider.java
+++ b/providers/allhands/src/java/org/sakaiproject/provider/authzGroup/AllHandsGroupProvider.java
@@ -144,6 +144,15 @@ public class AllHandsGroupProvider implements GroupProvider
 		return rv;
 	}
 
+	// This signature was added to the interface to support speedup of displaying the list of available rosters,
+	// but implemented this method signature only for the implementations currently in use.
+	// Some implementations -- including this one -- do not implement this method signature.
+	// This signature was added here merely to complete the maven build (it ignores the added parameter).
+	// You must edit to specify processing if you actually use this class.
+	public Map getGroupRolesForUser(String userId, String academicSessionEid) {
+		return getGroupRolesForUser(userId);
+	}
+
 	public String[] unpackId(String id)
 	{
 		String[] rv = null;

--- a/providers/cm-authz-provider/src/java/org/sakaiproject/coursemanagement/impl/provider/CourseOfferingRoleResolver.java
+++ b/providers/cm-authz-provider/src/java/org/sakaiproject/coursemanagement/impl/provider/CourseOfferingRoleResolver.java
@@ -152,4 +152,12 @@ public class CourseOfferingRoleResolver extends BaseRoleResolver {
 		return sectionRoles;
 	}
 
+	// This signature was added to the interface to support speedup of displaying the list of available rosters,
+	// but implemented this method signature only for certain implementations.
+	// Some implementations -- including this one -- do not implement this method signature.
+	// This signature is here merely to complete the maven build (it ignores the added parameter).
+	// You must edit to specify processing if you actually use this class.
+	public Map<String, String> getGroupRoles(CourseManagementService cmService, String userEid, String academicSessionEid) {
+		return getGroupRoles(cmService, userEid);
+	}
 }

--- a/providers/cm-authz-provider/src/java/org/sakaiproject/coursemanagement/impl/provider/CourseSetRoleResolver.java
+++ b/providers/cm-authz-provider/src/java/org/sakaiproject/coursemanagement/impl/provider/CourseSetRoleResolver.java
@@ -136,6 +136,15 @@ public class CourseSetRoleResolver extends BaseRoleResolver {
 		return sectionRoles;
 	}
 
+	// This signature was added to the interface to support speedup of displaying the list of available rosters,
+	// but implemented this method signature only for the implementations currently in use.
+	// Some implementations -- including this one -- do not implement this method signature.
+	// This signature here merely to complete the maven build (it ignores the added parameter).
+	// You must edit to specify processing if you actually use this class.
+	public Map<String, String> getGroupRoles(CourseManagementService cmService, String userEid, String academicSessionEid) {
+		return getGroupRoles(cmService, userEid);
+	}
+
 	private Set<String> getCourseSetEids(CourseManagementService cmService, Section section) {
 		// Look up the hierarchy for any course sets
 		CourseOffering co;

--- a/providers/cm-authz-provider/src/java/org/sakaiproject/coursemanagement/impl/provider/RoleResolver.java
+++ b/providers/cm-authz-provider/src/java/org/sakaiproject/coursemanagement/impl/provider/RoleResolver.java
@@ -55,4 +55,15 @@ public interface RoleResolver {
 	 * @return The user's roles, or null if the user has no role in this CM object
 	 */
 	public Map<String, String> getGroupRoles(CourseManagementService cmService, String userEid);
+
+	  /**
+	 * Gets a single user's roles in all sections with which s/he is associated and which are part of
+	 * a CourseOffering in a given AcademicSession.
+	 *
+	 * @param userEid The user's enterprise ID
+	 * @param academicSessionEid the selected academic session enterprise ID
+	 * @param cmService The CM service impl. We pass this in rather than injecting it into every RoleResolver
+	 * @return The user's roles, or null if the user has no role in this CM object
+	 */
+	public Map<String, String> getGroupRoles(CourseManagementService cmService, String userEid, String academicSessionEid);
 }

--- a/providers/sample/src/java/org/sakaiproject/provider/authzGroup/SampleGroupProvider.java
+++ b/providers/sample/src/java/org/sakaiproject/provider/authzGroup/SampleGroupProvider.java
@@ -353,6 +353,15 @@ public class SampleGroupProvider implements GroupProvider
 		return rv;
 	}
 
+	// This signature was added to the interface to support speedup of displaying the list of available rosters,
+	// but implemented this method signature only for the implementations currently in use.
+	// Some implementations -- including this one -- do not implement this method signature.
+	// This signature was added here merely to complete the maven build (it ignores the added parameter).
+	// You must edit to specify processing if you actually use this class.
+	public Map getGroupRolesForUser(String userId, String acadEid) {
+		return getGroupRolesForUser(userId);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -13563,7 +13563,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			return;
 		}
 		
-		Map map = groupProvider.getGroupRolesForUser(userId);
+		Map<String, String> map = groupProvider.getGroupRolesForUser(userId, academicSessionEid);
 		if (map == null)
 			return;
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41026

This PR improves the performance of displaying roster lists in Site Info by creating an overloaded method (in several areas) which takes an extra parameter (the academic session EID). In this way, you can limit what rosters are loaded by the selected academic session, instead of always asking for every roster the user belongs to regardless of the user's selection.

This patch has been running in a large production instance for over 5 years without issue.