### PR TITLE
SAK-43936 - Gradebook: no points validation when editing a Gradebook …

### DIFF
--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookHelper.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookHelper.java
@@ -30,4 +30,31 @@ public class GradebookHelper {
             throw new InvalidGradeItemNameException("Grade Item name is invalid: " + title);
         }
     }
+
+    /**
+     * Validate assignment points and name is valid
+     * @param assignmentDefition
+     * @throws InvalidGradeItemNameException
+     * @throws AssignmentHasIllegalPointsException
+     * @throws ConflictingAssignmentNameException
+     */
+    
+	public static void validateAssignmentNameAndPoints(final org.sakaiproject.service.gradebook.shared.Assignment assignmentDefinition) 
+		throws InvalidGradeItemNameException, AssignmentHasIllegalPointsException, ConflictingAssignmentNameException {
+		// Ensure that points is > zero.
+		final Double points = assignmentDefinition.getPoints();
+		if ((points == null) || (points <= 0)) {
+			throw new AssignmentHasIllegalPointsException("Points must be > 0");
+		}	
+		
+		// validate the name
+		final String validatedName = StringUtils.trimToNull(assignmentDefinition.getName());
+		if (validatedName == null) {
+			throw new ConflictingAssignmentNameException("You cannot save an assignment without a name");
+		}
+
+		// name cannot contain these chars as they are reserved for special columns in import/export
+		validateGradeItemName(validatedName);
+		
+	}
 }

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookHelper.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookHelper.java
@@ -23,12 +23,19 @@ public class GradebookHelper {
      * Validate a grade item title by checking against the reserved characters
      * @param title
      * @throws InvalidGradeItemNameException
+     * @throws ConflictingAssignmentNameException
+     * returns validatedName
      */
-    public static void validateGradeItemName(final String title) throws InvalidGradeItemNameException {
-        if (StringUtils.isBlank(title)
-            || StringUtils.startsWithAny(title, GradebookService.INVALID_CHARS_AT_START_OF_GB_ITEM_NAME)) {
+    public static String validateGradeItemName(String title) throws InvalidGradeItemNameException, ConflictingAssignmentNameException {
+		// validate the name
+		title = StringUtils.trimToNull(title);
+        if (StringUtils.isBlank(title)) {
+			throw new ConflictingAssignmentNameException("You cannot save an assignment without a name");
+        }
+        else if (StringUtils.startsWithAny(title, GradebookService.INVALID_CHARS_AT_START_OF_GB_ITEM_NAME)) {
             throw new InvalidGradeItemNameException("Grade Item name is invalid: " + title);
         }
+        return title;
     }
 
     /**
@@ -37,24 +44,16 @@ public class GradebookHelper {
      * @throws InvalidGradeItemNameException
      * @throws AssignmentHasIllegalPointsException
      * @throws ConflictingAssignmentNameException
+     * @return validated name
      */
     
-	public static void validateAssignmentNameAndPoints(final org.sakaiproject.service.gradebook.shared.Assignment assignmentDefinition) 
+	public static String validateAssignmentNameAndPoints(final org.sakaiproject.service.gradebook.shared.Assignment assignmentDefinition) 
 		throws InvalidGradeItemNameException, AssignmentHasIllegalPointsException, ConflictingAssignmentNameException {
 		// Ensure that points is > zero.
 		final Double points = assignmentDefinition.getPoints();
 		if ((points == null) || (points <= 0)) {
 			throw new AssignmentHasIllegalPointsException("Points must be > 0");
 		}	
-		
-		// validate the name
-		final String validatedName = StringUtils.trimToNull(assignmentDefinition.getName());
-		if (validatedName == null) {
-			throw new ConflictingAssignmentNameException("You cannot save an assignment without a name");
-		}
-
-		// name cannot contain these chars as they are reserved for special columns in import/export
-		validateGradeItemName(validatedName);
-		
+		return validateGradeItemName(assignmentDefinition.getName());
 	}
 }

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookHelper.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookHelper.java
@@ -27,10 +27,10 @@ public class GradebookHelper {
      * returns validatedName
      */
     public static String validateGradeItemName(String title) throws InvalidGradeItemNameException, ConflictingAssignmentNameException {
-		// validate the name
-		title = StringUtils.trimToNull(title);
+        // validate the name
+        title = StringUtils.trimToNull(title);
         if (StringUtils.isBlank(title)) {
-			throw new ConflictingAssignmentNameException("You cannot save an assignment without a name");
+            throw new ConflictingAssignmentNameException("You cannot save an assignment without a name");
         }
         else if (StringUtils.startsWithAny(title, GradebookService.INVALID_CHARS_AT_START_OF_GB_ITEM_NAME)) {
             throw new InvalidGradeItemNameException("Grade Item name is invalid: " + title);

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
@@ -298,13 +298,8 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
     private GradebookAssignment prepareNewAssignment(final String name, final Double points, final Date dueDate, final Boolean isNotCounted, final Boolean isReleased, 
             final Boolean isExtraCredit, final Integer sortOrder, final Integer categorizedSortOrder)
     {
-        final String validatedName = StringUtils.trimToNull(name);
-        if (validatedName == null){
-            throw new ConflictingAssignmentNameException("You cannot save an assignment without a name");
-        }
-
         // name cannot contain these special chars as they are reserved for special columns in import/export
-        GradebookHelper.validateGradeItemName(validatedName);
+        final String validatedName = GradebookHelper.validateGradeItemName(name);
 
         final GradebookAssignment asn = new GradebookAssignment();
         asn.setName(validatedName);

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -622,10 +622,9 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			throw new GradebookSecurityException();
 		}
 
-		GradebookHelper.validateAssignmentNameAndPoints(assignmentDefinition);
+		final String validatedName = GradebookHelper.validateAssignmentNameAndPoints(assignmentDefinition);
 
 		final Gradebook gradebook = getGradebook(gradebookUid);
-		final String validatedName = StringUtils.trimToNull(assignmentDefinition.getName());
 
 		// if attaching to category
 		if (assignmentDefinition.getCategoryId() != null) {
@@ -648,8 +647,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 			throw new GradebookSecurityException();
 		}
 		
-		GradebookHelper.validateAssignmentNameAndPoints(assignmentDefinition);
-		final String validatedName = StringUtils.trimToNull(assignmentDefinition.getName());
+		final String validatedName = GradebookHelper.validateAssignmentNameAndPoints(assignmentDefinition);
 
 		final Gradebook gradebook = this.getGradebook(gradebookUid);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -2130,30 +2130,22 @@ public class GradebookNgBusinessService {
 	 * @param assignment
 	 * @return
 	 */
-	public boolean updateAssignment(final Assignment assignment) {
+	public void updateAssignment(final Assignment assignment) {
 		final String siteId = getCurrentSiteId();
 		final Gradebook gradebook = getGradebook(siteId);
 
 		// need the original name as the service needs that as the key...
 		final Assignment original = this.getAssignment(assignment.getId());
 
-		try {
-			this.gradebookService.updateAssignment(gradebook.getUid(), original.getId(), assignment);
+		this.gradebookService.updateAssignment(gradebook.getUid(), original.getId(), assignment);
 
-			EventHelper.postUpdateAssignmentEvent(gradebook, assignment, getUserRoleOrNone());
+		EventHelper.postUpdateAssignmentEvent(gradebook, assignment, getUserRoleOrNone());
 
-			if (original.getCategoryId() != null && assignment.getCategoryId() != null
-					&& original.getCategoryId().longValue() != assignment.getCategoryId().longValue()) {
-				updateAssignmentCategorizedOrder(gradebook.getUid(), assignment.getCategoryId(), assignment.getId(),
-						Integer.MAX_VALUE);
-			}
-
-			return true;
-		} catch (final Exception e) {
-			log.error("An error occurred updating the assignment", e);
+		if (original.getCategoryId() != null && assignment.getCategoryId() != null
+				&& original.getCategoryId().longValue() != assignment.getCategoryId().longValue()) {
+			updateAssignmentCategorizedOrder(gradebook.getUid(), assignment.getCategoryId(), assignment.getId(),
+					Integer.MAX_VALUE);
 		}
-
-		return false;
 	}
 
 	/**

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
@@ -216,12 +216,36 @@ public class AddOrEditGradeItemPanel extends BasePanel {
 
 		// OK
 		if (validated) {
+
+			Long assignmentId = null;
+			boolean success = true;
+
+			try {
+				if (AddOrEditGradeItemPanel.this.mode == UiMode.EDIT) {
+					assignmentId = assignment.getId();
+					AddOrEditGradeItemPanel.this.businessService.updateAssignment(assignment);
+				} 
+				else {
+					assignmentId = AddOrEditGradeItemPanel.this.businessService.addAssignment(assignment);
+				}
+				rubricsService.saveRubricAssociation(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, assignmentId.toString(), getRubricParameters(""));
+			}
+			catch (final AssignmentHasIllegalPointsException e) {
+				error(new ResourceModel("error.addgradeitem.points").getObject());
+				success = false;
+			} catch (final ConflictingAssignmentNameException e) {
+				error(new ResourceModel("error.addgradeitem.title").getObject());
+				success = false;
+			} catch (final ConflictingExternalIdException e) {
+				error(new ResourceModel("error.addgradeitem.exception").getObject());
+				success = false;
+			} catch (final Exception e) {
+				error(new ResourceModel("error.addgradeitem.exception").getObject());
+				success = false;
+			}
+				
 			if (AddOrEditGradeItemPanel.this.mode == UiMode.EDIT) {
-
-				final boolean success = AddOrEditGradeItemPanel.this.businessService.updateAssignment(assignment);
-
 				if (success) {
-					rubricsService.saveRubricAssociation(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, assignment.getId().toString(), getRubricParameters(""));
 					getSession().success(MessageFormat.format(getString("message.edititem.success"), assignment.getName()));
 					setResponsePage(getPage().getPageClass(),
 							new PageParameters().add(GradebookPage.FOCUS_ASSIGNMENT_ID_PARAM, assignment.getId()));
@@ -231,27 +255,7 @@ public class AddOrEditGradeItemPanel extends BasePanel {
 				}
 
 			} else {
-
-				Long assignmentId = null;
-
-				boolean success = true;
-				try {
-					assignmentId = AddOrEditGradeItemPanel.this.businessService.addAssignment(assignment);
-				} catch (final AssignmentHasIllegalPointsException e) {
-					error(new ResourceModel("error.addgradeitem.points").getObject());
-					success = false;
-				} catch (final ConflictingAssignmentNameException e) {
-					error(new ResourceModel("error.addgradeitem.title").getObject());
-					success = false;
-				} catch (final ConflictingExternalIdException e) {
-					error(new ResourceModel("error.addgradeitem.exception").getObject());
-					success = false;
-				} catch (final Exception e) {
-					error(new ResourceModel("error.addgradeitem.exception").getObject());
-					success = false;
-				}
 				if (success) {
-					rubricsService.saveRubricAssociation(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, assignmentId.toString(), getRubricParameters(""));
 					final String successMessage = MessageFormat.format(getString("notification.addgradeitem.success"), assignment.getName());
 					getSession()
 							.success(successMessage);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.java
@@ -162,20 +162,21 @@ public class BulkEditItemsPanel extends BasePanel {
 
 			final List<Assignment> assignments = (List<Assignment>) form.getModelObject();
 
-			boolean result = false;
-			for (final Assignment a : assignments) {
+			try {
+				for (final Assignment a : assignments) {
 
-				log.debug("Bulk edit assignment: {}", a);
-				result = BulkEditItemsPanel.this.businessService.updateAssignment(a);
-			}
-			for (int count=0; count < BulkEditItemsPanel.this.getDeletableItemsList().size(); count++){
-				BulkEditItemsPanel.this.businessService.removeAssignment(BulkEditItemsPanel.this.getDeletableItemsList().get(count));
-			}
-			BulkEditItemsPanel.this.clearDeletableItemsList();
-			if (result) {
+					log.debug("Bulk edit assignment: {}", a);
+					BulkEditItemsPanel.this.businessService.updateAssignment(a);
+				}
+				for (int count=0; count < BulkEditItemsPanel.this.getDeletableItemsList().size(); count++){
+					BulkEditItemsPanel.this.businessService.removeAssignment(BulkEditItemsPanel.this.getDeletableItemsList().get(count));
+				}
+				BulkEditItemsPanel.this.clearDeletableItemsList();
 				getSession().success(getString("bulkedit.update.success"));
-			} else {
+			}
+			catch (final Exception e) {
 				getSession().error(getString("bulkedit.update.error"));
+				log.warn("An error occurred updating the assignment", e);
 			}
 			setResponsePage(GradebookPage.class);
 		}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -202,11 +202,14 @@ public class GradeImportConfirmationStep extends BasePanel {
 					final Assignment assignment = GradeImportConfirmationStep.this.businessService.getAssignment(item.getItemTitle());
 					assignment.setPoints(points);
 
-					final boolean updated = GradeImportConfirmationStep.this.businessService.updateAssignment(assignment);
-					if (!updated) {
+					try {
+						GradeImportConfirmationStep.this.businessService.updateAssignment(assignment);
+					}
+					catch (final Exception e) {
 						getSession().error(MessageHelper.getString("importExport.error.pointsmodification", assignment.getName()));
 						GradeImportConfirmationStep.this.errors = true;
 						errorColumns.add(item);
+                        log.warn("An error occurred updating the assignment", e);
 					}
 
 					assignmentMap.put(StringUtils.trim(assignment.getName()), assignment.getId());

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeImportConfirmationStep.java
@@ -209,7 +209,7 @@ public class GradeImportConfirmationStep extends BasePanel {
 						getSession().error(MessageHelper.getString("importExport.error.pointsmodification", assignment.getName()));
 						GradeImportConfirmationStep.this.errors = true;
 						errorColumns.add(item);
-                        log.warn("An error occurred updating the assignment", e);
+						log.warn("An error occurred updating the assignment", e);
 					}
 
 					assignmentMap.put(StringUtils.trim(assignment.getName()), assignment.getId());


### PR DESCRIPTION
This ended up being a lot more complicated than I expected.

* Problem 1: `updateAssignment` returned a boolean true/false and did a `catch (final Exception e) {` only logging the error. There was no way to tell what the error was
* Problem 2: Exceptions were only caught when adding an assignment
* Problem 3: This method didn't check for a problem with points at all

When working on this I ended up refactoring a lot of this because of redundancy between `addAssignment `and `updateAssignment `checking for errors. There's probably more refactoring that can be done. 

I had `updateAssignment` either do the update or throw an Exception so it ended up just changing to a `void`.

I could have changed this to a less-code-change solution and just have `updateAssignment` check for points and return false, but then we wouldn't have the specific message related to points in the UI. 