### PR TITLE
TII-264 - TurnitinOC - 'Invalid JSON' response when using special characters

### DIFF
--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -16,9 +16,11 @@
 package org.sakaiproject.contentreview.turnitin.oc;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.DataOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -632,11 +634,12 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 			// Convert data to string:
 			connection.setDoOutput(true);
 			wr = new DataOutputStream(connection.getOutputStream());
+			BufferedWriter br = new BufferedWriter(new OutputStreamWriter(wr, "UTF-8"));
 			ObjectMapper objectMapper = new ObjectMapper();
 			String dataStr = objectMapper.writeValueAsString(data);
-			wr.writeBytes(dataStr);
-			wr.flush();
-			wr.close();
+			br.write(dataStr);
+			br.flush();
+			br.close();
 		} else if (dataBytes != null) {
 			connection.setDoOutput(true);
 			wr = new DataOutputStream(connection.getOutputStream());

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -611,7 +611,6 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		throws Exception {
 		// Set variables
 		HttpURLConnection connection = null;
-		DataOutputStream wr = null;
 		URL url = null;
 
 		// Construct URL
@@ -629,22 +628,20 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 			connection.setRequestProperty(entry.getKey(), entry.getValue());
 		}
 
-		// Set Post body:
-		if (data != null) {
-			// Convert data to string:
-			connection.setDoOutput(true);
-			wr = new DataOutputStream(connection.getOutputStream());
-			BufferedWriter br = new BufferedWriter(new OutputStreamWriter(wr, "UTF-8"));
-			ObjectMapper objectMapper = new ObjectMapper();
-			String dataStr = objectMapper.writeValueAsString(data);
-			br.write(dataStr);
-			br.flush();
-			br.close();
-		} else if (dataBytes != null) {
-			connection.setDoOutput(true);
-			wr = new DataOutputStream(connection.getOutputStream());
-			wr.write(dataBytes);
-			wr.close();
+		connection.setDoOutput(true);
+		try (DataOutputStream wr = new DataOutputStream(connection.getOutputStream())) {
+			// Set Post body:
+			if (data != null) {
+				// Convert data to string:
+				try (BufferedWriter br = new BufferedWriter(new OutputStreamWriter(wr, "UTF-8"))) {
+					ObjectMapper objectMapper = new ObjectMapper();
+					String dataStr = objectMapper.writeValueAsString(data);
+					br.write(dataStr);
+					br.flush();
+				}
+			} else if (dataBytes != null) {
+				wr.write(dataBytes);
+			}
 		}
 
 		// Send request:


### PR DESCRIPTION
When attempting to view originality reports for sakai demo student student0008 (El Niño), or student0009 (Ângeolo Haslip), the following JSON is sent to TII:

{"similarity":{"modes":{"all_sources":true,"match_overview":true}},"viewer_default_permissions_set":"INSTRUCTOR","author_metadata_override":{"given_name":"
El","family_name":"Niño"},"viewer_user_id":"some uid","locale":"en"}
The response is a 400 with message "Invalid JSON".
Students without accent characters are fine.

Encode transmissions to TII in UTF-8