### PR TITLE
SAK-41305: Samigo > Download File Submissions page shows internal IDs for each question

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -413,4 +413,8 @@
 		float: left;
 	}
 
+	.downloanQuestionCheckbox label {
+		display: none;
+	}
+
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41305

If you create an assessment with a couple File Upload Questions and download student submissions using *Download File Submissions*, random numbers display underneath the check boxes to select questions from which you want to download. See before and after screenshots in the JIRA.

These are probably internal IDs of some sort, but they have no meaning, are confusing to the user and just clutter up the UI. Let's hide them.