### PR TITLE
SAK-33996 display the overridden letter course grade with the student's calculated percent next to it. 

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/CourseGradeFormatter.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/CourseGradeFormatter.java
@@ -132,20 +132,7 @@ public class CourseGradeFormatter {
 
 		// percentage
 		// not shown in final grade mode
-		final String calculatedGrade;
-		if (this.showOverride && StringUtils.isNotBlank(courseGrade.getEnteredGrade())) {
-
-			// if mapping doesn't exist for this grade override (mapping may have been changed!), map it to 0.
-			// TODO this should probably inform the instructor
-			Double mappedGrade = this.gradebook.getSelectedGradeMapping().getGradeMap().get(courseGrade.getEnteredGrade());
-			if (mappedGrade == null) {
-				mappedGrade = new Double(0);
-			}
-			calculatedGrade = FormatHelper.formatDoubleAsPercentage(mappedGrade);
-
-		} else {
-			calculatedGrade = FormatHelper.formatStringAsPercentage(courseGrade.getCalculatedGrade());
-		}
+		final String calculatedGrade = FormatHelper.formatStringAsPercentage(courseGrade.getCalculatedGrade());
 
 		if (StringUtils.isNotBlank(calculatedGrade)
 				&& (this.gradebook.isCourseAverageDisplayed() || shouldDisplayFullCourseGrade())) {


### PR DESCRIPTION
Old behavior displayed a percent correlated with the new overridden letter grade.