### PR TITLE
SAK-41058: assignments > can circumvent gradebook category with drop/keep uniform point value validation

### DIFF
--- a/assignment/bundles/resources/assignment.properties
+++ b/assignment/bundles/resources/assignment.properties
@@ -369,6 +369,8 @@ plesuse3 = Please use a positive number or zero for the grade field.
 
 plesuse4 = {0} is greater than the maximum value allowed by the system. Please enter a value no greater than {1}.
 
+pleasee6 = Points must match assignments in the selected Gradebook category ({0})
+
 points = Points
 
 prevassig.hidass     = Hide assignment

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7009,7 +7009,7 @@ public class AssignmentAction extends PagedResourceActionII {
                     if (thisCatRef != -1) {
                         for(CategoryDefinition thisCategoryDefinition : categoryDefinitions) {
                             if (Objects.equals(thisCategoryDefinition.getId(), thisCatRef)) {
-                                if (thisCategoryDefinition.getIsDropped()) {
+                                if (thisCategoryDefinition.getDropKeepEnabled()) {
                                     Double thisCategoryPoints = thisCategoryDefinition.getPointsForCategory();
                                     if (thisCategoryPoints != null) {
                                         droppedCategoryPoints = thisCategoryPoints;

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/CategoryDefinition.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/CategoryDefinition.java
@@ -21,6 +21,9 @@ import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -33,19 +36,19 @@ public class CategoryDefinition implements Serializable {
   
     private static final long serialVersionUID = 1L;
 	
-    private Long id;
-    private String name;
-    private Double weight;
-    private Integer dropLowest;
-    private Integer dropHighest;
-    private Integer keepHighest;
-    private Boolean extraCredit;
-    private Integer categoryOrder;
-    private Boolean isDropped;
+    @Getter @Setter private Long id;
+    @Getter @Setter private String name;
+    @Getter @Setter private Double weight;
+    @Getter @Setter private Integer dropLowest;
+    @Getter @Setter private Integer dropHighest;
+    @Getter @Setter private Integer keepHighest;
+    @Getter @Setter private Boolean extraCredit;
+    @Getter @Setter private Integer categoryOrder;
+    @Getter @Setter private Boolean dropKeepEnabled;
     
     public static Comparator<CategoryDefinition> orderComparator;
 
-    private List<Assignment> assignmentList;
+    @Getter @Setter private List<Assignment> assignmentList;
     
     public CategoryDefinition() {
     	
@@ -55,118 +58,6 @@ public class CategoryDefinition implements Serializable {
     	this.id = id;
     	this.name = name;
     }
-    
-    /**
-     * 
-     * @return the id of the Category object
-     */
-    public Long getId()
-    {
-        return id;
-    }
-    
-    /**
-     * 
-     * @param id the id of the Category object
-     */
-    public void setId(Long id)
-    {
-        this.id = id;
-    }
-    
-    /**
-     * 
-     * @return the category name
-     */
-    public String getName()
-    {
-        return name;
-    }
-    
-    /**
-     * 
-     * @param name the category name
-     */
-    public void setName(String name)
-    {
-        this.name = name;
-    }
-    
-    /**
-     * 
-     * @return the weight set for this category if part of a weighted gradebook.
-     * null if gradebook is not weighted
-     */
-    public Double getWeight()
-    {
-        return weight;
-    }
-    
-    /**
-     * the weight set for this category if part of a weighted gradebook.
-     * null if gradebook is not weighted
-     * @param weight
-     */
-    public void setWeight(Double weight)
-    {
-        this.weight = weight;
-    }
-
-    /**
-     * Get the list of Assignments associated with this category
-     * @return 
-     */
-	public List<Assignment> getAssignmentList() {
-		return assignmentList;
-	}
-
-	 /**
-     * Set the list of Assignments for this category
-     * @return 
-     */
-	public void setAssignmentList(List<Assignment> assignmentList) {
-		this.assignmentList = assignmentList;
-	}
-
-	public Integer getDropLowest() {
-		return dropLowest;
-	}
-
-	public void setDropLowest(Integer dropLowest) {
-		this.dropLowest = dropLowest;
-	}
-
-	public Integer getDropHighest() {
-		return dropHighest;
-	}
-
-	public void setDropHighest(Integer dropHighest) {
-		this.dropHighest = dropHighest;
-	}
-
-	public Integer getKeepHighest() {
-		return keepHighest;
-	}
-
-	public void setKeepHighest(Integer keepHighest) {
-		this.keepHighest = keepHighest;
-	}
-
-	public Boolean isExtraCredit() {
-		return extraCredit;
-	}
-
-	public void setExtraCredit(Boolean extraCredit) {
-		this.extraCredit = extraCredit;
-	}
-
-	public Integer getCategoryOrder() {
-		return categoryOrder;
-	}
-
-	public void setCategoryOrder(Integer categoryOrder) {
-		this.categoryOrder = categoryOrder;
-	}
 	
 	@Override
 	public String toString() {
@@ -207,19 +98,12 @@ public class CategoryDefinition implements Serializable {
 		return totalPoints.doubleValue();
 	}
 
-	public Boolean getIsDropped() {
-		return isDropped;
-	}
-
-	public void setIsDropped(Boolean isDropped) {
-		this.isDropped = isDropped;
-	}
-
 	public boolean isAssignmentInThisCategory(String assignmentId) {
-		for (Assignment thisAssignment : this.assignmentList) {
+		for (Assignment thisAssignment : assignmentList) {
 			if (thisAssignment.getExternalId() == null) {
 				continue;
 			}
+
 			if (thisAssignment.getExternalId().equalsIgnoreCase(assignmentId)) {
 				return true;
 			}
@@ -229,11 +113,11 @@ public class CategoryDefinition implements Serializable {
 	}
 
 	public Double getPointsForCategory() {
-		if (!this.isDropped) {
+		if (!dropKeepEnabled) {
 			return null;
 		}
 
-		for (Assignment thisAssignment : this.assignmentList) {
+		for (Assignment thisAssignment : assignmentList) {
 			return thisAssignment.getPoints();
 		}
 

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/CategoryDefinition.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/CategoryDefinition.java
@@ -41,6 +41,7 @@ public class CategoryDefinition implements Serializable {
     private Integer keepHighest;
     private Boolean extraCredit;
     private Integer categoryOrder;
+    private Boolean isDropped;
     
     public static Comparator<CategoryDefinition> orderComparator;
 
@@ -204,5 +205,38 @@ public class CategoryDefinition implements Serializable {
 			}
 		}
 		return totalPoints.doubleValue();
+	}
+
+	public Boolean getIsDropped() {
+		return isDropped;
+	}
+
+	public void setIsDropped(Boolean isDropped) {
+		this.isDropped = isDropped;
+	}
+
+	public boolean isAssignmentInThisCategory(String assignmentId) {
+		for (Assignment thisAssignment : this.assignmentList) {
+			if (thisAssignment.getExternalId() == null) {
+				continue;
+			}
+			if (thisAssignment.getExternalId().equalsIgnoreCase(assignmentId)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public Double getPointsForCategory() {
+		if (!this.isDropped) {
+			return null;
+		}
+
+		for (Assignment thisAssignment : this.assignmentList) {
+			return thisAssignment.getPoints();
+		}
+
+		return null;
 	}
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -715,6 +716,16 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 			Category persistedCategory = null;
 			if (categoryId != null) {
 				persistedCategory = getCategory(categoryId);
+				if (persistedCategory.isDropScores()) {
+					List<GradebookAssignment> thisCategoryAssignments = getAssignmentsForCategory(categoryId);
+					for (GradebookAssignment thisAssignment : thisCategoryAssignments) {
+						if (!Objects.equals(thisAssignment.getPointsPossible(), points)) {
+							String errorMessage = "Assignment points mismatch the selected Gradebook Category ("
+								+ thisAssignment.getPointsPossible().toString() + ") and cannot be added to Gradebook )";
+							throw new InvalidCategoryException(errorMessage);
+						}
+					}
+				}
 				if (persistedCategory == null || persistedCategory.isRemoved() ||
 						!persistedCategory.getGradebook().getId().equals(gradebook.getId())) {
 					throw new InvalidCategoryException("The category with id " + categoryId +

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -466,7 +466,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 							Long categoryId = null;
 							try {
 								categoryId = createCategory(gradebook.getId(), c.getName(), c.getWeight(), c.getDropLowest(),
-										c.getDropHighest(), c.getKeepHighest(), c.isExtraCredit(), c.getCategoryOrder());
+										c.getDropHighest(), c.getKeepHighest(), c.getExtraCredit(), c.getCategoryOrder());
 							} catch (final ConflictingCategoryNameException e) {
 								// category already exists. Could be from a merge.
 								log.info("Category: {} already exists in target site. Skipping creation.", c.getName());
@@ -506,7 +506,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			categories.forEach(c -> {
 				try {
 					createCategory(gradebook.getId(), c.getName(), c.getWeight(), c.getDropLowest(), c.getDropHighest(), c.getKeepHighest(),
-							c.isExtraCredit(), c.getCategoryOrder());
+							c.getExtraCredit(), c.getCategoryOrder());
 				} catch (final ConflictingCategoryNameException e) {
 					// category already exists. Could be from a merge.
 					log.info("Category: {} already exists in target site. Skipping creation.", c.getName());
@@ -2502,7 +2502,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			categoryDef.setDropHighest(category.getDropHighest());
 			categoryDef.setKeepHighest(category.getKeepHighest());
 			categoryDef.setAssignmentList(getAssignments(category.getGradebook().getUid(), category.getName()));
-			categoryDef.setIsDropped(category.isDropScores());
+			categoryDef.setDropKeepEnabled(category.isDropScores());
 			categoryDef.setExtraCredit(category.isExtraCredit());
 			categoryDef.setCategoryOrder(category.getCategoryOrder());
 		}
@@ -3344,7 +3344,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				existing.setDropLowest(newDef.getDropLowest());
 				existing.setDropHighest(newDef.getDropHighest());
 				existing.setKeepHighest(newDef.getKeepHighest());
-				existing.setExtraCredit(newDef.isExtraCredit());
+				existing.setExtraCredit(newDef.getExtraCredit());
 				existing.setCategoryOrder(categoryIndex);
 				updateCategory(existing);
 
@@ -3366,7 +3366,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		for (final Entry<CategoryDefinition, Integer> entry : newCategories.entrySet()) {
 			final CategoryDefinition newCat = entry.getKey();
 			this.createCategory(gradebook.getId(), newCat.getName(), newCat.getWeight(), newCat.getDropLowest(),
-					newCat.getDropHighest(), newCat.getKeepHighest(), newCat.isExtraCredit(), entry.getValue());
+					newCat.getDropHighest(), newCat.getKeepHighest(), newCat.getExtraCredit(), entry.getValue());
 		}
 
 		// if weighted categories, all uncategorised assignments are to be removed from course grade calcs

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -49,7 +49,6 @@ import org.hibernate.criterion.Restrictions;
 import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.hibernate.HibernateCriterionUtils;
-import org.sakaiproject.rubrics.logic.RubricsConstants;
 import org.sakaiproject.rubrics.logic.RubricsService;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
@@ -2503,6 +2502,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			categoryDef.setDropHighest(category.getDropHighest());
 			categoryDef.setKeepHighest(category.getKeepHighest());
 			categoryDef.setAssignmentList(getAssignments(category.getGradebook().getUid(), category.getName()));
+			categoryDef.setIsDropped(category.isDropScores());
 			categoryDef.setExtraCredit(category.isExtraCredit());
 			categoryDef.setCategoryOrder(category.getCategoryOrder());
 		}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -573,7 +573,7 @@ public class GbGradebookData {
 									.getString(),
 							nullable(categoryWeight),
 							category.getTotalPoints(),
-							category.isExtraCredit(),
+							category.getExtraCredit(),
 							userSettings.getCategoryColor(category.getName(), category.getId()),
 							!this.uiSettings.isCategoryScoreVisible(category.getName()),
 							FormatHelper.formatCategoryDropInfo(category)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -131,7 +131,7 @@ public class SettingsPage extends BasePage {
 							error(getString("settingspage.update.failure.categorymissingweight"));
 						} else {
 							// extra credit items do not participate in the weightings, so exclude from the tally
-							if (!cat.isExtraCredit()) {
+							if (!cat.getExtraCredit()) {
 								totalWeight = totalWeight.add(BigDecimal.valueOf(cat.getWeight()));
 							}
 						}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
@@ -323,7 +323,7 @@ public class AddOrEditGradeItemPanelContent extends BasePanel {
 				// checkbox
 				final CategoryDefinition category = categoryMap.get(selected);
 
-				if (category != null && category.isExtraCredit()) {
+				if (category != null && category.getExtraCredit()) {
 					extraCredit.setModelObject(false);
 					extraCredit.setEnabled(false);
 				} else {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
@@ -762,7 +762,7 @@ public class SettingsCategoryPanel extends BasePanel {
 				weight = BigDecimal.ZERO;
 			}
 
-			if (!categoryDefinition.isExtraCredit()) {
+			if (!categoryDefinition.getExtraCredit()) {
 				total = total.add(weight);
 			}
 		}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41058

In Gradebook, if you have a category with drop/highest/keep enabled, all items within the category must have the same maximum point value. This rule is enforced when creating gradebook items in Gradebook itself, but can be circumvented through tools which can send grades to the gradebook.