### PR TITLE
SAK-42692 - WebJars: Upgrade mathjs from 6.0.3 to 6.2.3

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -244,7 +244,7 @@
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>mathjs</artifactId>
-			<version>6.0.3</version>
+			<version>6.2.3</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -808,7 +808,7 @@ function includeWebjarLibrary(library) {
 		document.write('\x3Cscript src="' + webjars + 'awesomplete/' + libraryVersion + '/awesomplete.min.js' + ver + '">' + '\x3C/script>');
 		document.write('\x3Clink rel="stylesheet" href="' + webjars + 'awesomplete/' + libraryVersion + '/awesomplete.css' + ver + '"/>');
 	} else if (library == 'mathjs') {
-		libraryVersion = "6.0.3";
+		libraryVersion = "6.2.3";
 		document.write('\x3Cscript src="' + webjars + 'mathjs/' + libraryVersion + '/dist/math.min.js' + ver + '">' + '\x3C/script>');
 	} else if (library == 'handlebars') {
 		libraryVersion = "4.0.6";


### PR DESCRIPTION
This has not been tested yet and should be broken because the artifact is not in the maven repos yet.