### PR TITLE
SAK-41298 Document maxAuthenticationAge property for SAML auth

### DIFF
--- a/login/login-tool/tool/src/webapp/WEB-INF/xlogin-context.saml.adfs-prod.xml
+++ b/login/login-tool/tool/src/webapp/WEB-INF/xlogin-context.saml.adfs-prod.xml
@@ -216,7 +216,11 @@
     </bean>
 
     <!-- SAML 2.0 WebSSO Assertion Consumer -->
-    <bean id="webSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerImpl"/>
+    <bean id="webSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerImpl">
+        <!-- Duration in seconds after initial authentication with the IDP that SSO login will be allowed: see
+             https://docs.spring.io/spring-security-saml/docs/current/reference/html/configuration-advanced.html#time-interval -->
+        <property name="maxAuthenticationAge" value="7200"/>
+    </bean>
 
     <!-- SAML 2.0 Holder-of-Key WebSSO Assertion Consumer -->
     <bean id="hokWebSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerHoKImpl"/>

--- a/login/login-tool/tool/src/webapp/WEB-INF/xlogin-context.saml.xml
+++ b/login/login-tool/tool/src/webapp/WEB-INF/xlogin-context.saml.xml
@@ -272,7 +272,11 @@
     </bean>
 
     <!-- SAML 2.0 WebSSO Assertion Consumer -->
-    <bean id="webSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerImpl"/>
+    <bean id="webSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerImpl">
+        <!-- Duration in seconds after initial authentication with the IDP that SSO login will be allowed: see
+	     https://docs.spring.io/spring-security-saml/docs/current/reference/html/configuration-advanced.html#time-interval -->
+	<property name="maxAuthenticationAge" value="7200"/>
+    </bean>
 
     <!-- SAML 2.0 Holder-of-Key WebSSO Assertion Consumer -->
     <bean id="hokWebSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerHoKImpl"/>


### PR DESCRIPTION
For SAML auth the maxAuthenticationAge property controls how old an authentication assertion may be before it is no longer accepted.

https://stackoverflow.com/questions/39927651/maxauthenticationage-in-webssoprofileconsumerimpl

https://docs.spring.io/spring-security-saml/docs/current/reference/html/configuration-advanced.html

By default this is 7200s (2 hours), which may be shorter than that configured on the IdP. Hence a user using SAML auth may get a login failure, with "Unable to process that login" and the xloign page to login with username and password.

The maxAuthenticationPage property should be exposed in the sample SAML config files so that it's more visible for implementers.