### PR TITLE
SAK-42343 Fix previous instructor comments not displaying

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -647,7 +647,7 @@ $(document).ready(function(){
 						#if ($!prevFeedbackText)
 							<h4 id="toggleInline" class="toggleAnchor"><img alt="expand" class="expand" src="/library/image/sakai/expand.gif" /><img alt="collapse" class="collapse" src="/library/image/sakai/collapse.gif" />$tlang.getString("gradingsub.prefeetex3")</h4>
 							<div class="toggledContent inlinecoms">
-								$cheffeedbackhelper.showPrevFeedback($cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackText))
+								$cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackText)
 							</div>
 						#end
 						#*#else
@@ -932,7 +932,7 @@ $(document).ready(function(){
 								$tlang.getString("gradingsub.prefee2")
 							</h4>
 					<div class="toggledContent gencoms">					
-						$cheffeedbackhelper.showPrevFeedback($cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackComment))</div>
+						$cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackComment)</div>
 					#end					
 					#parse ("/vm/assignment/chef_assignments_student_view_feedback_attachments.vm")
 					## show previous grading/feedback attachments if any
@@ -1053,7 +1053,7 @@ $(document).ready(function(){
 				#if ($!prevFeedbackText)
 					<h5>$tlang.getString("gradingsub.prefeetex")</h5>
 					<div class="textPanel">
-						$cheffeedbackhelper.showPrevFeedback($cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackText))
+						$cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackText)
 					</div>
 				#end
 				## submitted attachment
@@ -1106,7 +1106,7 @@ $(document).ready(function(){
 					## for returned submission, show the instructor feedback
 					#if ($!prevFeedbackComment && $!prevFeedbackComment.trim().length() > 0)
 						<h5>$tlang.getString("gradingsub.prefee")</h5>
-						<div class="textPanel">$cheffeedbackhelper.showPrevFeedback($cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackComment))</div>
+						<div class="textPanel">$cheffeedbackhelper.escapeAssignmentFeedback($!prevFeedbackComment)</div>
 					#end
 					#parse ("/vm/assignment/chef_assignments_student_view_feedback_attachments.vm")
 				#end


### PR DESCRIPTION
It seems that there is no longer a showPrevFeedback() method.  Removing the call seems to fix the issue and seems to have no ill side effects.