### PR TITLE
SAK-29425 forums > add percent read and num authored to individual statistics UI

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
+++ b/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
@@ -297,7 +297,7 @@
 	}
 
 	.statsTally {
-		color: #655f62;
+		color: #666;
 		font-weight: bold;
 	}
 }

--- a/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
+++ b/library/src/morpheus-master/sass/modules/tool/forums/_forums.scss
@@ -295,4 +295,9 @@
 			margin: 0 $standard-space $standard-space 0;
 		}
 	}
+
+	.statsTally {
+		color: #655f62;
+		font-weight: bold;
+	}
 }

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -100,6 +100,8 @@ stat_sort_by_date=Sort by Date
 stat_byUser=by User
 stat_byTopic=by Topic
 stat_totalMessages=Total Messages
+stat_percent_read=<span class="statsTally">Percent Read:</span> {0}%
+stat_num_authored=<span class="statsTally">Messages Authored:</span> {0}
 
 cdfm_labels=Labels
 cdfm_newflag=New!

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
@@ -3112,4 +3112,17 @@ public class MessageForumStatisticsBean {
 		// Condenses to:
 		return topic.getPostAnonymous() && (!topic.getRevealIDsToRoles() || !uiPermissionsManager.isIdentifyAnonAuthors((DiscussionTopic) topic));
 	}
+
+    public int getPercentRead()
+    {
+        int totalPosts = 0;
+        List<Object[]> studentAuthoredStats = messageManager.findAuthoredMessageCountForAllStudents();
+        for (Object[] pair : studentAuthoredStats)
+        {
+            totalPosts += ((Long) pair[1]).intValue();
+        }
+
+        int numRead = getUserReadStatistics().size();
+        return (numRead / totalPosts) * 100;
+    }
 }

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
@@ -188,6 +188,17 @@
 
 	  	<h:outputText rendered="#{ForumTool.anonymousEnabled && ForumTool.siteHasAnonymousTopics && !mfStatisticsBean.pureAnon}" value="#{msgs.stat_forum_anonymous_omitted}" styleClass="instruction" />
 
+        <div>
+            <h:outputFormat value="#{msgs.stat_percent_read}" escape="false">
+                <f:param value="#{mfStatisticsBean.getPercentRead()}" />
+            </h:outputFormat>
+        </div>
+        <div>
+            <h:outputFormat value="#{msgs.stat_num_authored}" escape="false">
+                <f:param value="#{mfStatisticsBean.userAuthoredStatistics.size()}" />
+            </h:outputFormat>
+        </div>
+
 	  	<h:panelGrid columns="2" width="100%" style="margin:0">
    			<h:panelGroup>
     			<f:verbatim><h4 style="margin:0;padding:0"></f:verbatim>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-29425

Use case: Instructor would like for information displayed in the table on the Statistics page in Forums (msgcntr) to also display on each individual student's page.