### PR TITLE
SAK-41326: Site Info > new config to prevent stealthed tools being copied to duplicate sites

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3093,6 +3093,10 @@
 # DEFAULT: true
 # site.setup.allow.editRoster=false
 
+# Control if stealthed tools are removed when duplicating sites
+# DEFAULT: false
+# site.duplicate.removeStealthTools=true
+
 # SAK-13389: the ability to hide input area for adding non-official participant
 # DEFAULT=true
 # nonOfficialAccount=false


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41326

Currently, when sites which contain one or more stealthed tools are duplicated, these stealthed tools are copied into the new duplicate site. This may be undesirable for certain institutions, who would benefit from having a configuration option to control this behaviour.

This PR introduces a new sakai.property (`site.duplicate.removeStealthTools`), which determines if stealthed tools are copied during a site duplication. The property defaults to `false` to preserve OOTB functionality (stealthed tools will be copied to duplicates by default).