### PR TITLE
SAK-43514: Adding proper error message when using pipeline "|" in numeric response questions

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -519,6 +519,7 @@ fin_accepted_instruction=<b style="color:#860000;">Accepted characters</b>: numb
 fin_complex_note=Complex numbers should be in the form {a + bi} where "a" and "b" need to have explicitly stated values.
 fin_complex_example=For example: {1+1i} is valid whereas {1+i} is not. {0+9i} is valid whereas {9i} is not.
 fin_invalid_characters_error=Please only use allowed characters within numeric response fields. Acceptable inputs are real numbers like "9.3", complex numbers like "{9+10i}" (with the required braces), and scientific notation like "6.32e10" or "6.32E10".
+fin_first_greater_than_second_error = When defining a range of values, the value preceding the pipe "|" must be smaller than the value after the pipe!
 
 sa_invalid_length_error=This answer has exceeded the 32,000 character limit. Please reduce the amount of text.
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/validator/FinQuestionValidator.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/validator/FinQuestionValidator.java
@@ -79,7 +79,7 @@ public class FinQuestionValidator implements Validator {
 		        BigDecimal rango1 = new BigDecimal(number1);
 		        BigDecimal rango2 = new BigDecimal(number2);
 		        if (rango1.compareTo(rango2) != -1) {
-		        	String error=(String)ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.DeliveryMessages", "fin_invalid_characters_error");
+		        	String error= (String) ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.DeliveryMessages", "fin_first_greater_than_second_error");
 		        	throw new ValidatorException(new FacesMessage(error));
 		        }
 		    }


### PR DESCRIPTION
Adding a new error message variable in deliveryMessage.properties: When defining a range of values, the value preceding the pipe "|" must be smaller than the value after the pipe!
Assign this new error message to the case when users type in a number before the pipeline "|" greater than that after the pipeline.