### PR TITLE
SAK-41825 SAKAI-2720 Allow users to select a gradebook cateogry in sa…

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/AssessmentBaseIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/AssessmentBaseIfc.java
@@ -129,5 +129,9 @@ public interface AssessmentBaseIfc
 
   void updateAssessmentMetaData(String label, String entry);
 
+  Long getCategoryId();
+
+  void setCategoryId(Long categoryId);
+
   TypeIfc getType();
 }

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/PublishedAssessmentIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/PublishedAssessmentIfc.java
@@ -49,5 +49,9 @@ public interface PublishedAssessmentIfc
   Date getLastNeedResubmitDate();
 
   void setLastNeedResubmitDate(Date lastNeedResubmitDate);
+
+  Long getCategoryId();
+
+  void setCategoryId(Long categoryId);
   
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -168,6 +168,7 @@ student_identity_label=Anonymous Grading
 student_identity=Hide student identity from grader
 gradebook_options=Gradebook Options
 gradebook_options_help=Send assessment score to Gradebook immediately, regardless of options below
+gradebook_category_select=Select a Gradebook category (optional)
 
 recorded_score=If multiple submissions, record the
 highest_score=highest score

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -288,6 +288,11 @@ public class SaveAssessmentSettings
       evaluation.setScoringType(new Integer(assessmentSettings.getScoringType()));
     assessment.setEvaluationModel(evaluation);
 
+    // Add category unless unassigned (-1) is selected or defaulted. CategoryId comes
+    // from the web page as a string representation of a the long cat id.
+    if (!StringUtils.equals(assessmentSettings.getCategorySelected(), "-1")) {
+		assessment.setCategoryId(Long.parseLong((assessmentSettings.getCategorySelected())));
+    }
 
     // h. update ValueMap: it contains value for teh checkboxes in
     // authorSettings.jsp for: hasAvailableDate, hasDueDate,

--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -1441,3 +1441,6 @@ label#itemForm\:noFeedbackMsg {
 	list-style: none;
 	padding-left: 0;
 }
+.categorySelect {
+	margin-left: 8px;
+}

--- a/samigo/samigo-app/src/webapp/js/authoring.js
+++ b/samigo/samigo-app/src/webapp/js/authoring.js
@@ -765,3 +765,16 @@ if (typeof MathJax != 'undefined') {
     $(".mathjax-warning").show();
   });
 }
+
+function toggleCategories(checkbox) {
+    // Toggle categories selector. If categories are disabled it won't exist
+    // so check first.
+    var categoryDiv = $('#assessmentSettingsAction\\:toGradebookCategory');
+    if (categoryDiv.length) {
+        if ($(checkbox).prop("checked")) {
+            categoryDiv.fadeIn();
+        } else {
+            categoryDiv.fadeOut();
+        }
+    }
+}

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -601,9 +601,15 @@
     <h:panelGroup styleClass="row" layout="block" rendered="#{assessmentSettings.valueMap.toGradebook_isInstructorEditable==true && assessmentSettings.gradebookExists==true}">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.gradebook_options}"/>
       <div class="col-md-10 samigo-checkbox">
-        <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{assessmentSettings.toDefaultGradebook}"/>
+        <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{assessmentSettings.toDefaultGradebook}" onclick="toggleCategories(this);"/>
         <h:outputLabel value="#{assessmentSettingsMessages.gradebook_options_help}" for="toDefaultGradebook"/>
       </div>
+      <h:panelGroup layout="block" id="toGradebookCategory" styleClass="col-md-10 col-md-offset-2" rendered="#{assessmentSettings.categoriesEnabled}" style="display:#{(assessmentSettings.toDefaultGradebook)?'block':'none'}">
+        <h:outputLabel value="#{assessmentSettingsMessages.gradebook_category_select}" />
+        <h:selectOneMenu styleClass="categorySelect" id="selectCategory" value="#{assessmentSettings.categorySelected}">
+          <f:selectItems value="#{assessmentSettings.categoriesSelectList}" />
+        </h:selectOneMenu>
+      </h:panelGroup>
     </h:panelGroup>
 
   </div>

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -566,9 +566,15 @@
     <h:panelGroup styleClass="row" layout="block" rendered="#{publishedSettings.valueMap.toGradebook_isInstructorEditable==true && publishedSettings.gradebookExists==true}">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.gradebook_options}"/>
       <div class="col-md-10 samigo-checkbox">
-        <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{publishedSettings.toDefaultGradebook}" disabled="#{publishedSettings.firstTargetSelected == 'Anonymous Users'}"/>
+        <h:selectBooleanCheckbox id="toDefaultGradebook" value="#{publishedSettings.toDefaultGradebook}" disabled="#{publishedSettings.firstTargetSelected == 'Anonymous Users'}" onclick="toggleCategories(this);"/>
         <h:outputLabel value="#{assessmentSettingsMessages.gradebook_options_help}" for="toDefaultGradebook" />
       </div>
+      <h:panelGroup layout="block" id="toGradebookCategory" styleClass="col-md-10 col-md-offset-2" rendered="#{publishedSettings.categoriesEnabled}" style="display:#{(publishedSettings.toDefaultGradebook)?'block':'none'}">
+        <h:outputLabel value="#{assessmentSettingsMessages.gradebook_category_select}" />
+        <h:selectOneMenu styleClass="categorySelect" id="selectCategory" value="#{publishedSettings.categorySelected}">
+          <f:selectItems value="#{publishedSettings.categoriesSelectList}" />
+        </h:selectOneMenu>
+      </h:panelGroup>
     </h:panelGroup>
 
     </div>

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/AssessmentBase.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/AssessmentBase.hbm.xml
@@ -26,6 +26,7 @@
     <property name="createdDate" type="timestamp" column="CREATEDDATE" not-null="true" />
     <property name="lastModifiedBy" type="string" length="255" column="LASTMODIFIEDBY" not-null="true" />
     <property name="lastModifiedDate"  type="timestamp" column="LASTMODIFIEDDATE" not-null="true" />
+    <property name="categoryId" type="long" column="CATEGORYID" not-null="false" />
 
 <!--
     <property name="typeId">

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/AssessmentBaseData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/AssessmentBaseData.java
@@ -66,6 +66,7 @@ public class AssessmentBaseData
   private HashMap assessmentFeedbackMap = new HashMap();
   private Set securedIPAddressSet;
   private Integer questionSize;
+  private Long categoryId;
 
   public AssessmentBaseData() {}
 
@@ -407,5 +408,13 @@ public class AssessmentBaseData
 
   public void setQuestionSize(Integer questionSize) {
     this.questionSize = questionSize;
+  }
+
+  public Long getCategoryId() {
+    return categoryId;
+  }
+
+  public void setCategoryId(Long categoryId) {
+    this.categoryId = categoryId;
   }
 }

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessment.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessment.hbm.xml
@@ -27,6 +27,7 @@
     <property name="lastModifiedBy" type="string" length="255" column="LASTMODIFIEDBY" not-null="true" />
     <property name="lastModifiedDate" type="timestamp" column="LASTMODIFIEDDATE" not-null="true" />
     <property name="lastNeedResubmitDate" type="timestamp" column="LASTNEEDRESUBMITDATE" not-null="false" />
+    <property name="categoryId" type="long" column="CATEGORYID" not-null="false" />
     <set name="sectionSet" table="SAM_PUBLISHEDSECTION_T" cascade="all" order-by="sequence asc"
       inverse="true" lazy="true">
       <key column="ASSESSMENTID"/>

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessmentData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedAssessmentData.java
@@ -84,6 +84,7 @@ public class PublishedAssessmentData
   private Integer scoringType;
   private Date lastNeedResubmitDate;
   private Integer timeLimit;
+  private Long categoryId;
 
   
   public PublishedAssessmentData() {}
@@ -751,4 +752,11 @@ public class PublishedAssessmentData
 	  this.timeLimit = timeLimit;
   }
 
+  public Long getCategoryId() {
+    return categoryId;
+  }
+
+  public void setCategoryId(Long categoryId) {
+    this.categoryId = categoryId;
+  }
 }

--- a/samigo/samigo-pack/src/sql/mysql/patches/SAKAI-2720.sql
+++ b/samigo/samigo-pack/src/sql/mysql/patches/SAKAI-2720.sql
@@ -1,0 +1,3 @@
+-- SAKAI-2720 when adding a quiz to the gradebook, allow instructor to also select to which category the quiz should belong
+alter table SAM_ASSESSMENTBASE_T add CATEGORYID bigint(20);
+alter table SAM_PUBLISHEDASSESSMENT_T add CATEGORYID bigint(20);

--- a/samigo/samigo-pack/src/sql/oracle/patches/SAKAI-2720.sql
+++ b/samigo/samigo-pack/src/sql/oracle/patches/SAKAI-2720.sql
@@ -1,0 +1,3 @@
+-- SAKAI-2720 when adding a quiz to the gradebook, allow instructor to also select to which category the quiz should belong
+alter table SAM_ASSESSMENTBASE_T add column CATEGORYID NUMBER(19);
+alter table SAM_PUBLISHEDASSESSMENT_T add column CATEGORYID NUMBER(19);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentBaseFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentBaseFacade.java
@@ -80,6 +80,7 @@ public class AssessmentBaseFacade
   private HashMap assessmentMetaDataMap = new HashMap();
   private Set securedIPAddressSet;
   private String assessmentAttachmentMetaData;
+  private Long categoryId;
   
   /** AssessmentBaseFacade is the class that is exposed to developer
    *  It contains some of the useful methods specified in
@@ -224,6 +225,7 @@ public class AssessmentBaseFacade
     this.assessmentMetaDataMap = getAssessmentMetaDataMap(
         this.assessmentMetaDataSet);
     this.securedIPAddressSet = getSecuredIPAddressSet();
+    this.categoryId = getCategoryId();
   }
 
   // the following methods implements
@@ -799,5 +801,13 @@ public class AssessmentBaseFacade
   private void readObject(java.io.ObjectInputStream in) throws IOException,
       ClassNotFoundException {
     in.defaultReadObject();
+  }
+
+  public Long getCategoryId() {
+    return categoryId;
+  }
+
+  public void setCategoryId(Long categoryId) {
+    this.categoryId = categoryId;
   }
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentFacadeQueries.java
@@ -843,6 +843,7 @@ public class AssessmentFacadeQueries extends HibernateDaoSupport implements Asse
 		data.setLastModifiedBy(AgentFacade.getAgentString());
 		data.setLastModifiedDate(new Date());
 		int retryCount = PersistenceService.getInstance().getPersistenceHelper().getRetryCount();
+		data.setCategoryId(assessment.getCategoryId());
 		while (retryCount > 0) {
 			try {
 				getHibernateTemplate().saveOrUpdate(data);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacade.java
@@ -106,7 +106,8 @@ public class PublishedAssessmentFacade
   private String lastModifiedDateForDisplay;
   private int groupCount;
   private boolean selected;
-  
+  private Long categoryId;
+
   public PublishedAssessmentFacade() {
   }
 
@@ -882,5 +883,13 @@ public class PublishedAssessmentFacade
 
   public void setSelected(boolean selected) {
 	  this.selected = selected;
+  }
+
+  public Long getCategoryId() {
+    return categoryId;
+  }
+
+  public void setCategoryId(Long categoryId) {
+    this.categoryId = categoryId;
   }
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -206,6 +206,8 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 		publishedAssessment
 				.setAssessmentAttachmentSet(publishedAssessmentAttachmentSet);
 
+		publishedAssessment.setCategoryId(a.getCategoryId());
+
 		return publishedAssessment;
 	}
 
@@ -768,7 +770,7 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 							.equals(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK
 									.toString())) {
 				try {
-					gbsHelper.addToGradebook(publishedAssessment, null, g);
+					gbsHelper.addToGradebook(publishedAssessment, publishedAssessment.getCategoryId(), g);
 				} catch (Exception e) {
 					log.error("Removing published assessment: " + e);
 					delete(publishedAssessment);


### PR DESCRIPTION
…migo

This re-implements the work previously completed in SAKAI-278 for Sakai 11.
Instructors will be able to select a gradebook category from Samigo
for an assessment's associated gradebook item. Changes were made to the
original implementation to no longer use deprecated classes or methods.

Additionally, this expands upon the original feature to allow for
editing the category setting in published settings. This is done
by pulling in the GB setting everytime published settings is loaded
and then saving a new gradebook item if the category settings have
changed.