### PR TITLE
SAK-42951 Allow site import of other author's rubrics

### DIFF
--- a/rubrics/tool/src/main/java/org/sakaiproject/rubrics/security/CustomMethodSecurityExpressionHandler.java
+++ b/rubrics/tool/src/main/java/org/sakaiproject/rubrics/security/CustomMethodSecurityExpressionHandler.java
@@ -23,6 +23,7 @@
 package org.sakaiproject.rubrics.security;
 
 import org.aopalliance.intercept.MethodInvocation;
+import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.rubrics.logic.repository.CriterionRepository;
 import org.sakaiproject.rubrics.logic.repository.EvaluationRepository;
 import org.sakaiproject.rubrics.logic.repository.RatingRepository;
@@ -56,11 +57,14 @@ public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurity
     @Autowired
     private ToolItemRubricAssociationRepository toolItemRubricAssociationRepository;
 
+    @Autowired
+    private SecurityService securityService;
+
     protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
             Authentication authentication, MethodInvocation invocation) {
         CustomMethodSecurityExpressionRoot root =
                 new CustomMethodSecurityExpressionRoot(rubricRepository, criterionRepository, ratingRepository,
-                        evaluationRepository, toolItemRubricAssociationRepository, authentication);
+                        evaluationRepository, toolItemRubricAssociationRepository, securityService, authentication);
         root.setPermissionEvaluator(getPermissionEvaluator());
         root.setTrustResolver(this.trustResolver);
         root.setRoleHierarchy(getRoleHierarchy());


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42951

Added some proper security. You can only import rubrics from sites where
you are a rubrics.editor, or if you authored the rubric in question.