### PR TITLE
SAK-41256 - Millions of request to getI18NProperties with bullhorns disabled

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.i18n.utils.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.i18n.utils.js
@@ -1,6 +1,6 @@
 (function ($) {
 
-    if (!portal.loggedIn){
+    if (!portal.loggedIn) {
         return;
     }
 
@@ -22,34 +22,44 @@
 
         portal.i18n.translations[options.namespace] = portal.i18n.translations[options.namespace] || {};
 
-        $PBJQ.ajax({
-            url: '/sakai-ws/rest/i18n/getI18nProperties',
-            cache: true,
-            dataType: "text",
-            data: {locale: portal.locale,
-                    resourceclass: options.resourceClass,
-                    resourcebundle: options.resourceBundle},
-            })
-            .done(function (data, textStatus, jqXHR) {
+        if (sessionStorage.getItem(portal.locale + options.resourceClass + options.resourceBundle) !== null) {
+            portal.i18n.translations[options.namespace] = JSON.parse(sessionStorage[portal.locale + options.resourceClass + options.resourceBundle]);
+            if (options.callback) {
+                options.callback();
+            }
+        } else {
+            $PBJQ.ajax({
+                url: '/sakai-ws/rest/i18n/getI18nProperties' + portal.portalCDNQuery,
+                cache: true,
+                contentType: 'application/json',
+                data: {locale: portal.locale,
+                        resourceclass: options.resourceClass,
+                        resourcebundle: options.resourceBundle},
+                })
+                .done(function (data, textStatus, jqXHR) {
 
-                data.split("\n").forEach(function (pair) {
+                    data.split("\n").forEach(function (pair) {
 
-                    var keyValue = pair.split('=');
-                    if (keyValue.length == 2) {
-                        portal.i18n.translations[options.namespace][keyValue[0]] = keyValue[1];
+                        var keyValue = pair.split('=');
+                        if (keyValue.length == 2) {
+                            portal.i18n.translations[options.namespace][keyValue[0]] = keyValue[1];
+                        }
+
+                        if (options.debug) {
+                            console.log('Updated translations: ');
+                            console.log(portal.i18n.translations[options.namespace]);
+                        }
+                    });
+                    sessionStorage[portal.locale + options.resourceClass + options.resourceBundle] = JSON.stringify(portal.i18n.translations[options.namespace]);
+
+                    if (options.callback) {
+                        options.callback();
                     }
-
-                    if (options.debug) {
-                        console.log('Updated translations: ');
-                        console.log(portal.i18n.translations[options.namespace]);
-                    }
+                })
+                .fail(function (jqXHR, textStatus, errorThrown) {
+                    console.error(errorThrown);
                 });
-
-                if (options.callback) options.callback();
-            })
-            .fail(function (jqXHR, textStatus, errorThrown) {
-                console.log(errorThrown);
-            });
+        }
     };
 
     portal.i18n.tr = function (namespace, key, options) {


### PR DESCRIPTION
- One condition has been added to loggedIn, we check if bullhorns are enabled on server to run proper code.
- Even if bullhorns are enabled translations are not modified as fast to make a call to server on every page so that i18n have been added to sessionStorage so the ajax calls are just made once per session or when user change language.
- PortalCDN has been added to AJAX call so user's browser don't make it between deploys.