### PR TITLE
SAK-42819 Fixed the line-height spacing of the username in the Account Menu

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -174,7 +174,9 @@ body.is-logged-out{
 		}
 
 		.#{$namespace}userNav__submenuitem--displayid{
+			margin-top: $standard-space;
 			font-weight: normal;
+			line-height: 1.2;
 		}
 
 	}


### PR DESCRIPTION
Fixed line-height for longer usernames in the Account Menu.

See https://jira.sakaiproject.org/browse/SAK-42819 for before and after screenshots.