### PR TITLE
SAK-43435 Profile2: fix texts next to icons

### DIFF
--- a/profile2/tool/src/webapp/css/profile2.css
+++ b/profile2/tool/src/webapp/css/profile2.css
@@ -178,6 +178,7 @@ h2 {
 	background-position: center left;
     background-repeat: no-repeat;
     padding-left: 18px;
+    display: inline !important;
 }
 
 /* icons */


### PR DESCRIPTION
Font-awesome's own icon class introduced some changes that resulted in a compression of all the texts next to icons in the Profile tool. Even if it's not ideal, the best solution seems to be overriding the 'display' behavior of the component, already on its own css file. The tool adds classes to components from Java too, so it's hard to trace the number of cases, but this should solve all of them.