### PR TITLE
SAK-41209: GradebookNG > new sakai.property to disable 'Set Zero Score for Empty Cells'

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1839,6 +1839,10 @@
 # Default: 20,000
 # gradebookng.maxCommentLength=500
 
+# SAK-41209: control visibility of the 'Set Zero Score for Empty Cells' menu option
+# DEFAULT: true (visibile)
+# gradebookng.showSetZeroScore=false
+
 # ASSIGNMENT 1
 # Allows an instructor or any user with assignments management permissions to submit the assignment on behalf of a student 
 # who has no submission yet (via the View Assignment list by student)

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -42,7 +42,9 @@
                             <span class="caret"></span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-right" role="menu">
-                            <li><a href="javascript:void(0);" class="gb-set-zero-score" role="menuitem"><wicket:message key="coursegrade.option.setungraded" /></a></li>
+                            {if settings.isSetUngradedToZeroEnabled}
+                                <li><a href="javascript:void(0);" class="gb-set-zero-score" role="menuitem"><wicket:message key="coursegrade.option.setungraded" /></a></li>
+                            {/if}
                             {if !settings.isCategoryTypeWeighted}
                                 <li>
                                     <a href="javascript:void(0);" class="gb-toggle-points" role="menuitem">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -30,6 +30,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.wicket.Component;
 import org.apache.wicket.model.StringResourceModel;
+
+import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.gradebookng.business.GbCategoryType;
 import org.sakaiproject.gradebookng.business.GbRole;
 import org.sakaiproject.gradebookng.business.model.GbCourseGrade;
@@ -53,6 +55,9 @@ import lombok.Value;
 public class GbGradebookData {
 
 	private final int NULL_SENTINEL = 127;
+
+	private static final String SAK_PROP_SHOW_SET_ZERO_SCORE = "gradebookng.showSetZeroScore";
+	private static final boolean SAK_PROP_SHOW_SET_ZERO_SCORE_DEFAULT = true;
 
 	@Data
 	private class StudentDefinition {
@@ -386,6 +391,7 @@ public class GbGradebookData {
 		result.put("showPoints", this.uiSettings.getShowPoints());
 		result.put("isUserAbleToEditAssessments", isUserAbleToEditAssessments());
 		result.put("isStudentNumberVisible", this.isStudentNumberVisible);
+		result.put("isSetUngradedToZeroEnabled", ServerConfigurationService.getBoolean(SAK_PROP_SHOW_SET_ZERO_SCORE, SAK_PROP_SHOW_SET_ZERO_SCORE_DEFAULT));
 
 		return result;
 	};


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41209

It may be desirable for an institution to disable the ability for users to invoke the "Set Zero Score for Empty Cells" function, as it can be dangerous and difficult to reverse.

This PR introduces a new sakai.property (`gradebookng.showSetZeroScore`), which controls whether or not the option will appear in the menu. The property defaults to `true` to preserve OOTB functionality.

This may also be a desired interim solution for those who are concerned with related issues, https://jira.sakaiproject.org/browse/SAK-33110 and https://jira.sakaiproject.org/browse/SAK-41154.