### PR TITLE
SAK-43561: documentation for portal.autofavoritableUserTypes

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -978,6 +978,12 @@
 # DEFAULT: true
 # portal.autofavorite=false
 
+# SAK-41163 - Override default for auto favorite (portal.autofavorite) for specific user types
+# NOTE: Must be a comma separated list (or legacy equivalent)
+# DEFAULT: empty (all user types obey portal.autofavorite)
+# EXAMPLE: below example would set auto favorite to true for maintan and access users, all other types would be false
+# portal.autofavoritableUserTypes=maintain,access
+
 # SAK-42642 - Display stars for favorite sites beside their site titles in the top bar
 # DEFAULT: true
 # portal.favoriteSitesBar.showFavoriteStars=false


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43561

`default.sakai.properties` is missing documentation of the property added in [SAK-41163](https://jira.sakaiproject.org/browse/SAK-41163).