### PR TITLE
SAK-43233: Resources > enforce copyright selection for URLs on create if required

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -16,6 +16,12 @@
 		#end
 	</ol>
 
+	#if ($itemAlertMessage)
+		<div id="resourceAlert" class="sak-banner-success">$itemAlertMessage</div>
+	#else
+		<div id="resourceAlert" class="sak-banner-error hide"></div>
+	#end
+
 	<p class="instruction">
 		$tlang.getString("instr.urls")
 	</p>
@@ -116,7 +122,7 @@
 		#end
 		
 		<p class="act">
-			<input type="button" class="active" name="savechanges" id="saveChanges" onclick="showNotif('submitnotifxxx','saveChanges','addContentForm');document.getElementById('addContentForm').action='#toolLink("ResourcesHelperAction" "doAddUrls")&flow=save';submitform('addContentForm');" value="$tlang.getString("label.urlnow")" accesskey="s" />
+			<input type="button" class="active" name="savechanges" id="saveChanges" value="$tlang.getString("label.urlnow")" accesskey="s" />
 			<input type="button" name="cancel" onclick="document.getElementById('addContentForm').action='#toolLink("ResourcesHelperAction" "doCancel")';submitform('addContentForm');" value="$tlang.getString("label.cancel")" accesskey="x" />
 		</p>
 		<p id="submitnotifxxx"  class="sak-banner-info"  style="visibility:hidden">$tlang.getString("processmessage.url")</p>
@@ -124,3 +130,16 @@
 	</form>
 </div>
 #parse("/vm/resources/sakai_properties_scripts.vm")
+<script>
+	// Client side copyright check
+	var submitButton = document.getElementById("saveChanges");
+	submitButton.addEventListener("click", function()
+	{
+		if (checkCopyright(submitButton))
+		{
+			showNotif('submitnotifxxx','saveChanges','addContentForm');
+			document.getElementById('addContentForm').action='#toolLink("ResourcesHelperAction" "doAddUrls")&flow=save';
+			submitform('addContentForm');
+		}
+	});
+</script>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43233

There is a sakai.property to force selection of a copyright status (`copyright.requireChoice`).  There is also a new sakai.property (introduced in Sakai 12) to display the copyright selection component for the "Web Links (URLs)" resource type (`content.url.rightsdialog`).

If both properties are set to `true`, the copyright selection should be enforced when creating new Web Links; but it is not. If you do not select a copyright status (found within the "Add details for this item" panel), and save it should prompt you to select a copyright status, but it does not.

When editing a Web Link (with both properties set to `true`), the copyright enforcement is enforced.

Enforce copyright status selection on creation of Web Links when both properties are set to true.