### PR TITLE
TII-266 - TurnitinOC - improve error message when retrieving reports while connectivity to TII is down

### DIFF
--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -19,6 +19,7 @@ import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -954,6 +955,12 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 				}
 				handleReportStatus(item, status);
 
+			} catch (IOException e) {
+				log.error(e.getLocalizedMessage(), e);
+				item.setLastError("A problem occurred while retrieving an originality score from Turnitin");
+				item.setStatus(ContentReviewConstants.CONTENT_REVIEW_REPORT_ERROR_RETRY_CODE);
+				crqs.update(item);
+				errors++;
 			} catch (Exception e) {
 				log.error(e.getLocalizedMessage(), e);
 				item.setLastError(e.getMessage());


### PR DESCRIPTION
If you disable your internet connection and run the queue job, the 'last_error' column is populated with your turnitin service url's host name (because a java.net.UnknownHostException is thrown, and the exception message is just the host name). The last_error message should be replaced with something more akin to "Failed to retrieve an originality score from Turnitin"