### PR TITLE
SAK-41866 Library: Created standard set of Sakai message banners

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -137,6 +137,32 @@ $warn-color:                darken($warn-background-color, 35%) !default;
 $error-background-color:    #f2dede !default;
 $error-color:               darken($error-background-color, 30%) !default;
 
+/* Sakai Banners */
+// Information (info) banner
+$infoBanner-bordercolor: #5c9bd1;
+$infoBanner-bgcolor: #bde5f8;
+$infoBanner-color: $text-color;
+$infoBanner-icon: ".fa-info-circle";
+
+// Success banner
+$successBanner-bordercolor: #52b387;
+$successBanner-bgcolor: #d9f0e7;
+$successBanner-color: $text-color;
+$successBanner-icon: ".fa-check-circle";
+
+// Warning (warn) banner
+$warnBanner-bordercolor: #f1ba1b;
+$warnBanner-bgcolor: #fbeec9;
+$warnBanner-color: $text-color;
+$warnBanner-icon: ".fa-exclamation-circle";
+
+// Error banner
+$errorBanner-bordercolor: #cf4f16;
+$errorBanner-bgcolor: #f4dcd2;
+$errorBanner-color: $text-color;
+$errorBanner-icon: ".fa-ban";
+/* end of Sakai Banners */
+
 /* Swapped 'View As' view */
 $swapped-view-enabled: false !default;
 $swapped-view-primary: 		 #bf360c !default;

--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -67,6 +67,89 @@
   @include bs-callout($error-color, $error-background-color);
 }
 
+@mixin sakai-banner($bordercolor, $bgcolor, $color, $icon, $isInline: false) {
+	position: relative;
+	@if $isInline {
+		display: inline-block;
+		margin: 0;
+		padding: 0 $standard-space;
+	} @else {
+		display: block;
+		margin: $standard-spacing 0;
+		padding: $standard-spacing;
+	}
+	border-left: calc( #{$standard-spacing} / 2) solid $bordercolor;
+	background-color: $bgcolor;
+	color: $color;
+	
+	// display an icon indicating banner type on the left of the text
+	&:before {
+		content: '';
+		@extend .fa;
+		@extend .fa-fw;		// fixed width icons
+		@extend #{$icon};	// icon passed in through mixin's parameter
+		margin-right: $standard-space;	// space between icon and message text
+		color: $bordercolor;
+	}
+	
+	// display a closing X on the right of the banner to indicate that the banner is dismissible
+	.dismiss {
+		@if $isInline == false {
+			position: absolute;
+			top: $standard-spacing;			// space between icon and top edge of banner
+			right: $standard-spacing;		// space between icon and right edge of banner
+		} @else {
+			margin-left: $standard-space;	// space between icon and end of message text
+		}
+		text-decoration: none;
+		
+		span {
+			font-size: 0;		// hide the accessible text
+		}
+		
+		&:before {
+			content: '';
+			@extend .fa;
+			@extend .fa-fw;	// fixed width icons
+			@extend .fa-close;
+		}
+	}
+	
+	// any links in the banners should have the same text color contrast and be underlined
+	a[href] {
+		color: $color;
+		text-decoration: underline;
+	}
+}
+
+.sak-banner-info {
+	@include sakai-banner($infoBanner-bordercolor, $infoBanner-bgcolor, $text-color, $infoBanner-icon, false);
+}
+.sak-banner-info-inline {
+	@include sakai-banner($infoBanner-bordercolor, $infoBanner-bgcolor, $text-color, $infoBanner-icon, true);
+}
+.sak-banner-success {
+	@include sakai-banner($successBanner-bordercolor, $successBanner-bgcolor, $text-color, $successBanner-icon, false);
+}
+.sak-banner-success-inline {
+	@include sakai-banner($successBanner-bordercolor, $successBanner-bgcolor, $text-color, $successBanner-icon, true);
+}
+.sak-banner-warn {
+	@include sakai-banner($warnBanner-bordercolor, $warnBanner-bgcolor, $text-color, $warnBanner-icon, false);
+}
+.sak-banner-warn-inline {
+	@include sakai-banner($warnBanner-bordercolor, $warnBanner-bgcolor, $text-color, $warnBanner-icon, true);
+}
+.sak-banner-error {
+	@include sakai-banner($errorBanner-bordercolor, $errorBanner-bgcolor, $text-color, $errorBanner-icon, false);
+}
+.sak-banner-error-inline {
+	@include sakai-banner($errorBanner-bordercolor, $errorBanner-bgcolor, $text-color, $errorBanner-icon, true);
+}
+.sak-banner-dismiss {
+	padding-right: calc(#{$standard-spacing} + 1.2em + #{$standard-spacing});		// allow enough room for dismiss "X"
+}
+
 @mixin icon( $width : $icon-size, $height : $icon-size ){
 	border: 0px none;
 	display: inline-block;

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -448,7 +448,7 @@
 		<div style="clear:both"> </div>
 		#end
 	#if ($!viewRoster && !$!isMyWorkspace) 
-		<div class="messageInformation"> 
+		<div class="sak-banner-info"> 
 			$tlang.getFormattedMessage("sinfo.manage.participants.moved","?sakai_action=doMenu_siteInfo_manageParticipants") 
 		</div>
 	#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41866

Created the foundation for a standard set of Sakai message banners for the SWITCH project. Updated one banner in Site Info as an example. Additional subtasks will update the rest of the banners in the coming weeks from a team of SWITCH developers.

See https://jira.sakaiproject.org/browse/SAK-41866 for screenshots of the example banners and for more information. 