### PR TITLE
SAK-42676 Change navigational headings to h2 for page accessibility

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeFooterExtras.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeFooterExtras.vm
@@ -17,7 +17,7 @@
 
             #if (${sitePages.pageNavShowPresenceLoggedIn})
 
-                <h1 class="skip">${rloader.sit_presencehead}</h1>
+                <h2 class="skip">${rloader.sit_presencehead}</h2>
                 <div id="footerAppPresence" class="Mrphs-footerApp__presence">
                     <a href="#" id="presenceToggle" class="Mrphs-footerApp--toggle Mrphs-footerApp--toggle-users">
                         <span class="Mrphs-footerApp--icon icon-sakai-users"></span>
@@ -37,7 +37,7 @@
 
 #if ( $neoChat && ${loggedIn} )
 
-    <h1 class="skip">${rloader.sit_presencehead}</h1>
+    <h2 class="skip">${rloader.sit_presencehead}</h2>
 
     #if ($neoAvatar)
 

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageBody.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageBody.vm
@@ -23,7 +23,7 @@
 #end
 <!-- START VM includePageBody.vm -->
 
-<h1 class="skip" tabindex="-1" id="tocontent">${rloader.sit_contentshead}</h1>
+<h2 class="skip" tabindex="-1" id="tocontent">${rloader.sit_contentshead}</h2>
 
     #if ( $pageColumn1Tools ) 
         #set( $numberTools = $pageColumn0Tools.size() + $pageColumn1Tools.size() )

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePageNav.vm
@@ -10,7 +10,7 @@
 
     #end ## END of IF ($sitePages.siteHTMLInclude)
 
-    <h1 class="skip" tabindex="-1" id="totoolmenu">${rloader.sit_toolshead}</h1>
+    <h2 class="skip" tabindex="-1" id="totoolmenu">${rloader.sit_toolshead}</h2>
     <!--Added this check in to make sure that we just don't have an empty img element in the page. -->
 	#if(${sitePages.pageNavIconUrl} != "")
         <img src="${sitePages.pageNavIconUrl}" alt="" class="img_site_toolmenu">

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSitesNav.vm
@@ -1,5 +1,5 @@
 <nav id="linkNav" role="navigation" aria-labelledby="sitetabs" class="Mrphs-sitesNav" data-max-tools-int="$maxToolsInt" data-max-tools-anchor="${rloader.sit_alltools}">
-    <h1 class="skip" tabindex="-1" id="sitetabs">${rloader.sit_worksiteshead}</h1>
+    <h2 class="skip" tabindex="-1" id="sitetabs">${rloader.sit_worksiteshead}</h2>
     <div id="show-all-sites" tabindex="-1"><i class="fa fa-angle-double-left" aria-hidden="true"></i><span>${rloader.sit_more}</span></div>
     <div id="topnav_container">
         <ul class="Mrphs-sitesNav__menu" id="topnav" aria-label="${rloader.sit_worksiteshead}">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42676

I've changed the navigational headings (the headers that the skipnav links go to) from h1 tags to h2 tags, per the recommendations from consultation with the Sakai Accessibility Working Group as described in this article:
https://www.w3.org/WAI/tutorials/page-structure/headings/#main-heading-after-navigation