### PR TITLE
SAK-41800 Allow the character X or x in ISBN

### DIFF
--- a/rwiki/rwiki-util/radeox/src/java/org/radeox/macro/IsbnMacro.java
+++ b/rwiki/rwiki-util/radeox/src/java/org/radeox/macro/IsbnMacro.java
@@ -61,7 +61,7 @@ public class IsbnMacro extends BaseLocaleMacro
 
 		if (params.getLength() == 1)
 		{
-			String isbn = params.get("0").replaceAll("[^0-9-]", "");
+			String isbn = params.get("0").replaceAll("[^0-9xX-]", "");
 			BookServices.getInstance().appendUrl(writer, isbn); //$NON-NLS-1$
 			return;
 		}

--- a/rwiki/rwiki-util/radeox/src/test/java/org/radeox/test/macro/IsbnMacroTest.java
+++ b/rwiki/rwiki-util/radeox/src/test/java/org/radeox/test/macro/IsbnMacroTest.java
@@ -47,4 +47,12 @@ public class IsbnMacroTest extends MacroTestSupport
 				"(<a href=\"http://www.amazon.com/exec/obidos/ASIN/0201615630\">Amazon.com</a>)",
 				result);
 	}
+
+	public void testIsbnX() {
+		String result = EngineManager.getInstance().render("{isbn:059615448X}",
+				context);
+		assertEquals(
+				"(<a href=\"http://www.amazon.com/exec/obidos/ASIN/059615448X\">Amazon.com</a>)",
+				result);
+	}
 }


### PR DESCRIPTION
Old 10 digit ISBNS can have an X as the check digit. This fixes the Rwiki ISBN Macro to allow the X character.