### PR TITLE
SAK-39932 - Essay questions display two different maximum character limits

### DIFF
--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -30,6 +30,21 @@ sakai.editor.editors.ckeditor = sakai.editor.editors.ckeditor || {} ;
 var basePath = "/library/editor/ckextraplugins/";
 var webJars = "/library/webjars/"
 
+// Update properties in one object from another: https://stackoverflow.com/a/12534361/3708872
+// I believe this is available as lodash.merge but don't see that available here yet and this looked like the simplest version of that
+function objectMerge(obj/*, ...*/) {
+    for (var i=1; i<arguments.length; i++) {
+        for (var prop in arguments[i]) {
+            var val = arguments[i][prop];
+            if (typeof val == "object") // this also applies to arrays or null!
+                objectMerge(obj[prop], val);
+            else
+                obj[prop] = val;
+        }
+    }
+    return obj;
+}
+
 // Please note that no more parameters should be added to this signature.
 // The config object allows for name-based config options to be passed.
 // The w and h parameters should be removed as soon as their uses can be migrated.
@@ -216,9 +231,8 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         templates_replaceContent: false
     };
 
-    if (config != null && config.baseFloatZIndex) {
-	ckconfig.baseFloatZIndex = config.baseFloatZIndex;
-    }
+    // Merge config values into ckconfig
+    ckconfig = objectMerge(ckconfig, config);
 
     if (config && config.toolbarSet && ckconfig['toolbar_' + config.toolbarSet]) {
         ckconfig.toolbar = config.toolbarSet;

--- a/samigo/samigo-app/src/java/org/sakaiproject/jsf/renderer/RichTextEditArea.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/jsf/renderer/RichTextEditArea.java
@@ -99,6 +99,14 @@ public class RichTextEditArea extends Renderer
     String tmpCol = (String) component.getAttributes().get("columns");
     String tmpRow = (String) component.getAttributes().get("rows");
     String mode = (String) component.getAttributes().get("mode");
+    String tmpMaxCharCount = (String) component.getAttributes().get("maxCharCount");
+    
+    //Get max character parameter
+    int maxCharCount = 0;
+    if (tmpMaxCharCount != null) 
+    {
+    	maxCharCount = new Integer(tmpMaxCharCount).intValue();
+    }
 
     int col;
     int row;
@@ -167,17 +175,17 @@ public class RichTextEditArea extends Renderer
 
       if (tmpCol == null) {
     	  encodeCK(writer, (String) value, identity, outCol, 
-              outRow, justArea, clientId, valueHasRichText, hasToggle, true, mode);
+              outRow, justArea, clientId, valueHasRichText, hasToggle, true, mode, maxCharCount);
       }
       else {
     	  encodeCK(writer, (String) value, identity, outCol, 
-                  outRow, justArea, clientId, valueHasRichText, hasToggle, false, mode);
+                  outRow, justArea, clientId, valueHasRichText, hasToggle, false, mode, maxCharCount);
       }
   }
 
 
   private void encodeCK(ResponseWriter writer, String value, String identity, String outCol, 
-         String outRow, String justArea, String clientId, boolean valueHasRichText, String hasToggle, boolean columnsNotDefined, String mode) throws IOException {
+         String outRow, String justArea, String clientId, boolean valueHasRichText, String hasToggle, boolean columnsNotDefined, String mode, int maxCharCount) throws IOException {
 
     String componentId = StringUtils.isBlank(identity) ? clientId : clientId.contains(":") ? clientId.substring(0, clientId.indexOf(":") + 1) + identity : identity;
 
@@ -221,7 +229,7 @@ public class RichTextEditArea extends Renderer
     if(shouldToggle && !disableWysiwyg)
     {    	
     	String show_editor = rb.getString("show_editor");
-    	writer.write("<div class=\"toggle_link_container\"><a class=\"toggle_link\" id=\"" +componentId+ "_toggle\" href=\"javascript:show_editor('" + componentId + "', '" + samigoFrameId + "');\">" + show_editor + "</a></div>\n");
+    	writer.write("<div class=\"toggle_link_container\"><a class=\"toggle_link\" id=\"" +componentId+ "_toggle\" href=\"javascript:show_editor('" + componentId + "', '" + samigoFrameId + "', " + maxCharCount + ");\">" + show_editor + "</a></div>\n");
     }
     else {
         	value = ComponentManager.get(FormattedText.class).escapeHtmlFormattedTextarea((String) value);
@@ -243,7 +251,7 @@ public class RichTextEditArea extends Renderer
     	}
 	//if toggling is off or the content is already rich, make the editor show up immediately if hasToggle is not plain
 	if(!shouldToggle && (!hasToggle.equals("plain") || valueHasRichText)){
-		writer.write("<script type=\"text/javascript\" defer=\"1\">chef_setupformattedtextarea('" + componentId + "', false, '" + samigoFrameId +"');</script>");
+		writer.write("<script type=\"text/javascript\" defer=\"1\">chef_setupformattedtextarea('" + componentId + "', false, '" + samigoFrameId +"', " + maxCharCount + ");</script>");
     }
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/jsf/tag/RichTextEditArea.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/jsf/tag/RichTextEditArea.java
@@ -24,101 +24,34 @@ package org.sakaiproject.jsf.tag;
 import javax.faces.component.UIComponent;
 import javax.faces.el.ValueBinding;
 import javax.faces.webapp.UIComponentTag;
+
+import lombok.Getter;
+import lombok.Setter;
+
 import javax.faces.application.Application;
 import javax.faces.context.FacesContext;
 
 public class RichTextEditArea extends UIComponentTag
 {
+  @Setter @Getter 
   private String identity;
+  @Setter @Getter 
   private String value;
+  @Setter @Getter 
   private String columns;
+  @Setter @Getter 
   private String rows;
+  @Setter @Getter 
   private String justArea;
+  @Setter @Getter 
   private String hasToggle;
+  @Setter @Getter 
   private String mode;
+  @Setter @Getter 
   private String reset;
+  @Setter @Getter 
+  private String maxCharCount;
 
-  public void setIdentity(String newIdentity)
-  {
-	  identity = newIdentity;
-  }
-
-  public String getIdentity()
-  {
-    return identity;
-  }
-  
-  public void setValue(String newValue)
-  {
-    value = newValue;
-  }
-
-  public String getValue()
-  {
-    return value;
-  }
-
-  public void setColumns(String newC)
-  {
-    columns = newC;
-  }
-
-  public String getColumns()
-  {
-    return columns;
-  }
-
-  public void setRows(String newRows)
-  {
-    rows = newRows;
-  }
-
-  public String getRows()
-  {
-    return rows;
-  }
-
-  public void setJustArea(String newJ)
-  {
-    justArea = newJ;
-  }
-
-  public String getJustArea()
-  {
-    return justArea;
-  }
-
-  public void setHasToggle(String hasT)
-  {
-	  hasToggle = hasT;
-  }
-   
-  public String getHasToggle()
-  {
-	  return hasToggle;
-  }
-
-  public void setMode(String mode)
-  {
-	  this.mode = mode;
-  }
-   
-  public String getMode()
-  {
-	  return mode;
-  }
-
-  
-  public void setReset(String newR)
-  {
-	  reset = newR;
-  }
-   
-  public String getReset()
-  {
-	  return reset;
-  }
-  
   public String getComponentType()
 	{
 		return "SakaiRichTextEditArea";
@@ -140,6 +73,7 @@ public class RichTextEditArea extends UIComponentTag
     setString(component, "hasToggle", hasToggle);
     setString(component, "mode", mode);
     setString(component, "reset", reset);
+    setString(component, "maxCharCount", maxCharCount);
 	}
 
 	public void release()
@@ -153,6 +87,7 @@ public class RichTextEditArea extends UIComponentTag
     hasToggle = null;
     mode = null;
     reset = null;
+    maxCharCount = null;
   }
 
   public static void setString(UIComponent component, String attributeName,

--- a/samigo/samigo-app/src/webapp/WEB-INF/samigo.tld
+++ b/samigo/samigo-app/src/webapp/WEB-INF/samigo.tld
@@ -215,6 +215,16 @@
       <description>
       </description>
     </attribute>
+
+    <attribute>
+      <name>maxCharCount</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+      <description>
+	int value, max number of characters allowed
+      </description>
+    </attribute>
+
   </tag>
 
   <!-- ==== OBSOLETE display a tag for a set of navigation links ==== -->

--- a/samigo/samigo-app/src/webapp/js/samigo-global.js
+++ b/samigo/samigo-app/src/webapp/js/samigo-global.js
@@ -1,8 +1,8 @@
 // SAM-1817: This was originally in RichTextEditor.java
-function show_editor(client_id, frame_id) {
+function show_editor(client_id, frame_id, max_chars) {
 	var status =  document.getElementById(client_id + '_textinput_current_status');
 	status.value = "expanded";
-	chef_setupformattedtextarea(client_id, true, frame_id);
+	chef_setupformattedtextarea(client_id, true, frame_id, max_chars);
 	if (typeof setBlockDivs == "function" && typeof retainHideUnhideStatus == "function") {
 		setBlockDivs();
 		retainHideUnhideStatus('none');
@@ -22,7 +22,7 @@ function encodeHTML(text) {
 	return text;
 }
 
-function chef_setupformattedtextarea(client_id, shouldToggle, frame_id) {
+function chef_setupformattedtextarea(client_id, shouldToggle, frame_id, max_chars) {
 	$("body").height($("body").outerHeight() + 600);
 
 	var textarea_id = client_id + "_textinput";
@@ -34,7 +34,11 @@ function chef_setupformattedtextarea(client_id, shouldToggle, frame_id) {
 		input_text.value = input_text_encoded;
 	}
 
-	sakai.editor.launch(textarea_id,'','450','240');
+	config = ''
+	if (max_chars) {
+		config = {wordcount: {'maxCharCount' : 32000}}
+	}
+	sakai.editor.launch(textarea_id, config,'450','240');
 	//setMainFrameHeight(frame_id);
 }
 

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswer.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswer.jsp
@@ -40,7 +40,7 @@ should be included in file importing DeliveryMessages
 <%-- If studentRichText is true, show the rich text answer option --%>
 <h:panelGrid rendered="#{delivery.actionString!='reviewAssessment'
             && delivery.actionString!='gradeAssessment' && delivery.studentRichText}">
-	<samigo:wysiwyg rows="240" value="#{question.responseText}" hasToggle="yes">
+	<samigo:wysiwyg rows="240" value="#{question.responseText}" hasToggle="yes" maxCharCount="32000">
 	</samigo:wysiwyg>
 </h:panelGrid>
 

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswerLink.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswerLink.jsp
@@ -40,7 +40,7 @@ should be included in file importing DeliveryMessages
 <%-- If studentRichText is true, show the rich text answer option --%>
 <h:panelGrid rendered="#{delivery.actionString!='reviewAssessment'
            && delivery.actionString!='gradeAssessment' && delivery.studentRichText}">
-	<samigo:wysiwyg rows="140" value="#{question.responseText}" hasToggle="yes">
+	<samigo:wysiwyg rows="140" value="#{question.responseText}" hasToggle="yes" maxCharCount="32000">
 	    <f:validateLength maximum="32000"/>
 	</samigo:wysiwyg>
 </h:panelGrid>


### PR DESCRIPTION
* I added a new attribute to Samigo to specify the maxCharCount this is passed directly into CKEditor.

* To make changes to CKEditor config in the future a little more flexible I added a method to merge the configs passed in to the default. Previously only a few settings were overridden explicitly. 

I was thinking of just targeting this specific one but I can think of some other ways we might want to make use of this.

* I modified one of the Samigo files to Lombok since it needed it

Any comments appreciated! Thanks!