### PR TITLE
SAK-43381: admin workspace > announcements > fix cache refresh

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/AnnouncementObserver.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/AnnouncementObserver.java
@@ -57,10 +57,15 @@ public class AnnouncementObserver implements Observer {
         }
     }
 
+    /*
+     * Utility method to generate the channel ID based on the event reference.
+     * Normal channel ID: "/announcement/channel/<siteID>/main"
+     * Admin Workspace channel ID: "/announcement/channel/!site/motd"
+     */
     private String getChannel(final Event event) {
         final String[] resourceSplitted = event.getResource().split("/");
-        final String site = resourceSplitted[3];
-        return "/announcement/channel/" + site + "/main";
+        final String site = "!admin".equals(resourceSplitted[3]) ? "!site" : resourceSplitted[3];
+        return "/announcement/channel/" + site + ("!site".equals(site) ? "/motd" : "/main");
     }
 
 }

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -576,6 +576,11 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 	{
 		if (ref == null) return null;
 
+		// Used to resolve Site objects; "!site" refers to "!admin" site
+		if ("!site".equals(ref)) {
+			ref = "!admin";
+		}
+
 		MessageChannel channel = (MessageChannel) m_threadLocalManager.get(ref);
 		if (channel == null)
 		{
@@ -2219,8 +2224,8 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 		 */
 		public String getContext()
 		{
-			return m_context;
-
+			// Used to resolve Site objects; "!site" refers to "!admin" site
+			return "!site".equals(m_context) ? "!admin" : m_context;
 		} // getContext
 
 		/**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43381

Creating, editing and deleting Announcements via Admin Workspace (MOTD) appears to not work for a period of time until the cache is evicted.

This is caused by not building the channel ID for the MOTD (admin workspace) properly in `AnnouncementObserver`, so it effectively clears a non-existent cache in this context.