### PR TITLE
SAK-42688 Tool configuration option for duplication

### DIFF
--- a/basiclti/basiclti-portlet/src/webapp/WEB-INF/sakai/IMSBLTIPortlet.xml
+++ b/basiclti/basiclti-portlet/src/webapp/WEB-INF/sakai/IMSBLTIPortlet.xml
@@ -82,6 +82,9 @@
                 <!-- Allow multiple instances of this tool within one site -->
                 <configuration name="allowMultipleInstances" value="true" />
 
+                <!-- Allow this tool to be copied into a new site when a site is duplicated -->
+                <configuration name="allowToolDuplicate" value="true" />
+
         </tool>
 
         <!--Add New Tools Here -->


### PR DESCRIPTION
Add a tool configuration option that prevents a tool from being duplicated to a new site

When a site is duplicated, tools with this configuration:

    <configuration name="allowToolDuplicate" value="false" />

will not be copied to the duplicated site.