### PR TITLE
SAK-42326 Increased the tool name's z-index to properly overlap Gradebook spreadsheet

### DIFF
--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -59,7 +59,7 @@ body.is-logged-out{
 								top: -1px;
 								bottom: -1px;
 								left: $tool-menu-width-collapsed;
-								z-index: 50;
+								z-index: 100;
 								width: auto;
 								border-radius: 0 5px 5px 0;
 								line-height: 40px;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42326

Increased the z-index for the tool name when you hover over the collapsed tool menu, so the tool names can be seen properly and overlap the Gradebook spreadsheet's elements.