### PR TITLE
SAK-44085 Assignments NPE when time params are missing

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7457,21 +7457,35 @@ public class AssignmentAction extends PagedResourceActionII {
      * @return
      */
     private Instant putTimeInputInState(ParameterParser params, SessionState state, String monthString, String dayString, String yearString, String hourString, String minString, String invalidBundleMessage) {
-        int month = Integer.valueOf(params.getString(monthString));
+        String monthStr = params.getString(monthString);
+        int month = monthStr != null ? Integer.valueOf(monthStr) : 0;
         state.setAttribute(monthString, month);
-        int day = Integer.valueOf(params.getString(dayString));
+
+        String dayStr = params.getString(dayString);
+        int day = dayStr != null ? Integer.valueOf(dayStr) : 0;
         state.setAttribute(dayString, day);
-        int year = Integer.valueOf(params.getString(yearString));
+
+        String yearStr = params.getString(yearString);
+        int year = yearStr != null ? Integer.valueOf(yearStr) : 0;
         state.setAttribute(yearString, year);
-        int hour = Integer.valueOf(params.getString(hourString));
+
+        String hourStr = params.getString(hourString);
+        int hour = hourStr != null ? Integer.valueOf(hourStr) : 0;
         state.setAttribute(hourString, hour);
-        int min = Integer.valueOf(params.getString(minString));
+
+        String minStr = params.getString(minString);
+        int min = minStr != null ? Integer.valueOf(minStr) : 0;
         state.setAttribute(minString, min);
         // validate date
         if (!DateFormatterUtil.checkDate(day, month, year)) {
             addAlert(state, rb.getFormattedMessage("date.invalid", rb.getString(invalidBundleMessage)));
         }
-        return LocalDateTime.of(year, month, day, hour, min, 0).atZone(userTimeService.getLocalTimeZone().toZoneId()).toInstant();
+		try {
+			return LocalDateTime.of(year, month, day, hour, min, 0).atZone(userTimeService.getLocalTimeZone().toZoneId()).toInstant();
+		} catch (java.time.DateTimeException e) {
+            addAlert(state, rb.getFormattedMessage("date.invalid", rb.getString(invalidBundleMessage)));
+			return LocalDateTime.now().atZone(userTimeService.getLocalTimeZone().toZoneId()).toInstant();
+		}
     }
 
     /**


### PR DESCRIPTION
The smoker test clicks a lot of links in Sakai , often in someone what random orders.   And with tools that use state a lot, these paths can lead to Null Pointer Errors (NPE).   It is unlikely that these are click paths our users will travel down.  Sometimes the UI even recovers from the NPE and puts something up.

But we might as well fix these rare NPEs so future NPEs (i.e. perhaps a regression) jump out while running a future smoker test.