### PR TITLE
SAK-42197 - Webjars: Upgrade Elfinder from 2.1.48 to 2.1.49

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -159,7 +159,7 @@
 		<dependency>
 			<groupId>org.webjars.bower</groupId>
 			<artifactId>elfinder</artifactId>
-			<version>2.1.48</version>
+			<version>2.1.49</version>
 			<scope>runtime</scope>
 			<exclusions>
 				<!-- The exclusions are because the bower versions don't have concat/min versions -->

--- a/library/src/webapp/editor/elfinder/sakai/elfinder.html
+++ b/library/src/webapp/editor/elfinder/sakai/elfinder.html
@@ -9,8 +9,8 @@
     <script src="/library/webjars/jquery-ui/1.12.1/jquery-ui.min.js"></script>
 
   <!-- elFinder CSS (REQUIRED) -->
-  <link rel="stylesheet" type="text/css" href="/library/webjars/elfinder/2.1.48/css/elfinder.min.css">
-  <link rel="stylesheet" type="text/css" href="/library/webjars/elfinder/2.1.48/css/theme.css">
+  <link rel="stylesheet" type="text/css" href="/library/webjars/elfinder/2.1.49/css/elfinder.min.css">
+  <link rel="stylesheet" type="text/css" href="/library/webjars/elfinder/2.1.49/css/theme.css">
 
   <!-- Moono Theme CSS -->
   <link rel="stylesheet" href="/library/webjars/fontawesome/4.7.0/css/font-awesome.min.css">
@@ -20,7 +20,7 @@
   <link rel="stylesheet" type="text/css" href="css/sakai-11/theme.css">
 
   <!-- elFinder JS (REQUIRED) -->
-  <script src="/library/webjars/elfinder/2.1.48/js/elfinder.min.js"></script>
+  <script src="/library/webjars/elfinder/2.1.49/js/elfinder.min.js"></script>
 
   <!-- elFinder initialization (REQUIRED) -->
   <!-- Some initialization for Sakai-specific config is done first -->


### PR DESCRIPTION
I've requested a deployment in webjars, it may take a while to have this dependency in maven central.