### PR TITLE
SAK-44353 Group Manager and Date Manager do not change idiom

### DIFF
--- a/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/ThymeleafConfig.java
+++ b/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/ThymeleafConfig.java
@@ -14,16 +14,17 @@
 package org.sakaiproject.datemanager;
 
 import java.nio.charset.StandardCharsets;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.i18n.SessionLocaleResolver;
 import org.thymeleaf.spring5.ISpringTemplateEngine;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
@@ -76,4 +77,10 @@ public class ThymeleafConfig extends WebMvcConfigurerAdapter implements Applicat
 		templateResolver.setTemplateMode(TemplateMode.HTML);
 		return templateResolver;
 	}
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        return new SessionLocaleResolver();
+    }
+
 }

--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/config/ThymeleafConfig.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/config/ThymeleafConfig.java
@@ -22,9 +22,11 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.i18n.SessionLocaleResolver;
 import org.thymeleaf.spring5.ISpringTemplateEngine;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
@@ -75,6 +77,11 @@ public class ThymeleafConfig extends WebMvcConfigurerAdapter implements Applicat
         templateResolver.setSuffix(".html");
         templateResolver.setTemplateMode(TemplateMode.HTML);
         return templateResolver;
+    }
+    
+    @Bean
+    public LocaleResolver localeResolver() {
+        return new SessionLocaleResolver();
     }
 
 }


### PR DESCRIPTION
When the applications with Thymeleaf DateManager and GroupManager were initialized when the server was started, they took the default language of the platform, of the operating system of the machine. So, what I have done is to allow that when the entry point of these two applications is accessed, the language of the user session indicated in preferences is taken. This way it works properly.

I do the pull request with the changes.
Please merge with Sakai 21.x and 20.x.
Thank you.