### PR TITLE
SAK-41739: DA > prevent hierarchy job from auto-restarting

### DIFF
--- a/delegatedaccess/impl/src/java/org/sakaiproject/delegatedaccess/jobs/DelegatedAccessSiteHierarchyJob.java
+++ b/delegatedaccess/impl/src/java/org/sakaiproject/delegatedaccess/jobs/DelegatedAccessSiteHierarchyJob.java
@@ -16,7 +16,6 @@
 
 package org.sakaiproject.delegatedaccess.jobs;
 
-import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Date;
 import java.util.HashMap;
@@ -82,8 +81,9 @@ public class DelegatedAccessSiteHierarchyJob implements Job{
 
 	public void execute(JobExecutionContext arg0) throws JobExecutionException {
 		//this will stop the job if there is already another instance running
-		if(!jobIsRunning.compareAndSet(false, true)){
-			log.warn("Stopping job since this job is already running");
+		// or if this is an auto-recover restart attempt
+		if (!jobIsRunning.compareAndSet(false, true) || arg0.isRecovering()){
+			log.warn("Stopping job since this job is/was already running");
 			return;
 		}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41739

If the `DelegatedAccessSiteHierarchyJob` Quartz job gets interrupted while executing (for example, by a Tomcat restart) it will attempt to auto-relaunch itself when the server comes back up. Unfortunately, it does this too early in the process, before all the Spring beans are injected, and so it fails. This causes an infinite loop, where it will continue failing and trying to auto-relaunch on restart.