### PR TITLE
SAK-44072 - Request threads blocked on spring-beans synchronization

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -58,7 +58,7 @@
     <sakai.simple-xml.version>2.7.1</sakai.simple-xml.version>
     <sakai.spring.groupId>org.springframework</sakai.spring.groupId>
     <sakai.spring.artifactId>spring-core</sakai.spring.artifactId>
-    <sakai.spring.version>4.3.25.RELEASE</sakai.spring.version>
+    <sakai.spring.version>4.3.29.RELEASE</sakai.spring.version>
     <sakai.spring.data.commons.version>1.13.23.RELEASE</sakai.spring.data.commons.version>
     <sakai.spring.data.jpa.version>1.11.23.RELEASE</sakai.spring.data.jpa.version>
     <sakai.spring.data.rest.version>2.6.23.RELEASE</sakai.spring.data.rest.version>
@@ -66,7 +66,7 @@
     <sakai.spring.hateoas.version>0.25.2.RELEASE</sakai.spring.hateoas.version>
     <sakai.spring.plugin.version>1.2.0.RELEASE</sakai.spring.plugin.version>
     <sakai.spring.test.artifactId>spring-test</sakai.spring.test.artifactId>
-    <sakai.spring.test.version>4.3.25.RELEASE</sakai.spring.test.version>
+    <sakai.spring.test.version>4.3.29.RELEASE</sakai.spring.test.version>
     <sakai.tika.version>1.23</sakai.tika.version>
     <sakai.tomcat.version>9.0.33</sakai.tomcat.version>
     <sakai.velocity.version>1.6.4</sakai.velocity.version>


### PR DESCRIPTION
Only updated spring version, I didn't test that this actually fixes the issue but the fix is included.

I didn't update master/21 as that would need a spring 5.x update and isn't related to this issue. 