### PR TITLE
SAK-43053 Revert "SAK-41810: Error with Extra point if there is a category 0% (#7109)"

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3302,8 +3302,8 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		if (gradebook.getCategory_type() == GradebookService.CATEGORY_TYPE_WEIGHTED_CATEGORY) {
 			double totalWeight = 0;
 			for (final CategoryDefinition newDef : newCategoryDefinitions) {
-				BigDecimal bg = newDef.getWeight() == null ? null : new BigDecimal(newDef.getWeight());
-				if (bg == null || bg.compareTo(BigDecimal.ZERO) == 0) {
+
+				if (newDef.getWeight() == null) {
 					throw new IllegalArgumentException("No weight specified for a category, but weightings enabled");
 				}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/SettingsPage.java
@@ -139,9 +139,6 @@ public class SettingsPage extends BasePage {
 						if (catWeight == null) {
 							error(getString("settingspage.update.failure.categorymissingweight"));
 						}
-						else if (catWeight.compareTo(BigDecimal.ZERO) == 0) {
-							error(getString("settingspage.update.failure.categoryweightzero"));
-						}
 						else if (catWeight.signum() == -1) {
 							totalWeight = totalWeight.add(BigDecimal.valueOf(cat.getWeight()));
 							error(getString("settingspage.update.failure.categoryweightnegative"));


### PR DESCRIPTION
This reverts commit 4155a51528cfee9238c91a094372f518084d6ac5.

Based on comments from clients, I believe SAK-41810 was a mistake. I believe there are valid use cases for Gradebook category worth 0%