### PR TITLE
SAK-41234: GradebookNG > improve external item information message

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -141,7 +141,7 @@ error.addgradeitem.title = Title required and must be unique.
 error.addgradeitem.title.duplicate = The title ''{0}'' is a duplicate. Titles must be unique.
 error.addgradeitem.exception = Error creating Assignment.
 notification.addgradeitem.success = Gradebook item ''{0}'' has been created.
-info.edit_assignment_external_items=Please go to {0} to edit title, points, and due date.
+info.edit_assignment_external_items=Please go to {0} to edit the title, points, and due date, or to remove the item from the Gradebook.
 
 label.editgradeitem.title = Title
 label.editgradeitem.points = Point value


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41234

Amend the current message to indicate removal of external gradebook items must also be done through the external tool:

> Please go to `toolTitleHere` to edit the title, points, and due date, or to remove the item from the Gradebook.