### PR TITLE
SAK-41333: Some javascript error on Tests & Quizzes

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryTimer.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryTimer.jsp
@@ -40,14 +40,14 @@ Headings for delivery pages, needs to have msg=DeliveryMessages.properties, etc.
 <samigo:timerBar height="15" width="300"
     wait="#{delivery.timeLimit}"
     elapsed="#{delivery.timeElapse}"
-    expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=loaded; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
+    expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=10*'#{delivery.timeElapse}'; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
 </h:panelGroup>
 
 <h:panelGroup rendered="#{delivery.timeElapseAfterFileUpload != null && delivery.timeElapseDouble lt delivery.timeElapseAfterFileUploadDouble  && delivery.hasTimeLimit == true}">
 <samigo:timerBar height="15" width="300"
     wait="#{delivery.timeLimit}"
     elapsed="#{delivery.timeElapseAfterFileUpload}"
-    expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=loaded; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
+    expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=10*'#{delivery.timeElapse}'; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
 </h:panelGroup>
 
 <f:verbatim>  </span></f:verbatim>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/confirmSubmit.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/confirmSubmit.jsp
@@ -79,7 +79,7 @@ function saveTime()
 {
   if((typeof (document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'])!=undefined) && ((document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'])!=null) ){
   pauseTiming = 'false';
-  document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=loaded/10;
+  document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=${delivery.timeElapse};
  }
 }
 
@@ -168,7 +168,7 @@ function saveTime()
               && delivery.navigation ne '1'}" 
     />
   <h:commandButton id="save" type="submit" value="#{commonMessages.action_save}"
-     action="#{delivery.save_work}" onclick="disableSave();" 
+     action="#{delivery.save_work}"
      style="display:none"
      rendered="#{delivery.actionString=='previewAssessment'
                   || delivery.actionString=='takeAssessment'

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -129,7 +129,7 @@ function saveTime()
 {
   if((typeof (document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'])!=undefined) && ((document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'])!=null) ){
   pauseTiming = 'false';
-  document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=loaded/10;
+  document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=${delivery.timeElapse};
  }
 }
 function disableRationale(){

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverFillInNumeric.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverFillInNumeric.jsp
@@ -133,23 +133,25 @@ should be included in file importing DeliveryMessages
 <f:verbatim>
 <script>
 //Setup qtips
-$('.hasTooltip').each(function() { // Notice the .each() loop, discussed below
-    $(this).qtip({
-        content: {
-            text: $(this).next('div') // Use the "div" element after this for the content
-        },
-        position: {
-          target: 'mouse', 
-          adjust: {
-            mouse: false
-          }
-       },
-       style: {
-         classes: 'qtip-tipped qtip-shadow qtipBodyContent',
-       },
-       show: 'click',
-       hide: 'unfocus click'
-      });
-});
+window.onload = function() {
+	$('.hasTooltip').each(function() { // Notice the .each() loop, discussed below
+	    $(this).qtip({
+	        content: {
+	            text: $(this).next('div') // Use the "div" element after this for the content
+	        },
+	        position: {
+	          target: 'mouse', 
+	          adjust: {
+	            mouse: false
+	          }
+	       },
+	       style: {
+	         classes: 'qtip-tipped qtip-shadow qtipBodyContent',
+	       },
+	       show: 'click',
+	       hide: 'unfocus click'
+	      });
+	});
+};
 </script>
 </f:verbatim>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
@@ -72,9 +72,9 @@ function saveTime()
   //showElements(document.forms[0]);
   if((typeof (document.forms[0].elements['tableOfContentsForm:elapsed'])!=undefined) && ((document.forms[0].elements['tableOfContentsForm:elapsed'])!=null) ){
   pauseTiming = 'true';
-  // loaded is in 1/10th sec and elapsed is in sec, so need to divide by 10
-  if (self.loaded) {
-	document.forms[0].elements['tableOfContentsForm:elapsed'].value=loaded/10;
+  var timeElapse = ${delivery.timeElapse};
+  if (timeElapse) {
+	document.forms[0].elements['tableOfContentsForm:elapsed'].value=timeElapse;
   }
  }
 }
@@ -102,13 +102,13 @@ function saveTime()
   <samigo:timerBar height="15" width="300"
     wait="#{delivery.timeLimit}"
     elapsed="#{delivery.timeElapse}"
-    expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=loaded; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
+    expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=10*'#{delivery.timeElapse}'; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
  </h:panelGroup>
  <h:panelGroup rendered="#{delivery.timeElapseAfterFileUpload != null && delivery.timeElapseDouble lt delivery.timeElapseAfterFileUploadDouble && delivery.hasTimeLimit == true}">
  <samigo:timerBar height="15" width="300"
      wait="#{delivery.timeLimit}"
      elapsed="#{delivery.timeElapseAfterFileUpload}"
-     expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=loaded; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
+     expireScript="document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:elapsed'].value=10*'#{delivery.timeElapse}'; document.forms[0].elements['takeAssessmentForm:assessmentDeliveryHeading:outoftime'].value='true'; " />
 </h:panelGroup>
 
 <!-- END OF TIMER -->
@@ -209,7 +209,7 @@ function saveTime()
       disabled="#{delivery.actionString=='previewAssessment'}" />
   </h:panelGroup>
   <h:commandButton id="save" type="submit" value="#{commonMessages.action_save}"
-    action="#{delivery.save_work}" onclick="disableSave();" rendered="#{delivery.actionString=='previewAssessment'
+    action="#{delivery.save_work}" rendered="#{delivery.actionString=='previewAssessment'
       || delivery.actionString=='takeAssessment'
       || delivery.actionString=='takeAssessmentViaUrl'}" /> 
 

--- a/samigo/samigo-app/src/webapp/jsf/shared/removeMedia.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/shared/removeMedia.jsp
@@ -36,6 +36,7 @@
  <!-- content... -->
 
  <h:form>
+   <h:inputHidden id="showTimer" value="#{delivery.showTimer}"/>
    <h:inputHidden id="mediaId" value="#{mediaBean.mediaId}"/>
    <h3> <h:outputText  value="#{deliveryMessages.remove_media_conf}" /></h3>
    <div class="validation tier1">
@@ -55,6 +56,9 @@
         <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.UpdateTimerListener" />
       </h:commandButton>
    </p>
+   <!-- HEADING -->
+   <%@ include file="/jsf/delivery/questionProgress.jspf" %>
+   <%@ include file="/jsf/delivery/assessmentDeliveryTimer.jsp" %>
  </h:form>
  <!-- end content -->
 <!-- end content -->

--- a/samigo/samigo-app/src/webapp/jsf/widget/timerBar/timerbar.js
+++ b/samigo/samigo-app/src/webapp/jsf/widget/timerBar/timerbar.js
@@ -21,7 +21,7 @@
       var viewType = null;
       var viewGap = 0;
       var headerHeight;
-      var routePrefix = "";
+      var routePrefix = "../delivery/";
       var routeSuffix = "";
       var ajaxQuery = {
           "ajax": true


### PR DESCRIPTION
These are the three errors explained:

1. When you are on an assessment and student tries to save it, the error in the first screenshot appears because there is an undefined variable. DisableSave does not exists and it is unnecessary to keep it. It is needed to change variable loaded by its supossed value because it is undefined too. (first commit in the PR)

2. qtip plugin required images are not loaded (some images are heavier than others) and so we need to wait until all page has loaded (2nd commit)

3. RemoveMedia.jsp is in shared folder and when student tries to delete a file they can't see time variables because routePrefix is not correct, it supposes to be on same URL ("") but it's on "../delivery" because all other jsp assessment files are on "delivery" folder so we unify URL call. Also, showTimer is showed when students try to delete files. (3rd PR commit)