### PR TITLE
SAK-41204 Dropzone 4.4.0 introduced a default timeout of 30 seconds on uploads.

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
@@ -181,6 +181,7 @@ Dropzone.options.fileUploader = {
     uploadMultiple: false,
     addRemoveLinks: true,
     maxFilesize: $uploadMaxSize, // MB
+    timeout: 0, // Dropzone 4.4.0 introduced a 30sec default timeout
     previewTemplate: document.getElementById('preview-template').innerHTML,
     dictFallbackMessage: "$tlang.getString("dragndrop.dictFallbackMessage")",
     dictFallbackText: "$tlang.getString("dragndrop.dictFallbackText")",


### PR DESCRIPTION
Override the default with previous behavior: unlimited timeout to upload.