### PR TITLE
SAK-42082 Add only one grading asn bullhorn alert by user

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentReferenceReckoner.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentReferenceReckoner.java
@@ -42,6 +42,7 @@ public class AssignmentReferenceReckoner {
         private String id;
         @Getter(AccessLevel.NONE) private String reference;
         private String subtype;
+        private String submitter;
 
         @Override
         public String toString() {
@@ -79,6 +80,10 @@ public class AssignmentReferenceReckoner {
                 reference = reference + Entity.SEPARATOR + id;
             }
 
+            if (StringUtils.isNotBlank(submitter) && "s".equals(subtype)) {
+                reference = reference + Entity.SEPARATOR + submitter;
+            }
+
             return reference;
         }
 
@@ -99,7 +104,7 @@ public class AssignmentReferenceReckoner {
      * @return
      */
     @Builder(builderMethodName = "reckoner", buildMethodName = "reckon")
-    public static AssignmentReference newAssignmentReferenceReckoner(Assignment assignment, AssignmentSubmission submission, String container, String context, String id, String reference, String subtype) {
+    public static AssignmentReference newAssignmentReferenceReckoner(Assignment assignment, AssignmentSubmission submission, String container, String context, String id, String reference, String subtype, String submitter) {
         if (StringUtils.startsWith(reference, REFERENCE_ROOT)) {
             // we will get null, assignment, [a|c|s|grades|submissions], context, [auid], id
             String[] parts = StringUtils.splitPreserveAllTokens(reference, Entity.SEPARATOR);
@@ -114,6 +119,10 @@ public class AssignmentReferenceReckoner {
                     if ("s".equals(subtype) && parts.length > 5) {
                         if (container == null) container = parts[4];
                         if (id == null) id = parts[5];
+                        // submissions might have the submitter
+                        if (parts.length > 6) {
+                            if (submitter == null) submitter = parts[6];
+                        }
                     } else {
                         // others don't
                         if (parts.length > 4) {
@@ -142,6 +151,7 @@ public class AssignmentReferenceReckoner {
                 (context == null) ? "" : context,
                 (id == null) ? "" : id,
                 (reference == null) ? "" : reference,
-                (subtype == null) ? "" : subtype);
+                (subtype == null) ? "" : subtype,
+                (submitter == null) ? "" : submitter);
     }
 }

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1205,7 +1205,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                             User user = userDirectoryService.getUser(submitter.getSubmitter());
                             LRS_Statement statement = getStatementForAssignmentGraded(reference, submission.getAssignment(), submission, user);
                             // graded and saved before releasing it
-                            Event event = eventTrackingService.newEvent(AssignmentConstants.EVENT_GRADE_ASSIGNMENT_SUBMISSION, reference, null, true, NotificationService.NOTI_OPTIONAL, statement);
+                            String submissionReference = AssignmentReferenceReckoner.reckoner().submission(submission).submitter(submitter.getSubmitter()).reckon().getReference();
+                            Event event = eventTrackingService.newEvent(AssignmentConstants.EVENT_GRADE_ASSIGNMENT_SUBMISSION, submissionReference, null, true, NotificationService.NOTI_OPTIONAL, statement);
                             eventTrackingService.post(event);
                         } catch (UserNotDefinedException e) {
                             log.warn("Assignments could not find user ({}) while registering Event for LRSS", submitter.getSubmitter());
@@ -1221,7 +1222,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                         User user = userDirectoryService.getUser(submitter.getSubmitter());
                     	LRS_Statement statement = getStatementForAssignmentGraded(reference, submission.getAssignment(), submission, user);
                     	// releasing a submitted assignment or releasing grade to an unsubmitted assignment
-                    	Event event = eventTrackingService.newEvent(AssignmentConstants.EVENT_GRADE_ASSIGNMENT_SUBMISSION, reference, null, true, NotificationService.NOTI_OPTIONAL, statement);
+                    	String submissionReference = AssignmentReferenceReckoner.reckoner().submission(submission).submitter(submitter.getSubmitter()).reckon().getReference();
+                    	Event event = eventTrackingService.newEvent(AssignmentConstants.EVENT_GRADE_ASSIGNMENT_SUBMISSION, submissionReference, null, true, NotificationService.NOTI_OPTIONAL, statement);
                     	eventTrackingService.post(event);
                     } catch (UserNotDefinedException e) {
                         log.warn("Assignments could not find user ({}) while registering Event for LRSS", submitter.getSubmitter());
@@ -1238,7 +1240,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     User user = userDirectoryService.getUser(submitter.getSubmitter());
                     LRS_Statement statement = getStatementForUnsubmittedAssignmentGraded(reference, submission.getAssignment(), submission, user);
                     // releasing a submitted assignment or releasing grade to an unsubmitted assignment
-                    Event event = eventTrackingService.newEvent(AssignmentConstants.EVENT_GRADE_ASSIGNMENT_SUBMISSION, reference, null, true, NotificationService.NOTI_OPTIONAL, statement);
+                    String submissionReference = AssignmentReferenceReckoner.reckoner().submission(submission).submitter(submitter.getSubmitter()).reckon().getReference();
+                    Event event = eventTrackingService.newEvent(AssignmentConstants.EVENT_GRADE_ASSIGNMENT_SUBMISSION, submissionReference, null, true, NotificationService.NOTI_OPTIONAL, statement);
                     eventTrackingService.post(event);
                 } catch (UserNotDefinedException e) {
                     log.warn("Assignments could not find user ({}) while registering Event for LRSS", submitter.getSubmitter());

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentReferenceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentReferenceTest.java
@@ -92,6 +92,7 @@ public class AssignmentReferenceTest {
         final String context = UUID.randomUUID().toString();
         final String assignmentId = UUID.randomUUID().toString();
         final String submissionId = UUID.randomUUID().toString();
+        final String submitterId = UUID.randomUUID().toString();
         Assignment assignment = new Assignment();
         assignment.setId(assignmentId);
         assignment.setContext(context);
@@ -101,5 +102,7 @@ public class AssignmentReferenceTest {
         String reference = AssignmentReferenceReckoner.reckoner().submission(submission).reckon().getReference();
         Assert.assertNotNull(reference);
         Assert.assertEquals("/assignment/s/" + context + "/" + assignmentId + "/" + submissionId, reference);
+        reference = AssignmentReferenceReckoner.reckoner().submission(submission).submitter(submitterId).reckon().getReference();
+        Assert.assertEquals("/assignment/s/" + context + "/" + assignmentId + "/" + submissionId + "/" + submitterId, reference);
     }
 }

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
@@ -56,22 +56,20 @@ public class GradeAssignmentBullhornHandler extends AbstractBullhornHandler {
         String[] pathParts = ref.split("/");
 
         String siteId = pathParts[3];
-        String submissionId = pathParts[pathParts.length - 1];
+        String submissionId = pathParts[5];
+        String submitterId = pathParts[6];
         try {
             AssignmentSubmission submission = assignmentService.getSubmission(submissionId);
             if (submission.getGradeReleased()) {
                 Assignment assignment = submission.getAssignment();
                 String title = assignment.getTitle();
                 List<BullhornData> bhEvents = new ArrayList<>();
-                submission.getSubmitters().forEach(to -> {
-                    try {
-                        bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter()), false));
-                        countCache.remove(to.getSubmitter());
-                    } catch(Exception exc) {
-                        log.error("Error retrieving deep link for assignment {} and user {} on site {}", assignment.getId(), to.getSubmitter(), siteId, exc);
-                    }
-                });
-
+                try {
+                    bhEvents.add(new BullhornData(from, submitterId, siteId, title, assignmentService.getDeepLink(siteId, assignment.getId(), submitterId), false));
+                    countCache.remove(submitterId);
+                } catch(Exception exc) {
+                    log.error("Error retrieving deep link for assignment {} and user {} on site {}", assignment.getId(), submitterId, siteId, exc);
+                }
                 return Optional.of(bhEvents);
             }
         } catch (Exception ex) {


### PR DESCRIPTION
At the moment the same asn.grade.submission event is generated for every submitter, then looped again through submitters on bullhorns. We can't send just one single event when grading, because that would be cutting the current LRS behaviour, so I believe it's best to add the submitter id to the event reference.

Also, don't think we need to update the AssignmentReferenceReckoner just for this case, but maybe we could do it too.