### PR TITLE
SAK-41196 Have the logger come from job configuration.

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/logmessage/LogMessageJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/logmessage/LogMessageJob.java
@@ -15,10 +15,10 @@
  */
 package org.sakaiproject.component.app.scheduler.jobs.logmessage;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.quartz.JobExecutionException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
@@ -28,7 +28,6 @@ import org.sakaiproject.component.app.scheduler.jobs.AbstractConfigurableJob;
  * This is a simple Job that allows a message to be logged.
  * This is useful for testing and time stamping the log files.
  */
-@Slf4j
 public class LogMessageJob extends AbstractConfigurableJob {
 
     private static final Marker fatal = MarkerFactory.getMarker("FATAL");
@@ -38,6 +37,7 @@ public class LogMessageJob extends AbstractConfigurableJob {
         String level = getConfiguredProperty("level");
         String message = getConfiguredProperty("message");
         String logger = getConfiguredProperty("logger");
+        Logger log = LoggerFactory.getLogger(logger);
         if ("trace".equalsIgnoreCase(level)) {
             log.trace(message);
         } else if ("debug".equalsIgnoreCase(level)) {


### PR DESCRIPTION
The logger to use should come from the Job configuration.