### PR TITLE
SAK-41233: GradebookNG > add user's first and last name to grade log entry display

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverrideLogPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverrideLogPanel.java
@@ -121,7 +121,7 @@ public class CourseGradeOverrideLogPanel extends BasePanel {
 		final String grade = gradeLog.getGrade();
 
 		final GbUser grader = CourseGradeOverrideLogPanel.this.businessService.getUser(gradeLog.getGraderUuid());
-		final String graderDisplayId = (grader != null) ? grader.getDisplayId() : getString("unknown.user.id");
+		final String graderDisplayId = (grader != null) ? grader.getDisplayName() + " (" +  grader.getDisplayId() + ")" : getString("unknown.user.id");
 
 		String rval;
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
@@ -73,7 +73,7 @@ public class GradeLogPanel extends BasePanel {
 				final String grade = gradeLog.getGrade();
 
 				final GbUser grader = GradeLogPanel.this.businessService.getUser(gradeLog.getGraderUuid());
-				final String graderDisplayId = (grader != null) ? grader.getDisplayId() : getString("unknown.user.id");
+				final String graderDisplayId = (grader != null) ? grader.getDisplayName() + " (" +  grader.getDisplayId() + ")" : getString("unknown.user.id");
 
 				// add the entry
 				item.add(new Label("entry",


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41233

Currently the grade log (for both course grades, and grade items) displays only the user's ID who made the change. Depending on the institution/system/user, the user ID may not be helpful or intuitive information for the end user. To better assist the user in determining who actually made changes, let's also provide the user's first and last name. Ex: "John Doe (jdoe99)"

See screenshots in the JIRA.