### PR TITLE
SAK-41082: Forums > previous & next topic buttons can overlap breadcrumbs

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
+++ b/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
@@ -105,6 +105,13 @@
 		}
 	}
 
+	div.specialLink{
+		max-width: calc(100% - 260px);
+		@media #{$phone} {
+			max-width: unset;
+		}
+	}
+
 	.allMessages{
 		border: 1px solid #ddd;
 		border-collapse: collapse;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41082

The "Previous Topic" and "Next Topic" buttons can overlap the breadcrumbs at the large and medium screen size breakpoints. It's more easily encountered if the forum and/or topic have long titles. The problem doesn't exist at the small screen size breakpoint because it then gets it's own "row", and the breadcrumbs drop down below the buttons.

See before and after screenshots on the JIRA.