### PR TITLE
SAK-41091: Site Info > new sakai.property for more granular control of site creation notification emails

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3084,9 +3084,13 @@
 # DEFAULT: true
 # site.setup.import.addmissingtools=false
 
-# SAK-27580: Ability to disable site creation notification that goes to the site creator
+# SAK-27580: Ability to disable site creation notification that goes to the setup.request address
 # DEFAULT: true
 # site.setup.creation.notification = false
+
+# SAK-41091: Ability to disable site creation notification that goes to the user who created the site
+# DEFAULT: true
+# site.setup.creation.notification.user = false
 
 # SAK-29525: Open Template list by default when creating site
 # DEFAULT: false

--- a/site-manage/site-manage-api/api/src/java/org/sakaiproject/sitemanage/api/UserNotificationProvider.java
+++ b/site-manage/site-manage-api/api/src/java/org/sakaiproject/sitemanage/api/UserNotificationProvider.java
@@ -70,8 +70,10 @@ public interface UserNotificationProvider {
 	 * @param courseSite
 	 * @param termTitle
 	 * @param requestEmail
+     * @param sendToRequestEmail if the email should be sent to requestEmail given.
+	 * @param sendToUser if the email should be sent to the user who created the site
 	 */
-	public void notifySiteCreation(Site site, List notifySites, boolean courseSite, String termTitle, String requestEmail);
+	public void notifySiteCreation(Site site, List notifySites, boolean courseSite, String termTitle, String requestEmail, boolean sendToRequestEmail, boolean sendToUser);
 	
 	/**
 	 * send course site request information to course authorizer

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
@@ -308,7 +308,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 		emailTemplateServiceSend(NOTIFY_COURSE_REQUEST_REQUESTER, (new ResourceLoader()).getLocale(), currentUser, from, to, headerTo, replyTo, replacementValues);
 	}
 	
-	public void notifySiteCreation(Site site, List notifySites, boolean courseSite, String termTitle, String requestEmail) {
+	public void notifySiteCreation(Site site, List notifySites, boolean courseSite, String termTitle, String requestEmail, boolean sendToRequestEmail, boolean sendToUser) {
 		User currentUser = userDirectoryService.getCurrentUser();
 		String currentUserDisplayName = currentUser!=null?currentUser.getDisplayName():"";
 		String currentUserDisplayId = currentUser!=null?currentUser.getDisplayId():"";
@@ -348,16 +348,21 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 			replacementValues.put("numSections", "0");
 		}
 		replacementValues.put("sections", buf.toString());
-		
-		emailTemplateServiceSend(NOTIFY_SITE_CREATION, (new ResourceLoader()).getLocale(), currentUser, from, to, headerTo, replyTo, replacementValues);
-		
-		// send a confirmation email to site creator
-		from = requestEmail;
-		to = currentUserEmail;
-		headerTo = currentUserEmail;
-		replyTo = serverConfigurationService.getString("setup.request","no-reply@" + serverConfigurationService.getServerName());
-		emailTemplateServiceSend(NOTIFY_SITE_CREATION_CONFIRMATION, (new ResourceLoader()).getLocale(), currentUser, from, to, headerTo, replyTo, replacementValues);
-		
+
+		if (sendToRequestEmail)
+		{
+			emailTemplateServiceSend(NOTIFY_SITE_CREATION, (new ResourceLoader()).getLocale(), currentUser, from, to, headerTo, replyTo, replacementValues);
+		}
+
+		if (sendToUser)
+		{
+			// send a confirmation email to site creator
+			from = requestEmail;
+			to = currentUserEmail;
+			headerTo = currentUserEmail;
+			replyTo = serverConfigurationService.getString("setup.request","no-reply@" + serverConfigurationService.getServerName());
+			emailTemplateServiceSend(NOTIFY_SITE_CREATION_CONFIRMATION, (new ResourceLoader()).getLocale(), currentUser, from, to, headerTo, replyTo, replacementValues);
+		}
 	}
 	
 	/*

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UserNotificationProviderImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UserNotificationProviderImpl.java
@@ -20,20 +20,16 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Date;
-import java.util.HashMap;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 import org.sakaiproject.component.api.ServerConfigurationService;
-import org.sakaiproject.coursemanagement.api.AcademicSession;
 import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entitybroker.DeveloperHelperService;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.sitemanage.api.UserNotificationProvider;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
-import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
 
 @Slf4j
@@ -224,7 +220,7 @@ public class UserNotificationProviderImpl implements UserNotificationProvider {
 	/**
 	 * {@inheritDoc}
 	 */
-	public void notifySiteCreation(Site site, List notifySites, boolean courseSite, String termTitle, String requestEmail) {
+	public void notifySiteCreation(Site site, List notifySites, boolean courseSite, String termTitle, String requestEmail, boolean sendToRequestEmail, boolean sendToUser) {
 		// send emails
 		String id = site.getId();
 		String title = site.getTitle();
@@ -278,17 +274,23 @@ public class UserNotificationProviderImpl implements UserNotificationProvider {
 				buf.append(rb.getString("java.course2") + " " + course + "\n");
 			}
 		}
-		emailService.send(from, to, message_subject, buf.toString(), headerTo, replyTo, null);
-		
-		// send a confirmation email to site creator
-		from = requestEmail;
-		to = currentUserEmail;
-		headerTo = currentUserEmail;
-		replyTo = serverConfigurationService.getString("setup.request","no-reply@" + serverConfigurationService.getServerName());
-		String content = rb.getFormattedMessage("java.siteCreation.confirmation", new Object[]{title, serverConfigurationService.getServerName()});
-		content += "\n\n" + buf.toString();
-		emailService.send(from, to, message_subject, content, headerTo, replyTo, null);
-		
+
+		if (sendToRequestEmail)
+		{
+			emailService.send(from, to, message_subject, buf.toString(), headerTo, replyTo, null);
+		}
+
+		if (sendToUser)
+		{
+			// send a confirmation email to site creator
+			from = requestEmail;
+			to = currentUserEmail;
+			headerTo = currentUserEmail;
+			replyTo = serverConfigurationService.getString("setup.request","no-reply@" + serverConfigurationService.getServerName());
+			String content = rb.getFormattedMessage("java.siteCreation.confirmation", new Object[]{title, serverConfigurationService.getServerName()});
+			content += "\n\n" + buf.toString();
+			emailService.send(from, to, message_subject, content, headerTo, replyTo, null);
+		}
 	}
 	
 	/**

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -7546,9 +7546,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		String requestEmail = getSetupRequestEmailAddress();
 		User currentUser = UserDirectoryService.getCurrentUser();
 		// read from configuration whether to send out site notification emails, which defaults to be true
-		boolean sendSiteNotificationChoice = ServerConfigurationService.getBoolean("site.setup.creation.notification", true);
-		if (requestEmail != null && currentUser != null && sendSiteNotificationChoice) {
-			userNotificationProvider.notifySiteCreation(site, notifySites, courseSite, term_name, requestEmail);
+		boolean sendToRequestEmail = ServerConfigurationService.getBoolean("site.setup.creation.notification", true);
+		boolean sendToUser = ServerConfigurationService.getBoolean("site.setup.creation.notification.user", true);
+		if (requestEmail != null && currentUser != null && (sendToRequestEmail || sendToUser)) {
+			userNotificationProvider.notifySiteCreation(site, notifySites, courseSite, term_name, requestEmail, sendToRequestEmail, sendToUser);
 		} // if
 
 		// reset locale to user default


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41091

There is a sakai.property to control whether or not site creation notification emails are sent by the system (`site.setup.creation.notification`), which defaults to `true`. Currently, this single property determines if emails are sent to both the user who create the site, and the admin email address.

However, some institutions may want more granular control of this behaviour. For example, institution A may want the email sent to the users who created the sites, but not the admin address. Institution B may want the complete opposite behaviour.

The linked PR here **introduces a second sakai.property (`site.setup.creation.notification.user`)**, which controls if the user creating the site receives the notification email, and the original property would only control if the admin email address receives the emails. This new property also defaults to `true` to preserve OOTB functionality.