### PR TITLE
SAK-43605 Show message to disabled users on login page

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/UserAuthnComponent.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/UserAuthnComponent.java
@@ -149,7 +149,7 @@ public abstract class UserAuthnComponent implements AuthenticationManager
 				String disabled = user.getProperties().getProperty("disabled");
 				if (disabled != null && "true".equals(disabled))
 				{
-					throw new AuthenticationException("Account Disabled: The users authentication has been disabled");
+					throw new AuthenticationException("Account Disabled: The user's authentication has been disabled");
 				}
 				Authentication rv = new org.sakaiproject.util.Authentication(user.getId(), user.getEid());
 				return rv;

--- a/login/login-api/api/src/java/org/sakaiproject/login/api/Login.java
+++ b/login/login-api/api/src/java/org/sakaiproject/login/api/Login.java
@@ -30,6 +30,6 @@ public interface Login {
 	
 	public static final String EXCEPTION_INVALID = "invalid";
 	
-	public static final String EXCEPTION_DISABLED = "disabled";
+	public static final String EXCEPTION_DISABLED = "Account Disabled: The user's authentication has been disabled";
 	
 }


### PR DESCRIPTION
It seems this was broken on
https://github.com/sakaiproject/sakai/commit/dd5890f173f61e0ad629f58010bfc4e8e8d8a39d

A more ambitious (future) fix would consist of moving all the messages to a common place where both sides can check them.