### PR TITLE
SAK-41016 Lessons: Add an "a" to the documentation page to reflect the earlier change

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/instructions/website.html
+++ b/lessonbuilder/tool/src/webapp/templates/instructions/website.html
@@ -25,7 +25,7 @@ margin-right:345px;
 <h3> ADDING CONTENT FROM PACKAGES SUCH AS CAMTASIA, WIMBA CREATE AND ARTICULATE</h3>
 
 <p>
-The "Upload Content from ZIP File" dialog allows you to add content from a file.
+The "Upload Content from a ZIP File" dialog allows you to add content from a file.
 There is specific support for Camtasia, Wimba Create, and Articulate, but
 any ZIP file containing resources may be uploaded. Content will be uploaded into a folder
 in Resources. Where possible a link will be added in the Lesson to the content.</p>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41016

As @buckett mentioned in #6311, "Upload Content from ZIP File" should contain an "a" to be "Upload Content from a ZIP File" to reflect the main change for SAK-41016. This additional PR adds the "a" because #6311 was already merged.