### PR TITLE
SAK-41286: site-info > provide more info when displaying rosters available for selection

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1671,6 +1671,11 @@
 # DEFAULT: true
 # site-manage.importoption.siteinfo=false
 
+# SAK-41286 Control display of roster EIDs in Worksite Setup > New Course Site &
+# Site Info > Edit Class Roster(s)
+# DEFAULT: false
+# wsetup.showRosterEIDs=true
+
 # ########################################################################
 # GROUP PROVIDER (defined in kernel.properties)
 # ########################################################################

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -793,6 +793,9 @@ public class SiteAction extends PagedResourceActionII {
 	//SAK-22432 Template descriptions are not copied
 	private final static String SAK_PROP_COPY_TEMPLATE_DESCRIPTION = "site.setup.copy.template.description";
 
+	private static final String SAK_PROP_SHOW_ROSTER_EID = "wsetup.showRosterEIDs";
+	private static final boolean SAK_PROP_SHOW_ROSTER_EID_DEFAULT = false;
+
 	//Setup property to require (or not require) authorizer
 	private static final String SAK_PROP_REQUIRE_AUTHORIZER = "wsetup.requireAuthorizer";
 	//Setup property to email authorizer (default to true)
@@ -3302,6 +3305,9 @@ public class SiteAction extends PagedResourceActionII {
 			List ll = (List) state.getAttribute(STATE_TERM_COURSE_LIST);
 			context.put("termCourseList", state
 					.getAttribute(STATE_TERM_COURSE_LIST));
+
+			Boolean showRosterEIDs = ServerConfigurationService.getBoolean(SAK_PROP_SHOW_ROSTER_EID, SAK_PROP_SHOW_ROSTER_EID_DEFAULT);
+			context.put("showRosterEIDs", showRosterEIDs);
 
 			// SAK-29000
 			Boolean isAuthorizationRequired = ServerConfigurationService.getBoolean( SAK_PROP_REQUIRE_AUTHORIZER, Boolean.TRUE );
@@ -14083,14 +14089,14 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 	 */
 	public class CourseObject {
 		public String eid;
-
 		public String title;
-
+		public String description;
 		public List courseOfferingObjects;
 
 		public CourseObject(CourseOffering offering, List courseOfferingObjects) {
 			this.eid = offering.getEid();
 			this.title = offering.getTitle();
+			this.description = offering.getDescription();
 			this.courseOfferingObjects = courseOfferingObjects;
 		}
 
@@ -14100,6 +14106,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 
 		public String getTitle() {
 			return title;
+		}
+
+		public String getDescription() {
+			return description;
 		}
 
 		public List getCourseOfferingObjects() {

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
@@ -74,18 +74,13 @@
 				
 				## display only subject, course number and section
 				##and finally - the labels work, but having commas in the id does not validate. Can we concatenate or replace with underscore? Here is reqs on ids and labels: an id attribute value must begin with a letter (A-Z or a-z) and consist of the following characters: (A-Z), (a-z), (0-9), hyphens (-), underscores (_), colons (:), and periods (.).
-				#set($crosslisted=0)	
 				#set($courseNumber=0)
 				#set($hasRosters=false)
 				#foreach($courseObject in $termCourseList)
 					<table class="listHier lines nolines specialLink" cellpadding="0" cellspacing="0"  summary="$tlang.getString("nscourse.courselist.summary")" border="0" style="width:auto">
 					<tr>	
 					<th colspan="2" title="$!courseObject.eid">
-                                        $!courseObject.title $!courseObject.description
-					#if ($!courseObject.courseOfferingObjects.size() > 1)
-						(cross-listed)
-						#set($crosslisted=1)	
-					#end
+						$!courseObject.title #if($!courseObject.description) - $!courseObject.description#end #if($!showRosterEIDs) ($!courseObject.eid)#end
 					</th>
 					<th>
 						$tlang.getString("useOfficialDescription")


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41286

When selecting rosters to attach to a course site (either via _Worksite Setup_ when creating a new course site, or _Site Info_ > _Edit Class Roster(s)_), the only information displayed to the user about a given section is it's title. It can be beneficial to give the user more information here to better assist them in making a decision.

At some point in the past, someone already tried to (or thought about) adding the description to the display. We already have code in one of the velocity templates that would spit out this information, if the backing object in Java was populated accordingly. From `chef_site-newSiteCourse.vm` @ line 82:

```
<th colspan="2" title="$!courseObject.eid">
    $!courseObject.title $!courseObject.description
#if ($!courseObject.courseOfferingObjects.size() > 1)
    (cross-listed)
    #set($crosslisted=1)	
#end
```

However the Java object is never populated with the `description` attribute, so it's never printed to the screen.

The linked PR proposes the following:

1. Implement the display of `description` attribute
2. Remove the hard-coded English "(cross-listed)" string
3. Implement a new sakai.property (`wsetup.showRosterEIDs`) to additionally control the display of the roster EID in parenthesis, after the description
    - The new sakai.property will default to `false` to preserve original behaviour (do not display EIDs)