### PR TITLE
SAK-41258: Site Info > can't add roster if no rosters are already attached to site

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -433,7 +433,7 @@ sitedicla.remsel = Remove Selected
 sitedicla.tabhol = Table holds the information of site classes.
 sitedicla.theis  = There is no class assigned to the site
 sitedicla.upd    = Update
-sitedicla.yet    = yet
+sitedicla.yet    = yet.
 
 sitediconf.app        = Appearance
 sitediconf.term		= Term

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3413,6 +3413,7 @@ public class SiteAction extends PagedResourceActionII {
 			// Add the menus to vm
 			MenuBuilder.buildMenuForSiteInfo(portlet, data, state, context, site, rb, siteTypeProvider, SiteInfoActiveTab.EDIT_CLASS_ROSTERS);
 
+			context.put("allowAddSite", SiteService.allowAddSite(site.getId()));
 			context.put("siteTitle", site.getTitle());
 			coursesIntoContext(state, context, site);
 
@@ -10272,7 +10273,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				{
 					// if after the removal, there is no provider id, and there is no maintain role user anymore, show alert message and don't save the update
 					addAlert(state, rb.getString("sitegen.siteinfolist.nomaintainuser")
-							+ maintainRoleString + ".");
+							+ " " + maintainRoleString + ".");
 				}
 				else
 				{

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -9,8 +9,10 @@
 			<div class="clear"></div>
 		#end
 		<form name="removeClassForm" id="removeClassForm" action="#toolForm("$action")" method="post">
-		#if ($!providerCourseList && !$!providerCourseList.isEmpty()|| $!manualCourseList && !$!manualCourseList.isEmpty() || $!cmRequestedCourseList && !$!cmRequestedCourseList.isEmpty())
-				<a href="#" onclick="location = '#toolLink($action "doMenu_siteInfo_addClass")'; return false;">$tlang.getString('java.addclasses')</a>
+			#if ($!providerCourseList && !$!providerCourseList.isEmpty()|| $!manualCourseList && !$!manualCourseList.isEmpty() || $!cmRequestedCourseList && !$!cmRequestedCourseList.isEmpty())
+				#if ($allowAddSite)
+					<a href="#" onclick="location = '#toolLink($action "doMenu_siteInfo_addClass")'; return false;">$tlang.getString('java.addclasses')</a>
+				#end
 				<div class="table-responsive">
 				<table id="removeClass" class ="table table-bordered table-striped table-hover" cellpadding="0" cellspacing="0" summary ="$tlang.getString("sitedicla.tabhol")">
 					<tr>
@@ -76,16 +78,17 @@
 					<input type="submit" accesskey="s" class="active" name="eventSubmit_doContinue" id="btnRemove" disabled="disabled" value="$tlang.getString("sitedicla.remsel")" onclick="SPNR.disableControlsAndSpin( this, null );" />
 					<input type="submit" accesskey="x" name="eventSubmit_doBack" value="$tlang.getString("sitedicla.can")" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				</p>
-
-		#else
-			$tlang.getString("sitedicla.theis") $!siteTitle $tlang.getString("sitedicla.yet")
-			<p class="act">
-				<input type="hidden" name="back" value="12" />
-				<input type="hidden" name="templateIndex" value="$!templateIndex" />
-				<input type="submit" name="eventSubmit_doBack" value="$tlang.getString("sitedicla.can")" onclick="SPNR.disableControlsAndSpin( this, null );" />
-			</p>
-
-		#end
+			#else
+				$tlang.getString("sitedicla.theis") $!siteTitle $tlang.getString("sitedicla.yet")
+				#if ($allowAddSite)
+					<a href="#" onclick="location = '#toolLink($action "doMenu_siteInfo_addClass")'; return false;">$tlang.getString('java.addclasses')</a>
+				#end
+				<p class="act">
+					<input type="hidden" name="back" value="12" />
+					<input type="hidden" name="templateIndex" value="$!templateIndex" />
+					<input type="submit" name="eventSubmit_doBack" value="$tlang.getString("sitedicla.can")" aria-label=""$tlang.getString("sitedicla.can")" onclick="SPNR.disableControlsAndSpin( this, null );" />
+				</p>
+			#end
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 		</form>
 	</div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41258

This is a regression caused by the massive SWITCH-ing of site-manage in #5865 (https://jira.sakaiproject.org/browse/SAK-40098). This restores the ability to add a roster once all rosters have been removed from the site. I also fixed a few small messaging issues I noticed while I was testing.

The original permission check was passing `null` into `SiteService.allowAddSite()`, however it made more sense to pass in the actual site ID here.

