### PR TITLE
SAK-43609: Samigo improved wording: adding instructions about using radians in calculated questions

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -120,7 +120,7 @@ calc_question_answer_variance=You may define acceptable tolerance as a constant 
 calc_question_answer_decimal=Variables and formulas support decimals. Default is 3.
 calc_question_example1=Kevin has {x} apples. He buys {y} more. Now Kevin has [[{x}+{y}]]. Jane eats {z} apples. Kevin now has {{w}} apples.
 calc_question_example1_formula=The formula w in the example above would be defined as: {x} + {y} - {z}
-calc_question_functions=You can use the following math functions: SIN, COS, TAN, ASIN, ACOS, ATAN, ABS, EXP, SGN, SQRT, LOG10, and LN.
+calc_question_functions=You can use the following math functions: SIN, COS, TAN, ASIN, ACOS, ATAN, ABS, EXP, SGN, SQRT, LOG10, and LN. For trigonometric functions (SIN, COS, TAN, ASIN, ACOS, ATAN), radians are used for angles.
 calc_question_example2=Solve: COS({a}) * ({c} - {b}) = {{z}}.
 calc_question_example2_formula=The formula z in the example above would be defined as: COS({a}) * ({c} - {b})
 calc_question_example3=The area of a square is [[ {s} * {s} ]]m. Find the side length {{Z}}. Formula Z would be {s}.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43609

Add instructions about using radians in calculated questions in Test & Quizzes: "For trigonometric functions (SIN, COS, TAN, ASIN, ACOS, ATAN), radians are used for angles." 