### PR TITLE
SAK-44382 forums > rename 'watch' to 'notifications'

### DIFF
--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -745,8 +745,8 @@ cdfm_button_bar_permalink=Copy link
 cdfm_button_bar_permalink_message=Copy link for pasting into email
 
 # Watch forums options
-watch=Watch
-watch_forums_options=Watch Forums Options
+watch=Notifications
+watch_forums_options=Forums Notification Options
 watch_forums_options_instruction=Use the settings below to change what notifications <strong><u>you</u></strong> receive when activity in the forums of <strong><u>this</u></strong> site take place. Some topics may not allow email notifications.
 notify_for_all_postings=Send me an email whenever a new message is posted (to topics that allow notifications)
 notify_for_postings_to_my_thread=Send me an email when a conversation that I have contributed to receives a new message (within topics that allow notifications)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44382

The Forums Watch option is often overlooked, and users who want to enable notifications do not understand its purpose.

https://jira.sakaiproject.org/browse/FARM-2