### PR TITLE
SAK-42154 - Not able to delete attachment from private message

### DIFF
--- a/library/src/webapp/skin/tool_base.css
+++ b/library/src/webapp/skin/tool_base.css
@@ -183,7 +183,7 @@ table.listHier th a:hover{
 /*a column in a table that contains only a very small icon - all cells in the column have that class */
 /*see an announcement list where one announcement has an attachment*/
 table.listHier .attach{
-	width: .5em;
+	width: 24px;
 }
 
 /*make the currently sorted column header text bold,apply to <th> tag*/

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -116,11 +116,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.0</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -116,6 +116,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<version>4.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -3078,12 +3078,10 @@ public void processChangeSelectView(ValueChangeEvent eve)
     if (session.getAttribute(FilePickerHelper.FILE_PICKER_CANCEL) == null &&
         session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS) != null) 
     {
-      List refs = (List)session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
+      final List<Reference> refs = (List<Reference>) session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
       if(CollectionUtils.isNotEmpty(refs))
       {
-        for(int i=0; i<refs.size(); i++)
-        {
-          Reference ref = (Reference) refs.get(i);
+        for(Reference ref : refs) {
           Attachment thisAttach = prtMsgManager.createPvtMsgAttachment(
               ref.getId(), ref.getProperties().getProperty(ref.getProperties().getNamePropDisplayName()));
           attachments.add(new DecoratedAttachment(thisAttach));
@@ -3102,12 +3100,10 @@ public void processChangeSelectView(ValueChangeEvent eve)
     if (session.getAttribute(FilePickerHelper.FILE_PICKER_CANCEL) == null &&
         session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS) != null) 
     {
-      List refs = (List)session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
+      final List<Reference> refs = (List<Reference>) session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
       if(CollectionUtils.isNotEmpty(refs))
       {
-        for(int i=0; i<refs.size(); i++)
-        {
-          Reference ref = (Reference) refs.get(i);
+        for(Reference ref : refs) {
           Attachment thisAttach = prtMsgManager.createPvtMsgAttachment(
               ref.getId(), ref.getProperties().getProperty(ref.getProperties().getNamePropDisplayName()));
           allAttachments.add(new DecoratedAttachment(thisAttach));
@@ -3171,16 +3167,15 @@ public void processChangeSelectView(ValueChangeEvent eve)
 
     ExternalContext context = FacesContext.getCurrentInstance().getExternalContext();
 
-    Map paramMap = context.getRequestParameterMap();
+    Map<String, String> paramMap = context.getRequestParameterMap();
 
-    final String attachId = (String) CollectionUtils.emptyIfNull(paramMap.entrySet()).stream().
-            filter(entry -> ((Entry<Object, String>) entry).getKey() instanceof String && ((String) ((Entry<Object,
-                    String>) entry).getKey()).contains("pvmsg_current_attach")).
-            collect(Collectors.collectingAndThen(Collectors.toList(), list -> list.isEmpty() ? null : ((Entry<Object,
-                    String>) list.get(0)).getValue()));
-
-    if (StringUtils.isNotEmpty(attachId)) {
-      attachments.removeIf(da -> attachId.equalsIgnoreCase(da.getAttachment().getAttachmentId()));
+    if(paramMap != null) {
+        final String attachId = paramMap.entrySet().stream().
+                filter(entry -> entry.getKey().contains("pvmsg_current_attach")).
+                collect(Collectors.collectingAndThen(Collectors.toList(), list -> list.isEmpty() ? null : list.get(0).getValue()));
+        if (StringUtils.isNotEmpty(attachId)) {
+            attachments.removeIf(da -> attachId.equalsIgnoreCase(da.getAttachment().getAttachmentId()));
+        }
     }
     return null;
   }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.context.ExternalContext;
@@ -45,6 +46,8 @@ import javax.faces.event.ValueChangeEvent;
 import javax.faces.model.SelectItem;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.sakaiproject.api.app.messageforums.Area;
@@ -70,7 +73,6 @@ import org.sakaiproject.authz.api.PermissionsHelper;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.app.messageforums.MembershipItem;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.HiddenGroupImpl;
-import org.sakaiproject.component.app.messageforums.dao.hibernate.PrivateMessageImpl;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.PrivateTopicImpl;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -1829,6 +1831,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   private String returnDraftPage(){
 	  return processPvtMsgComposeCancel();
   }
+
   // created separate method as to be used with processPvtMsgSend() and processPvtMsgSaveDraft()
   public PrivateMessage constructMessage(boolean clearAttachments, PrivateMessage aMsg)
   {
@@ -1930,10 +1933,19 @@ public void processChangeSelectView(ValueChangeEvent eve)
       }
 
     }
-    //Add attachments
-    for(DecoratedAttachment attachment : (List<DecoratedAttachment>) attachments) {
-      prtMsgManager.addAttachToPvtMsg(aMsg, attachment.getAttachment());
-    }    
+
+    // Remove attachments from the message that are not in the bean
+    for (Attachment attachment : (List<Attachment>) aMsg.getAttachments()) {
+      if (attachments.stream().map(DecoratedAttachment::getAttachment).noneMatch(a -> a.getAttachmentId().equals(attachment.getAttachmentId()))) {
+        prtMsgManager.removePvtMsgAttachment(attachment);
+      }
+    }
+
+    // Add attachments to the message that are in the bean
+    for (DecoratedAttachment decoratedAttachment : attachments) {
+      prtMsgManager.addAttachToPvtMsg(aMsg, decoratedAttachment.getAttachment());
+    }
+
     if(clearAttachments){
     	//clear
     	attachments.clear();
@@ -3051,7 +3063,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   }
   
   //////////////////////////////   ATTACHMENT PROCESSING        //////////////////////////
-  private ArrayList attachments = new ArrayList();
+  private ArrayList<DecoratedAttachment> attachments = new ArrayList();
   
   private String removeAttachId = null;
   private ArrayList prepareRemoveAttach = new ArrayList();
@@ -3067,21 +3079,14 @@ public void processChangeSelectView(ValueChangeEvent eve)
         session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS) != null) 
     {
       List refs = (List)session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
-      if(refs != null && refs.size()>0)
+      if(CollectionUtils.isNotEmpty(refs))
       {
-        Reference ref = (Reference)refs.get(0);
-        
         for(int i=0; i<refs.size(); i++)
         {
-          ref = (Reference) refs.get(i);
+          Reference ref = (Reference) refs.get(i);
           Attachment thisAttach = prtMsgManager.createPvtMsgAttachment(
               ref.getId(), ref.getProperties().getProperty(ref.getProperties().getNamePropDisplayName()));
-          
-          //TODO - remove this as being set for test only  
-          //thisAttach.setPvtMsgAttachId(Long.valueOf(1));
-          
           attachments.add(new DecoratedAttachment(thisAttach));
-          
         }
       }
     }
@@ -3098,29 +3103,19 @@ public void processChangeSelectView(ValueChangeEvent eve)
         session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS) != null) 
     {
       List refs = (List)session.getAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
-      if(refs != null && refs.size()>0)
+      if(CollectionUtils.isNotEmpty(refs))
       {
-        Reference ref = (Reference)refs.get(0);
-        
         for(int i=0; i<refs.size(); i++)
         {
-          ref = (Reference) refs.get(i);
+          Reference ref = (Reference) refs.get(i);
           Attachment thisAttach = prtMsgManager.createPvtMsgAttachment(
               ref.getId(), ref.getProperties().getProperty(ref.getProperties().getNamePropDisplayName()));
-          
-          //TODO - remove this as being set for test only
-          //thisAttach.setPvtMsgAttachId(Long.valueOf(1));
           allAttachments.add(new DecoratedAttachment(thisAttach));
         }
       }
     }
     session.removeAttribute(FilePickerHelper.FILE_PICKER_ATTACHMENTS);
     session.removeAttribute(FilePickerHelper.FILE_PICKER_CANCEL);
-    
-//    if( allAttachments == null || (allAttachments.size()<1))
-//    {
-//      allAttachments.addAll(this.getDetailMsg().getMsg().getAttachments()) ;
-//    }
     return allAttachments;
   }
   
@@ -3171,45 +3166,23 @@ public void processChangeSelectView(ValueChangeEvent eve)
   }
   
   //Process remove attachment 
-  public String processDeleteAttach()
-  {
+  public String processDeleteAttach() {
     log.debug("processDeleteAttach()");
-    
-    ExternalContext context = FacesContext.getCurrentInstance().getExternalContext();
-    String attachId = null;
-    
-    Map paramMap = context.getRequestParameterMap();
-    Iterator<Entry<Object, String>> itr = paramMap.entrySet().iterator();
-    while(itr.hasNext())
-    {
-      Entry<Object, String> entry = itr.next();
-      Object key = entry.getKey();
-      if( key instanceof String)
-      {
-        String name =  (String)key;
-        int pos = name.lastIndexOf("pvmsg_current_attach");
-        
-        if(pos>=0 && name.length()==pos+"pvmsg_current_attach".length())
-        {
-          attachId = entry.getValue();
-          break;
-        }
-      }
-    }
-    
-    if (StringUtils.isNotEmpty(attachId)) {
-      for (int i = 0; i < attachments.size(); i++)
-      {
-        if (attachId.equalsIgnoreCase(((DecoratedAttachment) attachments.get(i)).getAttachment()
-            .getAttachmentId()))
-        {
-          attachments.remove(i);
-          break;
-        }
-      }
-    }
 
-    return null ;
+    ExternalContext context = FacesContext.getCurrentInstance().getExternalContext();
+
+    Map paramMap = context.getRequestParameterMap();
+
+    final String attachId = (String) CollectionUtils.emptyIfNull(paramMap.entrySet()).stream().
+            filter(entry -> ((Entry<Object, String>) entry).getKey() instanceof String && ((String) ((Entry<Object,
+                    String>) entry).getKey()).contains("pvmsg_current_attach")).
+            collect(Collectors.collectingAndThen(Collectors.toList(), list -> list.isEmpty() ? null : ((Entry<Object,
+                    String>) list.get(0)).getValue()));
+
+    if (StringUtils.isNotEmpty(attachId)) {
+      attachments.removeIf(da -> attachId.equalsIgnoreCase(da.getAttachment().getAttachmentId()));
+    }
+    return null;
   }
  
   
@@ -3266,7 +3239,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
       
       for(int i=0; i<attachments.size(); i++)
       {
-      	DecoratedAttachment thisAttach = (DecoratedAttachment)attachments.get(i);
+        DecoratedAttachment thisAttach = attachments.get(i);
         if(((Long)thisAttach.getAttachment().getPvtMsgAttachId()).toString().equals(removeAttachId))
         {
           attachments.remove(i);
@@ -4605,5 +4578,9 @@ public void processChangeSelectView(ValueChangeEvent eve)
         descMap.put("en-US", "User sent a private message with subject: " + subject);
         lrsObject.setDescription(descMap);
         return new LRS_Statement(student, verb, lrsObject);
+    }
+
+    public String getAttachmentReadableSize(final String attachmentSize) {
+      return FileUtils.byteCountToDisplaySize(Long.parseLong(attachmentSize));
     }
 }

--- a/msgcntr/messageforums-app/src/webapp/jsp/compose.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/compose.jsp
@@ -282,7 +282,8 @@
 					  <f:facet name="header">
 						  <h:outputText value="#{msgs.pvt_attsize}" />
 						</f:facet>
-						<h:outputText value="#{eachAttach.attachment.attachmentSize}"/>
+						<h:outputText
+								value="#{PrivateMessagesTool.getAttachmentReadableSize(eachAttach.attachment.attachmentSize)}"/>
 					</h:column>
 					<h:column rendered="#{!empty PrivateMessagesTool.attachments}">
 					  <f:facet name="header">

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -1320,7 +1320,7 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
         }
 
 
-        getHibernateTemplate().saveOrUpdate(message);
+        getHibernateTemplate().merge(message);
 
         if (logEvent && !isMessageFromForums(message)) { // Forums handles events itself
         	if (isNew) {


### PR DESCRIPTION
Commit to allow the deletion of attachments in private messages that were previously saved. 
Minor fix to display file type icon with a proper size.
Minor fix to display the attachment size in a readable way