### PR TITLE
Update roster2\tool\pom.xml

### DIFF
--- a/roster2/tool/pom.xml
+++ b/roster2/tool/pom.xml
@@ -177,7 +177,11 @@
                             <charset>UTF-8</charset>
                             <webappSourceDir>${basedir}/src/webapp</webappSourceDir>
                             <jsSourceDir>js/</jsSourceDir>
-                            <jsIncludes>*.js</jsIncludes>
+                            
+                            <jsSourceFiles>
+                                   <jsSourceFile>roster.js</jsSourceFile>
+                            </jsSourceFiles>
+                            
                             <jsTargetDir>js</jsTargetDir>
                             <jsFinalFile>roster.js</jsFinalFile>
                             <jsEngine>CLOSURE</jsEngine>


### PR DESCRIPTION
while building sakai using the command `mvn clean install`,  the following error occurs :

---------------------
[ERROR] Failed to execute goal com.samaxes.maven:minify-maven-plugin:1.7.6:minify (default-minify) on project library: Unable to parse configuration of mojo com.samaxes.maven:minify-maven-plugin:1.7.6:minify for parameter jsSourceIncludes: Cannot assign configuration entry 'jsSourceIncludes' with value '*.js' of type java.lang.String to property of type java.util.ArrayList -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.samaxes.maven:minify-maven-plugin:1.7.6:minify (default-minify) on project library: Unable to parse configuration of mojo com.samaxes.maven:minify-maven-plugin:1.7.6:minify for parameter jsSourceIncludes: Cannot assign configuration entry 'jsSourceIncludes' with value '*.js' of type java.lang.String to property of type java.util.ArrayList

-----------------------------
For fixing the above error , i have removed the line - `<jsIncludes>*.js</jsIncludes>`

and added all .js files within the `<jsSourceFiles>` tag as given below :

-----------------------------------------

`<jsSourceFiles>
           <jsSourceFile>roster.js</jsSourceFile>
</jsSourceFiles>`

--------------------------