### PR TITLE
SAK-43092 - Fix up POMs for Eclipse compatibility

### DIFF
--- a/basiclti/basiclti-impl/pom.xml
+++ b/basiclti/basiclti-impl/pom.xml
@@ -68,6 +68,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <scope>test</scope>

--- a/basiclti/tsugi-util/src/test/org/tsugi/oauth2/OAUTH2ObjectTest.java
+++ b/basiclti/tsugi-util/src/test/org/tsugi/oauth2/OAUTH2ObjectTest.java
@@ -1,4 +1,4 @@
-package org.tsugi.lti13;
+package org.tsugi.oauth2;
 
 import static org.junit.Assert.*;
 

--- a/cloud-storage/googledrive/impl/pom.xml
+++ b/cloud-storage/googledrive/impl/pom.xml
@@ -42,12 +42,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${sakai.jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${sakai.jackson.version}</version>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         <!--Spring Dependencies-->
         <dependency>

--- a/cloud-storage/onedrive/impl/pom.xml
+++ b/cloud-storage/onedrive/impl/pom.xml
@@ -42,12 +42,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${sakai.jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${sakai.jackson.version}</version>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         <!--Spring Dependencies-->
         <dependency>

--- a/gradebookng/tool/pom.xml
+++ b/gradebookng/tool/pom.xml
@@ -39,6 +39,10 @@
 			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-kernel-api</artifactId>
 		</dependency>

--- a/help/help-tool/pom.xml
+++ b/help/help-tool/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>jstl</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet.jsp</groupId>
       <artifactId>javax.servlet.jsp-api</artifactId>
     </dependency>

--- a/jobscheduler/scheduler-component-shared/pom.xml
+++ b/jobscheduler/scheduler-component-shared/pom.xml
@@ -129,6 +129,10 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jsf2/jsf2-widgets-sun/pom.xml
+++ b/jsf2/jsf2-widgets-sun/pom.xml
@@ -24,6 +24,10 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+    </dependency>
+    <dependency>
         <groupId>javax.faces</groupId>
         <artifactId>javax.faces-api</artifactId>
     </dependency>

--- a/jsf2/jsf2-widgets/pom.xml
+++ b/jsf2/jsf2-widgets/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-kernel-api</artifactId>
         </dependency>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -360,6 +360,12 @@
         <version>4.0.1</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>javax</groupId>
+        <artifactId>javaee-api</artifactId>
+        <version>8.0</version>
+        <scope>provided</scope>
+      </dependency>
       <!-- parser API inconsistancies -->
       <!-- force this version where used -->
       <dependency>

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -20,6 +20,10 @@
 			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-kernel-api</artifactId>
 		</dependency>

--- a/polls/impl/pom.xml
+++ b/polls/impl/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>jta</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>

--- a/portal/portal-chat/tool/pom.xml
+++ b/portal/portal-chat/tool/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/portal/portal-util/util/pom.xml
+++ b/portal/portal-util/util/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>3.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/reset-pass/reset-pass/pom.xml
+++ b/reset-pass/reset-pass/pom.xml
@@ -71,5 +71,9 @@
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-collections4</artifactId>
     </dependency>
+    <dependency>
+        <groupId>javax</groupId>
+        <artifactId>javaee-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/rwiki/rwiki-impl/rwiki-shared-serializer/src/java/uk/ac/cam/caret/sakai/rwiki/component/service/impl/XHTMLSerializer2.java
+++ b/rwiki/rwiki-impl/rwiki-shared-serializer/src/java/uk/ac/cam/caret/sakai/rwiki/component/service/impl/XHTMLSerializer2.java
@@ -467,4 +467,20 @@ public class XHTMLSerializer2 implements SerializationHandler
 		xmlStream.setWriter(arg0);
 	}
 
+	public String getOutputProperty(String name) {
+		return xmlStream.getOutputProperty(name);
+	}
+
+	public String getOutputPropertyDefault(String name) {
+		return xmlStream.getOutputPropertyDefault(name);
+	}
+
+	public void setOutputProperty(String name, String val) {
+		xmlStream.setOutputProperty(name, val);
+	}
+
+	public void setOutputPropertyDefault(String name, String val) {
+		xmlStream.setOutputPropertyDefault(name, val);
+	}
+
 }

--- a/search/elasticsearch/api/pom.xml
+++ b/search/elasticsearch/api/pom.xml
@@ -20,6 +20,10 @@
       <artifactId>elasticsearch</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sakaiproject.kernel</groupId>
+      <artifactId>sakai-kernel-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sakaiproject.search</groupId>
       <artifactId>search-api</artifactId>
     </dependency>

--- a/site-manage/site-manage-impl/impl/pom.xml
+++ b/site-manage/site-manage-impl/impl/pom.xml
@@ -90,6 +90,10 @@
             <version>1.0</version>
         </dependency>
         <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.sakaiproject.userauditservice</groupId>
             <artifactId>userauditservice-api</artifactId>
         </dependency>

--- a/syllabus/syllabus-app/pom.xml
+++ b/syllabus/syllabus-app/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+        <groupId>javax</groupId>
+        <artifactId>javaee-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sakaiproject.kernel</groupId>
       <artifactId>sakai-kernel-api</artifactId>
     </dependency>

--- a/tags/tags-impl/impl/pom.xml
+++ b/tags/tags-impl/impl/pom.xml
@@ -87,6 +87,10 @@
       <version>${sakai.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
       <scope>test</scope>

--- a/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/job/TagSynchronizer.java
+++ b/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/job/TagSynchronizer.java
@@ -22,7 +22,7 @@ package org.sakaiproject.tags.impl.job;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;;
+import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;


### PR DESCRIPTION
There were a few modules that would compile with Maven directly, but
throw errors when imported as Eclipse projects. The main two issues were
in the Java EE API and a Jackson coordinate change.

There are two minor code changes that I expect would have broken Maven
builds, but apparently did not. One was a test class/package mismatch
in LTI and the other was some missing method implementations for an XML
class in rwiki.