### PR TITLE
SAK-41251: GBNG > stack trace when entering grades in table

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -356,6 +356,7 @@ assignment.menulabel = Open menu for {0} column
 message.edititem.success=Gradebook item ''{0}'' has been updated.
 message.edititem.error=An error occurred updating the Gradebook item.
 message.editcomment.error=An error occurred editing the comment.
+comment.StringValidator.maximum=The comment entered exceeds the maximum allowance of ${maximum} characters.
 message.addcoursegradeoverride.success = The course grade was updated.
 message.addcoursegradeoverride.error = An error occurred updating the course grade.
 message.addcoursegradeoverride.invalid = The course grade entered is invalid according to the grading schema currently in use by this gradebook.

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -120,7 +121,7 @@ public class GradebookNgBusinessService {
 	@Setter
 	private UserDirectoryService userDirectoryService;
 
-	@Setter
+	@Setter @Getter
 	private ServerConfigurationService serverConfigService;
 
 	@Setter
@@ -749,8 +750,8 @@ public class GradebookNgBusinessService {
 
 		// if comment longer than MAX_COMMENT_LENGTH chars, error.
 		// SAK-33836 - MAX_COMMENT_LENGTH controlled by sakai.property 'gradebookng.maxCommentLength'; defaults to 20,000
-		if (CommentValidator.isCommentInvalid(comment)) {
-			log.error("Comment too long. Maximum {} characters.", CommentValidator.MAX_COMMENT_LENGTH);
+		if (CommentValidator.isCommentInvalid(comment, serverConfigService)) {
+			log.error("Comment too long. Maximum {} characters.", CommentValidator.getMaxCommentLength(serverConfigService));
 			return GradeSaveResponse.ERROR;
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -386,7 +386,7 @@ public class ImportGradesHelper {
 		}
 
 		// Perform comment validation; present error message with invalid gradebook items and corresponding student identifiers on current page
-		CommentValidationReport commentReport = new CommentValidator().validate(rows, columns);
+		CommentValidationReport commentReport = new CommentValidator().validate(rows, columns, businessService.getServerConfigService());
 		SortedMap<String, List<String>> invalidCommentsMap = commentReport.getInvalidComments();
 		if (!invalidCommentsMap.isEmpty()) {
 			List<String> badCommentEntries = new ArrayList<>();
@@ -397,7 +397,7 @@ public class ImportGradesHelper {
 			}
 
 			String badComments = StringUtils.join(badCommentEntries, ", ");
-			sourcePanel.error(MessageHelper.getString("importExport.error.invalidComments", CommentValidator.MAX_COMMENT_LENGTH, badComments));
+			sourcePanel.error(MessageHelper.getString("importExport.error.invalidComments", CommentValidator.getMaxCommentLength(businessService.getServerConfigService()), badComments));
 			hasValidationErrors = true;
 		}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.html
@@ -5,7 +5,8 @@
 	<wicket:panel>
 
 		<form class="form-vertical" wicket:id="form">
-		
+			<div wicket:id="editCommentFeedback"></div>
+
 			<textarea wicket:id="comment" rows="4" class="form-control form-group"></textarea>
 			
 			<div class="">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -22,6 +22,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextArea;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
@@ -31,6 +32,7 @@ import org.apache.wicket.validation.validator.StringValidator;
 import org.sakaiproject.gradebookng.business.importExport.CommentValidator;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.tool.component.GbAjaxButton;
+import org.sakaiproject.gradebookng.tool.component.GbFeedbackPanel;
 import org.sakaiproject.service.gradebook.shared.Assignment;
 
 import lombok.Getter;
@@ -99,6 +101,11 @@ public class EditGradeCommentPanel extends BasePanel {
 				}
 			}
 
+			@Override
+			protected void onError(final AjaxRequestTarget target, final Form<?> form) {
+				target.addChildren(form, FeedbackPanel.class);
+			}
+
 		};
 		form.add(submit);
 
@@ -123,10 +130,13 @@ public class EditGradeCommentPanel extends BasePanel {
 
 		// textarea
 		form.add(new TextArea<>("comment", new PropertyModel<>(formModel, "gradeComment"))
-				.add(StringValidator.maximumLength(CommentValidator.MAX_COMMENT_LENGTH)));
+				.add(StringValidator.maximumLength(CommentValidator.getMaxCommentLength(serverConfigService))));
 
 		// instant validation
 		// AjaxFormValidatingBehavior.addToAllFormComponents(form, "onkeyup", Duration.ONE_SECOND);
+
+		// feedback panel
+		form.add(new GbFeedbackPanel("editCommentFeedback"));
 
 		add(form);
 	}

--- a/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -8,6 +8,7 @@
 		class="org.sakaiproject.gradebookng.business.GradebookNgBusinessService">
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
+		<property name="serverConfigService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
 		<property name="gradebookService" ref="org.sakaiproject.service.gradebook.GradebookService" />
 		<property name="gradebookPermissionService" ref="org.sakaiproject.service.gradebook.GradebookPermissionService" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41251

You'll get a stack trace when entering grades in the table (see JIRA for actual stack trace). This is a regression caused by #6485 (https://jira.sakaiproject.org/browse/SAK-41222), where it was requested that all `ServerConfigurationService` calls be refactored to use the API rather than the Cover. This is apparently an area I neglected to test.

I also noticed that comment length validation is not properly implemented when adding/editing comments through the grades table. If the comment is too long, clicking the save button does nothing and the logs spit out warnings about message bundle keys not being found. This PR refactors this area to provide a proper feedback message to the user indicating why the comment was not saved.