### PR TITLE
SAK-41136 Moved the Rubrics SASS variables to the SASS modules

### DIFF
--- a/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_variables.scss
+++ b/library/src/morpheus-master/bootstrap-sass-3.3.7/assets/stylesheets/bootstrap/_variables.scss
@@ -821,46 +821,6 @@ $carousel-indicator-border-color:             #fff !default;
 $carousel-caption-color:                      #fff !default;
 
 
-//== Rubrics
-//
-//##
-
-$rubrics-manager-bg:            #f9f9f9 !default;
-$rubrics-manager-border-color:  #ddd !default;
-
-$rubrics-title-bg:              #f2f2f4 !default;
-$rubrics-title-active-bg:       #ced5e0 !default;
-$rubrics-title-border-color:    #e4e4e6 !default;
-$rubrics-title-border-size:     1px !default;
-
-$rubrics-icon-bg:               #6e757d !default;
-$rubrics-icon-active-bg:        #e7e7e7 !default;
-$rubrics-icon-color:            #f2f2f4 !default;
-
-$rubrics-lightbox-bg:           #fff !default;
-$rubrics-lightbox-border-color: #555 !default;
-$rubrics-lightbox-border-size:  1px !default;
-
-$rubrics-crit-border-color:     #d3d3d3 !default;
-$rubrics-crit-border-size:      1px !default;
-$rubrics-crit-detail-bg:        #f2f2f4 !default;
-$rubrics-crit-detail-color:     #414141 !default;
-$rubrics-crit-actions-bg:       #f2f2f4 !default;
-$rubrics-crit-title-color:      #2f2f2f !default;
-$rubrics-crit-item-title-color: #3a3a3a !default;
-
-$rubrics-item-color:            #747474 !default;
-$rubrics-item-points-color:     #444444 !default;
-
-$rubrics-rating-hover-bg:       #D7E1E7 !default;
-$rubrics-rating-selected-bg:    #bed8e7 !default;
-
-$rubrics-link-color:            #0093b8 !default;
-$rubrics-empty-bg:              #fff !default;
-$rubrics-disabled-label-color:  #ccc !default;
-$rubrics-popover-cancel-color:  #777 !default;
-
-
 //== Close
 //
 //##

--- a/library/src/morpheus-master/sass/modules/tool/rubrics/_rubrics.scss
+++ b/library/src/morpheus-master/sass/modules/tool/rubrics/_rubrics.scss
@@ -1,3 +1,5 @@
+@import "_rubrics_variables";
+
 .#{$namespace}sakai-rubrics {
     .manager-collapse-title {
         cursor: pointer;

--- a/library/src/morpheus-master/sass/modules/tool/rubrics/_rubrics_variables.scss
+++ b/library/src/morpheus-master/sass/modules/tool/rubrics/_rubrics_variables.scss
@@ -1,0 +1,36 @@
+// Rubrics variables
+
+$rubrics-manager-bg:            #f9f9f9 !default;
+$rubrics-manager-border-color:  #ddd !default;
+
+$rubrics-title-bg:              #f2f2f4 !default;
+$rubrics-title-active-bg:       #ced5e0 !default;
+$rubrics-title-border-color:    #e4e4e6 !default;
+$rubrics-title-border-size:     1px !default;
+
+$rubrics-icon-bg:               #6e757d !default;
+$rubrics-icon-active-bg:        #e7e7e7 !default;
+$rubrics-icon-color:            #f2f2f4 !default;
+
+$rubrics-lightbox-bg:           #fff !default;
+$rubrics-lightbox-border-color: #555 !default;
+$rubrics-lightbox-border-size:  1px !default;
+
+$rubrics-crit-border-color:     #d3d3d3 !default;
+$rubrics-crit-border-size:      1px !default;
+$rubrics-crit-detail-bg:        #f2f2f4 !default;
+$rubrics-crit-detail-color:     #414141 !default;
+$rubrics-crit-actions-bg:       #f2f2f4 !default;
+$rubrics-crit-title-color:      #2f2f2f !default;
+$rubrics-crit-item-title-color: #3a3a3a !default;
+
+$rubrics-item-color:            #747474 !default;
+$rubrics-item-points-color:     #444444 !default;
+
+$rubrics-rating-hover-bg:       #D7E1E7 !default;
+$rubrics-rating-selected-bg:    #bed8e7 !default;
+
+$rubrics-link-color:            #0093b8 !default;
+$rubrics-empty-bg:              #fff !default;
+$rubrics-disabled-label-color:  #ccc !default;
+$rubrics-popover-cancel-color:  #777 !default;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41136

The reorganization of the Rubrics CSS in SAK-41081 put the Rubrics SASS variables in the Bootstrap project's _variables.scss file. My fix moves these variables to the Sakai SASS files in the Rubrics tool folder as a separate file for organizational consistency. 