### PR TITLE
SAK-43666 Files over 2G have incorrect file size

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DefaultFileSystemHandler.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DefaultFileSystemHandler.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 
-import org.springframework.util.FileCopyUtils;
+import org.apache.commons.io.IOUtils;
 
 /**
  * The default implementation of FileSystemHandler, targeting local disk.
@@ -93,7 +93,7 @@ public class DefaultFileSystemHandler implements FileSystemHandler {
         }
 
         // write the file
-        return FileCopyUtils.copy(stream, new FileOutputStream(file));
+        return IOUtils.copyLarge(stream, new FileOutputStream(file));
     }
 
     @Override


### PR DESCRIPTION
Switch from Spring FileCopyUtils which returns an int to
commons-io IOUtils.copyLarge which returns long for file length,
to avoid getting an incorrect content length when uploading files
larger than 2G.