### PR TITLE
SAK-41703: assignments > fix scoring component icons for instructor view

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -14675,7 +14675,7 @@ public class AssignmentAction extends PagedResourceActionII {
      */
     protected void setScoringAgentProperties(Context context, Assignment assignment, AssignmentSubmission submission, boolean gradeView) {
         String associatedGbItem = assignment.getProperties().get(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
-        if (submission != null && StringUtils.isNotBlank(associatedGbItem) && assignment.getTypeOfGrade() == SCORE_GRADE_TYPE) {
+        if (!assignment.getIsGroup() && submission != null && StringUtils.isNotBlank(associatedGbItem) && assignment.getTypeOfGrade() == SCORE_GRADE_TYPE) {
             ScoringService scoringService = (ScoringService) ComponentManager.get("org.sakaiproject.scoringservice.api.ScoringService");
             ScoringAgent scoringAgent = scoringService.getDefaultScoringAgent();
 
@@ -14684,9 +14684,8 @@ public class AssignmentAction extends PagedResourceActionII {
             Set<AssignmentSubmissionSubmitter> submitters = submission.getSubmitters();
             String currentUser = sessionManager.getCurrentSessionUserId();
             AssignmentSubmissionSubmitter submitter = submitters.stream()
-                    .filter(s -> s.getSubmitter().equals(currentUser)).findAny()
-                    .orElseGet(() -> submitters.stream()
-                            .filter(AssignmentSubmissionSubmitter::getSubmittee).findAny()
+                    .filter(s -> s.getSubmitter().equals(currentUser)).findAny() // If in student context, get student's specific submission
+                    .orElseGet(() -> submitters.stream().findAny() // If in instructor context, just get the first available submission (group assignments don't show the icon anyway)
                             .orElse(null));
 
             if (scoringAgentEnabled && submitter != null) {
@@ -14726,7 +14725,7 @@ public class AssignmentAction extends PagedResourceActionII {
                     // Determine if a scoring component (like a rubric) has been associated with this gradebook item
                     ScoringComponent component = scoringService.getScoringComponent(
                             scoringAgent.getAgentId(), gradebookUid, gbItemId);
-                    boolean scoringComponentEnabled = component != null && !assignment.getIsGroup();
+                    boolean scoringComponentEnabled = component != null;
 
                     context.put("scoringComponentEnabled", scoringComponentEnabled);
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41703

Sometime after 12.0, the code in `AssignmentAction.setScoringAgentProperties()` was updated which introduced a regression where the instructor would not see the scoring component icons in the grade submission UI (provided there was a scoring component attached to the assignment/gradebook item).

The following lambda is what introduced the problem:

```
            AssignmentSubmissionSubmitter submitter = submitters.stream()
                    .filter(s -> s.getSubmitter().equals(currentUser)).findAny()
                    .orElseGet(() -> submitters.stream()
                            .filter(AssignmentSubmissionSubmitter::getSubmittee).findAny()
                            .orElse(null));
```

In the student context (where a student is looking at their own submission), the above code's `.filter()` routine would successfully find the studentt's own submission. However, in the instructor context (where the instructor is viewing the grading UI for a particular student's submission), the `filter` would not find any submission matching the current user because the current user is the instructor, not a student. In this scenario, the code then falls back to the `orElseGet()` routine. This then has it's own `filter`, which in my testing never returns a submission. This results in the `orElse` stipulation returning a `null` `AssignmentSubmissionSubmitter` object.

After the lambda is performed, there is a condition that must be passed before any further processing is performed:

```
if (scoringAgentEnabled && submitter != null) {
}
```

Where all the code which needs to be run in order to generate the scoring component icons/links is inside the conditional. If the `submitter` object is null (which is always the case in the instructor context), the conditional never passes and the icons/links are never rendered.

The bug was introduced some time after 12.0 (I haven't tracked down exactly what JIRA), but prior to the change the code was much different:

```
String studentId = submission.getSubmitters().toArray(new AssignmentSubmissionSubmitter[0])[0].getSubmitter();

            if (scoringAgentEnabled) {
                        // interesting stuff happens here
            }
```

You can see that it really didn't care what/who's submission it was dealing with; it just grabbed the first submission object from the array.

The linked PR proposes the following changes:

```
    protected void setScoringAgentProperties(Context context, Assignment assignment, AssignmentSubmission submission, boolean gradeView) {
        String associatedGbItem = assignment.getProperties().get(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
-        if (submission != null && StringUtils.isNotBlank(associatedGbItem) && assignment.getTypeOfGrade() == SCORE_GRADE_TYPE) {
+       if (!assignment.getIsGroup() && submission != null && StringUtils.isNotBlank(associatedGbItem) && assignment.getTypeOfGrade() == SCORE_GRADE_TYPE) {
            ScoringService scoringService = (ScoringService) ComponentManager.get("org.sakaiproject.scoringservice.api.ScoringService");
            ScoringAgent scoringAgent = scoringService.getDefaultScoringAgent();

            Set<AssignmentSubmissionSubmitter> submitters = submission.getSubmitters();
            String currentUser = sessionManager.getCurrentSessionUserId();
            AssignmentSubmissionSubmitter submitter = submitters.stream()
-                   .filter(s -> s.getSubmitter().equals(currentUser)).findAny()
-                   .orElseGet(() -> submitters.stream()
-                           .filter(AssignmentSubmissionSubmitter::getSubmittee).findAny()
+                   .filter(s -> s.getSubmitter().equals(currentUser)).findAny() // If in student context, get student's specific submission
+                   .orElseGet(() -> submitters.stream().findAny() // If in instructor context, just get the first available submission (group assignments don't show the icon anyway)
                            .orElse(null));

            if (scoringAgentEnabled && submitter != null) {
                    // Determine if a scoring component (like a rubric) has been associated with this gradebook item
                    ScoringComponent component = scoringService.getScoringComponent(
                            scoringAgent.getAgentId(), gradebookUid, gbItemId);
-                   boolean scoringComponentEnabled = component != null && !assignment.getIsGroup();
+                   boolean scoringComponentEnabled = component != null;
```

In this way, we move the group check to the very beginning for a better short circuit mechanism, and we revert back to the old logic of just grabbing any submission from the list for the instructor context, while retaining the new logic to select only the current user's (student's) submission in the student contexts.