### PR TITLE
SAK-41054: Drop Box > fix inconsistencies in UI messaging when referring to the tool

### DIFF
--- a/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/content/content.properties
+++ b/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/content/content.properties
@@ -37,7 +37,7 @@ access.group	= Select group(s)
 access.group1	= Visible to select groups: {0}
 access.public	= Public
 access.public1	= Visible to public
-access.dropbox	= Dropbox
+access.dropbox	= Drop Box
 access.dropbox1	= Visible to instructor and student
 
 access.title1	= Access

--- a/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/siteemacon/siteemacon.properties
+++ b/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/siteemacon/siteemacon.properties
@@ -44,15 +44,15 @@ this = This automatic notification message was sent by
 
 youcan = You can modify how you receive notifications at Home > Preferences.
 
-db.subj.upd = [ {0} - Dropbox item changed in "{1}" ] {2}
-db.subj.new = [ {0} - New dropbox item in "{1}" ] {2}
-db.subj.upd.dnd = [ {0} - Dropbox items changed in folder "{1}" ]
-db.subj.new.dnd = [ {0} - New dropbox items in folder "{1}" ]
+db.subj.upd = [ {0} - Drop Box item changed in "{1}" ] {2}
+db.subj.new = [ {0} - New Drop Box item in "{1}" ] {2}
+db.subj.upd.dnd = [ {0} - Drop Box items changed in folder "{1}" ]
+db.subj.new.dnd = [ {0} - New Drop Box items in folder "{1}" ]
 
-db.text.upd = A resource has been updated in the dropbox for "{0}" in the "{1}" site at {2} ({3}) 
-db.text.new = A new resource has been added to the dropbox for "{0}" in the "{1}" site at {2} ({3})
-db.text.upd.dnd = Several resources have been updated in the dropbox for "{0}" in the "{1}" site at {2} ({3}) 
-db.text.new.dnd = New resources have been added to the dropbox for "{0}" in the "{1}" site at {2} ({3})  
+db.text.upd = An item has been updated in the Drop Box for "{0}" in the "{1}" site at {2} ({3})
+db.text.new = A new item has been added to the Drop Box for "{0}" in the "{1}" site at {2} ({3})
+db.text.upd.dnd = Several items have been updated in the Drop Box for "{0}" in the "{1}" site at {2} ({3})
+db.text.new.dnd = New items have been added to the Drop Box for "{0}" in the "{1}" site at {2} ({3})
 
 db.text.location = Location: site "{0}" > Drop Box {1} > {2} 
-db.text.prefs = This automatic notification message was sent by {0} ({1}) from the dropbox in the {2} site. You can modify how you receive notifications at Home > Preferences.
+db.text.prefs = This automatic notification message was sent by {0} ({1}) from the Drop Box in the {2} site. You can modify how you receive notifications at Home > Preferences.

--- a/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/type/types.properties
+++ b/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/type/types.properties
@@ -11,7 +11,7 @@ access.site.fldr	 = Only <strong>members of this site</strong> can see this fold
 access.site.nochoice	 = Resources in the ''{0}'' folder can be viewed by <strong>all members of this site</strong>.
 access.site.noparent	 = Resources in this folder can be viewed by <strong>all members of this site</strong>.
 
-access.dropbox		 = Dropbox
+access.dropbox		 = Drop Box
 access.dropbox1	 = Visible to instructor and student
 access.group		 = Select group(s)
 access.group1		 = Visible to selected groups: {0}

--- a/content/content-bundles/resources/content.properties
+++ b/content/content-bundles/resources/content.properties
@@ -51,7 +51,7 @@ access.site1	= Visible to entire site
 access.group	= Select group(s)
 access.group1	= Visible to select groups: {0}
 access.group.missing	= Missing group(s)
-access.dropbox	= Dropbox
+access.dropbox	= Drop Box
 access.dropbox1	= Visible to instructor and student
 
 # Definitions for roles based on their ids. .anon is the roleid for pubview / public access.
@@ -328,7 +328,7 @@ list.sPerm    = Permissions
 list.select   = Check All
 list.show     = Show other sites
 list.site     = Site Resources
-list.site.dropbox   = List of drop boxes
+list.site.dropbox   = List of Drop Boxes
 list.toobig   = This collection is too big to expand.
 list.unselect = Uncheck All
 list.ame	  = Actions menu end
@@ -482,7 +482,7 @@ sh.sorttitas    = Sort by title ascending
 sh.sorttitdesc  = Sort by title descending
 sh.unsel        = Uncheck all
 
-dropbox_highlight=Highlight (<em class="recentItemInstruction">&nbsp;</em>) individual dropboxes with recent changes:
+dropbox_highlight=Highlight (<em class="recentItemInstruction">&nbsp;</em>) individual Drop Boxes with recent changes:
 sh.1day = 1 day
 sh.2day = 2 days
 sh.3day = 3 days

--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -42,7 +42,7 @@ access.role.origin.internal.choice	 = This file is <strong>viewable by all inter
 access.role.origin.internal.fldr		 = This folder and its contents are <strong>viewable by all internal users</strong>.
 
 access.inherited	 = (Inherited)
-access.dropbox		 = Dropbox
+access.dropbox		 = Drop Box
 access.dropbox1	 = Visible to instructor and student
 access.group		 = Select group(s)
 access.group1		 = Visible to selected groups: {0}
@@ -348,12 +348,12 @@ oct = OCT
 nov = NOV
 dec = DEC
 
-receive.confirm.dropbox.email.options = Dropbox Notification Options:
+receive.confirm.dropbox.email.options = Drop Box Notification Options:
 receive.confirm.dropbox.email.allow = Allow email notifications to be sent
 receive.confirm.dropbox.email.always = Always send email notifications
 receive.confirm.dropbox.email.none = Do not allow email notifications to be sent
-instr.dropbox.options = Choose whether email notifications should be sent for submissions within this dropbox 
-title.dropbox.options		 = Setting options for dropbox in worksite ''{0}''
+instr.dropbox.options = Choose whether email notifications should be sent for submissions within this Drop Box
+title.dropbox.options		 = Setting options for Drop Box in worksite ''{0}''
 
 # SAK-23350
 dropbox.privacy.note = Files in your Drop Box can only be seen by you and the site maintainers. Other participants cannot access them.
@@ -566,7 +566,7 @@ dropdown.duration_widget_qualifiers.11.label=Minute
 dropdown.duration_widget_qualifiers.12=second
 dropdown.duration_widget_qualifiers.12.label=Second
 
-multiple.file.upload = Upload files to multiple dropbox folders
+multiple.file.upload = Upload files to multiple Drop Box folders
 multiple.file.upload.nofileselected = No file selected
 multiple.file.upload.nousersselected = No users selected
 multiple.file.upload.siteusers = Available users

--- a/content/content-tool/tool/src/bundle/dropbox.properties
+++ b/content/content-tool/tool/src/bundle/dropbox.properties
@@ -1,3 +1,3 @@
 # descriptions for dropbox entities
-dropbox = Represents the Dropbox tool
-dropbox.action.site = Gets the dropbox items for a given site and user. URL should be of the form /direct/dropbox/site/SITEID/user/EID.format.
+dropbox = Represents the Drop Box tool
+dropbox.action.site = Gets the Drop Box items for a given site and user. URL should be of the form /direct/dropbox/site/SITEID/user/EID.format.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41054

There are several messages shown to the user which refer to the tool as "Dropbox" or "dropbox", in contradiction to the tool name and other messages which refer to the tool properly as "Drop Box". The linked PR also replaces a few instances of the word "resource" for "item", in reference to uploading items to a user's Drop Box.