### PR TITLE
SAK-42348 Announcement event  processing causing ArrayIndexOutOfBoundsException

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/AnnouncementObserver.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/AnnouncementObserver.java
@@ -41,13 +41,13 @@ public class AnnouncementObserver implements Observer {
         final String eventType = event.getEvent();
 
         if (eventType != null) {
-            String channelName = getChannel(event);
             switch(eventType) {
                 case AnnouncementService.SECURE_ANNC_ADD:
                 case AnnouncementService.SECURE_ANNC_UPDATE_ANY:
                 case AnnouncementService.SECURE_ANNC_UPDATE_OWN:
                 case AnnouncementService.SECURE_ANNC_REMOVE_ANY:
                 case AnnouncementService.SECURE_ANNC_REMOVE_OWN:
+                    String channelName = getChannel(event);
                     log.debug("Announcement event: {}", eventType);
                     messagesCache.remove(channelName);
                     break;


### PR DESCRIPTION
For non announcement events, this method should not be called