### PR TITLE
SAK-41024 - Lessons Print All pages option print content that is hidd…

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1316,7 +1316,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 					cols = colCount(itemList, i.getId());
 					sectionbreak = true;
 					colnum = 0;
-				    } else if ("colunn".equals(i.getFormat()))
+				    } else if ("column".equals(i.getFormat()))
 					colnum++;
 				    columnContainer = UIBranchContainer.make(sectionContainer, "column:");				    
 				    tableContainer = UIBranchContainer.make(columnContainer, "itemTable:");
@@ -1361,6 +1361,10 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 				    // for first item, if wasn't break, process it
 				}
 				
+				if (!simplePageBean.isItemVisible(i, currentPage)) {
+					continue;
+				}
+
 				if(httpServletRequest.getParameter("printall") != null && i.getSakaiId() != null && !"".equals(i.getSakaiId()) && StringUtils.isNumeric(i.getSakaiId())
 						&& !printedSubpages.contains(Long.valueOf(i.getSakaiId())))			
 				{
@@ -1394,9 +1398,6 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 				// (i.getType() == SimplePageItem.PAGE &&
 				// "button".equals(i.getFormat())))
 
-				if (!simplePageBean.isItemVisible(i, currentPage)) {
-					continue;
-				}
 				// break isn't a real item. probably don't want to count it
 				if (i.getType() != SimplePageItem.BREAK)
 				    anyItemVisible[0] = true;


### PR DESCRIPTION
…en or shown in another group

Moved security check up before the loop, also fixed a misspelling of column (not used anywhere else in the code) that had been in there since LSNBLDR-531. 08da59562d7d7f4443b9733056f2df858aef2def