### PR TITLE
SAK-41327: Samigo > clarify text shown to students when beginning a quiz

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -498,9 +498,9 @@ begin_assessment_msg_unlimited_submission=You can submit this assessment an unli
 begin_assessment_msg_unlimited_submission_continue=You can submit this assessment an unlimited number of times until {0}.
 begin_assessment_msg_num_submission_1=You can submit this
 begin_assessment_msg_num_submission_2=time(s).
-begin_assessment_msg_highest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your highest score will be recorded.
-begin_assessment_msg_latest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your latest score will be recorded.
-begin_assessment_msg_average=Your average score will be recorded.
+begin_assessment_msg_highest=If multiple submissions are allowed, answers from previous attempts will not be available within the assessment during subsequent attempts. Your highest score will be recorded.
+begin_assessment_msg_latest=If multiple submissions are allowed, answers from previous attempts will not be available within the assessment during subsequent attempts. Your latest score will be recorded.
+begin_assessment_msg_average=If multiple submissions are allowed, your average score will be recorded.
 begin_assessment_msg_attempt_autosubmit_warn_average=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be averaged with all previous attempts to determine your overall assessment score.  Do you want to begin a new attempt of this assessment?
 begin_assessment_msg_attempt_autosubmit_warn_last=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be recorded as your overall score for this assessment.  Do you want to begin a new attempt of this assessment?
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41327

Some students have expressed confusion over the current language displayed to them when starting a quiz. The current wording can give the student the impression that multiple attempts are allowed, even if the instructor has not enabled this setting for the quiz in question.

This PR proposes the following modifications to the messages:

```
- begin_assessment_msg_highest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your highest score will be recorded.
- begin_assessment_msg_latest=Answers from previous attempts will not be available within the assessment during subsequent attempts. Your latest score will be recorded.
- begin_assessment_msg_average=Your average score will be recorded.
+ begin_assessment_msg_highest=If multiple submissions are allowed, answers from previous attempts will not be available within the assessment during subsequent attempts. Your highest score will be recorded.
+ begin_assessment_msg_latest=If multiple submissions are allowed, answers from previous attempts will not be available within the assessment during subsequent attempts. Your latest score will be recorded.
+ begin_assessment_msg_average=If multiple submissions are allowed, your average score will be recorded.
```