### PR TITLE
SAK-41785 Retry setup of the LDAP connection pool after startup

### DIFF
--- a/providers/unboundid/src/java/org/sakaiproject/unboundid/UnboundidDirectoryProvider.java
+++ b/providers/unboundid/src/java/org/sakaiproject/unboundid/UnboundidDirectoryProvider.java
@@ -266,29 +266,43 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 			log.warn("Unboundid batchSize is larger than maxResultSize, batchSize has been reduced from: "+ batchSize + " to: "+ maxResultSize);
 		}
 
-		// Create a new LDAP connection pool with 10 connections
-		ServerSet serverSet = null;
+		createConnectionPool();
+		initLdapAttributeMapper();
+	}
 
-		// Set some sane defaults to better handle timeouts. Unboundid will wait 30 seconds by default on a hung connection.
-		LDAPConnectionOptions connectOptions = new LDAPConnectionOptions();
-		connectOptions.setAbandonOnTimeout(true);
-		connectOptions.setConnectTimeoutMillis(operationTimeout);
-		connectOptions.setResponseTimeoutMillis(operationTimeout); // Sakai should not be making any giant queries to LDAP
+        /**
+         * Create the LDAP connection pool
+         */
+        protected synchronized boolean createConnectionPool() {
 
-		if (isSecureConnection()) {
-			try {
-				// If testing locally only, could use `new TrustAllTrustManager()` as contructor parameter to SSLUtil
-				SSLUtil sslUtil = new SSLUtil();
-				SSLSocketFactory sslSocketFactory = sslUtil.createSSLSocketFactory();
+                if (connectionPool != null) {
+                        return true;
+                }
 
-				serverSet = new SingleServerSet(ldapHost[0], ldapPort[0], sslSocketFactory, connectOptions);
-			} catch (GeneralSecurityException ex) {
-				log.error("Error while initializing LDAP SSLSocketFactory");
-				throw new RuntimeException(ex);
-			}
-		} else {
-			serverSet = new SingleServerSet(ldapHost[0], ldapPort[0], connectOptions);
-		}
+                // Create a new LDAP connection pool with 10 connections
+                ServerSet serverSet = null;
+
+                // Set some sane defaults to better handle timeouts. Unboundid will wait 30 seconds by default on a hung connection.
+                LDAPConnectionOptions connectOptions = new LDAPConnectionOptions();
+                connectOptions.setAbandonOnTimeout(true);
+                connectOptions.setConnectTimeoutMillis(operationTimeout);
+                connectOptions.setResponseTimeoutMillis(operationTimeout); // Sakai should not be making any giant queries to LDAP
+
+                if (isSecureConnection()) {
+                        try {
+                                // If testing locally only, could use `new TrustAllTrustManager()` as contructor parameter to SSLUtil
+                                SSLUtil sslUtil = new SSLUtil();
+                                SSLSocketFactory sslSocketFactory = sslUtil.createSSLSocketFactory();
+
+                                serverSet = new SingleServerSet(ldapHost[0], ldapPort[0], sslSocketFactory, connectOptions);
+                        } catch (GeneralSecurityException ex) {
+                                log.error("Error while initializing LDAP SSLSocketFactory");
+                                throw new RuntimeException(ex);
+                        }
+                } else {
+                        serverSet = new SingleServerSet(ldapHost[0], ldapPort[0], connectOptions);
+                }
+
 
 		SimpleBindRequest bindRequest = new SimpleBindRequest(ldapUser, ldapPassword);
 		try {
@@ -297,10 +311,11 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 			connectionPool.setRetryFailedOperationsDueToInvalidConnections(retryFailedOperationsDueToInvalidConnections);
 		} catch (com.unboundid.ldap.sdk.LDAPException e) {
 			log.error("Could not init LDAP pool", e);
+			return false;
 		}
-		   
-		initLdapAttributeMapper();
-	}
+
+		return true;
+        }
 
 	/**
 	 * Lazily "injects" a {@link LdapAttributeMapper} if one
@@ -392,6 +407,11 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 
 		if ( !allowAuthenticationAdmin && securityService.isSuperUser(edit.getId())) {
 			log.debug("authenticateUser(): returning false, not authenticating for superuser (admin) {}", edit.getEid());
+			return false;
+		}
+
+		if (connectionPool == null && !createConnectionPool()) {
+			log.error("No LDAP connection pool available: unable to authenticate");
 			return false;
 		}
 
@@ -855,6 +875,10 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 	throws LDAPException {
 
 		log.debug("searchDirectory(): [filter = {}]", filter);
+
+		if (connectionPool == null && !createConnectionPool()) {
+			throw new LDAPException("No LDAP connection pool available: unable to search");
+		}
 
 		try {
 


### PR DESCRIPTION
With the unboundid LDAP provider using connection pooling, if an LDAP server is unavailable when Sakai starts, then the connection pool is not created and LDAP auth attempts will fail until the app server is restarted, even if the LDAP server comes back online.

This retries creation of the connection pool when an LDAP auth or search request is attempted, if the pool has not already been created.

The method is synchronized and there are some checks to avoid multiple connection pools being created.
