### PR TITLE
SAK-42184 Switch, announcements, admin-tools: implemented new banner classes 

### DIFF
--- a/admin-tools/src/webapp/vm/aliases/chef_aliases_confirm_remove.vm
+++ b/admin-tools/src/webapp/vm/aliases/chef_aliases_confirm_remove.vm
@@ -6,8 +6,8 @@
 	<h3>
 	$tlang.getString("alias.remove")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("alias.lert") $validator.escapeHtml($alertMessage)</div>#end
-	<div class="alertMessage">
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("alias.alert.message") $validator.escapeHtml($alertMessage)</div>#end
+	<div class="sak-banner-warn">
 		$tlang.getString("alias.remove.sure")
 	</div>
 	<table class="listHier" cellspacing="0" summary ="$tlang.getString("alias.remove.list.summary")">

--- a/admin-tools/src/webapp/vm/aliases/chef_aliases_edit.vm
+++ b/admin-tools/src/webapp/vm/aliases/chef_aliases_edit.vm
@@ -10,7 +10,7 @@
 			<h3>
 				$tlang.getString("alias.alias")
 			</h3>	
-		#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("alias.alert.message", $validator.escapeHtml($alertMessage))</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("alias.alert.message", $validator.escapeHtml($alertMessage))</div>#end
 			<div class="instruction">
 				$tlang.getString("alias.edit.review")
 			</div>

--- a/admin-tools/src/webapp/vm/aliases/chef_aliases_list.vm
+++ b/admin-tools/src/webapp/vm/aliases/chef_aliases_list.vm
@@ -6,7 +6,7 @@
 	<h3>
 		$tlang.getString("alias.aliases")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("alias.list.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("alias.alert.message") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("alias.list.defined")
 	</div>

--- a/admin-tools/src/webapp/vm/archive/chef_archive-batch-archive-confirm.vm
+++ b/admin-tools/src/webapp/vm/archive/chef_archive-batch-archive-confirm.vm
@@ -20,7 +20,7 @@ ul.sitelist li {
 		$tlang.getString("archive.batch.term.heading.confirm")
 	</h3>
 	
-	#if ($alertMessage)<br /><div class="alertMessage">$alertMessage</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$alertMessage</div>#end
 	
 	<p>$confirmString</p>
 	<ul class="sitelist">

--- a/admin-tools/src/webapp/vm/archive/chef_archive-batch.vm
+++ b/admin-tools/src/webapp/vm/archive/chef_archive-batch.vm
@@ -10,7 +10,7 @@
 		$tlang.getString("archive.vm.archive.batch")
 	</h3>
 	
-	#if ($alertMessage)<br /><div class="alertMessage">$alertMessage</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$alertMessage</div>#end
 	
 	<h4>$tlang.getString("archive.vm.export.term")</h4>
 		

--- a/admin-tools/src/webapp/vm/archive/chef_archive.vm
+++ b/admin-tools/src/webapp/vm/archive/chef_archive.vm
@@ -8,7 +8,7 @@
 	<h3>
 		$tlang.getString("archive.vm.archive.single")
 	</h3>
-	#if ($alertMessage)<br /><div class="alertMessage">$tlang.getString("archive.vm.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("archive.vm.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<form action="#toolForm("$action")" method="post">
 		
 		<h4>$tlang.getString("archive.vm.export")</h4>

--- a/admin-tools/src/webapp/vm/authz-helper/chef_permissions-Main.vm
+++ b/admin-tools/src/webapp/vm/authz-helper/chef_permissions-Main.vm
@@ -9,14 +9,13 @@
 	<h3>
 		$thelp.getString("per.lis.title")
 	</h3>
-		<div class="alertMessage">
+		<div class="sak-banner-error">
 			$thelp.getString("gen.alert")
 			## We do fallback message here so there is no chance of it not being set.
 			#if ($alertMessage) $validator.escapeHtml($alertMessage)
 			#else $thelp.getString("alert.prbset")
 			#end
 		</div>
-		<div class="clear"></div>
 
 	<form name= "permissionForm" action="#toolForm("$action")" method="post">
 		<div class="act">

--- a/admin-tools/src/webapp/vm/authz-helper/chef_permissions.vm
+++ b/admin-tools/src/webapp/vm/authz-helper/chef_permissions.vm
@@ -9,7 +9,7 @@
 	<h3>
 		$thelp.getString("per.lis.title")
 	</h3>
-		#if ($alertMessage)<div class="alertMessage">$thelp.getString("gen.alert") $validator.escapeHtml($alertMessage)</div><div class="clear"></div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$thelp.getString("gen.alert") $validator.escapeHtml($alertMessage)</div>#end
 
 	<div class="instruction">
 		$validator.escapeHtml($!description)
@@ -106,7 +106,7 @@
 						<input type="submit" name="eventSubmit_doCancel" value="$thelp.getString("gen.can")" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );" />
 					</div>
 			#else
-				<div class="alertMessage">$thelp.getString("per.alert")</div>
+				<div class="sak-banner-error">$thelp.getString("per.alert")</div>
 				<div class="act">
 					<input type="submit" name="eventSubmit_doCancel" value="$thelp.getString("gen.don")" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );" />
 				</div>

--- a/admin-tools/src/webapp/vm/authz/chef_realms_confirm_remove.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_confirm_remove.vm
@@ -4,9 +4,9 @@
 	<h3>
 		$tlang.getString("realm.confirm.removing")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("realm.confirm.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-warn">$tlang.getString("realm.confirm.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<form action="#toolForm("$action")" method="post">
-		<div class="alertMessage">$tlang.getString("realm.confirm.please")</div>
+		<div class="sak-banner-warn">$tlang.getString("realm.confirm.please")</div>
 		<div class="indnt2">
 			$validator.escapeHtml($realm.Id) <br />
 			$tlang.getString("realm.confirm.usedfor") $validator.escapeHtml($realm.Description)

--- a/admin-tools/src/webapp/vm/authz/chef_realms_edit.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_edit.vm
@@ -10,7 +10,7 @@
 	<h3>
 		$tlang.getString("realm.edit.edit") $validator.escapeHtml($!realm.Id)
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("realm.edit.alert") $validator.escapeHtml($alertMessage)</div>#end	
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("realm.edit.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("realm.edit.used") $validator.escapeHtml($!realm.Description): $tlang.getString("realm.edit.review")
 	</div>

--- a/admin-tools/src/webapp/vm/authz/chef_realms_edit_role.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_edit_role.vm
@@ -12,7 +12,7 @@
 	<h3>
 		$tlang.getString("realm.role.set")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("realm.role.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("realm.role.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<p class="instruction">	
 		$tlang.getString("realm.role.edit")
 		$validator.escapeHtml($!realm.Id)

--- a/admin-tools/src/webapp/vm/authz/chef_realms_edit_user.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_edit_user.vm
@@ -10,7 +10,7 @@
 		<h3>
 			$tlang.getString("realm.user.edit") $validator.escapeHtml($!realm.Id)
 		</h3>
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("realm.user.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("realm.user.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<p class="instruction">$tlang.getString("realm.user.used") $validator.escapeHtml($!realm.Description)</p>
 		
 		<p class="instruction">

--- a/admin-tools/src/webapp/vm/authz/chef_realms_list.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_list.vm
@@ -7,7 +7,7 @@
 #if($menu)
 	#toolbar($menu)
 #end
-			#if ($alertMessage)<div class="alertMessage">$tlang.getString("realm.list.alert") $validator.escapeHtml($alertMessage)</div>#end
+			#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("realm.list.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<div class="instruction clear">
 			$tlang.getString("realm.list.these")
 		</div>

--- a/admin-tools/src/webapp/vm/authz/chef_realms_saveas.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_saveas.vm
@@ -7,7 +7,7 @@
 	<h3>
 		$tlang.getString("reasav.savas")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("reasav.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("reasav.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("reasav.entnew")
 	</div>

--- a/admin-tools/src/webapp/vm/authz/chef_realms_saveas_role.vm
+++ b/admin-tools/src/webapp/vm/authz/chef_realms_saveas_role.vm
@@ -8,7 +8,7 @@
 		$tlang.getString("reasavrol.coprol")
 	</h3>
 
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("reasavrol.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("reasavrol.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("reasavrol.entanew")
 	</div>

--- a/admin-tools/src/webapp/vm/memory/chef_memory.vm
+++ b/admin-tools/src/webapp/vm/memory/chef_memory.vm
@@ -3,7 +3,7 @@
 	#if($menu)#menu($menu)#end
 	<h3>$tlang.getString("memory.vm.memory")</h3>
 		#if ($alertMessage)
-			<div class="alertMessage">
+			<div class="sak-banner-error">
 				$tlang.getFormattedMessage("memory.vm.alert.nosplit", $validator.escapeHtml($alertMessage))
 			</div>
 		#end

--- a/admin-tools/src/webapp/vm/sites/chef_sites_confirm_remove.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_confirm_remove.vm
@@ -4,9 +4,9 @@
 		$tlang.getString("sitconrem.remvi")
 	</h3>
 
-	#if ($alertMessage)<div class="alertMessage">$tlang.getSting("sitconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getSting("sitconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<form action="#toolForm("$action")" method="post">
-		<div class="alertMessage">$tlang.getString("sitconrem.plecon")</div>
+		<div class="sak-banner-error">$tlang.getString("sitconrem.plecon")</div>
 		<div class="indnt3">
 			$validator.escapeHtml($site.Title) ($validator.escapeHtml($site.Id))
 		</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_edit.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_edit.vm
@@ -11,7 +11,7 @@
 	<h3>
 		$tlang.getString("sitedi.edisit") $!site.Id
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("sitedi.revandmod")
 	</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_edit_group.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_edit_group.vm
@@ -12,7 +12,7 @@
 		<h3>
 			$tlang.getString("sitedigrp.edisit") $!site.Id / $tlang.getString("sitedigrp.grp") $!group.Id
 		</h3>
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitedigrp.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitedigrp.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<div class="instruction">
 			$tlang.getString("sitedigrp.revandmod")
 		</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_edit_page.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_edit_page.vm
@@ -12,7 +12,7 @@
 		<h3>
 			$tlang.getString("sitedipag.edisit") $!site.Id / $tlang.getString("sitedipag.pag") $!page.Id
 		</h3>
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitedipag.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitedipag.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<div class="instruction">
 			$tlang.getString("sitedipag.revandmod")
 		</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_edit_tool.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_edit_tool.vm
@@ -11,7 +11,7 @@
 	<h3>
 		$tlang.getString("siteditoo.edisit")  $!site.Id / $tlang.getString("siteditoo.pag") $!page.Id / $tlang.getString("siteditoo.too") $!tool.Id
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("siteditoo.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("siteditoo.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("siteditoo.revandmod")
 	</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_groups.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_groups.vm
@@ -7,7 +7,7 @@
 		<h3>
 			$tlang.getString("sitgrp.edisit") $!site.Id
 		</h3>
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitgrp.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitgrp.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<div class="instruction"> 
 			$tlang.getString("sitgrp.theare")
 		</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_list.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_list.vm
@@ -9,7 +9,7 @@
 	<h3>
 		$tlang.getString("sitlis.sites")
 	</h3>	
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitlis.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitlis.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<div class="instruction">
 			$tlang.getString("sitlis.theare") 
 		</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_page_properties.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_page_properties.vm
@@ -7,7 +7,7 @@
 	#if($menu)
 		#toolbar($menu)
 	#end
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<h3>
 		$tlang.getString("pagedi.edisit") $!page.Id
 	</h3>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_pages.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_pages.vm
@@ -8,7 +8,7 @@
 		<h4>
 			$tlang.getString("sitpag.edisit") $!site.Id
 		</h4>
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitpag.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitpag.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<div class="instruction">
 			$tlang.getString("sitpag.theare")
 		</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_properties.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_properties.vm
@@ -7,7 +7,7 @@
 	#if($menu)
 		#toolbar($menu)
 	#end
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<h3>
 		$tlang.getString("sitedi.edisit") $!site.Id
 	</h3>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_saveas.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_saveas.vm
@@ -6,7 +6,7 @@
 	<h3>
 		$tlang.getString("sitsav.savas")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitsav.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitsav.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<div class="instruction">
 		$tlang.getString("sitsav.entnew")
 	</div>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_tool_properties.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_tool_properties.vm
@@ -7,7 +7,7 @@
 	#if($menu)
 		#toolbar($menu)
 	#end
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sitedi.alert") $validator.escapeHtml($alertMessage)</div>#end
 	<h3>
 		$tlang.getString("tooldi.edisit") $!tool.Id
 	</h3>

--- a/admin-tools/src/webapp/vm/sites/chef_sites_tools.vm
+++ b/admin-tools/src/webapp/vm/sites/chef_sites_tools.vm
@@ -8,7 +8,7 @@
 		<h3>
 			$tlang.getString("sittoo.edisit") $!site.Id / $tlang.getString("sittoo.pag") $!page.Id
 		</h3>
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("sittoo.alert") $validator.escapeHtml($alertMessage)</div>#end		
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("sittoo.alert") $validator.escapeHtml($alertMessage)</div>#end
 #if ($tools.size() > 0)
 	<div class="instruction">
 		$tlang.getString("sittoo.theare")

--- a/admin-tools/src/webapp/vm/user/chef_users_confirm_remove.vm
+++ b/admin-tools/src/webapp/vm/user/chef_users_confirm_remove.vm
@@ -8,8 +8,8 @@
 	<h3>	$tlang.getString("useact.remuse")
 </h3>	
 
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
-		<div class="alertMessage">
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
+		<div class="sak-banner-error">
 			$permDelWarning
 		</div>
 		<table class="listHier" cellspacing="0" summary ="$tlang.getString("useact.remuse.list.summary")">

--- a/admin-tools/src/webapp/vm/user/chef_users_create.vm
+++ b/admin-tools/src/webapp/vm/user/chef_users_create.vm
@@ -13,13 +13,13 @@ ${includeLatestJQuery}
 	#toolbar($menu)
 #end
 
-	#if ($successMessage)<span class="success">$successMessage</span>#end
+	#if ($successMessage)<span class="sak-banner-success">$successMessage</span>#end
 
 	<h3>
 		$tlang.getString("usecre.entthe")
 	</h3>
 
-	#if ($alertMessage)<div class="alertMessage">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end	
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
 
 	<form name="user-create_edit" id="user-create_edit" action="#toolForm("$action")" method="post" autocomplete="on">
 		<fieldset>

--- a/admin-tools/src/webapp/vm/user/chef_users_edit.vm
+++ b/admin-tools/src/webapp/vm/user/chef_users_edit.vm
@@ -46,7 +46,7 @@ function removeOptionalAttributeBlock(elem) {
 			$tlang.getString("useedi.revandmod")
 		</h3>
 		
-		#if ($alertMessage)<div class="alertMessage" id="alertMsg">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error" id="alertMsg">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
 		<form name="$form-name" id="useredit" action="#toolForm("$action")" method="post" autocomplete="on">
 			<fieldset>
 				<legend>

--- a/admin-tools/src/webapp/vm/user/chef_users_import.vm
+++ b/admin-tools/src/webapp/vm/user/chef_users_import.vm
@@ -9,7 +9,7 @@
 			$tlang.getString("import.heading")
 		</h3>
 		#if ($alertMessage)
-			<div class="alertMessage">
+			<div class="sak-banner-error">
 				$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)
 			</div>
 		#end

--- a/admin-tools/src/webapp/vm/user/chef_users_list.vm
+++ b/admin-tools/src/webapp/vm/user/chef_users_list.vm
@@ -11,8 +11,8 @@
 		$tlang.getString("uselis.users")
 	</h3>
 
-		#if ($alertMessage)<div class="alertMessage">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
-		#if ($successMessage)<div class="success">$validator.escapeHtml($successMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)</div>#end
+		#if ($successMessage)<div class="sak-banner-success">$validator.escapeHtml($successMessage)</div>#end
 		<div class="instruction">
 			$tlang.getString("uselis.theare")
 		</div>

--- a/admin-tools/src/webapp/vm/user/chef_users_view.vm
+++ b/admin-tools/src/webapp/vm/user/chef_users_view.vm
@@ -11,7 +11,7 @@
 			$tlang.getString("usevie.revandmod")
 		</h3>
 		#if ($alertMessage)
-			<div class="alertMessage">
+			<div class="sak-banner-error">
 				$tlang.getString("useconrem.alert") $validator.escapeHtml($alertMessage)
 			</div>
 		#end

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-customize.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-customize.vm
@@ -21,7 +21,7 @@
 
 	<div class="page-header"><h3>$tlang.getString("custom.options")</h3></div>
 
-	#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 	<p class="instruction indnt2">
 		#if ($toolId == "sakai.announcements")
 			$tlang.getString("custom.setoptions")

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-delete.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-delete.vm
@@ -15,8 +15,8 @@
 	<h3>
 		$tlang.getString("del.deleting")
 	</h3>
-	#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
-	<div class="alertMessage">$tlang.getString("del.areyou")</div>
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
+	<div class="sak-banner-error">$tlang.getString("del.areyou")</div>
 	<form name="forNotLetDeleteSelectedOnLoad"></form>
 		<div class="table-responsive">
 			<table class="table table-bordered table-striped table-hover" cellspacing="0">

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-delete.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-delete.vm
@@ -16,7 +16,7 @@
 		$tlang.getString("del.deleting")
 	</h3>
 	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
-	<div class="sak-banner-error">$tlang.getString("del.areyou")</div>
+	<div class="sak-banner-warn">$tlang.getString("del.areyou")</div>
 	<form name="forNotLetDeleteSelectedOnLoad"></form>
 		<div class="table-responsive">
 			<table class="table table-bordered table-striped table-hover" cellspacing="0">

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-merge.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-merge.vm
@@ -17,7 +17,7 @@
 	<div class="page-header"><h3>$tlang.getString("merge.show")</h3></div>
 
 	<form name="Options" action="#toolForm("$action")" method="post">
-		#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 		<p class="instruction">
 			$tlang.getString("merge.select")
 		</p>

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-metadata.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-metadata.vm
@@ -12,7 +12,7 @@
 		#toolbar($menu)
 	#end
 
-	#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 	
 	<div class="page-header">
 	  <h2>$validator.escapeHtml($message.Header.subject)</h2>

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-preview.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-preview.vm
@@ -3,7 +3,7 @@
 	<h3>
 		$tlang.getString("pre.preview")
 	</h3>	
-	#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 	<table cellspacing="0" class="itemSummary indnt1" summary="">
 		<tr>
 			<th>$tlang.getString("gen.subject")</th>

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
@@ -13,7 +13,7 @@
 	#end
 	<div class="page-header"><h3>$tlang.getString("reorder.title")</h3></div>
  	
-	#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 	<div class="navPanel">
 			<span class="instruction">
 				$tlang.getString('reorder.instruction.general')
@@ -34,7 +34,7 @@
 			</li>
 			<li style="display:inline;color:#000">
 				<span id="failedValidMessage" style="display:none">$tlang.getString('reorder.fail.valid.message')</span>
-				<span id="messageHolder" class="messageSuccess" style="display:none"> </span>
+				<span id="messageHolder" class="sak-banner-success-inline" style="display:none"> </span>
 			</li>
 		</ul>	
 		<span id="lastMoveArray" style="display:none"></span >

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
@@ -79,7 +79,7 @@ function resizeFrame(){
 		</h3>
 	</div>
 	
-	#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+	#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 		
 		<p class="instruction">
 				#if ( $newAnn =="true")

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -77,7 +77,7 @@
 		  <h3>$tlang.getString("gen.announcements") <br /><small>$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</small></h3>
 		</div>
 
-		#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+		#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 ##		#if ($messageListVector.iterator().hasNext())
 		<div class="navPanel">
 			<div class="viewNav">
@@ -353,7 +353,7 @@
 		#if ($toolId == "sakai.synoptic.announcement") 
 		##in home portlet  - so reduce display to title, attach marker, body (if selected), author and date
 
-			#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+			#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 
 			<div class="page-header">
 			  <h3>$tlang.getString("gen.announcements") <br /><small>$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</small></h3>
@@ -423,7 +423,7 @@
 					  <h3>$tlang.getString("gen.announcements") <br /><small>$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</small></h3>
 					</div>
 
-					#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+					#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 
 					<div class="sakai-table-toolBar">
 						<div class="sakai-table-filterContainer">
@@ -676,7 +676,7 @@
 				#else
 					## <h3>$tlang.getString("gen.announcements")</h3>
 					<h3>$tlang.getString("gen.announcements") <span class="textPanelFooter">$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</span></h3>
-					#if ($alertMessage)<div class="alertMessage">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div><div class="clear"></div>#end
+					#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end
 
 						#if (!$messageListVector.iterator().hasNext())
 							<p class="instruction">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42184

Replaced various banners (info, success, warn, error) in announcements and admin-tools, with new banners created for SWITCH in SAK-41866. Also removed some unnecessary inline styles around/attached to these banners.

