### PR TITLE
SAK-41158 - Point values of gradebook items created from tests & quizzes can have precision errors

### DIFF
--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessmentData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessmentData.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.tool.assessment.data.dao.assessment;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -676,7 +677,7 @@ public class PublishedAssessmentData
   }
 
   public Double getTotalScore(){
-    double total = 0;
+    BigDecimal total = BigDecimal.valueOf(0);
     Iterator iter = this.sectionSet.iterator();
     while (iter.hasNext()){
       PublishedSectionData s = (PublishedSectionData) iter.next();
@@ -702,10 +703,10 @@ public class PublishedAssessmentData
 
       while (iter2.hasNext()){
         PublishedItemData item = (PublishedItemData)iter2.next();
-        total= total + item.getScore().doubleValue();
+        total = total.add(BigDecimal.valueOf(item.getScore().doubleValue()));
       }
     }
-    return  Double.valueOf(total);
+    return  Double.valueOf(total.doubleValue());
   }
 
   public Set getAssessmentAttachmentSet() {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
@@ -21,6 +21,7 @@
 
 package org.sakaiproject.tool.assessment.facade;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -717,7 +718,7 @@ public class PublishedAssessmentFacade
   }
 
   public Double getTotalScore(){
-    double total = 0;
+    BigDecimal total = BigDecimal.valueOf(0);
     Iterator iter = this.publishedSectionSet.iterator();
     while (iter.hasNext()){
       SectionDataIfc s = (SectionDataIfc) iter.next();
@@ -744,10 +745,10 @@ public class PublishedAssessmentFacade
 
       while (iter2.hasNext()){
         ItemDataIfc item = (ItemDataIfc)iter2.next();
-        total= total + item.getScore().doubleValue();
+        total = total.add(BigDecimal.valueOf(item.getScore().doubleValue()));
       }
     }
-    return  Double.valueOf(total);
+    return  Double.valueOf(total.doubleValue());
   }
 
   public PublishedAssessmentFacade clonePublishedAssessment(){


### PR DESCRIPTION
Steps:
1) Create a quiz with, say, 3 questions each worth 0.1 points
2) Create a gradebook category that uses at least one of the drop highest / drop lowest / keep highest features
3) Create an item in that gradebook category worth 0.3 points
Edit the quiz's gradebook item, adding it to that category
Symptom:
The point value doesn't match the existing items, so you get a feedback message indicating the point value doesn't match the maximum of 0.3. Cause we all know that 
0.1 + 0.1 + 0.1 = 0.30000000000000004
it's basic arithmetic!

Solution - when calculating the total point value of a quiz, use BigDecimal