### PR TITLE
SAK-43730 - T&Q: If instructor grades by question, instructor attachments are missing

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
@@ -230,6 +230,10 @@ $Id$
 
   <div class="samigo-question-callout">
   <t:dataList value="#{questionScores.deliveryItem}" var="question">
+  <div id="questionScoreItemAttachments">
+      <%@ include file="/jsf/evaluation/questionScoreItemAttachment.jsp" %>
+  </div>
+
   <h:panelGroup rendered="#{questionScores.typeId == '7'}">
     <f:subview id="displayAudioRecording">
       <%@ include file="/jsf/evaluation/item/displayAudioRecordingQuestion.jsp" %>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/questionScoreItemAttachment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/questionScoreItemAttachment.jsp
@@ -1,9 +1,7 @@
-<!--
-* $Id: attachment.jsp 6874 2006-03-22 17:01:47Z hquinn@stanford.edu $
 <%--
 ***********************************************************************************
 *
-* Copyright (c) 2006 The Sakai Foundation.
+* Copyright (c) 2004, 2005, 2006 The Sakai Foundation.
 *
 * Licensed under the Educational Community License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,15 +13,14 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under the License. 
+* limitations under the License.
 *
-***********************************************************************************/
+**********************************************************************************/
 --%>
--->
 <%@ taglib uri="http://myfaces.apache.org/tomahawk" prefix="t"%>
 
 <!-- ATTACHMENTS -->
-<%-- Expects 'question' is an instance of ItemContentsBean --%>
-<t:aliasBean alias="#{itemAttachmentList}" value="#{question.itemData.itemAttachmentList}" >
+<%-- Similar to /jsf/delivery/item/attachment.jsp: attachment.jsp expects 'question' is an instance of ItemContentsBean, while questionScore expects 'question' is a PublishedItemData instance --%>
+<t:aliasBean alias="#{itemAttachmentList}" value="#{question.itemAttachmentList}" >
   <%@ include file="/jsf/shared/itemAttachmentList.jsp" %>
 </t:aliasBean>

--- a/samigo/samigo-app/src/webapp/jsf/shared/itemAttachmentList.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/shared/itemAttachmentList.jsp
@@ -1,0 +1,54 @@
+<%--
+***********************************************************************************
+*
+* Copyright (c) 2004, 2005, 2006 The Sakai Foundation.
+*
+* Licensed under the Educational Community License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.osedu.org/licenses/ECL-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+**********************************************************************************/
+--%>
+<!-- ATTACHMENTS -->
+<h:outputText value="#{printMessages.attachments} " escape="false" rendered="#{not empty itemAttachmentList && delivery.fromPrint}"/>
+
+<h:dataTable value="#{itemAttachmentList}" var="attach" border="0">
+  <h:column>
+    <f:verbatim>&nbsp;&nbsp;&nbsp;&nbsp;</f:verbatim>
+    <h:outputText escape="false" value="
+      <embed src=\"#{delivery.protocol}/samigo-app/servlet/ShowAttachmentMedia?resourceId=#{attach.encodedResourceId}&mimeType=#{attach.mimeType}&filename=#{attach.filename}\" volume=\"50\" height=\"350\" width=\"400\" autostart=\"false\"/>" rendered="#{attach.isInlineVideo && !delivery.fromPrint}"/>
+    <h:outputText value="#{attach.filename}" rendered="#{attach.isInlineVideo && delivery.fromPrint}"/>
+
+    <h:outputText escape="false" value="
+      <embed src=\"#{delivery.protocol}/samigo-app/servlet/ShowAttachmentMedia?resourceId=#{attach.encodedResourceId}&mimeType=#{attach.mimeType}&filename=#{attach.filename}\" height=\"350\" width=\"400\"/>" rendered="#{attach.isInlineFlash && !delivery.fromPrint}"/>
+    <h:outputText value="#{attach.filename}" rendered="#{attach.isInlineFlash && delivery.fromPrint}"/>
+
+    <h:outputText escape="false" value="
+      <img src=\"#{delivery.protocol}/samigo-app/servlet/ShowAttachmentMedia?resourceId=#{attach.encodedResourceId}&mimeType=#{attach.mimeType}&filename=#{attach.filename}\" />" rendered="#{attach.isInlineImage}"/>
+
+    <h:panelGrid rendered="#{!attach.isMedia && !delivery.fromPrint}" border="0" columns="2">
+      <h:column>
+        <%@ include file="/jsf/shared/mimeicon.jsp" %>
+        <f:verbatim>&nbsp;&nbsp;</f:verbatim>
+        <h:outputLink value="#{attach.location}" target="new_window" rendered="#{!attach.isMedia}">
+           <h:outputText value="#{attach.filename}" />
+        </h:outputLink>
+      </h:column>
+      <h:column>
+        <f:verbatim>&nbsp;&nbsp;&nbsp;&nbsp;</f:verbatim>
+        <h:outputText escape="false" value="#{attach.fileSize} #{generalMessages.kb}" rendered="#{!attach.isLink}"/>
+      </h:column>
+    </h:panelGrid>
+    <h:outputText value="#{attach.filename}" rendered="#{!attach.isMedia && delivery.fromPrint}"/>
+
+  </h:column>
+</h:dataTable>
+


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43730

Note to reviewers:
The attachments that are rendered when students take a quiz are in /jsf/delivery/item/attachment.jsp.
The attachments that are rendered when viewing the Questions tab when grading is jsf/evaluation/questionScoreItemAttachment.jsp, (included from the questionScore.jsp page).
The former loads attachments from an ItemContentsBean, the latter loads attachments from a PublishedItemData instance. The attachments lists consist of the exact same types, and are rendered in the exact same manor, but the EL expressions pointing to these attachments lists differ.

I wanted to eliminate code duplication, so I used tomahawk's 'aliasBean' tags so that both contexts can use the same attachment rendering code. Then I moved the attachment rendering code into samigo/samigo-app/src/webapp/jsf/shared/itemAttachmentList.jsp. Seems like a logical place for code that's 'shared' between views, but if this isn't ideal, let me know. Also, the aliasBean tags aren't used anywhere else in samigo, but they are used by other tools.