### PR TITLE
SAK-41328: Samigo > interim solution for SAK-34222

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorImportExport.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorImportExport.properties
@@ -30,7 +30,9 @@ choose_file=Choose a file:
 import_instructions=Choose an IMS QTI-compliant <b>XML</b> file or an IMS Content Packaging <b>ZIP</b> file from your computer.
 import_pool_instructions=Choose an IMS QTI-compliant <b>XML</b> file from your computer.
 dash=-
-export_imagemap_message=<b>Note</b>: Hot Spot questions won't be exported because they don't match with a standard question type. You can copy them from a site to another one using question pools or the Import from Site feature.
+importExport_warningHeader=<b>Note:</b>
+importExport_warning1=<b>Hot Spot</b> questions won't be exported because they don't match with a standard question type. You can copy them from one site to another using question pools or the Import from Site feature.
+importExport_warning2=Tests that contain <b>Multiple Choice, Multiple Selection</b> questions with <b>All or Nothing</b> selected do not retain this setting on import to another site. To remedy this, after import, edit these questions before publishing to reset the selection back to <b>All or Nothing</b>.
 # deferred for later
 #import_instructions=Choose an IMS QTI-compliant XML file from your computer\
 # or an existing assessment to import.

--- a/samigo/samigo-app/src/webapp/jsf/qti/chooseExportType.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/qti/chooseExportType.jsp
@@ -83,7 +83,11 @@ function getSelectedType(qtiUrl, cpUrl, emtUrl, e2mt){
 		<br />
       </p>
       <p class="text-warning">
-        <h:outputText value="#{authorImportExport.export_imagemap_message}" escape="false" />
+        <h:outputText value="#{authorImportExport.importExport_warningHeader}" escape="false" />
+        <ul class="text-warning">
+            <li><h:outputText value="#{authorImportExport.importExport_warning1}" escape="false" /></li>
+            <li><h:outputText value="#{authorImportExport.importExport_warning2}" escape="false" /></li>
+        </ul>
       </p>
     </div>
     <br />
@@ -103,6 +107,7 @@ function getSelectedType(qtiUrl, cpUrl, emtUrl, e2mt){
      <div class="text-warning">
        <h:outputText value="#{authorImportExport.cp_message}"/>
      </div>
+     <br/>
     </h:panelGroup>
 
     <br/>

--- a/samigo/samigo-app/src/webapp/jsf/qti/importAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/qti/importAssessment.jsp
@@ -66,6 +66,8 @@
        </h:panelGroup>
    </div>
     <br/>
+    <h:outputText escape="false" value="#{authorImportExport.importExport_warning2}"/>
+    <br/>
     <br/>
      <%-- activates the valueChangeListener --%>
      <h:commandButton value="#{authorImportExport.import_action}" type="submit"


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41328

There is currently a bug in Samigo where if you have a quiz which contains any *Multiple Choice, Multiple Selection* questions that are set to require *All or Nothing* to get the question correct, exporting and importing this quiz into further sites will not retain the *All or Nothing* setting. The resulting imports will have changed this setting to *Correct minus Incorrect* without the user realizing it.

This is a usability issue for instructors, and can affect grading of students if the instructors don't fully vet each imported quiz before publishing. This bug is captured in https://jira.sakaiproject.org/browse/SAK-34222, and seems to be a deficiency in the export file produced.

In the interim, this PR proposes to add warnings in the UIs so that the instructor is aware of this up front:

> *Important:* Tests that contain *Multiple Choice, Multiple Selection* questions with *All or Nothing* selected do not retain this setting on import to another site. To remedy this, after import, edit these questions before publishing to reset the selection back to *All or Nothing*.

When a proper solution is implemented for https://jira.sakaiproject.org/browse/SAK-34222, it should also revert the changes introduced here.