### PR TITLE
SAK-41459 Grading forums: Portal is not defined in the modal window

### DIFF
--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubrics-language.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubrics-language.js
@@ -22,7 +22,7 @@ export class SakaiRubricsLanguage extends SakaiElement {
   }
 
   static loadTranslations() {
-    return loadProperties({ namespace: "rubrics", lang: portal.locale });
+    return loadProperties({ namespace: "rubrics", lang: parent.portal.locale });
   }
 }
 


### PR DESCRIPTION
When grading a forum with Rubrics, the portal variable is not defined in the modal window.

`
sakai-rubrics-language.js:25 Uncaught ReferenceError: portal is not defined
    at Function.loadTranslations (sakai-rubrics-language.js:25)
    at new SakaiRubricGrading (sakai-rubric-grading.js:13)
    at sakai-rubric-grading.js:105
loadTranslations @ sakai-rubrics-language.js:25
SakaiRubricGrading @ sakai-rubric-grading.js:13
(anonymous) @ sakai-rubric-grading.js:105
`