### PR TITLE
SAK-42376 - Content Picker accessibility - cannot tab into app store

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -109,7 +109,7 @@
 		</form>
 
 		<div id="modal-iframe-div" style="display:none" tabindex="-1" role="dialog">
-			<iframe name="sakai-basiclti-admin-iframe" id="sakai-basiclti-admin-iframe" src="/library/image/sakai/spinner.gif"></iframe>
+			<iframe name="sakai-basiclti-admin-iframe" id="sakai-basiclti-admin-iframe" src="/library/image/sakai/spinner.gif" tabindex="0"></iframe>
 		</div>
 	</div>
 

--- a/library/src/webapp/editor/ckextraplugins/contentitem/plugin.js
+++ b/library/src/webapp/editor/ckextraplugins/contentitem/plugin.js
@@ -23,6 +23,8 @@ CKEDITOR.plugins.add( 'contentitem',
                     // Iframe loaded callback.
                     var iframe = document.getElementById( this._.frameId );
                     ContentItemIFrameWindow = iframe.contentWindow;
+                    this.getDialog().addFocusable(this.getElement(), 0);
+                    this.focus();
                     // console.log(ContentItemIFrameWindow);
                },
 


### PR DESCRIPTION
This doesn't entirely fix the issue mentioned on SAK-42376 as it fixes the content item picker tabbing into the app store, not Lessons. We can either add to this or create a second ticket. 