### PR TITLE
SAK-42231 - CKEDITOR IMAGE2 plugin. Update from 4.11.1 -> 4.12.1

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -105,7 +105,7 @@
     <ckeditor.wordcount.version>1.17.4</ckeditor.wordcount.version>
     <ckeditor.a11ychecker.version>1.1.1</ckeditor.a11ychecker.version>
     <ckeditor.balloonpanel.version>4.9.2</ckeditor.balloonpanel.version>
-    <ckeditor.image2.version>4.11.1</ckeditor.image2.version>
+    <ckeditor.image2.version>4.12.1</ckeditor.image2.version>
     
   </properties>
   <distributionManagement>


### PR DESCRIPTION
The build should be broken because the dependency has not been populated to maven central, I've requested the population.