### PR TITLE
SAK-41264: Samigo > 'stop accepting now' not working on tests with 'no late submissions accepted'

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -121,7 +121,7 @@ implements ActionListener
 		}
 
 		EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_PUBLISHED_ASSESSMENT_SETTING_EDIT, "siteId=" + AgentFacade.getCurrentSiteId() + ", publishedAssessmentId=" + assessmentId, true));
-		boolean error = checkPublishedSettings(assessmentService, assessmentSettings, context);
+		boolean error = checkPublishedSettings(assessmentService, assessmentSettings, context, retractNow);
 		
 		if (error){
 			assessmentSettings.setOutcome("editPublishedAssessmentSettings");
@@ -231,7 +231,7 @@ implements ActionListener
 	    calendarService.updateAllCalendarEvents(assessment, assessmentSettings.getReleaseTo(), assessmentSettings.getGroupsAuthorized(), rb.getString("calendarDueDatePrefix") + " ", addDueDateToCalendar, notificationMessage);
 	}
 
-	public boolean checkPublishedSettings(PublishedAssessmentService assessmentService, PublishedAssessmentSettingsBean assessmentSettings, FacesContext context) {
+	public boolean checkPublishedSettings(PublishedAssessmentService assessmentService, PublishedAssessmentSettingsBean assessmentSettings, FacesContext context, boolean retractNow) {
 		boolean error = false;
 		// Title
 		String assessmentName = assessmentSettings.getTitle();
@@ -415,7 +415,7 @@ implements ActionListener
 	    }
 
 	    // if auto-submit is enabled, make sure late submission date is set
-	    if (assessmentSettings.getAutoSubmit() && retractDate == null) {
+	    if (assessmentSettings.getAutoSubmit() && retractDate == null && !retractNow) {
 	    	boolean autoSubmitEnabled = ServerConfigurationService.getBoolean("samigo.autoSubmit.enabled", false);
 	    	if (autoSubmitEnabled) {
 	    		String dateError4 = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages","retract_required_with_auto_submit");
@@ -576,7 +576,9 @@ implements ActionListener
 			}
 		}
 		else if (retractNow) {
+			assessmentSettings.setLateHandling(AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString());
 			control.setDueDate(new Date());
+			control.setRetractDate(new Date());
 		}
 		else if ("".equals(assessmentSettings.getRetractDateString())) {
 			control.setRetractDate(null);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41264

the *Stop Accepting Now* button in samigo's _Settings_ page on *Published Copies* is not correctly overriding any existing *due* or *late accept* date and immediately retracting the test.

*Stop Accepting Now* inserts a date in the _Late submissions accepted_ > *Yes, until* (aka Retract date) field to perform the override.  If desired, it also should allow you to enable *Autosubmit* at the time you *Stop Accepting*.

If you have a test that previously did NOT have *Autosubmit* enabled, has no due date, and doesn't accept late submissions, you select *Autosubmit*, then *Stop Accepting* it, you get an error: "The latest acceptance date must be set to force submission of saved student work after the due date."  As a result of several other JIRAs, you don't need a Retract date to use *Autosubmit*, so *Stop Accepting Now* can't force submission of a test that has no late submissions accepted.

How it *should* work: Clicking *Stop Accepting Now* enters a date in the _Late submissions accepted_ > *Yes, until* (aka Retract date) field.  If there was previously no due or late accept date, you select the *Autosubmit* option, click *Stop Accepting Now*, and confirm, the test is retracted and in-progress assessments are submitted next time the autosubmit job runs.