### PR TITLE
SAK-41391: Polls > in an Oracle environment poll options are not displayed in the order they're created

### DIFF
--- a/polls/api/src/java/org/sakaiproject/poll/hbm/Option.hbm.xml
+++ b/polls/api/src/java/org/sakaiproject/poll/hbm/Option.hbm.xml
@@ -8,9 +8,9 @@
 		<!-- create the primary key id, using native is typically the best way
 			to do this -->
 		<id name="optionId" type="long" column="OPTION_ID">
-	    	<generator class="native">
-                <param name="sequence">POLL_OPTION_ID_SEQ</param>
-	    	</generator>
+			<generator class="native">
+				<param name="sequence">POLL_OPTION_ID_SEQ</param>
+			</generator>
 		</id>
 		<!-- The remaining properties should just match the properties
 			of your value object.
@@ -20,18 +20,19 @@
 			Column names are optional but people often specify them. -->
 
 		<property name="pollId" type="long" not-null="true">
-            <column name="OPTION_POLL_ID"/>
-        </property>
-		<property name="optionText" type="materialized_clob" length="255" not-null="true">
-            <column name="OPTION_TEXT"/>
-        </property>
-        <property name="Uuid" type="string" length="255" not-null="true">
-        	<column name="OPTION_UUID" />
-        </property>
-        <property name="deleted" type="java.lang.Boolean">
-        	<column name="DELETED" />
-        </property>
-     </class>
-    
-	
+			<column name="OPTION_POLL_ID"/>
+		</property>
+		<property name="text" type="materialized_clob" length="255" not-null="true">
+			<column name="OPTION_TEXT"/>
+		</property>
+		<property name="Uuid" type="string" length="255" not-null="true">
+			<column name="OPTION_UUID" />
+		</property>
+		<property name="deleted" type="java.lang.Boolean">
+			<column name="DELETED" />
+		</property>
+		<property name="optionOrder" type="int" not-null="true">
+			<column name="OPTION_ORDER" />
+		</property>
+	</class>
 </hibernate-mapping>

--- a/polls/api/src/java/org/sakaiproject/poll/model/Option.java
+++ b/polls/api/src/java/org/sakaiproject/poll/model/Option.java
@@ -32,6 +32,7 @@ public class Option {
     private String status;
     private String uuid;
     private Boolean deleted = Boolean.FALSE;
+    private Integer optionOrder;
 
     public Option() {}
 
@@ -39,19 +40,7 @@ public class Option {
         this.optionId = oId;
     }
 
-    public void setOptionText(String option) {
-        text = option;
-    }
-
-    public String getOptionText() {
-        return text;
-    }
-
     public String getId() {
         return optionId+"";
-    }
-    
-    public void setId(Long id) {
-        this.optionId = optionId;
     }
 }

--- a/polls/api/src/java/org/sakaiproject/poll/util/PollUtil.java
+++ b/polls/api/src/java/org/sakaiproject/poll/util/PollUtil.java
@@ -52,7 +52,7 @@ public class PollUtil {
 
         element.setAttribute("id", option.getUuid());
         element.setAttribute("optionid", option.getOptionId().toString());
-        element.setAttribute("title", option.getOptionText());
+        element.setAttribute("title", option.getText());
         element.setAttribute("deleted", option.getDeleted().toString());
         stack.pop();
 
@@ -69,7 +69,7 @@ public class PollUtil {
                 //LOG THIS
             }
         }
-        option.setOptionText(element.getAttribute(TEXT));
+        option.setText(element.getAttribute(TEXT));
         option.setDeleted(Boolean.parseBoolean(element.getAttribute(DELETED)));
         return option;
     }

--- a/polls/impl/pom.xml
+++ b/polls/impl/pom.xml
@@ -61,7 +61,11 @@
         <dependency>
            <groupId>org.apache.commons</groupId>
            <artifactId>commons-lang3</artifactId>
-       </dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
@@ -125,6 +129,10 @@
             <groupId>oro</groupId>
             <artifactId>oro</artifactId>
             <version>2.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
         </dependency>
     </dependencies>
 

--- a/polls/impl/src/java/org/sakaiproject/poll/logic/impl/PollOrderOptionBackFillJob.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/logic/impl/PollOrderOptionBackFillJob.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2003-2019 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.poll.logic.impl;
+
+import java.util.Comparator;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.poll.logic.PollListManager;
+import org.sakaiproject.poll.model.Option;
+import org.sakaiproject.poll.model.Poll;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.SiteService.SelectionType;
+import org.sakaiproject.site.api.SiteService.SortType;
+
+/**
+ * This Quartz job is responsible for back-filling the 'order' attribute of all existing Poll options.
+ * It will iterate over all sites in the system, ordered by creation date. It will then request any
+ * existing Polls for the site, starting with the newest and working backwards, and back-fill the
+ * 'order' attribute of each poll's options based on the option's original ID value. If the options
+ * are not null, the job will abort to avoid re-setting already existing orders (in case the job is
+ * accidentally run more than once).
+ *
+ * @author Brian Jones (bjones86@uwo.ca)
+ */
+@Slf4j
+@DisallowConcurrentExecution
+public class PollOrderOptionBackFillJob implements Job
+{
+    // APIs
+    @Getter @Setter private SiteService     siteService;
+    @Getter @Setter private SecurityService securityService;
+    @Getter @Setter private PollListManager pollService;
+
+    private static final SecurityAdvisor YES_MAN = (String userId, String function, String reference) -> SecurityAdvisor.SecurityAdvice.ALLOWED;
+
+    /**
+     * This is the method that is fired when the job is 'triggered'.
+     *
+     * @param jobExecutionContext - the context of the job execution
+     * @throws JobExecutionException
+     */
+    @Override
+    public void execute( JobExecutionContext jobExecutionContext ) throws JobExecutionException
+    {
+        log.info( "Attempting to back-fill all existing Poll option orders..." );
+        int modifiedCount = 0;
+
+        // Iterate over sites in the system, ordered by creation date...
+        List<Site> sites = siteService.getSites( SelectionType.ANY, null, null, null, SortType.CREATED_ON_DESC, null );
+        if( !CollectionUtils.isEmpty( sites ) )
+        {
+            for( Site site : sites )
+            {
+                String siteID = site.getId();
+                List<Poll> pollsForSite = pollService.findAllPolls( siteID );
+                if( !CollectionUtils.isEmpty( pollsForSite ) )
+                {
+                    // Iterate over the polls for the site...
+                    for( Poll poll : pollsForSite )
+                    {
+                        try
+                        {
+                            // Iterate over Options in the poll...
+                            securityService.pushAdvisor( YES_MAN );
+                            List<Option> pollOptions = pollService.getOptionsForPoll( poll );
+                            if( !CollectionUtils.isEmpty( pollOptions ) )
+                            {
+                                // Check if any options have a null order
+                                boolean hasNullOptionOrder = false;
+                                for( Option option : pollOptions )
+                                {
+                                    if( option.getOptionOrder() == null )
+                                    {
+                                        hasNullOptionOrder = true;
+                                        break;
+                                    }
+                                }
+
+                                // If any of the option's order is null, we need to back-fill them
+                                if( hasNullOptionOrder )
+                                {
+                                    log.info( "Poll ID {} has options with null order, processing...", poll.getId() );
+
+                                    // Order the list by ID
+                                    pollOptions.sort( Comparator.comparingLong( Option::getOptionId ) );
+
+                                    // Iterate over the list
+                                    for( int i = 0; i < pollOptions.size(); i++ )
+                                    {
+                                        // Add order based on ID
+                                        Option option = pollOptions.get( i );
+                                        option.setOptionOrder(i);
+                                        pollService.saveOption( option );
+                                        modifiedCount++;
+                                        log.info( "Option {} ---> new order == {}", option.getId(), i );
+                                    }
+                                }
+                            }
+                        }
+                        catch( Exception ex )
+                        {
+                            log.error( "Unexcepted exception", ex );
+                        }
+                        finally
+                        {
+                            securityService.popAdvisor( YES_MAN );
+                        }
+                    }
+                }
+            }
+        }
+
+        log.info( "Processing finished, modified {} poll options", modifiedCount );
+    }
+}

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -36,7 +36,9 @@ import java.util.Vector;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.Data;
+
 import org.springframework.dao.DataAccessException;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -280,7 +282,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
         }
         Search search = new Search();
         search.addRestriction(new Restriction("pollId", pollId));
-        search.addOrder(new Order("optionId"));
+        search.addOrder(new Order("optionOrder"));
         List<Option> optionList = dao.findBySearch(Option.class, search);
         return optionList;
     }
@@ -569,7 +571,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
 				        while (fromOptions.hasNext()){
 				        	Option fromOption = (Option) fromOptions.next();
 				        	Option toOption = (Option) new Option();
-				        	toOption.setOptionText(fromOption.getOptionText());
+				        	toOption.setText(fromOption.getText());
 				        	toOption.setStatus(fromOption.getStatus());
 				        	toOption.setPollId(toPoll.getPollId());
 				        	toOption.setDeleted(fromOption.getDeleted());

--- a/polls/impl/src/test/org/sakaiproject/poll/logic/test/PollListManagerTest.java
+++ b/polls/impl/src/test/org/sakaiproject/poll/logic/test/PollListManagerTest.java
@@ -209,11 +209,11 @@ public class PollListManagerTest extends AbstractTransactionalJUnit4SpringContex
 		
 	    Option option1 = new Option();
 	    option1.setPollId(poll1.getPollId());
-	    option1.setOptionText("asdgasd");
+	    option1.setText("asdgasd");
 	    
 	    Option option2 = new Option();
 	    option2.setPollId(poll1.getPollId());
-	    option2.setOptionText("zsdbsdfb");
+	    option2.setText("zsdbsdfb");
 	    
 	    pollListManager.saveOption(option2);
 	    pollListManager.saveOption(option1);

--- a/polls/impl/src/test/org/sakaiproject/poll/logic/test/TestDataPreload.java
+++ b/polls/impl/src/test/org/sakaiproject/poll/logic/test/TestDataPreload.java
@@ -111,12 +111,12 @@ public class TestDataPreload {
 		
 		//add some options
 		Option option1 = new Option();
-		option1.setOptionText("Option 1");
+		option1.setText("Option 1");
 		option1.setPollId(poll1.getPollId());
 		dao.save(option1);
 		
 		Option option2 = new Option();
-		option2.setOptionText("Option 2");
+		option2.setText("Option 2");
 		option2.setPollId(poll1.getPollId());
 		dao.save(option2);
 		

--- a/polls/impl/src/webapp/WEB-INF/components.xml
+++ b/polls/impl/src/webapp/WEB-INF/components.xml
@@ -56,6 +56,29 @@
 		<property name="emailTemplates" ref="org.sakaiproject.poll.emailtemplates.List" />
 	</bean>
 
+	<!-- Job to back-fill Poll options' order -->
+	<bean id="pollOrderOptionBackFillJob" class="org.sakaiproject.poll.logic.impl.PollOrderOptionBackFillJob">
+		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
+		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
+		<property name="pollService" ref="org.sakaiproject.poll.logic.PollListManager" />
+	</bean>
+	<bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.pollOrderOptionBackFillJob"
+		class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+		init-method="init">
+
+		<property name="beanId">
+			<value>pollOrderOptionBackFillJob</value>
+		</property>
+
+		<property name="jobName">
+			<value>Backfill all existing poll options' order based on their original ID</value>
+		</property>
+
+		<property name="schedulerManager">
+			<ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
+		</property>
+	</bean>
+
 	<!-- Setup email templates -->
 	<bean id="org.sakaiproject.poll.emailtemplates.List" class="java.util.ArrayList">
 		<constructor-arg>

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/entityproviders/PollOptionEntityProvider.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/entityproviders/PollOptionEntityProvider.java
@@ -81,7 +81,7 @@ public class PollOptionEntityProvider extends AbstractEntityProvider implements 
             throw new IllegalArgumentException("Poll ID must be set to create an option");
         }
         // check minimum settings
-        if (option.getOptionText() == null) {
+        if (option.getText() == null) {
             throw new IllegalArgumentException("Poll Option text must be set to create an option");
         }
         checkOptionPermission(userReference, option);

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/entityproviders/PollsEntityProvider.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/entityproviders/PollsEntityProvider.java
@@ -547,7 +547,7 @@ public class PollsEntityProvider extends AbstractEntityProvider implements
 					"Poll ID must be set to create an option");
 		}
 		// check minimum settings
-		if (option.getOptionText() == null) {
+		if (option.getText() == null) {
 			throw new IllegalArgumentException(
 					"Poll Option text must be set to create an option");
 		}

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/params/PollToolBean.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/params/PollToolBean.java
@@ -274,30 +274,24 @@ public class PollToolBean {
 		if ("cancel".equals(submissionStatus))
 			return "cancel";
 		
-		log.debug("adding option with text " + option.getOptionText());
-		if (option.getOptionText() == null || option.getOptionText().trim().length()==0) {
+		log.debug("adding option with text " + option.getText());
+		if (option.getText() == null || option.getText().trim().length()==0) {
 			//errors.reject("vote_closed","vote closed");
 			// return null;
 		}
 		StringBuilder sb = new StringBuilder();
-		option.setOptionText(FormattedText.processFormattedText(option.getOptionText(), sb, true, true));
+		option.setText(FormattedText.processFormattedText(option.getText(), sb, true, true));
 
-		String text = option.getOptionText();
-		text = PollUtils.cleanupHtmlPtags(text);
-
-		option.setOptionText(text);
+		String text = PollUtils.cleanupHtmlPtags(option.getText());
+		option.setText(text);
+		option.setOptionOrder(manager.getOptionsForPoll(option.getPollId()).size());
 		manager.saveOption(option);
 		log.debug("Succesuly save option with id" + option.getId());
 
-		//voteBean.poll = manager.getPollById(option.getPollId());
-
-		
 		if ("option".equals(submissionStatus))
 			return "option";
 		else 
 			return "Saved";
-
-		
 	}
 
 	

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/producers/AddPollProducer.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/producers/AddPollProducer.java
@@ -37,8 +37,6 @@ import org.sakaiproject.poll.model.Vote;
 import org.sakaiproject.poll.tool.params.OptionViewParameters;
 import org.sakaiproject.poll.tool.params.PollViewParameters;
 import org.sakaiproject.poll.tool.params.VoteBean;
-import org.sakaiproject.tool.api.Session;
-import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.util.FormattedText;
 
 import uk.org.ponder.localeutil.LocaleGetter;
@@ -218,18 +216,18 @@ public class AddPollProducer implements ViewComponentProducer,NavigationCaseRepo
 			for (int i = 0; i < options.size(); i++){
 				Option o = (Option)options.get(i);
 				UIBranchContainer oRow = UIBranchContainer.make(actionBlock,"options-row:",o.getOptionId().toString());
-				UIVerbatim.make(oRow,"options-name",o.getOptionText());
+				UIVerbatim.make(oRow,"options-name",o.getText());
 
 
 				UIInternalLink editOption = UIInternalLink.make(oRow,"option-edit",UIMessage.make("new_poll_option_edit"),
 						new OptionViewParameters(PollOptionProducer.VIEW_ID, o.getOptionId().toString()));
 
-				editOption.decorators = new DecoratorList(new UITooltipDecorator(messageLocator.getMessage("new_poll_option_edit") +":" + FormattedText.convertFormattedTextToPlaintext(o.getOptionText())));
+				editOption.decorators = new DecoratorList(new UITooltipDecorator(messageLocator.getMessage("new_poll_option_edit") +":" + FormattedText.convertFormattedTextToPlaintext(o.getText())));
 
 				UIInternalLink deleteOption = UIInternalLink.make(oRow,"option-delete",UIMessage.make("new_poll_option_delete"),
 						new OptionViewParameters(PollOptionDeleteProducer.VIEW_ID,o.getOptionId().toString()));
 
-				deleteOption.decorators = new DecoratorList(new UITooltipDecorator(messageLocator.getMessage("new_poll_option_delete") +":" + FormattedText.convertFormattedTextToPlaintext(o.getOptionText())));
+				deleteOption.decorators = new DecoratorList(new UITooltipDecorator(messageLocator.getMessage("new_poll_option_delete") +":" + FormattedText.convertFormattedTextToPlaintext(o.getText())));
 
 			}
 		}

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/producers/PollOptionDeleteProducer.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/producers/PollOptionDeleteProducer.java
@@ -47,7 +47,6 @@ import uk.org.ponder.rsf.components.UIMessage;
 import uk.org.ponder.rsf.components.UIOutput;
 import uk.org.ponder.rsf.components.UISelect;
 import uk.org.ponder.rsf.components.UISelectChoice;
-import uk.org.ponder.rsf.components.UIVerbatim;
 import uk.org.ponder.rsf.components.decorators.UIFreeAttributeDecorator;
 import uk.org.ponder.rsf.flow.ARIResult;
 import uk.org.ponder.rsf.flow.ActionResultInterceptor;
@@ -115,11 +114,11 @@ public class PollOptionDeleteProducer implements ViewComponentProducer, ActionRe
 		UIOutput.make(tofill, "polls-html", null).decorate(new UIFreeAttributeDecorator(langMap));
 		
 		UIMessage.make(tofill, "error", "delete_option_message",
-				new Object[] { option.getOptionText() }
+				new Object[] { option.getText() }
 			);
 		
 		UIForm form = UIForm.make(tofill,"opt-form");
-		UIInput.make(form,"opt-text","#{option.optionText}",option.getOptionText());
+		UIInput.make(form,"opt-text","#{option.text}",option.getText());
 
 		Poll poll = pollListManager.getPollById(option.getPollId());
 		Boolean showVoteHandlingOptions = Boolean.FALSE;

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/producers/PollOptionProducer.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/producers/PollOptionProducer.java
@@ -35,8 +35,6 @@ import org.sakaiproject.poll.model.Poll;
 import org.sakaiproject.poll.tool.params.OptionViewParameters;
 import org.sakaiproject.poll.tool.params.PollViewParameters;
 import org.sakaiproject.poll.tool.params.VoteBean;
-import org.sakaiproject.tool.api.Session;
-import org.sakaiproject.tool.api.SessionManager;
 
 import uk.org.ponder.localeutil.LocaleGetter;
 import uk.org.ponder.messageutil.MessageLocator;
@@ -177,20 +175,20 @@ public class PollOptionProducer implements ViewComponentProducer,ViewParamsRepor
 		//UIOutput.make(form,"option-label",messageLocator.getMessage("new_poll_option"));
 
 
-		if (option.getOptionText() == null)
-			option.setOptionText("");
+		if (option.getText() == null)
+			option.setText("");
 
 		
 		if (!externalLogic.isMobileBrowser())
 		{
 			// show WYSIWYG editor
-		UIInput optText = UIInput.make(form,"optText:","#{option.optionText}",option.getOptionText());
+		UIInput optText = UIInput.make(form,"optText:","#{option.text}",option.getText());
 		richTextEvolver.evolveTextInput(optText);
 		}
 		else
 		{
 			// do not show WYSIWYG editor in the mobile view
-			UIInput optText = UIInput.make(form,"optText_mobile","#{option.optionText}",option.getOptionText());
+			UIInput.make(form,"optText_mobile","#{option.text}",option.getText());
 		}
 
 		form.parameters.add(new UIELBinding("#{option.pollId}",

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/producers/PollVoteProducer.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/producers/PollVoteProducer.java
@@ -166,8 +166,8 @@ public class PollVoteProducer implements ViewComponentProducer,ViewParamsReporte
 		String[] labels = new String[pollOptions.size()];
 		for (int i = 0;i<  pollOptions.size(); i++ ) {
 			Option po = (Option)pollOptions.get(i);
-			if (po.getOptionText() != null ) {
-				labels[i]= po.getOptionText();
+			if (po.getText() != null ) {
+				labels[i]= po.getText();
 			} else {
 				log.warn("Option text is null!");
 				labels[i]="null option!";
@@ -191,7 +191,7 @@ public class PollVoteProducer implements ViewComponentProducer,ViewParamsReporte
 		String selectID = radio.getFullID();
 		for (int i = 0;i < pollOptions.size(); i++ ) {
 			Option po = (Option)pollOptions.get(i);
-			log.debug("got option " + po.getOptionText() + " with id of  " + po.getId());
+			log.debug("got option " + po.getText() + " with id of  " + po.getId());
 			UIBranchContainer radioRow = UIBranchContainer.make(voteForm,
 					isMultiple ? "option:select"
 							: "option:radio"						 

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/producers/ResultsProducer.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/producers/ResultsProducer.java
@@ -49,7 +49,6 @@ import uk.org.ponder.rsf.components.UIContainer;
 import uk.org.ponder.rsf.components.UIForm;
 import uk.org.ponder.rsf.components.UIInternalLink;
 import uk.org.ponder.rsf.components.UILink;
-import uk.org.ponder.rsf.components.UIMessage;
 import uk.org.ponder.rsf.components.UIOutput;
 import uk.org.ponder.rsf.components.UISelect;
 import uk.org.ponder.rsf.components.UIVerbatim;
@@ -150,7 +149,7 @@ public class ResultsProducer implements ViewComponentProducer,NavigationCaseRepo
 		//Append an option for no votes
 		if (poll.getMinOptions()==0) {
 			Option noVote = new Option(Long.valueOf(0));
-			noVote.setOptionText(messageLocator.getMessage("result_novote"));
+			noVote.setText(messageLocator.getMessage("result_novote"));
 			noVote.setPollId(poll.getPollId());
 			pollOptions.add(noVote);
 		}
@@ -165,7 +164,7 @@ public class ResultsProducer implements ViewComponentProducer,NavigationCaseRepo
 			Option option = (Option) pollOptions.get(i);
 			log.debug("collating option " + option.getOptionId());
 			collatedVote.setoptionId(option.getOptionId());
-			collatedVote.setOptionText(option.getOptionText());
+			collatedVote.setOptionText(option.getText());
 			collatedVote.setDeleted(option.getDeleted());
 			for (int q=0; q <votes.size(); q++ ) {
 				Vote vote = (Vote)votes.get(q);

--- a/polls/tool/src/java/org/sakaiproject/poll/tool/validators/OptionValidator.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/validators/OptionValidator.java
@@ -42,22 +42,20 @@ public class OptionValidator implements Validator {
 
 	public void validate(Object obj, Errors errors) {
 
-
 		Option option = (Option) obj;
 		
 		// SAK-14725 : BugFix
 		String stripText = null;
 		
-		if(null != option.getOptionText()) {
-			stripText = FormattedText.convertFormattedTextToPlaintext(option.getOptionText()).trim();
+		if(null != option.getText()) {
+			stripText = FormattedText.convertFormattedTextToPlaintext(option.getText()).trim();
 		}
 		
 		log.debug("validating Option with id:" + option.getOptionId());
 		if (option.getStatus()!=null && (option.getStatus().equals("cancel") || option.getStatus().equals("delete")))
 			return;
 
-
-		if (option.getOptionText() == null || option.getOptionText().trim().length()==0 ||
+		if (option.getText() == null || option.getText().trim().length()==0 ||
 				stripText == null || stripText.length()==0) {
 			log.debug("OptionText is empty!");
 			errors.reject("option_empty","option empty");
@@ -65,9 +63,7 @@ public class OptionValidator implements Validator {
 		}
 
 		//if where here option is not null or empty but could be something like "&nbsp;&nbsp;"
-		String text = option.getOptionText();
-		
-
+		String text = option.getText();
 		text = PollUtils.cleanupHtmlPtags(text);
 		text = text.replace("&nbsp;", "");
 		text = StringEscapeUtils.unescapeHtml3(text).trim();
@@ -77,12 +73,5 @@ public class OptionValidator implements Validator {
 			errors.reject("option_empty","option empty");
 			return;
 		}
-
-
-
 	}
-
-
-
-
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41391

Conversion scripts PR: https://github.com/sakaiproject/sakai-reference/pull/49

This bug only affects those who are running with an Oracle database. When creating options for a poll the display of these options (for both instructors and students) may appear in a "random" order, rather than the order in which they were created.

The cause of this bug is that the code is doing an `ORDER BY` clause on the `optionId` column, which is the primary key of the table:

```
    public List<Option> getOptionsForPoll(Long pollId) {
        Poll poll;
		try {
			poll = getPollById(pollId, false);
		} catch (SecurityException e) {
			throw new SecurityException(e);
		}
        if (poll == null) {
            throw new IllegalArgumentException("Cannot get options for a poll ("+pollId+") that does not exist");
        }
        Search search = new Search();
        search.addRestriction(new Restriction("pollId", pollId));
        search.addOrder(new Order("optionId"));
        List<Option> optionList = dao.findBySearch(Option.class, search);
        return optionList;
    }
```

In MySQL, this field is defined as an `auto_increment` field, which guarantees that the IDs are unique and ascending:

```
mysql> describe poll_option;
+----------------+--------------+------+-----+---------+----------------+
| Field          | Type         | Null | Key | Default | Extra          |
+----------------+--------------+------+-----+---------+----------------+
| OPTION_ID      | bigint(20)   | NO   | PRI | NULL    | auto_increment |
| OPTION_POLL_ID | bigint(20)   | YES  |     | NULL    |                |
| OPTION_TEXT    | longtext     | YES  |     | NULL    |                |
| OPTION_UUID    | varchar(255) | YES  |     | NULL    |                |
| DELETED        | bit(1)       | YES  |     | NULL    |                |
| OPTION_ORDER   | int(11)      | YES  |     | NULL    |                |
+----------------+--------------+------+-----+---------+----------------+
```

So for those on MySQL, this bug never presents itself because the IDs of the options are always in the order in which they were created. However, in Oracle this field uses a sequence to generate the ID, and sequences do not behave in the same way an `auto_increment` field in MySQL does:

>     do not rely on sequences being
> 
>     a) gap free
>     b) sequential
>     c) always increasing
> 
>     Only think of them as "unique - nothing more, nothing less"

Source: https://asktom.oracle.com/pls/apex/f?p=100:11:0::::P11_QUESTION_ID:369390500346406705

Given these known limitations of Oracle's sequence, you can see how a situation can arise where the IDs of the options created by the user may or may not be in direct ascending order. The result is that the options may present themselves in a differing order than the user expects (a different order than they were created in).

The use of the primary key determining the "order" of the option also has a severe limitation: introducing a "re-order" functionality can become tricky if you have to manipulate primary keys.

This PR introduces a new, dedicated `OPTION_ORDER` column in the `POLL_OPTION` table to store the option's visual order. By doing so, it not only eliminates the Oracle bug, but it also lays the groundwork for introducing a "re-order" function for the end users (which will be coming in the future).

It also introduces a new Quartz job (named "Backfill all existing poll options' order based on their original ID"), which is a run-only-once task to back-fill the `OPTION_ORDER` column for all existing poll options (maybe not all, but any Polls that are attached to an existing site). The job outputs logger statements to track the process. For example:

```
28-Feb-2019 11:43:21.196 INFO [QuartzScheduler_Worker-3] org.sakaiproject.component.app.scheduler.jobs.PollOrderOptionBackFillJob.execute Attempting to back-fill all existing Poll option orders...
...
28-Feb-2019 11:43:22.106 INFO [QuartzScheduler_Worker-3] org.sakaiproject.component.app.scheduler.jobs.PollOrderOptionBackFillJob.execute Poll ID 4 has options with null order, processing...
...
28-Feb-2019 11:43:22.116 INFO [QuartzScheduler_Worker-3] org.sakaiproject.component.app.scheduler.jobs.PollOrderOptionBackFillJob.execute Option 7 ---> new order == 1
...
28-Feb-2019 11:44:04.234 INFO [QuartzScheduler_Worker-3] org.sakaiproject.component.app.scheduler.jobs.PollOrderOptionBackFillJob.execute Processing finished, modified 27 poll options
```

**IMPLICATIONS:**

1. Institutions must run the relevant conversion script
2. Institutions must run the Quartz job once (this is required because the SQL statement now orders by the `OPTION_ORDER` column, and null values in this column will cause the query to explode)