### PR TITLE
SCO-161: make SCORM Player (contrib) work inline (no iFrames)

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -729,7 +729,7 @@
 # This property controls when to bypasss the portal inlining process based on the URL.
 # Often this is the file suffix - but other patterns can be used.
 # This is a regular expression with vertical bars to indicate "or"
-# DEFAULT: \\.jpg$|\\.gif$|\\.js$|\\.png$|\\.jpeg$|\\.prf$|\\.css$|\\.zip$|\\.pdf\\.mov$|\\.json$|\\.jsonp$\\.xml$|\\.ajax$|\\.xls$|\\.xlsx$|\\.doc$|\\.docx$|uvbview$|linktracker$|hideshowcolumns$
+# DEFAULT: \\.jpg$|\\.gif$|\\.js$|\\.png$|\\.jpeg$|\\.prf$|\\.css$|\\.zip$|\\.pdf\\.mov$|\\.json$|\\.jsonp$\\.xml$|\\.ajax$|\\.xls$|\\.xlsx$|\\.doc$|\\.docx$|uvbview$|linktracker$|hideshowcolumns$|scormplayerpage
 # portal.bypass= 
 # To specify a different regular expression than the overall default for a particular Sakai tool, 
 # use a property with this pattern: 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -110,7 +110,7 @@ public class SiteHandler extends WorksiteHandler
 	// SAK-29180 - Normalize the properties, keeping the legacy pda sakai.properties names through Sakai-11 at least
 	private static final String BYPASS_URL_PROP = "portal.bypass";
 	private static final String LEGACY_BYPASS_URL_PROP = "portal.pda.bypass";
-	private static final String DEFAULT_BYPASS_URL = "\\.jpg$|\\.gif$|\\.js$|\\.png$|\\.jpeg$|\\.prf$|\\.css$|\\.zip$|\\.pdf\\.mov$|\\.json$|\\.jsonp$\\.xml$|\\.ajax$|\\.xls$|\\.xlsx$|\\.doc$|\\.docx$|uvbview$|linktracker$|hideshowcolumns$";
+	private static final String DEFAULT_BYPASS_URL = "\\.jpg$|\\.gif$|\\.js$|\\.png$|\\.jpeg$|\\.prf$|\\.css$|\\.zip$|\\.pdf\\.mov$|\\.json$|\\.jsonp$\\.xml$|\\.ajax$|\\.xls$|\\.xlsx$|\\.doc$|\\.docx$|uvbview$|linktracker$|hideshowcolumns$|scormplayerpage$";
 
 	// Make sure to lower-case the matching regex (i.e. don't use IResourceListener below)
 	private static final String BYPASS_QUERY_PROP = "portal.bypass.query";


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-161

Special thanks to @csev for pointers on where and how to accomplish this!

In it's current form, the SCORM Player (specifically the pop-up window generated when launching a module) requires the tool to be embedded in an iFrame. For Sakai 11+ this means that the SCORM tool IDs need to be added to the following sakai.property to ensure that the portal forces the tool into an iFrame, rather than inlining it:

> portal.iframesuppress=:all:sakai.scorm.singlepackage.tool:sakai.scorm.tool

If the SCORM Player tool IDs are not included in the above sakai.property, the result is that the pop-up window generated when launching a module will be wrapped in the portal navigation markup. See the screenshots on the JIRA for an illustration.

The code that decides whether to inline or not lives in core Sakai code, in portal's `SiteHandler`. We need to identify and modify the relevant code here so that the SCORM Player's module pop-up windows are not wrapped in the portal navigation, but are also not embedded in an iFrame.

The main reason we want to accomplish this is so we stop having to fight with the iFrame boundaries. For instance, when the tool is embedded in an iFrame, anything inside the iFrame cannot access resources from outside the iFrame. So, things like JavaScript and CSS provided by portal can't be used within the iFrame. This paradigm forces us to then import the JavaScript and CSS resources we need within the iFrame, duplicating these resources which is an efficiency and performance hit.

By inlining the tool, we can do away with a lot of code within SCORM Player to add the necessary portal resources within the iFrame.