### PR TITLE
SAK-43998 Pipe or back slash in Lesson sub page name error

### DIFF
--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -147,6 +147,7 @@ simplepage.resource=Add Content Links
 simplepage.resource.tooltip=Add links: Upload files, link to existing files in Resources or address of a page on the web.
 simplepage.resource-descrip=Add links: Upload files, link to existing files in Resources or address of a page on the web.
 simplepage.subpage=Add Subpage
+simplepage.subpage_invalid_chars=This field may not contain characters: | [ ] ^ ` \\ { }
 simplepage.subpage-next=Next page. (I.e. this is assumed to be the next page in a sequence, rather than a subpage.)
 simplepage.subpage-button=Show as button rather than link
 simplepage.subpage.tooltip=Create a new page and add a link to it here

--- a/lessonbuilder/tool/src/resources/messages_es.properties
+++ b/lessonbuilder/tool/src/resources/messages_es.properties
@@ -144,6 +144,7 @@ simplepage.resource=A\u00f1adir enlaces a contenido
 simplepage.resource.tooltip=A\u00f1adir enlaces\: subir ficheros, o enlazar a ficheros existentes en Recursos o a una p\u00e1gina web.
 simplepage.resource-descrip=A\u00f1adir enlaces\: subir ficheros, o enlazar a ficheros existentes en Recursos o a una p\u00e1gina web.
 simplepage.subpage=A\u00f1adir subp\u00e1gina
+simplepage.subpage_invalid_chars=Este campo no debe contener los caracteres | [ ] ^ ` \\ { }
 simplepage.subpage-next=P\u00e1gina siguiente\: En lugar de una \u201csubp\u00e1gina\u201d, se puede decir m\u00e1s exactamente que ser\u00e1 una \u201cp\u00e1gina siguiente\u201d. La diferencia m\u00e1s visible es la manera en que se muestra la p\u00e1gina en la ruta de navegaci\u00f3n de la parte superior\: En el caso de \u201csubp\u00e1gina\u201d, cuando se navega hacia \u00e9sta, en la ruta de navegaci\u00f3n se muestra a esta subp\u00e1gina como de un nivel diferente, inferior. En el caso de \u201cp\u00e1gina siguiente\u201d, esta p\u00e1gina sustituye a la p\u00e1gina de partida en la ruta de navegaci\u00f3n, el nivel jer\u00e1rquico es el mismo.
 simplepage.subpage-button=Mostrar como un bot\u00f3n en lugar de como un enlace
 simplepage.subpage.tooltip=Crear una nueva p\u00e1gina y a\u00f1adirle un enlace

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -3271,6 +3271,10 @@ function checkSubpageForm() {
 		$('#subpage-error').text(msg("simplepage.page_notblank"));
 		$('#subpage-error-container').show();
 		return false;
+	} else if(/[{[}\]|\^\`]/.test($('#subpage-title').val())) {
+		$('#subpage-error').text(msg("simplepage.subpage_invalid_chars"));
+		$('#subpage-error-container').show();
+		return false;
 	}else {
 		$('#subpage-error-container').hide();
 		return true;

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -1131,6 +1131,7 @@
 			  <p rsf:id="msg=simplepage.must_be_youtube" id="simplepage.must_be_youtube"></p>
 			  <p rsf:id="msg=simplepage.item_notblank" id="simplepage.item_notblank"></p>
 			  <p rsf:id="msg=simplepage.page_notblank" id="simplepage.page_notblank"></p>
+			  <p rsf:id="msg=simplepage.subpage_invalid_chars" id="simplepage.subpage_invalid_chars"></p>
 			  <p rsf:id="msg=simplepage.tag_iframe" id="simplepage.tag_iframe"></p>
 			  <p rsf:id="msg=simplepage.tag_img" id="simplepage.tag_img"></p>
 			  <p rsf:id="msg=simplepage.edit_quiz" id="simplepage.edit_quiz"></p>
@@ -1190,7 +1191,8 @@
                     <p class="shorttext required">
                         <span class="reqStar">*</span>
                         <label class="pageTitle" rsf:id="subpage-label" for="subpage-title"></label>
-                        <input type="text" name="subpage-title" id="subpage-title" rsf:id="subpage-title" maxlength="255" length="30" /><br />
+                        <input type="text" name="subpage-title" id="subpage-title" rsf:id="subpage-title" maxlength="255" length="30" />
+                        <label>*<span rsf:id="msg=simplepage.subpage_invalid_chars"></span></label><br />
                     </p>
                 
                     <p class="shorttext required" style="margin-top: 1em; margin-bottom:1em">


### PR DESCRIPTION
Hi,

I've made a solution for this issue: to validate de characters of the subpage title. This way the links from the left pannel do not cause errors.

This patch should be merged with sakai 21.x, 20.x and 19.x

Thank you in advance.