### PR TITLE
SAK-43656 - Gradebook / weighted and extra credit categories use the same icon

### DIFF
--- a/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
@@ -292,7 +292,10 @@
 #gradeTableWrapper .currentCol .gb-extra-credit {
   background-color: #FCF8E3 !important;
 }
-.gb-flag-equal-weight:before,
+.gb-flag-equal-weight:before {
+  content: '\2696';
+  color: rgb(200,144,0);
+}
 .gb-flag-extra-credit:before {
   content: '\f0fe';
   color: rgb(200,144,0);


### PR DESCRIPTION
I couldn't find any good icons as part of the font this was using so I just picked the Unicode "Scales". At least it's visually different. 