### PR TITLE
SAK-41687: GradebookNG > hide 'edit release settings' based on sakai.property

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -23,7 +23,7 @@
                     </span>
                     {else}
                     <span class="gb-flag-not-released" wicket:message="title:label.coursegrade.notreleased">
-                        {if settings.isUserAbleToEditAssessments}
+                        {if settings.isUserAbleToEditAssessments && settings.isShowDisplayCourseGradeToStudentEnabled}
                             <span aria-hidden="true" style="display:none;" class="gb-tooltip-extras">
                                 <div>
                                     <a href="javascript:void(0);" class="gb-gradebook-settings"><wicket:message key="label.coursegrade.editsettings"/></a>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -59,6 +59,9 @@ public class GbGradebookData {
 	private static final String SAK_PROP_SHOW_SET_ZERO_SCORE = "gradebookng.showSetZeroScore";
 	private static final boolean SAK_PROP_SHOW_SET_ZERO_SCORE_DEFAULT = true;
 
+	private static final String SAK_PROP_SHOW_COURSE_GRADE_STUDENT = "gradebookng.showDisplayCourseGradeToStudent";
+	private static final Boolean SAK_PROP_SHOW_COURSE_GRADE_STUDENT_DEFAULT = true;
+
 	private final List<StudentDefinition> students;
 	private final List<ColumnDefinition> columns;
 	private final List<GbStudentGradeInfo> studentGradeInfoList;
@@ -396,6 +399,7 @@ public class GbGradebookData {
 		result.put("isStudentNumberVisible", this.isStudentNumberVisible);
 		result.put("isSectionsVisible", this.isSectionsVisible && ServerConfigurationService.getBoolean("gradebookng.showSections", true));
 		result.put("isSetUngradedToZeroEnabled", ServerConfigurationService.getBoolean(SAK_PROP_SHOW_SET_ZERO_SCORE, SAK_PROP_SHOW_SET_ZERO_SCORE_DEFAULT));
+		result.put("isShowDisplayCourseGradeToStudentEnabled", ServerConfigurationService.getBoolean(SAK_PROP_SHOW_COURSE_GRADE_STUDENT, SAK_PROP_SHOW_COURSE_GRADE_STUDENT_DEFAULT));
 
 		return result;
 	};


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41687

[SAK-41222](https://jira.sakaiproject.org/browse/SAK-41222) introduced a new sakai.property to control the ability of instructors/maintainers to change the "Display final Grades to Students" option. However, if an instructor clicks on the "Grade not visible" eyeball icon in the "Course Grade" header cell, an "Edit Release Settings" link still appears in the resulting pop-up. The link takes them to the settings page, where they will not be able to change the setting (in the scenario where the sakai.property is set to false, thus not giving the instructor the option at all in this interface).

The link in the pop-up should be conditionally rendered, according to the value of the sakai.property introduced in [SAK-41222](https://jira.sakaiproject.org/browse/SAK-41222).