### PR TITLE
SAK-42874 T&Qs remove 'copy from pool' option inside pool menu

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/item/itemHeadings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/item/itemHeadings.jsp
@@ -19,6 +19,10 @@ jQuery(document).ready(function() {
 	if ( itemType == 2 || itemType == 12 ) {
 		$('#itemFormHeading\\:changeQType2').find('option[value=1]').attr('selected', true);
 	}
+	var itemAuthorTarget = "${itemauthor.target}";
+	if(itemAuthorTarget == 'questionpool') {
+		$('#itemFormHeading\\:changeQType2').find('option:last').remove();
+	}
 });
 
 //Display the EMI question example
@@ -179,25 +183,9 @@ function displayEMIHelp(){
 <div class="form-group row">
     <h:outputLabel styleClass="col-md-2" value="#{authorMessages.change_q_type} &#160;" escape="false" rendered="#{itemauthor.target == 'assessment' && author.isEditPendingAssessmentFlow || (itemauthor.target == 'questionpool' && itemauthor.itemType == '')}"/>
   <div class="col-md-10">
-<%-- todo:
-listener set selectFromQuestionPool, eliminating the rendered attribute
---%>
 
-<%-- from question pool context, do not show question pool as option --%>
-<h:selectOneMenu rendered="#{(itemauthor.target == 'assessment' && questionpool.importToAuthoring == 'true') || (itemauthor.target == 'questionpool' && itemauthor.itemType == '')}" onchange="changeTypeLink(this);"
-  value="#{itemauthor.currentItem.itemType}" required="true" id="changeQType1">
-  <f:valueChangeListener
-           type="org.sakaiproject.tool.assessment.ui.listener.author.StartCreateItemListener" />
-
-  <f:selectItems value="#{itemConfig.itemTypeSelectList}" />
-</h:selectOneMenu>
-
-<%-- not from qpool , show the last option: copy from question pool --%>
-<h:selectOneMenu onchange="changeTypeLink(this);" rendered="#{author.isEditPendingAssessmentFlow && itemauthor.target == 'assessment' && questionpool.importToAuthoring == 'false'}"
-  value="#{itemauthor.currentItem.itemType}" required="true" id="changeQType2">
-  <f:valueChangeListener
-           type="org.sakaiproject.tool.assessment.ui.listener.author.StartCreateItemListener" />
-
+<h:selectOneMenu onchange="changeTypeLink(this);" value="#{itemauthor.currentItem.itemType}" required="true" id="changeQType2">
+  <f:valueChangeListener type="org.sakaiproject.tool.assessment.ui.listener.author.StartCreateItemListener" />
   <f:selectItems value="#{itemConfig.itemTypeSelectList}" />
 </h:selectOneMenu>
 
@@ -211,8 +199,7 @@ listener set selectFromQuestionPool, eliminating the rendered attribute
     <h:outputText  value=" (#{authorMessages.example_emi_question})"/>
 </h:outputLink>
 
-<h:message rendered="#{questionpool.importToAuthoring == 'true' && itemauthor.target == 'assessment'}" for="changeQType1" infoClass="sak-banner-info" warnClass="sak-banner-warn" errorClass="sak-banner-error" fatalClass="sak-banner-error"/>
-<h:message rendered="#{questionpool.importToAuthoring == 'false' && itemauthor.target == 'assessment'}" for="changeQType2" infoClass="sak-banner-info" warnClass="sak-banner-warn" errorClass="sak-banner-error" fatalClass="sak-banner-error"/>
+<h:message for="changeQType2" infoClass="sak-banner-info" warnClass="sak-banner-warn" errorClass="sak-banner-error" fatalClass="sak-banner-error"/>
 </div>
 </div>
 </h:form>

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/selectQuestionType.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/selectQuestionType.jsp
@@ -36,10 +36,9 @@
 <div class="portletBody">
 <!-- content... -->
 <!-- FORM -->
-<h:form>
+<h:form id="selectQuestionType">
 
 <!-- CHANGE TYPE -->
- 
 <h:panelGrid columns="2">
 
   <h:outputText styleClass="number" value="1" />
@@ -55,7 +54,7 @@
 </h:panelGrid>
 
 <p class="act">
-<h:commandButton type="submit"  action="#{itemauthor.doit}" value="#{commonMessages.action_save}" styleClass="active">
+<h:commandButton type="submit" action="#{itemauthor.doit}" value="#{commonMessages.action_save}" styleClass="active">
    <f:actionListener
            type="org.sakaiproject.tool.assessment.ui.listener.author.StartCreateItemListener" />
    <f:param name="poolId" value="#{questionpool.currentPool.id}"/>
@@ -69,6 +68,12 @@
 
 </h:form>
 </div>
+
+<script>
+jQuery(document).ready(function(){//SAK-42873 removing copy from question pool option
+	$('#selectQuestionType\\:selType').find('option:last').remove();
+});
+</script>
 
 <!-- end content -->
     </body>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42874

Previously this was suposed to be managed by two different selectOneMenu within the ItemHeadings file, but their selectItems are equal. I also believe the rendered options were a bit strange, I'd say the only important check for this is itemauthor.target == 'questionpool' but I'd like someone else to confirm that, if possible.