### PR TITLE
SAK-41276: improve user facing content cleaned message

### DIFF
--- a/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/content/content.properties
+++ b/config/localization/bundles/src/bundle/org/sakaiproject/localization/bundle/content/content.properties
@@ -574,7 +574,7 @@ prefs_opt1 = Do not send me low priority resource notifications
 
 # AntiSamy Cleaner
 unknown_error_markup=Unknown error processing text markup
-content_has_been_cleaned=Your HTML contains tags or attributes that are not permitted and have been removed from your content.
+content_has_been_cleaned=Your HTML contains formatting tags or attributes that are not permitted and have been removed. This change should not affect content.
 
 # Zip Compression
 permission_error_zip=You do not have the proper permissions for compressing to zip archive


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41276

The current wording of the message shown to users when offending content has been stripped by AntiSamy could be slightly confusing to users:

> Your HTML contains tags or attributes that are not permitted and have been removed from your content.

The linked PR proposes updating this text to the following, to reassure users that their valuable content should remain in tact:

> Your HTML contains tags or attributes that are not permitted and have been removed. This change may affect some formatting, but should not affect actual content.