### PR TITLE
SAK-41984 Submission confirmation page: show honor only when due

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1605,14 +1605,13 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     public Map<String,Boolean> getProgressBarStatus(AssignmentSubmission submission) {//currently this is only for student
         Map<String, Boolean> statusMap = new LinkedHashMap<>();
         if(submission == null) {
-            statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.HONOR_ACCEPTED, ""), false);
             statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.IN_PROGRESS, ""), false);
             statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.SUBMITTED, ""), false);
             statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.RETURNED, ""), false);
             return statusMap;
         }
         Assignment assignment = submission.getAssignment();
-        Instant submitTime = submission.getDateSubmitted();
+        Instant latestSubmitTime = submission.getDateSubmitted();
         Instant returnTime = submission.getDateReturned();
         if (assignment.getHonorPledge()) {
             if(submission.getHonorPledge()) {
@@ -1631,9 +1630,10 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         } else {
             statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.SUBMITTED, ""), false);
         }
-        if (submitTime != null && submission.getReturned() && returnTime != null && returnTime.isBefore(submitTime)) {
+        if (latestSubmitTime != null && submission.getReturned() && returnTime != null && returnTime.isBefore(latestSubmitTime)) {
             statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.RESUBMITTED, ""), true);
-            if (submitTime.isAfter(assignment.getDueDate())) {
+            statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.SUBMITTED, ""), true);
+            if (latestSubmitTime.isAfter(assignment.getDueDate())) {
                 statusMap.put(getFormattedStatus(AssignmentConstants.SubmissionStatus.LATE, ""), true);
             }
         }

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2031,6 +2031,10 @@ public class AssignmentAction extends PagedResourceActionII {
             context.put("assignment", a);
             context.put("assignmentReference", assignmentReference);
             context.put("honorPledgeText", serverConfigurationService.getString("assignment.honor.pledge", rb.getString("gen.hpa.text")));
+            Map<String, Boolean> statusMap = new LinkedHashMap<>();
+            statusMap.put(rb.getString("gen.hpsta"), false);
+            statusMap.putAll(assignmentService.getProgressBarStatus(null));
+            context.put("statusMap", statusMap);
         } else {
             addAlert(state, rb.getString("youarenot18"));
             doList_assignments(data);

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment_honor_pledge.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment_honor_pledge.vm
@@ -12,7 +12,9 @@
             #assignmentTitleIcon($assignment)
             $validator.escapeHtml($!assignment.Title)
         </h3>
-        #progressBar($!service.getProgressBarStatus($!submission))
+
+        #progressBar($statusMap)
+
         <div class="jumbotron" id="honor-pledge-agreement">
             <h4>$tlang.getString("gen.hpa.title")</h4>
             <p>$!honorPledgeText</p>


### PR DESCRIPTION
This was the only way to solve this case avoiding changes on the api, while at the same time keeping the map order (LinkedHash from java).

Also as of now a resubmitted status will always mean a submission was made.