### PR TITLE
SAK-43224 : Empty title alert not being shown on group creation

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/webapp/content/templates/GroupEdit.html
@@ -32,7 +32,7 @@
 	 $(document).ready(function() {
 		$('#save').click(function() {
 			if ($('#group_title').val() === "") {
-		   		$('.messageValidation').show();
+		   		$('.emptyGroupTitleAlert').show();
 		   		$('#group_title').focus();
 		   		return false;
 		  	}
@@ -73,7 +73,7 @@
 		<div class="page-header">
 			<h1 rsf:id="prompt"></h1>
 		</div>
-		<p id="" class="sak-banner-warn" rsf:id="emptyGroupTitleAlert" style="display:none"/>
+		<p id="emptyGroupTitleAlert" class="sak-banner-warn" rsf:id="emptyGroupTitleAlert" style="display:none"/>
 		<p rsf:id="instructions" class="instruction">
 		</p>
 


### PR DESCRIPTION
Quick fix, although this tool will be replaced in the soon future (SAK-40672)