### PR TITLE
SAK-41129 - Add a better validation message for the required field.  …

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/dfCompose.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfCompose.jsp
@@ -64,7 +64,7 @@
 				     <h:outputText value="#{msgs.cdfm_info_required_sign}" styleClass="reqStar"/>
 					<h:outputText value="#{msgs.cdfm_title}"/>
 				</h:outputLabel>
-					   <h:inputText value="#{ForumTool.composeTitle}" style="width:30em;" maxlength="250" required="true" id="df_compose_title">
+					   <h:inputText value="#{ForumTool.composeTitle}" style="width:30em;" maxlength="250" required="true" id="df_compose_title" requiredMessage="#{msgs.cdfm_invalidMessageTitleString}">
 					     <f:validator validatorId="MessageTitle" />
 						 <f:validateLength minimum="1" maximum="255"/>
 					   </h:inputText>


### PR DESCRIPTION
…It's actually the same message that shows when using the MessageTitleValidator, though that one probably never gets thrown as the native required message will run first.