### PR TITLE
SAK-40080 Assignments: Updated the wording of the Resubmissions option on the grading list page

### DIFF
--- a/assignment/bundles/resources/assignment.properties
+++ b/assignment/bundles/resources/assignment.properties
@@ -853,11 +853,11 @@ all = All
 
 allowResubmission.show = Show Settings for Allowing Resubmissions
 allowResubmission.hide = Hide Settings for Allowing Resubmissions
-allowResubmission.label = Select User(s) and Allow Resubmission
-allowResubmission.groups.label = Select Group(s) and Allow Resubmission
-allowResubmission.instruction = Select user(s) and apply the resubmission settings.
-allowResubmission.groups.instruction = Select group(s) and apply the resubmission settings.
-allowResubmission.nouser = Please choose at least one user for setting the resubmission choices.
+allowResubmission.label = Set Resubmission Options for Multiple Students
+allowResubmission.groups.label = Set Resubmission Options for Multiple Groups
+allowResubmission.instruction = Select students from the table below. Set the number of resubmissions each student is allowed and the date they can resubmit by. Click "Update" to allow the selected students to resubmit to this assignment.
+allowResubmission.groups.instruction = Select groups from the table below. Set the number of resubmissions each group is allowed and the date they can resubmit by. Click "Update" to allow the selected groups to resubmit to this assignment.
+allowResubmission.nouser = Please choose at least one user or group from the table below for setting the resubmission options.
 allowResubmission.toggleall   = Select/unselect all to allow for resubmission
 allowResubmission.select.student = Allow resubmission from 
 #SAK-31405

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -273,9 +273,7 @@ function printView(url) {
 					</div>
 				#end
 				<div id="sendFeedbackPanelContent" style="display:none;">
-					<p class="text-info">
-						$tlang.getString("sendFeedback.instruction")
-					</p>
+					<p>$tlang.getString("sendFeedback.instruction")</p>
 					<textarea cols=40 rows=5 name="commentFeedback"></textarea>
 					<div class="form-group">
 						<label>$tlang.getString("sendFeedback.options"):</label>
@@ -304,14 +302,14 @@ function printView(url) {
 					</a>
 				</p>
 				<div id="allowResubmissionPanelContent" style="display:none; overflow: hidden;">
-				<p class="text-info">
+				<p>
 				#if ($assignment.IsGroup)
 					$tlang.getString("allowResubmission.groups.instruction")
 				#else
 					$tlang.getString("allowResubmission.instruction")
 				#end
 				</p>
-							<p class="shorttext" id="allowResubmitNumber">
+							<p id="allowResubmitNumber">
 								<label for="allowResubmitNumber">
 									$tlang.getString("allow.resubmit.number")
 								</label>
@@ -324,7 +322,7 @@ function printView(url) {
 									<option value="-1" #if($!value_allowResubmitNumber == -1)selected="selected"#end>$tlang.getString("allow.resubmit.number.unlimited")</option>
 								</select>
 							</p>
-							<p class="shorttext" id="allowResubmitTime" style="$!resubmitStyle">
+							<p id="allowResubmitTime" style="$!resubmitStyle">
 								## only show date selection when allowed to resubmit
 								<label>
 									$tlang.getString("gen.acesubunt")


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40080

I've updated the wording and some minor colour and styling issues on the Assignments grading list page for the Resubmissions panel to reflect the changes done SAK-40074 to the twin panel for feedback.

See https://jira.sakaiproject.org/browse/SAK-40080 for the before and after screenshots.