### PR TITLE
SAK-41192 - Parsing errors when grading tests & quizzes with 1000+ points

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/util/ContextUtil.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/util/ContextUtil.java
@@ -336,6 +336,7 @@ public static ArrayList paramArrayValueLike(String paramPart)
   public static String getRoundedValue(Double orig, int maxdigit) {
       Locale loc = new ResourceLoader().getLocale();
       NumberFormat nf = NumberFormat.getInstance(loc);
+      nf.setGroupingUsed(false);
       nf.setMaximumFractionDigits(maxdigit);
       String newscore = nf.format(orig);
       return newscore;


### PR DESCRIPTION
There's a NumberFormat in ContextUtil.getRoundedValue(...), which adds grouping separators, I.e. the comma in "1,000". Some of these commas make their way into text fields (scores on the Questions tab for instance); when you submit those text fields validation errors ensue as commas are unexpected. I don't believe there are any other UIs in Sakai that use grouping on grades.

Eliminate the grouping commas by invoking 'setGroupingUsed(false)' on the NumberFormat instance