### PR TITLE
SAK-42148 Remove unused OSP properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2360,7 +2360,7 @@
 ## HELP TOOL (helpPath defined in PATHS section above)
 # Comma separated list of tools or categories whose help should not be added to the help index.
 # DEFAULT: none
-# help.hide=sakai.profile,OSP Guide
+# help.hide=sakai.profile,sakai.announement
 
 # External URL to direct help
 # DEFAULT: none (null)
@@ -2478,64 +2478,6 @@
 # DEFAULT: sakai.resources
 # podcasts.toolid=sakai.resources
 
-# PORTFOLIO (OSP)
-
-# A map of the default permissions for the OSP presentation tool. Each numbered instance of this variable should have a corresponding siteTypes and value option. 
-# For example, if presentation.permissions.map.1 is set, at a minimum:
-#   presentation.permissions.map.1.siteTypes
-#   presentation.permissions.map.1.value.count
-#   presentation.permissions.map.1.value.1 
-# must be set.
-
-# Count of the number of items in the settings
-# presentation.permissions.map.count=
-
-# A list of site types (portfolio, course, project, etc.) for which the permission map defined in presentation.permissions.map should be used.  
-# presentation.permissions.map.1.siteTypes=
-
-# A list of the permissions that should be assigned to the role specified in presentation.permissions.map. 
-# presentation.permissions.map.1.value.count=
-# presentation.permissions.map.1.value.1= 
-
-# Whether or not to override or include the existing presentation layout permissions with those set in presentationLayout.permissions.map. 
-# If set to true, only the permissions set in presentationLayout.permissions.map will be set. 
-# If set to false, the permissions set in presentationLayout.permissions.map will be set in addition to any existing permissions. 
-# presentationLayout.permissions.override
-
-# A map of the default permissions for the OSP presentation layout tool. Each numbered instance of this variable should have a corresponding siteTypes and value option.
-# For example, if presentation.permissions.map.1 is set, at a minimum:
-#   presentationLayout.permissions.map.1.siteTypes
-#   presentationLayout.permissions.map.1.value.count
-#   presentationLayout.permissions.map.1.value.1 
-# must be set.
-
-# Count of the number of items in the settings
-# presentationLayout.permissions.map.count
-
-# A list of site types (portfolio, course, project, etc.) for which the permission map should be used.
-# presentationLayout.permissions.map.1.siteTypes
-
-# A list of the permissions that should be assigned to the role specified in presentationLayout.permissions.map. 
-# presentationLayout.permissions.map.1.value.count=
-# presentationLayout.permissions.map.1.value.1= 
-
-# A map of the default permissions for the OSP presentation template tool. Each numbered instance of this variable should have a corresponding siteTypes and value option. 
-# For example, if  presentationTemplate.permissions.map.1 is set, at a minimum:
-#   presentationTemplate.permissions.map.1.siteTypes
-#   presentationTemplate.permissions.map.1.value.count
-#   presentationTemplate.permissions.map.1.value.1 
-# must be set.
-
-# Count of the number of items in the settings
-# presentationTemplate.permissions.map.count=
-
-# A list of site types (portfolio, course, project, etc.) for which the permission map defined in presentation.permissions.map should be used.  
-# presentationTemplate.permissions.map.1.siteTypes=
-
-# A list of the permissions that should be assigned to the role specified in presentation.permissions.map. 
-# presentationTemplate.permissions.map.1.value.count=
-# presentationTemplate.permissions.map.1.value.1=  
- 
 # Option to turn off having display names when zipping file
 # DEFAULT: true
 # dropbox.zip.haveDisplayname=false


### PR DESCRIPTION
The presentation tool was part of OSP which isn’t part of Sakai any more. The properties can therefore be removed from the default properties file.