### PR TITLE
SAK-4328 ContentHostingService: Validate filename

### DIFF
--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -1322,6 +1322,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 					
 					// create resource
 					try {
+						Validator.checkFilename(displayName);
 						ContentResourceEdit edit = getContentService().addResource(contentCollectionId, displayName, null, ContentHostingService.MAXIMUM_ATTEMPTS_FOR_UNIQUENESS);
 						
 						edit.setResourceType(CitationService.CITATION_LIST_ID);
@@ -1359,6 +1360,9 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 					} catch (IdUnusedException e) {
 						message = e.getMessage();
 						log.warn("IdUnusedException in ensureCitationListExists() {}", e);
+					}  catch (InvalidFilenameException e) {
+						message = e.getMessage();
+						log.warn("InvalidFilenameException in ensureCitationListExists() {}", e);
 					}
 				}
 				

--- a/content/content-bundles/resources/types.properties
+++ b/content/content-bundles/resources/types.properties
@@ -78,6 +78,7 @@ action.select		 = - Select Action -
 action.compresszipfolder = Compress to ZIP Archive
 action.expandziparchive  = Expand ZIP Archive
 alert.exists		 = The folder ''{0}'' already exists in this folder.
+alert.invalid.name   = The resource or folder ''{0}'' name contains forbidden characters. Please use a different name.
 alert.noperm		 = You do not have permission to change this item.
 alert.nofldr		 = Please provide the folder name.
 alert.nosort		 = Unable to complete Sort

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
@@ -93,6 +93,7 @@ import org.sakaiproject.exception.IdUniquenessException;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.IdUsedException;
 import org.sakaiproject.exception.InconsistentException;
+import org.sakaiproject.exception.InvalidFilenameException;
 import org.sakaiproject.exception.OverQuotaException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
@@ -1358,8 +1359,8 @@ public class FilePickerAction extends PagedResourceHelperAction
 				props.addProperty(ResourceProperties.PROP_DESCRIPTION, filename);
 
 				// make an attachment resource for this URL
-				try
-				{
+				try {
+					Validator.checkFilename(filename);
 					String siteId = toolManager.getCurrentPlacement().getContext();
 
 					String toolName = (String) toolSession.getAttribute(STATE_ATTACH_TOOL_NAME);
@@ -1432,6 +1433,10 @@ public class FilePickerAction extends PagedResourceHelperAction
 				catch(IdUsedException ignore)
 				{
 					// other exceptions should be caught earlier
+				}
+				catch(InvalidFilenameException ex)
+				{
+					addAlert(state, trb.getFormattedMessage("alert.invalid.name", new String[]{filename}));
 				}
 				catch(RuntimeException e)
 				{
@@ -1994,6 +1999,7 @@ public class FilePickerAction extends PagedResourceHelperAction
 				InputStream contentStream = resource.streamContent();
 				String contentType = resource.getContentType();
 				String filename = FilenameUtils.getName(itemId);
+				Validator.checkFilename(filename);
 				String resourceId = Validator.escapeResourceName(filename);
 
 				String siteId = toolManager.getCurrentPlacement().getContext();
@@ -2051,6 +2057,10 @@ public class FilePickerAction extends PagedResourceHelperAction
 			catch(InconsistentException ignore)
 			{
 				// other exceptions should be caught earlier
+			}
+			catch(InvalidFilenameException e)
+			{
+				addAlert(state, trb.getFormattedMessage("alert.invalid.name", new String[]{""}));
 			}
 			catch(RuntimeException e)
 			{

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -127,6 +127,7 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.IdUsedException;
 import org.sakaiproject.exception.InUseException;
 import org.sakaiproject.exception.InconsistentException;
+import org.sakaiproject.exception.InvalidFilenameException;
 import org.sakaiproject.exception.OverQuotaException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
@@ -1148,8 +1149,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			{
 				continue;
 			}
-			try
-			{
+			try {
+				Validator.checkFilename(name);
 				ContentCollectionEdit edit = contentHostingService.addCollection(collectionId, Validator.escapeResourceName(name), MAXIMUM_ATTEMPTS_FOR_UNIQUENESS);
 				ResourcePropertiesEdit props = edit.getPropertiesEdit();
 				props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, name);
@@ -1212,6 +1213,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			{
 				// TODO Auto-generated catch block
 				log.warn("TypeException id = {}{}", collectionId, name, e);
+			} catch (InvalidFilenameException e) {
+				addAlert(state, trb.getFormattedMessage("alert.invalid.name", new Object[] { name }));
 			}
 		}
 		return (new_collections.isEmpty() ? null : new_collections);
@@ -1256,8 +1259,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 				
 				basename = sb.toString();
 			}
-			try
-			{
+			try {
+				Validator.checkFilename(basename);
 				ContentResourceEdit resource = contentHostingService.addResource(collectionId,Validator.escapeResourceName(basename),Validator.escapeResourceName(extension),MAXIMUM_ATTEMPTS_FOR_UNIQUENESS);
 				
 				extractContent(fp, resource);
@@ -1372,6 +1375,10 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			{
 				addAlert(trb.getFormattedMessage("alert.unable1", new Object[]{name}));
 				log.warn("ServerOverloadException {}", (Object) e);
+			}
+			catch (InvalidFilenameException e) {
+				addAlert(trb.getFormattedMessage("alert.invalid.name", new Object[]{name}));
+				log.warn("InvalidFilenameException {}", (Object) e);
 			}
 		}
 		
@@ -4355,7 +4362,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			catch(TypeException ex)
 			{
 				log.warn("{}TypeException.", this);
-				throw ex;				
+				throw ex;
 			}
 			catch(PermissionException ex)
 			{
@@ -6237,7 +6244,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 					
 					basename = sb.toString();
 				}
-				
+
+				Validator.checkFilename(basename);
 				// create resource
 				ContentResourceEdit resource = contentHostingService.addResource(collectionId, Validator.escapeResourceName(basename), Validator.escapeResourceName(extension), MAXIMUM_ATTEMPTS_FOR_UNIQUENESS);
 				
@@ -6403,6 +6411,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			catch (IdLengthException e)
 			{
 				addAlert(state, trb.getFormattedMessage("alert.toolong", e.getReference()));
+			} catch (InvalidFilenameException e) {
+				addAlert(state, trb.getFormattedMessage("alert.invalid.name", new Object[]{name}));
 			}
 		}
 		else if("cancel".equals(user_action))
@@ -9183,8 +9193,8 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			String basename = name.trim();
             String extension = ".URL";
             
-            try
-			{
+            try {
+				Validator.checkFilename(basename);
 				ContentResourceEdit resource = contentHostingService.addResource(collectionId,Validator.escapeResourceName(basename),Validator.escapeResourceName(extension),MAXIMUM_ATTEMPTS_FOR_UNIQUENESS);
 				
 				extractContent(fp, resource);
@@ -9299,6 +9309,9 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 				addAlert(state, trb.getFormattedMessage("alert.toolong", new Object[]{e.getMessage()}));
 				// TODO Auto-generated catch block
 				log.warn("IdLengthException ", e);
+			} catch (InvalidFilenameException e) {
+				addAlert(state, trb.getFormattedMessage("alert.invalid.name", new Object[]{ basename }));
+				log.warn("InvalidFilenameException ", e);
 			}
 			catch (OverQuotaException e)
 			{
@@ -9558,6 +9571,16 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 	        } else if ("".equals(displayName)) {
 	            displayName = filename;
 	        }
+
+	        try {
+	            Validator.checkFilename(filename);
+	        } catch (InvalidFilenameException e) {
+	            // Invalid file name
+	            addAlert(state, trb.getFormattedMessage("alert.invalid.name", new Object[] { filename }));
+	            state.setAttribute(STATE_MODE, MODE_DROPBOX_MULTIPLE_FOLDERS_UPLOAD);
+	            return;
+	        }
+
 	        String SEPARATOR = "/";
 	        String COLLECTION_DROPBOX = "/group-user/";
 	        String contentType = fileitem.getContentType();

--- a/kernel/api/src/main/java/org/sakaiproject/exception/InvalidFilenameException.java
+++ b/kernel/api/src/main/java/org/sakaiproject/exception/InvalidFilenameException.java
@@ -1,0 +1,33 @@
+/**********************************************************************************
+ * Copyright (c) 2019 Apereo Foundation
+
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *       http://opensource.org/licenses/ecl2
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.exception;
+
+/**
+ * InvalidFilenameException is thrown whenever a resource name contains forbidden characters. \ / : * ? " < > |
+ */
+public class InvalidFilenameException extends SakaiException
+{
+
+    /**
+     * @param id The resource for which the name contains invalid characters.
+     */
+    public InvalidFilenameException(String id) {
+        super(id);
+    }
+
+}

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/Validator.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/Validator.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.exception.IdInvalidException;
+import org.sakaiproject.exception.InvalidFilenameException;
 
 /**
  * <p>
@@ -45,7 +46,7 @@ import org.sakaiproject.exception.IdInvalidException;
 public class Validator
 {
 	/** These characters are not allowed in a resource id */
-	public static final String INVALID_CHARS_IN_RESOURCE_ID = "^/\\{}[]()%*?#&=\n\r\t\b\f";
+	public static final String INVALID_CHARS_IN_RESOURCE_ID = "^/\\{}[]()%*?#&=\n\r\t\b\f<>:\"|";
 
 	/** These characters are not allowed in a user id */
 	protected static final String INVALID_CHARS_IN_USER_ID = "^/\\%*?\n\r\t\b\f";
@@ -477,6 +478,16 @@ public class Validator
 
 	} // checkResourceId
 
+    /**
+     * Check for a valid filename.
+     * 
+     * @Throws an InvalidFileNameException if the file name is not valid
+     */
+    public static void checkFilename(String filename) throws InvalidFilenameException {
+        if (StringUtils.isBlank(filename) || StringUtils.containsAny(filename, INVALID_CHARS_IN_FILENAME)) {
+            throw new InvalidFilenameException(filename);
+        }
+    } // checkFilename
 
 	/**
 	 * Check for a syntactically valid site type.


### PR DESCRIPTION
In the first implementation of this Jira, I modified the Kernel to include the exception when adding a collection or a resource using the contentHostingService API. However, is not needed because the problem resides in Resources, where the user can insert forbidden characters, they can't insert forbidden characters through file upload (Operating systems don't allow these characters).