### PR TITLE
SAK-41974: Statistics: Don't appear 'Average presence time per visit' since 11.x

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4160,7 +4160,7 @@
 # sitestats.debug=true 
 
 # STAT-61 : Server-wide stats are enabled by default in Sakai 10+
-# serverWideStatsEnabled@org.sakaiproject.sitestats.api.StatsManager=true
+# serverWideStatsEnabled@org.sakaiproject.sitestats.api.StatsManager.target=true
 
 # External Database feature
 # In order to configure sitestats to use a different database for its tables set the following sakai property:

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
@@ -85,7 +85,7 @@ citationsEnabledByDefault@org.sakaiproject.citation.api.ConfigurationService=tru
 assignment.group.submission.enabled=true
 assignment.visible.date.enabled=true
 
-serverWideStatsEnabled@org.sakaiproject.sitestats.api.StatsManager=true
+serverWideStatsEnabled@org.sakaiproject.sitestats.api.StatsManager.target=true
 
 content.html.forcedownload=false
 
@@ -102,7 +102,7 @@ search.experimental = true
 samigo.autoSubmit.enabled = true
 
 ## Test STAT-351
-enableSitePresences@org.sakaiproject.sitestats.api.StatsManager=true
+enableSitePresences@org.sakaiproject.sitestats.api.StatsManager.target=true
 display.users.present=true
 
 # Test SAK-23812


### PR DESCRIPTION
Don't appear "Average presence time per visit" because the property is wrong

The bean was changed on SAK-32358 but the property is still on org.sakaiproject.sitestats.api.StatsManage instead of org.sakaiproject.sitestats.api.StatsManage.target 

Check the table sst_presences