### PR TITLE
SAK-42582 WebJars: CKEditor image2 plugin upgrade to 4.13.0

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -105,7 +105,7 @@
     <ckeditor.wordcount.version>1.17.6</ckeditor.wordcount.version>
     <ckeditor.a11ychecker.version>1.1.1</ckeditor.a11ychecker.version>
     <ckeditor.balloonpanel.version>4.9.2</ckeditor.balloonpanel.version>
-    <ckeditor.image2.version>4.12.1</ckeditor.image2.version>
+    <ckeditor.image2.version>4.13.0</ckeditor.image2.version>
     
   </properties>
   <distributionManagement>


### PR DESCRIPTION
This should be broken because the webjar is not in the maven repositories yet.