### PR TITLE
SAK-42721: check that assignment url is not empty string

### DIFF
--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
@@ -70,13 +70,8 @@ public class GradeAssignmentBullhornHandler extends AbstractBullhornHandler {
                 List<BullhornData> bhEvents = new ArrayList<>();
                 submission.getSubmitters().forEach(to -> {
                     try {
-                        String url = assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter());
-                        // TODO fix Assignment so that the submitter list doesn't contain users that have dropped the course (SAK-42721)
-                        if (!url.isEmpty()) {
-                            bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, url));
-                        } else {
-                            log.warn("Submitter {} probably doesn't have any permission on the assignment {}", to.getSubmitter(), assignment.getId());
-                        }
+                        Optional.ofNullable(assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter()))
+                                .ifPresent(u -> bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, u)));
                         countCache.remove(to.getSubmitter());
                     } catch(Exception exc) {
                         log.error("Error retrieving deep link for assignment {} and user {} on site {}", assignment.getId(), to.getSubmitter(), siteId, exc);

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.assignment.api.AssignmentConstants;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
@@ -70,8 +71,10 @@ public class GradeAssignmentBullhornHandler extends AbstractBullhornHandler {
                 List<BullhornData> bhEvents = new ArrayList<>();
                 submission.getSubmitters().forEach(to -> {
                     try {
-                        Optional.ofNullable(assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter()))
-                                .ifPresent(u -> bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, u)));
+                        String url = assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter());
+                        if (StringUtils.isNotBlank(url)) { 
+                            bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, url));
+                        }
                         countCache.remove(to.getSubmitter());
                     } catch(Exception exc) {
                         log.error("Error retrieving deep link for assignment {} and user {} on site {}", assignment.getId(), to.getSubmitter(), siteId, exc);

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
@@ -71,8 +71,11 @@ public class GradeAssignmentBullhornHandler extends AbstractBullhornHandler {
                 submission.getSubmitters().forEach(to -> {
                     try {
                         String url = assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter());
+                        // TODO fix Assignment so that the submitter list doesn't contain users that have dropped the course (SAK-42721)
                         if (!url.isEmpty()) {
                             bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, url));
+                        } else {
+                            log.warn("Submitter {} probably doesn't have any permission on the assignment {}", to.getSubmitter(), assignment.getId());
                         }
                         countCache.remove(to.getSubmitter());
                     } catch(Exception exc) {

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/beans/bullhornhandlers/GradeAssignmentBullhornHandler.java
@@ -70,7 +70,10 @@ public class GradeAssignmentBullhornHandler extends AbstractBullhornHandler {
                 List<BullhornData> bhEvents = new ArrayList<>();
                 submission.getSubmitters().forEach(to -> {
                     try {
-                        bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter())));
+                        String url = assignmentService.getDeepLink(siteId, assignment.getId(), to.getSubmitter());
+                        if (!url.isEmpty()) {
+                            bhEvents.add(new BullhornData(from, to.getSubmitter(), siteId, title, url));
+                        }
                         countCache.remove(to.getSubmitter());
                     } catch(Exception exc) {
                         log.error("Error retrieving deep link for assignment {} and user {} on site {}", assignment.getId(), to.getSubmitter(), siteId, exc);


### PR DESCRIPTION
If user doesn't have permissions for this assignment, the url is an empty string which causes an oracle error on our environment since it's interpreted as NULL (the url column having a not null constraint)