### PR TITLE
SAK-41027: GBNG > incorrect default tooltip when toggling mutually exclusive drop/keep settings

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -476,7 +476,7 @@ settingspage.categories.total = Total:
 settingspage.categories.instructions.categoryvisibility = A category will only be visible if there is at least one Gradebook item assigned to it.
 settingspage.categories.instructions.uncounteditems = If 'Categories & weighting' is enabled, uncategorized items will not be counted toward the course grade.
 settingspage.categories.instructions.applydropkeep = To apply drop highest, drop lowest, or keep highest, all items in the category must have the same score value.
-settingspage.categories.hover.dropkeepusage = 'Drop highest' / 'Drop lowest' cannot be used in the same category with 'keep Highest'.
+settingspage.categories.hover.dropkeepusage = 'Drop highest' / 'Drop lowest' cannot be used in the same category with 'Keep Highest'.
 settingspage.categories.hover.categoriesweightingpoints = 'Categories & weighting' is not compatible with the 'Points' final course grade display option.
 
 settingspage.categories.runningtotalerror=Weighting for the categories must equal 100%

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
@@ -470,7 +470,7 @@ public class SettingsCategoryPanel extends BasePanel {
 				});
 				categoryDropHighest.setEnabled(dropKeepEnabled && categoryDropHighestEnabled);
 				if (!categoryDropHighest.isEnabled()) {
-					addDropKeepDisabledToolTip(categoryDropHighest, DropKeepUsage.CATEGORY);
+					addDropKeepDisabledToolTip(categoryDropHighest, dropKeepEnabled ? DropKeepUsage.EXCLUSIVE : DropKeepUsage.CATEGORY);
 				}
 				item.add(categoryDropHighest);
 
@@ -513,7 +513,7 @@ public class SettingsCategoryPanel extends BasePanel {
 				});
 				categoryDropLowest.setEnabled(dropKeepEnabled && categoryDropLowestEnabled);
 				if (!categoryDropLowest.isEnabled()) {
-					addDropKeepDisabledToolTip(categoryDropLowest, DropKeepUsage.CATEGORY);
+					addDropKeepDisabledToolTip(categoryDropLowest, dropKeepEnabled ? DropKeepUsage.EXCLUSIVE : DropKeepUsage.CATEGORY);
 				}
 				item.add(categoryDropLowest);
 
@@ -556,7 +556,7 @@ public class SettingsCategoryPanel extends BasePanel {
 				});
 				categoryKeepHighest.setEnabled(dropKeepEnabled && categoryKeepHighestEnabled);
 				if (!categoryKeepHighest.isEnabled()) {
-					addDropKeepDisabledToolTip(categoryKeepHighest, DropKeepUsage.CATEGORY);
+					addDropKeepDisabledToolTip(categoryKeepHighest, dropKeepEnabled ? DropKeepUsage.EXCLUSIVE : DropKeepUsage.CATEGORY);
 				}
 				item.add(categoryKeepHighest);
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41027

The default tooltip on the disabled input field refers to the point values, rather than the mutually exclusive settings message you should see. There's also a reference to an inconsistently capitalized setting in the mutually exclusive tooltip.

Steps to reproduce in the JIRA.