### PR TITLE
SAK-42205 - Webjars: Upgrade CKEDITOR from 4.11.4 to 4.12.1

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>war</packaging>
 	<properties>
 		<!-- This is used in re-write rules as well -->
-		<ckeditor.version>4.11.4</ckeditor.version>
+		<ckeditor.version>4.12.1</ckeditor.version>
 		<bootstrap-version>3.3.7</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<!-- Default extra plugins enabled -->

--- a/library/src/morpheus-master/sass/modules/editor/_base.scss
+++ b/library/src/morpheus-master/sass/modules/editor/_base.scss
@@ -2,7 +2,7 @@
 .cke {
 	.cke_button__sakaipreview {
 		.cke_button__sakaipreview_icon {
-			background: url(/library/webjars/ckeditor/4.11.4/full/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1632px !important;
+			background: url(/library/webjars/ckeditor/4.12.1/full/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1632px !important;
 			background-size: 16px !important;
 		}
 	}

--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -796,7 +796,7 @@ function includeWebjarLibrary(library) {
 		libraryVersion = "1.10.19";
 		document.write('\x3Cscript type="text/javascript" src="' + webjars + 'datatables/' + libraryVersion + '/js/jquery.dataTables.min.js' + ver + '">' + '\x3C/script>');
 	} else if (library == 'ckeditor') {
-		libraryVersion = "4.11.4";
+		libraryVersion = "4.12.1";
 		document.write('\x3Cscript type="text/javascript" src="' + webjars + 'ckeditor/' + libraryVersion + '/full/ckeditor.js' + ver + '">' + '\x3C/script>');
 	} else if (library == 'awesomplete') {
 		libraryVersion = "1.1.4";

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
@@ -36,8 +36,8 @@ public class EditorRegistryImpl implements EditorRegistry {
 		//TODO: pull this out to somewhere appropriate
 		register("textarea", "textarea", "/library/editor/textarea/textarea.js", "/library/editor/textarea.launch.js", "");
 		register("fckeditor", "FCKeditor", "/library/editor/FCKeditor/fckeditor.js", "/library/editor/fckeditor.launch.js", "");
-		register("ckeditor", "CKEditor", "/library/webjars/ckeditor/4.11.4/full/ckeditor.js", "/library/editor/ckeditor.launch.js",
-				"var CKEDITOR_BASEPATH='/library/webjars/ckeditor/4.11.4/full/';\n");
+		register("ckeditor", "CKEditor", "/library/webjars/ckeditor/4.12.1/full/ckeditor.js", "/library/editor/ckeditor.launch.js",
+				"var CKEDITOR_BASEPATH='/library/webjars/ckeditor/4.12.1/full/';\n");
 	}
 	
 	public void destroy() {


### PR DESCRIPTION
This PR should be broken because 4.12.1 is not populated in maven central yet.