### PR TITLE
TII-261 - TurnitinOC - retry delay algorithm improvements

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5222,6 +5222,18 @@ rubrics.integration.token-secret=12345678900909091234
 # default: empty
 # turnitin.oc.apiKey=mysupersecret
 
+# Maximum delay between retires after recoverable errors
+# default: 240
+# turnitin.oc.max.retry.minutes=240
+
+# Maximum number of retries for recoverable errors
+# default: 16
+# turnitin.oc.max.retry=16
+
+# Skips any delays intended to reduce traffic to the content review servers. 
+# For local development only; do not set this in production!
+# turnitin.oc.skip.delays=false
+
 # If true, any file type will be accepted by Sakai. Invalid file types will still be rejected by Turnitin.
 # default: false
 # turnitin.accept.all.files=false

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5214,26 +5214,11 @@
 # The secret shared between Sakai and the rubrics service to secure JWTs
 rubrics.integration.token-secret=12345678900909091234
 
-# Required URL for the TurnitinOC content review service API
-# default: empty
-# turnitin.oc.serviceUrl=https://example.com/api
+# ###############################
+# Content-Review
+# ###############################
 
-# Required API KEY for the TurnitinOC content review service API
-# default: empty
-# turnitin.oc.apiKey=mysupersecret
-
-# Maximum delay between retires after recoverable errors
-# default: 240
-# turnitin.oc.max.retry.minutes=240
-
-# Maximum number of retries for recoverable errors
-# default: 16
-# turnitin.oc.max.retry=16
-
-# Skips any delays intended to reduce traffic to the content review servers. 
-# For local development only; do not set this in production!
-# default: false
-# turnitin.oc.skip.delays=false
+# TurnitinOC configuration is documented in content-review/impl/turnitin-oc/README.md
 
 # If true, any file type will be accepted by Sakai. Invalid file types will still be rejected by Turnitin.
 # default: false

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5232,6 +5232,7 @@ rubrics.integration.token-secret=12345678900909091234
 
 # Skips any delays intended to reduce traffic to the content review servers. 
 # For local development only; do not set this in production!
+# default: false
 # turnitin.oc.skip.delays=false
 
 # If true, any file type will be accepted by Sakai. Invalid file types will still be rejected by Turnitin.

--- a/content-review/impl/turnitin-oc/README.md
+++ b/content-review/impl/turnitin-oc/README.md
@@ -1,4 +1,4 @@
-## Turnitin OC Content Review Implmentation
+## Turnitin OC Content Review Implementation
 
 This is the Turnitin Originality Check content review implementation which is for use with those that use the TurnitinOC service.
 
@@ -17,6 +17,19 @@ assignment.useContentReview=true
 # Required API KEY for the Turnitin content review service API
 # default: empty
 # example: turnitin.oc.apiKey=mysupersecret
+
+# Maximum delay between retires after recoverable errors (Optional)
+# default: 240
+# turnitin.oc.max.retry.minutes=240
+
+# Maximum number of retries for recoverable errors (Optional)
+# default: 16
+# turnitin.oc.max.retry=16
+
+# Skips any delays intended to reduce traffic to the content review servers. (Optional)
+# For local development only; do not set this in production!
+# default: false
+# turnitin.oc.skip.delays=false
 
 # turnitin.accept.all.files (Optional)
 # If true, any file type will be accepted by Sakai. Invalid file types will still be rejected by Turnitin.

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -119,8 +119,6 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 
 	private static final String SERVICE_NAME = "Turnitin";
 	private static final String TURNITIN_OC_API_VERSION = "v1";
-	private static final int TURNITIN_OC_MAX_RETRY_MINUTES = 240; // 4 hours
-	private static final int TURNITIN_MAX_RETRY = 16;
 	private static final String INTEGRATION_FAMILY = "sakai";
 	private static final String CONTENT_TYPE_JSON = "application/json";
 	private static final String CONTENT_TYPE_BINARY = "application/octet-stream";
@@ -167,6 +165,9 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	private String serviceUrl;
 	private String apiKey;
 	private String sakaiVersion;
+	private int maxRetryMinutes;
+	private int maxRetry;
+	private boolean skipDelays;
 
 	private HashMap<String, String> BASE_HEADERS = new HashMap<String, String>();
 	private HashMap<String, String> SUBMISSION_REQUEST_HEADERS = new HashMap<String, String>();
@@ -265,6 +266,14 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		apiKey = serverConfigurationService.getString("turnitin.oc.apiKey", "");
 		// Retrieve Sakai Version if null set default 		
 		sakaiVersion = serverConfigurationService.getString("version.sakai", "UNKNOWN");
+
+		// Maximum delay between retries after recoverable errors
+		maxRetryMinutes = serverConfigurationService.getInt("turnitin.oc.max.retry.minutes", 240); // 4 hours
+		// Maximum number of retries for recoverable errors
+		maxRetry = serverConfigurationService.getInt("turnitin.oc.max.retry", 16);
+		// For local development only; do not set this in production:
+		skipDelays = serverConfigurationService.getBoolean("turnitin.oc.skip.delays", false);
+
 		autoExcludeSelfMatchingScope =Arrays.stream(AUTO_EXCLUDE_SELF_MATCHING_SCOPE.values())
 				.filter(e -> e.name().equalsIgnoreCase(serverConfigurationService.getString("turnitin.oc.auto_exclude_self_matching_scope")))
 				.findAny().orElse(AUTO_EXCLUDE_SELF_MATCHING_SCOPE.GROUP).name();
@@ -1271,7 +1280,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 			item.setNextRetryTime(cal.getTime());
 			crqs.update(item);
 			// If retry count is above maximum increment error count, set status to nine and stop retrying
-		} else if (item.getRetryCount().intValue() > TURNITIN_MAX_RETRY) {
+		} else if (item.getRetryCount().intValue() > maxRetry) {
 			item.setStatus(ContentReviewConstants.CONTENT_REVIEW_SUBMISSION_ERROR_RETRY_EXCEEDED_CODE);
 			crqs.update(item);
 			return false;
@@ -1288,10 +1297,14 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	}
 
 	public int getDelayTime(long retries) {
+		if (skipDelays)
+		{
+			return 0;
+		}
 		// exponential retry algorithm that caps the retries off at 36 hours (checking once every 4 hours max)
-		int minutes = (int) Math.pow(2, retries < TURNITIN_MAX_RETRY ? retries : 1); // built in check for max retries
+		int minutes = (int) Math.pow(2, retries < maxRetry ? retries : 1); // built in check for max retries
 																						// to fail quicker
-		return minutes > TURNITIN_OC_MAX_RETRY_MINUTES ? TURNITIN_OC_MAX_RETRY_MINUTES : minutes;
+		return minutes > maxRetryMinutes ? maxRetryMinutes : minutes;
 	}
 
 	public void queueContent(String userId, String siteId, String assignmentReference, List<ContentResource> content)


### PR DESCRIPTION
A couple constants are defined:
private static final int TURNITIN_OC_MAX_RETRY_MINUTES = 240; // 4 hours
private static final int TURNITIN_MAX_RETRY = 16;

Following through the retry delay algorithm: 
Σ(retry = 1..16) min(2^retry, 240)
2+4+8+16+32+64+128+240*9=2414 minutes
The delays sum to ~40 hours

In our experience there are situations where Turnitin servers are unresponsive, or a change is required on our side, and the retry automatically corrects it. But in many cases it takes more than 40 hours before these situations are resolved.

Add configuration to modify the behaviour of how we delay between retries