### PR TITLE
SAK-42147 Keep default properties inline with docs.

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
@@ -167,20 +167,20 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
 	
 	public void checkAndSetDefaultPropertiesIfNotSet() {
 		if(enableSiteVisits == null) {
-			enableSiteVisits = serverConfigurationService.getBoolean("display.users.present", false) || serverConfigurationService.getBoolean("presence.events.log", false);
+			enableSiteVisits = serverConfigurationService.getBoolean("display.users.present", true) || serverConfigurationService.getBoolean("presence.events.log", true);
 		}
 		if(visitsInfoAvailable == null) {
 			visitsInfoAvailable	= enableSiteVisits;
 		}
 		if(enableSitePresences == null) {
 			// turn off, by default
-			enableSitePresences = false;// serverConfigurationService.getBoolean("display.users.present", false) || serverConfigurationService.getBoolean("presence.events.log", false);
+			enableSitePresences = false;// serverConfigurationService.getBoolean("display.users.present", true) || serverConfigurationService.getBoolean("presence.events.log", true);
 		}else if(enableSitePresences.booleanValue()){
 			// if turned on, make sure "display.users.present" is true
 			// this feature doesn't work properly with "presence.events.log"
-			if(serverConfigurationService.getBoolean("display.users.present", false)) {
-				enableSitePresences = serverConfigurationService.getBoolean("display.users.present", false);
-			}else if(serverConfigurationService.getBoolean("presence.events.log", false)) {
+			if(serverConfigurationService.getBoolean("display.users.present", true)) {
+				enableSitePresences = serverConfigurationService.getBoolean("display.users.present", true);
+			}else if(serverConfigurationService.getBoolean("presence.events.log", true)) {
 				enableSitePresences = false;
 				log.warn("Disabled SiteStats presence tracking: doesn't work properly with 'presence.events.log' => only plays nicely with 'display.users.present'");
 			}

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
@@ -250,8 +250,8 @@ public class StatsManagerTest extends AbstractJUnit4SpringContextTests {
 		smi.setVisitsInfoAvailable(null);
 		smi.setEnableSitePresences(null);
 		smi.checkAndSetDefaultPropertiesIfNotSet();
-		Assert.assertEquals(false, M_sm.getEnableSiteVisits());
-		Assert.assertEquals(false, M_sm.getVisitsInfoAvailable());
+		Assert.assertEquals(true, M_sm.getEnableSiteVisits());
+		Assert.assertEquals(true, M_sm.getVisitsInfoAvailable());
 		Assert.assertEquals(false, M_sm.getEnableSitePresences()); // off, by default
 		
 		// revert


### PR DESCRIPTION
SiteStats isn’t using the documented default values for display.users.present and presence.events.log, this change has Sitestats match the documentation and the values in the portal.