### PR TITLE
SAK-42104 Switch implemented consistent page headers for Statistics, Section Info, Podcasts, Commons

### DIFF
--- a/commons/tool/src/webapp/WEB-INF/bootstrap.jsp
+++ b/commons/tool/src/webapp/WEB-INF/bootstrap.jsp
@@ -41,7 +41,9 @@
         <div id="Mrphs-sakai-commons" class="portletBody commons-portletBody">
 
             <ul id="commons-toolbar" class="navIntraTool actionToolBar hidden" role="menu"></ul>
-
+            <div class="page-header">
+                <h1>Commons</h1>
+            </div>
             <div id="commons-main-container">
                 <div id="commons-content"></div>
             </div>

--- a/podcasts/podcasts-app/src/webapp/podcasts/podAdd.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podAdd.jsp
@@ -30,7 +30,9 @@
   <h:form id="podAdd" enctype="multipart/form-data">
 
     <div>  <!-- Page title and Instructions -->
-       <h3><h:outputText value="#{msgs.add_title}" /></h3>
+        <div class="page-header">
+            <h1><h:outputText value="#{msgs.add_title}" /></h1>
+        </div>
 		<%-- SAK-9822: added error message when too large file was attempted to be uploaded  --%>
 	    <h:outputText value="#{podHomeBean.maxSizeExceededAlert}" styleClass="alertMessage" rendered="#{podHomeBean.uploadStatus}" />
        <h:outputText value="#{msgs.add_directions}" styleClass="indnt1" /> <br />

--- a/podcasts/podcasts-app/src/webapp/podcasts/podFeedRevise.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podFeedRevise.jsp
@@ -12,7 +12,9 @@
     <h:form id="podFeedRev" >
 
     <div>  <!-- Page title and Instructions -->
-      <h3><h:outputText value="#{msgs.podfeed_revise_title}" /></h3>
+      <div class="page-header">
+        <h1><h:outputText value="#{msgs.podfeed_revise_title}" /></h1>
+      </div>
       <div class="indnt1">
           <p class="instruction"> 
             <h:outputText value="#{msgs.podfeed_revise_directions}" />

--- a/podcasts/podcasts-app/src/webapp/podcasts/podMain.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podMain.jsp
@@ -31,10 +31,10 @@
 		<h:panelGroup rendered="#{podHomeBean.hasReadPerm || podHomeBean.hasAllGroups}"> 
 			<h:panelGrid>
  	  	  		<h:messages styleClass="alertMessage" id="errorMessages" rendered="#{!empty facesContext.maximumSeverity}"/>
-				<h:panelGroup> 
-	 	      		<f:verbatim><h3></f:verbatim>
- 		        	<h:outputText value="#{msgs.podcast_home_title}" />
- 	    			<f:verbatim></h3></f:verbatim>
+				<h:panelGroup>
+					<div class="page-header">
+						<h1><h:outputText value="#{msgs.podcast_home_title}" /></h1>
+					</div>
  	      		</h:panelGroup>
  	  		</h:panelGrid>
  	    </h:panelGroup>

--- a/podcasts/podcasts-app/src/webapp/podcasts/podNoResource.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podNoResource.jsp
@@ -7,11 +7,11 @@
 
 <%-- Students (access) get no podcasts exist --%>
 <h:panelGroup rendered="#{! podHomeBean.canUpdateSite}" >
-	<f:verbatim><div><h3></f:verbatim>
+	<f:verbatim><div class="page-header"><h1></f:verbatim>
  	        	
 	<h:outputText value="#{msgs.podcast_home_title}" />
  	      	  
- 	<f:verbatim></h3>
+    <f:verbatim></h1></div>
 	<div class="indnt1">
     <br /></f:verbatim>
         

--- a/podcasts/podcasts-app/src/webapp/podcasts/podOptions.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podOptions.jsp
@@ -19,7 +19,9 @@
   <script type="text/javascript" src="./scripts/popupscripts.js"></script>
   <h:form enctype="multipart/form-data">
     <div>  <!-- Page title and Instructions -->
-      <h3><h:outputText value="#{msgs.options_title}" /></h3>
+      <div class="page-header">
+        <h1><h:outputText value="#{msgs.options_title}" /></h1>
+      </div>
       <div class="indnt1">
           <p class="instruction"> 
             <h:outputText value="#{msgs.options_directions1}" />

--- a/podcasts/podcasts-app/src/webapp/podcasts/podRevise.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podRevise.jsp
@@ -31,7 +31,9 @@
   <h:form id="podRev" enctype="multipart/form-data">
 
     <div>  <!-- Page title and Instructions -->
-      <h3><h:outputText value="#{msgs.revise_title}" /></h3>
+      <div class="page-header">
+        <h1><h:outputText value="#{msgs.revise_title}" /></h1>
+      </div>
       <div class="indnt1">
           <p class="instruction"> 
             <h:outputText value="#{msgs.revise_directions}" />

--- a/sections/sections-app/src/webapp/deleteSections.jsp
+++ b/sections/sections-app/src/webapp/deleteSections.jsp
@@ -8,12 +8,14 @@
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
 
-	<h3>
-	    <h:outputFormat value="#{msgs.overview_page_header}">
-	        <f:param value="#{overviewBean.siteRole}"/>
-	    </h:outputFormat>
-	</h3>
-
+    <div class="page-header">
+        <h1>
+            <h:outputFormat value="#{msgs.overview_page_header}">
+                <f:param value="#{overviewBean.siteRole}"/>
+            </h:outputFormat>
+        </h1>
+    </div>
+    
     <t:div styleClass="alertMessage">
         <h:outputText value="#{msgs.overview_delete_section_confirmation_pre}"/>
         <t:dataList

--- a/sections/sections-app/src/webapp/editManagers.jsp
+++ b/sections/sections-app/src/webapp/editManagers.jsp
@@ -10,7 +10,9 @@
         </t:aliasBean>
     </h:panelGroup>
 
-        <h3><h:outputText value="#{msgs.edit_manager_page_header}"/></h3>
+        <div class="page-header">
+            <h1><h:outputText value="#{msgs.edit_manager_page_header}"/></h1>
+        </div>
         <h4><h:outputText value="#{editManagersBean.sectionDescription}"/></h4>
 
         <%@ include file="/inc/globalMessages.jspf"%>

--- a/sections/sections-app/src/webapp/editSection.jsp
+++ b/sections/sections-app/src/webapp/editSection.jsp
@@ -7,9 +7,11 @@
     <t:aliasBean alias="#{viewName}" value="editSection">
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
-    
-    <h3><h:outputText value="#{msgs.edit_section_page_header}"/></h3>
-        
+
+    <div class="page-header">
+        <h1><h:outputText value="#{msgs.edit_section_page_header}"/></h1>
+    </div>
+
     <%@ include file="/inc/globalMessages.jspf"%>
 
 	<t:aliasBean alias="#{bean}" value="#{editSectionBean}">

--- a/sections/sections-app/src/webapp/editStudentSections.jsp
+++ b/sections/sections-app/src/webapp/editStudentSections.jsp
@@ -9,11 +9,13 @@
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
 
-        <h3>
-            <h:outputFormat value="#{msgs.edit_student_sections_page_header}">
-                <f:param value="#{editStudentSectionsBean.studentName}"/>
-            </h:outputFormat>
-        </h3>
+        <div class="page-header">
+            <h1>
+                <h:outputFormat value="#{msgs.edit_student_sections_page_header}">
+                    <f:param value="#{editStudentSectionsBean.studentName}"/>
+                </h:outputFormat>
+            </h1>
+        </div>
 
 		<t:div styleClass="instruction">
             <h:outputFormat value="#{msgs.edit_student_sections_current_sections}">

--- a/sections/sections-app/src/webapp/editStudents.jsp
+++ b/sections/sections-app/src/webapp/editStudents.jsp
@@ -8,7 +8,9 @@
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
 
-        <h3><h:outputText value="#{msgs.edit_student_page_header}"/></h3>
+        <div class="page-header">
+            <h1><h:outputText value="#{msgs.edit_student_page_header}"/></h1>
+        </div>
         <h4><h:outputText value="#{editStudentsBean.sectionDescription}"/></h4>
 
         <%@ include file="/inc/globalMessages.jspf"%>

--- a/sections/sections-app/src/webapp/options.jsp
+++ b/sections/sections-app/src/webapp/options.jsp
@@ -12,9 +12,10 @@
     <t:aliasBean alias="#{viewName}" value="options">
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
-		<div class="page-header">
-        	<h1><h:outputText value="#{msgs.options_page_header}"/></h1>
-		</div>
+
+        <div class="page-header">
+            <h1><h:outputText value="#{msgs.options_page_header}"/></h1>
+        </div>
         <h4><h:outputText value="#{msgs.options_page_subheader}"/></h4>
         
         <%@ include file="/inc/globalMessages.jspf"%>

--- a/sections/sections-app/src/webapp/options.jsp
+++ b/sections/sections-app/src/webapp/options.jsp
@@ -12,8 +12,9 @@
     <t:aliasBean alias="#{viewName}" value="options">
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
-
-        <h3><h:outputText value="#{msgs.options_page_header}"/></h3>
+		<div class="page-header">
+        	<h1><h:outputText value="#{msgs.options_page_header}"/></h1>
+		</div>
         <h4><h:outputText value="#{msgs.options_page_subheader}"/></h4>
         
         <%@ include file="/inc/globalMessages.jspf"%>

--- a/sections/sections-app/src/webapp/overview.jsp
+++ b/sections/sections-app/src/webapp/overview.jsp
@@ -7,6 +7,7 @@
     <t:aliasBean alias="#{viewName}" value="overview">
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
+
     <div class="page-header">
         <h1>
             <h:outputFormat value="#{msgs.overview_page_header}">

--- a/sections/sections-app/src/webapp/overview.jsp
+++ b/sections/sections-app/src/webapp/overview.jsp
@@ -7,12 +7,13 @@
     <t:aliasBean alias="#{viewName}" value="overview">
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
-
-	<h3>
-	    <h:outputFormat value="#{msgs.overview_page_header}">
-	        <f:param value="#{overviewBean.siteRole}"/>
-	    </h:outputFormat>
-	</h3>
+    <div class="page-header">
+        <h1>
+            <h:outputFormat value="#{msgs.overview_page_header}">
+                <f:param value="#{overviewBean.siteRole}"/>
+            </h:outputFormat>
+        </h1>
+    </div>
 	<div class="instructions">
 		<h:outputText value="#{overviewBean.instructions}"/>
 	</div>

--- a/sections/sections-app/src/webapp/roster.jsp
+++ b/sections/sections-app/src/webapp/roster.jsp
@@ -8,8 +8,10 @@
         <%@ include file="/inc/navMenu.jspf"%>
     </t:aliasBean>
 
-	<h3><h:outputText value="#{msgs.student_member}"/></h3>
-	
+    <div class="page-header">
+	    <h1><h:outputText value="#{msgs.student_member}"/></h1>
+    </div>
+
 	<div class="instructions">	
 		<h:outputText value="#{msgs.roster_instructions}"
 			rendered="#{ ! rosterBean.externallyManaged}"/>

--- a/sections/sections-app/src/webapp/roster.jsp
+++ b/sections/sections-app/src/webapp/roster.jsp
@@ -9,7 +9,7 @@
     </t:aliasBean>
 
     <div class="page-header">
-	    <h1><h:outputText value="#{msgs.student_member}"/></h1>
+        <h1><h:outputText value="#{msgs.student_member}"/></h1>
     </div>
 
 	<div class="instructions">	

--- a/sections/sections-app/src/webapp/studentView.jsp
+++ b/sections/sections-app/src/webapp/studentView.jsp
@@ -10,8 +10,10 @@
 
     <sakai:flowState bean="#{studentViewBean}"/>
 
-        <h3><h:outputText value="#{msgs.student_view_page_header}"/></h3>
-    
+        <div class="page-header">
+            <h1><h:outputText value="#{msgs.student_view_page_header}"/></h1>
+        </div>
+
         <t:div styleClass="instructions" rendered="#{not empty studentViewBean.instructions}">
             <h:outputText value="#{studentViewBean.instructions}"/>
         </t:div>

--- a/sitestats/sitestats-tool/src/webapp/html/pages/AdminPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/AdminPage.html
@@ -34,7 +34,9 @@
             <div class="portletBody">
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
 			<div style="width:100% !important">
-			    <h2><wicket:message key="menu_sitelist">[menu_sitelist]</wicket:message></h2>
+				<div class="page-header">
+					<h1><wicket:message key="menu_sitelist">[menu_sitelist]</wicket:message></h1>
+				</div>
 			    <span class="instruction"><wicket:message key="instructions_sitelist">[instructions]</wicket:message></span>
 			    
 			    <div class="navPanel">

--- a/sitestats/sitestats-tool/src/webapp/html/pages/AdminPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/AdminPage.html
@@ -33,10 +33,10 @@
 
             <div class="portletBody">
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
-			<div style="width:100% !important">
-				<div class="page-header">
-					<h1><wicket:message key="menu_sitelist">[menu_sitelist]</wicket:message></h1>
-				</div>
+                <div style="width:100% !important">
+                <div class="page-header">
+                    <h1><wicket:message key="menu_sitelist">[menu_sitelist]</wicket:message></h1>
+                </div>
 			    <span class="instruction"><wicket:message key="instructions_sitelist">[instructions]</wicket:message></span>
 			    
 			    <div class="navPanel">

--- a/sitestats/sitestats-tool/src/webapp/html/pages/OverviewPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/OverviewPage.html
@@ -38,10 +38,11 @@
             <!-- Menu -->
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
 		    <!-- Page title -->
-            <h2>
-                <wicket:message key="menu_overview">[menu_overview]</wicket:message>
-            </h2>
-		    
+            <div class="page-header">
+                <h1>
+                    <wicket:message key="menu_overview">[menu_overview]</wicket:message>
+                </h1>
+            </div>
 		    <!-- Last Job run -->
 		    <span wicket:id="lastJobRun"></span>
 		    

--- a/sitestats/sitestats-tool/src/webapp/html/pages/OverviewPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/OverviewPage.html
@@ -43,6 +43,7 @@
                     <wicket:message key="menu_overview">[menu_overview]</wicket:message>
                 </h1>
             </div>
+
 		    <!-- Last Job run -->
 		    <span wicket:id="lastJobRun"></span>
 		    

--- a/sitestats/sitestats-tool/src/webapp/html/pages/PreferencesPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/PreferencesPage.html
@@ -33,11 +33,11 @@
 
 		<div class="portletBody">
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
-			<div class="page-header">
-				<h1>
-					<wicket:message key="menu_prefs">[menu_prefs]</wicket:message>
-				</h1>
-			</div>
+            <div class="page-header">
+                <h1>
+                    <wicket:message key="menu_prefs">[menu_prefs]</wicket:message>
+                </h1>
+            </div>
             
             <form wicket:id="prefsForm" name="prefsForm">
     

--- a/sitestats/sitestats-tool/src/webapp/html/pages/PreferencesPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/PreferencesPage.html
@@ -33,10 +33,11 @@
 
 		<div class="portletBody">
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
-            <h2>
-                <wicket:message key="menu_prefs">[menu_prefs]</wicket:message>
-            </h2>
-            
+			<div class="page-header">
+				<h1>
+					<wicket:message key="menu_prefs">[menu_prefs]</wicket:message>
+				</h1>
+			</div>
             
             <form wicket:id="prefsForm" name="prefsForm">
     

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ReportDataPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ReportDataPage.html
@@ -60,10 +60,11 @@
 		        </span>
 	        
 	            <!-- Page title -->
-	            <h2>
-	                <span wicket:id="reportAction"></span>
-	            </h2>
-	            
+                <div class="page-header">
+                    <h1>
+	                    <span wicket:id="reportAction"></span>
+                    </h1>
+                </div>
 	            <!-- Header: data information -->
 	            <table class="summaryTable">
                     <tbody>

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ReportDataPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ReportDataPage.html
@@ -65,6 +65,7 @@
 	                    <span wicket:id="reportAction"></span>
                     </h1>
                 </div>
+
 	            <!-- Header: data information -->
 	            <table class="summaryTable">
                     <tbody>

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ReportsEditPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ReportsEditPage.html
@@ -37,10 +37,11 @@
             <!-- Menu -->
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
             <!-- Page title -->
-            <h2>
-                <span wicket:id="reportAction"></span>
-            </h2>
-            
+            <div class="page-header">
+                <h1>
+                    <span wicket:id="reportAction"></span>
+                </h1>
+            </div>
 		    <!-- Last Job run -->
             <span wicket:id="lastJobRun"></span>
 		    

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ReportsPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ReportsPage.html
@@ -35,11 +35,11 @@
             <!-- Menu -->
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
             <!-- Page title -->
-			<div class="page-header">
-				<h1>
-					<span wicket:id="pageTitle">[reports]</span>
-				</h1>
-			</div>
+            <div class="page-header">
+                <h1>
+                    <span wicket:id="pageTitle">[reports]</span>
+                </h1>
+            </div>
 		    <!-- Last Job run -->
             <span wicket:id="lastJobRun"></span>
 		    

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ReportsPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ReportsPage.html
@@ -35,10 +35,11 @@
             <!-- Menu -->
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
             <!-- Page title -->
-            <h2>
-                <span wicket:id="pageTitle">[reports]</span>
-            </h2>
-            
+			<div class="page-header">
+				<h1>
+					<span wicket:id="pageTitle">[reports]</span>
+				</h1>
+			</div>
 		    <!-- Last Job run -->
             <span wicket:id="lastJobRun"></span>
 		    

--- a/sitestats/sitestats-tool/src/webapp/html/pages/ServerWidePage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/ServerWidePage.html
@@ -36,8 +36,9 @@
             <!-- Menu -->
             <menu wicket:id="menu" class="navIntraTool">[menu]</menu>
             <!-- Page title -->
-            <h2><wicket:message key="menu_serverwide">[menu_serverwide]</wicket:message></h2>
-            
+            <div class="page-header">
+                <h1><wicket:message key="menu_serverwide">[menu_serverwide]</wicket:message></h1>
+            </div>
             <!-- Contents -->
             <form wicket:id="serverWideReportForm">
                 <div id="content" style="width:100%">

--- a/sitestats/sitestats-tool/src/webapp/html/pages/UserActivityPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/UserActivityPage.html
@@ -28,9 +28,11 @@
 				<div class="content">
 					<div class="page-header">
 						<!-- Page title -->
-						<h2>
-							<wicket:message key="menu_useractivity">User Activity</wicket:message>
-						</h2>
+						<div class="page-header">
+							<h1>
+								<wicket:message key="menu_useractivity">User Activity</wicket:message>
+							</h1>
+						</div>
 						<!-- Last Job run -->
 						<span wicket:id="lastJobRunContainer"><span wicket:id="lastJobRun"></span></span>
 					</div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42104

Changed `<h2>` or `<h3>` tags (used as primary page headings) to `<h1>` and added `<div class="page-header">`. Added a header in commons for consistency.