### PR TITLE
SAK-42221 SAK-34741 Lombok doesn't like boolean fields starting with is

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemBean.java
@@ -103,7 +103,7 @@ public class ItemBean
   private int totalMCAsnwers;
   private CalculatedQuestionBean calculatedQuestion;
   @Getter @Setter
-  private boolean isExtraCredit;
+  private boolean extraCredit;
   
   private String requireAllOk = "false";
   private String imageMapSrc="";

--- a/samigo/samigo-app/src/webapp/jsf/author/inc/extraCreditSetting.jspf
+++ b/samigo/samigo-app/src/webapp/jsf/author/inc/extraCreditSetting.jspf
@@ -2,6 +2,6 @@
 <h:panelGroup styleClass="form-group row" layout="block">
     <h:outputLabel value="#{authorMessages.extra_credit}" for="extraCredit" styleClass="col-md-4 col-lg-2 form-control-label"/>
     <div class="col-md-2">
-        <h:selectBooleanCheckbox id="extraCredit" value="#{itemauthor.currentItem.isExtraCredit}" disabled="#{author.isEditPoolFlow}" />
+        <h:selectBooleanCheckbox id="extraCredit" value="#{itemauthor.currentItem.extraCredit}" disabled="#{author.isEditPoolFlow}" />
     </div>
 </h:panelGroup>


### PR DESCRIPTION
Getter for lombok automatically creates boolean accessor as isExtraCredit for
the field isExtraCredit instead of getIsExtraCredit or isIsExtraCredit.
When this is referenced in the template as .isExtraCredit it is not found because
neither getIsExtraCredit nor isIsExtraCredit exists. Changing the name of the
field in ItemBean to extraCredit allows Lombok to create the accessor isExtraCredit
which is then found when using .extraCredit in the template.