### PR TITLE
SAK-41095: Lessons > reorder doesn't work in IE11

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ReorderProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ReorderProducer.java
@@ -160,11 +160,6 @@ public class ReorderProducer implements ViewComponentProducer, NavigationCaseRep
 			for (SimplePageItem i : items) {
 
 				if (i == null) {
-				    // marker between used and not used
-				    UIContainer row = UIBranchContainer.make(tofill, "item:");
-				    UIOutput.make(row, "seq", "---").decorate(new UIFreeAttributeDecorator("class", "marker"));
-				    UIOutput.make(row, "text-snippet", messageLocator.getMessage(secondPageId == null ? "simplepage.reorder-belowdelete" : "simplepage.reorder-aboveuse"));
-				    second = true;
 				    continue;
 				}
 

--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -660,6 +660,12 @@ a.edit-link:link, a.edit-link:visited, a.section-merge-link:link, a.section-merg
 .flc-reorderer-module:hover {
     border:1px solid #000;
 }
+.reorderItemsContainer {
+    min-height: 60px;
+}
+.ui-sortable-handle {
+    cursor: move;
+}
 .reordSeqContainer {
     position: absolute;
     width:50px;

--- a/lessonbuilder/tool/src/webapp/js/reorder.js
+++ b/lessonbuilder/tool/src/webapp/js/reorder.js
@@ -1,74 +1,46 @@
-(function($, fluid){
-    //fluid.setLogging(true);
-    initlayoutReorderer = function(){
-        fluid.reorderLayout("#layoutReorderer", {
-            listeners: {
-                afterMove: function(args){
-                    recalculate();
-                }
-            },
-            styles: {
-                defaultStyle: "layoutReorderer-movable-default",
-                selected: "layoutReorderer-movable-selected",
-                dragging: "layoutReorderer-movable-dragging",
-                mouseDrag: "layoutReorderer-movable-mousedrag",
-                dropMarker: "layoutReorderer-dropMarker",
-                avatar: "layoutReorderer-avatar"
-            },
-            disableWrap: true,
-            containerRole: fluid.reorderer.roles.LIST
-        });
-    };
-})(jQuery, fluid);
-
 var recalculate = function(){
     var keepList = '';
     var removeList = '';
-    jQuery('.col1 .layoutReorderer-module').each(function(i){
+    $('.col1 .layoutReorderer-module').each(function(i){
         i > 0 ? keepList = keepList + ' ' + $(this).find('.reorderSeq').text() : keepList = $(this).find('.reorderSeq').text();
     });
-    jQuery('.col2 .layoutReorderer-module').each(function(i){
+    $('.col2 .layoutReorderer-module').each(function(i){
         i > 0 ? removeList = removeList + ' ' + $(this).find('.reorderSeq').text() : removeList = $(this).find('.reorderSeq').text();
     });
     
     keepList=keepList + ' --- ';
     keepList=keepList.replace('  ',' ');
     removeList=removeList.replace('  ',' ');
-    jQuery('input[id=order]').val(keepList + removeList);
-    
-    if (jQuery('.col2 .layoutReorderer-module').length===0){
-        jQuery('.col2 #deleteListHead').attr('class','deleteListMessageEmpty');
-    }
-    else {
-        jQuery('.col2 #deleteListHead').attr('class','deleteListMessage');
-    }
-    $('.layoutReorderer-module').find('.marker').closest('.layoutReorderer-module').remove();
+    $('input[id=order]').val(keepList + removeList);
 };
 $(document).ready(function(){
-    $('.layoutReorderer-module').find('.marker').closest('.layoutReorderer-module').remove();
+    $(".reorderItemsContainer").sortable({
+        start: function(event, ui) {
+            recalculate();
+        },
+        stop: function(event, ui) {
+            recalculate();
+        },
+        connectWith: ".reorderItemsContainer",
+        placeholder: "ui-state-highlight",
+        forcePlaceholderSize: true
+    }).disableSelection();
+
     recalculate();
 
-/*
-    jQuery('.col1 .layoutReorderer-module').each(function(i){
-        i > 0 ? ids = ids + ' ' + $(this).find('.reorderSeq').text() : ids = $(this).find('.reorderSeq').text();
-    });
-    
-    ids=ids + ' --- '
-    ids=ids.replace('  ',' ')
-    jQuery('input[id=order]').val(ids);
-
-*/    
     $('#save').click(function(e){
-	    recalculate();
-	    return true;
-	});
+        recalculate();
+        return true;
+    });
 
     $('.deleteAnswerLink').click(function(e){
         e.preventDefault();
-        $(this).closest('.layoutReorderer-module').addClass('highlightEl').hide().appendTo('#reorderCol2').fadeIn(2000, function(){
+        $(this).closest('.layoutReorderer-module').addClass('highlightEl').hide().appendTo('#deleteListHead').fadeIn(2000, function(){
             $(this).removeClass('highlightEl');
         });
-        
+
+        $(".reorderItemsContainer").sortable('refresh');
+
         recalculate();
     });
 });

--- a/lessonbuilder/tool/src/webapp/templates/Reorder.html
+++ b/lessonbuilder/tool/src/webapp/templates/Reorder.html
@@ -8,10 +8,8 @@
         <link href="/lessonbuilder-tool/css/Simplepagetool.css" rel="stylesheet" media="all" />
         <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
         <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
-        <script type="text/javascript" src="/library/js/fluid/1.5/MyInfusion.js">
-        </script>
-        <script type="text/javascript" src="$context/js/reorder.js">
-        </script>
+        <script type="text/javascript" src="/library/webjars/jquery/1.12.4/jquery.min.js"></script>
+        <script type="text/javascript" src="$context/js/reorder.js"></script>
         <link rel="stylesheet" rsf:id="scr=rewrite-url" href="../css/Simplepagetool.css" type="text/css"/>
         <title rsf:id="msg=simplepage.reorder_header"></title>
     </head>
@@ -29,7 +27,7 @@
                 <div class="columnSetup2 fluid-vertical-order">
                     <!-- invalid drag n drop message template --><!-- Column #1 -->
                     <div class="flc-reorderer-column col1" id="reorderCol1">
-                        <div>
+                        <div class="reorderItemsContainer">
                             <div rsf:id="item:" class="flc-reorderer-module layoutReorderer-module">
                                 <div class="reordSeqContainer">
                                     <div rsf:id="seq" class="reorderSeq">
@@ -51,7 +49,8 @@
                         </div><!-- Column #2 -->
                     </div>
                     <div class="flc-reorderer-column col2" id="reorderCol2">
-                        <div class="deleteListMessageEmpty" id="deleteListHead"><span rsf:id="msg=simplepage.reorder_delebox">Drop off here</span></div>
+                        <span rsf:id="msg=simplepage.reorder_delebox">Drop off here</span>
+                        <div class="deleteListMessageEmpty reorderItemsContainer" id="deleteListHead"></div>
                     </div>
                 </div>
             </div>
@@ -69,8 +68,5 @@
                 </p>
             </form>
         </div>
-        <script type="text/javascript">
-            initlayoutReorderer();
-        </script>
     </body>
 </html>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41095

When using IE11, the "Reorder" functionality in Lessons is broken. The solution is to replace the Fluid JavaScript reorder with jQuery's, which also results in code reduction. The IE11 specific bug is detailed in the testing steps on the JIRA.