### PR TITLE
SAK-42911 Change part titles by default when one is created

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/AuthorPartListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/AuthorPartListener.java
@@ -53,7 +53,7 @@ public class AuthorPartListener implements ActionListener
     SectionBean sectionBean = (SectionBean) ContextUtil.lookupBean(
                                           "sectionBean");
     // clean it
-    sectionBean.setSectionTitle("");
+    sectionBean.setSectionTitle("Default");
     sectionBean.setAssessmentTitle(assessmentBean.getTitle());
     sectionBean.setSectionDescription("");
     sectionBean.setSectionId("");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42911

The first time you create a question its part has the title "Default", but whenever you create or edit an assesment and you add a part its title label is empty and you need to add one to be able to create the part otherwise you will see the message "Part title cannot be empty".

If you add by default the title "Default" when you are creating the part, you won't need to add one and those titles will not be visible to assessment takers anyway. It makes sense that this works this way.

