### PR TITLE
SAK-41617 - default.sakai.properties advertises using asterisks after package names in log.config

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1088,8 +1088,8 @@
 # DEFAULT: INFO level
 # Example 1:
 # log.config.count=2
-# log.config.1=DEBUG.org.sakaiproject.content.*
-# log.config.2=DEBUG.org.sakaiproject.event.impl.*
+# log.config.1=DEBUG.org.sakaiproject.content
+# log.config.2=DEBUG.org.sakaiproject.event.impl
 # ALTERNATELY: use a comma seperate list of the debug levels desired
 # log.config=DEBUG.org.sakaiproject.content.*,DEBUG.org.sakaiproject.event.impl.*
 


### PR DESCRIPTION
The examples:
```
# log.config.count=2
# log.config.1=DEBUG.org.sakaiproject.content.*
# log.config.2=DEBUG.org.sakaiproject.event.impl.*
```
The asterisks don't actually work in this pattern.
Replace these examples with:
```
# log.config.count=2
# log.config.1=DEBUG.org.sakaiproject.content
# log.config.2=DEBUG.org.sakaiproject.event.impl
```