### PR TITLE
SAK-43810: jsf > add tabindex=0 to colour picker icons (a11y)

### DIFF
--- a/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/InputColorRenderer.java
+++ b/jsf/jsf-widgets/src/java/org/sakaiproject/jsf/renderer/InputColorRenderer.java
@@ -177,6 +177,7 @@ public class InputColorRenderer extends Renderer
     writer.write("  src=\"" + COLOR_ICON + "\" ");
     writer.write("  border=\"0\"");
     writer.write("  alt=\"" + CLICKALT + "\" ");
+    writer.write("  tabindex=\"0\" ");
     writer.write("  onclick=\"javascript:TCP.popup(" +
       "document.getElementById('" + clientId + "'),'','" +
       COLOR_PATH + "')\" />");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43810

Since nothing else has a `tabindex`, adding `tabindex="0"` allows the `<img>` tags to enter the default order of tab elements (source code order).