### PR TITLE
SAK-41891 Library changed gateway css links to prevent un-styled pages

### DIFF
--- a/library/src/webapp/content/gateway/about.html
+++ b/library/src/webapp/content/gateway/about.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>About Sakai</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-		<link href="/library/skin/default/neo-default.css" type="text/css" rel="stylesheet" media="all"/>
+		<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/gateway/about_mn.html
+++ b/library/src/webapp/content/gateway/about_mn.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>Сакайн CLE-ын талаар</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/gateway/acknowledgments.html
+++ b/library/src/webapp/content/gateway/acknowledgments.html
@@ -4,7 +4,7 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>Acknowledgments</title>
 	<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-	<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+	<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
 </head>
 <div class="portletBody">
 	<p>Copyright 2003-2014 The Apereo Foundation.  All rights reserved.</p>

--- a/library/src/webapp/content/gateway/acknowledgments_mn.html
+++ b/library/src/webapp/content/gateway/acknowledgments_mn.html
@@ -4,7 +4,7 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>Мэдэгдэлүүд</title>
 	<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-	<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+	<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
 </head>
 <div class="portletBody">
 	<p>Зохиогчийн эрхээр хамгаалагдсан 2003-2011 Сакайн сан.  Бүх эрхүүд хамгаалагдсан.</p>

--- a/library/src/webapp/content/gateway/features.html
+++ b/library/src/webapp/content/gateway/features.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title>Sakai Features</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
 	</head>
 	<body style="width:95%">
 		<div class="portletBody">

--- a/library/src/webapp/content/gateway/features_mn.html
+++ b/library/src/webapp/content/gateway/features_mn.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title>Sakai CLE Features</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
 	</head>
 	<body style="width:95%">
 		<div class="portletBody">

--- a/library/src/webapp/content/gateway/training.html
+++ b/library/src/webapp/content/gateway/training.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>Training</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/gateway/training_mn.html
+++ b/library/src/webapp/content/gateway/training_mn.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>Дадлага</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
 	</head>
 	<body>
 		<div class="portletBody">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41891

Small fix-when you aren't logged in to Sakai, the gateway sites (Features, Acknowledgements, etc.) are unstyled because they reference library/skin/default/tool.css instead of /library/skin/morpheus-default/tool.css. This PR fixes those stylesheet links 