### PR TITLE
webcomponents won't build as root user

### DIFF
--- a/webcomponents/pom.xml
+++ b/webcomponents/pom.xml
@@ -67,7 +67,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install</arguments>
+                            <arguments>install --unsafe-perm</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The webcomponents "assets" folder won't build if you compile as a root user, tested in a ubuntu distribution.

Source: https://til.codes/npm-install-failed-with-cannot-run-in-wd-2/
Documentation: https://docs.npmjs.com/misc/config#unsafe-perm

This may introduce security concerns.