### PR TITLE
SAK-43061 Add delete column to bulk edit modal in gbng

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/GradebookNgApplication.properties
@@ -132,6 +132,7 @@ label.addgradeitem.due.help = Select a date
 label.addgradeitem.category = Category
 label.addgradeitem.nocategoryassigned = Items not assigned to a category will not count toward the course grade.
 label.addgradeitem.toggle.all = Toggle all
+label.addgradeitem.delete.toggle.all = Toggle all the items to be deleted.
 label.addgradeitem.release = Release item to students?
 label.addgradeitem.release.toggle.all = Toggle all the items to be released.
 label.addgradeitem.include = Include item in course grade calculations?
@@ -640,6 +641,7 @@ bulkedit.heading=Bulk Edit Items
 bulkedit.column.header.gradebookitem=Gradebook Item
 bulkedit.column.header.release=Release to students
 bulkedit.column.header.include=Include in course grade calculations
+bulkedit.column.header.delete=Delete
 bulkedit.update.success = The gradebook items were successfully updated
 bulkedit.update.error = Some gradebook items could not be updated. Please try again. If the problem persists, contact your System Administrator.
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -213,6 +213,8 @@ public class GradebookPage extends BasePage {
 		this.form.add(this.courseGradeStatisticsWindow);
 
 		this.bulkEditItemsWindow = new GbModalWindow("bulkEditItemsWindow");
+		this.bulkEditItemsWindow.setWidthUnit("%");
+		this.bulkEditItemsWindow.setInitialWidth(65);
 		this.bulkEditItemsWindow.setPositionAtTop(true);
 		this.bulkEditItemsWindow.showUnloadConfirmation(false);
 		this.form.add(this.bulkEditItemsWindow);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.html
@@ -10,15 +10,17 @@
 				<thead>
 					<tr>
 						<th class="col-md-4"><wicket:message key="bulkedit.column.header.gradebookitem" /></th>
-						<th class="col-md-1"><wicket:message key="bulkedit.column.header.release" /><br/><input type="checkbox" id="releaseToggleAll" onclick="releaseToggleCheckboxes();" wicket:message="aria-label:label.addgradeitem.release.toggle.all"> <span wicket:id="toggleAllLabel">Toggle All</span></th>
-						<th class="col-md-1"><wicket:message key="bulkedit.column.header.include" /><br/><input type="checkbox" id="includeToggleAll" onclick="includeToggleCheckboxes();" wicket:message="aria-label:label.addgradeitem.include.toggle.all"> <span wicket:id="toggleAllLabel">Toggle All</span></th>
+						<th class="col-md-1"><wicket:message key="bulkedit.column.header.release" /><br/><input type="checkbox" id="releaseToggleAll" onchange="releaseToggleCheckboxes();" wicket:message="aria-label:label.addgradeitem.release.toggle.all"> <label for="releaseToggleAll" wicket:id="releaseToggleAllLabel">Toggle All</label></th>
+						<th class="col-md-1"><wicket:message key="bulkedit.column.header.include" /><br/><input type="checkbox" id="includeToggleAll" onchange="includeToggleCheckboxes();" wicket:message="aria-label:label.addgradeitem.include.toggle.all"> <label for="includeToggleAll" wicket:id="includeToggleAllLabel">Toggle All</label></th>
+						<th class="col-md-1"><wicket:message key="bulkedit.column.header.delete" /><br/><input type="checkbox" id="deleteToggleAll" onchange="deleteToggleCheckboxes();" wicket:message="aria-label:label.addgradeitem.delete.toggle.all"> <label for="deleteToggleAll" wicket:id="deleteToggleAllLabel">Toggle All</label></th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr wicket:id="listView">
-						<td><span wicket:id="itemTitle">item title</span></td>
-						<td><input wicket:id="release" type="checkbox" wicket:message="aria-label:label.addgradeitem.release" /></td>
-						<td><input wicket:id="include" type="checkbox" wicket:message="aria-label:label.addgradeitem.include"  /></td>
+						<td><span wicket:id="itemTitle" class="itemTitle" >item title</span></td>
+						<td><input wicket:id="release" type="checkbox" class="release" wicket:message="aria-label:label.addgradeitem.release" /></td>
+						<td><input wicket:id="include" type="checkbox" class="include" wicket:message="aria-label:label.addgradeitem.include"  /></td>
+						<td><input wicket:id="delete" type="checkbox" class="deleteBox" wicket:message="aria-label:label.addgradeitem.delete" onclick="disableAndStrikeoutOneRow(this);"/></td>
 					</tr>
 				</tbody>
 			</table>

--- a/gradebookng/tool/src/webapp/scripts/gradebook-bulk-edit.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-bulk-edit.js
@@ -2,16 +2,16 @@
  *                    Gradebook Bulk Edit Javascript                                   
  *************************************************************************************/
 function toggleCheckboxes(checkboxFamily) {
-  if(document.getElementById(checkboxFamily+'ToggleAll').checked) {
+  if(document.getElementById(checkboxFamily+'ToggleAll').checked) { //selecting all
     $(':checkbox').each(function() {
-      if(this.name.includes(checkboxFamily)) {
-        this.checked = true;
+      if(this.name.includes(checkboxFamily) && !this.checked && !this.disabled) {
+        this.click();
       }
     });
-  } else {
+  } else {  //deselecting all
     $(':checkbox').each(function() {
-      if(this.name.includes(checkboxFamily)) {
-        this.checked = false;
+      if(this.name.includes(checkboxFamily) && this.checked && !this.disabled) {
+        this.click();
       }
     });
   }
@@ -25,3 +25,27 @@ function includeToggleCheckboxes() {
   toggleCheckboxes('include');
 }
 
+function deleteToggleCheckboxes() {
+  toggleCheckboxes('delete');
+}
+
+function disableAndStrikeoutOneRow(deleteBox) {
+    var listRow = deleteBox.parentElement.parentElement;
+    var releaseBox = listRow.getElementsByClassName('release')[0];
+    var includeBox = listRow.getElementsByClassName('include')[0];
+    var titleBox = listRow.getElementsByClassName('itemTitle')[0];
+    if (deleteBox.checked){
+        if (includeBox.disabled){	//if Include is already disabled, it's supposed to stay disabled; this appears to be the case for Uncategorized items.
+            includeBox.setAttribute('class', includeBox.getAttribute('class') + ' stayDisabled');	//fake CSS class to denote that this box should always be disabled
+        }
+        releaseBox.disabled = true;
+        includeBox.disabled = true;
+        titleBox.setAttribute('style', 'text-decoration: line-through;');
+    } else {
+        releaseBox.disabled = false;
+        if (!includeBox.getAttribute('class').includes('stayDisabled')){	//don't enable ones that are marked as stayDisabled.
+            includeBox.disabled = false;
+        }
+        titleBox.removeAttribute('style');
+    }
+}


### PR DESCRIPTION
Add additional functionality to the bulk edit modal that allows for
multiple items to be deleted. This feature also fixes the toggle all
for release and include columns.