### PR TITLE
SAK-42465 Add user.view.any permission to allow global user lookups for webservices

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/UserEntityProvider.java
@@ -578,8 +578,8 @@ public class UserEntityProvider extends AbstractEntityProvider implements CoreEn
         // If config, internal request or admin, give full access
         if (developerHelperService.getConfigurationSetting("entity.users.viewall", false) ||
                 developerHelperService.isEntityRequestInternal(ref.toString()) ||
-                developerHelperService.isUserAdmin(developerHelperService.getCurrentUserReference()) ||
-                user.getId().equals(developerHelperService.getCurrentUserId())) {
+                user.getId().equals(developerHelperService.getCurrentUserId()) ||
+                developerHelperService.isUserAllowedInEntityReference(developerHelperService.getCurrentUserReference(), UserDirectoryService.SECURE_VIEW_USER_ANY, user.getReference())) {
             EntityUser eu = new EntityUser(user);
             return eu;
         } else if (hasProfile) {

--- a/entitybroker/core-providers/src/test/org/sakaiproject/entitybroker/providers/UserEntityProviderRestrictedViewTest.java
+++ b/entitybroker/core-providers/src/test/org/sakaiproject/entitybroker/providers/UserEntityProviderRestrictedViewTest.java
@@ -34,6 +34,7 @@ import org.sakaiproject.util.BaseResourceProperties;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -115,7 +116,7 @@ public class UserEntityProviderRestrictedViewTest {
         when(developerHelperService.isEntityRequestInternal("/user/1")).thenReturn(false);
         when(developerHelperService.getCurrentUserReference()).thenReturn("/user/admin");
         when(developerHelperService.getCurrentUserId()).thenReturn("admin");
-        when(developerHelperService.isUserAdmin("/user/admin")).thenReturn(true);
+        when(developerHelperService.isUserAllowedInEntityReference(eq("/user/admin"), eq(UserDirectoryService.SECURE_VIEW_USER_ANY), any())).thenReturn(true);
 
         when(adminSite.getToolForCommonId("sakai.profile2")).thenReturn(toolConfiguration);
 
@@ -148,9 +149,7 @@ public class UserEntityProviderRestrictedViewTest {
         when(developerHelperService.getConfigurationSetting("entity.users.viewall", false)).thenReturn(false);
         when(developerHelperService.getConfigurationSetting("user.explicit.id.only", false)).thenReturn(false);
         when(developerHelperService.isEntityRequestInternal("/user/1")).thenReturn(false);
-        when(developerHelperService.getCurrentUserReference()).thenReturn("/user/1");
         when(developerHelperService.getCurrentUserId()).thenReturn("1");
-        when(developerHelperService.isUserAdmin("/user/1")).thenReturn(false);
 
         when(userSite.getToolForCommonId("sakai.profile2")).thenReturn(toolConfiguration);
 

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/UserDirectoryService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/UserDirectoryService.java
@@ -50,6 +50,9 @@ public interface UserDirectoryService extends EntityProducer
 	/** Name for the event of updating any user info. */
 	static final String SECURE_UPDATE_USER_ANY = "user.upd.any";
 
+	/** Name for the ability for read access to any user's details. */
+	static final String SECURE_VIEW_USER_ANY = "user.view.any";
+
 	/** Name for the event of updating one's own user info. */
 	static final String SECURE_UPDATE_USER_OWN = "user.upd.own";
 	

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -606,6 +606,7 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 			functionManager().registerFunction(SECURE_UPDATE_USER_OWN_PASSWORD);
 			functionManager().registerFunction(SECURE_UPDATE_USER_OWN_TYPE);
 			functionManager().registerFunction(SECURE_UPDATE_USER_ANY);
+			functionManager().registerFunction(SECURE_VIEW_USER_ANY);
 			functionManager().registerFunction("user.studentnumber.visible");
 			
 


### PR DESCRIPTION
This adds a new user.view.any permission to support the use-case for a webservice account
to be able to look up user information through the /direct/user endpoint, without the account
needing to be admin-equivalent.

This can be achieved at a global level by setting the server configuration property
entity.users.viewall=true, but that applies to all users. The user.view.any permission
can be set for a specific account or group of accounts by creating a special account
type (e.g. "webservice"), creating a user template role (e.g. !user.template.webservice),
 and then setting the permission for the .auth role in the template realm.