### PR TITLE
SAK-41976 Removed the taborder override from Site Info's Short Description

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -216,7 +216,7 @@
 				</span>
 			</label>
 			<div class="col-sm-6">
-				<textarea  name="short_description" id="short_description" tabindex="2" rows="2" cols="45" onkeyup="LimitText(this,80)">$validator.escapeHtmlTextarea($!short_description)</textarea>
+				<textarea  name="short_description" id="short_description" rows="2" cols="45" onkeyup="LimitText(this,80)">$validator.escapeHtmlTextarea($!short_description)</textarea>
 			</div>
 		</div>	
 		## Skin & Site Icon ##


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41976

The tabindex="2" on the Short Description field caused tabbing jump over over the short description field. I've removed the unnecessary tabindex on Short Description, as suggested by Jen in SAK-41976.