### PR TITLE
SAK-41217 - Samigo: Questions worth over 1000 points display with a comma in the student view when taking quiz

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -111,7 +111,7 @@ $(window).load( function() {
     <h:outputText value="#{assessmentBean.questionSize} #{authorMessages.existing_q} #{authorMessages.dash} " rendered="#{assessmentBean.questionSize == 1}" />
     <h:outputText value="#{assessmentBean.questionSize} #{authorMessages.existing_qs} #{authorMessages.dash} " rendered="#{assessmentBean.questionSize == 0}" />
     <h:outputText value="#{assessmentBean.totalScore}">
-      <f:convertNumber maxFractionDigits="2"/>
+      <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText value="&#160;" escape="false" />
     <h:outputText value="#{authorMessages.total_pts}" rendered="#{assessmentBean.totalScore > 1}" />

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -323,11 +323,11 @@ document.links[newindex].onclick();
 				<h:outputText value="#{question.roundedMaxPointsToDisplay} #{deliveryMessages.pt}" rendered="#{delivery.actionString=='reviewAssessment'}"/>
 				<%-- DELIVER ASSESSMENT --%>
 				<h:outputText value="#{question.roundedMaxPoints}" rendered="#{delivery.settings.displayScoreDuringAssessments != '2' && question.itemData.scoreDisplayFlag && delivery.actionString!='reviewAssessment'}"  >
-					<f:convertNumber maxFractionDigits="2"/>
+					<f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
 				</h:outputText>
-				<h:outputText value="#{deliveryMessages.pt}" rendered="#{delivery.settings.displayScoreDuringAssessments != '2' && question.itemData.scoreDisplayFlag && delivery.actionString!='reviewAssessment'}"  />
+				<h:outputText value=" #{deliveryMessages.pt}" rendered="#{delivery.settings.displayScoreDuringAssessments != '2' && question.itemData.scoreDisplayFlag && delivery.actionString!='reviewAssessment'}"  />
 				<h:outputText value="#{deliveryMessages.discount} #{question.itemData.discount} "  rendered="#{question.itemData.discount!='0.0' && delivery.settings.displayScoreDuringAssessments != '2' && question.itemData.scoreDisplayFlag}"  >
-					<f:convertNumber maxFractionDigits="2"/>
+					<f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
 				</h:outputText>
 			</span>
 		</h:panelGroup>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
@@ -132,7 +132,7 @@ function saveTime()
     <h:outputText value="#{deliveryMessages.table_of_contents} " />
     <h:outputText styleClass="tier10" value="#{deliveryMessages.tot_score} " />
     <h:outputText value="#{delivery.tableOfContents.maxScore}">
-      <f:convertNumber maxFractionDigits="2"/>
+      <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText value="#{deliveryMessages.pt}" />
   </h4>
@@ -178,7 +178,7 @@ function saveTime()
                 	<f:convertNumber maxFractionDigits="2"/>
                 </h:outputText>
                 <h:outputText escape="false" value=" (#{question.pointsDisplayString}#{deliveryMessages.splash}#{question.roundedMaxPointsToDisplay} #{deliveryMessages.pt})" rendered="#{(delivery.settings.displayScoreDuringAssessments != '2' && question.itemData.scoreDisplayFlag) || question.pointsDisplayString!=''}">
-                	<f:convertNumber maxFractionDigits="2"/>
+                	<f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
                 </h:outputText>
                 <f:param name="partnumber" value="#{part.number}" />
                 <f:param name="questionnumber" value="#{question.number}" />

--- a/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
@@ -134,7 +134,7 @@ function saveTime()
     <h:outputText value="#{delivery.tableOfContents.maxScore}">
       <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
-    <h:outputText value="#{deliveryMessages.pt}" />
+    <h:outputText value=" #{deliveryMessages.pt}" />
   </h4>
  
 </div>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -199,7 +199,7 @@ function toPoint(id)
         <t:dataList layout="unorderedList" itemStyleClass="list-group-item" styleClass="list-group question-wrapper" value="#{part.itemContents}" var="question">
                 <span class="badge">
                   <h:outputText escape="false" value="#{question.roundedMaxPoints}">
-                    <f:convertNumber maxFractionDigits="2"/>
+                    <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
                   </h:outputText>
                   <h:outputText escape="false" value=" #{deliveryMessages.pt} "/>
                 </span>

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/AudioRecording.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/AudioRecording.jsp
@@ -42,7 +42,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputText escape="false" value="#{printMessages.answer_point}: " />
     <h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/CalculatedQuestion.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/CalculatedQuestion.jsp
@@ -35,7 +35,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/ExtendedMatchingItems.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/ExtendedMatchingItems.jsp
@@ -58,7 +58,7 @@
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/FileUpload.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/FileUpload.jsp
@@ -50,7 +50,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputText escape="false" value="#{printMessages.answer_point}: "/>
     <h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/FillInNumeric.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/FillInNumeric.jsp
@@ -38,7 +38,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/FillInTheBlank.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/FillInTheBlank.jsp
@@ -35,7 +35,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/ImageMapQuestion.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/ImageMapQuestion.jsp
@@ -56,7 +56,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/Matching.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/Matching.jsp
@@ -56,7 +56,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/MultipleChoiceMultipleCorrect.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/MultipleChoiceMultipleCorrect.jsp
@@ -64,7 +64,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/MultipleChoiceSingleCorrect.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/MultipleChoiceSingleCorrect.jsp
@@ -63,7 +63,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
   	<h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/ShortAnswer.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/ShortAnswer.jsp
@@ -35,7 +35,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
     <h:outputLabel value="#{printMessages.answer_point}: "/>
   	<h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />

--- a/samigo/samigo-app/src/webapp/jsf/print/preview_item/TrueFalse.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/print/preview_item/TrueFalse.jsp
@@ -50,7 +50,7 @@ should be included in file importing DeliveryMessages
   <h:panelGroup styleClass="answerBlock" rendered="#{printSettings.showKeys || printSettings.showKeysFeedback}">
     <h:outputLabel value="#{printMessages.answer_point}: "/>
     <h:outputText value="#{question.itemData.score}">
-        <f:convertNumber maxFractionDigits="2"/>
+        <f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
     </h:outputText>
     <h:outputText escape="false" value=" #{authorMessages.points_lower_case}" />
   	<h:outputText value="<br />" escape="false" />


### PR DESCRIPTION
Wanted to check all screens that would display the point value when testing SAK-41192. The student taking the quiz has the point value displayed with a comma.

No user-facing errors and no errors in the logs.