### PR TITLE
SAK-41591 - JS Error on Samigo for old android devices and browsers

### DIFF
--- a/samigo/samigo-app/src/webapp/js/questionProgress.js
+++ b/samigo/samigo-app/src/webapp/js/questionProgress.js
@@ -1,4 +1,4 @@
-<!-- Javascript for the Question Progress Panel-->
+/* Javascript for the Question Progress Panel */
 (function (questionProgress, $, undefined) {
 	var origWrapWidth = 0;
 	var CLICK_PANEL_WIDTH = 299;
@@ -8,6 +8,7 @@
 	var arrowSuffix = "']";
 	var rightArrowSuffix = ":rightArrow";
 	var downArrowSuffix = ":downArrow";
+	var qPToggleOnNoStorage = false;
 
 	$('#questionProgressClick').click(function () {
 		toggle(400);
@@ -48,12 +49,19 @@
 	}
 
 	function getQPToggleOn() {
+		if(localStorage === null) {
+			return qPToggleOnNoStorage;
+		}
 		var value = localStorage.getItem('QPToggleOn');
 		return value == '1';
 	}
 
 	function setQPToggleOn(QPToggleOn) {
-		localStorage.setItem('QPToggleOn', (QPToggleOn ? '1' : '0'));
+		if(localStorage !== null) {
+			localStorage.setItem('QPToggleOn', (QPToggleOn ? '1' : '0'));
+		} else {
+			qPToggleOnNoStorage = !qPToggleOnNoStorage;
+		}
 	}
 
 	function partLinkClickEvent(event) {


### PR DESCRIPTION
We have several students which uses old browser versions without localStorage in their browsers so they get a JS error and they can't complete an exam.

![image](https://user-images.githubusercontent.com/3238226/55312714-76521900-5466-11e9-967b-68f374d04d4a.png)

This fixes that issue.