### PR TITLE
SAK-42019 Convert Samigo settings pages to tab layout

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -143,6 +143,16 @@ public final class SamigoConstants {
     public static final     String      EVAL_BUNDLE                                         = "org.sakaiproject.tool.assessment.bundle.EvaluationMessages";
     public static final     String      AUTHOR_BUNDLE                                       = "org.sakaiproject.tool.assessment.bundle.AuthorMessages";
 
+    /*
+     * Settings Tab Indexes
+     */
+    public static final     int         ABOUT_TAB                                           = 0;
+    public static final     int         AVAILABILITY_SUBISSIONS_TAB                         = 1;
+    public static final     int         DELIVERY_EXCEPTIONS_TAB                             = 2;
+    public static final     int         GRADING_FEEDBACK_TAB                                = 3;
+    public static final     int         LAYOUT_APPEARANCE_TAB                               = 4;
+    public static final     int         PUBLISH_TAB                                         = 5;
+
     private SamigoConstants() {
     	throw new AssertionError();
     }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -20,10 +20,16 @@ heading_availability=Availability and Submissions
 heading_grading_feedback=Grading and Feedback
 heading_extended_time=Exceptions to Time Limit and Delivery Date
 heading_layout=Layout and Appearance
+heading_publish=Publish
 heading_background=Change background?
 clear_calendar_alt=Clear Date
 
+ready_to_publish_heading=Are you ready to release this assessment to students?
+ready_to_publish_text1=If you're ready to release the assessment to students, then click on the "Save Settings and Publish" button.  The assessment will not be visible to students until the available date and time you specified in the "Availability & Submissions" section.
+ready_to_publish_text2=If you're not quite ready to release the assessment, then click on the "Save & Exit" button.  You'll need to return to this tab when you're ready to release the assessment to students.
+
 settings=Settings
+settings_info=Assessment settings are located on the five tabs below. You can navigate through the sections to customize your assessment. Click on the "Save & Exit" button (at the bottom of the page) at any time to save your changes. Please visit the "Publish" tab to release the assessment to students.
 template_title=Title
 template_authors=Author(s)
 template_description=Description/Intro (optional)

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -20,13 +20,8 @@ heading_availability=Availability and Submissions
 heading_grading_feedback=Grading and Feedback
 heading_extended_time=Exceptions to Time Limit and Delivery Date
 heading_layout=Layout and Appearance
-heading_publish=Publish
 heading_background=Change background?
 clear_calendar_alt=Clear Date
-
-ready_to_publish_heading=Are you ready to release this assessment to students?
-ready_to_publish_text1=If you're ready to release the assessment to students, then click on the "Save Settings and Publish" button.  The assessment will not be visible to students until the available date and time you specified in the "Availability & Submissions" section.
-ready_to_publish_text2=If you're not quite ready to release the assessment, then click on the "Save & Exit" button.  You'll need to return to this tab when you're ready to release the assessment to students.
 
 settings=Settings
 settings_info=Assessment settings are located on the five tabs below. You can navigate through the sections to customize your assessment. Click on the "Save & Exit" button (at the bottom of the page) at any time to save your changes. Please visit the "Publish" tab to release the assessment to students.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages.properties
@@ -32,6 +32,7 @@ action_print=Print
 action_duplicate=Duplicate
 action_select=-- Select Action --
 action_save=Save
+action_save_and_exit=Save & Exit
 action_save_pair=Save Pairing
 delete=Delete
 delete_attempt=Delete attempt

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -33,6 +33,8 @@ import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.content.api.ContentResource;
@@ -203,6 +205,10 @@ public class AssessmentSettingsBean
   private ExtendedTime extendedTime;
   private ExtendedTime transitoryExtendedTime;
   private boolean editingExtendedTime = false;
+
+  @Getter
+  @Setter
+  private int activeTabIndex = SamigoConstants.ABOUT_TAB; // Used to track which settings tab the user had/has open
   
   // SAM-2323 jQuery-UI datepicker
   private final TimeUtil tu = new TimeUtil();
@@ -1762,11 +1768,13 @@ public class AssessmentSettingsBean
             this.extendedTimes.add(this.extendedTime);
             resetExtendedTime();
         }
+        this.activeTabIndex = SamigoConstants.DELIVERY_EXCEPTIONS_TAB;
     }
 
     public void deleteExtendedTime() {
         this.extendedTimes.remove(this.transitoryExtendedTime);
         this.transitoryExtendedTime = null;
+        this.activeTabIndex = SamigoConstants.DELIVERY_EXCEPTIONS_TAB;
     }
 
     public void editExtendedTime() {
@@ -1774,6 +1782,7 @@ public class AssessmentSettingsBean
       this.extendedTime = new ExtendedTime(this.transitoryExtendedTime);
       //Remove from the list but keep transitory available for cancel
       this.extendedTimes.remove(this.transitoryExtendedTime);
+      this.activeTabIndex = SamigoConstants.DELIVERY_EXCEPTIONS_TAB;
     }
 
     public void saveEditedExtendedTime() {
@@ -1795,5 +1804,6 @@ public class AssessmentSettingsBean
         this.extendedTime = new ExtendedTime(this.getAssessment().getData());
         this.transitoryExtendedTime = null;
         this.editingExtendedTime = false;
+        this.activeTabIndex = SamigoConstants.ABOUT_TAB;
     }
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -40,6 +40,8 @@ import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
@@ -202,6 +204,10 @@ public class PublishedAssessmentSettingsBean
   private ExtendedTime extendedTime;
   private ExtendedTime transitoryExtendedTime;
   private boolean editingExtendedTime = false;
+
+  @Getter
+  @Setter
+  private int activeTabIndex = SamigoConstants.ABOUT_TAB; // Used to track which settings tab the user had/has open
   
   // SAM-2323 jQuery-UI datepicker
   private final TimeUtil tu = new TimeUtil();
@@ -1658,11 +1664,13 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
           this.extendedTimes.add(this.extendedTime);
           resetExtendedTime();
       }
+      this.activeTabIndex = SamigoConstants.DELIVERY_EXCEPTIONS_TAB;
   }
 
   public void deleteExtendedTime() {
       this.extendedTimes.remove(this.transitoryExtendedTime);
       this.transitoryExtendedTime = null;
+      this.activeTabIndex = SamigoConstants.DELIVERY_EXCEPTIONS_TAB;
   }
 
   public void editExtendedTime() {
@@ -1670,6 +1678,7 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
     this.extendedTime = new ExtendedTime(this.transitoryExtendedTime);
     //Remove from the list but keep transitory available for cancel
     this.extendedTimes.remove(this.transitoryExtendedTime);
+    this.activeTabIndex = SamigoConstants.DELIVERY_EXCEPTIONS_TAB;
   }
 
   public void saveEditedExtendedTime() {
@@ -1691,6 +1700,7 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
     this.extendedTime = new ExtendedTime(this.getAssessment().getData());
     this.transitoryExtendedTime = null;
     this.editingExtendedTime = false;
+    this.activeTabIndex = SamigoConstants.ABOUT_TAB;
   }
 
         public String getDisplayScoreDuringAssessments(){

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -236,12 +236,11 @@
 
 <div class="tier1" id="jqueryui-tabs">
     <ul>
-        <li><a href="#about-tab"><h:outputText value="#{assessmentSettingsMessages.heading_about} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#submissions-tab"><h:outputText value="#{assessmentSettingsMessages.heading_availability} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#extendedtime-tab"><h:outputText value="#{assessmentSettingsMessages.heading_extended_time} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#feedback-tab"><h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#layout-tab"><h:outputText value="#{assessmentSettingsMessages.heading_layout} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#publish-tab"><h:outputText value="#{assessmentSettingsMessages.heading_publish}" /></a></li>
+        <li><a href="#about-tab"><h:outputText value="#{assessmentSettingsMessages.heading_about} " /></a></li>
+        <li><a href="#submissions-tab"><h:outputText value="#{assessmentSettingsMessages.heading_availability} " /></a></li>
+        <li><a href="#extendedtime-tab"><h:outputText value="#{assessmentSettingsMessages.heading_extended_time} " /></a></li>
+        <li><a href="#feedback-tab"><h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback} " /></a></li>
+        <li><a href="#layout-tab"><h:outputText value="#{assessmentSettingsMessages.heading_layout} " /></a></li>
     </ul>
 <div id="about-tab">
     <h3>
@@ -794,32 +793,21 @@
   </h:panelGroup>
 
 </div><!-- END Layout and Appearance Category -->
-<div id="publish-tab">
-    <!-- Publish -->
-    <h:panelGroup styleClass="form-group row" layout="block">
-        <h:panelGroup styleClass="col-md-12" layout="block">
-            <!-- save & publish -->
-            <h4><h:outputText value="#{assessmentSettingsMessages.ready_to_publish_heading}" /></h4>
-            <p><h:outputText value="#{assessmentSettingsMessages.ready_to_publish_text1}" /></p>
-            <p><h:outputText value="#{assessmentSettingsMessages.ready_to_publish_text2}" /></p>
-            <p class="act">
-                <!-- save & publish -->
-                <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" styleClass="active" rendered="#{assessmentSettings.hasQuestions}"
-                                  action="#{assessmentSettings.getOutcomePublish}" onclick="setBlockDivs();updateItemNavigation(false);" >
-                    <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ConfirmPublishAssessmentListener" />
-                    <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.PublishAssessmentListener" />
-                </h:commandButton>
-
-                <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" rendered="#{not assessmentSettings.hasQuestions}"
-                                  action="#{assessmentSettings.getOutcomePublish}" disabled="true" />
-            </p>
-        </h:panelGroup>
-    </h:panelGroup>
-</div>
 </div>
  <p class="act">
+
+ <!-- save & publish -->
+  <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" styleClass="active" rendered="#{assessmentSettings.hasQuestions}"
+      action="#{assessmentSettings.getOutcomePublish}" onclick="setBlockDivs();updateItemNavigation(false);" >
+      <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ConfirmPublishAssessmentListener" />
+      <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.PublishAssessmentListener" />
+  </h:commandButton>
+
+  <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" rendered="#{not assessmentSettings.hasQuestions}"
+      action="#{assessmentSettings.getOutcomePublish}" disabled="true" />
+
   <!-- Save button -->
-  <h:commandButton type="submit" value="#{commonMessages.action_save_and_exit}" action="#{assessmentSettings.getOutcomeSave}"  onclick="setBlockDivs();updateItemNavigation(false);">
+  <h:commandButton type="submit" value="#{commonMessages.action_save}" action="#{assessmentSettings.getOutcomeSave}"  onclick="setBlockDivs();updateItemNavigation(false);">
       <f:param name="assessmentId" value="#{assessmentSettings.assessmentId}"/>
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.SaveAssessmentSettingsListener"/>
   </h:commandButton>

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -52,20 +52,10 @@
       <script type="text/javascript">
         $(document).ready(function() {
           // set up the accordion for settings
-          var accordionPanel = 1;
           var itemName = "samigo_assessmentsettings_" + <h:outputText value="#{assessmentSettings.assessmentId}"/>;
-          if (window.sessionStorage && window.sessionStorage.getItem(itemName)) {
-              accordionPanel = parseInt(window.sessionStorage.getItem(itemName));
-          }
-          $("#jqueryui-accordion").accordion({
-              heightStyle: "content",
-              activate: function(event, ui) {
-                  if (window.sessionStorage) {
-                      window.sessionStorage.setItem(itemName, $("#jqueryui-accordion").accordion("option", "active"));
-                  }
-              },
-              active: accordionPanel,
-              collapsible: true
+          var activeTab = $("#assessmentSettingsAction\\:activeTab").val();
+          $("#jqueryui-tabs").tabs({
+              active: parseInt(activeTab)
           });
           // This is a sub-accordion inside of the About the Assessment Panel
           $("#jqueryui-accordion-metadata").accordion({ heightStyle: "content",collapsible: true,active: false });
@@ -228,6 +218,7 @@
   <h:inputHidden id="assessmentId" value="#{assessmentSettings.assessmentId}"/>
   <h:inputHidden id="blockDivs" value="#{assessmentSettings.blockDivs}"/>
   <h:inputHidden id="itemNavigationUpdated" value="false" />
+  <h:inputHidden id="activeTab" value="#{assessmentSettings.activeTabIndex}"/>
 
   <!-- HEADINGS -->
   <%@ include file="/jsf/author/allHeadings.jsp" %>
@@ -235,23 +226,27 @@
      <h:outputText value="#{assessmentSettingsMessages.settings} #{assessmentSettingsMessages.dash} #{assessmentSettings.title}"/>
   </h1>
 
-  <div class="pull-right">
-      <a href="javascript:void(0)" id="expandLink" onclick="expandAccordion('<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>')">
-          <h:outputText value="#{assessmentSettingsMessages.expandAll}"/>
-      </a>
-      <a href="javascript:void(0)" id="collapseLink" style="display:none" onclick="collapseAccordion('<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>')">
-          <h:outputText value="#{assessmentSettingsMessages.collapseAll}"/>
-      </a>
-  </div>
-  <br/>
-  
+  <p class="help-block info-text">
+    <h:outputText value="#{assessmentSettingsMessages.settings_info}" />
+  </p>
+
   <p>
     <h:messages styleClass="messageSamigo" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
   </p>
 
-<div class="tier1" id="jqueryui-accordion">
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_about}" >
+<div class="tier1" id="jqueryui-tabs">
+    <ul>
+        <li><a href="#about-tab"><h:outputText value="#{assessmentSettingsMessages.heading_about} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#submissions-tab"><h:outputText value="#{assessmentSettingsMessages.heading_availability} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#extendedtime-tab"><h:outputText value="#{assessmentSettingsMessages.heading_extended_time} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#feedback-tab"><h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#layout-tab"><h:outputText value="#{assessmentSettingsMessages.heading_layout} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#publish-tab"><h:outputText value="#{assessmentSettingsMessages.heading_publish}" /></a></li>
+    </ul>
+<div id="about-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_about}" />
+    </h3>
 
 <!-- *** ASSESSMENT INTRODUCTION *** -->
   <div class="tier2" id="assessment-intro">
@@ -356,9 +351,11 @@
     </h:panelGroup>
   </div><!-- This is the end of the sub-accordion -->
 
-</samigo:hideDivision><!-- End the About this Assessment category -->
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_availability}"> 
+</div><!-- End the About this Assessment category -->
+<div id="submissions-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_availability}" />
+    </h3>
   <!-- *** RELEASED TO *** -->
   <div class="form-group row">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.released_to} " />
@@ -561,14 +558,18 @@
 
 </div><!-- This is the end of the sub-accordion -->
 
-</samigo:hideDivision><!-- END the Availabity and Submissions category -->
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_extended_time}" >
+</div><!-- END the Availabity and Submissions category -->
+<div id="extendedtime-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_extended_time}" />
+    </h3>
   <!-- Extended Time -->
   <%@ include file="inc/extendedTime.jspf"%>
-</samigo:hideDivision>
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_grading_feedback}" >
+</div>
+<div id="feedback-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback}" />
+    </h3>
 
   <!-- *** GRADING *** -->
   <div class="tier3">
@@ -706,9 +707,11 @@
 
      </h:panelGroup>
    </h:panelGroup>
- </samigo:hideDivision>
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_layout}" >
+</div>
+<div id="layout-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_layout}" />
+    </h3>
 
   <!-- *** ASSESSMENT ORGANIZATION *** -->
   <h:panelGroup rendered="#{assessmentSettings.valueMap.itemAccessType_isInstructorEditable==true or assessmentSettings.valueMap.displayChunking_isInstructorEditable==true or assessmentSettings.valueMap.displayNumbering_isInstructorEditable==true }" >
@@ -790,23 +793,33 @@
     </div>
   </h:panelGroup>
 
-</samigo:hideDivision><!-- END Layout and Appearance Category -->
+</div><!-- END Layout and Appearance Category -->
+<div id="publish-tab">
+    <!-- Publish -->
+    <h:panelGroup styleClass="form-group row" layout="block">
+        <h:panelGroup styleClass="col-md-12" layout="block">
+            <!-- save & publish -->
+            <h4><h:outputText value="#{assessmentSettingsMessages.ready_to_publish_heading}" /></h4>
+            <p><h:outputText value="#{assessmentSettingsMessages.ready_to_publish_text1}" /></p>
+            <p><h:outputText value="#{assessmentSettingsMessages.ready_to_publish_text2}" /></p>
+            <p class="act">
+                <!-- save & publish -->
+                <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" styleClass="active" rendered="#{assessmentSettings.hasQuestions}"
+                                  action="#{assessmentSettings.getOutcomePublish}" onclick="setBlockDivs();updateItemNavigation(false);" >
+                    <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ConfirmPublishAssessmentListener" />
+                    <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.PublishAssessmentListener" />
+                </h:commandButton>
 
+                <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" rendered="#{not assessmentSettings.hasQuestions}"
+                                  action="#{assessmentSettings.getOutcomePublish}" disabled="true" />
+            </p>
+        </h:panelGroup>
+    </h:panelGroup>
+</div>
 </div>
  <p class="act">
-
- <!-- save & publish -->
-  <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" styleClass="active" rendered="#{assessmentSettings.hasQuestions}"
-      action="#{assessmentSettings.getOutcomePublish}" onclick="setBlockDivs();updateItemNavigation(false);" >
-      <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ConfirmPublishAssessmentListener" />
-      <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.PublishAssessmentListener" />
-  </h:commandButton>
-
-  <h:commandButton  value="#{assessmentSettingsMessages.button_unique_save_and_publish}" type="submit" rendered="#{not assessmentSettings.hasQuestions}"
-      action="#{assessmentSettings.getOutcomePublish}" disabled="true" />
-      
   <!-- Save button -->
-  <h:commandButton type="submit" value="#{commonMessages.action_save}" action="#{assessmentSettings.getOutcomeSave}"  onclick="setBlockDivs();updateItemNavigation(false);">
+  <h:commandButton type="submit" value="#{commonMessages.action_save_and_exit}" action="#{assessmentSettings.getOutcomeSave}"  onclick="setBlockDivs();updateItemNavigation(false);">
       <f:param name="assessmentId" value="#{assessmentSettings.assessmentId}"/>
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.SaveAssessmentSettingsListener"/>
   </h:commandButton>

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -202,10 +202,10 @@
 
 <div class="tier1" id="jqueryui-tabs">
     <ul>
-        <li><a href="#about-tab"><h:outputText value="#{assessmentSettingsMessages.heading_about} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#submissions-tab"><h:outputText value="#{assessmentSettingsMessages.heading_availability} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#extendedtime-tab"><h:outputText value="#{assessmentSettingsMessages.heading_extended_time} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
-        <li><a href="#feedback-tab"><h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#about-tab"><h:outputText value="#{assessmentSettingsMessages.heading_about} " /></a></li>
+        <li><a href="#submissions-tab"><h:outputText value="#{assessmentSettingsMessages.heading_availability} " /></a></li>
+        <li><a href="#extendedtime-tab"><h:outputText value="#{assessmentSettingsMessages.heading_extended_time} " /></a></li>
+        <li><a href="#feedback-tab"><h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback} " /></a></li>
         <li><a href="#layout-tab"><h:outputText value="#{assessmentSettingsMessages.heading_layout} " /></a></li>
     </ul>
 <div id="about-tab">

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -57,20 +57,10 @@
       <script type="text/javascript">
         $(document).ready(function() {
           // set up the accordion for settings
-          var accordionPanel = 1;
           var itemName = "samigo_publishedsettings_" + <h:outputText value="#{publishedSettings.assessmentId}"/>;
-          if (window.sessionStorage && window.sessionStorage.getItem(itemName)) {
-              accordionPanel = parseInt(window.sessionStorage.getItem(itemName));
-          }
-          $("#jqueryui-accordion").accordion({
-              heightStyle: "content",
-              activate: function(event, ui) {
-                  if (window.sessionStorage) {
-                      window.sessionStorage.setItem(itemName, $("#jqueryui-accordion").accordion("option", "active"));
-                  }
-              },
-              active: accordionPanel,
-              collapsible: true
+          var activeTab = $("#assessmentSettingsAction\\:activeTab").val();
+          $("#jqueryui-tabs").tabs({
+              active: parseInt(activeTab)
           });
           // This is a sub-accordion inside of the About the Assessment Panel
           $("#jqueryui-accordion-metadata").accordion({ heightStyle: "content",collapsible: true,active: false });
@@ -198,6 +188,7 @@
   <h:inputHidden id="assessmentId" value="#{publishedSettings.assessmentId}"/>
   <h:inputHidden id="blockDivs" value="#{publishedSettings.blockDivs}"/>
   <h:inputHidden id="itemNavigationUpdated" value="false" />
+  <h:inputHidden id="activeTab" value="#{publishedSettings.activeTabIndex}"/>
   
   <!-- HEADINGS -->
   <%@ include file="/jsf/author/allHeadings.jsp" %>
@@ -205,23 +196,22 @@
      <h:outputText value="#{assessmentSettingsMessages.settings} #{assessmentSettingsMessages.dash} #{publishedSettings.title}"/>
   </h1>
 
-  <div class="pull-right">
-		<a href="javascript:void(0)" id="expandLink" onclick="expandAccordion('<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>')">
-				<h:outputText value="#{assessmentSettingsMessages.expandAll}"/>
-		</a>
-		<a href="javascript:void(0)" id="collapseLink" style="display:none" onclick="collapseAccordion('<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>')">
-				<h:outputText value="#{assessmentSettingsMessages.collapseAll}"/>
-		</a>
-  </div>
-	<br/>
-  
   <p>
     <h:messages styleClass="messageSamigo" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
   </p>
 
-<div class="tier1" id="jqueryui-accordion">
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_about}" >
+<div class="tier1" id="jqueryui-tabs">
+    <ul>
+        <li><a href="#about-tab"><h:outputText value="#{assessmentSettingsMessages.heading_about} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#submissions-tab"><h:outputText value="#{assessmentSettingsMessages.heading_availability} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#extendedtime-tab"><h:outputText value="#{assessmentSettingsMessages.heading_extended_time} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#feedback-tab"><h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback} " /><span class="fa fa-arrow-circle-o-right" aria-hidden="true"></span></a></li>
+        <li><a href="#layout-tab"><h:outputText value="#{assessmentSettingsMessages.heading_layout} " /></a></li>
+    </ul>
+<div id="about-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_about}" />
+    </h3>
 
   <!-- *** ASSESSMENT INTRODUCTION *** -->
   <div class="tier2" id="assessment-intro">
@@ -324,9 +314,11 @@
   </h:panelGroup>
   </div><!-- This is the end of the sub-accordion -->
 
-</samigo:hideDivision><!-- End the About this Assessment category -->
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_availability}"> 
+</div><!-- End the About this Assessment category -->
+<div id="submissions-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_availability}" />
+    </h3>
   <!-- *** RELEASED TO *** -->
   <div class="form-group row">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.released_to} " />
@@ -526,14 +518,18 @@
 
 </div><!-- This is the end of the sub-accordion -->
 
-</samigo:hideDivision><!-- END the Availabity and Submissions category -->
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_extended_time}" >
+</div><!-- END the Availabity and Submissions category -->
+<div id="extendedtime-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_extended_time}" />
+    </h3>
   <!-- Extended Time -->
   <%@ include file="inc/publishedExtendedTime.jspf"%>
-</samigo:hideDivision>
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_grading_feedback}" >
+</div>
+<div id="feedback-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_grading_feedback}" />
+    </h3>
 
   <!-- *** GRADING *** -->
   <div class="tier3">
@@ -672,9 +668,11 @@
 
   </h:panelGroup>
 
-  </samigo:hideDivision>
-
-<samigo:hideDivision title="#{assessmentSettingsMessages.heading_layout}" >
+</div>
+<div id="layout-tab">
+    <h3>
+        <h:outputText value="#{assessmentSettingsMessages.heading_layout}" />
+    </h3>
 
   <!-- *** ASSESSMENT ORGANIZATION *** -->
   <h:panelGroup rendered="#{publishedSettings.valueMap.itemAccessType_isInstructorEditable==true or publishedSettings.valueMap.displayChunking_isInstructorEditable==true or publishedSettings.valueMap.displayNumbering_isInstructorEditable==true }" >
@@ -756,14 +754,12 @@
     </div>
   </h:panelGroup>
 
-</samigo:hideDivision><!-- END Layout and Appearance Category -->
-
-</div>
-
+</div><!-- END Layout and Appearance Category -->
+</div> <!-- END jquery ui tabs -->
 <p class="act">
 
   <!-- Save button -->
-  <h:commandButton type="submit" value="#{commonMessages.action_save}" action="#{publishedSettings.getOutcome}"  styleClass="active" onclick="setBlockDivs();updateItemNavigation(false);" >
+  <h:commandButton type="submit" value="#{commonMessages.action_save_and_exit}" action="#{publishedSettings.getOutcome}"  styleClass="active" onclick="setBlockDivs();updateItemNavigation(false);" >
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.SavePublishedSettingsListener" />
   </h:commandButton>
   


### PR DESCRIPTION
This change converts the jquery ui accordion used for Samigo settings to
the jquery ui tabs. The layout is more condusive to working through all
of the settings and provides quicker access and better awareness while
and instructor sets up their assessment. All settings have remained in the
same bucket and the tab names are taken from the accordion titles. There
is a new section "Publish" that contains some information and the save
settings and publish button. This is in a new tab so that users don't accidentally
publish an exam before they are ready. The save and cancel buttons remain at the
bottom of the page.