### PR TITLE
SAK-43019 Fixed questions view rubric behaviour

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
@@ -23,10 +23,7 @@
 package org.sakaiproject.tool.assessment.ui.bean.evaluation;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
@@ -454,11 +451,15 @@ public class AgentResults
 	
 	public String addAttachmentsRedirect() {
 
+		// We need to make sure that the state details are reapplied to the agent beans
 		QuestionScoresBean questionScoresBean = (QuestionScoresBean) ContextUtil.lookupBean("questionScores");
-		String evalId = this.getAssessmentGradingId() + "." + questionScoresBean.getItemId();
-		String entityId = RubricsConstants.RBCS_PUBLISHED_ASSESSMENT_ENTITY_PREFIX + questionScoresBean.getPublishedId() + "." + questionScoresBean.getItemId();
-		String rubricStateDetails = ContextUtil.lookupParam(RubricsConstants.RBCS_PREFIX + evalId + "-" + entityId + "-state-details");
-		this.setRubricStateDetails(rubricStateDetails);
+		questionScoresBean.getAgentResultsByItemGradingId().values().forEach(ar -> {
+
+			String evalId = ar.getAssessmentGradingId() + "." + questionScoresBean.getItemId();
+			String entityId = RubricsConstants.RBCS_PUBLISHED_ASSESSMENT_ENTITY_PREFIX + questionScoresBean.getPublishedId() + "." + questionScoresBean.getItemId();
+			String rubricStateDetails = ContextUtil.lookupParam(RubricsConstants.RBCS_PREFIX + evalId + "-" + entityId + "-state-details");
+			ar.setRubricStateDetails(rubricStateDetails);
+		});
 
 		// 1. redirect to add attachment
 		try	{

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -155,7 +155,7 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
   @Getter @Setter
   private Map userIdMap;
   @Getter @Setter
-  private Map agentResultsByItemGradingId;
+  private Map<Long, AgentResults> agentResultsByItemGradingId;
   @Getter @Setter
   private boolean anyItemGradingAttachmentListModified;
   @Getter @Setter

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -268,7 +268,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 //			}
 			log.debug("questionScores(): publishedAnswerHash.size = "
 					+ publishedAnswerHash.size());
-			Map agentResultsByItemGradingIdMap = new HashMap();
+			Map<Long, AgentResults> agentResultsByItemGradingIdMap = new HashMap<>();
 
 			TotalScoresBean totalBean = (TotalScoresBean) ContextUtil
 					.lookupBean("totalScores");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43019

Fixed an issue: If you mod one student's rubric, then add an attachment
to another students result, the first student's rubric is lost. This
fixes that.