### PR TITLE
SAK-44420 NPE when poll_option.deleted is null

### DIFF
--- a/polls/api/src/java/org/sakaiproject/poll/hbm/Option.hbm.xml
+++ b/polls/api/src/java/org/sakaiproject/poll/hbm/Option.hbm.xml
@@ -28,8 +28,8 @@
 		<property name="Uuid" type="string" length="255" not-null="true">
 			<column name="OPTION_UUID" />
 		</property>
-		<property name="deleted" type="java.lang.Boolean">
-			<column name="DELETED" />
+		<property name="deleted" type="java.lang.Boolean" not-null="true">
+			<column name="DELETED" default="0" />
 		</property>
 		<property name="optionOrder" type="int" not-null="true">
 			<column name="OPTION_ORDER" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44420

Accompanying conversion script PR: https://github.com/sakaiproject/sakai-reference/pull/94

We used to have protection against this on the Java side:

```
public Boolean getDeleted() {
	return (deleted == null) ? Boolean.FALSE : deleted;
}
```

However this was removed during some lombokification in https://jira.sakaiproject.org/browse/SAK-40814. This results in an NPE being thrown when accessing the Polls tool in a site which has `null` for this field in the database.

I'd prefer to leverage database constraints and default values to resolve this rather than adding the Java code back.