### PR TITLE
SAK-22934 Portal: Linked the logo to /portal/

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/header-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/header-snippet.vm
@@ -1,7 +1,7 @@
 ## Header that shows institution and/or banner logos
 
 <header role="banner" class="Mrphs-headerLogo">
-    <span class="Mrphs-headerLogo--institution"></span>
+    <a href="/portal/" class="Mrphs-headerLogo--institution"></a>
     <span class="Mrphs-headerLogo--banner"></span>
 
     #parse("/vm/morpheus/includeLoginNav.vm")


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-22934

Changed the span tag that contained the institution logo to an anchor tag so that clicking it takes the user to the /portal/ page. However, the questions of whether every user has a /portal/ page arose. Should probably test with different types of users.