### PR TITLE
SAK-42652 - WebJars: Upgrade codemirror from 5.48.2 to 5.49.0 (Oct-2019)

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>codemirror</artifactId>
-			<version>5.48.2</version>
+			<version>5.49.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/library/src/webapp/editor/elfinder/sakai/js/src/editors.js
+++ b/library/src/webapp/editor/elfinder/sakai/js/src/editors.js
@@ -63,7 +63,7 @@ var ckeditor = (function() {
 
 // Codemirror (code editor)
 var codemirror = (function() {
-  var url = '/library/webjars/codemirror/5.48.2/';
+  var url = '/library/webjars/codemirror/5.49.0/';
   var codemirrorjs = url + 'lib/codemirror.js';
   var scripts = []; // keeps track of loaded codemirror js files
   var instance;     // one reference to the editor instance


### PR DESCRIPTION
Verified in my local environment.