### PR TITLE
SAK-41603 - Queuing multiple attachments to the content review service - errors prevent subsequent attachments from being queued

### DIFF
--- a/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/ContentReviewQueueServiceImpl.java
+++ b/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/ContentReviewQueueServiceImpl.java
@@ -53,7 +53,6 @@ public class ContentReviewQueueServiceImpl implements ContentReviewQueueService 
 		Objects.requireNonNull(taskId, "taskId cannot be null");
 		Objects.requireNonNull(content, "content cannot be null");
 		
-		boolean errorsPresent = false;
 		StringBuilder errors = new StringBuilder();
 		String delim = "";
 		for (ContentResource resource : content) {
@@ -69,7 +68,6 @@ public class ContentReviewQueueServiceImpl implements ContentReviewQueueService 
 			Optional<ContentReviewItem> existingItem = itemDao.findByProviderAndContentId(providerId, contentId);
 			
 			if (existingItem.isPresent()) {
-				errorsPresent = true;
 				errors.append(delim).append("Content " + contentId + " is already queued");
 				delim = ", ";
 				continue;
@@ -82,7 +80,7 @@ public class ContentReviewQueueServiceImpl implements ContentReviewQueueService 
 			itemDao.create(item);
 		}
 
-		if (errorsPresent)
+		if (errors.length() > 0)
 		{
 			throw new QueueException(errors.toString());
 		}


### PR DESCRIPTION
In ContentReviewQueueServiceImpl.queueContent(...), we throw a QueueException if an item already exists. If you're resubmitting multiple attachments, and some of these attachments already exist, this QueueException will abort the whole process. We should instead aggregate these and then just throw one exception after the valid items have been queued