### PR TITLE
SAK-42472: Lessons: Short Answer Question displays red X after student submission

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -7693,6 +7693,9 @@ public class SimplePageBean {
 					break;
 				}
 			}
+			if(totalTokens == 0 && !theirResponse.isEmpty()) {
+				foundAnswer = true;
+			}
 			if(foundAnswer) {
 				correct = true;
 			}else {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42472

This PR changes how short answer questions are marked as correct or incorrect. If the question has no associated correct answers, anything the student submits is now considered to be correct, unless the submission is empty.