### PR TITLE
SAK-42418 Give sitestats /direct/runreport a siteID for system-wide reports

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsEntityProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsEntityProvider.java
@@ -149,7 +149,11 @@ public class SiteStatsEntityProvider extends AbstractEntityProvider implements A
         if (reportDef == null) {
             throw new EntityException("Report with id '" + reportId + "' doesn't exist.", "", HttpServletResponse.SC_BAD_REQUEST);
         }
-
+        
+        if (reportDef.getReportParams().getSiteId() == null || reportDef.getReportParams().getSiteId().length() == 0) {
+            reportDef.getReportParams().setSiteId(siteId);
+        }
+        
         Report report = reportManager.getReport(reportDef, true, null);
 
         List<StrippedStat> stripped = new ArrayList<StrippedStat>();

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsEntityProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsEntityProvider.java
@@ -152,7 +152,6 @@ public class SiteStatsEntityProvider extends AbstractEntityProvider implements A
         }
         
         // system-wide reports will not have siteID set, and will try to run across all sites--which is bad
-        //if (reportDef.getReportParams().getSiteId() == null || reportDef.getReportParams().getSiteId().length() == 0) {
         if (StringUtils.isBlank(reportDef.getReportParams().getSiteId())) {
             reportDef.getReportParams().setSiteId(siteId);
         }

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsEntityProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/SiteStatsEntityProvider.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.entitybroker.exception.EntityException;
 import org.sakaiproject.entitybroker.EntityView;
@@ -150,7 +151,9 @@ public class SiteStatsEntityProvider extends AbstractEntityProvider implements A
             throw new EntityException("Report with id '" + reportId + "' doesn't exist.", "", HttpServletResponse.SC_BAD_REQUEST);
         }
         
-        if (reportDef.getReportParams().getSiteId() == null || reportDef.getReportParams().getSiteId().length() == 0) {
+        // system-wide reports will not have siteID set, and will try to run across all sites--which is bad
+        //if (reportDef.getReportParams().getSiteId() == null || reportDef.getReportParams().getSiteId().length() == 0) {
+        if (StringUtils.isBlank(reportDef.getReportParams().getSiteId())) {
             reportDef.getReportParams().setSiteId(siteId);
         }
         


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42418

Set the siteID in the report params if it's null so it doesn't try to run the report across all sites.