### PR TITLE
SAK-44151 General small improvements and fixes for Lessons

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -74,9 +74,14 @@ import java.io.FileNotFoundException;
 
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.lang3.StringUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.jsoup.Jsoup;
 import org.jsoup.select.Elements;
 import org.sakaiproject.authz.api.AuthzRealmLockException;
+import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -510,6 +515,28 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		    addAttr(doc, itemElement, "samewindow", item.isSameWindow() ? "true" : "false");
 		
 		String attrString = item.getAttributeString(); //json encoded attributes
+
+		final JSONParser jsonParser = new JSONParser(); // JSON parser used to parse the attribute string into a JSON object
+
+		try {
+			JSONObject attributeObj = (JSONObject) jsonParser.parse(attrString); // Get full attribute string as JSON object
+			JSONArray checklistArr = (JSONArray) attributeObj.get("checklistItems"); // Get the checklist JSON array from the object
+
+			if (checklistArr != null && !checklistArr.isEmpty()) {
+				for (Object checklistObj : checklistArr) { // Iterate through each checklist item to check for links
+					JSONObject checklistObjJson = (JSONObject) checklistObj;
+					if (checklistObjJson != null && checklistObjJson.get("link") != null && (Long) checklistObjJson.get("link") > 0L) { // Null safe check if it is a linked checklist item
+						checklistObjJson.put("link", -2L); // This is a linked checklist item so set it to -2 to indicate link needs to be updated
+					}
+				}
+			}
+			attributeObj.put("checklistItems", checklistArr); // Update the JSON object for the JSON attribute with the modified checklist
+
+			attrString = attributeObj.toJSONString(); // Replace the attribute string with the version with the modified checklist
+		} catch (ParseException e) {
+			log.error("Exception caught while parsing checklist array. No modifications will be made to attribute string.", e.getMessage(), e);
+		}
+
 		if (attrString != null) {
 		    Element attributeElement = doc.createElement("attributes");
 		    attributeElement.setTextContent(attrString);
@@ -884,7 +911,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		       item.setGroupOwned(s.equals("true"));
 
 		   if (RESTORE_GROUPS) {
-		       String groupString = mergeGroups(itemElement, "ownerGroup", siteGroups);
+		       String groupString = mergeGroups(itemElement, "ownerGroup", siteGroups, fromSiteId);
 		       if (groupString != null)
 			   item.setOwnerGroups(groupString);
 		   }
@@ -899,7 +926,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		   // awareness comes from the other tools, enabling this produces
 		   // inconsistent results
 		   if (RESTORE_GROUPS) {
-		       String groupString = mergeGroups(itemElement, "group", siteGroups);
+		       String groupString = mergeGroups(itemElement, "groups", siteGroups, fromSiteId);
 		       if (groupString != null)
 			   item.setGroups(groupString);
 		   }
@@ -1006,31 +1033,41 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
        return needFix;
     }
 
-    String mergeGroups(Element itemElement, String attr, Collection<Group> siteGroups) {
+    String mergeGroups(Element itemElement, String attr, Collection<Group> siteGroups, String fromSiteId) {
 
 	// not currently doing this, although the code has been tested.
 	// The problem is that other tools don't do it. Since much of our group
 	// awareness comes from the other tools, enabling this produces
 	// inconsistent results
 
-	NodeList groups = itemElement.getElementsByTagName(attr);
+	String groups = itemElement.getAttribute(attr);
 	String groupString = null;
-	
-	// translate groups from title to ID
-	if (groups != null && siteGroups != null) {
-	    for (int n = 0; n < groups.getLength(); n ++) {
-		Element group = (Element)groups.item(n);
-		String title = group.getAttribute("title");
-		if (title != null && !title.equals("")) {
-		    for (Group g: siteGroups) {
-			if (title.equals(g.getTitle())) {
-			    if (groupString == null)
-				groupString = g.getId();
-			    else
-				groupString = groupString + "," + g.getId();
+	Site oldSite = null;
+	try {
+		oldSite = siteService.getSite(fromSiteId);
+	} catch (Exception e) {
+		log.debug("site " + fromSiteId + " not found.", e);
+	}
+	// For each old group, get the corresponding new group id
+	if (!groups.isEmpty() && siteGroups != null && oldSite != null) {
+		final String[] parts = groups.split(",");
+		for (int n = 0; n < parts.length; n ++) {
+			final Group group = oldSite.getGroup(parts[n]);
+			final String providerID = group.getProviderGroupId();
+			if(providerID == null ) { // only transfer groups which are not old rosters
+				final String title = group.getTitle();
+				if (title != null && !title.equals("")) {
+					for (Group g : siteGroups) {
+						if (title.equals(g.getTitle())) {
+							if (groupString == null) {
+								groupString = g.getId();
+							} else {
+								groupString = groupString + "," + g.getId();
+							}
+						}
+					}
+				}
 			}
-		    }
-		}
 	    }
 	}
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -3445,9 +3445,18 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 
 									UIVerbatim.make(row, "select-checklistitem-linked-details", tooltipContent);
 								}
-							}
+								UIOutput.make(row, "select-checklistitem-name", checklistItemName).decorate(new UIStyleDecorator("checklist-checkbox-label"));
 
-							UIOutput.make(row, "select-checklistitem-name", checklistItemName).decorate(new UIStyleDecorator("checklist-checkbox-label"));
+							} else if (checklistItem.getLink() < -1L) {	// getLink will give out -2 for items that were once linked but broke during site duplication.
+								input.decorate(new UIDisabledDecorator(true));
+								UIOutput.make(row, "select-checklistitem-link-broken");
+								String toolTipMessage = "simplepage.checklist.external.link.details.broken";
+								String tooltipContent = messageLocator.getMessage(toolTipMessage);
+								UIVerbatim.make(row, "select-checklistitem-linked-details", tooltipContent);
+								UIOutput.make(row, "select-checklistitem-name", checklistItemName).decorate(new UIStyleDecorator("checklist-checkbox-label link-broken"));
+							} else {
+								UIOutput.make(row, "select-checklistitem-name", checklistItemName).decorate(new UIStyleDecorator("checklist-checkbox-label"));
+							}
 							index++;
 						}
 					}

--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -199,6 +199,7 @@ simpleapge.checklist.edit_externalLink=Edit external link
 simplepage.checklist.external.unlink=Remove Link
 simplepage.checklist.external.link.details.incomplete=This item is linked to '<strong>{}</strong>' and will be automatically checked once '<strong>{}</strong>' is completed.
 simplepage.checklist.external.link.details.complete=This item is linked to the complete item: '<strong>{}</strong>'.
+simplepage.checklist.external.link.details.broken=Edit this checklist to re-link all items.
 simplepage.checklist.external.link.details.notvisible=This linked item is currently not visible.
 simplepage.checklist.external.link.hidden=Name is not available
 simplepage.checklist.external.link.info=It is only possible to link to required items.

--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -1226,6 +1226,10 @@ div[role="dialog"] {
     margin: 10px 0 
 }
 
+textarea.shortAnswerInput {
+    width: 100%;
+}
+
 .deleteCandidate td:first-child {
     background: transparent url('/library/image/silk/delete.png') 2px 3px no-repeat;
 }

--- a/lessonbuilder/tool/src/webapp/css/checklist.css
+++ b/lessonbuilder/tool/src/webapp/css/checklist.css
@@ -84,24 +84,32 @@ p.edit-group {
 }
 .checklist-checkbox ~ span.checklist-checkbox-label {
     background-image: url("../images/gray_unchecked.png");
-    background-position: left center;
+    background-position: left top 8px;
     background-repeat: no-repeat;
 }
 .checklist-checkbox:checked ~ span.checklist-checkbox-label {
     background-image: url("../images/green_checkmark.png");
-    background-position: left center;
+    background-position: left top 8px;
     background-repeat: no-repeat;
 }
 .checklist-checkbox-label {
     padding: 0.5em 0.5em 0.5em 22px;
+    display: inline-block;
+    vertical-align: top;
 }
-label.checklistLabel.disabled:hover input.checklist-checkbox ~ span.checklist-checkbox-label {
+label.checklistLabel.disabled:hover input.checklist-checkbox ~ span.checklist-checkbox-label, label.checklistLabel.disabled input.checklist-checkbox ~ span.link-broken {
     background-image: none;
     cursor: not-allowed;
+    vertical-align: top;
+    padding-bottom: 13px;
+}
+span.link-broken-icon {
+    line-height: .5em;
+    padding-top: 2.5%;
 }
 label.checklistLabel:hover .checklist-checkbox ~ span.checklist-checkbox-label {
     background-image: url("../images/gray_checkmark.png");
-    background-position: left center;
+    background-position: left top 8px;
     background-repeat: no-repeat;
     cursor: pointer;
 }
@@ -109,7 +117,7 @@ label.checklistLabel:hover .checklist-checkbox:checked ~ span.checklist-checkbox
     background-image: url("../images/green_checkmark.png");
 }
 .checklistLabel {
-    line-height: 2em;
+    line-height: 1.5em;
 }
 .hideNameCheckbox {
     margin: 1em .5em 0 4em !important;
@@ -157,10 +165,15 @@ legend.no-border {
     display: none;
 }
 
+#additionalSettings h3.checklist-settings-header {
+    padding-left: calc(.5em + 16px);
+}
 
-.checklistLabel.disabled:hover .externally-linked {
-    margin-right: -19px;
+.checklistLabel.disabled:hover .externally-linked, .link-broken {
+    margin-right: -22px;
     display: inline-block;
+    vertical-align: 20px;
+    margin-top: 8px;
 }
 
 .tooltip-content {

--- a/lessonbuilder/tool/src/webapp/js/checklist.js
+++ b/lessonbuilder/tool/src/webapp/js/checklist.js
@@ -40,7 +40,7 @@
             modal: true,
             resizable: false,
             draggable: false
-        }).parent('.ui-dialog').css('zIndex', 150000);
+        }).parent('.ui-dialog').css('zIndex', 900);
 
         $("#externalLink-dialog-close").click(function(e){
             e.preventDefault();
@@ -78,7 +78,15 @@
     checklist.addChecklistItem = function () {
         var clonedAnswer = $("#copyableChecklistItemDiv").clone(true);
         clonedAnswer.show();
-        var num = $("#createdChecklistItems").find("li").length + 1; // Should be currentNumberOfChecklistItems + 1
+        var num = 0;
+        var itemNamesOnScreen = document.getElementsByClassName('checklist-item-name');
+        for(var count=0; count<itemNamesOnScreen.length; count++){  //observe all the named items currently onscreen to try and get the largest index
+            var nameNow = itemNamesOnScreen[count].name.replace('checklist-item-name','0'); //get the index number of the current item alone, adding 0 just in case there isn't one
+            if(parseInt(nameNow) > num){    //if the index of the current item is larger than the old one, we have a new highest number.
+                num = parseInt(nameNow);
+            }
+        }
+        num = num + 1;  //num should be incremented by 1 over the largest existing index.
 
         clonedAnswer.find(".checklist-item-id").val("-1");
         clonedAnswer.find(".checklist-item-name").val("");

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -39,7 +39,7 @@ function msg(s) {
 
 function setupdialog(oe) {
 	oe.dialog("option", "width", modalDialogWidth());
-	$('.ui-dialog').css('zIndex',150000);
+	$('.ui-dialog').css('zIndex', 900);
 }
 
 function checksize(oe) {
@@ -366,14 +366,14 @@ $(document).ready(function() {
 			modal: false,
 			resizable: false,
 			draggable: false
-                }).parent('.ui-dialog').css('zIndex',150000);
+                }).parent('.ui-dialog').css('zIndex',900);
 
 		$('#moreDiv').dialog({
 			autoOpen: false,
 			modal: false,
 			resizable: false,
 			draggable: false
-		}).parent('.ui-dialog').css('zIndex',150000);
+		}).parent('.ui-dialog').css('zIndex',900);
 
 		$('#column-dialog').dialog({
 			autoOpen: false,
@@ -381,7 +381,7 @@ $(document).ready(function() {
 			width: 'auto',
 			resizable: false,
 			draggable: true
-		}).parent('.ui-dialog').css('zIndex',150000);
+		}).parent('.ui-dialog').css('zIndex',900);
 
 		$('#delete-confirm').dialog({
 			autoOpen: false,
@@ -395,7 +395,7 @@ $(document).ready(function() {
 				      }},{text:msg("simplepage.cancel_message"),
 				          click: function() {
 				          $( this ).dialog( "close" );}}
-				]}).parent('.ui-dialog').css('zIndex',150000);
+				]}).parent('.ui-dialog').css('zIndex',900);
 		
 		$(window).resize(function() {
 			var modalDialogList = ['#subpage-dialog', '#edit-item-dialog', '#edit-multimedia-dialog',
@@ -1340,6 +1340,7 @@ $(document).ready(function() {
 			$("#question-prerequisite").prop("checked", false);
 			$("#question-show-poll").prop("checked", false);
 			$("#multipleChoiceSelect").click();
+			$("#multipleChoiceSelect").prop('checked',true);	//the Click above will trigger the right hide/show of things itself, but it will not actually display multipleChoiceSelect as Checked, so we do it explicitly here.
 			resetMultipleChoiceAnswers();
 			resetShortanswers();
 			
@@ -1672,25 +1673,21 @@ $(document).ready(function() {
 	                    $("#pagestuff").show();
 
 				var sbpgreleasedate = row.find(".subpagereleasedate").text();
-				if(sbpgreleasedate === '') {
+				localDatePicker({
+					input: '#release_date2',
+					useTime: 1,
+					parseFormat: 'YYYY-MM-DD HH:mm:ss',
+					val: sbpgreleasedate,
+					ashidden: { iso8601: 'releaseDate2ISO8601' }
+				});
+				if(sbpgreleasedate === '') {	//if there is no release date set, don't check the box and se the date-related fields blank
 					$("#page-releasedate2").prop('checked', false);
-					localDatePicker({
-						input: '#release_date2',
-						useTime: 1,
-						parseFormat: 'YYYY-MM-DD HH:mm:ss',
-						val: sbpgreleasedate,
-						ashidden: { iso8601: 'releaseDate2ISO8601' }
-					});
-				}
-				else {
+					$("#release_date2").val('');
+					$("#releaseDate2ISO8601").val('');
+				} else {
 					$("#page-releasedate2").prop('checked', true);
-					localDatePicker({
-						input: '#release_date2',
-						useTime: 1,
-						parseFormat: 'YYYY-MM-DD HH:mm:ss',
-						val: sbpgreleasedate,
-						ashidden: { iso8601: 'releaseDate2ISO8601' }
-					});
+					$("#releaseDate2ISO8601").val(sbpgreleasedate);
+					$("#release_date2").val(moment(sbpgreleasedate).format('MM/DD/YYYY h:mm a'));
 				}
 
 			    var pagenext = row.find(".page-next").text();
@@ -2729,12 +2726,16 @@ function setCollapsedStatus(header, collapse) {
 	header.find('.sectionCollapsedIcon').show();
 	header.find('.toggleCollapse').text(msg('simplepage.clickToExpand'));
 	header.attr('aria-expanded', 'false');
+	header.addClass('closedSectionHeader');
+	header.removeClass('openSectionHeader');
     } else {
 	header.find('.collapseIcon').removeClass("fa-toggle-down");
 	header.find('.collapseIcon').addClass("fa-toggle-up");
 	header.find('.sectionCollapsedIcon').hide();
 	header.find('.toggleCollapse').text(msg('simplepage.clickToCollapse'));
 	header.attr('aria-expanded', 'true');
+	header.addClass('openSectionHeader');
+	header.removeClass('closedSectionHeader');
     }
 }
 
@@ -2758,6 +2759,11 @@ function closeEditItemDialog() {
 	$("#edit-item-dialog").dialog("close");
 	$('#edit-item-error-container').hide();
 	$("#select-resource-group").hide();
+	if (!$("#page-releasedate2").prop('checked')){	// if the date-release option isn't checked, we should clear out the date-related values on close.
+		$("#release_date2").val('');
+		$("#releaseDate2ISO8601").val('');
+		$("#release_date_string").val('')
+	}
 	oldloc.focus();
 }
 

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -109,7 +109,7 @@
 		</form>
 
 		<div id="modal-iframe-div" style="display:none" tabindex="-1" role="dialog">
-			<iframe name="sakai-basiclti-admin-iframe" id="sakai-basiclti-admin-iframe" src="/library/image/sakai/spinner.gif" tabindex="0"></iframe>
+			<iframe name="sakai-basiclti-admin-iframe" id="sakai-basiclti-admin-iframe" src="/library/image/sakai/spinner.gif" style="min-height: 80vh;" tabindex="0"></iframe>
 		</div>
 	</div>
 

--- a/lessonbuilder/tool/src/webapp/templates/Checklist.html
+++ b/lessonbuilder/tool/src/webapp/templates/Checklist.html
@@ -85,7 +85,7 @@
         <hr />
         <h3><span rsf:id="msg=simplepage.optional.settings" /></h3>
         <div id="additionalSettings">
-            <h3><span rsf:id="msg=simplepage.appearance.settings" /></h3>
+            <h3 class="checklist-settings-header"><span rsf:id="msg=simplepage.appearance.settings" /></h3>
             <div id="stylingstuff" class="stylingstuff">
                 <p class="shorttext">
                     <label for="indent-level"><span rsf:id="msg=simplepage.indent.level"/></label>
@@ -96,7 +96,7 @@
                     <input rsf:id="customCssClass" type="text" id="customCssClass" length="30" maxlength="99" class="edit-form-input"/>
                 </p>
             </div>
-            <h3 id="groupHeader"><span rsf:id="msg=simplepage.group.settings" /></h3>
+            <h3 class="checklist-settings-header" id="groupHeader"><span rsf:id="msg=simplepage.group.settings" /></h3>
             <div id="grouplist" rsf:id="grouplist">
                 <span rsf:id="group-list-span"/>
                 <p rsf:id="msg=simplepage.select-group"></p>

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -726,6 +726,7 @@
                                                 <label class="checklistLabel">
                                                     <input type="checkbox" rsf:id="select-checklistitem" />
                                                     <span class="fa fa-link fa-lg externally-linked" rsf:id="select-checklistitem-linked-icon"></span>
+                                                    <span class="fa fa-chain-broken fa-lg link-broken link-broken-icon" rsf:id="select-checklistitem-link-broken"></span>
                                                     <span rsf:id="select-checklistitem-name"></span>
                                                 </label>
                                                 <span class="tooltip-content" rsf:id="select-checklistitem-linked-details" ></span>
@@ -901,7 +902,7 @@
 				      <input type="hidden" rsf:id="csrf5" />
                                         <input type="hidden" rsf:id="shortanswerId" />
                                         <div id="answerInput"><span rsf:id="msg=simplepage.answer"></span></div>
-                                        <textarea rsf:id="shortanswerInput" aria-labelledby="answerInput"></textarea>
+                                        <textarea rsf:id="shortanswerInput" aria-labelledby="answerInput" class="shortAnswerInput" rows="4"></textarea>
                                         <input class="bold question-submit" type="submit" value="Answer!" rsf:id="answerShortanswer" />
                                     </form>
                                 </div>
@@ -921,7 +922,7 @@
                             </div>
 
                         </div>
-                        <div rsf:id="question-td" role="toolbar" class="edit-col"><div><a role="button" href="#" class="usebutton gradingPaneLink" rsf:id="questionGradingPaneLink" ><span aria-hidden="true" class="fa-list-ul fa-edit-icon"></span></a><a role="button" aria-haspopup="dialog" aria-controls="question-dialog" href="#" class="usebutton edit-question" onclick="return false" rsf:id="edit-question"><span aria-hidden="true" class="fa-edit fa-edit-icon"></span></a><a role="button" href="#" class="usebutton del-item-link" onclick="return false"><span aria-hidden="true" class="fa-trash-o fa-edit-icon"></span></a><a role="button" aria-haspopup="dialog" aria-controls="addContentDiv" ref="#" class="usebutton add-link" onclick="return false"><span aria-hidden="true" class="fa-plus fa-edit-icon plus-edit-icon"></span></a></div></div>
+                        <div rsf:id="question-td" role="toolbar" class="edit-col"><div><a role="button" href="#" class="usebutton gradingPaneLink" rsf:id="questionGradingPaneLink" ><span aria-hidden="true" class="fa-list-ul fa-edit-icon"></span></a><a role="button" aria-haspopup="dialog" aria-controls="question-dialog" href="#" class="usebutton edit-question" onclick="return false" rsf:id="edit-question"><span aria-hidden="true" class="fa-edit fa-edit-icon"></span></a><a role="button" href="#" class="usebutton del-item-link" onclick="return false"><span aria-hidden="true" class="fa-trash-o fa-edit-icon"></span></a><a role="button" aria-haspopup="dialog" aria-controls="addContentDiv" href="#" class="usebutton add-link" onclick="return false"><span aria-hidden="true" class="fa-plus plus-edit-icon fa-edit-icon"></span></a></div></div>
                         
                         <span style="display:none" rsf:id="questionId" class="question-id"></span>
                         <span style="display:none" rsf:id="questionAnswer" class="questionAnswer"></span>


### PR DESCRIPTION
These improvements and bug fixes include:
- toggling a css class on section headers based on if the section is open or closed
- Fixing a typo in the polls markup causing styling inconsistencies
- Lowering all of the z-index values for lessons dialogs
- Fixing styling inconsistencies in Checklist feature
- Adding tabindex to the Learning Apps iframe
- Linked checklist items are broken when imported into a new site, but are not
indicated as broken to the user
- Change checklist item duplication to use JSON instead of String manipulation
- Fix date picker when no date is set
- Fix issue with checklist item indexes
- Fix auto select multiple choice on add question load
- Keep subpage group release info on duplication / import
- Fix group releasing LTI items in Lessons