### PR TITLE
SAK-43668: Grader WC > allow resubmission checkbox is too sticky

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/grader/sakai-grader.js
+++ b/webcomponents/tool/src/main/frontend/js/grader/sakai-grader.js
@@ -343,7 +343,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
               <span>${this.assignmentsI18n["allow.resubmit.number"]}:</span>
               <select aria-label="${this.i18n["attempt_selector_label"]}" @change=${e => this.resubmitNumber = e.target.value}>
                 ${Array(10).fill().map((_, i) => html`
-                  <option value="${i + 1}" .selected=${this.submission.allowResubmitNumber == (i + 1)}>${i + 1}</option>
+                  <option value="${i + 1}" .selected=${this.submission.allowResubmitNumber === (i + 1)}>${i + 1}</option>
                 `)}
                 <option value="-1" .selected=${this.submission.allowResubmitNumber === "-1"}>${this.i18n["unlimited"]}</option>
               </select>
@@ -714,7 +714,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
       const numDecimals = number.includes(".") ? number.split(".")[1].length : 0;
 
       // If the user has highlighted the current entry, they want to replace it.
-      if (numDecimals == 2 && ((e.target.selectionEnd - e.target.selectionStart) < e.target.value.length)) {
+      if (numDecimals === 2 && ((e.target.selectionEnd - e.target.selectionStart) < e.target.value.length)) {
         e.preventDefault();
         return false;
       }
@@ -747,6 +747,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
         this.toggleInlineFeedback(null, true);
       }
       this.submission = this.submissions[currentIndex - 1];
+      this.showResubmission = this.submission.allowResubmitNumber > 0 ? true : false;
     }
   }
 
@@ -757,6 +758,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
     }
 
     this.submission = this.submissions.find(s => s.id === e.target.value);
+    this.showResubmission = this.submission.allowResubmitNumber > 0 ? true : false;
   }
 
   next() {
@@ -771,6 +773,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
         this.toggleInlineFeedback(null, true);
       }
       this.submission = this.submissions[currentIndex + 1];
+      this.showResubmission = this.submission.allowResubmitNumber > 0 ? true : false;
     }
   }
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43668

When the instructor uses the grader to grade and allows a resubmission for one student, then moving to grade the next student, the resubmission selection is kept. This is not how the "old" grading interface worked for assignments and I think it will cause errors and confusion for the instructor. In the "old" grading interface, the instructor had to set allow resubmission for each student individually if the option was not already set when creating the assignment.

JIRA Triage agreed this should behave the same as the "old" grading UI.