### PR TITLE
SAK-42248 Fix empty error banner displaying when uploading/importing files

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -1256,6 +1256,19 @@
 							}" >
 						$tlang.getString("grading.add")</label>
 						<span id="gradebookListWarnAssoc" class="alertMessageInline" style="display:none;border:none">$tlang.getString("grading.associate.warn")</span>
+						#if ($!value_totalCategories > 0)
+							## show the "Category list" choices or not
+							<p id="categoryList" class="checkbox  indnt4" #if($!gradebookChoice.equals("$!gradebookChoice_add"))style="display:block" #else style="display:none" #end>
+								<label for="category">
+									$tlang.getString("grading.categorylist")
+								</label>
+								<select name="$name_Category" id="category">
+									#foreach ($i in $categoryKeys)
+										<option value="$i" #if ($i == $!value_Category)selected="selected"#end>$categoryTable.get($i)</option>
+									#end
+								</select>
+							</p>
+						#end
 					</div>
 					#end
 					## if there exists properiate assignment entries in Gradebook
@@ -1322,19 +1335,6 @@
 						#end
 					</select>
 				</div>
-			#end
-			#if ($!value_totalCategories > 0)
-				## show the "Category list" choices or not
-				<p id="categoryList" class="checkbox  indnt4" #if($!gradebookChoice.equals("$!gradebookChoice_add"))style="display:block" #else style="display:none" #end>
-					<label for="category">
-						$tlang.getString("grading.categorylist")
-					</label>
-					<select name="$name_Category" id="category">
-						#foreach ($i in $categoryKeys)
-							<option value="$i" #if ($i == $!value_Category)selected="selected"#end>$categoryTable.get($i)</option>
-						#end
-					</select>
-				</p>
 			#end
 		#end
 

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
@@ -15,7 +15,7 @@
     #if ($itemAlertMessage)
         <div class="sak-banner-success">$itemAlertMessage</div>
     #else
-        <div class="sak-banner-error"></div>
+        <div class="sak-banner-error" style = "display:none"></div>
     #end
     <div id="dragDropWrapper">
     <form name="dropzone-form" action="#toolLink("ResourcesHelperAction" "doPost")&flow=save" class="dropzone" id="file-uploader">

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -1128,8 +1128,8 @@
 		// 'Please select...' is always the first element in the drop down, but only enforce this if configured via sakai.properties
 		if (requireChoice && copyrightSelect !== null && copyrightSelect.selectedIndex < 1)
 		{
-			$('.alertMessage').html('$tlang.getString("label.alert") $copyrightError');
-			$('.alertMessage').show();
+			$('.sak-banner-error').html('$tlang.getString("label.alert") $copyrightError');
+			$('.sak-banner-error').show();
 			window.scrollTo(0, 0);
 			copyrightSelect.focus();
 
@@ -1138,7 +1138,7 @@
 		}
 
 		// Copyright status has been selected; let the calling site submit the necessary form
-		$('.alertMessage').hide();
+		$('.sak-banner-error').hide();
 		submitButton.disabled = true;
 		return true;
 	}


### PR DESCRIPTION
Added display:none to prevent empty error banner from displaying while uploading files, similar to https://jira.sakaiproject.org/browse/SAK-41516 (https://github.com/sakaiproject/sakai/pull/6706). 

Should fix bugs https://jira.sakaiproject.org/browse/SAK-42248 and https://jira.sakaiproject.org/browse/SAK-42121.

