### PR TITLE
SAK-34190 allow deleting a published assessment with submissions 

### DIFF
--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/logic/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/logic/RubricsServiceImpl.java
@@ -738,8 +738,6 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
 
             for (Resource<ToolItemRubricAssociation> associationResource : associationResources) {
                 String associationHref = associationResource.getLink(Link.REL_SELF).getHref();
-                deleteRubricEvaluationsForAssociation(associationHref, toolId);
-                
                 ToolItemRubricAssociation association = associationResource.getContent();
                 String created = association.getMetadata().getCreated().toString();
                 String owner = association.getMetadata().getOwnerId();
@@ -820,7 +818,7 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
         }
     }
 
-    public void deleteRubricEvaluationsForAssociation(String associationHref, String tool){
+    private void deleteRubricEvaluationsForAssociation(String associationHref, String tool){
         try{
             String [] assocSplitted = associationHref.split("/");
             Long associationId = Long.valueOf(assocSplitted[assocSplitted.length-1]);
@@ -839,8 +837,6 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
             Optional<Resource<ToolItemRubricAssociation>> associationResource = getRubricAssociationResource(toolId, id, null);
             if (associationResource.isPresent()) {
                 String associationHref = associationResource.get().getLink(Link.REL_SELF).getHref();
-                //deleteRubricEvaluationsForAssociation(associationHref, toolId);//??
-
                 ToolItemRubricAssociation association = associationResource.get().getContent();
                 String created = association.getMetadata().getCreated().toString();
                 String owner = association.getMetadata().getOwnerId();

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -550,7 +550,7 @@ denied_edit_publish_assessment_settings_error=Sorry! You do not have right to pu
 denied_take_assessment_error=Sorry! You do not have right to take this assessment in the site, however, you may view them.
 denied_submit_for_grade_error=Sorry! You do not have right to submit this assessment in the site for grade.
 denied_grade_assessment_error=Sorry! You do not have right to grade this assessment in the site.
-denied_delete_other_members_assessment_error=Sorry! You do not have the right to delete the following assessments or must delete all submissions associated with them:
+denied_delete_other_members_assessment_error=Sorry! You do not have the right to delete the following assessments:
 # please add comment
 duplicateName_error=You cannot have duplicate assessment titles.  Please choose another title.
 # 0 points for survey

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemoveAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemoveAssessmentListener.java
@@ -270,12 +270,6 @@ public class RemoveAssessmentListener implements ActionListener
             return false;
         }
 
-        //Alert user to remove submissions associated with the assessment before delete the assessment
-        int submissions = publishedAssessmentService.getTotalSubmissionForEachAssessment(publishedAssessment.getPublishedAssessmentId().toString());
-        if (submissions > 0) {
-            author.setOutcome("removeError");
-            return false;
-        }
         return true;
     }
 


### PR DESCRIPTION
as we now have restoration capabilities in "Trash" tab

This makes Samigo behave like Assignments. Delete a published assessment is no problem as restoration (with submissions) is simple.