### PR TITLE
SAK-42925 Don't render group picker unless i18n is initialised.

### DIFF
--- a/webcomponents/tool/src/main/frontend/sakai-group-picker.js
+++ b/webcomponents/tool/src/main/frontend/sakai-group-picker.js
@@ -42,6 +42,10 @@ class SakaiGroupPicker extends SakaiElement {
 
   get siteId() { return this._siteId; }
 
+  shouldUpdate(changedProps) {
+    return this.i18n;
+  }
+
   render() {
 
     return html`


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42925