### PR TITLE
SAK-44207 Update sequence definition in hbm.xml files for Hibernate 5

### DIFF
--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
@@ -454,6 +454,7 @@
 				<prop key="hibernate.enable_lazy_load_no_trans">true</prop>
 				<prop key="hibernate.current_session_context_class">org.springframework.orm.hibernate5.SpringSessionContext</prop>
 				<prop key="org.apache.ignite.hibernate.default_access_type">READ_ONLY</prop>
+				<prop key="hibernate.id.new_generator_mappings">false</prop>
 				<!-- prop key="hibernate.cache.query_cache_factory">org.sakaiproject.hibernate.IgniteStandardQueryCacheFactory</prop -->
 			</props>
 		</property>


### PR DESCRIPTION
Many sequences were not being created in Oracle via auto.ddl.
In Hibernate 5.3 the setting hibernate.id.new_generator_mappings is set to true by default.
This makes the old way of defining a sequence using generator class="native" not work. Instead,
this should be updated to class="org.hibernate.id.enhanced.SequenceStyleGenerator" and sequence
parameter is now called sequence_name.