### PR TITLE
SAK-41791 - Add configuration to expose content-review errors to the UI

### DIFF
--- a/assignment/bundles/resources/assignment.properties
+++ b/assignment/bundles/resources/assignment.properties
@@ -953,6 +953,8 @@ content_review.error.REPORT_ERROR_RETRY_CODE = An error occurred while retrievin
 content_review.error.REPORT_ERROR_NO_RETRY_CODE = An error occurred while retrieving the originality report for this attachment. The report cannot be retrieved.
 content_review.error.SUBMISSION_ERROR_RETRY_EXCEEDED_CODE = All attempts to submit this attachment for originality review failed. Limit on submission attempts reached.
 content_review.pending.info = This attachment has been submitted and is pending review.
+content_review.notYetSubmitted = This item has not yet been submitted to {0}.
+content_review.errorFromSource = Latest response from {0}: {1}
 
 content_review.error = An unknown error occurred. The originality review for this attachment is not available.
 content_review.error.createAssignment=An error with {0} has occurred while creating this assignment. {1} has saved the assignment in draft mode. Please try posting this assignment again later. {2}

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -212,6 +212,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Setter private UserTimeService userTimeService;
 
     private boolean allowSubmitByInstructor;
+    private boolean exposeContentReviewErrorsToUI;
 
     public void init() {
         allowSubmitByInstructor = serverConfigurationService.getBoolean("assignments.instructor.submit.for.student", true);
@@ -220,6 +221,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         } else {
             log.info("Instructor submission of assignments is enabled");
         }
+
+        exposeContentReviewErrorsToUI = serverConfigurationService.getBoolean("contentreview.expose.errors.to.ui", false);
 
         // register as an entity producer
         entityManager.registerEntityProducer(this, REFERENCE_ROOT);
@@ -3930,7 +3933,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             reviewResult.setReviewReport(getReviewReport(cr, referenceReckoner.getReference()));
             String iconUrl = getReviewIconCssClass(reviewResult);
             reviewResult.setReviewIconCssClass(iconUrl);
-            reviewResult.setReviewError(getReviewError(reviewResult.getStatus()));
+            reviewResult.setReviewError(getReviewError(reviewResult));
 
             if ("true".equals(reviewResult.isInline())) {
                 reviewResults.add(0, reviewResult);
@@ -4024,31 +4027,46 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         }
     }
 
-    private String getReviewError(Long status){
-        if (status == null){
-            log.debug("getReviewReport(ContentResource) called with status == null");
+    private String getReviewError(ContentReviewResult reviewResult){
+        if (reviewResult == null) {
+            log.debug("getReviewReport(ContentReviewResult) called with reviewResult == null");
             return null;
         }
+        if(reviewResult.getStatus() == null) {
+            log.debug("getReviewReport(ContentReviewResult) called with reviewResult.getStatus() == null");
+            return null;
+        }
+        Long status = reviewResult.getStatus();
         //This should use getLocalizedReviewErrorMesage(contentId) to get a i18n message of the error
         String errorMessage = null;
+        boolean exposeError = false;
         if (status.equals(ContentReviewConstants.CONTENT_REVIEW_REPORT_ERROR_NO_RETRY_CODE)){
             errorMessage = resourceLoader.getString("content_review.error.REPORT_ERROR_NO_RETRY_CODE");
         } else if (status.equals(ContentReviewConstants.CONTENT_REVIEW_REPORT_ERROR_RETRY_CODE)) {
             errorMessage = resourceLoader.getString("content_review.error.REPORT_ERROR_RETRY_CODE");
         } else if (status.equals(ContentReviewConstants.CONTENT_REVIEW_SUBMISSION_ERROR_NO_RETRY_CODE)) {
             errorMessage = resourceLoader.getString("content_review.error.SUBMISSION_ERROR_NO_RETRY_CODE");
+            exposeError = true;
         } else if (status.equals(ContentReviewConstants.CONTENT_REVIEW_SUBMISSION_ERROR_RETRY_CODE)) {
             errorMessage = resourceLoader.getString("content_review.error.SUBMISSION_ERROR_RETRY_CODE");
+            exposeError = true;
         } else if (status.equals(ContentReviewConstants.CONTENT_REVIEW_SUBMISSION_ERROR_RETRY_EXCEEDED_CODE)) {
             errorMessage = resourceLoader.getString("content_review.error.SUBMISSION_ERROR_RETRY_EXCEEDED_CODE");
         } else if (status.equals(ContentReviewConstants.CONTENT_REVIEW_SUBMISSION_ERROR_USER_DETAILS_CODE)) {
             errorMessage = resourceLoader.getString("content_review.error.SUBMISSION_ERROR_USER_DETAILS_CODE");
-        } else if (ContentReviewConstants.CONTENT_REVIEW_SUBMITTED_AWAITING_REPORT_CODE.equals(status) || ContentReviewConstants.CONTENT_REVIEW_NOT_SUBMITTED_CODE.equals(status)) {
+        } else if (ContentReviewConstants.CONTENT_REVIEW_SUBMITTED_AWAITING_REPORT_CODE.equals(status)) {
             errorMessage = resourceLoader.getString("content_review.pending.info");
+        } else if (ContentReviewConstants.CONTENT_REVIEW_NOT_SUBMITTED_CODE.equals(status)) {
+            errorMessage = resourceLoader.getFormattedMessage("content_review.notYetSubmitted", new Object[] { contentReviewService.getServiceName() });
         }
 
         if (errorMessage == null) {
             errorMessage = resourceLoader.getString("content_review.error");
+        }
+
+        // Expose the underlying CRS error to the UI
+        if (exposeError && exposeContentReviewErrorsToUI) {
+            errorMessage += " " + resourceLoader.getFormattedMessage("content_review.errorFromSource", contentReviewService.getServiceName(), reviewResult.getContentReviewItem().getLastError());
         }
 
         return errorMessage;

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -222,7 +222,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             log.info("Instructor submission of assignments is enabled");
         }
 
-        exposeContentReviewErrorsToUI = serverConfigurationService.getBoolean("contentreview.expose.errors.to.ui", false);
+        exposeContentReviewErrorsToUI = serverConfigurationService.getBoolean("contentreview.expose.errors.to.ui", true);
 
         // register as an entity producer
         entityManager.registerEntityProducer(this, REFERENCE_ROOT);

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2047,6 +2047,11 @@
 # Default: false
 # contentreview.option.student_preview.default=true
 
+# Determines if error messages directly from the content review service will be exposed to end users
+# If false, a generic message is displayed instead
+# Default: false
+# contentreview.expose.errors.to.ui=false
+
 # SAK-31923
 # Sets the separation char on exporting to 
 

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2049,7 +2049,7 @@
 
 # Determines if error messages directly from the content review service will be exposed to end users
 # If false, a generic message is displayed instead
-# Default: false
+# Default: true
 # contentreview.expose.errors.to.ui=false
 
 # SAK-31923


### PR DESCRIPTION
For content review errors, we currently swallow any messages from the content review service, and instead display messages from our own message bundles such as the following:
"An error occurred while submitting this item to the originality checking service."

It can be beneficial to show content-review errors to end users so that they can understand and resolve issues on their own, such as "the submission contains less than 20 words", "the due date has passed", etc.

Add configuration in sakai.properties allowing institutions to display these messages to end users