### PR TITLE
TurnitinOC - add_to_index property should match the assignment setting

### DIFF
--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -690,7 +690,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		reportData.put("view_settings", viewSettings);
 		
 		Map<String, Object> indexingSettings = new HashMap<String, Object>();
-		indexingSettings.put("add_to_index", true);
+		indexingSettings.put("add_to_index", "true".equals(assignmentSettings.get("store_inst_index")));
 		reportData.put("indexing_settings", indexingSettings);
 
 		HashMap<String, Object> response = makeHttpCall("PUT",


### PR DESCRIPTION
Currently in generateSimilarityReport, we have the following line:
indexingSettings.put("add_to_index", true);
We should pull this from the assignment settings