### PR TITLE
SAK-42577: reset-pass > no longer checks invalid account types

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3845,7 +3845,7 @@
 
 # Comma-separated list of domain names that are not allowed to use the Reset Password system
 # DEFAULT: empty/null (all domains are allowed to use the service)
-# resetPass.invalidEmailDomains=sakaiproject.org
+# resetPass.invalidEmailDomains=sakailms.org
 
 # ########################################################################
 # SSP Early Alert integration

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3838,20 +3838,14 @@
 # Reset Password
 # ########################################################################
 
-# Role that can use the password reset tool by default.
-# guest users are ones that are created by Site Info when adding external participants.
-# registered  users are ones the are created by the New Account tool on the Gateway site.
-# DEFAULT: guest
-# resetRoles=guest,registered
-
-# resetAllRoles allows this to work for any roles in the system (overrides resetRoles above)
-# DEFAULT: false
-# resetPass.resetAllRoles=true
-
 # If set to false then password reset users get sent a new email, otherwise they get a link to allow
 # them to reset their password. This prevents people from changing password they don't own.
 # DEFAULT: false
 # siteManage.validateNewUsers=true
+
+# Comma-separated list of domain names that are not allowed to use the Reset Password system
+# DEFAULT: empty/null (all domains are allowed to use the service)
+# resetPass.invalidEmailDomains=sakaiproject.org
 
 # ########################################################################
 # SSP Early Alert integration

--- a/reset-pass/reset-pass/pom.xml
+++ b/reset-pass/reset-pass/pom.xml
@@ -66,6 +66,10 @@
     <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-lang3</artifactId>
-       </dependency>
+    </dependency>
+    <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-collections4</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/reset-pass/reset-pass/src/bundle/org/sakaiproject/tool/resetpass/bundle/Messages.properties
+++ b/reset-pass/reset-pass/src/bundle/org/sakaiproject/tool/resetpass/bundle/Messages.properties
@@ -1,4 +1,5 @@
 noemailprovided=You must provide your email address
+wrongtype=The email address provided references a domain which is not allowed to use this service to reset a password.
 
 mainTitle= Reset your password
 mainText= This password service is only available for guest users on {0}.

--- a/reset-pass/reset-pass/src/java/org/sakaiproject/tool/resetpass/UserValidator.java
+++ b/reset-pass/reset-pass/src/java/org/sakaiproject/tool/resetpass/UserValidator.java
@@ -15,24 +15,41 @@
  */
 package org.sakaiproject.tool.resetpass;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.tool.api.Placement;
+import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
-import org.sakaiproject.authz.api.SecurityService;
 
 @Slf4j
 public class UserValidator implements Validator {
 
 	public String userEmail;
+
+	// Prefix for error messages - indicates they are to be pulled from tool configuration rather than a resource bundle
+	private static final String TOOL_CONFIG_PREFIX = "toolconfig_";
+
+	// Sakai.property key for invalid domains in reset password email requests
+	private static final String SAK_PROP_INVALID_EMAIL_DOMAINS = "resetPass.invalidEmailDomains";
+
+	// Message bundle key for wrong type message (invalid domain)
+	private static final String WRONG_TYPE_MSG_BUNDLE_KEY = "wrongtype";
+
+	// Message bundle key for no email provided message
+	private static final String NO_EMAIL_MSG_BUNDLE_KEY = "noemailprovided";
 
 	public boolean supports(Class clazz) {
 		return clazz.equals(User.class);
@@ -53,65 +70,60 @@ public class UserValidator implements Validator {
 		this.securityService = ss;
 	}
 
+	private ToolManager toolManager;
+	public void setToolManager(ToolManager tm) {
+		this.toolManager = tm;
+	}
+
 	public void validate(Object obj, Errors errors) {
 		RetUser retUser = (RetUser)obj;
 		log.debug("validating user " + retUser.getEmail());
 
-		if (retUser.getEmail() == null || "".equals(retUser.getEmail()))
-		{
+		// Short circuit: no email provided
+		if (StringUtils.isBlank(retUser.getEmail())) {
 			log.debug("no email provided");
-			errors.reject("noemailprovided", "no email provided");
+			errors.reject(NO_EMAIL_MSG_BUNDLE_KEY, "no email provided");
 			return;
 		}
-		
-		Collection<User> c = this.userDirectoryService.findUsersByEmail(retUser.getEmail().trim());
-		if (c.size()>1) {
-			// Email is tied to more than one user, null out the user and transfer to next page
-			log.warn("more than one account with email: {}", retUser.getEmail());
-			retUser.setUser(null);
+
+		// Short circuit: domain provided not allowed
+		List<String> invalidDomains = serverConfigurationService.getStringList(SAK_PROP_INVALID_EMAIL_DOMAINS, new ArrayList<>());
+		if (CollectionUtils.isNotEmpty(invalidDomains) && invalidDomains.stream().anyMatch( d -> retUser.getEmail().toLowerCase().contains(d.toLowerCase()))) {
+			Placement placement = toolManager.getCurrentPlacement();
+			String toolPropWrongType = placement.getConfig().getProperty(WRONG_TYPE_MSG_BUNDLE_KEY);
+			if (StringUtils.isBlank(toolPropWrongType)) {
+				errors.reject(WRONG_TYPE_MSG_BUNDLE_KEY, "wrong type");
+			} else {
+				errors.reject(TOOL_CONFIG_PREFIX + WRONG_TYPE_MSG_BUNDLE_KEY, toolPropWrongType);
+			}
+
 			return;
-		} else if (c.size()==0) {
-			// User doesn't exist, null out the user and transfer to next page
+		}
+
+		// User doesn't exist, null out the user and transfer to next page
+		Collection<User> c = this.userDirectoryService.findUsersByEmail(retUser.getEmail().trim());
+		if (CollectionUtils.isEmpty(c)) {
 			log.debug("no such email: {}", retUser.getEmail());
 			retUser.setUser(null);
 			return;
 		}
 
-		Iterator<User> i = c.iterator();
-		User user = (User)i.next();
-		log.debug("got user " + user.getId() + " of type " + user.getType());
+		// Email is tied to more than one user, null out the user and transfer to next page
+		else if (c.size() > 1) {
+			log.warn("more than one account with email: {}", retUser.getEmail());
+			retUser.setUser(null);
+			return;
+		}
+
+		// Email belongs to super user, null out the user and transfer to next page
+		User user = (User) c.iterator().next();
 		if (securityService.isSuperUser(user.getId())) {
-			// Email belongs to super user, null out the user and transfer to next page
 			log.warn("tryng to change superuser password");
 			retUser.setUser(null);
 			return;
 		}
 
-		boolean allroles = serverConfigurationService.getBoolean("resetPass.resetAllRoles",false);
-		if (!allroles){
-			// SAK-24379 - deprecate the resetRoles property
-			String[] roles = serverConfigurationService.getStrings("accountValidator.accountTypes.accept");
-			String[] rolesOld = serverConfigurationService.getStrings("resetRoles");
-			if (rolesOld != null)
-			{
-				log.warn("Found the resetRoles property; it is deprecated in favour of accountValidator.accountTypes.accept");
-				if (roles == null)
-				{
-					roles = rolesOld;
-				}
-			}
-			if (roles == null ){
-				roles = new String[]{"guest"};
-			}
-			List<String> rolesL = Arrays.asList(roles);
-			if (!rolesL.contains(user.getType())) {
-				// Email belongs to a user who's type is not allowed to use this tool, null out the user and transfer to the next page
-				log.warn("this is a user type which isn't allowed to reset password via tool");
-				retUser.setUser(null);
-				return;
-			}
-		}
-
+		// All checks have passed successfully
 		retUser.setUser(user);
 	}
 }

--- a/reset-pass/reset-pass/src/webapp/WEB-INF/applicationContext.xml
+++ b/reset-pass/reset-pass/src/webapp/WEB-INF/applicationContext.xml
@@ -18,6 +18,7 @@
                 <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
                 <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
                 <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
+                <property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
             </bean>
         </property>
    </bean>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42577

SAK-42256 refactored reset-pass so that it would not leak information to the user about whether or not an account exists with the given email address.

However, we didn't notice that as a result of this work there is now a regression in that it doesn't report/validate on a sakai.property to reject attempts for certain account types. Unfortunately, we can't just restore this original functionality because that would be defeating the purpose of hardening the system to not expose undue information to a potential attacker.

To address this regression, we actually need to change the original implementation to be based off a sakai.property like invalidEmailInIdAccountString, which lists domains which are not allowed to use services like New Account, rather than a list of allowed user types (which forces us to resolve User objects in the back end to identify the user type, and reporting on this finding divulges information about if the account exists or not).

In this way, the domain can be checked before trying to resolve the User object, we can display some messaging about the domain being invalid or not allowed, and we don't leak any information about if the account exists or not (either via messaging, or by code analysis).

This is a significant change in behvaiour, and will necessitate removing old sakai.properties ("resetPass.resetAllRoles", "accountValidator.accountTypes.accept", and "resetRoles" which is the legacy version of the former), and introducing a new property to duplicate the "invalidEmailInIdAccountString" for Reset Password, so that institutions can define two separate lists of allowed domains, one for New Account and one for Reset Password.
