### PR TITLE
SAK-42319 Fixed button spacing added from .act container in the Sakai table toolbar

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/_table.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_table.scss
@@ -166,6 +166,11 @@ table{
 		{
 			margin-right: $standard-space;
 		}
+		
+		&.act 
+		{
+			margin: 0;	// remove margins added with .act
+		}
 	}
 
 	.sakai-table-searchFilterControls
@@ -176,6 +181,11 @@ table{
 		input:last-of-type, button:last-of-type
 		{
 			margin-right: 0;
+		}
+		
+		&.act 
+		{
+			margin: 0;	// remove margins added with .act
 		}
 	}
 
@@ -190,6 +200,11 @@ table{
 
 		input[type=button], input[type=submit], button {
 			margin: 0 calc(#{$standard-spacing} / 2) $standard-spacing 0 !important;
+		}
+		
+		&.act 
+		{
+			margin: 0;	// remove margins added with .act
 		}
 	}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42319

Cases of the primary action button add using .act adds additional spacing around the buttons. This fix removes the addition spaces. 

See SAK-42319 for some before and after screenshots.