### PR TITLE
SAK-41347: Worksite Setup > Softly Deleted Sites > display 'Delete' button conditionally based on permission

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1532,8 +1532,10 @@ public class SiteAction extends PagedResourceActionII {
 			// If we're in the restore view
 			context.put("showRestore", SiteConstants.SITE_TYPE_DELETED.equals((String) state.getAttribute(STATE_VIEW_SELECTED)));
 
-			if (SecurityService.isSuperUser()) {
+			boolean isSuperUser = SecurityService.isSuperUser();
+			if (isSuperUser) {
 				context.put("superUser", Boolean.TRUE);
+				context.put("canDelSoftDel", Boolean.TRUE);
 			} else {
 				context.put("superUser", Boolean.FALSE);
 			}
@@ -1648,9 +1650,20 @@ public class SiteAction extends PagedResourceActionII {
 			context.put("portalUrl", portalUrl);
 
 			List<Site> allSites = prepPage(state);
-						
 			state.setAttribute(STATE_SITES, allSites);
 			context.put("sites", allSites);
+
+			if (!isSuperUser) {
+				boolean canDelSoftDel = false;
+				for (Site s : allSites) {
+					canDelSoftDel = SecurityService.unlock("site.del.softly.deleted", s.getReference());
+					if (canDelSoftDel) {
+						break;
+					}
+				}
+
+				context.put("canDelSoftDel", canDelSoftDel);
+			}
 
 			context.put("totalPageNumber", Integer.valueOf(totalPageNumber(state)));
 			context.put("searchString", state.getAttribute(STATE_SEARCH));

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-list.vm
@@ -83,8 +83,10 @@
 								onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_hard_delete';document.getElementById('sitesForm').submit();return false;" />
 						#end
 					#else
-						<input type="button" id="btnSoftDelete1" name="btnSoftDelete1" class="actionButton" value="$tlang.getString("java.delete")" disabled="disabled"
-							onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_delete';document.getElementById('sitesForm').submit();return false;" />
+						#if( $superUser || $canDelSoftDel )
+							<input type="button" id="btnHardDelete1" name="btnHardDelete1" class="actionButton" value="$tlang.getString("java.delete")" disabled="disabled" aria-label="$tlang.getString("java.delete")"
+								onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_delete';document.getElementById('sitesForm').submit();return false;" />
+						#end
 						#if( $showRestore )
 							<input type="button" id="btnRestore1" name="btnRestore1" class="actionButton" value="$tlang.getString("java.restore")" disabled="disabled"
 								onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_restore';document.getElementById('sitesForm').submit();return false;" />
@@ -308,7 +310,7 @@
 							onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doGet_site';document.getElementById('sitesForm').submit();return false;" />
 						<input type="button" id="btnSoftDelete2" name="btnSoftDelete2" class="actionButton" value="$tlang.getString("java.delete")" disabled="disabled"
 							onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_delete';document.getElementById('sitesForm').submit();return false;" />
-						#if( $superUser )
+						#if( $superUser || $canDelSoftDel )
 							<input type="button" id="btnHardDelete2" name="btnHardDelete2" class="actionButton" value="$tlang.getString("java.delete.hard")" disabled="disabled"
 								onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_hard_delete';document.getElementById('sitesForm').submit();return false;" />
 						#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41347

The permission "site.del" determines if a user can softly delete a site, and the permission "site.del.softly.deleted" determines if a user can hard delete a previously softly deleted site.

However when a user is in the "View: Softly Deleted Sites" UI, the "Delete" button is present regardless of if the user has the "site.del.softly.deleted" permission. If the user lacks this permission, makes some selections from the table and selects "Delete", they will be presented with an error message indicating they don't have the necessary permissions to perform the action.

This PR introduces more logic to conditionally render the (hard) "Delete" button in the "View: Softly Deleted Sites" UI.