### PR TITLE
SAK-41050 protect against NPE in iterator

### DIFF
--- a/search/elasticsearch/util/src/java/org/sakaiproject/search/elasticsearch/SiteElasticSearchIndexBuilder.java
+++ b/search/elasticsearch/util/src/java/org/sakaiproject/search/elasticsearch/SiteElasticSearchIndexBuilder.java
@@ -245,8 +245,9 @@ public class SiteElasticSearchIndexBuilder extends BaseElasticSearchIndexBuilder
             BulkRequestBuilder bulkRequest = client.prepareBulk();
 
             for (final EntityContentProducer ecp : producers) {
+            	Iterator<String> i = ecp.getSiteContentIterator(siteId);
 
-                for (Iterator<String> i = ecp.getSiteContentIterator(siteId); i.hasNext(); ) {
+                while ( i != null && i.hasNext() ) {
 
                     if (bulkRequest.numberOfActions() < bulkRequestSize) {
                         String reference = i.next();


### PR DESCRIPTION
`03-Dec-2018 11:54:23.359 ERROR [[elasticsearch content indexer default]] org.sakaiproject.search.elasticsearch.SiteElasticSearchIndexBuilder.rebuildSiteIndex An exception occurred while rebuilding the index of 'b125e21b-daf6-4bde-bb99-27ef5a2c086d'
java.lang.NullPointerException
        at org.sakaiproject.search.elasticsearch.SiteElasticSearchIndexBuilder.rebuildSiteIndex(SiteElasticSearchIndexBuilder.java:249)
        at org.sakaiproject.search.elasticsearch.SiteElasticSearchIndexBuilder$RebuildSiteTask.run(SiteElasticSearchIndexBuilder.java:314)
        at java.util.TimerThread.mainLoop(Timer.java:555)
        at java.util.TimerThread.run(Timer.java:505)`