### PR TITLE
SAK-41018 Rubrics: delete evaluations before deleting association

### DIFF
--- a/rubrics/tool/src/main/java/org/sakaiproject/rubrics/RubricsConfiguration.java
+++ b/rubrics/tool/src/main/java/org/sakaiproject/rubrics/RubricsConfiguration.java
@@ -26,11 +26,13 @@ import javax.validation.Valid;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 import lombok.Data;
 
 @Data
 @Configuration
+@Validated
 @ConfigurationProperties(prefix = "rubrics")
 public class RubricsConfiguration {
 


### PR DESCRIPTION
Also, unify delete methods that were doing the same into one function
valid for all the elements.