### PR TITLE
SAK-42914 Fixed the static variables for the starred sites top bar

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -128,10 +128,10 @@ public class SiteHandler extends WorksiteHandler
 	// This is Sakai 11 only so please do not back-port or merge this default value
 	private static final String IFRAME_SUPPRESS_DEFAULT = ":all:sakai.gradebook.gwt.rpc:com.rsmart.certification:sakai.rsf.evaluation:kaltura.media:kaltura.my.media";
 
-	private static final String SAK_PROP_SHOW_FAV_STARS = "portal.favoriteSitesBar.showFavStarsOnAllSites";
+	private static final String SAK_PROP_SHOW_FAV_STARS = "portal.favoriteSitesBar.showFavoriteStars";
 	private static final boolean SAK_PROP_SHOW_FAV_STARS_DFLT = true;
 
-	private static final String SAK_PROP_SHOW_FAV_STARS_ON_ALL = "portal.favoriteSitesBar.showFavoriteStars";
+	private static final String SAK_PROP_SHOW_FAV_STARS_ON_ALL = "portal.favoriteSitesBar.showFavStarsOnAllSites";
 	private static final boolean SAK_PROP_SHOW_FAV_STARS_ON_ALL_DFLT = true;
 
 	private static final long AUTO_FAVORITES_REFRESH_INTERVAL_MS = 30000;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42914

Noticed that the static variable names were swapped on my PR for the original stars contribution (#7441), which prevented the sakai.properties from working properly. I've switched them back and retested the various combinations. 