### PR TITLE
SAK-42230 - CKEDITOR: Upgrade wordcount plugin from 1.17.4 to 1.17.6

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -102,7 +102,7 @@
 
     <!-- These should only be updated when the webjars version is updated -->
     <ckeditor.autosave.version>0.18.1</ckeditor.autosave.version>
-    <ckeditor.wordcount.version>1.17.4</ckeditor.wordcount.version>
+    <ckeditor.wordcount.version>1.17.6</ckeditor.wordcount.version>
     <ckeditor.a11ychecker.version>1.1.1</ckeditor.a11ychecker.version>
     <ckeditor.balloonpanel.version>4.9.2</ckeditor.balloonpanel.version>
     <ckeditor.image2.version>4.11.1</ckeditor.image2.version>


### PR DESCRIPTION
The build should be broken because the dependency has not been populated to maven central, I've requested the population.