### PR TITLE
SAK-41303: Samigo > further quality password field label for clarity

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -95,7 +95,7 @@ select_all_groups=Select All Groups
 
 high_security_allow_only_specified_ip=Allow only specified IP Addresses
 high_security_secondary_id_pw=Secondary Password
-high_security_password=Password
+high_security_password=Assessment Password
 
 question_layout=Question Layout
 layout_by_question=Each Question is on a separate Web page


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41303

It's been reported that users have erroneously input their own institutional passwords into this field, thinking it required their personal password to save the settings. This resulted in students not being able to take said quizzes because they obviously did not know the instructors' password, and the instructor clearly would not distribute their personal passwords to students. This was further complicated in older Sakai installations where there was also a 'Username' field, which may have prompted some browsers to automatically fill in these fields with saved values.

To try to prevent the issue from occurring, and to make the assessment password field less confusing for some users, this PR proposes changing the label to be "Assessment Password", rather than just "Password".