### PR TITLE
SAK-41980 Portal changed SkipNav link for sites menu

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/skipNav-snippet.vm
@@ -16,7 +16,7 @@
             </a>
         </li>
         <li class="Mrphs-skipNav__menuitem Mrphs-skipNav__menuitem--worksite">
-            <a href="#txtSearch" id="more-sites-menu" class="Mrphs-skipNav__link js-toggle-sites-nav" title="${rloader.sit_jumpworksite}" accesskey="w">
+            <a href="#" id="more-sites-menu" class="Mrphs-skipNav__link js-toggle-sites-nav" title="${rloader.sit_jumpworksite}" accesskey="w">
                 <i class="fa fa-th all-sites-icon" aria-hidden="true"></i> ${rloader.sit_worksites}
                 <span class="accesibility_key">[w]</span>
             </a>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41980

My jira post has an explanation of the problem (tapping sites menu on mobile changes the page scroll and pulls up the keyboard, which disrupts the mobile experience) and a video demo.

I modified the `<a href="#txtSearch">` link so that the modal would pop up without affecting the scroll of the page and without focusing on the search box (which pulls up a keyboard). 