### PR TITLE
SAK-33892 - NPE creating site with LTI tool and extra parameter tool

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -12642,6 +12642,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		if (state.getAttribute(STATE_LTITOOL_SELECTED_LIST) != null)
 		{
 			Site site = getStateSite(state);
+			if (site == null)
+			{
+				return;
+			}
 			Properties reqProps = params.getProperties();
 			// remember the reqProps may contain multiple lti inputs, so we need to differentiate those inputs and store one tool specific input into the map
 			HashMap<String, Map<String, Object>> ltiTools = (HashMap<String, Map<String, Object>>) state.getAttribute(STATE_LTITOOL_SELECTED_LIST);


### PR DESCRIPTION
So it seems like the problem here was that the site wasn't available here when the validation failed. I tried to call this with the "true" parameter, however if the site id from this return was actually stored in the state it caused it to save back to the "My Workspace" site and corrupt that site.

So I added a new parameter which will just get the site (from the state) if it exists use the context (which was available) but NOT store it to the state. This got this particular case to proceed through for LTI lookups which needed some type of site.

This seemed like a lower risk fix than changing anything in LTI. I changed the default for 

`protected Site getStateSite(SessionState state) {`

To just call this with a false (even though it previously was true) because calling autoContext false will never get to the point of state storing. There was only ONE place which also called this and expected the state to be stored which I've updated. 