### PR TITLE
SAK-42209 Don't show alert for non-electronic assignments

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -10406,9 +10406,6 @@ public class AssignmentAction extends PagedResourceActionII {
         // whether the user can access the Submission object
         if (s != null) {
             String status = assignmentService.getSubmissionStatus(s.getId());
-            if ("Not Started".equals(status) || (rb.getString("gen.notsta").equals(status))) {
-                addAlert(state, rb.getString("stuviewsubm.theclodat"));
-            }
 
             // show submission view unless group submission with group error
             Assignment a = s.getAssignment();

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -45,7 +45,7 @@ $(document).ready(function(){
 		#set($closeDate = $submission.CloseDate)
 	#end
 	#set ($submissionType = $assignment.TypeOfSubmission.ordinal())
-	#if ($allowSubmit && !$submission && $closeDate && $currentTime.isAfter($closeDate) )
+	#if ($allowSubmit && !$submission && $closeDate && $currentTime.isAfter($closeDate) && !$!nonElectronicType)
 		<div class="alertMessage">$tlang.getString("stuviewsubm.theclodat")</div><div class="clear"></div>
 	#end
 
@@ -442,7 +442,7 @@ $(document).ready(function(){
 		#if ($returned)
 			<h3>$tlang.getString("gen.resubmission")</h3> 
 		#else
-				<h3>$tlang.getString("gen.submission")</h3> 
+			<h3>$tlang.getString("gen.submission")</h3> 
 		#end	
 
 		#set($notes = [])


### PR DESCRIPTION
On AssignmentAction initially I was adding a non-electronic check, but finally I'm removing an alert because the message says "The close date of the assignment has passed. You can no longer submit..." but the conditions have nothing to do with the text.

I could handle it differenly if anyone thinks that message is still necessary in there.