### PR TITLE
SAK-41287: Worksite Setup > new config for default site visibility setting

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1638,6 +1638,13 @@
 # worksitesetup.sort.order.section=
 #### End SAK-21707
 
+# SAK-41287 Control the default selection of "Site Visibility" when creating new sites
+# Only applies to site types which are able to have this setting changed, and not restricted to either
+# always being private, or always being public. For context, see "site.types.publicChangeable",
+# "site.types.publicOnly", and "site.types.privateOnly" sakai.properties
+# DEFAULT: true ("public")
+# wsetup.defaultSiteVisibility=false
+
 # SAK-23256 - Whether or not to filter the dropdown in Worksite Setup to just terms that the instructor has sites in
 # This is only relevant if you are using the CM_MEMBERSHIP tables and the internal course management 
 # Admin will still see the full list

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -411,6 +411,9 @@ public class SiteAction extends PagedResourceActionII {
 	private final static String[] PUBLIC_SITE_TYPES_SAK_PROP = ServerConfigurationService.getStrings("site.types.publicOnly");
 	private final static String[] PRIVATE_SITE_TYPES_SAK_PROP = ServerConfigurationService.getStrings("site.types.privateOnly");
 
+	private static final String SAK_PROP_DEFAULT_SITE_VIS = "wsetup.defaultSiteVisibility";
+	private static final boolean SAK_PROP_DEFAULT_SITE_VIS_DFLT = true;
+
 	private final static String STATE_SITE_QUEST_UNIQNAME = "site_quest_uniqname";
 	
 	private static final String STATE_SITE_ADD_COURSE = "canAddCourse";
@@ -9517,6 +9520,10 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 			if (forward) {
 				if (getStateSite(state) == null)
 				{
+					boolean siteVisibilityDefault = ServerConfigurationService.getBoolean(SAK_PROP_DEFAULT_SITE_VIS, SAK_PROP_DEFAULT_SITE_VIS_DFLT);
+					siteInfo = (SiteInfo) state.getAttribute(STATE_SITE_INFO);
+					siteInfo.include = siteVisibilityDefault;
+
 					// alerts after clicking Continue but not Back
 					if (!forward) {
 						// removing previously selected template site


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41287

This PR proposes implementing a new sakai.property (`wsetup.defaultSiteVisibility`), which controls the default value selected in the "Site Visibility" section of "Site Access", when creating a new site of any type. The new config option will default to `true` to preserve OOTB functionality.

NOTE: this config will only be taken into effect for site types which you've defined as being able to change this "public" vs. "private" setting by the end user, via the existing sakai.property `site.types.publicChangeable`. The relevant OOTB defaults effectively make course sites always public, and does not give the user the option to change this value for course sites. Therefore, OOTB, this *new* property will only control the default selection for project types. In order to test the effects on both course and project sites, you would have to explicitly set `site.types.publicChangeable=course,project`.