### PR TITLE
SAK-41250 - Auto favorite button located under the Organize Favorites tab is working incorrect

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -459,8 +459,9 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				&& (s.getId().equals(myWorkspaceSiteId) || effectiveSite
 						.equals(myWorkspaceSiteId))));
 		
-		String siteTitle = Validator.escapeHtml(getUserSpecificSiteTitle(s, false, false, siteProviders));
-		String siteTitleTruncated = FormattedText.makeShortenedText(siteTitle, null, null, null);
+		String siteTitleRaw = getUserSpecificSiteTitle(s, false, false, siteProviders);
+		String siteTitle = Validator.escapeHtml(siteTitleRaw);
+		String siteTitleTruncated = Validator.escapeHtml(FormattedText.makeShortenedText(siteTitleRaw, null, null, null));
 		m.put("siteTitle", siteTitle);
 		m.put("siteTitleTrunc", siteTitleTruncated);
 		m.put("fullTitle", siteTitle);

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -162,8 +162,8 @@
 
                         <div class="onoffswitch" style="display: none">
                             <button role="switch" aria-checked="true" aria-labelledby="autofav-description" class="btn btn-lg" id="autoFavoritesEnabled">
-                                <span class="onoffswitch-inner">${rloader.moresite_favorites_on}</span>
-                                <span class="onoffswitch-switch">${rloader.moresite_favorites_off}</span>
+                                <span class="onoffswitch-inner">${rloader.moresite_favorites_off}</span>
+                                <span class="onoffswitch-switch">${rloader.moresite_favorites_on}</span>
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
Auto favorite button located under the Sites → Organize Favorites tab is working incorrect as i have indicated in the attachment. So when the button is enabled, it is actually closed.