### PR TITLE
SAK-43818: Updating a grade stores the total point value as the sorting value instead of the percentage

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
@@ -32,9 +32,10 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.gradebookng.business.GradeSaveResponse;
 import org.sakaiproject.gradebookng.business.util.CourseGradeFormatter;
 import org.sakaiproject.gradebookng.business.util.FormatHelper;
-import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.gradebookng.business.model.GbCourseGrade;
+import org.sakaiproject.gradebookng.tool.model.GbGradebookData;
 import org.sakaiproject.service.gradebook.shared.CategoryScoreData;
 import org.sakaiproject.service.gradebook.shared.CourseGrade;
 import org.sakaiproject.tool.gradebook.Gradebook;
@@ -51,20 +52,15 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 	}
 
 	private class GradeUpdateResponse implements ActionResponse {
-		private String courseGrade;
-		private String points;
+		private String[] courseGradeData;
 		private String categoryScore;
 		private List<Long> droppedItems;
-		private boolean isOverride;
 		private boolean extraCredit;
 
-		public GradeUpdateResponse(final boolean extraCredit, final String courseGrade, final String points, final boolean isOverride,
-				final String categoryScore, List<Long> droppedItems) {
-			this.courseGrade = courseGrade;
+		public GradeUpdateResponse(final boolean extraCredit, final String[] courseGradeData, final String categoryScore, List<Long> droppedItems) {
+			this.courseGradeData = courseGradeData;
 			this.categoryScore = categoryScore;
 			this.droppedItems = droppedItems;
-			this.points = points;
-			this.isOverride = isOverride;
 			this.extraCredit = extraCredit;
 		}
 
@@ -77,9 +73,9 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 			ObjectNode result = mapper.createObjectNode();
 
 			ArrayNode courseGradeArray = mapper.createArrayNode();
-			courseGradeArray.add(courseGrade);
-			courseGradeArray.add(points);
-			courseGradeArray.add(isOverride ? 1 : 0);
+			for (String data : courseGradeData) {
+				courseGradeArray.add(data);
+			}
 
 			result.put("courseGrade", courseGradeArray);
 			result.put("categoryScore", categoryScore);
@@ -174,29 +170,17 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 		}
 
 		final CourseGrade studentCourseGrade = businessService.getCourseGrade(studentUuid);
+		final Gradebook gradebook = businessService.getGradebook();
+		final CourseGradeFormatter courseGradeFormatter = new CourseGradeFormatter(
+				gradebook,
+				page.getCurrentRole(),
+				businessService.isCourseGradeVisible(businessService.getCurrentUser().getId()),
+				page.getUiSettings().getShowPoints(),
+				true);
+		final GbCourseGrade gbcg = new GbCourseGrade(studentCourseGrade);
+		gbcg.setDisplayString(courseGradeFormatter.format(studentCourseGrade));
 
-		boolean isOverride = false;
-		String grade = "-";
-		String points = "0";
-
-		if (studentCourseGrade != null) {
-			final GradebookUiSettings uiSettings = page.getUiSettings();
-			final Gradebook gradebook = businessService.getGradebook();
-			final CourseGradeFormatter courseGradeFormatter = new CourseGradeFormatter(
-					gradebook,
-					page.getCurrentRole(),
-					businessService.isCourseGradeVisible(businessService.getCurrentUser().getId()),
-					uiSettings.getShowPoints(),
-					true);
-
-			grade = courseGradeFormatter.format(studentCourseGrade);
-			if (studentCourseGrade.getPointsEarned() != null) {
-				points = FormatHelper.formatDoubleToDecimal(studentCourseGrade.getPointsEarned());
-			}
-			if (studentCourseGrade.getEnteredGrade() != null) {
-				isOverride = true;
-			}
-		}
+		final String[] courseGradeData = GbGradebookData.getCourseGradeData(gbcg, gradebook.getSelectedGradeMapping().getGradeMap());
 
 		Optional<CategoryScoreData> catData = categoryId == null ?
 				Optional.empty() : businessService.getCategoryScoreForStudent(Long.valueOf(categoryId), studentUuid, true);
@@ -207,9 +191,7 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 
 		return new GradeUpdateResponse(
 				result.equals(GradeSaveResponse.OVER_LIMIT),
-				grade,
-				points,
-				isOverride,
+				courseGradeData,
 				categoryScore,
 				droppedItems);
 	}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -420,41 +420,39 @@ public class GbGradebookData {
 			}
 		});
 
-		for (final GbStudentGradeInfo studentGradeInfo : GbGradebookData.this.studentGradeInfoList) {
-			// String[0] = A+ (95%) [133/140] -- display string
-			// String[1] = 95 -- raw percentage for sorting
-			// String[2] = 1 -- '1' if an override, '0' if calculated
-			final String[] gradeData = new String[3];
-
-			final GbCourseGrade gbCourseGrade = studentGradeInfo.getCourseGrade();
-			final CourseGrade courseGrade = gbCourseGrade.getCourseGrade();
-
-			gradeData[0] = gbCourseGrade.getDisplayString();
-
-			if (StringUtils.isNotBlank(courseGrade.getEnteredGrade())) {
-				gradeData[2] = "1";
-			} else {
-				gradeData[2] = "0";
-			}
-
-			if (StringUtils.isNotBlank(courseGrade.getEnteredGrade())) {
-				Double mappedGrade = this.courseGradeMap.get(courseGrade.getEnteredGrade());
-				if (mappedGrade == null) {
-					mappedGrade = new Double(0);
-				}
-				gradeData[1] = FormatHelper.formatGradeForDisplay(mappedGrade);
-			} else {
-				if (courseGrade.getPointsEarned() == null) {
-					gradeData[1] = "0";
-				} else {
-					gradeData[1] = FormatHelper.formatGradeForDisplay(courseGrade.getCalculatedGrade());
-				}
-			}
-
-			result.add(gradeData);
+		for (final GbStudentGradeInfo studentGradeInfo : studentGradeInfoList) {
+			result.add(getCourseGradeData(studentGradeInfo.getCourseGrade(), courseGradeMap));
 		}
 
 		return result;
+	}
+
+	/**
+	 * Returns the following data about the course grade, needed by the client-side grades table:
+	 * String[0] = A+ (95%) [133/140] -- display string
+	 * String[1] = 95 -- raw percentage for sorting
+	 * String[2] = 1 -- '1' if an override, '0' if calculated
+	 * @param gbCourseGrade the course grade, with an appropriate display string already set
+	 * @param courseGradeMap grading scale map in use
+	 * @return course grade information
+	 */
+	public static String[] getCourseGradeData(GbCourseGrade gbCourseGrade, Map<String, Double> courseGradeMap) {
+		final String[] gradeData = new String[3];
+		gradeData[0] = gbCourseGrade.getDisplayString();
+		gradeData[2] = "0";
+
+		final CourseGrade courseGrade = gbCourseGrade.getCourseGrade();
+		if (courseGrade == null) {
+			gradeData[1] = "";
+		} else if (StringUtils.isNotBlank(courseGrade.getEnteredGrade())) {
+			Double mappedGrade = courseGradeMap.get(courseGrade.getEnteredGrade());
+			gradeData[1] = FormatHelper.formatGradeForDisplay(mappedGrade);
+			gradeData[2] = "1";
+		} else {
+			gradeData[1] = FormatHelper.formatGradeForDisplay(courseGrade.getCalculatedGrade());
+		}
+
+		return gradeData;
 	}
 
 	private List<Score> gradeList() {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43818

When the gradebook loads, it stores the percentage value for each course grade separately for the purposes of sorting. When a grade is updated, the total points earned are stored in this location instead. This results in incorrect sorting until the full page is refreshed.

For example, if the gradebook contains one item worth 10 points, a student with 80% will have 80 as the sorting value. If you then change their grade for that item from 8 to 9, the sorting value for their course grade becomes 9 instead of the expected value of 90. When sorting on the course grade in descending order, even students with 10% as their course grade will appear before this student.