### PR TITLE
SAK-44373 Fix average gpa calculation in course grade statistics

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/stats/CourseGradeStatistics.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/stats/CourseGradeStatistics.java
@@ -15,6 +15,7 @@
  */
 package org.sakaiproject.gradebookng.tool.stats;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -109,13 +110,18 @@ public class CourseGradeStatistics extends BaseStatistics {
 			return "-";
 		}
 
+		Map<String, Double> gpaScoresMap = this.getGPAScoresMapFromBottomPercents(this.bottomPercents);
+		if (gpaScoresMap == null) {
+			// Something was formatted incorrectly so return n/a
+			return "n/a";
+		}
 		// get all of the non null mapped grades
 		// mapped grades will be null if the student doesn't have a course grade yet.
 		final List<String> mappedGrades = this.courseGradeMap.values().stream().filter(c -> c.getMappedGrade() != null)
-				.map(c -> (c.getMappedGrade())).collect(Collectors.toList());
-		Double averageGPA = 0.0;
+				.map(CourseGrade::getMappedGrade).collect(Collectors.toList());
+		double averageGPA = 0.0;
 		for (final String mappedGrade : mappedGrades) {
-			final Double grade = this.bottomPercents.get(mappedGrade);
+			final Double grade = gpaScoresMap.get(mappedGrade);
 			if (grade != null) {
 				averageGPA += grade;
 			} else {
@@ -125,6 +131,29 @@ public class CourseGradeStatistics extends BaseStatistics {
 		averageGPA /= mappedGrades.size();
 
 		return String.format("%.2f", averageGPA);
+	}
+
+	private Map<String, Double> getGPAScoresMapFromBottomPercents(Map<String, Double> bottomPercents) {
+		final Map<String, Double> gpaScoresMap = new HashMap<>();
+
+		final String gradeMapRegex = "^\\w+(\\+?|-?) ?\\(\\d+\\.?\\d*\\)$"; // e.g. "A (4.0)" or "B+ (3.33)"
+
+		for (String gradeLabel : bottomPercents.keySet()) {
+			// Check if mapping is formatted correctly and add store gpa double if so
+			if (gradeLabel.matches(gradeMapRegex)) {
+				try {
+					double gpaValue = Double.parseDouble(gradeLabel.substring(gradeLabel.indexOf("(")+1, gradeLabel.indexOf(")")));
+					gpaScoresMap.put(gradeLabel, gpaValue);
+				} catch (NumberFormatException numberFormatException) {
+					log.debug("Unable to parse gpa double from grade schema map.", numberFormatException);
+					return null;
+				}
+			} else {
+				// One of the grade maps is formatted incorrectly so stop here and return null
+				return null;
+			}
+		}
+		return gpaScoresMap;
 	}
 
 }


### PR DESCRIPTION
Average course gpa was calculated incorrectly as a percentage. This
maps the grade labels from the schema to a gpa value when entered in
the format "Grade (gpa)" e.g. "A (4.0)". And then calculates the average
course gpa based on the gpa values taken from the map or n/a if the
labels are not formatted correctly. This used when the grade schema is
set to Grade Points.