### PR TITLE
SAK-43971 Resources - Fixed padding on breadcrumbs

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -1,9 +1,4 @@
 .#{$namespace}sakai-resources {
-
-	ul, ol {
-		padding-top: 0;
-	}
-
 	input, textarea{
 		max-width: 100%;
 	}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43971

Removed some old padding from Resources that was causing the breadcrumbs padding to be off. 