### PR TITLE
SAK-43299 site info > make accordion sections the size of their content

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -12,6 +12,7 @@
 			header: 'h4',
 			active: false,
 			collapsible: true,
+			heightStyle: 'content',
 			change: function(event, ui){
 				utils.resizeFrame();
 			},


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43299

If you have a lot more sections than groups, or vice versa, the sections of the accordion are equal heights, using the maximum content height. This results in a lot of whitespace in the section that doesn't have as much content.

This PR changes the jQuery widget to make each section uniquely sized, based on the content of each rather than the max of all.