### PR TITLE
SAK-42613: Edu-services > ExternalAssessmentService > add api to retrieve internal id

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookExternalAssessmentService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookExternalAssessmentService.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 
 /**
  * This service is designed for use by external assessment engines. These use
@@ -337,4 +338,14 @@ public interface GradebookExternalAssessmentService {
 	 * @return Whether the gradebook has categories enabled
 	 */
 	public boolean isCategoriesEnabled(String gradebookUid);
+
+	/**
+	 * Get the internal ID of an externally managed assessment (gradebook item) by it's external ID
+	 * @param gradebookUUID the UUID of the gradebook to check
+	 * @param externalID the external ID of the assessment (gradebook item) in question
+	 * @return Long value of the internal ID of the assessment (gradebook item) in question
+	 * @throws GradebookNotFoundException
+	 * @throws AssessmentNotFoundException
+	 */
+	public OptionalLong getInternalAssessmentID(String gradebookUUID, String externalID) throws GradebookNotFoundException, AssessmentNotFoundException;
 }

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookExternalAssessmentServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -988,5 +989,15 @@ public class GradebookExternalAssessmentServiceImpl extends BaseHibernateManager
 	public boolean isCategoriesEnabled(String gradebookUid) {
 		final Gradebook gradebook = getGradebook(gradebookUid);
 		return gradebook.getCategory_type() != GradebookService.CATEGORY_TYPE_NO_CATEGORY;
+	}
+
+	@Override
+	public OptionalLong getInternalAssessmentID(final String gradebookUUID, final String externalID) throws GradebookNotFoundException, AssessmentNotFoundException {
+
+		final GradebookAssignment asn = getExternalAssignment(gradebookUUID, externalID);
+		if (asn == null) {
+			throw new AssessmentNotFoundException("There is no assessment id=" + gradebookUUID + " in gradebook uid=" + externalID);
+		}
+		return asn == null || asn.getId() == null ? OptionalLong.empty() : OptionalLong.of(asn.getId());
 	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42613

When working with the `GradebookExternalAssessmentService`, you use the external ID of the gradebook item in question to interact with the service. If the external service does not provide some functionality you require, you need to also utilize the (internal) `GradebookService`.

The `GradebookService` operates primarily on the (internal) ID of the gradebook item in question, rather than the external ID. This is not so problematic if you either know the internal ID already, or if the "name" of the gradebook item corresponds directly with something you already know (for instance in the case of Assignments, the assignment name typically corresponds to the gradebook item name).

However, there could be situations where you only have the external assessment ID, and you know that there's a possibility that the entity's name may not correspond exactly to it's gradebook item's name. In this type of situation, there's no good way to get the gradebook item (or related functionality) you need through the (internal) `GradebookService` by way of the external ID, apart from getting *all* the gradebook items for the site, iterating over them and doing some brittle comparison routine.

In these cases, it would be a lot easier and a lot more intuitive to just provide a method in the external service to retrieve the internal ID of the gradebook item, for subsequent use with the (internal) `GradebookService`.