### PR TITLE
SAK-43178 First time you log in as a user, you don't have your sites as favorites even with the autofavorite option activated

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
@@ -198,7 +198,7 @@ public class FavoritesHandler extends BasePortalHandler
 		Set<String> newFavorites = new LinkedHashSet<String>();
 
 		for (String userSite : userSites) {
-			if (!oldSiteSet.contains(userSite) && !existingFavorites.contains(userSite) && !firstTimeFavs) {
+			if (!oldSiteSet.contains(userSite) && !existingFavorites.contains(userSite)) {
 				newFavorites.add(userSite);
 			}
 		}


### PR DESCRIPTION
The first time you log in as a new user, if you are enrolled in a site before you do it, it won't be showed in your favorites even if the option it's ON.

It would make sense that new users could see all their sites the first time they log in.
