### PR TITLE
SAK-43598 remove fake itemgrading created in Linear Access to assessment

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -707,7 +707,6 @@ public class SubmitToGradingActionListener implements ActionListener {
 		case 15: // CALCULATED_QUESTION
 		case 16: //IMAGEMAP_QUESTION 	
 		case 11: // FIN
-			boolean addedToAdds = false;
 			for (int m = 0; m < grading.size(); m++) {
 				ItemGradingData itemgrading = grading.get(m);
 				itemgrading.setAgentId(AgentFacade.getAgentString());
@@ -719,14 +718,15 @@ public class SubmitToGradingActionListener implements ActionListener {
 				String s = itemgrading.getAnswerText();
 				if (itemgrading.getItemGradingId() != null
 						&& itemgrading.getItemGradingId().intValue() > 0) {
-					 if (itemgrading.getPublishedAnswerId()!=null && s!=null && !s.equals("")) {					 
+					 if ("1".equals(delivery.getNavigation()) && itemgrading.getPublishedAnswerId()==null && (s==null || s.equals(""))) {
+						//Mark this as the fake itemgrading record
+						{fake=m;}	 
+				     } else {
 						 log.debug("s = " + s);
 						 // Change to allow student submissions in rich-text [SAK-17021]
 						 itemgrading.setAnswerText(s);
 						 adds.add(itemgrading);
-					 } else
-						//Mark this as the fake itemgrading record
-					 {fake=m;}	 
+				     }	
 				}
 				else if (s != null && !s.equals("")) {
 					log.debug("s = " + s);
@@ -741,7 +741,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 					removes.add(grading.get(fake));
 				} else {
 					adds.add(grading.get(fake));
-				};
+				}
 			}
 			break;
 		case 2: // MCMR

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -712,35 +712,35 @@ public class SubmitToGradingActionListener implements ActionListener {
 				itemgrading.setAgentId(AgentFacade.getAgentString());
 				itemgrading.setSubmittedDate(new Date());
 			}
-			int fake=-1;
+			int fakeitemgrading=-1;
 			for (int m = 0; m < grading.size(); m++) {
 				ItemGradingData itemgrading = grading.get(m);
 				String s = itemgrading.getAnswerText();
 				if (itemgrading.getItemGradingId() != null
 						&& itemgrading.getItemGradingId().intValue() > 0) {
-					 if ("1".equals(delivery.getNavigation()) && itemgrading.getPublishedAnswerId()==null && (s==null || s.equals(""))) {
+					if ("1".equals(delivery.getNavigation()) && itemgrading.getPublishedAnswerId()==null && StringUtils.isBlank(s)) {
 						//Mark this as the fake itemgrading record
-						{fake=m;}	 
-				     } else {
-						 log.debug("s = " + s);
-						 // Change to allow student submissions in rich-text [SAK-17021]
-						 itemgrading.setAnswerText(s);
-						 adds.add(itemgrading);
-				     }	
+						fakeitemgrading=m;	 
+				    } else {
+						log.debug("Existing Itemgrading with AnswerText = {}",s);
+						// Change to allow student submissions in rich-text [SAK-17021]
+						itemgrading.setAnswerText(s);
+						adds.add(itemgrading);
+				    }	
 				}
-				else if (s != null && !s.equals("")) {
-					log.debug("s = " + s);
+				else if (StringUtils.isNotBlank(s)) {
+					log.debug("New Itemgrading with AnswerText = {}", s);
 					// Change to allow student submissions in rich-text [SAK-17021]
 					itemgrading.setAnswerText(s);
 					adds.add(itemgrading);
 				}
 			}
 			//Now if the list of adds is empty we add the fake itemgrading, otherwise we deleted as it is not longer necessary
-			if (fake>-1) {
+			if (fakeitemgrading>-1) {
 				if (adds.size()>0) {
-					removes.add(grading.get(fake));
+					removes.add(grading.get(fakeitemgrading));
 				} else {
-					adds.add(grading.get(fake));
+					adds.add(grading.get(fakeitemgrading));
 				}
 			}
 			break;

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -713,23 +713,35 @@ public class SubmitToGradingActionListener implements ActionListener {
 				itemgrading.setAgentId(AgentFacade.getAgentString());
 				itemgrading.setSubmittedDate(new Date());
 			}
+			int fake=-1;
 			for (int m = 0; m < grading.size(); m++) {
 				ItemGradingData itemgrading = grading.get(m);
+				String s = itemgrading.getAnswerText();
 				if (itemgrading.getItemGradingId() != null
 						&& itemgrading.getItemGradingId().intValue() > 0) {
-					adds.addAll(grading);
-					break;
-				} else if (itemgrading.getAnswerText() != null && !itemgrading.getAnswerText().equals("")) {
-					String s = itemgrading.getAnswerText();
+					 if (itemgrading.getPublishedAnswerId()!=null && s!=null && !s.equals("")) {					 
+						 log.debug("s = " + s);
+						 // Change to allow student submissions in rich-text [SAK-17021]
+						 itemgrading.setAnswerText(s);
+						 adds.add(itemgrading);
+					 } else
+						//Mark this as the fake itemgrading record
+					 {fake=m;}	 
+				}
+				else if (s != null && !s.equals("")) {
 					log.debug("s = " + s);
 					// Change to allow student submissions in rich-text [SAK-17021]
 					itemgrading.setAnswerText(s);
-					adds.addAll(grading);
-					if (!addedToAdds) {
-						adds.addAll(grading);
-						addedToAdds = true;
-					}
+					adds.add(itemgrading);
 				}
+			}
+			//Now if the list of adds is empty we add the fake itemgrading, otherwise we deleted as it is not longer necessary
+			if (fake>-1) {
+				if (adds.size()>0) {
+					removes.add(grading.get(fake));
+				} else {
+					adds.add(grading.get(fake));
+				};
 			}
 			break;
 		case 2: // MCMR


### PR DESCRIPTION
The fake itemgrading should be deleted when a real itemgrading coming from the user is present.
In those type of questions it was not controled producing duplicated itemgradings for the same question that produces grading problems for CQ.