### PR TITLE
SAK-44057 Improve entitybroker DHS getCurrentLocationReference

### DIFF
--- a/entitybroker/impl/src/java/org/sakaiproject/entitybroker/impl/devhelper/DeveloperHelperServiceImpl.java
+++ b/entitybroker/impl/src/java/org/sakaiproject/entitybroker/impl/devhelper/DeveloperHelperServiceImpl.java
@@ -271,8 +271,7 @@ public class DeveloperHelperServiceImpl extends AbstractDeveloperHelperService {
         String location = null;
         try {
             String context = toolManager.getCurrentPlacement().getContext();
-            Site s = siteService.getSite( context );
-            location = s.getReference(); // get the entity reference to the site
+            location = siteService.siteReference(context); // get the entity reference to the site
         } catch (Exception e) {
             // sakai failed to get us a location so we can assume we are not inside the portal
             location = null;


### PR DESCRIPTION
There is no need to get the site here, as the transformation from a site id (context) to a site reference is a simple string manipulation for which SiteService already has a method.

Calling getSite() has performance implications as it returns a copy of the site from the site cache (usually).
