### PR TITLE
SAK-42738: switch from npm install to npm ci

### DIFF
--- a/webcomponents/tool/pom.xml
+++ b/webcomponents/tool/pom.xml
@@ -111,7 +111,7 @@
                         </goals>
                         <configuration>
                             <arguments>
-                                install --unsafe-perm --save-dev
+                                ci --unsafe-perm --save-dev
                                 @ckeditor/ckeditor5-dev-webpack-plugin
                                 @ckeditor/ckeditor5-dev-utils
                                 postcss-loader@3
@@ -129,7 +129,7 @@
                         </goals>
                         <configuration>
                             <arguments>
-                                install --unsafe-perm
+                                ci --unsafe-perm
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42738

The webcomponents project runs some NPM goals. The "install" goal specifically will modify the following files if the Maven build fails:

* webcomponents/tool/src/main/frontend/package-lock.json
* webcomponents/tool/src/main/frontend/package.json

This can be a problem if you're not aware of the issue and constantly checking if these files were modified after a failed build. The danger is that these unintended modifications can leak into commits if you're not extra careful.

According to some articles online, NPM 5.7.0 introduced the "ci" command as an    "additional way to achieve fast and reproducible builds...", and changing from "install" to "ci" resolves this issue.

References:
* https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
* https://github.com/jhipster/generator-jhipster/issues/8642