### PR TITLE
SAK-42749 Partial fix for copied course content

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -60,6 +60,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
+import java.net.InetAddress;
+import java.net.URL;
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -71,6 +77,8 @@ import org.jsoup.select.Elements;
 import org.sakaiproject.authz.api.AuthzRealmLockException;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -178,6 +186,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
    private GradebookIfc gradebookIfc;
    private LessonBuilderAccessAPI lessonBuilderAccessAPI;
    private MessageSource messageSource;
+	private LTIService ltiService;
    public void setLessonBuilderAccessAPI(LessonBuilderAccessAPI l) {
        lessonBuilderAccessAPI = l;
    }
@@ -738,6 +747,23 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			   sakaiId = "/group/" + siteId + "/" + sakaiId.substring(prefix.length());
 		       else
 			   log.error("sakaiId not recognized " + sakaiId);
+		   } else if (type == SimplePageItem.BLTI) {
+			   try {
+				   // We need to import the BLTI tool to the new site and update the sakaiid
+				   String[] bltiId = sakaiId.split("/");
+				   Long ltiContentId = Long.valueOf(bltiId[2]);
+
+				   Map<String, Object> ltiContent = ltiService.getContentDao(ltiContentId, oldSiteId, securityService.isSuperUser());
+				   String launchUrl = (String) ltiContent.get(LTIService.LTI_LAUNCH);
+				   String ltiTitle = (String) ltiContent.get(LTIService.LTI_TITLE);
+				   String xmlStr = (String) ltiContent.get(LTIService.LTI_XMLIMPORT);
+				   String ltiCustom = (String) ltiContent.get(LTIService.LTI_CUSTOM);
+				   Long ltiToolId = getLong(ltiContent.get(LTIService.LTI_TOOL_ID));
+				   sakaiId = importLTITool(siteId, launchUrl, ltiTitle, xmlStr, ltiCustom, ltiToolId);
+			   } catch (Exception e) {
+				   log.warn("Unable to import LTI tool to new site " + e);
+				   e.printStackTrace();
+			   }
 		   } else if (type == SimplePageItem.PAGE) {
 		       // sakaiId should be the new page ID
 		       Long newPageId = pageMap.get(Long.valueOf(sakaiId));
@@ -1699,6 +1725,10 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	messageSource = s;
     }
 
+	public void setLtiService(LTIService s) {
+		ltiService = s;
+	}
+
     // sitestats support
 
     public boolean entityExists(String id) {
@@ -2194,5 +2224,109 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
         }
         return replacedBody;
     }
+
+	private String importLTITool(String siteId, String launchUrl, String bltiTitle, String strXml, String custom, Long ltiToolId)
+			throws Exception
+	{
+		if ( ltiService == null ) return null;
+
+		// If there is no launch url saved in the lti content get it from the corresponding tool
+		if (launchUrl == null) {
+			Map<String, Object> ltiTool = ltiService.getToolDao(ltiToolId, siteId, securityService.isSuperUser());
+			launchUrl = (String) ltiTool.get(LTIService.LTI_LAUNCH);
+		}
+		String toolUrl = launchUrl;
+		int pos = toolUrl.indexOf("?");
+		if ( pos > 0 ) {
+			toolUrl = toolUrl.substring(0, pos);
+		}
+
+		// Check for global tool configurations (prefer global)
+		Map<String,Object> theTool = null;
+		List<Map<String,Object>> tools = ltiService.getToolsDao(null,null,0,0,"!admin");
+		String lastLaunch = "";
+		for ( Map<String,Object> tool : tools ) {
+			String toolLaunch = (String) tool.get(LTIService.LTI_LAUNCH);
+			// Prefer the longest match
+			if (toolUrl.startsWith(toolLaunch) && toolLaunch.length() > lastLaunch.length()) {
+				theTool = tool;
+				lastLaunch = toolLaunch;
+			}
+		}
+
+		// Check for within-site tool configurations (prefer global)
+		if ( theTool == null ) {
+			tools = ltiService.getToolsDao(null,null,0,0,siteId);
+			lastLaunch = "";
+			for ( Map<String,Object> tool : tools ) {
+				String toolLaunch = (String) tool.get(LTIService.LTI_LAUNCH);
+				// Prefer the longest match
+				if ( toolUrl.startsWith(toolLaunch) && toolLaunch.length() > lastLaunch.length()) {
+					theTool = tool;
+					lastLaunch = toolLaunch;
+				}
+			}
+		}
+
+		// If we still do not have a tool configuration throw an error
+		if ( theTool == null ) {
+			log.error("LORI Launch configuration not found- "+toolUrl);
+			throw new Exception("LORI Launch configuration not found");
+		}
+
+		// Found a tool - time to insert content
+		Map<String,Object> theContent = null;
+
+		Properties props = new Properties ();
+		String toolId = getLong(theTool.get(LTIService.LTI_ID)).toString();
+		props.setProperty(LTIService.LTI_TOOL_ID,toolId);
+		props.setProperty(LTIService.LTI_PLACEMENTSECRET, UUID.randomUUID().toString());
+		props.setProperty(LTIService.LTI_TITLE, bltiTitle);
+		props.setProperty(LTIService.LTI_PAGETITLE, bltiTitle);
+		props.setProperty(LTIService.LTI_LAUNCH,launchUrl);
+		props.setProperty(LTIService.LTI_SITE_ID,siteId);
+
+		if ( strXml != null) props.setProperty(LTIService.LTI_XMLIMPORT,strXml);
+		if ( custom != null ) props.setProperty(LTIService.LTI_CUSTOM,custom);
+
+		log.debug("Inserting content associated with toolId="+toolId);
+
+		// Insert as admin into siteId, on error throw upwards
+		Object result = ltiService.insertContentDao(props, "!admin");
+		if ( result instanceof String ) {
+			log.error("Could not insert content - "+result);
+		} else {
+			log.debug("Adding LTI tool "+result);
+		}
+		if ( result instanceof Long ) theContent = ltiService.getContentDao((Long) result, siteId);
+
+		String sakaiId = null;
+		if ( theContent != null ) {
+			sakaiId = "/blti/" + theContent.get(LTIService.LTI_ID);
+		}
+		return sakaiId;
+	}
+
+	private Long getLong(Object key) {
+		Long retval = getLongNull(key);
+		if (retval != null)
+			return retval;
+		return new Long(-1);
+	}
+
+	private Long getLongNull(Object key) {
+		if (key == null)
+			return null;
+		if (key instanceof Number)
+			return new Long(((Number) key).longValue());
+		if (key instanceof String) {
+			try {
+				return new Long((String) key);
+			} catch (Exception e) {
+				return null;
+			}
+		}
+		return null;
+	}
 
 }

--- a/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -294,7 +294,7 @@ simplePageBean.addForumSummary
     <property name="securityService"><ref bean="org.sakaiproject.authz.api.SecurityService"/></property>
     <property name="contentHostingService"><ref bean="org.sakaiproject.content.api.ContentHostingService"/></property>
     <property name="sessionManager"><ref bean="org.sakaiproject.tool.api.SessionManager"/></property>
-
+    <property name="ltiService" ref="org.sakaiproject.lti.api.LTIService" />
     <property name="toolManager" ref="org.sakaiproject.tool.api.ActiveToolManager" />
     <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
     <property name="memoryService"><ref bean="org.sakaiproject.memory.api.MemoryService"/></property>


### PR DESCRIPTION
This PR addresses an issue where copying a course did not result in LTI content being updated for the new course and using old, and incorrect, links. The PR consists of two commits, one is the work from David Bauer at University of Dayton, and the second is Warpwire's adjustment to handle LTI content in text fields.