### PR TITLE
SAK-42451 Allow CM services to be used with a SecurityAdvisor

### DIFF
--- a/edu-services/cm-service/cm-api/api/src/java/org/sakaiproject/coursemanagement/api/CourseManagementService.java
+++ b/edu-services/cm-service/cm-api/api/src/java/org/sakaiproject/coursemanagement/api/CourseManagementService.java
@@ -34,6 +34,13 @@ import org.sakaiproject.coursemanagement.api.exception.IdNotFoundException;
  * @author <a href="mailto:jholtzman@berkeley.edu">Josh Holtzman</a>
  */
 public interface CourseManagementService {
+
+        /**
+         * Security function and entity reference for use in SecurityAdivsors to permit
+         * CM admin functions without setting a session to admin
+         */
+	public static final String SECURE_CM_ADMIN = "cm.admin";
+	public static final String ENTITY_CM_ADMIN = "/cm/admin";
 	
 	/**
 	 * Gets a CourseSet by its eid.

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/aop/CourseManagementAdministrationAuthzAdvisor.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/aop/CourseManagementAdministrationAuthzAdvisor.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.MethodBeforeAdvice;
 
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.coursemanagement.api.CourseManagementService;
 import org.sakaiproject.coursemanagement.impl.exception.PermissionException;
 
 @Slf4j
@@ -40,11 +41,11 @@ public class CourseManagementAdministrationAuthzAdvisor implements MethodBeforeA
 	public void before(Method method, Object[] oa, Object obj) throws Throwable {
 		if(log.isDebugEnabled()) log.debug("Checking authorization for CM Administration actions");
 
-		// We can't check the standard site- or group- or resource-based authorization for modifying CM data,
-		// since CM isn't scoped by sakai references.  So we allow only the super user.
-		if(!securityService.isSuperUser()) {
+		// Check the special cm.admin and /cm/admin permission and entity reference. This check will allow
+		// the super user to modify CM data, or code which uses a SecurityAdvisor to permit this security check.
+		if(!securityService.unlock(CourseManagementService.SECURE_CM_ADMIN, CourseManagementService.ENTITY_CM_ADMIN)) {
 			if(log.isDebugEnabled()) log.debug("Denying access to CM Administration on method " + method);
-			throw new PermissionException("Only Sakai super-users (admins) can modify CM data");
+			throw new PermissionException("No permission to modify CM data");
 		}
 
 		if(log.isDebugEnabled()) log.debug("This user is permitted to use the CM Admin service");


### PR DESCRIPTION
Introduces a pseudo permission and reference that can be allowed
in a SecurityAdvisor to enable code to perform CM updates, without
requiring the user session to be set to admin.