### PR TITLE
SAK-34322: samigo > block editing published quiz to send grades to existing gradebook item

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -855,7 +855,7 @@ implements ActionListener
 			try{
 				assessmentName = TextFormat.convertPlaintextToFormattedTextNoHighUnicode(assessmentSettings.getTitle().trim());
 				gbItemExists = gbsHelper.isAssignmentDefined(assessmentName, g);
-				if (assessmentSettings.getToDefaultGradebook() && gbItemExists && isTitleChanged){
+				if (assessmentSettings.getToDefaultGradebook() && gbItemExists){
 					String gbConflict_error=ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages","gbConflict_error");
 					context.addMessage(null,new FacesMessage(gbConflict_error));
 					return false;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-34322

You can change a published quiz's settings to save grades to the Gradebook even when there is an existing gradebook item of the same title. When students submit to this quiz it fails to push the grade to the gradebook due to the duplication.