### PR TITLE
SAK-43958: date manager > samigo > include feedback on and until dates

### DIFF
--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/model/DateManagerUpdate.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/model/DateManagerUpdate.java
@@ -16,11 +16,16 @@ package org.sakaiproject.datemanager.api.model;
 import java.time.Instant;
 
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 @AllArgsConstructor
+@RequiredArgsConstructor
 public class DateManagerUpdate {
-	public Object object;
-	public Instant openDate;
-	public Instant dueDate;
-	public Instant acceptUntilDate;
+	@NonNull public Object object;
+	@NonNull public Instant openDate;
+	@NonNull public Instant dueDate;
+	@NonNull public Instant acceptUntilDate;
+	public Instant feedbackStartDate;
+	public Instant feedbackEndDate;
 }

--- a/site-manage/datemanager/impl/src/bundle/datemanager.properties
+++ b/site-manage/datemanager/impl/src/bundle/datemanager.properties
@@ -8,6 +8,9 @@ error.release.date.not.found = Could not read Release date
 error.open.date.before.due.date = Open date must fall before due date
 error.open.date.before.close.date = Open date must fall before close date
 error.due.date.before.accept.until = Due date cannot fall after Accept Until date
+error.feedback.start.not.found=Could not read Show Feedback On date
+error.feedback.end.not.found=Could not read Show Feedback Until date
+error.feedback.start.before.feedback.end=Show Feedback On date must fall before Show Feedback Until date
 error.uncaught = Uncaught error
 
 itemtype.draft = Draft

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -83,6 +83,7 @@ import org.sakaiproject.util.api.FormattedText;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentFeedbackIfc;
 
 @Slf4j
 public class DateManagerServiceImpl implements DateManagerService {
@@ -353,6 +354,15 @@ public class DateManagerServiceImpl implements DateManagerService {
 			assobj.put("tool_title", toolTitle);
 			assobj.put("url", url);
 			assobj.put("extraInfo", rb.getString("itemtype.draft"));
+			if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(assessment.getAssessmentFeedback().getFeedbackDelivery())) {
+				assobj.put("feedback_start", formatToUserDateFormat(control.getFeedbackDate()));
+				assobj.put("feedback_end", formatToUserDateFormat(control.getFeedbackEndDate()));
+				assobj.put("feedback_by_date", true);
+			} else {
+				assobj.put("feedback_start", null);
+				assobj.put("feedback_end", null);
+				assobj.put("feedback_by_date", false);
+			}
 			jsonAssessments.add(assobj);
 		}
 		for (PublishedAssessmentFacade paf : pubAssessments) {
@@ -370,6 +380,15 @@ public class DateManagerServiceImpl implements DateManagerService {
 			assobj.put("tool_title", toolTitle);
 			assobj.put("url", url);
 			assobj.put("extraInfo", "false");
+			if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(assessment.getAssessmentFeedback().getFeedbackDelivery())) {
+				assobj.put("feedback_start", formatToUserDateFormat(control.getFeedbackDate()));
+				assobj.put("feedback_end", formatToUserDateFormat(control.getFeedbackEndDate()));
+				assobj.put("feedback_by_date", true);
+			} else {
+				assobj.put("feedback_start", null);
+				assobj.put("feedback_end", null);
+				assobj.put("feedback_by_date", false);
+			}
 			jsonAssessments.add(assobj);
 		}
 		return jsonAssessments;
@@ -396,6 +415,8 @@ public class DateManagerServiceImpl implements DateManagerService {
 				Instant openDate = userTimeService.parseISODateInUserTimezone((String)jsonAssessment.get("open_date")).toInstant();
 				Instant dueDate = userTimeService.parseISODateInUserTimezone((String)jsonAssessment.get("due_date")).toInstant();
 				Instant acceptUntil = userTimeService.parseISODateInUserTimezone((String)jsonAssessment.get("accept_until")).toInstant();
+				Instant feedbackStart = userTimeService.parseISODateInUserTimezone((String)jsonAssessment.get("feedback_start")).toInstant();
+				Instant feedbackEnd = userTimeService.parseISODateInUserTimezone((String)jsonAssessment.get("feedback_end")).toInstant();
 				boolean isDraft = Boolean.parseBoolean(jsonAssessment.get("is_draft").toString());
 
 				Object assessment;
@@ -428,19 +449,43 @@ public class DateManagerServiceImpl implements DateManagerService {
 					errored = true;
 				}
 
+				Integer feedbackMode = isDraft ? ((AssessmentFacade) assessment).getAssessmentFeedback().getFeedbackDelivery()
+												: ((PublishedAssessmentFacade) assessment).getAssessmentFeedback().getFeedbackDelivery();
+				if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(feedbackMode)) {
+					if (feedbackStart == null) {
+						errors.add(new DateManagerError("feedback_start", rb.getString("error.feedback.start.not.found"), "assessments", toolTitle, i));
+						errored = true;
+					}
+					if (feedbackEnd == null) {
+						errors.add(new DateManagerError("feedback_end", rb.getString("error.feedback.end.not.found"), "assessments", toolTitle, i));
+						errored = true;
+					}
+					if (feedbackStart != null && feedbackEnd != null && feedbackEnd.isBefore(feedbackStart)) {
+						errors.add(new DateManagerError("feedback_end", rb.getString("error.feedback.start.before.feedback.end"), "assessments", toolTitle, i));
+						errored = true;
+					}
+				}
+
 				if (errored) {
 					continue;
 				}
 
-				log.debug("Open {} ; Due {} ; Until {}", jsonAssessment.get("open_date_label"), jsonAssessment.get("due_date_label"), jsonAssessment.get("accept_until_label"));
+				log.debug("Open {} ; Due {} ; Until {} ; Feedback Start {} ; Feedback End {}", jsonAssessment.get("open_date_label"), jsonAssessment.get("due_date_label"),
+								jsonAssessment.get("accept_until_label"), jsonAssessment.get("feedback_start_label"), jsonAssessment.get("feedback_end_label"));
 				if(StringUtils.isBlank((String)jsonAssessment.get("due_date_label"))) {
 					dueDate = null;
 				}
 				if(StringUtils.isBlank((String)jsonAssessment.get("accept_until_label"))) {
 					acceptUntil = null;
 				}
+				if(StringUtils.isBlank((String)jsonAssessment.get("feedback_start_label"))) {
+					feedbackStart = null;
+				}
+				if(StringUtils.isBlank((String)jsonAssessment.get("feedback_end_label"))) {
+					feedbackEnd = null;
+				}
 
-				DateManagerUpdate update = new DateManagerUpdate(assessment, openDate, dueDate, acceptUntil);
+				DateManagerUpdate update = new DateManagerUpdate(assessment, openDate, dueDate, acceptUntil, feedbackStart, feedbackEnd);
 
 				if (dueDate != null && !update.openDate.isBefore(update.dueDate)) {
 					errors.add(new DateManagerError("open_date", rb.getString("error.open.date.before.due.date"), "assessments", toolTitle, idx));
@@ -482,6 +527,10 @@ public class DateManagerServiceImpl implements DateManagerService {
 				if (lateHandling && update.acceptUntilDate != null) {
 					control.setRetractDate(Date.from(update.acceptUntilDate));
 				}
+				if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(assessment.getAssessmentFeedback().getFeedbackDelivery())) {
+					control.setFeedbackDate(Date.from(update.feedbackStartDate));
+					control.setFeedbackEndDate(Date.from(update.feedbackEndDate));
+				}
 				assessment.setAssessmentAccessControl(control);
 				assessmentServiceQueries.saveOrUpdate(assessment);
 
@@ -495,6 +544,10 @@ public class DateManagerServiceImpl implements DateManagerService {
 				}
 				if (lateHandling && update.acceptUntilDate != null) {
 					control.setRetractDate(Date.from(update.acceptUntilDate));
+				}
+				if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(assessment.getAssessmentFeedback().getFeedbackDelivery())) {
+					control.setFeedbackDate(Date.from(update.feedbackStartDate));
+					control.setFeedbackEndDate(Date.from(update.feedbackEndDate));
 				}
 				assessment.setAssessmentAccessControl(control);
 				pubAssessmentServiceQueries.saveOrUpdate(assessment);

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -12,6 +12,8 @@ column.end.date = End Date
 column.accept.until = Accept Until Date
 column.show.until = Show Until Date
 column.close.date = Close Date
+column.feedback.start.date = Show Feedback On
+column.feedback.end.date = Show Feedback Until
 
 errors.instruction = Your update could not be saved due to the following errors:
 

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -169,6 +169,8 @@
 						assessmentJson.open_date_day_of_week = undefined;
 						assessmentJson.due_date_day_of_week = undefined;
 						assessmentJson.accept_until_day_of_week = undefined;
+						assessmentJson.feedback_start_day_of_week = undefined;
+						assessmentJson.feedback_end_day_of_week = undefined;
 						updates.assessments.push(assessmentJson);
 					/*[/]*/
 
@@ -282,6 +284,12 @@
 						// Disable accept_until date input if no late submissions (assessments) allowed
 						if (dataTool == 'assessments' && dataField == 'accept_until') {
 							var disabled = !updates[dataTool][dataIdx].late_handling;
+							$(elt).prop('disabled', disabled);
+							$td.find('.ui-datepicker-trigger').prop('disabled', disabled);
+						}
+						// Disable feedback start and end date inputs if feedback on date not used (assessments)
+						if (dataTool === 'assessments' && (dataField === 'feedback_start' || dataField === 'feedback_end')) {
+							var disabled = !updates[dataTool][dataIdx].feedback_by_date;
 							$(elt).prop('disabled', disabled);
 							$td.find('.ui-datepicker-trigger').prop('disabled', disabled);
 						}

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -28,15 +28,17 @@
 						<th th:case="'announcements'" th:text="#{column.end.date}">End Date</th>
 					</th:block>
 					<th:block th:switch="${toolId}">
-						<th:block th:case="'gradebookItems'"></th:block>
-						<th:block th:case="'signupMeetings'"></th:block>
-						<th:block th:case="'resources'"></th:block>
-						<th:block th:case="'calendarEvents'"></th:block>
-						<th:block th:case="'forums'"></th:block>
-						<th:block th:case="'announcements'"></th:block>
-						<th:block th:case="'lessons'"></th:block>
 						<th th:case="'assignments'" th:text="#{column.accept.until}">Accept Until Date</th>
 						<th th:case="'assessments'" th:text="#{column.accept.until}">Accept Until Date</th>
+						<th:block th:case="*"></th:block>
+					</th:block>
+					<th:block th:switch="${toolId}">
+						<th th:case="'assessments'" th:text="#{column.feedback.start.date}">Show Feedback On</th>
+						<th:block th:case="*"></th:block>
+					</th:block>
+					<th:block th:switch="${toolId}">
+						<th th:case="'assessments'" th:text="#{column.feedback.end.date}">Show Feedback Until</th>
+						<th:block th:case="*"></th:block>
 					</th:block>
 				</tr>
 			</thead>
@@ -87,6 +89,30 @@
 									<div><small class="errors"></small></div>
 								</div>
 							</td>
+						</th:block>
+						<th:block th:switch="${toolId}">
+							<td th:case="'assessments'">
+								<div>
+									<input type="text" class="form-control datepicker" />
+									<input type="hidden" th:value="${item.feedback_start}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="feedback_start" />
+									<div><small class="text-muted day-of-week"></small></div>
+									<div><small class="errors"></small></div>
+								</div>
+							</td>
+							<th:block th:case="*">
+							</th:block>
+						</th:block>
+						<th:block th:switch="${toolId}">
+							<td th:case="'assessments'">
+								<div>
+									<input type="text" class="form-control datepicker" />
+									<input type="hidden" th:value="${item.feedback_end}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="feedback_end" />
+									<div><small class="text-muted day-of-week"></small></div>
+									<div><small class="errors"></small></div>
+								</div>
+							</td>
+							<th:block th:case="*">
+							</th:block>
 						</th:block>
 					</tr>
 				</th:block>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43958

"1) If an instructor uses feedback after a set date, they would still need to go into the test settings to update the feedback date(s), which decreases the usefulness of Date Manager.

2) If an instructor neglects to update the feedback date and those are set in the past, the feedback works as if Immediate Feedback was selected, potentially allowing students to change their answers mid-test. If an instructor doesn't realize that the Feedback Date would have this effect if set before the due date, they may think that setting the due & accept until dates through Date Manager is sufficient."