### PR TITLE
SAK-41304: Samigo > improve wording of wildcard option in FITB question author screens

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -320,7 +320,7 @@ note_place_curly=NOTE: Place curly braces ({}) around words requiring a blank.
 defining_answers=<b>Defining Answers</b>
 fib_note_1=Place curly brackets "{}" around word(s) requiring blank response field(s). <br />Example: Roses are {red} and violets are {blue}. 
 fib_note_2=Insert a pipe "|" between answer options like synonyms.<br />Example: {They are|They're} very happy. 
-fib_note_3=Insert an asterisk (*) for one or more wildcard characters.<br />Example: It's raining {c*} and {d*s}.
+fib_note_3=Insert an asterisk ( * ) for one or more wildcard characters. For an answer to be marked correct, it must include at least one character in place of the asterisk.
 note_defining_answers=Place curly brackets "{}" around numeric value(s) requiring blank response field(s). Example: 3*3={9}.
 range=<b>Range:</b>Insert a pipe "|" between a range of values.
 range_example= Example: The price is {12.2|14.5}. Student answer between 12.2 and 14.5 will be considered valid.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41304

Instructions in the authoring of *Fill in the Blank* questions describe using a wilcard * to allow entry of any character to count as a valid response.  However, it is not clear that the wildcard means at least one character must be entered there by the student for the answer to be correct.  This can result in unexpected scoring.  This PR proposes to change the wording of the existing instruction:

> Insert an asterisk (*) for one or more wildcard characters.

To the following:

> Insert an asterisk (*) for one or more required wildcard characters.