### PR TITLE
SAK-42588: announcements > synoptic > change header from h1 to h3

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -74,7 +74,7 @@
 	#if ($isOnWorkspaceTab.equals("true")) ##in workspace
 		
 		<div class="page-header">
-			<h1>$tlang.getString("gen.announcements") <br /><small>$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</small></h1>
+			<h3>$tlang.getString("gen.announcements") <br /><small>$tlang.getFormattedMessage("gen.viewing.days.phrase.brackets", $daysList.toArray())</small></h3>
 		</div>
 
 		#if ($alertMessage)<div class="sak-banner-error">$tlang.getFormattedMessage("gen.alert.message", $alertMessage)</div>#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42588

The header for the Announcement synoptic widget is an `<h1>`, when all others are `<h3>`.