### PR TITLE
SAK-31709 - Favorites doesn't work if site id is numeric

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
@@ -23,6 +23,9 @@ import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.user.cover.PreferencesService;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.sakaiproject.site.cover.SiteService;
 import org.sakaiproject.user.api.Preferences;
 import java.util.Collections;
@@ -45,7 +48,7 @@ import org.sakaiproject.exception.InUseException;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.site.api.SiteService.SelectionType;
 import org.sakaiproject.site.api.SiteService.SortType;
-
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -56,6 +59,7 @@ import org.json.simple.parser.ParseException;
  * Handles AJAX requests from the "More Sites" drawer.
  *
  */
+@Slf4j
 public class FavoritesHandler extends BasePortalHandler
 {
 	private static final String URL_FRAGMENT = "favorites";
@@ -188,46 +192,60 @@ public class FavoritesHandler extends BasePortalHandler
 		if( !newFavorites.equals(existingFavorites) || firstTimeFavs ) {
 			// There are new favourites and need to update database. 
 			// We will not lock database if it's not neccessary
-			PreferencesEdit edit = PreferencesService.edit(userId);
-			ResourcePropertiesEdit props = edit.getPropertiesEdit(org.sakaiproject.user.api.PreferencesService.SITENAV_PREFS_KEY);
-			if (firstTimeFavs) {
-				props.removeProperty(FIRST_TIME_PROPERTY);
-				props.addProperty(FIRST_TIME_PROPERTY, String.valueOf(false));
-			}
-			props.removeProperty(SEEN_SITES_PROPERTY);
-			for (Site userSite : userSites) {
-				props.addPropertyToList(SEEN_SITES_PROPERTY, userSite.getId());
-			}
-			props.removeProperty(FAVORITES_PROPERTY);
-			for (String siteId : newFavorites) {
-				props.addPropertyToList(FAVORITES_PROPERTY, siteId);
-			}
+			PreferencesEdit edit = null;
+			try {
+				edit = PreferencesService.edit(userId);
+				ResourcePropertiesEdit props = edit.getPropertiesEdit(org.sakaiproject.user.api.PreferencesService.SITENAV_PREFS_KEY);
+				if (firstTimeFavs) {
+					props.removeProperty(FIRST_TIME_PROPERTY);
+					props.addProperty(FIRST_TIME_PROPERTY, String.valueOf(false));
+				}
+				props.removeProperty(SEEN_SITES_PROPERTY);
+				for (Site userSite : userSites) {
+					props.addPropertyToList(SEEN_SITES_PROPERTY, userSite.getId());
+				}
+				props.removeProperty(FAVORITES_PROPERTY);
+				for (String siteId : newFavorites) {
+					props.addPropertyToList(FAVORITES_PROPERTY, siteId);
+				}
 
-			PreferencesService.commit(edit);
+				PreferencesService.commit(edit);
+			}
+			catch (PermissionException | InUseException | IdUnusedException e){
+				log.info("Exception editing user preferences", e);
+				PreferencesService.cancel(edit);
+			}
 		}
 
 		return newFavorites;
 	}
 
-	private void saveUserFavorites(String userId, UserFavorites favorites) throws PermissionException, InUseException, IdUnusedException, PortalHandlerException {
+	private void saveUserFavorites(String userId, UserFavorites favorites) throws PortalHandlerException {
 		if (userId == null) {
 			return;
 		}
 
-		PreferencesEdit edit = PreferencesService.edit(userId);
-		ResourcePropertiesEdit props = edit.getPropertiesEdit(org.sakaiproject.user.api.PreferencesService.SITENAV_PREFS_KEY);
+		PreferencesEdit edit = null;
+		try {
+			edit = PreferencesService.edit(userId);
+			ResourcePropertiesEdit props = edit.getPropertiesEdit(org.sakaiproject.user.api.PreferencesService.SITENAV_PREFS_KEY);
 
-		// Replace all existing values
-		props.removeProperty(FAVORITES_PROPERTY);
+			// Replace all existing values
+			props.removeProperty(FAVORITES_PROPERTY);
 
-		for (String siteId : favorites.favoriteSiteIds) {
-			props.addPropertyToList(FAVORITES_PROPERTY, siteId);
+			for (String siteId : favorites.favoriteSiteIds) {
+				props.addPropertyToList(FAVORITES_PROPERTY, siteId);
+			}
+
+			props.removeProperty(AUTO_FAVORITE_ENABLED_PROPERTY);
+			props.addProperty(AUTO_FAVORITE_ENABLED_PROPERTY, String.valueOf(favorites.autoFavoritesEnabled));
+
+			PreferencesService.commit(edit);
 		}
-
-		props.removeProperty(AUTO_FAVORITE_ENABLED_PROPERTY);
-		props.addProperty(AUTO_FAVORITE_ENABLED_PROPERTY, String.valueOf(favorites.autoFavoritesEnabled));
-
-		PreferencesService.commit(edit);
+		catch (PermissionException | InUseException | IdUnusedException e){
+			log.info("Exception editing user preferences", e);
+			PreferencesService.cancel(edit);
+		}
 	}
 
 	public static class UserFavorites {
@@ -254,7 +272,14 @@ public class FavoritesHandler extends BasePortalHandler
 			JSONObject obj = (JSONObject)parser.parse(json);
 
 			UserFavorites result = new UserFavorites();
-			result.favoriteSiteIds = new LinkedHashSet<String>((List<String>)obj.get("favoriteSiteIds"));
+			result.favoriteSiteIds = new LinkedHashSet<String>();
+
+			JSONArray favoriteSiteIds = (JSONArray) obj.get("favoriteSiteIds");
+			if (favoriteSiteIds != null) {
+				for (Object favoriteSiteId : favoriteSiteIds) {
+					result.favoriteSiteIds.add(String.valueOf(favoriteSiteId));
+				}
+			}
 			result.autoFavoritesEnabled = (Boolean)obj.get("autoFavoritesEnabled");
 
 			return result;


### PR DESCRIPTION
The change for this was in line 275-282. That does an explicit conversion to get the value of the Json as a String. Otherwise it was having a problem in the for loop. I thought about doing it where the exception was but that seems like it could cause issues for anything else that might use that value and the exception was that this would always be String values.

The rest of this change is exception handling that resulted in the call going up into the response as a stack trace. Seems better to print it out to the logs when there's an error here and also cancel the edit if there is a problem (Like IdUseException) which was thrown up but never seen.