### PR TITLE
SAK-44071: Update Presence correctly by clearing timer and update active tabs

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.update.presence.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.update.presence.js
@@ -1,19 +1,6 @@
 var activeTabListenerAttached = false,// initial load
     handleVisibilityChange = function(){}; 
 
-// Set the name of the hidden property and the change event for visibility
-var hidden, visibilityChange;
-if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support 
-    hidden = "hidden";
-    visibilityChange = "visibilitychange";
-} else if (typeof document.msHidden !== "undefined") {
-    hidden = "msHidden";
-    visibilityChange = "msvisibilitychange";
-} else if (typeof document.webkitHidden !== "undefined") {
-    hidden = "webkitHidden";
-    visibilityChange = "webkitvisibilitychange";
-}
-
 function updatePresenceTimeout(_ms, _go) {
     if (window.sakaiLastPresenceTimeOut !== null) {
         clearTimeout(window.sakaiLastPresenceTimeOut);

--- a/library/src/morpheus-master/js/src/sakai.morpheus.update.presence.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.update.presence.js
@@ -1,4 +1,4 @@
-var active_tab_listener_attached = false; // initial load
+var activeTabListenerAttached = false; // initial load
 
 // Set the name of the hidden property and the change event for visibility
 var hidden, visibilityChange;
@@ -14,7 +14,7 @@ if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and 
 }
 
 function updatePresenceTimeout(_ms, _go) {
-    if (window.sakaiLastPresenceTimeOut != null) {
+    if (window.sakaiLastPresenceTimeOut !== null) {
         clearTimeout(window.sakaiLastPresenceTimeOut);
         window.sakaiLastPresenceTimeOut = null;
     }
@@ -23,22 +23,10 @@ function updatePresenceTimeout(_ms, _go) {
     }
 }
 
-// Triggers when visibility changes
-function handleVisibilityChange() {
-    if (document.hidden) {
-        console.log("hidden");
-        updatePresenceTimeout(window.sakaiPresenceTimeDelay, false); //stop
-    } else  {
-        console.log("visible");
-        updatePresenceTimeout(window.sakaiPresenceTimeDelay, false); 
-        updatePresence(); //start immediately
-    }
-}
-
 function updatePresence() {
-  if (!active_tab_listener_attached) {
+  if (!activeTabListenerAttached) {
     document.addEventListener("visibilitychange", handleVisibilityChange, false);
-    active_tab_listener_attached = true;
+    activeTabListenerAttached = true;
   }
 
   if (document.hidden) {
@@ -93,4 +81,14 @@ function updatePresence() {
       updatePresenceTimeout(60000, true);
     }
   });
+}
+
+// Triggers when visibility changes
+function handleVisibilityChange() {
+    if (document.hidden) {
+        updatePresenceTimeout(window.sakaiPresenceTimeDelay, false); //stop
+    } else  {
+        updatePresenceTimeout(window.sakaiPresenceTimeDelay, false); 
+        updatePresence(); //start immediately
+    }
 }

--- a/library/src/morpheus-master/js/src/sakai.morpheus.update.presence.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.update.presence.js
@@ -1,4 +1,5 @@
-var activeTabListenerAttached = false; // initial load
+var activeTabListenerAttached = false,// initial load
+    handleVisibilityChange = function(){}; 
 
 // Set the name of the hidden property and the change event for visibility
 var hidden, visibilityChange;
@@ -84,11 +85,11 @@ function updatePresence() {
 }
 
 // Triggers when visibility changes
-function handleVisibilityChange() {
+handleVisibilityChange = function(event) {
     if (document.hidden) {
         updatePresenceTimeout(window.sakaiPresenceTimeDelay, false); //stop
     } else  {
         updatePresenceTimeout(window.sakaiPresenceTimeDelay, false); 
         updatePresence(); //start immediately
     }
-}
+};


### PR DESCRIPTION
1. The setTimeout handle is not cleared properly and might cause a cascade effect if multiple updatePresence function calls are made.

2. Presence sends out a lot of HTTP requests for each tab open in a browser - this creates unnecessary load on the server.

A more accurate portrayal of activity is when a user is active on the tab that is open in the browser - this reduces the number of presence requests that are sent to the server.
