### PR TITLE
SAK-41223: GradebookNG > Import > extend 'hide items with no changes' to external items

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
@@ -85,7 +85,8 @@ public class GradeItemImportSelectionStep extends BasePanel {
 
 		// get the count of items that are selectable
 		GradeItemImportSelectionStep.this.selectableItems = importWizardModel.getProcessedGradeItems().stream()
-				.filter(item -> item.getStatus() != Status.SKIP).collect(Collectors.toList()).size();
+				.filter(item -> item.getStatus() != Status.SKIP && item.getStatus() != Status.EXTERNAL)
+				.collect(Collectors.toList()).size();
 
 		omissionsPanel = new GradeItemImportOmissionsPanel("omissionsPanel", model);
 		add(omissionsPanel);
@@ -126,6 +127,7 @@ public class GradeItemImportSelectionStep extends BasePanel {
 
 				// toggle elements
 				target.appendJavaScript("$('.no_changes').toggle();");
+				target.appendJavaScript("$('.external').toggle();");
 				if (GradeItemImportSelectionStep.this.selectableItems == 0) {
 					target.appendJavaScript("$('.selection_form').toggle();");
 					// TODO show a message


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41223

When importing a spreadsheet which contains columns for externally managed gradebook items, these items cannot be selected during the "Gradebook Item Import Selection" step. It's understood that these items can't be imported because the grades are managed elsewhere, and the rows are coloured differently to visually distinguish them along with having a status of "External".

However, it can be confusing for users that when the click the "Hide items with no changes" button, these external items remain, giving them the impression that maybe they can be imported after all, or maybe there are changes to these items which will be processed by the import. The user would probably be better served if the button extended it's behaviour to also hide the externally managed gradebook items from the table.