### PR TITLE
SAK-42581 WebJars: Upgrade CKEditor from 4.12.1 to 4.13.0

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>war</packaging>
 	<properties>
 		<!-- This is used in re-write rules as well -->
-		<ckeditor.version>4.12.1</ckeditor.version>
+		<ckeditor.version>4.13.0</ckeditor.version>
 		<bootstrap-version>3.3.7</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<!-- Default extra plugins enabled -->

--- a/library/src/morpheus-master/sass/modules/editor/_base.scss
+++ b/library/src/morpheus-master/sass/modules/editor/_base.scss
@@ -2,7 +2,7 @@
 .cke {
 	.cke_button__sakaipreview {
 		.cke_button__sakaipreview_icon {
-			background: url(/library/webjars/ckeditor/4.12.1/full/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1632px !important;
+			background: url(/library/webjars/ckeditor/4.13.0/full/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1632px !important;
 			background-size: 16px !important;
 		}
 	}

--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -796,7 +796,7 @@ function includeWebjarLibrary(library) {
 		libraryVersion = "1.10.19";
 		document.write('\x3Cscript src="' + webjars + 'datatables/' + libraryVersion + '/js/jquery.dataTables.min.js' + ver + '">' + '\x3C/script>');
 	} else if (library == 'ckeditor') {
-		libraryVersion = "4.12.1";
+		libraryVersion = "4.13.0";
 		document.write('\x3Cscript src="' + webjars + 'ckeditor/' + libraryVersion + '/full/ckeditor.js' + ver + '">' + '\x3C/script>');
 	} else if (library == 'awesomplete') {
 		libraryVersion = "1.1.4";

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
@@ -33,11 +33,12 @@ public class EditorRegistryImpl implements EditorRegistry {
 	private HashMap<String, Editor> editors = new HashMap<String, Editor>();
 	
 	public void init() {
+		String ckEditorVersion = "4.13.0";
 		//TODO: pull this out to somewhere appropriate
 		register("textarea", "textarea", "/library/editor/textarea/textarea.js", "/library/editor/textarea.launch.js", "");
 		register("fckeditor", "FCKeditor", "/library/editor/FCKeditor/fckeditor.js", "/library/editor/fckeditor.launch.js", "");
-		register("ckeditor", "CKEditor", "/library/webjars/ckeditor/4.12.1/full/ckeditor.js", "/library/editor/ckeditor.launch.js",
-				"var CKEDITOR_BASEPATH='/library/webjars/ckeditor/4.12.1/full/';\n");
+		register("ckeditor", "CKEditor", String.format("/library/webjars/ckeditor/%s/full/ckeditor.js", ckEditorVersion) , "/library/editor/ckeditor.launch.js",
+				String.format("var CKEDITOR_BASEPATH='/library/webjars/ckeditor/%s/full/';\n", ckEditorVersion));
 	}
 	
 	public void destroy() {


### PR DESCRIPTION
This should be broken because the webjar is not in the maven repositories yet.