### PR TITLE
SAK-41763: XSS in chat user name - 12.x

### DIFF
--- a/chat/chat-tool/tool/pom.xml
+++ b/chat/chat-tool/tool/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>
-      <version>1.0.4</version>
+      <version>1.1.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/chat/chat-tool/tool/src/webapp/jsp/prelude.jspf
+++ b/chat/chat-tool/tool/src/webapp/jsp/prelude.jspf
@@ -3,7 +3,9 @@
 %><%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c" 
 %><%@ taglib uri="http://sakaiproject.org/jsf/sakai" prefix="sakai" 
 %><%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t" 
-%><%
+%><%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" 
+%>
+<%
     response.setContentType("text/html; charset=UTF-8");
     response.addDateHeader("Expires", System.currentTimeMillis() - (1000L * 60L * 60L * 24L * 365L));
     response.addDateHeader("Last-Modified", System.currentTimeMillis());

--- a/chat/chat-tool/tool/src/webapp/jsp/roomMonitor.jspf
+++ b/chat/chat-tool/tool/src/webapp/jsp/roomMonitor.jspf
@@ -42,7 +42,7 @@
             <c:out value="<span class='chatUserOnline'></span>" escapeXml="false" />
             <c:out value="</span>" escapeXml="false" />
 
-            <c:out value="<span class='chatNameDate'><span class='chatName'>${message.owner}</span>" escapeXml="false" />
+            <c:out value="<span class='chatNameDate'><span class='chatName'>${fn:escapeXml(message.owner)}</span>" escapeXml="false" />
             <c:set var="chatDate" value="" />
 
             <c:if test="${ChatTool.displayDate && ChatTool.displayTime}">


### PR DESCRIPTION
For this fix to be applied to 12.x, I needed to add some runtime libraries and upgrade taglibs from 1.0.4. I chose 1.1.2 because this is the version already used by the site/admin-prefs tool in 12.x.