### PR TITLE
SAK-44116: T&Q: Retake does not respect due date

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
@@ -666,22 +666,7 @@ public class SelectActionListener implements ActionListener {
 				}
 			}
     	} else {
-    		// LATE SUBMISSION ARE NOT HANDLED: Test retract date and retakes
-    		if (retractDate == null || retractDate.after(currentDate)) {
-				int actualNumberRetake = 0;
-				if (actualNumberRetakeHash.get(f.getPublishedAssessmentId()) != null) {
-					actualNumberRetake = (actualNumberRetakeHash.get(f.getPublishedAssessmentId()));
-				}
-				if (actualNumberRetake < numberRetake) {
-					returnValue = true;
-				} else {
-					returnValue = false;
-				}
-    		}
-    		else{
-	    		// Retract date has passed: Assessment is not available    		
-	    		returnValue = false;
-    		}
+	    	returnValue = false;
     	}
 	}
 	else {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44116

Removing the code in this else block resolves the issue in the ticket. The issue is that when the due date has passed and late submissions are not allowed, this else block runs and the "retractDate == null" test passes and allows the student access if they have been granted a retake.

Since late submissions are not allowed in this scenario, the value of retract date is meaningless and should not be checked anyway. If an instructor wants to allow retakes to be submitted late, they can use availability exceptions for this.