### PR TITLE
SAK-41123 - In section info, if you block a readOnly group you are no…

### DIFF
--- a/sections/sections-app-util/src/java/org/sakaiproject/tool/section/decorator/SectionDecorator.java
+++ b/sections/sections-app-util/src/java/org/sakaiproject/tool/section/decorator/SectionDecorator.java
@@ -75,6 +75,7 @@ public class SectionDecorator implements RowGroupable,Serializable, Comparable{
 
     // SAK-23495
     protected boolean readOnly;
+    protected boolean isReadOnlyCategory;
     private static Set<String> readOnlyCategories;
 
     protected boolean lockedForDeletion;
@@ -104,6 +105,7 @@ public class SectionDecorator implements RowGroupable,Serializable, Comparable{
             }
         }
         this.readOnly = readOnlyCategories.contains(section.getCategory()) || section.isLocked();  
+        this.isReadOnlyCategory = readOnlyCategories.contains(section.getCategory());
         this.lockedForDeletion = section.isLockedForDeletion();  
     }
 
@@ -142,6 +144,14 @@ public class SectionDecorator implements RowGroupable,Serializable, Comparable{
     public boolean isReadOnly() {
     	return readOnly;
     }
+    public boolean isReadOnlyCategory() {
+        return isReadOnlyCategory;
+    }
+
+    public void setReadOnlyCategory(boolean isReadOnlyCategory) {
+        this.isReadOnlyCategory = isReadOnlyCategory;
+    }
+
     public boolean isLockedForDeletion() {
         return lockedForDeletion;
     }

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/EditStudentsBean.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/EditStudentsBean.java
@@ -320,6 +320,6 @@ public class EditStudentsBean extends EditManagersBean implements Serializable {
 	public boolean isFromCategoryReadOnly(String secUuid) {
 		CourseSection section=getSectionManager().getSection(secUuid);
 		SectionDecorator sc=new SectionDecorator(section, true);
-		return sc.isReadOnly() && !section.isLocked();
+		return sc.isReadOnlyCategory();
     }
 }


### PR DESCRIPTION
…t able to see unassigned students

This shouldn't be this way because is a ReadOnly group used to fill the custom groups.