### PR TITLE
SAK-41232: GradebookNG > improve ability to import a custom exported file

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -48,14 +48,14 @@
                                 </div>
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" wicket:id="includeStudentDisplayId">
-                                        <wicket:message key="importExport.export.advancedOption.includeStudentDisplayId"/>
+                                        <input type="checkbox" wicket:id="includeStudentName">
+                                        <wicket:message key="importExport.export.advancedOption.includeStudentName"/>
                                     </label>
                                 </div>
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" wicket:id="includeStudentName">
-                                        <wicket:message key="importExport.export.advancedOption.includeStudentName"/>
+                                        <input type="checkbox" wicket:id="includeStudentDisplayId">
+                                        <wicket:message key="importExport.export.advancedOption.includeStudentDisplayId"/>
                                     </label>
                                 </div>
                                 <wicket:enclosure child="includeStudentNumber">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -280,11 +280,11 @@ public class ExportPanel extends BasePanel {
 				if (!isCustomExport || this.includeStudentId) {
 					header.add(getString("importExport.export.csv.headers.studentId"));
 				}
-				if (isCustomExport && this.includeStudentDisplayId) {
-					header.add(getString("importExport.export.csv.headers.studentDisplayId"));
-				}
 				if (!isCustomExport || this.includeStudentName) {
 					header.add(getString("importExport.export.csv.headers.studentName"));
+				}
+				if (isCustomExport && this.includeStudentDisplayId) {
+					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.studentDisplayId")));
 				}
 				if (isCustomExport && this.includeStudentNumber) {
 					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.studentNumber")));
@@ -352,11 +352,11 @@ public class ExportPanel extends BasePanel {
 					if (!isCustomExport || this.includeStudentId) {
 						line.add(studentGradeInfo.getStudentEid());
 					}
-					if (isCustomExport && this.includeStudentDisplayId) {
-						line.add(studentGradeInfo.getStudentDisplayId());
-					}
 					if (!isCustomExport || this.includeStudentName) {
 						line.add(studentGradeInfo.getStudentLastName() + ", " + studentGradeInfo.getStudentFirstName());
+					}
+					if (isCustomExport && this.includeStudentDisplayId) {
+						line.add(studentGradeInfo.getStudentDisplayId());
 					}
 					if (isCustomExport && this.includeStudentNumber)
 					{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41232

When you elect to do a custom export of the Gradebook, the message to the user states:

> Customized exports can only be imported back into the system if Student ID and Student Name are retained in the first and second columns and all other formatting conventions are followed.

However, the "Student Display ID" option is in between the "Student ID" and "Student Name" options (the two which must be retained as the first and second columns in the file in order to make it compatible with the import function). If "Student Display ID" is selected, it effectively produces a CSV which will not be able to be imported because the "Student Display ID" column will be in the second column. the "Student Display ID" column is also not prefixed with the "#" prefix, which tells the import function to ignore the column.

If a user were to try to upload the file after making some grade changes, they would be presented with an error message, and they would likely be confused because the two columns necessary have technically been retained, but are not in the right places due to their selections for the custom export. In order to fix this on their own, the user would have to realize the column order doesn't match what the message originally said, they would have to manually reorder the columns, and add the "#" prefix to the "Student Display ID" column, save and re-upload.

A better solution to this is to alter the code so that the "Student Display ID" column comes after the "Student Name" column, and is prefixed with the "#" so it isn't interpreted as a gradebook item.

See screenshots in the JIRA.