### PR TITLE
SAK-41394: Clean up polls events

### DIFF
--- a/polls/api/src/java/org/sakaiproject/poll/logic/ExternalLogic.java
+++ b/polls/api/src/java/org/sakaiproject/poll/logic/ExternalLogic.java
@@ -231,6 +231,6 @@ public interface ExternalLogic {
     /**
      * Register a statement with the system LearningResourceStoreService
      */
-    public void registerStatement(String pollText, boolean newPoll);
+    public void registerStatement(String pollText, boolean newPoll, String pollId);
 
 }

--- a/polls/impl/src/java/org/sakaiproject/poll/logic/impl/ExternalLogicImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/logic/impl/ExternalLogicImpl.java
@@ -487,6 +487,10 @@ public class ExternalLogicImpl implements ExternalLogic {
         return new LRS_Statement(student, verb, lrsObject);
     }
 
+    private String getPollRef(String pollId) {
+        return "poll" + getCurrentLocationReference() + "/poll/" + pollId;
+    }
+
     /**
      * @see org.sakaiproject.poll.logic.ExternalLogic#registerStatement(java.lang.String, org.sakaiproject.poll.model.Vote)
      */
@@ -494,19 +498,20 @@ public class ExternalLogicImpl implements ExternalLogic {
     public void registerStatement(String pollText, Vote vote) {
         if (null != learningResourceStoreService) {
             LRS_Statement statement = getStatementForUserVotedInPoll(pollText, vote);
-            Event event = eventTrackingService.newEvent("poll.vote", "vote", null, true, NotificationService.NOTI_OPTIONAL, statement);
+            Event event = eventTrackingService.newEvent("poll.vote", getPollRef(vote.getPollId().toString()), null, true, NotificationService.NOTI_OPTIONAL, statement);
             eventTrackingService.post(event);
         }
     }
 
     /**
-     * @see org.sakaiproject.poll.logic.ExternalLogic#registerStatement(java.lang.String, boolean)
+     * @see org.sakaiproject.poll.logic.ExternalLogic#registerStatement(java.lang.String, boolean, java.lang.String)
      */
     @Override
-    public void registerStatement(String pollText, boolean newPoll) {
+    public void registerStatement(String pollText, boolean newPoll, String pollId) {
         if (null != learningResourceStoreService) {
             LRS_Statement statement = getStatementForUserEditPoll(pollText, newPoll);
-            Event event = eventTrackingService.newEvent("poll.edit", "edit poll", null, true, NotificationService.NOTI_OPTIONAL, statement);
+            String eventType = newPoll ? "poll.add" : "poll.update";
+            Event event = eventTrackingService.newEvent(eventType, getPollRef(pollId), null, true, NotificationService.NOTI_OPTIONAL, statement);
             eventTrackingService.post(event);
         }
     }

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -162,13 +162,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
             return false;
         }
         log.debug(" Poll  " + t.toString() + "successfuly saved");
-        externalLogic.registerStatement(t.getText(), newPoll);
-        if (newPoll)
-        	externalLogic.postEvent("poll.add", "poll/site/"
-                    + t.getSiteId() + "/poll/" + t.getId(), true);
-        else
-        	externalLogic.postEvent("poll.update", "poll/site/"
-                    + t.getSiteId() + " /poll/" + t.getId(), true);
+        externalLogic.registerStatement(t.getText(), newPoll, t.getPollId().toString());
 
         return true;
     }

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollVoteManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollVoteManagerImpl.java
@@ -56,8 +56,6 @@ public class PollVoteManagerImpl implements PollVoteManager {
 			saveVote(vote);
             externalLogic.registerStatement(pollListManager.getPollById(pollId).getText(), vote);
 		}
-
-		externalLogic.postEvent("poll.vote", "poll/site/" + externalLogic.getCurrentLocationReference() +"/poll/" +  pollId, true);
 	}
 
 	public boolean saveVote(Vote vote)  {

--- a/polls/impl/src/test/org/sakaiproject/poll/logic/test/stubs/ExternalLogicStubb.java
+++ b/polls/impl/src/test/org/sakaiproject/poll/logic/test/stubs/ExternalLogicStubb.java
@@ -208,7 +208,7 @@ public class ExternalLogicStubb implements ExternalLogic {
     }
 
     @Override
-    public void registerStatement(String pollText, boolean newPoll) {
+    public void registerStatement(String pollText, boolean newPoll, String pollId) {
         // TODO Auto-generated method stub
     }
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41394

Events fired by the polls tool do not have a consistent ref format, and are sometimes duplicated or misnamed because the LRS support added to polls creates its own events in addition to the existing polls events.

After this patch:

- all polls event refs will use the same format: poll/site/<site_id>/poll/<integer_poll_id>
- events with LRS support will not fire any additional events, and the LRS events will use a proper poll ref instead of simple strings like "vote" and "edit poll"
- the "poll.edit" event fired by the LRS support code will use the original event name, "poll.update" instead
- the "poll.vote" event will fire once for each selected option (for polls that allow multiple selection), as this is how the LRS support works. This differs from legacy behaviour of one event for the entire voting action but has likely been the case since the LRS support was added.