### PR TITLE
SAK-42315 Updated .instruction banner class to be visually simpler

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -28,6 +28,7 @@ $font-family-url: "https://fonts.googleapis.com/css?family=Open+Sans:400,500,700
 $font-family: "Open Sans",sans-serif;
 $default-font-size: 14px !default;
 $default-font-weight: 400 !default;										// 400 or 700 as you wish
+$default-font-size-small: 12px;
 $header-font-family: $font-family;
 $header-font-weight: 700 !default;										// 400 or 700 as you wish
 
@@ -136,6 +137,8 @@ $warn-background-color:     #F6ECB7 !default;
 $warn-color:                darken($warn-background-color, 35%) !default;
 $error-background-color:    #f2dede !default;
 $error-color:               darken($error-background-color, 30%) !default;
+$instruction-size:          $default-font-size-small;
+$instruction-color:         #555;
 
 /* Sakai Banners */
 // Information (info) banner

--- a/library/src/morpheus-master/sass/modules/tool/_menu.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_menu.scss
@@ -111,7 +111,8 @@
 }
 
 .instruction{
-	@include bs-callout($instruction-color, $instruction-background-color);
+	font-size: $instruction-size;
+	color: $instruction-color;
 }
 
 .listNav{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42315

The old .instruction class banner appears too often and too prominent. Now that the Sakai banners have been updated in SAK-41866, it is time to make .instruction more subtle.

See SAK-42315 for before and after screenshots.