### PR TITLE
SAK-42793 Fixed site tool names overflowing top submenu

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -861,7 +861,8 @@ body.is-logged-out{
 				left: 0;
 				z-index: 99;
 				display: none;
-				width: 100%;
+				min-width: 100%;	// at minimum, the menu should be the width of the site title
+				width: max-content; // if the content is wider than the site title, expand to the longest tool name
 				border: $sites-nav-menu-item-border-thickness solid $sites-nav-submenu-border-color;
 				box-shadow: 0 3px 2px rgba( $text-color, 0.35);
 				background: $sites-nav-menu-item-background;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42793

When tool names are wider than site titles (e.g. Home), make sure the tool names have enough width in the tool menu by making the menu wide enough for them. 