### PR TITLE
SAK-43849: copyright alert demo displays velocity syntax

### DIFF
--- a/access/access-impl/impl/src/java/org/sakaiproject/access/tool/AccessServlet.java
+++ b/access/access-impl/impl/src/java/org/sakaiproject/access/tool/AccessServlet.java
@@ -281,6 +281,7 @@ public class AccessServlet extends VmServlet
 			}
 
 			setVmReference("validator", new Validator(), req);
+			setVmReference("formattedText", formattedText, req);
 			setVmReference("props", props, req);
 			setVmReference("tlang", rb, req);
 
@@ -438,6 +439,7 @@ public class AccessServlet extends VmServlet
 		ResourceProperties props = new BaseResourceProperties();
 		setVmReference("props", props, req);
 		setVmReference("validator", new Validator(), req);
+		setVmReference("formattedText", formattedText, req);
 		setVmReference("sample", Boolean.TRUE.toString(), req);
 		setVmReference("tlang", rb, req);
 		res.setContentType("text/html; charset=UTF-8");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43849

In Resources or Dropbox, selecting "what's this" next to the copyright alert section displays invalid text.

#7839 just missed a few places where `formattedText` needed to be put into the Velocity template's `context`.