### PR TITLE
SAK-42346: Site Info > Manage Participants > Printable Version > NoSuchMethodError runtime exception

### DIFF
--- a/site-manage/site-manage-tool/tool/pom.xml
+++ b/site-manage/site-manage-tool/tool/pom.xml
@@ -93,6 +93,16 @@
             <artifactId>fop</artifactId>
             <version>1.0</version>
         </dependency>
+
+        <!-- This old version of xmlgraphics-commons is needed to support Manage Participants > Printable View.
+             With the newer (2.3) version (provided by master's pom.xml), you'll get a runtime NoSuchMethodError on org.apache.xmlgraphics.xmp.Metadata.mergeInto(Lorg/apache/xmlgraphics/xmp/Metadata;)V.
+             Until the code in SiteInfoToolServlet.generatePDF() is updated to use FOP v2.0+, this needs to stay here. -->
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>xmlgraphics-commons</artifactId>
+            <version>1.5</version>
+        </dependency>
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42346

When clicking on Site Info > Manage Participants > Printable version, the new tab that opens up displays a stack trace.

This was caused by a library upgrade done in [SAK-41909](https://jira.sakaiproject.org/browse/SAK-41909). Until we upgrade the code in `SiteInfoToolServlet.generatePDF()` to use a newer version of Apache FOP, we need the older version of `xmlgraphics-commons` (v1.5 versus 2.3).