### PR TITLE
SAK-42438 Upped timeout of dropzone.js uploads to 4 mins

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -535,6 +535,12 @@
 # The UI should show hidden as the default when uploading files
 # content.dnd.visibility.hidden=false
 
+# Upload timeout used by the dropzone.js component, where it defaults to 30 seconds. We're using 4 minutes as the 
+# default in Sakai, specified in milliseconds. Before v4.4.0 of dropzone the request never timed out.
+# https://www.dropzonejs.com/#config-timeout
+# DEFAULT: 240000
+# content.upload.timeout=60000
+
 # Enable zip content handling (affects resources), on by default
 # Allows users to upload zip files and have them be expanded into the content (resources tool) and 
 # allows downloading a zip file of a folder or folders from Sakai content (through resources tool)

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesConstants.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesConstants.java
@@ -25,6 +25,7 @@ public class ResourcesConstants
 {
 	// SAK-29332
 	public static final String SAK_PROP_MAX_UPLOAD_FILE_SIZE = "content.upload.max";
+	public static final String SAK_PROP_UPLOAD_TIMEOUT = "content.upload.timeout";
 	public static final String SAK_PROP_MASTER_SITE_QUOTA = "content.quota";
 	public static final String DEFAULT_MAX_FILE_SIZE_STRING = "20";
 	public static final String DEFAULT_SITE_QUOTA_STRING = "0";

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -649,7 +649,10 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 			max_file_size_mb = "20";
 		}
 		context.put("uploadMaxSize", max_file_size_mb);
-		
+
+		context.put("uploadTimeout"
+            , ServerConfigurationService.getString(ResourcesConstants.SAK_PROP_UPLOAD_TIMEOUT, "240000"));
+
 		String uploadMax = ServerConfigurationService.getString(ResourcesConstants.SAK_PROP_MAX_UPLOAD_FILE_SIZE);
 		String instr_uploads = rb.getFormattedMessage("instr.uploads", new String[]{ uploadMax });
 		context.put("instr_uploads", instr_uploads);

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
@@ -1,6 +1,6 @@
 <!-- resources/sakai_create_uploads.vm, use with org.sakaiproject.tool.content.ResourcesHelperAction.java -->
-<script type="text/javascript">
-    includeWebjarLibrary('dropzone');
+<script>
+    includeWebjarLibrary("dropzone");
 </script>
 
 <div class="portletBody specialLink">
@@ -172,7 +172,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 
 Dropzone.options.fileUploader = {
     // do not change these values as the dropzone logic depends on these values
@@ -192,6 +192,7 @@ Dropzone.options.fileUploader = {
     dictRemoveFile: "$tlang.getString("dragndrop.dictRemoveFile")",
     dictMaxFilesExceeded: "$tlang.getString("dragndrop.dictMaxFilesExceeded")",
     dictFolderUploadError: "$tlang.getString("dragndrop.dictFolderUploadError")",
+    timeout: $uploadTimeout,
 
     init: function() {
         var dz = this;


### PR DESCRIPTION
Added a Sakai property to configure it, too.

https://jira.sakaiproject.org/browse/SAK-42438