### PR TITLE
SAK-43519 Only show external tool rubric when grade released

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -327,7 +327,7 @@ public class GradeSummaryTablePanel extends BasePanel {
 							sakaiRubricButton.add(AttributeModifier.append("evaluated-item-id", assignment.getId() + "." + studentUuid));
 							sakaiRubricButton.add(AttributeModifier.append("token", rubricsService.generateJsonWebToken(RubricsConstants.RBCS_TOOL_GRADEBOOKNG)));
 
-							addInstructorAttributeOrHide(sakaiRubricButton, assignment.getId(), studentUuid, showingStudentView);
+							addInstructorAttributeOrHide(sakaiRubricButton, assignment, studentUuid, showingStudentView);
 
 							if (assignment.getId() != null) {
 								sakaiRubricButton.add(AttributeModifier.append("entity-id", assignment.getId()));
@@ -344,7 +344,7 @@ public class GradeSummaryTablePanel extends BasePanel {
 							sakaiRubricButton.add(AttributeModifier.append("display", "icon"));
 							sakaiRubricButton.add(AttributeModifier.append("token", rubricsService.generateJsonWebToken(RubricsConstants.RBCS_TOOL_GRADEBOOKNG)));
 
-							addInstructorAttributeOrHide(sakaiRubricButton, assignment.getId(), studentUuid, showingStudentView);
+							addInstructorAttributeOrHide(sakaiRubricButton, assignment, studentUuid, showingStudentView);
 
 							if (assignment.isExternallyMaintained()) {
 								sakaiRubricButton.add(AttributeModifier.append("tool-id", RubricsConstants.RBCS_TOOL_ASSIGNMENT));
@@ -391,14 +391,14 @@ public class GradeSummaryTablePanel extends BasePanel {
 		});
 	}
 
-	private void addInstructorAttributeOrHide(WebMarkupContainer sakaiRubricButton, Long assignmentId, String studentId, boolean showingStudentView) {
+	private void addInstructorAttributeOrHide(WebMarkupContainer sakaiRubricButton, Assignment assignment, String studentId, boolean showingStudentView) {
 
 		if (!showingStudentView && (GradeSummaryTablePanel.this.getUserRole() == GbRole.INSTRUCTOR
 					|| GradeSummaryTablePanel.this.getUserRole() == GbRole.TA)) {
 			sakaiRubricButton.add(AttributeModifier.append("instructor", true));
 		} else {
-			GradeDefinition gradeDefinition = businessService.getGradeForStudentForItem(studentId, assignmentId);
-			if (gradeDefinition.getGrade() == null) {
+			GradeDefinition gradeDefinition = businessService.getGradeForStudentForItem(studentId, assignment.getId());
+			if (assignment.isExternallyMaintained() && gradeDefinition.getGrade() == null) {
 				sakaiRubricButton.setVisible(false);
 			}
 		}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43519?filter=16773

We should only show rubrics from external tools (not LTI, we're talking
assignments, Samigo, etc) when the tool has released the grade.
Internally maintained gb items can show the rubric button all the time
as it will allow preview by the student.