### PR TITLE
SAK-42653 WebJars: Upgrade fullcalendar from 4.2.0 to 4.3.1 (Oct-2019)

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -65,12 +65,12 @@
  <script type="text/javascript" src="$context/js/jquery.cluetip.min.js"></script>
  <link rel="stylesheet" href="$context/css/jquery.cluetip.css" type="text/css" />
  <link rel="stylesheet" href="/library/editor/ckextraplugins/folder-listing/css/file-tree.css" type="text/css"/>
- <link href="/library/webjars/fullcalendar/4.2.0/packages/core/main.min.css" rel="stylesheet" />
- <link href="/library/webjars/fullcalendar/4.2.0/packages/daygrid/main.min.css" rel="stylesheet" />
- <link href="/library/webjars/fullcalendar/4.2.0/packages/timegrid/main.min.css" rel="stylesheet" />
- <script type="text/javascript" src="/library/webjars/fullcalendar/4.2.0/packages/core/main.min.js"></script>
- <script type="text/javascript" src="/library/webjars/fullcalendar/4.2.0/packages/daygrid/main.min.js" rel="stylesheet"></script>
- <script type="text/javascript" src="/library/webjars/fullcalendar/4.2.0/packages/timegrid/main.min.js" rel="stylesheet"></script>
+ <link href="/library/webjars/fullcalendar/4.3.1/core/main.min.css" rel="stylesheet" />
+ <link href="/library/webjars/fullcalendar/4.3.1/daygrid/main.min.css" rel="stylesheet" />
+ <link href="/library/webjars/fullcalendar/4.3.1/timegrid/main.min.css" rel="stylesheet" />
+ <script src="/library/webjars/fullcalendar/4.3.1/core/main.min.js"></script>
+ <script src="/library/webjars/fullcalendar/4.3.1/daygrid/main.min.js"></script>
+ <script src="/library/webjars/fullcalendar/4.3.1/timegrid/main.min.js"></script>
  <script type="text/javascript" src="$context/js/peer-eval.js"></script>
  <script type="text/javascript" src="$context/js/hoverIntent.js"></script>
  <script type="text/javascript" src="/library/editor/ckextraplugins/folder-listing/js/file-tree.js"></script>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -200,7 +200,7 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>fullcalendar</artifactId>
-			<version>4.2.0</version>
+			<version>4.3.1</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Verified in my local environment.