### PR TITLE
SAK-41752: Worksite Setup > 'Hard Delete' button not displaying in top section when present in bottom section

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-list.vm
@@ -78,7 +78,7 @@
 							onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doGet_site';document.getElementById('sitesForm').submit();return false;" />
 						<input type="button" id="btnSoftDelete1" name="btnSoftDelete1" class="actionButton" value="$tlang.getString("java.delete")" disabled="disabled"
 							onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_delete';document.getElementById('sitesForm').submit();return false;" />
-						#if ($superUser)
+						#if ($superUser|| $canDelSoftDel)
 							<input type="button" id="btnHardDelete1" name="btnHardDelete1" class="actionButton" value="$tlang.getString("java.delete.hard")" disabled="disabled"
 								onclick="SPNR.disableControlsAndSpin( this, null );document.getElementById('sakai_action').value='doMenu_site_hard_delete';document.getElementById('sitesForm').submit();return false;" />
 						#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41752

The logic to display the 'Hard Delete' button isn't synchronized properly between the top and bottom action panels. The bottom panel is displaying the 'Hard Delete' button appropriately when the user has the correct permissions. However, the top section does not display this button when it should for non-admin users.