### PR TITLE
SAK-43950 no need for col2of2 explicit min-width 

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -496,7 +496,6 @@ $footer-link-separator: #ccc;
 
 // Overview page column widths. Total to add up to 96% as the columns have a margin.
 $col1of2-width: 48% !default;
-$col2of2-width: 48% !default;
 
 $divider-shadow: 0 1px 5px rgba(0,0,0,.3) !default;
 $divider-shadow-fixed: 0 1px 0 $tool-border-color !default;

--- a/library/src/morpheus-master/sass/modules/_main.scss
+++ b/library/src/morpheus-master/sass/modules/_main.scss
@@ -58,7 +58,6 @@
 		min-width: $col1of2-width;
 	}
 	#col2of2 {
-		min-width: $col2of2-width;
 		margin-right: $standard-spacing;		// space on the end
 	}
 }


### PR DESCRIPTION
as it was causing issues with breakpoints in Sakai 20+ for desktops 1050px+