### PR TITLE
SAK-43251 Fixed display issues with the User Activity page header

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/_base.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_base.scss
@@ -211,7 +211,7 @@
 
 		h1, h2, h3
 		{
-			margin: $standard-spacing 0 0 0; // vertical margins will collapse into one
+			margin: 0;
 			padding: 0;
 			line-height: 1;
 		}

--- a/sitestats/sitestats-tool/src/webapp/html/pages/UserActivityPage.html
+++ b/sitestats/sitestats-tool/src/webapp/html/pages/UserActivityPage.html
@@ -26,16 +26,14 @@
 				<menu wicket:id="menu" class="navIntraTool">[menu]</menu>
 
 				<div class="content">
-					<div class="page-header">
 						<!-- Page title -->
 						<div class="page-header">
 							<h1>
 								<wicket:message key="menu_useractivity">User Activity</wicket:message>
 							</h1>
-						</div>
 						<!-- Last Job run -->
-						<span wicket:id="lastJobRunContainer"><span wicket:id="lastJobRun"></span></span>
-					</div>
+							<span wicket:id="lastJobRunContainer"><span wicket:id="lastJobRun"></span></span>
+						</div>
 
 					<!-- FORM -->
 					<form wicket:id="form" class="userTrackingForm">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43251

On the User Activity page of the Statistics tool, the page header was duplicated, which caused two lines below the heading. 

I removed the duplicate div and the extra margin. 

See SAK-43251 for before and after screenshots.