### PR TITLE
SAK-43259 Lessons: Error when printing and there's a calendar

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1335,6 +1335,12 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		headJs.append("/library/js/headscripts.js");
 		headJs.append(PortalUtils.getCDNQuery());
 		headJs.append("\"></script>\n");
+
+		String [] parts = getParts(req);
+		if ((parts.length > 2) && (parts[1].equals("tool"))) {
+			headJs.append("<script src=\""+PortalUtils.getWebjarsPath()+"momentjs/"+PortalUtils.MOMENTJS_VERSION+"/min/moment-with-locales.min.js"+PortalUtils.getCDNQuery()+"\"></script>\n");
+		}
+
 		headJs.append("<script type=\"text/javascript\">var sakai = sakai || {}; sakai.editor = sakai.editor || {}; " +
 				"sakai.editor.editors = sakai.editor.editors || {}; " +
 				"sakai.editor.editors.ckeditor = sakai.editor.editors.ckeditor || {}; " +

--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/PortalUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/PortalUtils.java
@@ -36,6 +36,11 @@ import org.sakaiproject.coursemanagement.api.CourseManagementService;
 public class PortalUtils
 {
 
+	/**
+	 * External libraries versions
+	 */
+	public static final String MOMENTJS_VERSION = "2.24.0";//TODO SAK-43259 : This string should be updated when the version of the library is modified
+
 	private static CourseManagementService courseManagementService = (CourseManagementService) ComponentManager.get(CourseManagementService.class);
 
 	/**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43259

Providing a working solution for the bug, to get the conversation started about how to manage it. This problem affects not only the case described on the jira's title, but also every url access to tools using moment, and of course the same can happen with other libraries. Adding library versions on more places is far from ideal, but as long as Sakai supports this kind of tool access we have to solve the bugs. Even if that's redesigned we can provide a quick fix first. We can discuss on this PR about adding a headscripts Java component (a similar feature to the headscripts js thing on library). DirecttoolHandler or ToolHandler might be other places where to add it, although the former doesn't cover every possible call and the latter is executed more times than needed. It could also be checked against specific tools but I'm a bit against it.