### PR TITLE
SAK-43539: add some large sections to demo data

### DIFF
--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SampleDataLoader.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SampleDataLoader.java
@@ -361,73 +361,73 @@ public class SampleDataLoader implements BeanFactoryAware {
 
 			loadDiscussionSection("Discussion 1 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), null, null, null,
-					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 2 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "B Building 202",
 					getTime("10:00" + AMPM[0]), getTime("11:30" + AMPM[0]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 3 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "B Hall 11",
 					getTime("9:00" + AMPM[0]), getTime("10:30" + AMPM[0]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 4 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "C Building 100",
 					getTime("1:30" + AMPM[1]), getTime("3:00" + AMPM[1]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 5 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "Building 10",
 					getTime("9:00" + AMPM[0]), getTime("10:00" + AMPM[0]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 6 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "Hall 200",
 					getTime("4:00" + AMPM[1]), getTime("5:00" + AMPM[1]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 7 (mega-roster) " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "Main Lecture Hall",
 					getTime("4:00" + AMPM[1]), getTime("5:00" + AMPM[1]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(true));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(1000));
 
 			// Discussion sections, second Course Offering
 
 			loadDiscussionSection("Discussion 1 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), null, null, null,
-					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 2 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "2 Building A",
 					getTime("11:30" + AMPM[0]), getTime("1:00" + AMPM[1]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 3 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "101 Hall A",
 					getTime("10:00" + AMPM[0]), getTime("11:00" + AMPM[0]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 4 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "202 Building",
 					getTime("8:00" + AMPM[0]), getTime("9:00" + AMPM[0]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 5 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "11 Hall B",
 					getTime("2:00" + AMPM[1]), getTime("3:30" + AMPM[1]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 6 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "100 Building C",
 					getTime("3:00" + AMPM[1]), getTime("4:00" + AMPM[1]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(30));
 
 			loadDiscussionSection("Discussion 7 (mega-roster) " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "Main Lecture Hall",
 					getTime("3:00" + AMPM[1]), getTime("4:00" + AMPM[1]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(true));
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(1000));
 		}
 
 		if(log.isInfoEnabled()) log.info("Finished loading sample CM data");
@@ -487,8 +487,8 @@ public class SampleDataLoader implements BeanFactoryAware {
 		if(log.isDebugEnabled()) log.debug("Created section " + secEid);
 	}
 
-	protected int incrementStudentCount(boolean mega) {
-		studentMemberCount += mega ? 1000 : 30;
+	protected int incrementStudentCount(int increment) {
+		studentMemberCount += increment;
 		return studentMemberCount;
 	}
 

--- a/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SampleDataLoader.java
+++ b/edu-services/cm-service/cm-impl/hibernate-impl/impl/src/java/org/sakaiproject/coursemanagement/impl/SampleDataLoader.java
@@ -361,63 +361,73 @@ public class SampleDataLoader implements BeanFactoryAware {
 
 			loadDiscussionSection("Discussion 1 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), null, null, null,
-					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 2 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "B Building 202",
 					getTime("10:00" + AMPM[0]), getTime("11:30" + AMPM[0]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 3 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "B Hall 11",
 					getTime("9:00" + AMPM[0]), getTime("10:30" + AMPM[0]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 4 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "C Building 100",
 					getTime("1:30" + AMPM[1]), getTime("3:00" + AMPM[1]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 5 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "Building 10",
 					getTime("9:00" + AMPM[0]), getTime("10:00" + AMPM[0]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 6 " + CC1, as.getEid(), co1Eid,
 					discussionCategory.getCategoryCode(), "Hall 200",
 					getTime("4:00" + AMPM[1]), getTime("5:00" + AMPM[1]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+
+			loadDiscussionSection("Discussion 7 (mega-roster) " + CC1, as.getEid(), co1Eid,
+					discussionCategory.getCategoryCode(), "Main Lecture Hall",
+					getTime("4:00" + AMPM[1]), getTime("5:00" + AMPM[1]),
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(true));
 
 			// Discussion sections, second Course Offering
 
 			loadDiscussionSection("Discussion 1 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), null, null, null,
-					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, false, false, false, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 2 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "2 Building A",
 					getTime("11:30" + AMPM[0]), getTime("1:00" + AMPM[1]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 3 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "101 Hall A",
 					getTime("10:00" + AMPM[0]), getTime("11:00" + AMPM[0]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 4 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "202 Building",
 					getTime("8:00" + AMPM[0]), getTime("9:00" + AMPM[0]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 5 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "11 Hall B",
 					getTime("2:00" + AMPM[1]), getTime("3:30" + AMPM[1]),
-					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{false, true, false, true, false, false, false}, studentMemberCount, incrementStudentCount(false));
 
 			loadDiscussionSection("Discussion 6 " + CC2, as.getEid(), co2Eid,
 					discussionCategory.getCategoryCode(), "100 Building C",
 					getTime("3:00" + AMPM[1]), getTime("4:00" + AMPM[1]),
-					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount());
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(false));
+
+			loadDiscussionSection("Discussion 7 (mega-roster) " + CC2, as.getEid(), co2Eid,
+					discussionCategory.getCategoryCode(), "Main Lecture Hall",
+					getTime("3:00" + AMPM[1]), getTime("4:00" + AMPM[1]),
+					new boolean[]{true, false, true, false, true, false, false}, studentMemberCount, incrementStudentCount(true));
 		}
 
 		if(log.isInfoEnabled()) log.info("Finished loading sample CM data");
@@ -477,8 +487,8 @@ public class SampleDataLoader implements BeanFactoryAware {
 		if(log.isDebugEnabled()) log.debug("Created section " + secEid);
 	}
 
-	protected int incrementStudentCount() {
-		studentMemberCount += 30;
+	protected int incrementStudentCount(boolean mega) {
+		studentMemberCount += mega ? 1000 : 30;
 		return studentMemberCount;
 	}
 

--- a/providers/component/src/webapp/WEB-INF/components-demo.xml
+++ b/providers/component/src/webapp/WEB-INF/components-demo.xml
@@ -7,7 +7,7 @@
 			class="org.sakaiproject.provider.user.SampleUserDirectoryProvider"
 			init-method="init"
 			destroy-method="destroy">
-		<property name="courseStudents"><value>500</value></property>
+		<property name="courseStudents"><value>1200</value></property>
 		<property name="valueEncryptionUtilities" ref="org.sakaiproject.user.detail.ValueEncryptionUtilities"/>
 	</bean>
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43539

The demo data created when bringing up an instance with `-Dsakai.demo=true` is of great benefit for a multitude of purposes, but most important of all is testing and QA. This data set is used on the nightly servers, where all community testing is performed.

The current demo data creates multiple offerings for multiple terms, and multiple sections within each offering. However, each section is currently limited to 30 students. While this provides a satisfactory test bed for most things, performance and scalability issues are difficult to identify when using small data sets.

To better assist with the discovery and reporting of performance and scalability issues, it would be beneficial to have a few of the provided demo sections contain much more than 30 students.

This PR proposes adding 1 new section to each offering, which will contain 1000 students. Each of these large sections will be the last in the available list (currently number 7), and will be labelled "Discussion 7 (mega-roster)..." in the UI to be as clear as possible.

While this does introduce some extra wait time when bringing up a server with `-Dsakai.demo=true` the first time, I think it's reasonable to expect some delays in this situation. I'm of the opinion that the benefits far outweigh having to wait a little more the first time you bring up your server (or the first time after the DB has been wiped).