### PR TITLE
SAK-43798: Sorting by course grade doesn't work correctly if there are empty score cells

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -660,8 +660,8 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     editor: false,
     width: GbGradeTable.settings.showPoints ? 220 : 140,
     sortCompare: function(a, b) {
-        var a_points = parseFloat(a[1]);
-        var b_points = parseFloat(b[1]);
+        const a_points = parseFloat(a[1]);
+        const b_points = parseFloat(b[1]);
         const aIsNaN = isNaN(a_points);
         const bIsNaN = isNaN(b_points);
 

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -660,20 +660,20 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     editor: false,
     width: GbGradeTable.settings.showPoints ? 220 : 140,
     sortCompare: function(a, b) {
-        const a_points = parseFloat(a[1]);
-        const b_points = parseFloat(b[1]);
-        const aIsNaN = isNaN(a_points);
-        const bIsNaN = isNaN(b_points);
+        const a_percent = parseFloat(a[1]);
+        const b_percent = parseFloat(b[1]);
+        const aIsNaN = isNaN(a_percent);
+        const bIsNaN = isNaN(b_percent);
 
         // treat NaN as less than real numbers
-        if (a_points > b_points || (!aIsNaN && bIsNaN)) {
+        if (a_percent > b_percent || (!aIsNaN && bIsNaN)) {
             return 1;
         }
-        if (a_points < b_points || (aIsNaN && !bIsNaN)) {
+        if (a_percent < b_percent || (aIsNaN && !bIsNaN)) {
             return -1;
         }
         return 0;
-    },
+    }
   });
 
   if (GbGradeTable.settings.isStudentNumberVisible) {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -662,11 +662,14 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     sortCompare: function(a, b) {
         var a_points = parseFloat(a[1]);
         var b_points = parseFloat(b[1]);
+        const aIsNaN = isNaN(a_points);
+        const bIsNaN = isNaN(b_points);
 
-        if (a_points > b_points) {
+        // treat NaN as less than real numbers
+        if (a_points > b_points || (!aIsNaN && bIsNaN)) {
             return 1;
         }
-        if (a_points < b_points) {
+        if (a_points < b_points || (aIsNaN && !bIsNaN)) {
             return -1;
         }
         return 0;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43798

If there are empty score cells in the gradebook tool, sorting by course grade will not work correctly. The screenshot shows that sometimes the empty cells whose content are "-" are sorted on the above when sorting by ascending or descending order according to course grade (see screenshot).