### PR TITLE
SAK-43674 Assignment reminder emails will never send

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -92,6 +92,17 @@ public interface AssignmentService extends EntityProducer {
     public boolean allowAddAssignment(String context);
 
     /**
+     * Check permissions for adding an Assignment.
+     *
+     * @param context -
+     *                Describes the portlet context - generated with DefaultId.getChannel().
+     * @param user -
+     *             The user for which the permission will be checked
+     * @return True if the provided User is allowed to add an Assignment, false if not.
+     */
+    public boolean allowAddAssignment(String context, String userId);
+
+    /**
      * Check permissions for updating an Assignment based on context.
      *
      * @param context -
@@ -144,6 +155,16 @@ public interface AssignmentService extends EntityProducer {
      * @return The Collection (Group) of groups defined for the context of this site that the end user has add assignment permissions in, empty if none.
      */
     public Collection<Group> getGroupsAllowAddAssignment(String context);
+
+    /**
+     * Get the collection of Groups defined for the context of this site that the end user has add assignment permissions in.
+     * @param context -
+     *                Describes the portlet context - generated with DefaultId.getChannel().
+     * @param userId -
+     *               The user for which the permission will be checked
+     * @return The Collection (Group) of groups defined for the context of this site that the end user has add assignment permissions in, empty if none.
+     */
+    public Collection<Group> getGroupsAllowAddAssignment(String context, String userId);
 
     /**
      * Get the collection of Groups defined for the context of this site that the end user has update assignment permissions in.

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -599,7 +599,12 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
     @Override
     public Collection<Group> getGroupsAllowAddAssignment(String context) {
-        return getGroupsAllowFunction(SECURE_ADD_ASSIGNMENT, context, null);
+        return getGroupsAllowAddAssignment(context, null);
+    }
+
+    @Override
+    public Collection<Group> getGroupsAllowAddAssignment(String context, String userId) {
+        return getGroupsAllowFunction(SECURE_ADD_ASSIGNMENT, context, userId);
     }
 
     @Override
@@ -652,10 +657,15 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
     @Override
     public boolean allowAddAssignment(String context) {
+        return allowAddAssignment(context, null);
+    }
+
+    @Override
+    public boolean allowAddAssignment(String context, String userId) {
         String resourceString = AssignmentReferenceReckoner.reckoner().context(context).reckon().getReference();
-        if (permissionCheck(SECURE_ADD_ASSIGNMENT, resourceString, null)) return true;
+        if (permissionCheck(SECURE_ADD_ASSIGNMENT, resourceString, userId)) return true;
         // if not, see if the user has any groups to which adds are allowed
-        return (!getGroupsAllowAddAssignment(context).isEmpty());
+        return (!getGroupsAllowAddAssignment(context, userId).isEmpty());
     }
 
     @Override

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/reminder/AssignmentDueReminderServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/reminder/AssignmentDueReminderServiceImpl.java
@@ -132,7 +132,7 @@ public class AssignmentDueReminderServiceImpl implements AssignmentDueReminderSe
             // Do not send reminders if the site is unpublished or softly deleted
             if (site.isPublished() && !site.isSoftlyDeleted()) {
                 for (Member member : site.getMembers()) {
-                    if (member.isActive() && assignmentService.canSubmit(assignment, member.getUserId()) && !assignmentService.allowAddAssignment(assignment.getContext()) && checkEmailPreference(member)) {
+                    if (member.isActive() && assignmentService.canSubmit(assignment, member.getUserId()) && !assignmentService.allowAddAssignment(assignment.getContext(), member.getUserId()) && checkEmailPreference(member)) {
                         sendEmailReminder(site, assignment, member);
                     }
                 }


### PR DESCRIPTION
Allow add assignment should be checked for each member of the site to
determine if an email reminder should be sent instead of checking the
permission of the current user. Fixes regression in SAK-42667