### PR TITLE
SAK-41345: Email Archive > restore proper rejection messages (regression)

### DIFF
--- a/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
+++ b/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
@@ -26,6 +26,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.sakaiproject.alias.api.AliasService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
@@ -91,6 +92,9 @@ public class SakaiMessageHandlerTest {
     private SessionManager sessionManager;
 
     @Mock
+    private EmailService emailService;
+
+    @Mock
     private Session session;
 
     private SakaiMessageHandlerFactory messageHandlerFactory;
@@ -109,6 +113,7 @@ public class SakaiMessageHandlerTest {
         messageHandlerFactory.setContentHostingService(contentHostingService);
         messageHandlerFactory.setMailArchiveService(mailArchiveService);
         messageHandlerFactory.setSessionManager(sessionManager);
+        messageHandlerFactory.setEmailService(emailService);
 
         // Binding to port 0 means that it picks a random port to listen on.
         when(serverConfigurationService.getInt("smtp.port", 25)).thenReturn(0);
@@ -143,7 +148,6 @@ public class SakaiMessageHandlerTest {
     @Test(expected = SMTPException.class)
     public void testRejectedAddress() throws Exception {
         when(aliasService.getTarget("user")).thenThrow(IdUnusedException.class);
-        when(rb.getString("err_addr_unknown")).thenReturn("err_addr_unknown");
         SmartClient client = createClient();
         client.from("sender@example.com");
         client.to("user@sakai.example.com");

--- a/mailarchive/mailarchive-subetha/src/webapp/WEB-INF/components.xml
+++ b/mailarchive/mailarchive-subetha/src/webapp/WEB-INF/components.xml
@@ -19,6 +19,7 @@
         <property name="threadLocalManager" ref="org.sakaiproject.thread_local.api.ThreadLocalManager"/>
         <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
         <property name="mailArchiveService" ref="org.sakaiproject.mailarchive.api.MailArchiveService"/>
+        <property name="emailService" ref="org.sakaiproject.email.api.EmailService"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41345

In Sakai 10.x and earlier, when using the Email Archive tool to send emails to either an invalid email address, or to a site email address from an account which did not have permission to do so, you would get rejection messages (emails) indicating the failure (and would also include the original email as an attachment).

When the community transitioned from using James to Subetha in Sakai 11.x+, these rejection messages were lost. Instead, the current behaviour is that Subetha just swallows these exceptions and there isn't any obvious indication to the user that a problem occurred. This PR reintroduces these rejection emails.

**NOTE:** I haven't tested this locally, but it's been running in a large production instance for over a year without issue.