### PR TITLE
SAK-41132: GBNG > make category colour selection deterministic on category name rather than ID

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -531,7 +531,7 @@ public class GbGradebookData {
 
 					nullable(a1.getCategoryId()),
 					a1.getCategoryName(),
-					userSettings.getCategoryColor(a1.getCategoryName(), a1.getCategoryId()),
+					userSettings.getCategoryColor(a1.getCategoryName()),
 					nullable(categoryWeight),
 					a1.isCategoryExtraCredit(),
 
@@ -549,7 +549,7 @@ public class GbGradebookData {
 						nullable(categoryWeight),
 						getCategoryPoints(a1.getCategoryId()),
 						a1.isCategoryExtraCredit(),
-						userSettings.getCategoryColor(a1.getCategoryName(), a1.getCategoryId()),
+						userSettings.getCategoryColor(a1.getCategoryName()),
 						!this.uiSettings.isCategoryScoreVisible(a1.getCategoryName()),
 						FormatHelper.formatCategoryDropInfo(this.categories.stream()
 								.filter(c -> c.getId().equals(a1.getCategoryId()))
@@ -574,7 +574,7 @@ public class GbGradebookData {
 							nullable(categoryWeight),
 							category.getTotalPoints(),
 							category.getExtraCredit(),
-							userSettings.getCategoryColor(category.getName(), category.getId()),
+							userSettings.getCategoryColor(category.getName()),
 							!this.uiSettings.isCategoryScoreVisible(category.getName()),
 							FormatHelper.formatCategoryDropInfo(category)));
 				}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -151,16 +151,16 @@ public class GradebookUiSettings implements Serializable {
 		this.categoryColors.put(categoryName, rgbColorString);
 	}
 
-	public String getCategoryColor(final String categoryName, final Long categoryID) {
+	public String getCategoryColor(final String categoryName) {
 		if (!this.categoryColors.containsKey(categoryName)) {
-			setCategoryColor(categoryName, generateRandomRGBColorString(categoryID));
+			setCategoryColor(categoryName, generateRandomRGBColorString(categoryName));
 		}
 		return this.categoryColors.get(categoryName);
 	}
 
 	public void initializeCategoryColors(final List<CategoryDefinition> categories) {
 		for (CategoryDefinition category : categories) {
-			setCategoryColor(category.getName(), generateRandomRGBColorString(category.getId()));
+			setCategoryColor(category.getName(), generateRandomRGBColorString(category.getName()));
 		}
 	}
 
@@ -178,11 +178,11 @@ public class GradebookUiSettings implements Serializable {
 	/**
 	 * Helper to generate a RGB CSS color string with values between 180-250 to ensure a lighter color e.g. rgb(181,222,199)
 	 */
-	public static String generateRandomRGBColorString(Long categoryID) {
-		if (categoryID == null) {
-			categoryID = -1L;
+	public static String generateRandomRGBColorString(String categoryName) {
+		if (categoryName == null) {
+			categoryName = "";
 		}
-		final Random rand = new Random(categoryID);
+		final Random rand = new Random(categoryName.hashCode());
 		final int min = 180;
 		final int max = 250;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
@@ -67,7 +67,7 @@ public class SortGradeItemsByCategoryPanel extends Panel {
 				Collections.sort(assignments, new CategorizedAssignmentComparator());
 
 				categoryItem.add(new AttributeModifier("style",
-						String.format("border-left-color: %s", settings.getCategoryColor(category.getName(), category.getId()))));
+						String.format("border-left-color: %s", settings.getCategoryColor(category.getName()))));
 				categoryItem.add(new Label("name", category.getName()));
 				categoryItem.add(new ListView<Assignment>("gradeItemList", assignments) {
 					@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
@@ -83,8 +83,7 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 			@Override
 			protected void populateItem(final ListItem<String> categoryItem) {
 				final String categoryName = categoryItem.getModelObject();
-				final Long categoryID = categoryNameToIdMap.get(categoryName);
-				final String categoryColor = settings.getCategoryColor(categoryName, categoryID);
+				final String categoryColor = settings.getCategoryColor(categoryName);
 
 				WebMarkupContainer categoryFilter = new WebMarkupContainer("categoryFilter");
 				if (!categoriesEnabled) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41132

In SAK-33827 we made the colour selection algorithm deterministic based on category ID, so the colour didn't change every time you visited or reset the tool. This improvement was well received by the community, but was requested to be improved such that the determining factor is the category name rather than it's ID. In this way, as long as the category name stays the same, the colour will stay the same (for example, across site duplication, site content copies, etc.)