### PR TITLE
SAK-44416 restore ability to entity link to assignments

### DIFF
--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTestConfiguration.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTestConfiguration.java
@@ -42,6 +42,7 @@ import org.sakaiproject.calendar.api.CalendarService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.contentreview.service.ContentReviewService;
+import org.sakaiproject.elfinder.SakaiFsService;
 import org.sakaiproject.email.api.DigestService;
 import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entity.api.EntityManager;
@@ -306,6 +307,11 @@ public class AssignmentTestConfiguration {
     @Bean(name = "org.sakaiproject.rubrics.logic.RubricsService")
     public RubricsService rubricsService() {
         return mock(RubricsService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.elfinder.SakaiFsService")
+    public SakaiFsService sakaiFsService() {
+        return mock(SakaiFsService.class);
     }
 
     @Bean(name = "org.sakaiproject.search.api.SearchService")

--- a/assignment/impl/src/webapp/WEB-INF/components.xml
+++ b/assignment/impl/src/webapp/WEB-INF/components.xml
@@ -298,4 +298,12 @@
         <property name="gradebookService" ref="org.sakaiproject.service.gradebook.GradebookService"/>
         <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
     </bean>
+
+    <bean id="org.sakaiproject.assignment.impl.AssignmentSiteFsVolume"
+          class="org.sakaiproject.assignment.impl.AssignmentToolFsVolumeFactory"
+          init-method="init">
+        <property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService"/>
+        <property name="sakaiFsService" ref="org.sakaiproject.elfinder.SakaiFsService"/>
+        <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+    </bean>
 </beans>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44416

#8415 removed the bean definition for `AssignmentSiteFsVolume`, thus removing the ability to entity link to assignments. This needs to be restored.