### PR TITLE
SAK-42630 Avoid a possible NPE when catching errors during assessment preview

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -557,6 +557,12 @@ public class DeliveryActionListener
     	EventLogFacade eventLogFacade = new EventLogFacade();
     	EventLogData eventLogData = null;
 
+        if (delivery.getAssessmentGradingId() == null) {
+                // Probably an assessment preview
+                log.warn("No assessmentGradingId available for preview or delivery: this failure will not be recorded in the T&Q event log");
+                throw e;
+        }
+
     	List eventLogDataList = eventService.getEventLogData(delivery.getAssessmentGradingId());
     	if(eventLogDataList != null && eventLogDataList.size() > 0) {
     		eventLogData= (EventLogData) eventLogDataList.get(0);


### PR DESCRIPTION
DeliveryActionListener has a large try/catch block that catches RuntimeException
and then adds an error the error log.

If an exception is caught for an assessment preview, the real error is masked
because the T&Q event logging code attempts to get an assessmentGradingId
which is null (and really there's nothing meaningful to log here since it's a
preview and the event log doesn't log previews).

So we should check for that and throw the real exception earlier before
attempting to update the event log.