### PR TITLE
SAK-44378 Lessons : group visibility not working for external tool

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -5135,10 +5135,16 @@ public class SimplePageBean {
 				return false;
 			    break;
 			case SimplePageItem.BLTI:
-			    if (bltiEntity != null)
-				entity = bltiEntity.getEntity(item.getSakaiId());
-			    if (entity == null || entity.notPublished())
-				return false;
+			    if (bltiEntity != null) {
+			      entity = bltiEntity.getEntity(item.getSakaiId());
+			    }
+			    if (entity == null || entity.notPublished()) {
+			      return false;
+			    } else {
+			      // After checking that it exists reset to null so that groups are
+			      // checked internal to Lessons
+			      entity = null;
+			    }
 			}
 		    }
 		} finally {


### PR DESCRIPTION
Hi;

There is a fixing of an issue in lessons, related to groups, in sakai 21.x that has not been applicated to 20.x and 19.x.
The method isItemVisible of the java class SimplePageBean lacks the the code of the snippet below.

This arrangement should be applied to 20 and 19.
For this reason I request that this commit be merged in sakai 20 and 19.
Thank you very much in advance.