### PR TITLE
SAK-43177 Library remove uppercase default from primary buttons

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -151,7 +151,7 @@ $button-disabled-font-weight:   300 !default;
 $button-primary-text-color:                 #fff !default;
 $button-primary-background:                 $primary-color !default;
 $button-primary-border-color:               $primary-color !default;
-$button-primary-text-transform: uppercase !default;
+$button-primary-text-transform: none !default;
 $button-primary-font-weight: 600 !default;
 $button-primary-shadow: $material-elevation-2dp !default;
 // hover and focus states for primary action button:


### PR DESCRIPTION
Looks like https://github.com/sakaiproject/sakai/pull/8055 accidentally reverted the primary buttons back to uppercase.