### PR TITLE
SAK-44262 Fix rubrics table creation in Oracle

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Criterion.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Criterion.java
@@ -78,8 +78,8 @@ public class Criterion implements Modifiable, Serializable, Cloneable {
     @Lob
     private String description;
 
-    @Column(columnDefinition = "double default 0")
-    private Double weight = 0D;
+    @Column(columnDefinition="float default 0")
+    private Float weight = 0F;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinTable(name = "rbc_criterion_ratings")

--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Rubric.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Rubric.java
@@ -39,6 +39,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.PostLoad;
 import javax.persistence.PostUpdate;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -76,7 +78,7 @@ public class Rubric implements Modifiable, Serializable, Cloneable {
     private String title;
     private String description;
 
-    @Column(columnDefinition = "boolean default false", nullable = false)
+    @Column(nullable = false)
     private Boolean weighted = Boolean.FALSE;
 
     @ManyToMany(cascade = CascadeType.ALL)
@@ -166,5 +168,19 @@ public class Rubric implements Modifiable, Serializable, Cloneable {
     @Override
     public void setModified(Metadata metadata) {
         this.metadata = metadata;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (this.weighted == null) {
+            this.weighted = Boolean.FALSE;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        if (this.weighted == null) {
+            this.weighted = Boolean.FALSE;
+        }
     }
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44262

rbc_rubric and rbc_criterion were not getting automatically created in Oracle
because the columnDefinition configuration there previously was not compatitble.
This removes that property and instead sets the default values with PrePersist
JPA annotation.