### PR TITLE
SAK-42923 assignments > import > new sakai.property to control group creation

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2006,6 +2006,11 @@
 # DEFAULT: false (import only the assignment no submissions)
 # assignment.merge.import.submissions=true
 
+# SAK-42923 create groups on import if not present in destination site, or, if the groups are present use them.
+# Setting this to false will revert all imported assignments to be released to the entire destination site (legacy behaviour).
+# DEFAULT: true (import will create and use groups in the destination site)
+# assignment.create.groups.on.import=false
+
 # ######################################
 # SAK-29406 Allow Assignment tool to grade with two decimal points
 # ######################################


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42923

Some folks like the new behaviour (create groups if they don't exist, use groups if they do exist in destination site), some folks prefer the legacy behaviour (everything imports as released to site).

This PR provides a new sakai.property (`assignment.create.groups.on.import`) to control which behaviour takes place. Default OOTB is the new behaviour (create/use groups in destination site).