### PR TITLE
SAK-42027 Library navigation prevent subnav from disappearing upon sc…

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -365,9 +365,6 @@ body.is-logged-out{
 
 		&.moving{
 			top: -4.2em;
-			#mastLogin #loginLinks ul.#{$namespace}userNav__subnav{
-				display: none;
-			}
 		}
 	}
 


### PR DESCRIPTION
…roll

https://jira.sakaiproject.org/browse/SAK-42027

Previously, the subnav would become display:none once the top header was moving. This meant that it randomly disappeared once you scrolled down, and the link wouldn't open/close the subnav anymore until you scrolled back up.

