### PR TITLE
SAK-41203 removing code that was throwing error

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/item/imageMapQuestion.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/item/imageMapQuestion.jsp
@@ -350,9 +350,6 @@
 <!-- end content -->
 </div>
 
-<script type="text/javascript">
-applyMenuListener("controllingSequence");
-</script>
     </body>
   </html>
 </f:view>


### PR DESCRIPTION
@bjones86 I've seen you extended the method here:
https://github.com/sakaiproject/sakai/commit/896eff65b1a0a7a42577f5f8cf84863a25aea720
This wasn't working before, because it wasn't even pointing to the .js file that defines it, but I'm wondering if it's right just removing it or not. Thanks!

(All the fields on that screen seem to be properly stored)