### PR TITLE
SAK-41106 - Sites don't appear as auto-favorited before first time login

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -970,7 +970,7 @@
 # DEFAULT: false
 # portal.forceOverviewToTop=true
 
-# SAK-32296 - Set default tabs to show
+# SAK-32296 - Set default tabs to show, also doubles as a limit for first time favorites (if autofavorite set below)
 # DEFAULT: 
 # portal.default.tabs=15
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
@@ -42,6 +42,7 @@ import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.SiteService.SelectionType;
+import org.sakaiproject.site.api.SiteService.SortType;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.user.api.PreferencesEdit;
@@ -198,7 +199,7 @@ public class FavoritesHandler extends BasePortalHandler
 		}
 
 		// This should not call getUserSites(boolean, boolean) because the property is variable, while the call is cacheable otherwise
-		List<String> userSites = siteService.getSiteIds(SelectionType.MEMBER, null, null, null, null, null);
+		List<String> userSites = siteService.getSiteIds(SelectionType.MEMBER, null, null, null, SortType.CREATED_ON_DESC, null);
 		Set<String> newFavorites = new LinkedHashSet<String>();
 
 		for (String userSite : userSites) {


### PR DESCRIPTION
There were 3 suggestions I'd made on the jira. This fix is implementing #3. It will always try to favorite at least portal.default.tabs number of sites the first time someone logs in.

1) Have a another property to always favorite new sites on the first time for a user, no matter if it's the first time logging in ever or the first time since the upgrade when this feature existed.

2) Set some kind of preference on the user when they are created to say they're first time and haven't seen favorites, then when they get around to this favorites logic remove that. Then when it gets around to them remove that.

3) Previous suggestions by Austin (and possibly others?) to have a limit (probably set by property) for the number of sites auto favorite can add on the first time. (Maybe a reasonable compromise?)