### PR TITLE
SAK-44452 - None of the above isn't checked when it is the answer on grading Questions

### DIFF
--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemText.java
@@ -164,7 +164,7 @@ public class PublishedItemText
           distractor.setId(new Long(0));
           distractor.setLabel(rb.getString("choice_labels").split(":")[answersSorted.size()]);
           distractor.setText("none_above");
-          distractor.setIsCorrect(false);
+          distractor.setIsCorrect(!hasCorrectAnswers());
           distractor.setScore(this.getItem().getScore());
           distractor.setSequence(new Long(answers.size()));
           answers.add(distractor);


### PR DESCRIPTION
There is a similar pattern in `ItemText.java` but the distractor never displays there as this is only during grading so I don't think correct/incorrect is applicable.