### PR TITLE
SAK-41957: Forums ClassCastException when calling services from SiteStats

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
@@ -486,7 +486,8 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
             return (Topic) q.uniqueResult();
         };
 
-        return getHibernateTemplate().execute(hcb);
+        // unproxy to avoid ClassCastException in certain scenarios
+        return (Topic) HibernateUtils.unproxy(getHibernateTemplate().execute(hcb));
 
     }
 
@@ -557,7 +558,8 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
           return (BaseForum) q.uniqueResult();
       };
 
-      return getHibernateTemplate().execute(hcb);
+      // unproxy the result to avoid ClassCastException in certain scenarios
+      return (BaseForum) HibernateUtils.unproxy(getHibernateTemplate().execute(hcb));
 
     }
 

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/detailed/refresolvers/MsgForumsReferenceResolver.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/detailed/refresolvers/MsgForumsReferenceResolver.java
@@ -82,7 +82,7 @@ public class MsgForumsReferenceResolver
 				Message msg = dfMan.getMessageById(parsedRef.itemId);
 				if (msg == null)
 				{
-					log.error("Unable to retrieve message for id: " + parsedRef.itemId);
+					log.error("Unable to retrieve message for id: {}", parsedRef.itemId);
 					return ResolvedEventData.ERROR;
 				}
 
@@ -91,14 +91,14 @@ public class MsgForumsReferenceResolver
 				Topic tpc = msg.getTopic(); // lightweight topic, has only the id
 				if (tpc == null || tpc.getId() == null)
 				{
-					log.error("Message " + msg.getId() + " has no topic.");
+					log.error("Message {} has no topic.", msg.getId());
 					return ResolvedEventData.ERROR;
 				}
 
 				Optional<DiscussionTopic> dTopic = findTopic(tpc.getId(), dfMan);
 				if (!dTopic.isPresent())
 				{
-					log.error("Unable to find DiscussionTopic for topic id: " + tpc.getId());
+					log.error("Unable to find DiscussionTopic for topic id: {}", tpc.getId());
 					return ResolvedEventData.ERROR;
 				}
 
@@ -128,7 +128,7 @@ public class MsgForumsReferenceResolver
 				}
 				return new MessageData(td, thread, msg.getTitle(), msg.getAuthor(), msg.getCreated(), false);
 			default:
-				log.error("Invalid HierarchyLevel: " + parsedRef.level + " for ref " + ref);
+				log.error("Invalid HierarchyLevel: {} for ref {}", parsedRef.level, ref);
 				return ResolvedEventData.ERROR;
 		}
 	}
@@ -150,7 +150,7 @@ public class MsgForumsReferenceResolver
 		catch (IllegalArgumentException e)
 		{
 			// this is thrown if any of the valueOf() calls above fail, in which case the ref is malformed and cannot be resolved
-			log.warn("Unable to parse, ref is malformed: " + eventRef, e) ;
+			log.warn("Unable to parse, ref is malformed: {}", eventRef, e) ;
 			return Optional.empty();
 		}
 	}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41957

Forums uses a single-table inheritance structure to model topics and forums. Internally, Forums service methods will often cast directly to the appropriate subclass. For example, a Topic object is cast to DiscussionTopic.

When these methods are called from SiteStats with the default database setting, Hibernate returns proxy objects instead of the real objects. The proxy objects are for the base class (ie. TopicImpl_$$_jvst4cf_3b), which then cannot be cast to the subclass (DiscussionTopic) and we get a ClassCastException. Interestingly, the same code does not return proxies when called from within Forums, or from SiteStats when it is configured to use an external database.

To get around this problem, this patch unproxies the objects similarly to SAK-24996. It also fixes some error handling bugs uncovered in SiteStats as a result of this issue.