### PR TITLE
SAK-44305 Messages > Compose Message > Specify Recipient > Save Draft > Recipient not Saved

### DIFF
--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsTypeManager.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsTypeManager.java
@@ -85,6 +85,8 @@ public interface MessageForumsTypeManager
    * @return
    */
   public String getDraftPrivateMessageType();
+
+  public String getDraftReceivedPrivateMessageType();
   
   /**
    * @return

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -1176,12 +1176,30 @@ public void processChangeSelectView(ValueChangeEvent eve)
 	  setAttachments(attachments);
 	  
 	  setSelectedLabel(draft.getLabel());
-	  
+
+	  List<PrivateMessageRecipient> recipients = draft.getRecipients();
+	  String draftReceivedType = typeManager.getDraftReceivedPrivateMessageType();
+	  Map<Boolean, List<PrivateMessageRecipient>> receivers = recipients.stream().filter(r -> draftReceivedType.equals(r.getTypeUuid()))
+			  .collect(Collectors.partitioningBy(r -> r.getBcc()));
+	  if (totalComposeToList == null || totalComposeToBccList == null) {
+		  initializeComposeToLists();
+	  }
+	  selectedComposeToList = recipientsToMembershipIds(receivers.get(Boolean.FALSE), totalComposeToList);
+	  selectedComposeBccList = recipientsToMembershipIds(receivers.get(Boolean.TRUE), totalComposeToBccList);
+
+	  setBooleanEmailOut(draft.getExternalEmail());
+
 	  //go to compose page
 	  setFromMainOrHp();
 	  fromMain = (StringUtils.isEmpty(msgNavMode)) || ("privateMessages".equals(msgNavMode));
 	  log.debug("processPvtMsgDraft()");
 	  return PVTMSG_COMPOSE;
+  }
+
+  private List<String> recipientsToMembershipIds(List<PrivateMessageRecipient> recipients, List<MembershipItem> memberships) {
+	  List<String> userIds = recipients.stream().map(r -> r.getUserId()).collect(Collectors.toList());
+	  return memberships.stream().filter(m -> m.getUser() != null).filter(m -> userIds.contains(m.getUser().getId()))
+			  .map(m -> m.getId()).collect(Collectors.toList());
   }
 
   /**

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsTypeManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsTypeManagerImpl.java
@@ -59,8 +59,8 @@ public class MessageForumsTypeManagerImpl implements MessageForumsTypeManager
   private static final String DELETED = "DeletedPrivateMessageType";
 
   private static final String DRAFT = "DraftPrivateMessageType";
-  
-  
+
+  private static final String DRAFT_RECEIVED = "DraftReceivedPrivateMessageType";
   
   // Permission Level Types
   private static final String OWNER = "Owner Permission Level";
@@ -393,6 +393,20 @@ public class MessageForumsTypeManagerImpl implements MessageForumsTypeManager
       return (typeManager.createType(AUTHORITY, DOMAIN, DRAFT,
           "Draft Private Message Type", "Draft Private Message Type").getUuid());
     }
+  }
+  /* (non-Javadoc)
+   * @see org.sakaiproject.api.app.messageforums.MessageForumsTypeManager#getDraftReceivedPrivateMessageType()
+   */
+  @Override
+  public String getDraftReceivedPrivateMessageType()
+  {
+    Type type = typeManager.getType(AUTHORITY, DOMAIN, DRAFT_RECEIVED);
+    if (type == null)
+    {
+      type = typeManager.createType(AUTHORITY, DOMAIN, DRAFT_RECEIVED, "Draft Received Private Message Type", "Draft Received Private Message Type");
+    }
+
+    return type.getUuid();
   }
 
   /* (non-Javadoc)

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/PrivateMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/PrivateMessageManagerImpl.java
@@ -1115,7 +1115,7 @@ public class PrivateMessageManagerImpl extends HibernateDaoSupport implements Pr
       return pmessage;
   }
 
-  private boolean getForwardingEnabled(Map<User, Boolean> recipients, Map<String, PrivateForum> pfMap, String currentUserAsString, String contextId, List recipientList, List<InternetAddress> fAddresses) throws MessagingException{
+  private boolean getForwardingEnabled(Map<User, Boolean> recipients, Map<String, PrivateForum> pfMap, String currentUserAsString, String contextId, List recipientList, List<InternetAddress> fAddresses, boolean draft) throws MessagingException{
 	  boolean forwardingEnabled = false;
 	  //this only needs to be done if the message is not being sent
 	  int submitterEmailReceiptPref;
@@ -1162,13 +1162,10 @@ public class PrivateMessageManagerImpl extends HibernateDaoSupport implements Pr
 			  fAddresses.add(new InternetAddress(oldPf.getAutoForwardEmail()));
 		  }
 
-		  /** determine if current user is equal to recipient */
-		  Boolean isRecipientCurrentUser =
-				  (currentUserAsString.equals(userId) ? Boolean.TRUE : Boolean.FALSE);
-
-		  PrivateMessageRecipientImpl receiver = new PrivateMessageRecipientImpl(
-				  userId, typeManager.getReceivedPrivateMessageType(), contextId,
-				  isRecipientCurrentUser, bcc);
+		  // if saving a draft, set the recipient type to "draft received" so that the message will not show up for the recipient yet
+		  String type = draft ? typeManager.getDraftReceivedPrivateMessageType() : typeManager.getReceivedPrivateMessageType();
+		  PrivateMessageRecipientImpl receiver = new PrivateMessageRecipientImpl(userId, type, contextId,
+				  currentUserAsString.equals(userId), bcc);
 		  recipientList.add(receiver);
 		  }
 	  return forwardingEnabled;
@@ -1207,7 +1204,8 @@ public class PrivateMessageManagerImpl extends HibernateDaoSupport implements Pr
       throw new IllegalArgumentException("Null Argument");
     }
 
-    if (recipients.size() == 0 && !message.getDraft().booleanValue())
+    final boolean draft = message.getDraft();
+    if (recipients.isEmpty() && !draft)
     {
       /** for no just return out
         throw new IllegalArgumentException("Empty recipient list");
@@ -1227,19 +1225,6 @@ public class PrivateMessageManagerImpl extends HibernateDaoSupport implements Pr
 
     User currentUser = currentUser(message, isMailArchive);
     List recipientList = new UniqueArrayList();
-
-    /** test for draft message */
-    if (message.getDraft().booleanValue())
-    {
-      PrivateMessageRecipientImpl receiver = new PrivateMessageRecipientImpl(
-      		currentUserAsString, typeManager.getDraftPrivateMessageType(),
-      		contextId, Boolean.TRUE, false);
-
-      recipientList.add(receiver);
-      message.setRecipients(recipientList);
-      saveMessage(message, isMailArchive, contextId, currentUserAsString);
-      return;
-    }
 
     //build the message body
     List additionalHeaders = new ArrayList(1);
@@ -1275,12 +1260,12 @@ public class PrivateMessageManagerImpl extends HibernateDaoSupport implements Pr
     	}
 
 		List<InternetAddress> fAddresses = new ArrayList();
-		boolean forwardingEnabled = getForwardingEnabled(recipients, pfMap, currentUserAsString, contextId, recipientList, fAddresses);
+		boolean forwardingEnabled = getForwardingEnabled(recipients, pfMap, currentUserAsString, contextId, recipientList, fAddresses, draft);
 		//this only needs to be done if the message is not being sent
     
     /** add sender as a saved recipient */
     PrivateMessageRecipientImpl sender = new PrivateMessageRecipientImpl(
-    		currentUserAsString, typeManager.getSentPrivateMessageType(),
+    		currentUserAsString, draft ? typeManager.getDraftPrivateMessageType() : typeManager.getSentPrivateMessageType(),
     		contextId, Boolean.TRUE, false);
 
     recipientList.add(sender);
@@ -1290,6 +1275,10 @@ public class PrivateMessageManagerImpl extends HibernateDaoSupport implements Pr
 	Message savedMessage = saveMessage(message, isMailArchive, contextId, currentUserAsString);
 
     message.setId(savedMessage.getId());
+
+    if (draft) {
+    	return;
+    }
 
     String bodyString = buildMessageBody(message);
     List<InternetAddress> replyEmail  = new ArrayList<>();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44305

If a user begins to compose a message, specifies the recipient, and all other fields as necessary, and then saves the draft, upon returning to that draft later on, the user will find that the recipient is no longer listed.

--

For the recipients, this is what is happening:

When you save a message, the recipients are saved to a table and are assigned a recipient type: received, sent, deleted, draft, custom. For a normal message, the TO and BCC users get the "received" type, and the sender gets the "sent" type. When you save a draft, the TO and BCC users are ignored, and the sender gets a "draft" type.

This is important because of how message folders are populated. When you go into the Sent folder, for example, it queries for all messages that you are a recipient of with type "sent". Same goes for the other folders. If a saved draft were to retain the TO and BCC recipients, they would need to be assigned a type, so they would obviously get the "received" type. However, this will cause the message to appear in their Received folder.

This PR solves the issue by creating a new recipient type "draft received" which is not used to populate any folders. When saving a draft, recipients are given this new type. When opening a draft, this type is searched for and used to pre-populate the TO and BCC fields. Additionally, when opening a draft, the draft's CC email setting is used to pre-populate that option now as well.

Known issue: When sending to groups, Messages expands the group members instead of saving a reference to the group. This results in the recipient list only containing individual users when opening a draft. For example, when you select "All Participants" for the TO field and save the draft, when you open the draft the TO field will be populated by the individual members of the site at the time of saving the draft.