### PR TITLE
SAK-34512: Samigo > user data loss when feedback text exceeds 4000 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ sakai-demo.zip
 velocity.log
 node_modules
 webcomponents/tool/src/main/frontend/dist
+rubrics/tool/src/main/frontend
 bower_components
 rebel.xml
 rsf/sakai-rsf-web/templates/overlays

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -581,6 +581,7 @@ submissions_allowed_error=The Time Allowed must be a positive integer. Example v
 corrAnswer=You must select at least one Answer.
 partial_credit_limit_summary="% Value" for an incorrect answer selection needs to be a whole number between 0 and 99.
 partial_credit_limit_detail=Value needs to be a whole number between 0 and 99.
+feedbackTooLong=The provided feedback text is too long. Correct and incorrect feedback cannot exceed {0} characters each.
 
 edit_published_assessment_warn_1=This assessment has been retracted from student view.  
 edit_published_assessment_warn_21=Click "Republish" or "Regrade and Republish" to make it available to students.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.tool.assessment.ui.listener.author;
 
 import java.text.DateFormat;
+import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -119,6 +120,7 @@ public class ItemAddListener
     implements ActionListener {
 
   private static final TagService tagService= (TagService) ComponentManager.get( TagService.class );
+  private static final int MAX_FEEDBACK_CHARS = 4000;
     //private static ContextUtil cu;
   //private String scalename; // used for multiple choice Survey
   private boolean error = false;
@@ -197,7 +199,13 @@ public class ItemAddListener
 		error=true;
 	    }
 	}
-    
+
+	if(StringUtils.length(item.getCorrFeedback()) > MAX_FEEDBACK_CHARS || StringUtils.length(item.getIncorrFeedback()) > MAX_FEEDBACK_CHARS) {
+		String feedbackTooLong = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AuthorMessages", "feedbackTooLong");
+		context.addMessage(null, new FacesMessage(MessageFormat.format(feedbackTooLong, new Object[]{MAX_FEEDBACK_CHARS})));
+		error = true;
+	}
+
     if(error) { 
     	return;
     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34512

Adding correct or incorrect feedback text that exceeds 4000 characters causes an exception to be thrown. The result is the loss of user data for the question, and not just the feedback text which exceeded the limit: the question text and answer are also lost, even if you saved them separately.

This affects both Oracle and MySQL.