### PR TITLE
SAK-41422 Removed the fixed width from the buttons to show entire button text

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/signup/_signup.scss
+++ b/library/src/morpheus-master/sass/modules/tool/signup/_signup.scss
@@ -103,5 +103,12 @@
     legend{
         font-size: inherit;
     }
-        
+
+	.orgGroupSync > input {
+		width: 100%;					// match the width of the buttons in the same cell
+	}
+
+	.orgGroupSync > input + input {
+		margin-top: $standard-space;	// if a button appears on top of another button, add spacing
+	}
 }

--- a/signup/tool/src/webapp/signup/organizer/orgSignupMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/orgSignupMeeting.jsp
@@ -541,7 +541,7 @@
 					 rendered="#{!OrganizerSignupMBean.announcementType}"
 					 columnClasses="orgTimeslotCol,orgMaxAttsCol,orgSlotStatusCol,orgGroupSync,orgWaiterStatusCol"	
 					 rowClasses="oddRow,evenRow"
-					 styleClass="signupTable" style="width:98%">
+					 styleClass="signupTable">
 							<!-- TS start and end times -->
 							<h:column>		   
 								<f:facet name="header">
@@ -805,10 +805,10 @@
 								<f:facet name="header">
 									<h:outputText value="#{msgs.group_synchronise_heading}"/>
 								</f:facet>
-								<h:commandButton id="synctogroup" value="#{msgs.group_synchronise_button}" action="#{OrganizerSignupMBean.synchroniseGroupMembership}" actionListener="#{OrganizerSignupMBean.attrListener}"   onmousedown="assignDeleteClick(this,'#{msgs.synchronisetogroup_confirmation}');" title="#{msgs.event_tool_tips_syncTogroup}" style="margin-top:5px;width:150px">									
+								<h:commandButton id="synctogroup" value="#{msgs.group_synchronise_button}" action="#{OrganizerSignupMBean.synchroniseGroupMembership}" actionListener="#{OrganizerSignupMBean.attrListener}"   onmousedown="assignDeleteClick(this,'#{msgs.synchronisetogroup_confirmation}');" title="#{msgs.event_tool_tips_syncTogroup}">
         								<f:attribute name="timeslottoGroup" value="toGroup" />
                                 </h:commandButton>
-								<h:commandButton id="syncfromgroup" value="#{msgs.fromgroup_synchronise_button}" action="#{OrganizerSignupMBean.synchroniseGroupMembership}" actionListener="#{OrganizerSignupMBean.attrListener}"  onmousedown="assignDeleteClick(this,'#{msgs.synchronisefromgroup_confirmation}');" title="#{msgs.event_tool_tips_syncFromgroup}" style="margin-top:5px;width:150px">
+								<h:commandButton id="syncfromgroup" value="#{msgs.fromgroup_synchronise_button}" action="#{OrganizerSignupMBean.synchroniseGroupMembership}" actionListener="#{OrganizerSignupMBean.attrListener}"  onmousedown="assignDeleteClick(this,'#{msgs.synchronisefromgroup_confirmation}');" title="#{msgs.event_tool_tips_syncFromgroup}">
 									<f:attribute name="timeslottoGroup" value="" />
 								</h:commandButton>
 					   		</h:column>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41422

I've removed the inline styles that was applying a fixed width on the buttons, which limited how much text the button could display and therefore cutting off the buttons' text. 

I added some styles to control the buttons' width and spacing. I assume the original fixed-width was for the buttons to be the same width when they contained different lengths of text. My new styles recreates that functionality while allowing the buttons to be as wide as they need to be for their text.

See before and after screenshots in https://jira.sakaiproject.org/browse/SAK-41422