### PR TITLE
SAK-40413 Duplicated removals cause log error trace

### DIFF
--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_viewList.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_viewList.vm
@@ -299,7 +299,7 @@
 	</table>
 	
 ## Section awareness
-#if ($!groups || ($!groups.size()>1)) #set ($show_group = "true") #else #set ($show_group = "false") #end
+#if ($!groups && ($!groups.size()>0)) #set ($show_group = "true") #else #set ($show_group = "false") #end
 #if ($show_group =="false")
 	## no show this selection, but set default to site
 	<input type="hidden" name="scheduleTo" id="site" value="site" checked="checked" />


### PR DESCRIPTION
- These removals are also on the service class. Service class needs it for this process but also for the transferEntities one, so keeping those.
- Also solving calendar vm error log trace.