### PR TITLE
SAK-41685: propagate IdUnusedException if the site does not exist so …

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -1049,7 +1049,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 	 * 		  flag to include merged channel messages, true returns ALL messages including merged sites/channels
 	 * @return a list of Message objects or specializations of Message objects (may be empty).
 	 * @exception IdUnusedException
-	 *            If this name is not defined for a announcement channel.
+	 *            If this name is not defined for a announcement channel, or the channel references a site that does not exist.
 	 * @exception PermissionException
 	 *            if the user does not have read permission to the channel.
 	 * @exception NullPointerException
@@ -1097,8 +1097,6 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 			{
 				Collections.reverse(messageList);
 			}			
-		} catch (IdUnusedException e) {
-			log.warn(e.getMessage());
 		}
 		catch (PermissionException e) {
 			log.warn(e.getMessage());

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -1098,9 +1098,6 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 				Collections.reverse(messageList);
 			}			
 		}
-		catch (PermissionException e) {
-			log.warn(e.getMessage());
-		}
 		catch (NullPointerException e) {
 			log.warn(e.getMessage());
 		}

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -224,7 +224,6 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 			try {
 				announcements.addAll(announcementService.getMessages(channel, new ViewableFilter(null, t, numberOfAnnouncements), true, false));
 			} catch (PermissionException | IdUnusedException | NullPointerException ex) {
-				log.warn("User: {} does not have access to view the announcement channel: {}. Skipping...", currentUserId, channel);
 				//user may not have access to view the channel but get all public messages in this channel
 				AnnouncementChannel announcementChannel = (AnnouncementChannel)announcementService.getChannelPublic(channel);
 				if(announcementChannel != null){


### PR DESCRIPTION
…it can be handled

We're testing this fix out in our 19.0 instance, allowing the method to propagate the exception enables the MOTD web service (in AnnouncementEntityProviderImpl) to return the public announcements for the channel (which is already done in the catch).
Doesn't seem to be called anywhere else, and it doesn't affect calls to the web service to retrieve the announcements for a site, even if the site does not exist.