### PR TITLE
SAK-43179 20.x/Library revert become user banner to darker green to avoid documentation issues

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -201,7 +201,7 @@ $swapped-view-enabled: false !default;
 $swapped-view-primary: 		 #bf360c !default;
 
 /* Admin Become User view */
-$become-user-primary: hsl(240,55%,40%) !default;
+$become-user-primary: hsl(147, 93%, 22%) !default;
 
 /* This is the gradient in the header of the page */
 $header-gradient-a: #fafafa !default;


### PR DESCRIPTION
Still darker than the original green in 20.0 but reverting from the purple which may abruptly disorient users in a .x update.

Related to 
https://jira.sakaiproject.org/browse/SAK-42942
