### PR TITLE
SAK-41010 Remove jstl library from lib and move to tool scope

### DIFF
--- a/admin-su/pom.xml
+++ b/admin-su/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>taglibs</groupId>

--- a/chat/chat-tool/tool/pom.xml
+++ b/chat/chat-tool/tool/pom.xml
@@ -99,8 +99,6 @@
     <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>jstl</artifactId>
-        <version>${sakai.jstl.version}</version>
-        <scope>compile</scope>
     </dependency>
     <dependency>
         <groupId>org.jboss.weld.servlet</groupId>

--- a/commons/tool/pom.xml
+++ b/commons/tool/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -128,12 +128,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- incorporated jstl-shared-deploy pom.  Can be dropped once it's confirmed that JSF-related tools are bundling it up in their webapps. -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <!-- quartz scheduler -->
         <dependency>

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -45,7 +45,6 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>

--- a/help/help-tool/pom.xml
+++ b/help/help-tool/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>javax.servlet.jsp</groupId>

--- a/jobscheduler/scheduler-tool/pom.xml
+++ b/jobscheduler/scheduler-tool/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.jsf</groupId>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -871,7 +871,6 @@
         <groupId>javax.servlet</groupId>
         <artifactId>jstl</artifactId>
         <version>${sakai.jstl.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>javax.transaction</groupId>

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -50,7 +50,6 @@
 		<dependency>
 		  <groupId>javax.servlet</groupId>
 		  <artifactId>jstl</artifactId>
-		  <version>${sakai.jstl.version}</version>
 		  <scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/podcasts/podcasts-app/pom.xml
+++ b/podcasts/podcasts-app/pom.xml
@@ -74,7 +74,10 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
-    
+    <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>jstl</artifactId>
+    </dependency>
   </dependencies>
 <!-- needed so it will compile the java files,
 		process the properties bundles,

--- a/roster2/pom.xml
+++ b/roster2/pom.xml
@@ -35,4 +35,5 @@
     </dependency>
   </dependencies>
 
+
 </project>

--- a/roster2/tool/pom.xml
+++ b/roster2/tool/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>

--- a/rwiki/rwiki-tool/tool/pom.xml
+++ b/rwiki/rwiki-tool/tool/pom.xml
@@ -111,7 +111,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>taglibs</groupId>

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -156,11 +156,6 @@
         </dependency>
 	    <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-            <scope>compile</scope>
-        </dependency>
-		<dependency>
-            <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
@@ -265,8 +260,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>${sakai.jstl.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.servlet</groupId>

--- a/signup/pom.xml
+++ b/signup/pom.xml
@@ -131,7 +131,6 @@
 				<groupId>javax.servlet</groupId>
 				<artifactId>jstl</artifactId>
 				<version>1.1.2</version>
-				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>taglibs</groupId>

--- a/signup/tool/pom.xml
+++ b/signup/tool/pom.xml
@@ -118,7 +118,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>

--- a/simple-rss-portlet/pom.xml
+++ b/simple-rss-portlet/pom.xml
@@ -47,7 +47,6 @@
       	<dependency>
          	<groupId>javax.servlet</groupId>
          	<artifactId>jstl</artifactId>
-         	<version>1.2</version>
       	</dependency>
 		<dependency>
 			<groupId>taglibs</groupId>

--- a/user/user-tool-prefs/tool/pom.xml
+++ b/user/user-tool-prefs/tool/pom.xml
@@ -87,7 +87,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
          <groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
I've changed the pom files to remove jstl library from tomcat /lib folder and add it into the tools it's needed (syllabus, rss news, signup and podcasts).