### PR TITLE
SAK-43795: Gradebook: Deleting a score cell will automatically set the cell to be zero

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.gradebookng.business.GradeSaveResponse;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
@@ -39,6 +40,7 @@ import org.sakaiproject.service.gradebook.shared.CategoryScoreData;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.tool.gradebook.Gradebook;
 import org.sakaiproject.util.NumberUtil;
+import org.sakaiproject.util.api.FormattedText;
 
 public class GradeUpdateAction extends InjectableAction implements Serializable {
 
@@ -132,8 +134,11 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 		target.addChildren(page, FeedbackPanel.class);
 
 		final String rawOldGrade = params.get("oldScore").textValue();
-		// Adding a zero to allow to score a decimal value less than 1 without adding a zero before
-		final String rawNewGrade = "0" + params.get("newScore").textValue();
+		String rawNewGrade = StringUtils.trimToEmpty(params.get("newScore").textValue());
+		final String decimal = ComponentManager.get(FormattedText.class).getDecimalSeparator();
+		if (rawNewGrade.startsWith(decimal)) {
+			rawNewGrade = "0" + rawNewGrade;  // prepend a 0 so this passes validation (ie. ".1 " becomes "0.1")
+		}
 
 		if (StringUtils.isNotBlank(rawNewGrade)
 				&& (!NumberUtil.isValidLocaleDouble(rawNewGrade) || FormatHelper.validateDouble(rawNewGrade) < 0)) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43795



Given the gradebook settings include point grades, display released Gradebook items to students, display assignment statistics to students, display course grade statistics, and no categories: in 20.x and 21.x

When an instructor enters a valid score into a score cell and then deletes the contents in the score cell by clicking the cell once and press "delete" on the keyboard, the score cell becomes empty, but the course grade will be updated as if the score became 0. (See the first screenshot)

This issue only appears in 20.x and 21.x. In 19.x nightly server, if the user does the above actions, the score cell becomes empty and the course grade will be updated as if the score was not set at all, i.e., as if it were "-". (See the second screenshot) This should be the expected behavior because when an instructor user deletes a score cell, it doesn't mean a zero score, but means an unset score.