### PR TITLE
SAK-41083: Site Info > duplicate course site email notification missing course term variable

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -7540,7 +7540,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		String term_name = "";
 		if (state.getAttribute(STATE_TERM_SELECTED) != null) {
 			term_name = ((AcademicSession) state
-					.getAttribute(STATE_TERM_SELECTED)).getEid();
+					.getAttribute(STATE_TERM_SELECTED)).getTitle();
 		}
 		// get the request email from configuration
 		String requestEmail = getSetupRequestEmailAddress();
@@ -9803,6 +9803,9 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 											ResourcePropertiesEdit rp = site.getPropertiesEdit();
 											rp.addProperty(Site.PROP_SITE_TERM, term.getTitle());
 											rp.addProperty(Site.PROP_SITE_TERM_EID, term.getEid());
+
+											// Need to set STATE_TERM_SELECTED so it shows in the notification email
+											state.setAttribute(STATE_TERM_SELECTED, term);
 										} else {
 											log.warn("termId=" + termId + " not found");
 										}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41083

When duplicating a course site, an email notification is sent. This email does not populate the course term variable, even if selected by the user in the UI. The result is that the email body and subject line lack the information and seem cut off:

> Official Course Site duplicated site (ID b137ac88-ee6a-4479-b832-865b90c1f55a) was set up by Sakai Instructor (instructor, email instructor@example.edu) on 2018-12-13 18:41:44 for

for..... what?? It should say something like:

> Official Course Site duplicated site (ID b137ac88-ee6a-4479-b832-865b90c1f55a) was set up by Sakai Instructor (instructor, email instructor@example.edu) on 2018-12-13 18:41:44 for Spring 2018