### PR TITLE
SAK-42904 Missing documentation for property for disabling duplicate email addresses for accounts

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1112,7 +1112,9 @@
 # Default: You have entered an email address ending with "{1}", which is restricted. Please try again with a different email address.
 # user.email.invalid.domain.message=You have entered a {0} email address ending with "{1}". Please log in with your existing {0} account.
 
-
+# Allow users with duplicated email
+# DEFAULT: true
+# user.email.allowduplicates=false
 
 # ########################################################################
 # LOGGING


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42904