### PR TITLE
SAK-41899: rubric name space web components as sakai-rubric to at keep a convention

### DIFF
--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-creator-name.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-creator-name.js
@@ -41,4 +41,4 @@ export class SakaiRubricCreatorName extends SakaiElement {
   }
 }
 
-customElements.define("creator-name", SakaiRubricCreatorName);
+customElements.define("sakai-rubric-creator-name", SakaiRubricCreatorName);

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-modified-date.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-modified-date.js
@@ -25,4 +25,4 @@ export class SakaiRubricModifiedDate extends SakaiElement {
   }
 }
 
-customElements.define("modified-date", SakaiRubricModifiedDate);
+customElements.define("sakai-rubric-modified-date", SakaiRubricModifiedDate);

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-readonly.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-readonly.js
@@ -35,9 +35,9 @@ export class SakaiRubricReadonly extends SakaiElement {
           </span>
         </div>
 
-        <div class="hidden-xs"><site-title site-id="${this.rubric.metadata.ownerId}"></site-title></div>
-        <div class="hidden-xs"><creator-name creator-id="${this.rubric.metadata.creatorId}"></creator-name></div>
-        <div class="hidden-xs"><modified-date modified="${this.rubric.metadata.modified}"></modified-date></div>
+        <div class="hidden-xs"><sakai-rubric-site-title site-id="${this.rubric.metadata.ownerId}"></sakai-rubric-site-title></div>
+        <div class="hidden-xs"><sakai-rubric-creator-name creator-id="${this.rubric.metadata.creatorId}"></sakai-rubric-creator-name></div>
+        <div class="hidden-xs"><sakai-rubric-modified-date modified="${this.rubric.metadata.modified}"></sakai-rubric-modified-date></div>
 
         <div class="actions">
           <div class="action-container">

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-site-title.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric-site-title.js
@@ -41,4 +41,4 @@ export class SakaiRubricSiteTitle extends SakaiElement {
   }
 }
 
-customElements.define("site-title", SakaiRubricSiteTitle);
+customElements.define("sakai-rubric-site-title", SakaiRubricSiteTitle);

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric.js
@@ -5,8 +5,8 @@ import {SakaiRubricCriteriaReadonly} from "./sakai-rubric-criteria-readonly.js";
 import {SakaiRubricEdit} from "./sakai-rubric-edit.js";
 import {SakaiItemDelete} from "./sakai-item-delete.js";
 import {SakaiRubricSiteTitle} from "./sakai-rubric-site-title.js";
-import {SakaiRubricModifiedDate} from "./sakai-rubric-modified-date.js";
-import {SakaiRubricCreatorName} from "./sakai-rubric-creator-name.js";
+import {SakaiRubricModifiedDate} from "./sakai-rubric-sakai-rubric-modified-date.js";
+import {SakaiRubricCreatorName} from "./sakai-rubric-sakai-rubric-creator-name.js";
 import {tr} from "./sakai-rubrics-language.js";
 import {SharingChangeEvent} from "./sharing-change-event.js";
 
@@ -73,9 +73,9 @@ export class SakaiRubric extends SakaiElement {
           }
         </div>
 
-        <div class="hidden-xs"><site-title site-id="${this.rubric.metadata.ownerId}"></site-title></div>
-        <div class="hidden-xs"><creator-name creator-id="${this.rubric.metadata.creatorId}"></creator-name></div>
-        <div class="hidden-xs"><modified-date modified="${this.rubric.metadata.modified}"></modified-date></div>
+        <div class="hidden-xs"><sakai-rubric-site-title site-id="${this.rubric.metadata.ownerId}"></sakai-rubric-site-title></div>
+        <div class="hidden-xs"><sakai-rubric-creator-name creator-id="${this.rubric.metadata.creatorId}"></sakai-rubric-creator-name></div>
+        <div class="hidden-xs"><sakai-rubric-modified-date modified="${this.rubric.metadata.modified}"></sakai-rubric-modified-date></div>
 
         <div class="actions">
           <div class="action-container">

--- a/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric.js
+++ b/rubrics/tool/src/main/frontend/webcomponents/sakai-rubric.js
@@ -5,8 +5,8 @@ import {SakaiRubricCriteriaReadonly} from "./sakai-rubric-criteria-readonly.js";
 import {SakaiRubricEdit} from "./sakai-rubric-edit.js";
 import {SakaiItemDelete} from "./sakai-item-delete.js";
 import {SakaiRubricSiteTitle} from "./sakai-rubric-site-title.js";
-import {SakaiRubricModifiedDate} from "./sakai-rubric-sakai-rubric-modified-date.js";
-import {SakaiRubricCreatorName} from "./sakai-rubric-sakai-rubric-creator-name.js";
+import {SakaiRubricModifiedDate} from "./sakai-rubric-modified-date.js";
+import {SakaiRubricCreatorName} from "./sakai-rubric-creator-name.js";
 import {tr} from "./sakai-rubrics-language.js";
 import {SharingChangeEvent} from "./sharing-change-event.js";
 


### PR DESCRIPTION
Before you look for a the JIRA (https://github.com/sakaiproject/sakai-reference/issues/66)

What this changes: The web components in Rubric generally follow a naming convention to ensure there aren't name collisions later on (nice). But, 3 do not so they should be renamed to ensure consistency:
- site-title
- modified-date
- creator-name

This PR will rename these to ensure this happens. I have more feedback about the components as well as fixes but will wait until I'm able to figure out how to get a JIRA account so I can submit a real issue to start said conversation around some of these issues.