### PR TITLE
SAK-41057: edu-services > external GB item 'release to students' setting overwritten on update

### DIFF
--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradebookAssignment.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradebookAssignment.java
@@ -88,7 +88,7 @@ public class GradebookAssignment extends GradableObject {
 	@Getter @Setter private String externalId;
 	@Getter @Setter private String externalAppName;
 	@Getter @Setter private String externalData;
-	@Setter private Boolean released;
+	@Setter @Getter private Boolean released;
 	@Getter @Setter private Category category;
 	@Getter @Setter private Double averageTotal;
 	@Setter private Boolean ungraded;

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
@@ -239,7 +240,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 				asn.setName(title);
 				asn.setDueDate(dueDate);
 				// support selective release
-				asn.setReleased(true);
+				asn.setReleased(BooleanUtils.isTrue(asn.getReleased()));
 				asn.setPointsPossible(Double.valueOf(points));
 				session.update(asn);
 				log.info("External assessment updated in gradebookUid={}, externalId={} by userUid={}", gradebookUid, externalId,
@@ -780,7 +781,7 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 			asn.setName(title);
 			asn.setDueDate(dueDate);
 			// support selective release
-			asn.setReleased(true);
+			asn.setReleased(BooleanUtils.isTrue(asn.getReleased()));
 			asn.setPointsPossible(points);
 			if (ungraded != null) {
 				asn.setUngraded(ungraded.booleanValue());


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41057

If the instructor has edited an external gradebook item in the Gradebook to remove the "Release to Students" setting, editing the associated quiz/assignment/etc. through the external tool will overwrite the instructor's previous choice to not release the item to the students.