### PR TITLE
SAK-42763 Add warning log in BasicEmailService setContent Method

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
@@ -1325,6 +1325,10 @@ public class BasicEmailService implements EmailService
 				// attach the file to the message
 				MimeBodyPart mbp = createAttachmentPart(attachment);
 				int mbpSize = mbp.getSize();
+				if (mbpSize < 0)
+				{
+					log.warn("Unexpected MIME body part size: " + mbpSize);
+				}
 				if ( (attachmentRunningTotal + mbpSize) < maxAttachmentSize )
 				{
 					embeddedAttachments.add(mbp);


### PR DESCRIPTION
This is a log to help warn/test; As mentioned in SAK-42763, this logs a warning that shows - setContent method in BasicEmailService is failing to get the size of the MIME body part resulting in a -1.