### PR TITLE
SAK-42101 Consistent Headings in Portal, Roster2, Samigo, Signup, and Site-Manage

### DIFF
--- a/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ViewTitleRenderer.java
+++ b/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/ViewTitleRenderer.java
@@ -46,7 +46,7 @@ public class ViewTitleRenderer extends Renderer
 		if (!component.isRendered()) return;
 
 		ResponseWriter writer = context.getResponseWriter();
-		writer.startElement("h3", null);
+		writer.startElement("h1", null);
 
 		// TODO: Should we really write out the ID?  Is there any need for this in this tag?
 //		String id = (String) RendererUtil.getAttribute(context, component, "id");
@@ -76,7 +76,7 @@ public class ViewTitleRenderer extends Renderer
 		if (!component.isRendered()) return;
 
 		ResponseWriter writer = context.getResponseWriter();
-		writer.endElement("h3");
+		writer.endElement("h1");
 	}
 }
 

--- a/roster2/tool/src/handlebars/overview.handlebars
+++ b/roster2/tool/src/handlebars/overview.handlebars
@@ -1,5 +1,9 @@
 <!-- top toolbar -->
 <div class="sakai-table-toolBar">
+    <!-- header for overview part -->
+    <div class="page-header">
+        <h1>{{translate 'navbar_overview'}}</h1>
+     </div>
     <div class="sakai-table-filterContainer">
         <div class="sakai-table-viewFilter">
             <label for="roster-roles-selector">{{translate 'roles_label'}}</label>

--- a/roster2/tool/src/handlebars/permissions.handlebars
+++ b/roster2/tool/src/handlebars/permissions.handlebars
@@ -1,2 +1,6 @@
-<h3>{{translate 'title_permissions'}}: {{siteTitle}}</h3>
+<div class="page-header">
+    <h1>
+        {{translate 'title_permissions'}}: {{siteTitle}}
+    </h1>
+</div>
 <sakai-tool-permissions tool="roster" />

--- a/samigo/samigo-app/src/webapp/jsf/author/createAssessment_title.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/createAssessment_title.jsp
@@ -42,6 +42,13 @@
         <script type="text/JavaScript">includeWebjarLibrary('datatables');</script>
         <script type="text/javascript" src="/samigo-app/js/info.js"></script>
 
+<%--        header--%>
+        <div class="page-header">
+            <h1>
+                <h:outputText value="#{questionPoolMessages.add} #{authorFrontDoorMessages.assessments}" />
+            </h1>
+        </div>
+
         <div class="samigo-container">
             <p>
                 <h:messages styleClass="messageSamigo" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
@@ -116,9 +116,11 @@
     </li>
 </ul>
 
-<h1>
-  <h:outputText value="#{generalMessages.questionPool}"/>
-</h1>
+<div class="page-header">
+    <h1>
+      <h:outputText value="#{generalMessages.questionPool}"/>
+    </h1>
+</div>
 
 <h:outputText rendered="#{questionpool.importToAuthoring == 'true'}" value="#{questionPoolMessages.msg_imp_poolmanager}"/>
 

--- a/samigo/samigo-app/src/webapp/jsf/template/templateIndex.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/template/templateIndex.jsp
@@ -40,10 +40,11 @@
   <!-- HEADINGS -->
   <%@ include file="/jsf/template/templateHeadings.jsp" %>
   <h:messages styleClass="messageSamigo" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
-
-<h3>
-   <h:outputText value="#{templateMessages.index_templates}"/>
- </h3>
+<div class="page-header">
+    <h1>
+       <h:outputText value="#{templateMessages.index_templates}"/>
+    </h1>
+</div>
 
 <div class="tier1">
  <h:outputText value="#{templateMessages.index_desc}"  rendered="#{authorization.createTemplate}"/>

--- a/signup/tool/src/webapp/signup/attendee/addSignupAttendee.jsp
+++ b/signup/tool/src/webapp/signup/attendee/addSignupAttendee.jsp
@@ -16,7 +16,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_addSignup_attendee_page_title}"/>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.event_addSignup_attendee_page_title}"/>
+				</div>
 
 				<h:panelGrid columns="2" columnClasses="titleColumn,valueColumn" style="margin-top:20px;">
 					<h:outputText value="#{msgs.event_name}" styleClass="titleText" escape="false"/>

--- a/signup/tool/src/webapp/signup/attendee/editComment.jsp
+++ b/signup/tool/src/webapp/signup/attendee/editComment.jsp
@@ -16,7 +16,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_edit_comment_page_title}"/>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.event_edit_comment_page_title}"/>
+				</div>
 				<div class="table-responsive">
 				<h:panelGrid columns="2" columnClasses="titleColumn,valueColumn" style="margin-top:20px;">
 					<h:outputText value="#{msgs.event_name}" styleClass="titleText" escape="false"/>

--- a/signup/tool/src/webapp/signup/attendee/signupMeeting.jsp
+++ b/signup/tool/src/webapp/signup/attendee/signupMeeting.jsp
@@ -92,7 +92,9 @@
 				rendered="#{messageUIBean.error}" />
 
 			<h:form id="meeting">
-				<sakai:view_title value="#{msgs.event_participant_view_page_title}" />
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.event_participant_view_page_title}" />
+				</div>
 
 				<%-- show title only when collapsed --%>
 				<h:panelGrid id="showMeetingTitleOnly" columns="2" columnClasses="titleColumn,valueColumn" styleClass="orgShowTitleOnly">

--- a/signup/tool/src/webapp/signup/download/downloadSelections.jsp
+++ b/signup/tool/src/webapp/signup/download/downloadSelections.jsp
@@ -168,7 +168,11 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
-			 	<sakai:view_title value="#{msgs.signup_download}"/>
+				<div class="page-header">
+					<h1>
+						<h:outputText value="#{msgs.signup_download}"/>
+					</h1>
+				</div>
 				
 				<h:outputText value="&nbsp;" escape="false"/>
 				

--- a/signup/tool/src/webapp/signup/download/downloadSelections.jsp
+++ b/signup/tool/src/webapp/signup/download/downloadSelections.jsp
@@ -168,14 +168,14 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
-                <div class="page-header">
-                    <h1>
-                        <h:outputText value="#{msgs.signup_download}"/>
-                    </h1>
-                </div>
-				
+				<div class="page-header">
+					<h1>
+						<sakai:view_title value="#{msgs.signup_download}"/>
+					</h1>
+				</div>
+
 				<h:outputText value="&nbsp;" escape="false"/>
-				
+
 				<h:panelGrid columns="1">
 					<h:outputText value="#{msgs.events_organizer_download_instruction}"  rendered="#{DownloadEventBean.allowedToUpdate && DownloadEventBean.meetingsAvailable}" escape="false"/>
 					<h:outputText value="#{msgs.events_attendee_download_instruction}" rendered="#{!DownloadEventBean.allowedToUpdate && DownloadEventBean.meetingsAvailable}" escape="false"/>

--- a/signup/tool/src/webapp/signup/download/downloadSelections.jsp
+++ b/signup/tool/src/webapp/signup/download/downloadSelections.jsp
@@ -168,11 +168,11 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
-				<div class="page-header">
-					<h1>
-						<h:outputText value="#{msgs.signup_download}"/>
-					</h1>
-				</div>
+                <div class="page-header">
+                    <h1>
+                        <h:outputText value="#{msgs.signup_download}"/>
+                    </h1>
+                </div>
 				
 				<h:outputText value="&nbsp;" escape="false"/>
 				

--- a/signup/tool/src/webapp/signup/download/downloadSelections.jsp
+++ b/signup/tool/src/webapp/signup/download/downloadSelections.jsp
@@ -169,9 +169,7 @@
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
 				<div class="page-header">
-					<h1>
-						<sakai:view_title value="#{msgs.signup_download}"/>
-					</h1>
+					<sakai:view_title value="#{msgs.signup_download}"/>
 				</div>
 
 				<h:outputText value="&nbsp;" escape="false"/>

--- a/signup/tool/src/webapp/signup/newMeeting/assignStudents.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/assignStudents.jsp
@@ -54,7 +54,9 @@
 						
 		<sakai:view_content>
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_assign_attendee_page_title}"/>
+				<div class="page-header">
+			 		<sakai:view_title value="#{msgs.event_assign_attendee_page_title}"/>
+				</div>
 
 				<h:panelGrid columns="2" style="margin-top:20px;margin-bottom:20px;" columnClasses="titleColumn,valueColumn">
 					<h:outputText value="#{msgs.event_date}" styleClass="titleText" escape="false"/>

--- a/signup/tool/src/webapp/signup/newMeeting/step1.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step1.jsp
@@ -87,7 +87,7 @@
             <h:form id="meeting" >              
                 <div class="page-header">
                     <h1>
-                        <h:outputText value="#{msgs.create_new_event} #{msgs.basic}"/>
+                        <sakai:view_title value="#{msgs.create_new_event} #{msgs.basic}"/>
                     </h1>
                 </div>
                 <sakai:doc_section>

--- a/signup/tool/src/webapp/signup/newMeeting/step1.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step1.jsp
@@ -86,14 +86,15 @@
      		<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>
             <h:form id="meeting" >              
                 <div class="page-header">
-                    <h1>
-                        <sakai:view_title value="#{msgs.create_new_event} #{msgs.basic}"/>
-                    </h1>
+                    <sakai:view_title value="#{msgs.create_new_event} #{msgs.basic}"/>
                 </div>
                 <sakai:doc_section>
                     <h:panelGrid columns="1" styleClass="instruction" style="background:#fff;">
                         <h:outputText value="#{msgs.create_instruction} " escape="false" />                      
-                        <h:panelGroup>                           
+                        <h:panelGroup>                           site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
+
+
+
                             <h:outputText value="#{msgs.star_character}" style="color:#B11;" />
                             <h:outputText value="&nbsp;#{msgs.required2}" escape="false" />
                         </h:panelGroup>

--- a/signup/tool/src/webapp/signup/newMeeting/step1.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step1.jsp
@@ -85,7 +85,7 @@
         <sakai:view_content>
      		<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>
             <h:form id="meeting" >              
-				<div class="page-header">
+                <div class="page-header">
                     <h1>
                         <h:outputText value="#{msgs.create_new_event} #{msgs.basic}"/>
                     </h1>

--- a/signup/tool/src/webapp/signup/newMeeting/step1.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step1.jsp
@@ -85,7 +85,11 @@
         <sakai:view_content>
      		<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>
             <h:form id="meeting" >              
-				<sakai:view_title value="#{msgs.create_new_event} #{msgs.basic}"/>
+				<div class="page-header">
+                    <h1>
+                        <h:outputText value="#{msgs.create_new_event} #{msgs.basic}"/>
+                    </h1>
+                </div>
                 <sakai:doc_section>
                     <h:panelGrid columns="1" styleClass="instruction" style="background:#fff;">
                         <h:outputText value="#{msgs.create_instruction} " escape="false" />                      

--- a/signup/tool/src/webapp/signup/newMeeting/step2.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step2.jsp
@@ -50,7 +50,9 @@
 			<h:outputText value="#{messageUIBean.infoMessage}" styleClass="information" escape="false" rendered="#{messageUIBean.info}"/>      			
 				
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_step5_page_title}"/>
+				<div class="page-header">
+			 		<sakai:view_title value="#{msgs.event_step5_page_title}"/>
+				</div>
 			 	<div class="form">
 					<%-- title --%>
 					<div class="row">

--- a/signup/tool/src/webapp/signup/organizer/cancelTimeslot.jsp
+++ b/signup/tool/src/webapp/signup/organizer/cancelTimeslot.jsp
@@ -15,7 +15,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 			<h:form id="meeting">
-		 		<sakai:view_title value="#{msgs.cancel_timeslot}"/>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.cancel_timeslot}"/>
+				</div>
 				<sakai:doc_section>
 					<h:outputText value="#{msgs.confirm_cancel}"/>
 				</sakai:doc_section>

--- a/signup/tool/src/webapp/signup/organizer/copyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/copyMeeting.jsp
@@ -178,7 +178,9 @@
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 			<h:outputText id="iframeId" value="#{CopyMeetingSignupMBean.iframeId}" style="display:none"/>	
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_copy_meeting_page_title}"/>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.event_copy_meeting_page_title}"/>
+				</div>
 				<sakai:doc_section>
 					<h:panelGrid columns="1" styleClass="instruction">						
 						<h:panelGroup> 

--- a/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
@@ -112,7 +112,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_modify_meeting_page_title}"/>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.event_modify_meeting_page_title}"/>
+				</div>
 			 	<sakai:doc_section> 
 					<h:panelGrid columns="1" styleClass="instruction">						
 						<h:panelGroup>

--- a/signup/tool/src/webapp/signup/organizer/orgSignupMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/orgSignupMeeting.jsp
@@ -262,7 +262,9 @@
 				<h:inputHidden id="userActionType" value="#{OrganizerSignupMBean.userActionType}"/>
 				<h:inputHidden id="selectedFirstUser"  value="#{OrganizerSignupMBean.selectedFirstUser}"/>
 			
-			 	<sakai:view_title value="#{msgs.organizer_page_title}"/>
+			 	<div class="page-header">
+					<sakai:view_title value="#{msgs.organizer_page_title}"/>
+				</div>
 			 	<%-- show title only when collapsed --%>
 			 	<div id="showMeetingTitleOnly" styleClass="orgShowTitleOnly">
 					<div class="row">

--- a/signup/tool/src/webapp/signup/organizer/userDefTsBlocks.jsp
+++ b/signup/tool/src/webapp/signup/organizer/userDefTsBlocks.jsp
@@ -167,7 +167,9 @@
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 				
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_view_userDefined_Timeslot_page_title}"/>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.event_view_userDefined_Timeslot_page_title}"/>
+				</div>
 
 					<h:outputText value="#{msgs.warn_reschedule_event}" styleClass="alertMessage" style="width:85%" escape="false" rendered="#{UserDefineTimeslotBean.someoneSignedUp}"/>
 					

--- a/signup/tool/src/webapp/signup/organizer/viewComment.jsp
+++ b/signup/tool/src/webapp/signup/organizer/viewComment.jsp
@@ -26,7 +26,9 @@
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 				
 			<h:form id="meeting">
-			 	<sakai:view_title value="#{msgs.event_view_comment_page_title}"/>
+				<div class="page-headerf">
+			 		<sakai:view_title value="#{msgs.event_view_comment_page_title}"/>
+				</div>
 				<div class="table-responsive">
 				<h:panelGrid columns="2" columnClasses="titleColumn,valueColumn">
 				

--- a/signup/tool/src/webapp/signup/organizer/viewComment.jsp
+++ b/signup/tool/src/webapp/signup/organizer/viewComment.jsp
@@ -26,7 +26,7 @@
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 				
 			<h:form id="meeting">
-				<div class="page-headerf">
+				<div class="page-header">
 			 		<sakai:view_title value="#{msgs.event_view_comment_page_title}"/>
 				</div>
 				<div class="table-responsive">

--- a/signup/tool/src/webapp/signup/signupMeetings.jsp
+++ b/signup/tool/src/webapp/signup/signupMeetings.jsp
@@ -190,9 +190,11 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
-				<div class="page-header">
-			 		<h1><h:outputText value="#{msgs.signup_tool}"/></h1>
-				</div>
+                <div class="page-header">
+                    <h1>
+                        <h:outputText value="#{msgs.signup_tool}"/>
+                    </h1>
+                </div>
 				<h:panelGroup styleClass="" rendered="#{(SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable) or (!SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable)}">
 					<h:outputText value="#{msgs.events_organizer_instruction}"  rendered="#{SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable}" escape="false"/>
 					<h:outputText value="&nbsp;" escape="false"/>

--- a/signup/tool/src/webapp/signup/signupMeetings.jsp
+++ b/signup/tool/src/webapp/signup/signupMeetings.jsp
@@ -190,8 +190,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
-			 	<sakai:view_title value="#{msgs.signup_tool}"/>
-
+				<div class="page-header">
+			 		<h1><h:outputText value="#{msgs.signup_tool}"/></h1>
+				</div>
 				<h:panelGroup styleClass="" rendered="#{(SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable) or (!SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable)}">
 					<h:outputText value="#{msgs.events_organizer_instruction}"  rendered="#{SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable}" escape="false"/>
 					<h:outputText value="&nbsp;" escape="false"/>

--- a/signup/tool/src/webapp/signup/signupMeetings.jsp
+++ b/signup/tool/src/webapp/signup/signupMeetings.jsp
@@ -190,11 +190,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/> 
 			<h:form id="items">
-                <div class="page-header">
-                    <h1>
-                        <h:outputText value="#{msgs.signup_tool}"/>
-                    </h1>
-                </div>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.signup_tool}"/>
+				</div>
 				<h:panelGroup styleClass="" rendered="#{(SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable) or (!SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable)}">
 					<h:outputText value="#{msgs.events_organizer_instruction}"  rendered="#{SignupMeetingsBean.allowedToUpdate && SignupMeetingsBean.meetingsAvailable}" escape="false"/>
 					<h:outputText value="&nbsp;" escape="false"/>

--- a/signup/tool/src/webapp/signup/updatePermission.jsp
+++ b/signup/tool/src/webapp/signup/updatePermission.jsp
@@ -16,11 +16,9 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 			<h:form id="meeting">
-                <div class="page-header">
-                    <h1>
-                        <h:outputText value="#{msgs.permission_page_title}"/>
-                    </h1>
-                </div>
+				<div class="page-header">
+					<sakai:view_title value="#{msgs.permission_page_title}"/>
+				</div>
 				<sakai:doc_section>
 				 <h:panelGrid columns="1" styleClass="instruction" style="background:#fff;">
                         <h:outputText value="#{msgs.permission_note_for_view_attend_group}" escape="false" />                                             

--- a/signup/tool/src/webapp/signup/updatePermission.jsp
+++ b/signup/tool/src/webapp/signup/updatePermission.jsp
@@ -16,7 +16,11 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 			<h:form id="meeting">
-		 		<sakai:view_title value="#{msgs.permission_page_title}"/>
+				<div class="page-header">
+					<h1>
+		 				<h:outputText value="#{msgs.permission_page_title}"/>
+					</h1>
+				</div>
 				<sakai:doc_section>
 				 <h:panelGrid columns="1" styleClass="instruction" style="background:#fff;">
                         <h:outputText value="#{msgs.permission_note_for_view_attend_group}" escape="false" />                                             

--- a/signup/tool/src/webapp/signup/updatePermission.jsp
+++ b/signup/tool/src/webapp/signup/updatePermission.jsp
@@ -16,11 +16,11 @@
 		<sakai:view_content>
 			<h:outputText value="#{msgs.event_error_alerts} #{messageUIBean.errorMessage}" styleClass="alertMessage" escape="false" rendered="#{messageUIBean.error}"/>      			
 			<h:form id="meeting">
-				<div class="page-header">
-					<h1>
-		 				<h:outputText value="#{msgs.permission_page_title}"/>
-					</h1>
-				</div>
+                <div class="page-header">
+                    <h1>
+                        <h:outputText value="#{msgs.permission_page_title}"/>
+                    </h1>
+                </div>
 				<sakai:doc_section>
 				 <h:panelGrid columns="1" styleClass="instruction" style="background:#fff;">
                         <h:outputText value="#{msgs.permission_note_for_view_attend_group}" escape="false" />                                             

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -15,7 +15,9 @@
  	<div id="page-order-body" class="portletBody">
 		<a href="#" rsf:id="redirect">go back</a>
 		<div rsf:id="content:">
-			<h3 rsf:id="msg=page_title">page_title</h3>
+			<div class="page-header">
+				<h1 rsf:id="msg=page_title">page_title</h1>
+			</div>
 			<div class="alertMessageContainer">
 				<div class="alert alert-info" id="call-results" role="alert">
 					<span rsf:id="msg=welcome">Note: Changes to page ordering will not take effect until you click 'Save'. Deleting, Adding or Editing a Page is saved immediately</span>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/CreateJoinableGroups.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/CreateJoinableGroups.html
@@ -13,7 +13,9 @@
     <body>
         <div class="portletBody">
             <form rsf:id="groups-form">
-                <h3 rsf:id="prompt"></h3>
+                <div class="page-header">
+                    <h1 rsf:id="prompt"></h1>
+                </div>
                 <p rsf:id="instructions" class="instruction"></p>
                 <div rsf:id="error-row:">
                     <div class="alertMessage" rsf:id="error">

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
@@ -21,7 +21,9 @@
                 </div>
             </div>
             <form rsf:id="groups-form">
-                <h3 rsf:id="prompt"></h3>
+				<div class="page-header">
+                	<h1 rsf:id="prompt"></h1>
+				</div>
                 <p rsf:id="msg=group.autocreate.instructions" class="instruction">Select a course roster to create a separate group for that roster.</p>
                 <div rsf:id="roster_options:">
                     <h4 rsf:id="msg=instruction.header.roster">From Rosters</h4>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupAutoCreate.html
@@ -21,9 +21,9 @@
                 </div>
             </div>
             <form rsf:id="groups-form">
-				<div class="page-header">
-                	<h1 rsf:id="prompt"></h1>
-				</div>
+                <div class="page-header">
+                    <h1 rsf:id="prompt"></h1>
+                </div>
                 <p rsf:id="msg=group.autocreate.instructions" class="instruction">Select a course roster to create a separate group for that roster.</p>
                 <div rsf:id="roster_options:">
                     <h4 rsf:id="msg=instruction.header.roster">From Rosters</h4>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
@@ -70,7 +70,9 @@
 	</div>
 
 	<form rsf:id="groups-form" id="groups-form">
-		<h3 rsf:id="prompt"></h3>
+		<div class="page-header">
+			<h1 rsf:id="prompt"></h1>
+		</div>
 		<p id="" class="messageValidation" rsf:id="emptyGroupTitleAlert" style="display:none"/>
 		<p rsf:id="instructions" class="instruction">
 		</p>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupImportStep1.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupImportStep1.html
@@ -18,7 +18,9 @@
         <div class="alertMessage" rsf:id="error">import1.error.title</div>
     </div>
     <div rsf:id="content:">
-        <h3 rsf:id="msg=import1.title">import1.title</h3>
+        <div class="page-header">
+            <h1 rsf:id="msg=import1.title">import1.title</h1>
+        </div>
         <b><p rsf:id="msg=import1.instr.req.header">import1.instr.req.header</p></b>
 		<ul>
 			<li rsf:id="import1.instr.req.1">import1.instr.req.1</li>

--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupList.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupList.html
@@ -22,8 +22,9 @@
 				<li><span><a href="#" rsf:id="auto_add" class="item_control" title="Automatically Create New Group" onclick="">Auto Groups</a></span></li>
 				<li><span><a href="#" rsf:id="import_add" class="item_control" title="Automatically Create New Group" onclick="">Auto Groups</a></span></li>
 			</ul>
-
-			<h3 rsf:id="group-list-title">Groups</h3>
+			<div class="page-header">
+				<h1 rsf:id="group-list-title">Groups</h1>
+			</div>
 			<!-- alert message -->
 			<div rsf:id="error-row:">
 				<div class="alertMessage" rsf:id="error">We Have Errors!</div>

--- a/site-manage/site-manage-link-helper/src/webapp/vm/sakai_link.vm
+++ b/site-manage/site-manage-link-helper/src/webapp/vm/sakai_link.vm
@@ -1,6 +1,8 @@
 #javascript("/library/js/spinner.js")
 <div class="portletBody">
-<h3>$tlang.getString('title')</h3>
+    <div class="page-header">
+        <h1>$tlang.getString('title')</h1>
+    </div>
 #if ($alertMessage)
     <div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div><div style="display:block;clear:both" ></div>
 #end

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -15,7 +15,9 @@
 <div id="participant-body" class="portletBody">
 	<div rsf:id="content:">
 		<!-- instruction for adding participant to course sites  -->
-		<h2 rsf:id="msg=java.addp">Add Participant</h2>
+		<div class="page-header">
+			<h1 rsf:id="msg=java.addp">Add Participant</h1>
+		</div>
 		<p>
 			<span rsf:id="add.official" class="highlight"></span>
 			<span rsf:id = "add.official1"></span>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
@@ -5,6 +5,12 @@
 
 <div class="portletBody">
     #if($menu)#toolbar($menu)#end
+    ## header for manage tools page
+    <div class="page-header">
+        <h1>
+            $tlang.getString("java.edittools")
+        </h1>
+    </div>
 
     <div class="siteInfoContent">
         #if (!$!existSite)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
@@ -7,9 +7,7 @@
     #if($menu)#toolbar($menu)#end
     ## header for manage tools page
     <div class="page-header">
-        <h1>
-            $tlang.getString("java.edittools")
-        </h1>
+        <h1>$tlang.getString("java.edittools")</h1>
     </div>
 
     <div class="siteInfoContent">

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
@@ -1,14 +1,17 @@
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm,v 1.3 2005/05/25 17:42:01 gsilver.umich.edu Exp $ -->
 <div class="portletBody container-fluid">
 	#if($menu)#toolbar($menu)#end
-	#if (!$!site)
-		<h3>$tlang.getString("nscourse.creating")</h3>
-		<p class="step">
-			$tlang.getString("nscourse.course_sections_selection") - $term.title
-		</p>
-	#else
-		<h3>$tlang.getString("nscourse.edit") <span class="highlight">$!siteTitle</span></h3>
-	#end
+	## header for edit class roster's editing course/section info
+	<div class="page-header">
+		#if (!$!site)
+			<h1>$tlang.getString("nscourse.creating")</h1>
+			<p class="step">
+				$tlang.getString("nscourse.course_sections_selection") - $term.title
+			</p>
+		#else
+			<h1>$tlang.getString("nscourse.edit") <span class="highlight">$!siteTitle</span></h1>
+		#end
+	</div>
 	#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div>#end
 	<p class="instruction">
 		#if (!$!site)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -65,11 +65,20 @@
 </script>
 <div class ="portletBody">
 	#if($menu)#toolbar($menu)#end
+
+##  header for manage access page
+<div class="page-header">
 	#if (!$!site)
-		<h3>
+		<h1>
 			$tlang.getString("ediacc.other.setsitacc")
-		</h3>
+		</h1>
+	#else
+		<h1>
+			$tlang.getString("java.siteaccess")
+		</h1>
+
 	#end
+</div>
 	#if ($alertMessage)
 		<div class="alertMessage">$tlang.getString("ediacc.alert") $alertMessage</div>
 		<div class="clear"></div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -69,14 +69,9 @@
     ##  header for manage access page
 	<div class="page-header">
 		#if (!$!site)
-			<h1>
-				$tlang.getString("ediacc.other.setsitacc")
-			</h1>
+			<h1>$tlang.getString("ediacc.other.setsitacc")</h1>
 		#else
-			<h1>
-				$tlang.getString("java.siteaccess")
-			</h1>
-
+			<h1>$tlang.getString("java.siteaccess")</h1>
 		#end
     </div>
 	#if ($alertMessage)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -66,19 +66,19 @@
 <div class ="portletBody">
 	#if($menu)#toolbar($menu)#end
 
-##  header for manage access page
-<div class="page-header">
-	#if (!$!site)
-		<h1>
-			$tlang.getString("ediacc.other.setsitacc")
-		</h1>
-	#else
-		<h1>
-			$tlang.getString("java.siteaccess")
-		</h1>
+    ##  header for manage access page
+    <div class="page-header">
+        #if (!$!site)
+            <h1>
+                $tlang.getString("ediacc.other.setsitacc")
+            </h1>
+        #else
+            <h1>
+                $tlang.getString("java.siteaccess")
+            </h1>
 
-	#end
-</div>
+        #end
+    </div>
 	#if ($alertMessage)
 		<div class="alertMessage">$tlang.getString("ediacc.alert") $alertMessage</div>
 		<div class="clear"></div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -67,17 +67,17 @@
 	#if($menu)#toolbar($menu)#end
 
     ##  header for manage access page
-    <div class="page-header">
-        #if (!$!site)
-            <h1>
-                $tlang.getString("ediacc.other.setsitacc")
-            </h1>
-        #else
-            <h1>
-                $tlang.getString("java.siteaccess")
-            </h1>
+	<div class="page-header">
+		#if (!$!site)
+			<h1>
+				$tlang.getString("ediacc.other.setsitacc")
+			</h1>
+		#else
+			<h1>
+				$tlang.getString("java.siteaccess")
+			</h1>
 
-        #end
+		#end
     </div>
 	#if ($alertMessage)
 		<div class="alertMessage">$tlang.getString("ediacc.alert") $alertMessage</div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -5,9 +5,7 @@
 
 	## header for edit class roster(s) page
 	<div class="page-header">
-		<h1>
-			$tlang.getString("java.editc")
-		</h1>
+		<h1>$tlang.getString("java.editc")</h1>
 	</div>
 
 	<div class="siteInfoContent">

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -3,6 +3,13 @@
 <div class ="portletBody">
 	#if($menu)#toolbar($menu)#end
 
+	## header for edit class roster(s) page
+	<div class="page-header">
+		<h1>
+			$tlang.getString("java.editc")
+		</h1>
+	</div>
+
 	<div class="siteInfoContent">
 		#if ($alertMessage)
 			<div class="alertMessage">$tlang.getString("sitedicla.alert") $alertMessage</div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -3,12 +3,12 @@
 <div class ="portletBody">
 	#if($menu)#toolbar($menu)#end
 
-	## header for edit class roster(s) page
-	<div class="page-header">
-		<h1>
-			$tlang.getString("java.editc")
-		</h1>
-	</div>
+    ## header for edit class roster(s) page
+    <div class="page-header">
+        <h1>
+            $tlang.getString("java.editc")
+        </h1>
+    </div>
 
 	<div class="siteInfoContent">
 		#if ($alertMessage)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editClass.vm
@@ -3,12 +3,12 @@
 <div class ="portletBody">
 	#if($menu)#toolbar($menu)#end
 
-    ## header for edit class roster(s) page
-    <div class="page-header">
-        <h1>
-            $tlang.getString("java.editc")
-        </h1>
-    </div>
+	## header for edit class roster(s) page
+	<div class="page-header">
+		<h1>
+			$tlang.getString("java.editc")
+		</h1>
+	</div>
 
 	<div class="siteInfoContent">
 		#if ($alertMessage)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -2,8 +2,14 @@
 ## Edit Site Information
 <div class="portletBody container-fluid">
 	#if($menu)#toolbar($menu)#end
-	## definie form
+	## header for edit site information page
+	<div class="page-header">
+		<h1>
+			$tlang.getString("java.editsite")
+		</h1>
+	</div>
 	<form name="classInformationForm" id="classInformationForm" method="post" action="#toolForm("SiteAction")">
+	## definie form
 	#if(!$existingSite)
 		## adding new site
 		<h3>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -4,9 +4,7 @@
 	#if($menu)#toolbar($menu)#end
 	## header for edit site information page
 	<div class="page-header">
-		<h1>
-			$tlang.getString("java.editsite")
-		</h1>
+		<h1>$tlang.getString("java.editsite")</h1>
 	</div>
 	<form name="classInformationForm" id="classInformationForm" method="post" action="#toolForm("SiteAction")">
 	## definie form

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importMtrlMaster.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importMtrlMaster.vm
@@ -1,6 +1,13 @@
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/sitesetup/chef_site-siteInfo-importMtrlMaster.vm,v 1.2 2005/06/06 20:06:02 htripath.indiana.edu Exp $ -->
 <div class="portletBody">
 	#if($menu)#toolbar($menu)#end
+	## header for import from archived page
+	<div class="page-header">
+		<h1>
+			$tlang.getString("java.importFile")
+		</h1>
+	</div>
+
 	#if ($alertMessage)
 		<div class="alertMessage">$tlang.getString("sitinfimp.alert") $alertMessage</div>
 		<div class="clear"></div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importMtrlMaster.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importMtrlMaster.vm
@@ -3,9 +3,7 @@
 	#if($menu)#toolbar($menu)#end
 	## header for import from archived page
 	<div class="page-header">
-		<h1>
-			$tlang.getString("java.importFile")
-		</h1>
+		<h1>$tlang.getString("java.importFile")</h1>
 	</div>
 
 	#if ($alertMessage)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importSelection.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importSelection.vm
@@ -3,9 +3,7 @@
 	#if($menu)#toolbar($menu)#end
 	##header for import from site page
 	<div class="page-header">
-		<h1>
-			$tlang.getString("java.import")
-		</h1>
+		<h1>$tlang.getString("java.import")</h1>
 	</div>
 
 	#if ($alertMessage)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importSelection.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-importSelection.vm
@@ -1,6 +1,13 @@
 ##<!-- $Header: /cvs/sakai2/legacy/tools/src/webapp/vm/sitesetup/chef_site-siteInfo-importSelection.vm,v 1.0 2007/10/29 08:00:00 tnguyen.iupui.edu Exp $ -->
 <div class="portletBody">
 	#if($menu)#toolbar($menu)#end
+	##header for import from site page
+	<div class="page-header">
+		<h1>
+			$tlang.getString("java.import")
+		</h1>
+	</div>
+
 	#if ($alertMessage)
 		<div class="alertMessage">$tlang.getString("sitinfimp.alert") $alertMessage</div>
 		<div class="clear"></div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -24,6 +24,11 @@
 
 <div class ="portletBody specialLink container-fluid">
 	#if($menu)#toolbar($menu)#end
+	## header for site info page
+	<div class="page-header">
+		<h1>$tlang.getString("sinfo.other")</h1>
+	</div>
+
 	#if ($alertMessage)
 		<div class="alertMessage">$tlang.getString("gen.alert") $alertMessage</div>
 		<div class="clear"></div>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
@@ -3,9 +3,11 @@
 
         <input type="hidden" name="eventSubmit_doManage_overview_option" value="x" />
         <input type="hidden" name="option" value="cancel" />
-        <h3>
-            $tlang.getString("manover.header") <span class="highlight">$!site.Title</span>
-        </h3>
+        <div class="page-header">
+            <h1>
+                $tlang.getString("manover.header") <span class="highlight">$!site.Title</span>
+            </h1>
+        </div>
         #if ($alertMessage)<div class="alertMessage">$tlang.getString("manover.alert") $validator.escapeHtml($alertMessage)</div>#end
         <p class="instruction">
             $tlang.getString("manover.instr")

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
@@ -4,9 +4,7 @@
         <input type="hidden" name="eventSubmit_doManage_overview_option" value="x" />
         <input type="hidden" name="option" value="cancel" />
         <div class="page-header">
-            <h1>
-                $tlang.getString("manover.header") <span class="highlight">$!site.Title</span>
-            </h1>
+            <h1>$tlang.getString("manover.header") <span class="highlight">$!site.Title</span></h1>
         </div>
         #if ($alertMessage)<div class="alertMessage">$tlang.getString("manover.alert") $validator.escapeHtml($alertMessage)</div>#end
         <p class="instruction">

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageParticipants.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageParticipants.vm
@@ -8,6 +8,12 @@
 
     #if($menu)#toolbar($menu)#end
 
+    ## header for manage participants page
+    <div class="page-header">
+        <h1>
+            $tlang.getString("java.manageParticipants")
+        </h1>
+    </div>
     <div class="participantsHeader">
         <div>
             <em>$tlang.getString("sitegen.siteinfolist.lastupdated") $realmModifiedTime</em>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageParticipants.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageParticipants.vm
@@ -10,9 +10,7 @@
 
     ## header for manage participants page
     <div class="page-header">
-        <h1>
-            $tlang.getString("java.manageParticipants")
-        </h1>
+        <h1>$tlang.getString("java.manageParticipants")</h1>
     </div>
     <div class="participantsHeader">
         <div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42101

Changed h3 tags for page headings to h1 tags and nested them inside div class="page-header". Also added in headers where there were missing headers (in Site Info ⇒ Main site homepage,  Edit site info, Manage tools,  Manage participants, Edit class roster, Manage access, Import from site, Import from archive file; and in Tests and Quizzes ⇒ add assessments)

