### PR TITLE
SAK-41058 > bug fix for Double comparison

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7238,7 +7238,7 @@ public class AssignmentAction extends PagedResourceActionII {
                     if (droppedCategoryPoints != -1) {
                         int factor = assignmentService.getScaleFactor();
                         Double enteredPoints = new Double(displayGrade(state, gradePoints, factor));
-                        if (enteredPoints != droppedCategoryPoints) {
+                        if (!enteredPoints.equals(droppedCategoryPoints)) {
                           addAlert(state, rb.getFormattedMessage("pleasee6", new Object[] {droppedCategoryPoints.toString()}));
                         }
                     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41058

A bug was discovered during testing. Non-primitive `Double`s were being compared with `!=` rather than `!<>.equals()`.