### PR TITLE
SAK-30348 - Drafted submissions should not be sent to the Content Review Service

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -733,4 +733,12 @@ public interface AssignmentService extends EntityProducer {
     String getUsersLocalDateTimeString(Instant date);
 
     public List<ContentReviewResult> getContentReviewResults(AssignmentSubmission submission);
+
+    /**
+     * Determines whether it is appropriate to display the content review results for a submission. For instance, this will be false if the submission is a draft or if the user doesn't have permission
+     * Note: this doesn't check if content review is enabled in the site / if the associated assignment has content review enabled; it is assumed that this has been handled by the caller.
+     * @param submission
+     * @return true if content review results for the given submission can be displayed.
+     */
+    public boolean isContentReviewVisibleForSubmission(AssignmentSubmission submission);
 }

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -3953,6 +3953,31 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         return reviewResults;
     }
 
+    @Override
+    public boolean isContentReviewVisibleForSubmission(AssignmentSubmission submission)
+    {
+        if (submission == null)
+        {
+            throw new IllegalArgumentException("isContentReviewVisibleForSubmission invoked with submission = null");
+        }
+
+        Assignment assignment = submission.getAssignment();
+        String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+
+        boolean hasInstructorPermission = allowGradeSubmission(assignmentReference);
+        boolean hasStudentPermission = false;
+        // If we have instructor permission, we can short circuit past student checks
+        // Student checks: ensure the assignment is configured to allow students to view reports, and that the user is permitted to get the specified submission
+        if (!hasInstructorPermission && Boolean.valueOf(assignment.getProperties().get("s_view_report")))
+        {
+            String submissionReference = AssignmentReferenceReckoner.reckoner().submission(submission).reckon().getReference();
+            hasStudentPermission = allowGetSubmission(submissionReference);
+        }
+
+        // Content Review results should be visible iff the user has permission and the submission is not a draft
+        return (hasInstructorPermission || hasStudentPermission) && submission.getSubmitted() && submission.getDateSubmitted() != null;
+    }
+
     /**
      * Gets all attachments in the submission that are acceptable to the content review service
      */

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6460,7 +6460,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 }
 
                 // SAK-26322 - add inline as an attachment for the content review service
-                if (a.getContentReview()) {
+                if (post && a.getContentReview()) {
                     if (!isHtmlEmpty(text)) {
                         prepareInlineForContentReview(text, submission, state, u);
                     }
@@ -6487,13 +6487,12 @@ public class AssignmentAction extends PagedResourceActionII {
         //We will be replacing the inline submission's attachment
         //firstly, disconnect any existing attachments with AssignmentSubmission.PROP_INLINE_SUBMISSION set
         Set<String> attachments = submission.getAttachments();
-        for (String attachment : attachments) {
+        attachments.removeIf(attachment ->
+        {
             Reference reference = entityManager.newReference(attachment);
             ResourceProperties referenceProperties = reference.getProperties();
-            if ("true".equals(referenceProperties.getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION))) {
-                attachments.remove(attachment);
-            }
-        }
+            return "true".equals(referenceProperties.getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION));
+        });
 
         //now prepare the new resource
         //provide lots of info for forensics - filename=InlineSub_assignmentId_userDisplayId_(for_studentDisplayId)_date.html

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -196,7 +196,7 @@
                         $reviewServiceName&nbsp;$tlang.getString("review.report")
                     </th>
                     <td>
-                        #if (!$submission)
+                        #if (!$submission || !$!service.isContentReviewVisibleForSubmission($!submission))
                             $tlang.getString("review.notavail")
                         #else
                             #set($reviewResults=$!service.getContentReviewResults($!submission))

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -697,33 +697,34 @@ function printView(url) {
 							#end	
 							#if ($allowReviewService && $assignment.ContentReview)
 								<td headers="reviewService">
-
-									#set($reviewResults=$!service.getContentReviewResults($!submission)) ##falta ContentReviewResults
-									#if ($reviewResults.size() >= 3)
-										<div>
-											<input class="disclosureTriangle" type="image" onclick="ASN.handleReportsTriangleDisclosure(this, this.parentNode.parentNode.children[1]); return false;" src="#imageLink("sakai/expand.gif")" alt="$tlang.getString('review.report.expand')"/>
-											## TODO: reconsider for i18n:
-											$reviewResults.size() $tlang.getString("review.reports")
-										</div>
-										<div id="reportsDiv" style="display:none;">
-									#end
-									#foreach($reviewResult in $reviewResults)
-										<div>
-											#set ($props = $reviewResult.getContentResource().Properties)
-											<span class="reportIcon">
-												#if (!$reviewResult.getReviewReport().equals("Error"))<a href="$reviewResult.getReviewReport()" target="_blank">#end
-												<span class="$reviewResult.getReviewIconCssClass()" title="#if($reviewResult.getReviewReport().equals("Error"))$reviewResult.getReviewError()#{else}$reviewResult.getReviewScore()#end"></span>
-												#if (!$reviewResult.getReviewReport().equals("Error"))</a>#end
-											</span>
-											#if ($reviewResult.isInline())
-												$tlang.getString("submission.inline")
-											#else
-												$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
-											#end
-										</div>
-									#end
-									#if ($reviewResults.size() >= 3)
-										</div>
+									#if ($!service.isContentReviewVisibleForSubmission($!submission))
+										#set($reviewResults=$!service.getContentReviewResults($!submission)) ##falta ContentReviewResults
+										#if ($reviewResults.size() >= 3)
+											<div>
+												<input class="disclosureTriangle" type="image" onclick="ASN.handleReportsTriangleDisclosure(this, this.parentNode.parentNode.children[1]); return false;" src="#imageLink("sakai/expand.gif")" alt="$tlang.getString('review.report.expand')"/>
+												## TODO: reconsider for i18n:
+												$reviewResults.size() $tlang.getString("review.reports")
+											</div>
+											<div id="reportsDiv" style="display:none;">
+										#end
+										#foreach($reviewResult in $reviewResults)
+											<div>
+												#set ($props = $reviewResult.getContentResource().Properties)
+												<span class="reportIcon">
+													#if (!$reviewResult.getReviewReport().equals("Error"))<a href="$reviewResult.getReviewReport()" target="_blank">#end
+													<span class="$reviewResult.getReviewIconCssClass()" title="#if($reviewResult.getReviewReport().equals("Error"))$reviewResult.getReviewError()#{else}$reviewResult.getReviewScore()#end"></span>
+													#if (!$reviewResult.getReviewReport().equals("Error"))</a>#end
+												</span>
+												#if ($reviewResult.isInline())
+													$tlang.getString("submission.inline")
+												#else
+													$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
+												#end
+											</div>
+										#end
+										#if ($reviewResults.size() >= 3)
+											</div>
+										#end
 									#end
 								</td>
 							#end

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -163,7 +163,7 @@
                     $reviewServiceName&nbsp;$tlang.getString("review.report")
                 </th>
                 <td>
-                    #if (!$submission)
+                    #if (!$submission || !$!service.isContentReviewVisibleForSubmission($!submission))
                         $tlang.getString("review.notavail")
                     #else
                         #set($reviewResults=$!service.getContentReviewResults($!submission))

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -265,8 +265,7 @@ $(document).ready(function(){
 					</div>
 				</div>
 			#end
-			#set($allowStudentViewReport = $assignment.Properties.get("s_view_report")) 
-			#if($!submitted && $!dateSubmitted && $allowReviewService && $assignment.ContentReview && $!allowStudentViewReport.equals('true'))
+			#if($allowReviewService && $assignment.ContentReview && $!submission && $!service.isContentReviewVisibleForSubmission($!submission))
 				<div class="row">
 					<div class="col-lg-4 col-sm-6 col-xs-12">
 						<div class="itemSummaryHeader">$reviewServiceName&nbsp;$tlang.getString("review.report")</div>

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -648,7 +648,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		return response;
 	}
 
-	private void generateSimilarityReport(String reportId, String assignmentRef, boolean isDraft) throws Exception {
+	private void generateSimilarityReport(String reportId, String assignmentRef) throws Exception {
 		
 		Assignment assignment = assignmentService.getAssignment(entityManager.newReference(assignmentRef));
 		Map<String, String> assignmentSettings = assignment.getProperties();
@@ -666,8 +666,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		reportData.put("view_settings", viewSettings);
 		
 		Map<String, Object> indexingSettings = new HashMap<String, Object>();
-		//Drafts are not added to index to avoid self plagiarism
-		indexingSettings.put("add_to_index", !isDraft);
+		indexingSettings.put("add_to_index", true);
 		reportData.put("indexing_settings", indexingSettings);
 
 		HashMap<String, Object> response = makeHttpCall("PUT",
@@ -888,8 +887,8 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 							ContentReviewItem referenceItem = quededReferenceItem.isPresent() ? quededReferenceItem.get() : null;							
 							if (referenceItem != null && checkForContentItemInSubmission(referenceItem, assignment)) {
 								// Regenerate similarity request for reference id
-								// Report is recalled after due date, no need to account for draft
-								generateSimilarityReport(referenceItem.getExternalId(), referenceItem.getTaskId(), false);
+								// Report is recalled after due date
+								generateSimilarityReport(referenceItem.getExternalId(), referenceItem.getTaskId());
 								//reschedule reference item by setting score to null, reset retry time and set status to awaiting report
 								referenceItem.setStatus(ContentReviewConstants.CONTENT_REVIEW_SUBMITTED_AWAITING_REPORT_CODE);
 								referenceItem.setRetryCount(Long.valueOf(0));
@@ -1110,12 +1109,6 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		return cal.getTime();
 	}
 
-	private boolean checkForDraft(ContentReviewItem item, Assignment assignment) throws Exception {
-		// Checks if current item is a draft or submitted
-		AssignmentSubmission currentSubmission = assignmentService.getSubmission(assignment.getId(), item.getUserId());
-		return Optional.ofNullable(!currentSubmission.getSubmitted()).orElse(false);
-	}
-	
 	private boolean checkForContentItemInSubmission(ContentReviewItem item, Assignment assignment) {
 		try {
 			AssignmentSubmission currentSubmission = assignmentService.getSubmission(assignment.getId(), item.getUserId());
@@ -1163,10 +1156,8 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 
 			switch (submissionStatus) {
 			case "COMPLETE":
-				// Check if current item is a draft submission
-				boolean submissionIsDraft = checkForDraft(item, assignment);
 				// If submission status is complete, start similarity report process
-				generateSimilarityReport(item.getExternalId(), item.getTaskId(), submissionIsDraft);
+				generateSimilarityReport(item.getExternalId(), item.getTaskId());
 				// Update item status for loop 2
 				item.setStatus(ContentReviewConstants.CONTENT_REVIEW_SUBMITTED_AWAITING_REPORT_CODE);
 				// Reset retry count
@@ -1179,10 +1170,9 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 				// Schedule next retry time
 				item.setNextRetryTime(cal.getTime());
 				crqs.update(item);
-				// Check for items that generate reports both immediately and on due date or draft items
+				// Check for items that generate reports both immediately and on due date
 				// Create a placeholder item that will regenerate and index report after due date
-				if (assignmentDueDate != null && assignmentDueDate.after(new Date())
-						&& (GENERATE_REPORTS_IMMEDIATELY_AND_ON_DUE_DATE.equals(reportGenSpeed) || submissionIsDraft)) {
+				if (assignmentDueDate != null && assignmentDueDate.after(new Date()) && GENERATE_REPORTS_IMMEDIATELY_AND_ON_DUE_DATE.equals(reportGenSpeed)) {
 					createPlaceholderItem(item, assignmentDueDate);
 				}
 				break;
@@ -1593,7 +1583,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 			if (StringUtils.isNotEmpty(secrete_key_encoded) && signature_header.equals(secrete_key_encoded)) {
 				if (SUBMISSION_COMPLETE_EVENT_TYPE.equals(eventType)) {
 					if (webhookJSON.has("id") && STATUS_COMPLETE.equals(webhookJSON.get("status"))) {
-						// Allow cb to access assignment settings, needed for draft check
+						// Allow cb to access assignment settings, needed for due date check
 						SecurityAdvisor advisor = pushAdvisor();
 						try {
 							log.info("Submission complete webhook cb received");


### PR DESCRIPTION
Tasks accomplished in this PR:
1. Hide originality reports for draft submissions to polish the UI
2. Prevent the assignment service from submitting to TII when saving draft
3. Rip any special handling of draft submissions out of the content review services