### PR TITLE
SAK-33755 - Posting assignment due date to calendar does not add it t…

### DIFF
--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -3287,11 +3287,10 @@ extends VelocityPortletStateAction
 		boolean firstTime = true; // Don't need to do complex checking the first time.
 		Vector events = new Vector(); // A vector of vectors, each of the vectors containing a range of previous events.
 		
-		//This +1 and -1 here are from SAK-13120 to work around an issue with endTime being included and not adding correctly
-		Time timeObj = TimeService.newTimeLocal(year,month,day,time,00,00,000+1);
+		Time timeObj = TimeService.newTimeLocal(year,month,day,time,00,00,000);
 		
 		long duration = ((30*60)*(1000));
-		Time updatedTime = TimeService.newTime(timeObj.getTime()+ duration-1);
+		Time updatedTime = TimeService.newTime(timeObj.getTime()+ duration);
 		
 		/*** include the start time ***/
 		TimeRange timeRangeObj = TimeService.newTimeRange(timeObj,updatedTime,true,false);

--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_viewWeek.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_viewWeek.vm
@@ -327,13 +327,18 @@
         #set ($startTime = $dStart.get($n))
 	#end
 
+    ## This is a fudged endtime it will not include work if the endtime is intended to be included
     #set ($endTime = $event.getRange().lastTime(0))
+    #set ($endTimeActual = $event.getRange().lastTime())
+
     #if ($endTime.after($dEnd.get($n)))
         ## use the page end time as event's first time temporarily
         #set ($endTime = $dEnd.get($n))
 	#end
 
     #set ($du = $endTime.getTime().intValue() - $startTime.getTime().intValue())
+    ## The Real non-fudged endtime
+    #set ($dureal = $endTime.getTime().intValue() - $startTime.getTime().intValue())
     #set($dhour = $helper.getduration($du.longValue(),3600000))
     #set($dminute = $helper.getFractionIn($du.longValue(),$dhour))
 
@@ -353,6 +358,7 @@
 
     #set ($rowspan = 1)
     #set ($startMinInt = $startTime.breakdownLocal().getMin())
+	## $event.getDisplayName():$startTime:$endTime:$startMinInt:$duMin<br>
     #if ($startMinInt <30)
     #set ($rowspan = $rowspan + (($duMin - (30 - $startMinInt))/30))
     #set ($oneMore = ($duMin - (30 - $startMinInt))%30)
@@ -363,8 +369,13 @@
     #end
     ###set ($oneMore = ($duMin - (30 - $startMinInt))%30)
     #if ($oneMore > 0)
-    #set ($rowspan = $rowspan + 1)
+    	#set ($rowspan = $rowspan + 1)
     #end
+    ## This endtime may have been fudged, if so it will need an extra row as it's being returned from getNewEvents
+    #if ($endTime != $endTimeActual)
+    	#set ($rowspan = $rowspan + 1)
+    #end
+    
 #end    ## endof macro-rowspan
 
 


### PR DESCRIPTION
…o the day or weekly view

This reverts an patch from SAK-13120 and applies directly to the macro in weekly view instead. 

This is assignment due date on the weekly view
![image](https://user-images.githubusercontent.com/27447/50742797-d88bdc80-11dd-11e9-9bca-a36bd807ec2f.png)

And this is on the day view
![image](https://user-images.githubusercontent.com/27447/50742807-ec374300-11dd-11e9-9456-a21a160e6d37.png)

I also verified that SAK-13120 works. I had to use the groovy in SAK-33360 to test that. The only issue with this is it will take up an extra row on the week and day view. I feel like this is *fine*. This is because with the end time included, it's also picked up as a start time. Ideally we'll change some of these views in 20 to a new calendar (@mpellicer mentioned this) but from my testing this fixes a lot of related issues.

![image](https://user-images.githubusercontent.com/27447/50742869-85665980-11de-11e9-83ee-7b5f469f757a.png)

This was all started from a really old hack on SAK-5748 where people didn't want to see the end time as :59 if the end time wasn't "included". However if it wasn't included it caused the issue on SAK-13120.
