### PR TITLE
SAK-41346: Site Info > allow maintainer to delete last roster in course site

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3097,6 +3097,19 @@
 # DEFAULT: false
 # site.duplicate.removeStealthTools=true
 
+# SAK-41346: Control if maintainer of course sites are able to delete the last remaining roster
+# attached to a site. If this is enabled, the user deleting the roster will automatically be
+# enrolled as a non-provided user in the maintain role, allowing the user to continue using
+# the site after the roster has been removed.
+#
+# WARNING: enabling this may have legal implications depending on your local privacy laws. For
+# example: FERPA in USA, FIPPA in regions of Canada, GDPR in regions of Europe, etc. More
+# information and an example of how this can come into play can be found on the JIRA ticket:
+# https://jira.sakaiproject.org/browse/SAK-41346
+#
+# DEFAULT: false
+# site.setup.allowDelLastRoster=true
+
 # SAK-13389: the ability to hide input area for adding non-official participant
 # DEFAULT=true
 # nonOfficialAccount=false

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -810,7 +810,10 @@ public class SiteAction extends PagedResourceActionII {
 
 	private static final String SAK_PROP_RM_STLTH_ON_DUP = "site.duplicate.removeStealthTools";
 	private static final boolean SAK_PROP_RM_STLTH_ON_DUP_DEFAULT = false;
-	
+
+	private static final String SAK_PROP_ALLOW_DEL_LAST_ROSTER = "site.setup.allowDelLastRoster";
+	private static final boolean SAK_PROP_ALLOW_DEL_LAST_ROSTER_DFLT = false;
+
 	// state variable for whether any multiple instance tool has been selected
 	private String STATE_MULTIPLE_TOOL_INSTANCE_SELECTED = "state_multiple_tool_instance_selected";
 	// state variable for lti tools
@@ -10345,6 +10348,14 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 							hasNonProvidedMainroleUser = true;
 					}
 				}
+
+				String currentUserId = SessionManager.getCurrentSessionUserId();
+				boolean allowDelLastRoster = ServerConfigurationService.getBoolean(SAK_PROP_ALLOW_DEL_LAST_ROSTER, SAK_PROP_ALLOW_DEL_LAST_ROSTER_DFLT);
+				if (allowDelLastRoster && !hasNonProvidedMainroleUser && realmEdit1.hasRole(currentUserId, maintainRoleString)) {
+					realmEdit1.addMember(currentUserId, maintainRoleString, true, false);
+					hasNonProvidedMainroleUser = true;
+				}
+
 				if (!hasNonProvidedMainroleUser)
 				{
 					// if after the removal, there is no provider id, and there is no maintain role user anymore, show alert message and don't save the update


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41346

Currently if an instructor tries to delete the only remaining roster attached to a course site (and there are no manually enrolled users with the maintain role), the instructor will receive an error message:

> Alert: The site has to have at least one user with role Instructor.

This PR proposes to change this behaviour so that the user is automatically enrolled as a non-provided maintainer role in the course site so that they are able to delete the last roster attached to a site. This has been reported as a pain point for users, as they have to remember to add a roster before they can remove the last roster. It also allows them to utilize the site without having a roster attached.