### PR TITLE
SAK-43194 - Stack trace when returning to PostEm landing page after adding item

### DIFF
--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ToolUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ToolUtils.java
@@ -210,7 +210,11 @@ public class ToolUtils
 		if (!trinity) return pageUrl;
 
 		pageUrl = Web.returnUrl(req, "/" + portalPrefix + "/" + Web.escapeUrl(effectiveSiteId));
-		if (reset || resetSiteProperty) {
+		// Check the tool configuration to see if this tool needs to be always reset
+		Properties toolConfig = pageTool.getTool().getRegisteredConfig();
+		boolean resetToolProperty = Boolean.parseBoolean(toolConfig.getProperty(Portal.CONFIG_AUTO_RESET));
+
+		if (reset || resetSiteProperty || resetToolProperty) {
 			pageUrl = pageUrl + "/tool-reset/";
 		} else {
 			pageUrl = pageUrl + "/tool/";

--- a/postem/postem-app/src/webapp/WEB-INF/tools/sakai.postem.xml
+++ b/postem/postem-app/src/webapp/WEB-INF/tools/sakai.postem.xml
@@ -8,6 +8,7 @@
 			
 		<category name="course" />
 		<category name="project" />
+		<configuration name="portal.experimental.auto.reset" value="true" />
 
 	</tool>	
 </registration>


### PR DESCRIPTION
Adding a property for auto reset to be able to be defined on the tool level.

This will cause these tools to reset when navigating back into them from another tool.