### PR TITLE
SAK-41488 Rubrics : Allow longer descriptions

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Criterion.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Criterion.java
@@ -33,6 +33,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -68,6 +69,8 @@ public class Criterion implements Modifiable, Serializable, Cloneable {
     private Long id;
 
     private String title;
+
+    @Lob
     private String description;
 
     @OneToMany(cascade = CascadeType.ALL)

--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Rating.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Rating.java
@@ -30,6 +30,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.PostLoad;
 import javax.persistence.PostUpdate;
@@ -62,6 +63,8 @@ public class Rating implements Modifiable, Serializable, Cloneable {
     private Long id;
 
     private String title;
+
+    @Lob
     private String description;
     private Integer points;
 

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-criterion-edit.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-criterion-edit.js
@@ -66,7 +66,7 @@ export class SakaiRubricCriterionEdit extends SakaiElement {
             <label>
               <sr-lang key="criterion_description">Criterion Description</sr-lang>
             </label>
-            <textarea id="criterion-description-field-${this.criterion.id}" class="form-control" maxlength="255">${this.criterionClone.description}</textarea>
+            <textarea id="criterion-description-field-${this.criterion.id}" class="form-control">${this.criterionClone.description}</textarea>
           </div>
         </div>
       </div>

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-criterion-rating-edit.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-criterion-rating-edit.js
@@ -65,7 +65,7 @@ export class SakaiRubricCriterionRatingEdit extends SakaiElement {
             <label for="">
               <sr-lang key="rating_description">Rating Description</sr-lang>
             </label>
-            <textarea name="" id="rating-description-${this.rating.id}" class="form-control" maxlength="255">${this.rating.description}</textarea>
+            <textarea name="" id="rating-description-${this.rating.id}" class="form-control">${this.rating.description}</textarea>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Attaching mysql ddbb script in case someone was using an old ddbb (no need
to incorporate it to the official code if it makes the 19release):

```
ALTER TABLE `rbc_criterion` CHANGE COLUMN `description` `description`
LONGTEXT NULL DEFAULT NULL ;
ALTER TABLE `rbc_rating` CHANGE COLUMN `description` `description`
LONGTEXT NULL DEFAULT NULL ;
```