### PR TITLE
TurnitinOC - CORRUPT_FILE error code - mention password protected files

### DIFF
--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -1226,7 +1226,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 				errorStr = "The uploaded file requires a password in order to be opened";
 				break;
 			case "CORRUPT_FILE":
-				errorStr = "The uploaded file appears to be corrupt";
+				errorStr = "The uploaded file appears to be corrupt or password protected";
 				break;
 			case "ERROR":
 				errorStr = "Submission returned with ERROR status";


### PR DESCRIPTION
If you upload a password protected pdf (and possibly any password protected format that Turnitin supports), the Turnitin returns the 'CORRUPT_FILE' error. We interpret that for end users as "The uploaded file appears to be corrupt", which is misleading in the password protection scenario