### PR TITLE
SAK-41300: Samigo > importing quiz released to anon users doesn't preserve the setting

### DIFF
--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
@@ -34,7 +34,6 @@ import java.util.StringTokenizer;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
@@ -49,8 +48,6 @@ import org.xml.sax.SAXException;
 
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.samigo.util.SamigoConstants;
-import org.sakaiproject.site.cover.SiteService;
-import org.sakaiproject.tool.assessment.shared.api.assessment.SecureDeliveryServiceAPI;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentAccessControl;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentFeedback;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentMetaData;
@@ -65,7 +62,6 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.questionpool.QuestionPoolItemIfc;
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
-import org.sakaiproject.tool.assessment.data.model.Tree;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
 import org.sakaiproject.tool.assessment.facade.ItemFacade;
@@ -86,7 +82,6 @@ import org.sakaiproject.tool.assessment.services.ItemService;
 import org.sakaiproject.tool.assessment.services.QuestionPoolService;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
 import org.sakaiproject.tool.assessment.util.TextFormat;
-import org.sakaiproject.tool.cover.ToolManager;
 import org.sakaiproject.util.FormattedText;
 
 /**
@@ -731,11 +726,6 @@ public class AuthoringHelper
       
       // Assessment Attachment
       exHelper.makeAssessmentAttachmentSet(assessment);
-
-      String siteTitle = SiteService.getSite(ToolManager.getCurrentPlacement().getContext()).getTitle();
-      if(siteTitle != null && !siteTitle.equals(assessment.getAssessmentAccessControl().getReleaseTo())){
-          assessment.getAssessmentAccessControl().setReleaseTo(siteTitle);
-      }
 
       assessmentService.saveAssessment(assessment);
       return assessment;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41300

When importing a quiz which was exported with the _Assessment released to_ setting set to "Anonymous", this setting is not preserved. It ends up being released to the entire site when imported.

The behaviour should be as follows:

* If quiz is released to default *Entire Site* in site 1, imported quiz should be released to *Entire Site* in site 2.
* If quiz is released to *Selected Group(s)* in site 1, imported quiz should be released to *Entire Site* in site 2.
* If quiz is released to *Anonymous Users* in site 1, imported quiz should be released to *Anonymous Users* in site 2. *Issue:* Currently, anonymous release assessments are switching to *Entire Site* release.

This bug was introduced in  [SAK-36910](https://jira.sakaiproject.org/browse/SAK-36910), and George Pipkin [commented](https://jira.sakaiproject.org/browse/SAK-36910?focusedCommentId=198875&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-198875) with his findings there, but never received any feedback. It seems like the code from [SAK-36910](https://jira.sakaiproject.org/browse/SAK-36910) is unnecessary and introduces the bug described in this ticket.