### PR TITLE
SAK-37996 & SAK-42387 - Add video files to the default inlines

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -623,6 +623,12 @@
 # DEFAULT: <!DOCTYPE html>
 #content.html.doctype=<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 
+# SAK-7638: Mime types for inline configuring inline content
+# In kernel, Validator.java -> letBrowserInline there's also some additional pre-configured mime types
+# These are the configured defaults
+# DEFAULT: video/mp4,video/webm,video/quicktime,audio/mpeg
+# content.mime.inline=video/mp4,video/quicktime,video/3gpp,video/x-ms-wmv,audio/mpeg,audio/wav,audio/x-wav
+
 # #######################################################################
 # CLOUD-CONTENT
 # #######################################################################
@@ -3795,7 +3801,7 @@
 
 # SAK-42105 Configure browser features for iframes
 # default: allow="autoplay;fullscreen;encypted-media;microphone 'self';camera 'self'"
-# browser.feature.allow.count=3
+# browser.feature.allow.count=5
 # browser.feature.allow.1=autoplay
 # browser.feature.allow.2=fullscreen
 # browser.feature.allow.3=encrypted-media

--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -311,3 +311,5 @@ browser.feature.allow.2=fullscreen *
 browser.feature.allow.3=encrypted-media *
 browser.feature.allow.4=camera 'self'
 browser.feature.allow.5=microphone 'self'
+
+content.mime.inline=video/mp4,video/webm,video/quicktime,audio/mpeg


### PR DESCRIPTION
@jesusmmp mentioned on SAK-37593 that this fixed it. I thought about hard coding this into the validator but some people may not want to override these video files and I also saw they weren't documented so figured I'd add these in there instead of validator.