### PR TITLE
SAK-41348: Worksite Setup > position and primary action for 'continue with no roster' button

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
@@ -76,6 +76,7 @@
 				##and finally - the labels work, but having commas in the id does not validate. Can we concatenate or replace with underscore? Here is reqs on ids and labels: an id attribute value must begin with a letter (A-Z or a-z) and consist of the following characters: (A-Z), (a-z), (0-9), hyphens (-), underscores (_), colons (:), and periods (.).
 				#set($crosslisted=0)	
 				#set($courseNumber=0)
+				#set($hasRosters=false)
 				#foreach($courseObject in $termCourseList)
 					<table class="listHier lines nolines specialLink" cellpadding="0" cellspacing="0"  summary="$tlang.getString("nscourse.courselist.summary")" border="0" style="width:auto">
 					<tr>	
@@ -91,6 +92,7 @@
 					</th>
 					</tr>
 					#foreach($courseOfferingObject in $courseObject.courseOfferingObjects)
+						#set($hasRosters=true)
 						<tr class="exclude"><td colspan="3" style="white-space:nowrap">
 						#if ($providerCourseList) 
 							#set($endKey = $courseNumber + $!courseOfferingObject.sections.size() - $!providerCourseList.size())
@@ -235,6 +237,19 @@
 					#if ($!basedOnTemplate) value="$tlang.getString('sitetype.done')" #else value="$tlang.getString('gen.continue')" #end
 					onclick="SPNR.disableControlsAndSpin( this, null );document.addCourseForm.option.value='continue'; document.addCourseForm.submit(); return false;"
 					/>
+				## SAK-28990 controlled via sakai.property sitemanage.continueWithNoRoster.enabled
+				#if( $!contNoRosterEnabled )
+				<input
+					#if( !$hasRosters ) class="active" #end
+					type="submit"
+					accesskey="x"
+					name="Cancel"
+					id="cancelButton"
+					value="$tlang.getString('nscourse.no_rosters')"
+					aria-label="$tlang.getString('nscourse.no_rosters')"
+					onclick="SPNR.disableControlsAndSpin( this, null );document.addCourseForm.option.value='norosters'; document.addCourseForm.submit(); return false;"
+					/>
+				#end
 				<input
 					type="submit" 
 					accesskey="b"
@@ -251,17 +266,6 @@
 					value="$tlang.getString('gen.cancel')"
 					onclick="SPNR.disableControlsAndSpin( this, null );document.addCourseForm.option.value='cancel'; document.addCourseForm.submit(); return false;"
 					/>
-				## SAK-28990 controlled via sakai.property sitemanage.continueWithNoRoster.enabled
-				#if( $!contNoRosterEnabled )
-				<input
-					type="submit" 
-					accesskey="x"
-					name="Cancel" 
-					id="cancelButton" 
-					value="$tlang.getString('nscourse.no_rosters')"
-					onclick="SPNR.disableControlsAndSpin( this, null );document.addCourseForm.option.value='norosters'; document.addCourseForm.submit(); return false;"
-					/>
-				#end
 				</p>
 			#else
 				#if( !$skipCourseSectionSelection || !$skipManualCourseCreation)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41348

If a user selects to create a course site which does not yet have any rosters for selection (and the continue with no roster button is enabled via sakai.properties), the 'Continue' button is disabled, the "Back' button becomes the primary action button, and the "Continue with no roster" button is displayed to the very right, after the "Back" and "Cancel" buttons.

The linked PR proposes moving the "Continue with no roster" button to be to the right of the "Continue" button, with the "Back" and "Cancel" buttons further to the right. It also makes the 'Continue with no roster" button the primary action button when there are no rosters selectable (instead of the "Back" button becoming primary).