### PR TITLE
SAK-43826: Rubrics - Support weighted criterions  (fix previews)

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-preview.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-preview.js
@@ -47,7 +47,7 @@ export class SakaiRubricPreview extends RubricsElement {
         token="${this.token}"
         criteria="${JSON.stringify(this.rubric.criterions)}"
         gradeFieldId="${this.gradeFieldId}"
-        ?weighted=${this.rubric.weighted}
+        .weighted=${this.rubric.weighted}
         ></sakai-rubric-criterion-preview>
     `;
   }

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-readonly.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-readonly.js
@@ -49,7 +49,7 @@ export class SakaiRubricReadonly extends RubricsElement {
 
       <div class="collapse-details" role="tabpanel" aria-labelledby="rubric_toggle_${this.rubric.id}" id="collapse_shared_${this.rubric.id}">
         <div class="rubric-details style-scope sakai-rubric">
-          <sakai-rubric-criteria-readonly criteria="${JSON.stringify(this.rubric.criterions)}" ?weighted=${this.rubric.weighted}></sakai-rubric-criteria-readonly>
+          <sakai-rubric-criteria-readonly criteria="${JSON.stringify(this.rubric.criterions)}" .weighted=${this.rubric.weighted}></sakai-rubric-criteria-readonly>
         </div>
       </div>
     `;

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student.js
@@ -86,7 +86,7 @@ class SakaiRubricStudent extends RubricsElement {
       ${this.preview || this.forcePreview ? html`
         <sakai-rubric-criterion-preview
           criteria="${JSON.stringify(this.rubric.criterions)}"
-          ?weighted=${this.rubric.weighted}
+          .weighted=${this.rubric.weighted}
         ></sakai-rubric-criterion-preview>
         ` : html`
         <sakai-rubric-criterion-student
@@ -95,7 +95,7 @@ class SakaiRubricStudent extends RubricsElement {
           evaluation-details="${JSON.stringify(this.evaluation.criterionOutcomes)}"
           ?preview="${this.preview}"
           entity-id="${this.entityId}"
-          ?weighted=${this.rubric.weighted}
+          .weighted=${this.rubric.weighted}
         ></sakai-rubric-criterion-student>
       `}
     `;

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
@@ -128,7 +128,7 @@ export class SakaiRubric extends RubricsElement {
               <sakai-rubric-criteria-readonly
                 criteria="${JSON.stringify(this.rubric.criterions)}"
                 token="${this.token}"
-                ?weighted=${this.rubric.weighted}
+                .weighted=${this.rubric.weighted}
               />`
             : html`
               <sakai-rubric-criteria
@@ -139,7 +139,7 @@ export class SakaiRubric extends RubricsElement {
                 @save-weights="${this.handleSaveWeights}"
                 @weight-changed="${this.handleCriterionWeightChange}"
                 @refresh-total-weight="${this.handleRefreshTotalWeight}"
-                ?weighted=${this.rubric.weighted}
+                .weighted=${this.rubric.weighted}
                 total-weight="${this.totalWeight}"
                 ?valid-weight="${this.validWeight}"
               />`


### PR DESCRIPTION
This change fixes passing the property "weighted" to rubrics previews/read-only.
Although I don't understand why stopped working after the code style changes requested at the PR.

My main doubt is whats the difference between "." and "?"
"?" works at 
    "webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js":142
but it doesn't work at
    "webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js":131

Using dot works with my cases.

@adrianfish Can you help me with this?