### PR TITLE
SAK-42837 - Messages - Error on log

### DIFF
--- a/msgcntr/messageforums-hbm/src/java/org/sakaiproject/component/app/messageforums/dao/hibernate/MessageImpl.hbm.xml
+++ b/msgcntr/messageforums-hbm/src/java/org/sakaiproject/component/app/messageforums/dao/hibernate/MessageImpl.hbm.xml
@@ -99,7 +99,7 @@
 	                    column="userSurrogateKey"/>
   	  </list>         
   	  -->
-  	  <list name="recipients" lazy="true" table="MFR_PVT_MSG_USR_T" cascade="all">
+  	  <list name="recipients" lazy="true" table="MFR_PVT_MSG_USR_T">
   	    <key column="messageSurrogateKey"/>
   	    <index column="user_index_col"/>
   	    <composite-element class="org.sakaiproject.component.app.messageforums.dao.hibernate.PrivateMessageRecipientImpl">


### PR DESCRIPTION
Deleted "cascade=all" in the MFR_PVT_MSG_USR_T table, to solve this problem, as we have seen this is the common cause of this type of problems (https://forum.hibernate.org/viewtopic.php?f=1&t=1000252&sid=04fa3e5bfe7f10c0d52a9f6c508de3e4). This "cascade" does not do anything in the table, since there is no FK to other tables, although it is related to tables MFR_MESSAGE_T and CMN_TYPE_T (https://confluence.sakaiproject.org/display/SPANISH/Limpieza+de+la+base+de+datos), currently if we do some update/delete in any of them the others are not affected, reason why the cascade has been eliminated without problems.