### PR TITLE
SAK-41093: Samigo > format dates consistently in submission notification email

### DIFF
--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
@@ -17,7 +17,15 @@ package org.sakaiproject.samigo.impl;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,6 +33,7 @@ import javax.mail.internet.InternetAddress;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.Setter;
+
 import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.authz.api.AuthzGroup;
@@ -46,7 +55,11 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
-import org.sakaiproject.user.api.*;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
 
 @Slf4j
@@ -156,7 +169,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
             // Format dates
             DateFormat dfIn                         = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
             DateFormat dfIn2                        = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
-            DateFormat dfOut                        = DateFormat.getDateInstance(DateFormat.DEFAULT, getUserLocale(user.getId()));
+            DateFormat dfOut                        = new SimpleDateFormat("yyyy-MMM-dd hh:mm a", getUserLocale(user.getId()));
             String formattedDueDate                 = (pubAssFac.getDueDate() == null) ? "" : dfOut.format(pubAssFac.getDueDate());
             Date submissionDate                     = null;
             String inSubmissionDateStr              = (notificationValues.get("submissionDate") == null) ? "" : notificationValues.get("submissionDate").toString();
@@ -272,20 +285,20 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
     }
     
     private Set<String> extractInstructorsFromGroups(Site site,String allGroups){
-    	
-    	Set<String> usersWithRole = new HashSet<String>();
-    	
-    	List<String> groups = Stream.of(allGroups)
-				.map(s -> s.split(";")).flatMap(Arrays::stream)
-				.collect(Collectors.toList());
-    	
-    	for (String groupId : groups){
-    		Group group = site.getGroup(groupId);
-    		Set <String> groupUsersWithRole = group.getUsersHasRole(group.getMaintainRole());
-    		usersWithRole.addAll(groupUsersWithRole);
-    	}
-    	
-    	return usersWithRole;
+
+        Set<String> usersWithRole = new HashSet<>();
+
+        List<String> groups = Stream.of(allGroups)
+                .map(s -> s.split(";")).flatMap(Arrays::stream)
+                .collect(Collectors.toList());
+
+        for (String groupId : groups){
+            Group group = site.getGroup(groupId);
+            Set <String> groupUsersWithRole = group.getUsersHasRole(group.getMaintainRole());
+            usersWithRole.addAll(groupUsersWithRole);
+        }
+
+        return usersWithRole;
     }
 
     private     void                notifyStudent                       (User user, String priStr, int assessmentSubmittedType,


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41093

The current email notification sent out when a user submits a quiz has some inconsistently formatted dates:

> The following assessment submission was recorded by Sakai:
> 
>     Site Title          : Discussion 3 SMPL101
>     Assessment          : due date
> 
>     Student             : 0061 Student (student0061)
>     Submission ID       : 8
>     Submitted on        : 2018-Dec-15 12:23 PM
>     Confirmation Number : 8-17-98871f2b-bbb3-4c6e-b047-446c163792fa-Sat Dec 15 12:23:23 EST 2018
> 
>     Assessment Due Date : 21-Dec-2018
>     Site ID             : 636d17b2-3980-4230-b560-c85e1fcece23
> 
> ---
> This automatic notification message was sent by Sakai (http://localhost:8080/portal)
> Control what email notifications you receive at Home -> Preferences -> Notifications

The "Submitted on" and "Assessment Due Date" fields use two different date formats. Let's be consistent here. After this PR, the dates in the email should be consistent:

> The following assessment submission was recorded by Sakai:
> 
>     Site Title          : Discussion 3 SMPL101
>     Assessment          : due date
> 
>     Student             : 0062 Student (student0062)
>     Submission ID       : 9
>     Submitted on        : 2018-Dec-15 12:43 PM
>     Confirmation Number : 9-17-a2e80501-2186-4a44-8821-1906df8cdb12-Sat Dec 15 12:43:16 EST 2018
> 
>     Assessment Due Date : 2018-Dec-21 07:00 PM
>     Site ID             : 636d17b2-3980-4230-b560-c85e1fcece23
> 
> ---
> This automatic notification message was sent by Sakai (http://localhost:8080/portal)
> Control what email notifications you receive at Home -> Preferences -> Notifications

This issue was originally fixed in SAM-3004 via `cc2143b`, but then regressed in SAM-3004 as well, via `1f47624`.