### PR TITLE
SAK-42702 Assignments canSubmit check current user when user is blank

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1917,6 +1917,10 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             return false;
         }
 
+        if (StringUtils.isBlank(userId)) {
+            userId = sessionManager.getCurrentSessionUserId();
+        }
+
         try {
             // return false only if the user is not allowed to submit and not allowed to add to the assignment
             if (!permissionCheckWithGroups(SECURE_ADD_ASSIGNMENT_SUBMISSION, assignment, userId) // check asn.submit for user on assignment consulting groups
@@ -1936,14 +1940,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             // whether the current time is after the assignment close date inclusive
             boolean isBeforeAssignmentCloseDate = !currentTime.isAfter(assignment.getCloseDate());
 
-            if (StringUtils.isBlank(userId)) {	
-                userId = sessionManager.getCurrentSessionUserId();	
-            }
-
-            AssignmentSubmission submission = null;
-            if (StringUtils.isNotBlank(userId)) {
-                submission = getSubmission(AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getId(), userId);
-            }
+            AssignmentSubmission submission = getSubmission(AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getId(), userId);
 
             if (submission != null) {
                 // check for allow resubmission or not first
@@ -1987,7 +1984,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
     @Override
     public boolean canSubmit(Assignment assignment) {
-        return canSubmit(assignment, null);
+        return canSubmit(assignment, sessionManager.getCurrentSessionUserId());
     }
 
     @Override


### PR DESCRIPTION
This is a small improvement over SAK-42680 PR #7485 which eliminated the main regression. 
Move the userId check a little higher, and adds the proper userId when calling the single param method.