### PR TITLE
SAK-42174 Switch, Gradebookng, Site, Reset-pass: implemented new banner classes

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/AccessDeniedPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/AccessDeniedPage.html
@@ -4,7 +4,7 @@
 <body>
 <wicket:extend>
   
-	<div wicket:id="message" class="messageInformation"></div>
+	<div wicket:id="message" class="sak-banner-info"></div>
 
 </wicket:extend>
 </body>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.html
@@ -5,10 +5,10 @@
 
 <wicket:extend>
   <form wicket:id="form" id="gradebookSpreadsheet">
-    <div id="gbConnectionTimeoutFeedback" class="messageWarning" style="display:none;">
+    <div id="gbConnectionTimeoutFeedback" class="sak-banner-warn" style="display:none;">
         <wicket:message key="feedback.connectiontimeout" />
     </div>
-    <div id="gbReorderColumnsFailed" class="messageWarning" style="display:none;">
+    <div id="gbReorderColumnsFailed" class="sak-banner-warn" style="display:none;">
         <wicket:message key="feedback.reordercolumnsfailed" />
     </div>
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/DeleteItemPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/DeleteItemPanel.html
@@ -6,7 +6,7 @@
 
 		<form class="form-vertical" wicket:id="form">
 
-			<p class="alert alert-warning" role="alert"><wicket:message key="delete.warning"></wicket:message></p>
+			<p class="sak-banner-warn" role="alert"><wicket:message key="delete.warning"></wicket:message></p>
 
 			<div class="act">
 				<input type="submit" wicket:id="submit" class="active" wicket:message="value:button.deleteitem" />

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.html
@@ -31,7 +31,7 @@
 
 				<div class="form-group" wicket:id="courseGradeType">
 				
-					<p class="messageError" wicket:id="minimumOptions">minimum options message</p>
+					<p class="sak-banner-error" wicket:id="minimumOptions">minimum options message</p>
 					
 					<div class="col-sm-offset-1 col-sm-20">
 						<div class="checkbox">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradingSchemaPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradingSchemaPanel.html
@@ -28,7 +28,7 @@
 							</div>
 							
 							<!--  message about duplicates -->
-							<div class="messageError" wicket:id="duplicateEntries">Duplicates found.</div>
+							<div class="sak-banner-error" wicket:id="duplicateEntries">Duplicates found.</div>
 						
 							<!--  schema table -->
 							<div wicket:id="schemaWrap">
@@ -60,7 +60,7 @@
 													
 							<!-- chart -->
 							<div>
-								<div wicket:id="noStudentsWithGradesMessage" class="messageInstruction">There are no students with grades</div>
+								<div wicket:id="noStudentsWithGradesMessage" class="sak-banner-info">There are no students with grades</div>
 								<canvas wicket:id="gradingSchemaChart" id="gradingSchemaChart"></canvas>
 							</div>
 			
@@ -81,8 +81,8 @@
 						</div>
 					</div>
 				</div>
-				<div class="messageWarning" wicket:id="modifiedSchema">Schema has been modified from default</div>
-				<div class="messageError" wicket:id="unsavedSchema">There are unsaved changes</div>
+				<div class="sak-banner-warn" wicket:id="modifiedSchema">Schema has been modified from default</div>
+				<div class="sak-banner-error" wicket:id="unsavedSchema">There are unsaved changes</div>
 				
 			</div>
 		</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.html
@@ -24,7 +24,7 @@
 
 			<div wicket:id="gradeSummaryTable"/>
 
-			<div wicket:id="noAssignments" class="messageInformation">
+			<div wicket:id="noAssignments" class="sak-banner-info">
 				<wicket:message key="no-assignments.label" />
 			</div>
 		</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -36,7 +36,7 @@
                             </div>
                         </div>
                         
-                       	<div class="messageWarning"><wicket:message key="importExport.export.advancedOption.warning" /></div>
+                       	<div class="sak-banner-warn"><wicket:message key="importExport.export.advancedOption.warning" /></div>
                        	
                         <div class="row">
                             <div class="col-sm-6">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.html
@@ -4,7 +4,7 @@
     <p><wicket:message key="importExport.confirmation.description" /></p>
 
     <div wicket:id="grades_update_container">
-    	<div class="sak-banner-info"><strong><wicket:message key="importExport.confirmation.update.heading" /></strong></div>
+    	<div class="sak-banner-info"><wicket:message key="importExport.confirmation.update.heading" /></div>
         <table class="table table-striped table-condensed grade_import_confirmation">
             <thead>
               <tr>
@@ -22,7 +22,7 @@
     </div>
 
     <div wicket:id="grades_create_container">
-   		<div class="sak-banner-info"><strong><wicket:message key="importExport.confirmation.create.heading" /></strong></div>
+   		<div class="sak-banner-info"><wicket:message key="importExport.confirmation.create.heading" /></div>
         <table class="table table-striped table-condensed grade_import_confirmation">
             <thead>
               <tr>
@@ -49,7 +49,7 @@
     
     <!--  TODO collapse these three containers -->
     <div wicket:id="grades_modify_container">
-   		<div class="sak-banner-info"><strong><wicket:message key="importExport.confirmation.modify.heading" /></strong></div>
+   		<div class="sak-banner-info"><wicket:message key="importExport.confirmation.modify.heading" /></div>
         <table class="table table-striped table-condensed grade_import_confirmation">
             <thead>
               <tr>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.html
@@ -4,7 +4,7 @@
     <p><wicket:message key="importExport.confirmation.description" /></p>
 
     <div wicket:id="grades_update_container">
-    	<div class="messageInformation"><strong><wicket:message key="importExport.confirmation.update.heading" /></strong></div>
+    	<div class="sak-banner-info"><strong><wicket:message key="importExport.confirmation.update.heading" /></strong></div>
         <table class="table table-striped table-condensed grade_import_confirmation">
             <thead>
               <tr>
@@ -22,7 +22,7 @@
     </div>
 
     <div wicket:id="grades_create_container">
-   		<div class="messageInformation"><strong><wicket:message key="importExport.confirmation.create.heading" /></strong></div>
+   		<div class="sak-banner-info"><strong><wicket:message key="importExport.confirmation.create.heading" /></strong></div>
         <table class="table table-striped table-condensed grade_import_confirmation">
             <thead>
               <tr>
@@ -49,7 +49,7 @@
     
     <!--  TODO collapse these three containers -->
     <div wicket:id="grades_modify_container">
-   		<div class="messageInformation"><strong><wicket:message key="importExport.confirmation.modify.heading" /></strong></div>
+   		<div class="sak-banner-info"><strong><wicket:message key="importExport.confirmation.modify.heading" /></strong></div>
         <table class="table table-striped table-condensed grade_import_confirmation">
             <thead>
               <tr>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.html
@@ -34,7 +34,7 @@
                         </div>
                         <div id="unknownUsers" class="panel-collapse collapse" role="tabpanel" aria-labelledby="unknownUsersHeader">
                             <div class="panel-body">
-                                <p class="messageInformation">
+                                <p class="sak-banner-info">
                                     <wicket:message wicket:id="unknownUsersInfo">Grade entries for these students will not be imported.</wicket:message>
                                 </p>
                                 <ul id="unknownUsersContent">

--- a/reset-pass/account-validator-tool/src/webapp/component-templates/Messages.html
+++ b/reset-pass/account-validator-tool/src/webapp/component-templates/Messages.html
@@ -10,15 +10,15 @@
  <div rsf:id="rsf-messages:" style="display:inline" >
    <div rsf:id="error-messages:">
      
-       <span rsf:id="message:"><span rsf:id="payload-component" class="alertMessage">Error message for user here</span></span>
-       <span rsf:id="message:"><span rsf:id="payload-component" class="alertMessage">Second message here</span></span>
+       <span rsf:id="message:"><span rsf:id="payload-component" class="sak-banner-error">Error message for user here</span></span>
+       <span rsf:id="message:"><span rsf:id="payload-component" class="sak-banner-error">Second message here</span></span>
     
    </div>
    <div rsf:id="info-messages:">
-       <span rsf:id="message:"><span rsf:id="payload-component" class="success">Information message for user here</span></span>
+       <span rsf:id="message:"><span rsf:id="payload-component" class="sak-banner-success">Information message for user here</span></span>
   </div>
    
-   <div rsf:id="confirm-messages:" class="messageComfirm">
+   <div rsf:id="confirm-messages:" class="sak-banner-warn">
      <ul>
        <li rsf:id="message:"><span rsf:id="payload-component">Confirm message for user here</span></li>
  	</ul>	

--- a/reset-pass/account-validator-tool/src/webapp/templates/transferMemberships.html
+++ b/reset-pass/account-validator-tool/src/webapp/templates/transferMemberships.html
@@ -40,7 +40,7 @@
 							<label><span rsf:id="msg=password">Password</span><span class="reqStar">*</span></label>
 							<input id="password" type="password" class="inputBox required" rsf:id="password" autocomplete="off" name="userpass" onfocus="VALIDATOR.checkTransferStatus();" onkeyup="VALIDATOR.checkTransferStatus();" oninput="VALIDATOR.checkTransferStatus();" required="required"/>
 						</div>
-						<p id="validate.loginexisting" rsf:id="validate.loginexisting" class="messageValidation">Discard the account...</p>
+						<p id="validate.loginexisting" rsf:id="validate.loginexisting" class="sak-banner-warn">Discard the account...</p>
 						<div id="transferMembershipsDiv">
 							<input id="transferMemberships" rsf:id="transferMemberships" class="submit" type="submit" onclick="VALIDATOR.doTransferMemberships(); return false;" value="Transfer Memberships"/>
 						</div>

--- a/reset-pass/reset-pass/src/webapp/content/templates/form.html
+++ b/reset-pass/reset-pass/src/webapp/content/templates/form.html
@@ -12,7 +12,7 @@
 <h3 rsf:id="msg=mainTitle">reset your password</h3>
 
 	<div rsf:id="error-row:">
-		<div class="alertMessage" rsf:id="error">We Have Errors!</div>
+		<div class="sak-banner-error" rsf:id="error">We Have Errors!</div>
 		</div>
 		<p rsf:id="main">Some</p>
 		<p rsf:id="instructions">If you are a UCT student, please use the <a href="http://password.uct.ac.za" target="_blank">password self service tool</a> or visit a computer lab on campus to have your account reset. If you are a staff member, please log a call with the <a href="http://www.icts.uct.ac.za/modules.php?name=blocks" target="_blank">ICTS helpdesk.</a></p>

--- a/site/admin-perms-tool/src/main/webapp/WEB-INF/jsp/sitePerms.jsp
+++ b/site/admin-perms-tool/src/main/webapp/WEB-INF/jsp/sitePerms.jsp
@@ -28,7 +28,7 @@
 
 <div class="permsMessages">
   <c:if test="${not empty(messages)}">
-  <div class="messageInformation">
+  <div class="sak-banner-info">
       <c:forEach var="message" items="${messages}" varStatus="counter">
       <ul style="margin:0px;">
           <li>${message}</li>
@@ -37,7 +37,7 @@
   </div>
   </c:if>
   <c:if test="${not empty(errors)}">
-  <div class="messageError">
+  <div class="sak-banner-error">
       <c:forEach var="message" items="${errors}" varStatus="counter">
       <ul style="margin:0px;">
           <li>${message}</li>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -21,7 +21,7 @@
 </div>
 <div th:fragment="loadBundlesFromDb (enabled)">
   <div th:unless="${enabled}">
-    <div class="alert alert-warning" role="alert" th:text="#{common.warning}">
+    <div class="sak-banner-warn" role="alert" th:text="#{common.warning}">
       Message bundle editing is not activated, please see your Administrator.
     </div>
     <p></p>
@@ -29,7 +29,7 @@
 </div>
 <div th:fragment="admin (admin)">
   <div th:unless="${admin}">
-    <div class="alert alert-danger" role="alert" th:text="#{common.danger}">
+    <div class="sak-banner-error" role="alert" th:text="#{common.danger}">
       You must be an admin to use this tool, please see your Administrator.
     </div>
     <p></p>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/modules.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/modules.html
@@ -21,7 +21,7 @@
       </form>
       <div th:switch="${ #lists.isEmpty(properties) }">
         <div th:case="true">
-          <div class="alert alert-info" role="alert" th:text="#{modules.info}">Please select a module and a locale from the drop down lists above, and then click Filter.</div>
+          <div class="sak-banner-info" role="alert" th:text="#{modules.info}">Please select a module and a locale from the drop down lists above, and then click Filter.</div>
         </div>
         <div th:case="false">
           <table id="modulesTable" class="table table-striped table-bordered dataTable">

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/search.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/search.html
@@ -19,7 +19,7 @@
       </form>
       <div th:switch="${ #lists.isEmpty(properties) }">
         <div th:case="true">
-          <div class="alert alert-info" role="alert" th:text="#{search.entertext}">Please enter the text to search for in the provided field.</div>
+          <div class="sak-banner-info" role="alert" th:text="#{search.entertext}">Please enter the text to search for in the provided field.</div>
         </div>
         <div th:case="false">
           <table id="searchTable" class="table table-striped table-bordered dataTable">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42174

Replaced various banners (info, success, warn, error) in **gradebook**, **site**, **reset-pass**, with new banners created for SWITCH in SAK-41866. Also removed some unnecessary inline styles around/attached to these banners.