### PR TITLE
SAK-43672: lessons > use raw question text for edit rather than rendered text

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -3210,6 +3210,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 					UIOutput.make(tableRow, "questionDiv");
 					
 					UIOutput.make(tableRow, "questionText", i.getAttribute("questionText"));
+					UIInput.make(tableRow, "raw-question-text", "#{simplePageBean.questionText}", i.getAttribute("questionText"));
 					
 					List<SimplePageQuestionAnswer> answers = new ArrayList<SimplePageQuestionAnswer>();
 					if("multipleChoice".equals(i.getAttribute("questionType"))) {

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -1392,7 +1392,8 @@ $(document).ready(function() {
 			var itemId = row.find(".question-id").text();
 			$("#questionEditId").val(itemId);
 			
-			var questionText = row.find(".questionText").text();
+			$("#activeQuestion").val(row.find(".raw-question-text").prop("name"));
+			var questionText = row.find(".raw-question-text").val();
 			$("#question-text-input").val(questionText);
 			
 			resetMultipleChoiceAnswers();
@@ -3639,7 +3640,9 @@ function prepareQuestionDialog() {
 
 	updateMultipleChoiceAnswers();
 	updateShortanswers();
-	
+
+	$("input[name='" + $("#activeQuestion").val() + "'").val($("#question-text-input").val());
+
 	// RSF bugs out if we don't undisable these before submitting
 	$("#multipleChoiceSelect").prop("disabled", false);
 	$("#shortanswerSelect").prop("disabled", false);

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -499,9 +499,9 @@
 		  <li id="error-item" rsf:id="error-item:"><span id="error-item-text" rsf:id="error-item-text">missing page</span></li>
 		</ul>
 		<div class="itemclass" rsf:id="itemContainer:" role="main" style="z-index: 1;">
-
+			<input type="hidden" id="activeQuestion" />
             <div style="display:none" rsf:id="current-item-id"></div>
-			
+
 			<h2 rsf:id="msg=simplepage.maincontent" class="offscreen" id="maintablelabel"></h2>
 <!-- WARNING: javascript for add-break-section adds section, ul, li, and sectionedit markup, so if you change here, keep it in sync -->
 			<div rsf:id="sectionWrapper:"><!-- start section wrapper -->
@@ -963,6 +963,7 @@
                                 <img src="/library/image/silk/text_list_bullets.png" class="item-image question-image"/>
                                 <span class="offscreen" rsf:id="questionNote"></span>
                                 <h3 class="questionText" rsf:id="questionText"></h3>
+                                <input type="hidden" class="raw-question-text" rsf:id="raw-question-text" />
                                 <div class="multiplechoiceDiv" rsf:id="multipleChoiceDiv">
                                     <form action="#" rsf:id="multipleChoiceForm" class="multipleChoiceForm">
 				      <input type="hidden" rsf:id="csrf4" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43672

When using Lesson's "Questions", editing a saved question populates the text from the rendered HTML rather than the raw saved value. This presents problems with using LaTeX, as the raw text and the rendered text are completely different after MathJax parses it. The result is that it saves correctly the first time, but editing the question populates the rendered text rather than original. People don't notice this and are confused when the save the edit and it breaks the LaTeX that worked initially.

Solution is to dump the raw text to a hidden input and use that to populate the edit rather than the rendered text.