### PR TITLE
SAK-44383 samigo > provide return link on DD UI for URL delivered quizzes

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -411,7 +411,7 @@ public class PublishedAssessmentSettingsBean implements Serializable {
       setIpAddresses(assessment);
 
       // publishedUrl
-      generatePublishedURL(assessment);
+      this.publishedUrl = generatePublishedURL(assessment);
 
       // secure delivery
       SecureDeliveryServiceAPI secureDeliveryService = SamigoApiFactory.getInstance().getSecureDeliveryServiceAPI(); 
@@ -1880,7 +1880,7 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
     this.categorySelected = categorySelected;
   }
 
-  public void generatePublishedURL(PublishedAssessmentFacade paf) {
+  public String generatePublishedURL(PublishedAssessmentFacade paf) {
       FacesContext context = FacesContext.getCurrentInstance();
       ExternalContext extContext = context.getExternalContext();
 
@@ -1890,6 +1890,6 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
       int index = server.indexOf(extContext.getRequestContextPath() + "/"); // "/samigo-app/"
       server = server.substring(0, index);
       String url = server + extContext.getRequestContextPath();
-      this.publishedUrl = url + "/servlet/Login?id=" + this.alias;
+      return url + "/servlet/Login?id=" + this.alias;
   }
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -411,18 +411,8 @@ public class PublishedAssessmentSettingsBean implements Serializable {
       setIpAddresses(assessment);
 
       // publishedUrl
-      FacesContext context = FacesContext.getCurrentInstance();
-      ExternalContext extContext = context.getExternalContext();
-      // get the alias to the pub assessment
-      this.alias = assessment.getAssessmentMetaDataByLabel(
-          AssessmentMetaDataIfc.ALIAS);
-      String server = ( (javax.servlet.http.HttpServletRequest) extContext.
-                       getRequest()).getRequestURL().toString();
-      int index = server.indexOf(extContext.getRequestContextPath() + "/"); // "/samigo-app/"
-      server = server.substring(0, index);
-      String url = server + extContext.getRequestContextPath();
-      this.publishedUrl = url + "/servlet/Login?id=" + this.alias;
-      
+      generatePublishedURL(assessment);
+
       // secure delivery
       SecureDeliveryServiceAPI secureDeliveryService = SamigoApiFactory.getInstance().getSecureDeliveryServiceAPI(); 
       this.secureDeliveryAvailable = secureDeliveryService.isSecureDeliveryAvaliable();
@@ -1888,5 +1878,18 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
 
   public void setCategorySelected(String categorySelected) {
     this.categorySelected = categorySelected;
+  }
+
+  public void generatePublishedURL(PublishedAssessmentFacade paf) {
+      FacesContext context = FacesContext.getCurrentInstance();
+      ExternalContext extContext = context.getExternalContext();
+
+      // get the alias to the pub assessment
+      this.alias = paf.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.ALIAS);
+      String server = ((javax.servlet.http.HttpServletRequest) extContext.getRequest()).getRequestURL().toString();
+      int index = server.indexOf(extContext.getRequestContextPath() + "/"); // "/samigo-app/"
+      server = server.substring(0, index);
+      String url = server + extContext.getRequestContextPath();
+      this.publishedUrl = url + "/servlet/Login?id=" + this.alias;
   }
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2552,4 +2552,10 @@ public class DeliveryBean implements Serializable {
     public String getCDNQuery() {
         return PortalUtils.getCDNQuery();
     }
+
+    public String getPublishedURL() {
+        PublishedAssessmentSettingsBean pasBean = (PublishedAssessmentSettingsBean) ContextUtil.lookupBean("publishedSettings");
+        pasBean.generatePublishedURL(publishedAssessment);
+        return pasBean.getPublishedUrl();
+    }
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2555,7 +2555,6 @@ public class DeliveryBean implements Serializable {
 
     public String getPublishedURL() {
         PublishedAssessmentSettingsBean pasBean = (PublishedAssessmentSettingsBean) ContextUtil.lookupBean("publishedSettings");
-        pasBean.generatePublishedURL(publishedAssessment);
-        return pasBean.getPublishedUrl();
+        return pasBean.generatePublishedURL(publishedAssessment);
     }
 }

--- a/samigo/samigo-app/src/webapp/jsf/delivery/discrepancyInData.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/discrepancyInData.jsp
@@ -58,11 +58,12 @@
 
  <h:form id="discrepancyInData">
  <p class="act">
-       <h:commandButton value="#{deliveryMessages.button_return}" type="submit"
-         styleClass="active" action="select" rendered="#{delivery.actionString=='takeAssessment'}">
-          <f:actionListener
-            type="org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener" />
+       <h:commandButton value="#{deliveryMessages.button_return}" type="submit" styleClass="active" action="select" rendered="#{delivery.actionString=='takeAssessment'}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener" />
        </h:commandButton>
+       <h:outputLink rendered="#{delivery.actionString == 'takeAssessmentViaUrl'}" value="#{delivery.getPublishedURL()}">
+           <h:outputText value="#{deliveryMessages.button_return}" />
+       </h:outputLink>
  </p>
  </h:form>
   <!-- end content -->


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44383

Usage of samigo has increased drastically due to the pandemic. As an extension, more instructors are delivering quizzes using the published assessment URL. Due to other issues, it can be quite easy for students to get click happy and/or become impatient and refresh the page before it finishes loading. The result is that the students are taken to the "Data Discrepancy" page.

In a normal situation, this Data Discrepancy page provides the user with a button to return to the samigo landing page (quiz listing UI). However, in the case of a quiz delivered by published URL, this button does not appear (nor should it in this case, the instructor intended for the user to take a specific quiz, not give them the option to take other quizzes in the site as well, plus the tool itself may be intentionally hidden by the instructor).

So in the case of a quiz delivered by URL, upon reaching the Data Discrepancy page there is no way for the user to return to the quiz (unless they're critical thinkers and paste in the published assessment URL again into their URL bar). This has lead to a lot of complaints and support calls at our institution, which is becoming burdensome.

One way to address this (for quizzes delivered by URL) is to present the user with a link to take them back to the "Continue Assessment" page, so they're easily and quickly able to resume their quiz attempt without intervention or support.

Additional mitigation (blocking them from getting click happy) is handled in another ticket: SAK-44248.