### PR TITLE
SAK-41142 Removed link reference to nonexistent css file in Add Participants process

### DIFF
--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/EmailNoti.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/EmailNoti.html
@@ -4,7 +4,6 @@
 	<title>Same Role for participant</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="../css/AddParticipant.css" rel="stylesheet" type="text/css" />	
 	<script type="text/javascript" rsf:id="resize"/>
 	<script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 	<script type="text/javascript" src="/library/js/spinner.js"></script>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41142

To avoid a 404 console error, I've removed a link reference to an AddParticipant.css file that doesn't exist in the Sakai code anymore.