### PR TITLE
SCO-166: fix entity linking for SCORM Player

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1692,6 +1692,12 @@
         <version>${sakai.version}</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>org.sakaiproject.scorm</groupId>
+        <artifactId>scorm-api</artifactId>
+        <version>${sakai.version}</version>
+        <scope>provided</scope>
+      </dependency>
       <!-- UI dependencies; our glue packages, not the raw libraries, -->
       <!-- and only where we have duplication in dependencyManagement sections. -->
       <dependency>

--- a/textarea/elfinder-sakai/pom.xml
+++ b/textarea/elfinder-sakai/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>samigo-services</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.sakaiproject.scorm</groupId>
+            <artifactId>scorm-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sakaiproject.samigo</groupId>
             <artifactId>samigo-hibernate</artifactId>
         </dependency>

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/scorm/ScormFsItem.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/scorm/ScormFsItem.java
@@ -1,0 +1,31 @@
+package org.sakaiproject.elfinder.sakai.scorm;
+
+import cn.bluejoe.elfinder.service.FsItem;
+import cn.bluejoe.elfinder.service.FsVolume;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.sakaiproject.scorm.model.api.ContentPackage;
+
+/**
+ *
+ * @author bjones86
+ */
+@AllArgsConstructor
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class ScormFsItem implements FsItem
+{
+    @NonNull @Getter
+    private final String id;
+
+    @NonNull @Getter
+    private final FsVolume volume;
+
+    @EqualsAndHashCode.Exclude @Getter
+    private ContentPackage contentPackage;
+}

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/scorm/ScormSiteVolumeFactory.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/scorm/ScormSiteVolumeFactory.java
@@ -1,0 +1,295 @@
+package org.sakaiproject.elfinder.sakai.scorm;
+
+import cn.bluejoe.elfinder.service.FsItem;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.elfinder.sakai.ReadOnlyFsVolume;
+import org.sakaiproject.elfinder.sakai.SakaiFsService;
+import org.sakaiproject.elfinder.sakai.SiteVolume;
+import org.sakaiproject.elfinder.sakai.SiteVolumeFactory;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.scorm.api.ScormConstants;
+import org.sakaiproject.scorm.entity.ScormEntityProvider;
+import org.sakaiproject.scorm.exceptions.ResourceStorageException;
+import org.sakaiproject.scorm.model.api.ContentPackage;
+import org.sakaiproject.scorm.service.api.ScormContentService;
+import org.sakaiproject.site.api.SiteService;
+
+/**
+ *
+ * @author bjones86
+ */
+@Slf4j
+public class ScormSiteVolumeFactory implements SiteVolumeFactory
+{
+    private static final String DIRECTORY               = "directory";
+    private static final String SCORM_TYPE              = "sakai/scorm";
+    private static final String SCORM_DIRECT_URL_PREFIX = "/direct/scorm/";
+
+    // Sakai APIs
+    @Setter private ServerConfigurationService serverConfigurationService;
+    @Setter private ContentHostingService contentHostingService;
+    @Setter private SecurityService securityService;
+    @Setter private SiteService siteService;
+
+    // SCORM APIs
+    @Setter private ScormContentService scormContentService;
+
+    @Override
+    public String getPrefix()
+    {
+        return ScormEntityProvider.ENTITY_PREFIX;
+    }
+
+    @Override
+    public String getToolId()
+    {
+        return ScormConstants.SCORM_TOOL_ID;
+    }
+
+    @Override
+    public SiteVolume getVolume( SakaiFsService service, String siteID )
+    {
+        return new ScormSiteVolume( service, siteID );
+    }
+
+    @AllArgsConstructor
+    public class ScormSiteVolume extends ReadOnlyFsVolume implements SiteVolume
+    {
+        private SakaiFsService service;
+        @Getter private String siteId;
+
+        @Override
+        public SiteVolumeFactory getSiteVolumeFactory()
+        {
+            return ScormSiteVolumeFactory.this;
+        }
+
+        @Override
+        public long getLastModified( FsItem item )
+        {
+            if( !getRoot().equals( item ) && item instanceof ScormFsItem )
+            {
+                ContentPackage cp = ((ScormFsItem) item).getContentPackage();
+                return cp != null && cp.getModifiedOn() != null ? cp.getModifiedOn().getTime() / 1000 : 0L;
+            }
+
+            return 0L;
+        }
+
+        @Override
+        public String getMimeType( FsItem item )
+        {
+            return isFolder( item ) ? DIRECTORY : SCORM_TYPE;
+        }
+
+        @Override
+        public boolean isFolder( FsItem item )
+        {
+            return item instanceof ScormFsItem && ((ScormFsItem) item).getId().equals( "" );
+        }
+
+        @Override
+        public String getName()
+        {
+            return ScormConstants.SCORM_DFLT_TOOL_NAME;
+        }
+
+        @Override
+        public String getName( FsItem item )
+        {
+            if( getRoot().equals( item ) )
+            {
+                return getName();
+            }
+            if( item instanceof ScormFsItem )
+            {
+                ContentPackage cp = ((ScormFsItem) item).getContentPackage();
+                return cp.getTitle();
+            }
+            else
+            {
+                throw new IllegalArgumentException( "Could not get title for: " + item.toString() );
+            }
+        }
+
+        @Override
+        public FsItem getRoot()
+        {
+            return new ScormFsItem( "", this );
+        }
+
+        @Override
+        public FsItem getParent( FsItem item )
+        {
+            if( getRoot().equals( item ) )
+            {
+                return service.getSiteVolume( siteId ).getRoot();
+            }
+            else if( item instanceof ScormFsItem )
+            {
+                return getRoot();
+            }
+
+            return null;
+        }
+
+        @Override
+        public boolean hasChildFolder( FsItem item )
+        {
+            return item instanceof ScormFsItem;
+        }
+
+        @Override
+        public String getPath( FsItem item ) throws IOException
+        {
+            if( getRoot().equals( item ) )
+            {
+                return "";
+            }
+            else if( item instanceof ScormFsItem )
+            {
+                ScormFsItem scormItem = (ScormFsItem) item;
+                return "/" + getPrefix() + "/" + scormItem.getContentPackage().getContentPackageId();
+            }
+
+            throw new IllegalArgumentException( "Wrong Type: " + item.toString() );
+        }
+
+        @Override
+        public FsItem fromPath( String path )
+        {
+            if( StringUtils.isNotEmpty( path ) )
+            {
+                String[] parts = path.split( "/" );
+                if( parts.length > 2 && getPrefix().equals( parts[1] ) )
+                {
+                    try
+                    {
+                        ContentPackage cp = scormContentService.getContentPackage( Long.valueOf( parts[2] ) );
+                        return new ScormFsItem( buildEntityID( cp ), this, cp );
+                    }
+                    catch( NumberFormatException ex )
+                    {
+                        log.warn( "Could not parse SCORM Content Package ID = {}", parts[2], ex );
+                    }
+                    catch( ResourceStorageException ex )
+                    {
+                        log.warn( "Unexpected exception for SCORM linking", ex );
+                    }
+                }
+            }
+
+            return getRoot();
+        }
+
+        @Override
+        public FsItem[] listChildren( FsItem item )
+        {
+            List<FsItem> items = new ArrayList<>();
+
+            // Top level for a site, get all SCORM modules...
+            if( getRoot().equals( item ) )
+            {
+                for( ContentPackage cp : scormContentService.getContentPackages( siteId ) )
+                {
+                    items.add( new ScormFsItem( buildEntityID( cp ), this, cp ) );
+                }
+            }
+
+            return items.toArray( new FsItem[items.size()] );
+        }
+
+        @Override
+        public String getURL( FsItem item )
+        {
+            if( item instanceof ScormFsItem && StringUtils.isNotBlank( ((ScormFsItem) item).getId() ) )
+            {
+                ScormFsItem scormItem = ((ScormFsItem) item);
+                String serverURL = serverConfigurationService.getServerUrl();
+                return serverURL + SCORM_DIRECT_URL_PREFIX + scormItem.getId();
+            }
+
+            return null;
+        }
+
+        @Override
+        public long getSize( FsItem item ) throws IOException
+        {
+            if( !getRoot().equals( item ) && item instanceof ScormFsItem && securityService.unlock( ScormConstants.PERM_CONFIG, siteService.siteReference( siteId ) ) )
+            {
+                ContentPackage cp = ((ScormFsItem) item).getContentPackage();
+                if( cp != null )
+                {
+                    String resourceID = ScormConstants.ROOT_DIRECTORY + cp.getResourceId() + "/";
+                    try
+                    {
+                        if( contentHostingService.isCollection( resourceID ) )
+                        {
+                            return contentHostingService.getCollectionSize( resourceID );
+                        }
+                        else
+                        {
+                            return contentHostingService.getResource( resourceID ).getContentLength();
+                        }
+                    }
+                    catch( IdUnusedException uie )
+                    {
+                        log.debug( "Failed to file size as item can't be found: {}", resourceID, uie );
+                    }
+                    catch( Exception ex )
+                    {
+                        log.warn( "Failed to get size for: {}", resourceID, ex );
+                    }
+                }
+            }
+
+            return 0L;
+        }
+
+        /**
+         * Utility method to build an {@link org.sakaiproject.scorm.entity.ScormEntity} ID for the given {@link org.sakaiproject.scorm.model.api.ContentPackage}
+         * @param cp the {@link org.sakaiproject.scorm.model.api.ContentPackage} to build an entity ID for
+         * @return a {@link org.sakaiproject.scorm.entity.ScormEntity} ID in the format of "siteID:toolID:contentPackageID:resourceID:title"
+         */
+        private String buildEntityID( ContentPackage cp )
+        {
+            try
+            {
+                return siteId + ScormEntityProvider.ENTITY_PARAM_DELIMITER
+                       + siteService.getSite( siteId ).getToolForCommonId( ScormConstants.SCORM_TOOL_ID ).getId() + ScormEntityProvider.ENTITY_PARAM_DELIMITER
+                       + cp.getContentPackageId() + ScormEntityProvider.ENTITY_PARAM_DELIMITER
+                       + cp.getResourceId() + ScormEntityProvider.ENTITY_PARAM_DELIMITER
+                       + cp.getTitle();
+            }
+            catch( Exception ex )
+            {
+                log.warn( "Unexpected exception for SCORM linking", ex );
+            }
+
+            return null;
+        }
+
+        // Unimplemented methods below
+        @Override public boolean        exists              ( FsItem item )                     { return false; }
+        @Override public boolean        isRoot              ( FsItem item )                     { return false; }
+        @Override public boolean        isWriteable         ( FsItem fsi  )                     { return false; }
+        @Override public String         getDimensions       ( FsItem item )                     { return null;  }
+        @Override public String         getThumbnailFileName( FsItem fsi  )                     { return null;  }
+        @Override public InputStream    openInputStream     ( FsItem item ) throws IOException  { return null;  }
+    }
+}

--- a/textarea/elfinder-sakai/src/webapp/WEB-INF/applicationContext.xml
+++ b/textarea/elfinder-sakai/src/webapp/WEB-INF/applicationContext.xml
@@ -48,7 +48,14 @@
 								<bean class="org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService"/>
 							</property>
 							<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+						</bean>
 
+						<bean class="org.sakaiproject.elfinder.sakai.scorm.ScormSiteVolumeFactory">
+							<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
+							<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
+							<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+							<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
+							<property name="scormContentService" ref="org.sakaiproject.scorm.service.api.ScormContentService" />
 						</bean>
 					</set>
 				</property>

--- a/textarea/elfinder-sakai/src/webapp/WEB-INF/applicationContext.xml
+++ b/textarea/elfinder-sakai/src/webapp/WEB-INF/applicationContext.xml
@@ -50,13 +50,15 @@
 							<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
 						</bean>
 
-						<bean class="org.sakaiproject.elfinder.sakai.scorm.ScormSiteVolumeFactory">
+						<!-- Uncomment the following bean definition to enable entity linking to SCORM Player modules. -->
+						<!-- NOTE: this requires the SCORM Player project to be build and deployed to your Tomcat. -->
+						<!--<bean class="org.sakaiproject.elfinder.sakai.scorm.ScormSiteVolumeFactory">
 							<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 							<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
 							<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
 							<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 							<property name="scormContentService" ref="org.sakaiproject.scorm.service.api.ScormContentService" />
-						</bean>
+						</bean>-->
 					</set>
 				</property>
 			</bean>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-166

This is also dependant on https://github.com/sakaicontrib/SCORM.2004.3ED.RTE/pull/45

*I'm submitting this as a draft PR because I have major questions below...*

Since the switch to `elfinder`, this is what's necessary to hook up entities to the picker in CKEditor. Although the UI looks much nicer than before, in terms of code implementation it's actually much worse compared to what we had before.

In the old system all you had to do was code your `EntityProvider` and add a tiny string in a message bundle in core Sakai code. Your `EntityProvider` was completely isolated in your tool (even a contrib tool!), and if you didn't deploy that tool to your Tomcat nothing bad would happen. The picker would continue to work with the `EntityProvider`s that were registered on startup.

In the new paradigm, you have your `EntityProvider` in your tool code, and then you also need to provide both a `FsItem` and `SiteVolumeFactory` for your entity in the `textarea` project. This introduces functionality duplication between your `EntityProvider` and your `SiteVolumeFactory`, and also between your `Entity` and your `FsItem`.

Now, if you can ignore the voice in your head yelling at you for duplicating stuff in two places, it's not so bad... right? Well, maybe in the case of core tools. However, in the case of a contrib tool the problems get worse. You need to add dependencies to the contrib tool in core Sakai, and now if you don't actually deploy that contrib tool to your Tomcat, it's going to complain at startup, fail to create the `SakaiFsService` Spring bean and the result is that the `elfinder` plugin will fail to work at all. You can't link to anything, and you'll get an error message when you click "Browse Server".

So, what can we do about this? We can't just put the dependency inside a build profile, because you can't (as far as I'm aware) specify which classes to selectively include in the compilation, and dynamically alter the Spring bean definition in XML all through a Maven profile selection.

It would be nice if you could override or add supplemental items to the bean definition from another project (say, the contrib project in question), but I'm not sure if this is even possible. If it is, then you could just move your `FsItem` and `SiteVolumeFactory` into your respective project (be it contrib or core), and everything would be isolated nicely again.

I don't know of another option to handle this, other than forcing institutions who want this functionality to keep it as a local modification that needs to be applied and ported forwards indefinitely.

Any input on this would be fantastic, and I thank you all in advance.