### PR TITLE
TII-271 - TurnitinOC - NextRetryTime is ignored when submitting a paper in status 4

### DIFF
--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -1017,6 +1017,9 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		while ((nextItem = crqs.getNextItemInQueueToSubmit(getProviderId())).isPresent()) {
 			try {
 				ContentReviewItem item = nextItem.get();
+				if (item.getNextRetryTime().getTime() > new Date().getTime()) {
+					continue;
+				}
 				if (!incrementItem(item)) {
 					errors++;
 					continue;
@@ -1324,6 +1327,10 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		}
 	}
 	
+	/**
+	 * Bumps up the item's retryCount and nextRetryTime
+	 * @return true iff the retry count hasn't exceeded
+	 */
 	public boolean incrementItem(ContentReviewItem item) {
 		// If retry count is null set to 0
 		Calendar cal = Calendar.getInstance();


### PR DESCRIPTION
If you submit a paper with an error that's recoverable (for instance, if you're working locally, disconnect your internet and run the queue job), you may find multiple submission attempts occur in quick succession, and your retry count may shoot up to the maximum.