### PR TITLE
SAK-41740: DA > use friendly label for over-ridden hierarcy props

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4634,7 +4634,7 @@
 #override this by setting the label.  For example:
 #Hierarchy = school->dept->subj
 #delegatedaccess.search.hierarchyLabel.school=School
-#delegatedaccess.search.hierarchyLabel.dept=Deptartment
+#delegatedaccess.search.hierarchyLabel.dept=Department
 #delegatedaccess.search.hierarchyLabel.subj=Subject
  
 #Suggested Additional Properties:

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.java
@@ -478,7 +478,7 @@ public class SearchAccessPage extends BasePage implements Serializable {
 				item.add(new Label("type", new StringResourceModel("accessType" + searchResult.getType(), null)));
 				String level = "";
 				if(hierarchy != null && searchResult.getLevel() < hierarchy.length){
-					level = hierarchy[searchResult.getLevel()];
+					level = sakaiProxy.getHierarchySearchLabel(hierarchy[searchResult.getLevel()]);
 				}else{
 					level = new StringResourceModel("site", null).getObject();
 				}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41740

SAK-27769 introduced a new sakai.property to define friendly labels for use when not using the default hierarchy levels. However, some places in the UI are still using the property names, rather than their corresponding labels.

The `sakai.property` "delegatedaccess.hierarchy.site.properties" defines the list of properties, or "levels", when over-ridden:

```
#INFRSTR-257 - Delegated Access                                                                                               
#delegatedaccess.hierarchy.site.properties                                                                                    
#This property allows you to overwrite the default site hierarchy properties expected in a Site.                              
#Example:                                                                                                                     
#delegatedaccess.hierarchy.site.properties.count=3                                                                            
#delegatedaccess.hierarchy.site.properties.1=school                                                                           
#delegatedaccess.hierarchy.site.properties.2=dept                                                                       
#delegatedaccess.hierarchy.site.properties.3=subj
```

SAK-27769 introduced the corresponding "delegatedaccess.search.hierarchyLabel.<property>" to define friendly labels when the above property is used:

```
#delegatedaccess.search.hierarchyLabel.{hierarchyLevel}                                                                       
#This allows you to set labels for your hierarchy search options.  By default it will use the hierarchy level, but you can    
#override this by setting the label.  For example:                                                                            
#Hierarchy = school->dept->subj                                                                                               
#delegatedaccess.search.hierarchyLabel.school=School                                                                          
#delegatedaccess.search.hierarchyLabel.dept=Department                                                                       
#delegatedaccess.search.hierarchyLabel.subj=Subject
```

You can see from the screenshots attached to the JIRA ticket that not all UIs were updated to use this friendly label rather than the (unfriendly) property name.