### PR TITLE
SAK-31709 Correctly handle numeric Site IDs

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -369,7 +369,7 @@ $PBJQ(document).ready(function($){
   // selector to cope with Site IDs containing strange characters.
   var itemsBySiteId = {};
   $PBJQ('.site-favorite-btn', favoritesPane).each(function (i, e) {
-    itemsBySiteId[$PBJQ(e).data('site-id')] = $PBJQ(e).parent();
+    itemsBySiteId[$PBJQ(e).attr('data-site-id')] = $PBJQ(e).parent();
   });
 
   var button_states = {
@@ -464,7 +464,7 @@ $PBJQ(document).ready(function($){
 
   var renderFavorites = function (favorites) {
     $PBJQ('.site-favorite-btn', favoritesPane).each(function (idx, btn) {
-      var buttonSiteId = $PBJQ(btn).data('site-id');
+      var buttonSiteId = $PBJQ(btn).attr('data-site-id');
 
       if ($PBJQ(btn).closest('.my-workspace').length > 0) {
         setButton(btn, 'myworkspace');
@@ -494,7 +494,7 @@ $PBJQ(document).ready(function($){
   var listFavorites = function () {
     // Any favorite button with the 'site-favorite' class has been starred.
     return $PBJQ('.site-favorite-btn', favoritesPane).has('.site-favorite').map(function () {
-      return $PBJQ(this).data('site-id');
+      return $PBJQ(this).attr('data-site-id');
     }).toArray();
   }
 
@@ -660,7 +660,7 @@ $PBJQ(document).ready(function($){
   $PBJQ(favoritesPane).on('click', '.site-favorite-btn', function () {
     var self = this;
 
-    var siteId = $PBJQ(self).data('site-id');
+    var siteId = $PBJQ(self).attr('data-site-id');
     var originalState = $PBJQ(self).data('favorite-state');
 
     if (originalState === 'myworkspace') {
@@ -836,8 +836,8 @@ $PBJQ(document).ready(function($){
           highlightMaxItems();
 
           // Update our ordering based on the new selection
-          favoritesList = list.find('.organize-favorite-item').map(function () {
-            return $PBJQ(this).data('site-id');
+          favoritesList = list.find('.organize-favorite-item *[data-site-id]').map(function () {
+            return $PBJQ(this).attr('data-site-id');
           }).toArray();
 
           // and send it all to the server
@@ -874,7 +874,7 @@ $PBJQ(document).ready(function($){
       // The clicked item was currently in "purgatory", having been unfavorited
       // in the process of organizing favorites.  This click will promote it
       // back to a favorite
-      var siteId = $PBJQ(self).data('site-id');
+      var siteId = $PBJQ(self).attr('data-site-id');
       returnElementToOriginalPositionIfPossible(siteId)
 
       var newIndex = favoritesList.indexOf(siteId);
@@ -900,7 +900,7 @@ $PBJQ(document).ready(function($){
     // Set the favorite state for both the entry under "Organize" and the
     // original entry under "Sites"
     setButton(self, buttonState);
-    setButton(itemsBySiteId[$PBJQ(self).data('site-id')].find('.site-favorite-btn'),
+    setButton(itemsBySiteId[$PBJQ(self).attr('data-site-id')].find('.site-favorite-btn'),
               buttonState);
 
     setAllOrNoneStarStates();

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
@@ -254,7 +254,17 @@ public class FavoritesHandler extends BasePortalHandler
 			JSONObject obj = (JSONObject)parser.parse(json);
 
 			UserFavorites result = new UserFavorites();
-			result.favoriteSiteIds = new LinkedHashSet<String>((List<String>)obj.get("favoriteSiteIds"));
+			result.favoriteSiteIds = new LinkedHashSet<String>();
+
+			if (obj.get("favoriteSiteIds") != null) {
+			    // Site IDs might be numeric, so coerce everything to strings.
+			    for (Object siteId : (List<String>)obj.get("favoriteSiteIds")) {
+				if (siteId != null) {
+				    result.favoriteSiteIds.add(siteId.toString());
+				}
+			    }
+			}
+
 			result.autoFavoritesEnabled = (Boolean)obj.get("autoFavoritesEnabled");
 
 			return result;


### PR DESCRIPTION
Where a site's ID was numeric, the favorites JS was sending the Site
ID through as an integer rather than a string, causing an exception on
the server side.  Fixed this as follows:

  * Have the FavoritesHandler code (server-side) coerce all incoming
    Site IDs to Strings.

  * Modify the jQuery code to use `.attr()` instead of `.data()` when
    retrieving Site IDs off DOM elements.  This avoids any attempt to
    coerce the stored values into JS types, which we didn't want
    anyway.