### PR TITLE
SAK-41088: Site Info > Manage Tools > Confirmation page no longer indicates renamed tools

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-addRemoveFeatureConfirm.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-addRemoveFeatureConfirm.vm
@@ -14,9 +14,17 @@
 	<p class="instruction" id="removedInstruction" style="display:none">
 		$tlang.getString("addrc.youhave")
 	</p>
+
+	#set($homeToolTitle = $tlang.getString("java.home"))
 	<p class="indnt3">
 		#if (($oldSelectedHome) && (!$check_home))
-			$tlang.getString("java.home")
+			$homeToolTitle
+			#if ($!allowPageOrderHelper)
+				#set($customToolTitle = $validator.escapeHtml($!toolRegistrationTitleList.get($homeToolId)))
+				#if (!$!homeToolTitle.equals($customToolTitle))
+					($customToolTitle)
+				#end
+			#end
 			<br />
 			<script type="text/javascript">
 				document.getElementById('removedInstruction').style.display='block'
@@ -64,6 +72,12 @@
 					#else
 						$!oldToolTitle
 					#end
+					#if ($!allowPageOrderHelper)
+						#set($customToolTitle = $validator.escapeHtml($!toolRegistrationTitleList.get($!oldTool)))
+						#if (!$!oldToolTitle.equals($customToolTitle))
+							($customToolTitle)
+						#end
+					#end
 					<br />
 				#end
 			#end
@@ -89,7 +103,13 @@
 			#if (!$oldSelectedHome)
 				<span class="highlight">
 			#end
-			$tlang.getString("java.home")
+			$homeToolTitle
+			#if ($!allowPageOrderHelper)
+				#set($customToolTitle = $validator.escapeHtml($!toolRegistrationTitleList.get($homeToolId)))
+				#if(!$!homeToolTitle.equals($customToolTitle))
+					($customToolTitle)
+				#end
+			#end
 			#if (!$oldSelectedHome)
 				</span>
 			#end
@@ -117,10 +137,23 @@
 					<span class="highlight">
 				#end
 				#if ($newTool == "sakai.mailbox")
-					$!newToolTitle : $!emailId@$serverName
+					$!newToolTitle 
+					#if ($!allowPageOrderHelper)
+						#set($customToolTitle = $validator.escapeHtml($!toolRegistrationTitleList.get($!newTool)))
+						#if (!$!newToolTitle.equals($customToolTitle))
+							($customToolTitle)
+						#end
+					#end
+					: $!emailId@$serverName
 				#elseif ($!multipleToolIdTitleMap.containsKey($newTool))
 					## show tool title
-					$validator.escapeHtml($!multipleToolIdTitleMap.get($newTool))
+					$!newToolTitle
+					#if ($!allowPageOrderHelper)
+						#set($customToolTitle = $validator.escapeHtml($!toolRegistrationTitleList.get($!newTool)))
+						#if (!$!newToolTitle.equals($customToolTitle))
+							($customToolTitle)
+						#end
+					#end
 					## show tool configuration
 					#if ($!multipleToolIdTitleMap.containsKey($toolId))
 						#set($properties = $!multipleToolConfiguration.get($toolId))
@@ -145,6 +178,12 @@
 				#else
 					$!newToolTitle
 					## exclude Home tool 
+					#if (!$!newTool.equals($homeToolId) && $!allowPageOrderHelper)
+						#set($customToolTitle = $validator.escapeHtml($!toolRegistrationTitleList.get($!newTool)))
+						#if (!$!newToolTitle.equals($customToolTitle))
+							($customToolTitle)
+						#end
+					#end
 				#end
 				#if (!$found)
 					</span>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41088

This essentially just reverts the changes from SAK-41068 and adds some extra conditionals to render the custom tool title in brackets only if it differs from the original tool title.

Before:
> Announcements

After:
> Announcements (Custom Announcements Tool Title)

Also fixes an issue where instance based tools would display their custom tool title twice, instead of the original tool name with the custom tool name in brackets.

Before:
> Lessons Custom Title (Lessons Custom Title)

After:
> Lessons (Lessons Custom Title)

See screenshots in the JIRA.