### PR TITLE
SAK-42695 Calendar: fixed visual issues with recent UI redesign

### DIFF
--- a/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/Day.java
+++ b/calendar/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/Day.java
@@ -33,6 +33,7 @@ public class Day implements Serializable {
 	public final static String	STYLE_SELECTEDDAY				= "calSelectedDay";
 	public final static String	STYLE_WITH_ACTIVITY				= "calDayWithActivity";
 	public final static String	STYLE_WITHOUT_ACTIVITY			= "calDayWithoutActivity";
+	public final static String	STYLE_OTHER_WITH_ACTIVITY		= "calOtherDayWithActivity";
 	public final static String	STYLE_OTHER_WITHOUT_ACTIVITY	= "calOtherDayWithNoActivity";
 	private transient ResourceLoader				msgs					= new ResourceLoader("calendar");
 
@@ -84,6 +85,10 @@ public class Day implements Serializable {
 		StringBuilder buff = new StringBuilder();
 		if(isToday) buff.append(" " + STYLE_TODAY + " ");
 		if(occursInOtherMonth && !hasEvents) buff.append(" " + STYLE_OTHER_WITHOUT_ACTIVITY + " ");
+		else if(occursInOtherMonth && hasEvents) { 
+			buff.append(" " + STYLE_OTHER_WITH_ACTIVITY + " ");
+			if(isSelected) buff.append(" " + STYLE_SELECTEDDAY + " ");
+		}
 		else{
 			if(hasEvents) buff.append(" " + STYLE_WITH_ACTIVITY + " ");
 			else buff.append(" " + STYLE_WITHOUT_ACTIVITY + " ");

--- a/library/src/morpheus-master/sass/modules/tool/calendar/_calendar.scss
+++ b/library/src/morpheus-master/sass/modules/tool/calendar/_calendar.scss
@@ -73,12 +73,6 @@
 		}
 		
 		@media #{$smallPhone}{
-			input[name="eventSubmit_doDefaultview"] {
-				display: none;		// hide the button when there isn't any room
-			}
-		}
-		
-		@media #{$smallPhone}{
 			@include flex-direction(row);	// override tables default
 			@include align-items(center);	// override tables default
 		}
@@ -206,7 +200,8 @@
 
 		.borderGrayTodayEmptyMiddleBottom {
 			background-color: $calendar-day-background-color;
-			border: 1px solid $calendar-day-border-color;
+			border-top: 1px solid $calendar-day-border-color;
+			border-bottom: 1px solid $calendar-day-border-color;
 		}
 
 		.borderGrayTodayEmptyMiddleCenter {
@@ -362,7 +357,7 @@
 		.borderTodayBottom, .borderGrayTodayBottom, .borderOnlyLeftTodayBottom {
 			border-left: 1px double $calendar-day-today-border-color;	// using "double" here to resolve the border-collapse conflict
 			border-right: 1px double $calendar-day-today-border-color;
-			border-top: 1px solid $calendar-event-border-color;
+			border-top: 1px solid $calendar-day-today-border-color;
 			border-bottom: 1px double $calendar-day-today-border-color;
 		}
 
@@ -559,7 +554,7 @@
 		line-height: 1.4;
 		text-align: left;
 		
-		&:hover, &:focus {
+		&:hover {
 			border: 1px solid $link-color;
 		}
 
@@ -571,6 +566,10 @@
 			left: 0;
 			padding: 2px;
 			text-decoration: none;
+			
+			&:focus {
+				outline-offset: -#{$focus-outline-width};	// to provide enough space for the outline to appear with overflow:hidden
+			}
 		}
 	}
 	
@@ -587,7 +586,17 @@
 		border: 1px solid $calendar-day-border-color;
 		
 		@media #{$miniCalendarSize} {
-			&:hover {
+			&:hover, &:focus {
+				border: 1px solid $link-color;
+			}
+		}
+	}
+	
+	@media #{$miniCalendarSize} {
+		.calendarMonthView-notCurrentMonthDate > .squareCalendarDays {
+			border-color: transparent;		// to distinguish current month days from non-current month days
+			
+			&:hover, &:focus {
 				border: 1px solid $link-color;
 			}
 		}

--- a/library/src/morpheus-master/sass/modules/tool/calendar/_calendarSynoptic.scss
+++ b/library/src/morpheus-master/sass/modules/tool/calendar/_calendarSynoptic.scss
@@ -104,6 +104,10 @@
 			height: 100%;
 			border: 1px solid $calendar-day-border-color;	// to style the cell borders
 			text-align: center;
+			
+			&.calOtherDayWithNoActivity, &.calOtherDayWithActivity {
+				border: 0 none;		// to distinguish current month days from non-current month days
+			}
 		}
 
 		.calToday 			// today without events
@@ -122,7 +126,7 @@
 			}
 		}
 
-		.calDayWithActivity
+		.calDayWithActivity, .calOtherDayWithActivity
 		{
 			// background-color will be overriden if:
 			// 1. colors specified for high/medium/low priority events in Options (user preferences)
@@ -173,6 +177,8 @@
 				&.calSelectedDay		//today selected with activity
 				{
 					border-color: $calendar-today-event-text-color;
+					border-left: 0 none;	// removing side borders to avoid double thickness caused by the -1px margin from above (.calSelectedDay a) not applying to the sides
+					border-right: 0 none;
 				}
 			}
 		}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42695

Fixed some visual and accessibility issues with the recent Calendar UI redesign from SAK-42430, including:

- removed extra side border from the today cell with events in the synoptic calendar
- removed borders from cells of the next and previous months in the synoptic calendar and mini-month view to differentiate from the current month's days
- fixed a few border issues in Week and Day views that caused extra lines to appear or fill in missing lines
- fixed focus states for events in Week and Day views so they appear properly, so all events can be focused on
