### PR TITLE
SAK-44388 rwiki > improve tool tips

### DIFF
--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/edittoolbar.jsp
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/command-pages/edittoolbar.jsp
@@ -5,11 +5,11 @@
  **********************************************************************************/
 -->
 <div class="editToolBarContainer" >
-<a class="editToolBar" href="#" id="toolbarButtonSave" onclick="var form = document.getElementById('editForm'); var saveButton = document.getElementById('saveButton'); form.command_save.value = saveButton.value; form.submit();" ><img src="/library/image/transparent.gif" border="0"   title="${rlb.jsp_toolb_save}" alt="${rlb.jsp_toolb_save}" /></a>
-<a class="editToolBar" href="#" id="toolbarButtonBold" onclick="addMarkup('content','bold','__','__'); return false;" ><img src="/library/image/transparent.gif" border="0"   title="${rlb.jsp_toolb_bold}" alt="${rlb.jsp_toolb_bold}" /></a>
-<a class="editToolBar" href="#" id="toolbarButtonItalic" onclick="addMarkup('content','italic','~~','~~'); return false;" ><img src="/library/image/transparent.gif" border="0"  title="${rlb.jsp_toolb_italic}" alt="${rlb.jsp_toolb_italic}" /></a>
-<a class="editToolBar" href="#" id="toolbarButtonSuper" onclick="addMarkup('content','super','^^','^^'); return false;"  ><img src="/library/image/transparent.gif" border="0" title="${rlb.jsp_toolb_superscript}" alt="${rlb.jsp_toolb_superscript}" /></a>
-<a class="editToolBar" href="#" id="toolbarButtonSub" onclick="addMarkup('content','sub','%%','%%'); return false;"  ><img src="/library/image/transparent.gif" border="0" title="${rlb.jsp_toolb_subscript}" alt="${rlb.jsp_toolb_subscript}" /></a>
+<a class="editToolBar" href="#" id="toolbarButtonSave" onclick="var form = document.getElementById('editForm'); var saveButton = document.getElementById('saveButton'); form.command_save.value = saveButton.value; form.submit();" title="${rlb.jsp_toolb_save}" alt="${rlb.jsp_toolb_save}"></a>
+<a class="editToolBar" href="#" id="toolbarButtonBold" onclick="addMarkup('content','bold','__','__'); return false;" title="${rlb.jsp_toolb_bold}" alt="${rlb.jsp_toolb_bold}"></a>
+<a class="editToolBar" href="#" id="toolbarButtonItalic" onclick="addMarkup('content','italic','~~','~~'); return false;" title="${rlb.jsp_toolb_italic}" alt="${rlb.jsp_toolb_italic}"></a>
+<a class="editToolBar" href="#" id="toolbarButtonSuper" onclick="addMarkup('content','super','^^','^^'); return false;" title="${rlb.jsp_toolb_superscript}" alt="${rlb.jsp_toolb_superscript}"></a>
+<a class="editToolBar" href="#" id="toolbarButtonSub" onclick="addMarkup('content','sub','%%','%%'); return false;" title="${rlb.jsp_toolb_subscript}" alt="${rlb.jsp_toolb_subscript}"></a>
 <select name="toolbarButtonHeading" id="toobarButtonHeading" onChange="if ( this.value != 'none' ) { addMarkup('content','Heading 1','\n'+this.value+' ','\n'); this.value = 'none'; } return false;" >
 	<option value="none" ><c:out value="${rlb.jsp_toolb_headings}" /></option>
 	<option value="h1"><c:out value="${rlb.jsp_toolb_heading}" /> 1</option>
@@ -19,7 +19,7 @@
 	<option value="h5"><c:out value="${rlb.jsp_toolb_heading}" /> 5</option>
 	<option value="h6"><c:out value="${rlb.jsp_toolb_heading}" /> 6</option>
 </select>
-<a class="editToolBar" href="#" id="toolbarButtonTable" onclick="addMarkup('content','col|col|col\nnewrow|col|col','{table}\n','\n{table}'); return false;" ><img src="/library/image/transparent.gif" border="0" title="${rlb.jsp_toolb_table}" alt="${rlb.jsp_toolb_table}" /></a>
-<a class="editToolBar" href="#" id="toolbarButtonLink" onclick="addAttachment('content','editForm','editControl', 'link'); return false;"   ><img src="/library/image/transparent.gif" border="0" title="${rlb.jsp_toolb_link}" alt="${rlb.jsp_toolb_link}" /></a>
-<a class="editToolBar" href="#" id="toolbarButtonImage" onclick="addAttachment('content','editForm', 'editControl', 'embed'); return false;"   ><img src="/library/image/transparent.gif" border="0" title="${rlb.jsp_toolb_image}" alt="${rlb.jsp_toolb_image}" /></a> 
+<a class="editToolBar" href="#" id="toolbarButtonTable" onclick="addMarkup('content','col|col|col\nnewrow|col|col','{table}\n','\n{table}'); return false;" title="${rlb.jsp_toolb_table}" alt="${rlb.jsp_toolb_table}"></a>
+<a class="editToolBar" href="#" id="toolbarButtonLink" onclick="addAttachment('content','editForm','editControl', 'link'); return false;" title="${rlb.jsp_toolb_link}" alt="${rlb.jsp_toolb_link}"></a>
+<a class="editToolBar" href="#" id="toolbarButtonImage" onclick="addAttachment('content','editForm', 'editControl', 'embed'); return false;" title="${rlb.jsp_toolb_image}" alt="${rlb.jsp_toolb_image}"></a>
 </div>

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/macros.vm
@@ -456,45 +456,40 @@ function togglePresence(target) {
 #macro( edittoolbar ) 
 <div class="editToolBarContainer" >
 <a class="editToolBar" 
-			href="#" 
-			id="toolbarButtonSave" 
-			onclick="var form = document.getElementById('editForm'); var saveButton = document.getElementById('saveButton'); form.command_save.value = saveButton.value; form.submit();" >
-			<img src="/library/image/transparent.gif" 
-								border="0"   
-								title="${rlb.jsp_toolb_save}" 
-								alt="${rlb.jsp_toolb_save}" /></a>
+    href="#"
+    id="toolbarButtonSave"
+    onclick="var form = document.getElementById('editForm'); var saveButton = document.getElementById('saveButton'); form.command_save.value = saveButton.value; form.submit();"
+    title="${rlb.jsp_toolb_save}" 
+    alt="${rlb.jsp_toolb_save}" >
+</a>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonBold" 
-   onclick="addMarkup('wiki-textarea-content','bold','__','__'); return false;" >
-   <img src="/library/image/transparent.gif" 
-        border="0"   
-        title="${rlb.jsp_toolb_bold}" 
-        alt="${rlb.jsp_toolb_bold}" /></a>
+    href="#"
+    id="toolbarButtonBold"
+    onclick="addMarkup('wiki-textarea-content','bold','__','__'); return false;"
+    title="${rlb.jsp_toolb_bold}" 
+    alt="${rlb.jsp_toolb_bold}" >
+</a>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonItalic" 
-   onclick="addMarkup('wiki-textarea-content','italic','~~','~~'); return false;" >
-   <img src="/library/image/transparent.gif" 
-        border="0"  
-        title="${rlb.jsp_toolb_italic}" 
-        alt="${rlb.jsp_toolb_italic}" /></a>
+    href="#"
+    id="toolbarButtonItalic"
+    onclick="addMarkup('wiki-textarea-content','italic','~~','~~'); return false;"
+    title="${rlb.jsp_toolb_italic}" 
+    alt="${rlb.jsp_toolb_italic}" >
+</a>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonSuper" 
-   onclick="addMarkup('wiki-textarea-content','super','^^','^^'); return false;"  >
-   <img src="/library/image/transparent.gif" 
-        border="0" 
-        title="${rlb.jsp_toolb_superscript}" 
-        alt="${rlb.jsp_toolb_superscript}" /></a>
+    href="#"
+    id="toolbarButtonSuper"
+    onclick="addMarkup('wiki-textarea-content','super','^^','^^'); return false;"
+    title="${rlb.jsp_toolb_superscript}" 
+    alt="${rlb.jsp_toolb_superscript}" >
+</a>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonSub" 
-   onclick="addMarkup('wiki-textarea-content','sub','%%','%%'); return false;"  >
-   <img src="/library/image/transparent.gif" 
-        border="0" 
-        title="${rlb.jsp_toolb_subscript}" 
-        alt="${rlb.jsp_toolb_subscript}" /></a>
+    href="#"
+    id="toolbarButtonSub"
+    onclick="addMarkup('wiki-textarea-content','sub','%%','%%'); return false;"
+    title="${rlb.jsp_toolb_subscript}" 
+    alt="${rlb.jsp_toolb_subscript}" >
+</a>
 <select name="toolbarButtonHeading" 
         id="toobarButtonHeading" 
         onChange="if ( this.value != 'none' ) { addMarkup('wiki-textarea-content','Heading 1','\n'+this.value+' ','\n'); this.value = 'none'; } return false;" >
@@ -507,29 +502,26 @@ function togglePresence(target) {
 	   <option value="h6">${rlb.jsp_toolb_heading} 6</option>
 </select>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonTable" 
-   onclick="addMarkup('wiki-textarea-content','${rlb.jsp_table_macro_markup}','{table}\n','\n{table}'); return false;" >
-   <img src="/library/image/transparent.gif" 
-        border="0" 
-        title="${rlb.jsp_toolb_table}" 
-        alt="${rlb.jsp_toolb_table}" /></a>
+    href="#"
+    id="toolbarButtonTable"
+    onclick="addMarkup('wiki-textarea-content','${rlb.jsp_table_macro_markup}','{table}\n','\n{table}'); return false;"
+    title="${rlb.jsp_toolb_table}" 
+    alt="${rlb.jsp_toolb_table}" >
+</a>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonLink" 
-   onclick="addAttachment('wiki-textarea-content','editForm','editControl', 'link'); return false;"   >
-   <img src="/library/image/transparent.gif" 
-        border="0" 
-        title="${rlb.jsp_toolb_link}" 
-        alt="${rlb.jsp_toolb_link}" /></a>
+    href="#"
+    id="toolbarButtonLink"
+    onclick="addAttachment('wiki-textarea-content','editForm','editControl', 'link'); return false;"
+    title="${rlb.jsp_toolb_link}" 
+    alt="${rlb.jsp_toolb_link}" >
+</a>
 <a class="editToolBar" 
-   href="#" 
-   id="toolbarButtonImage" 
-   onclick="addAttachment('wiki-textarea-content','editForm', 'editControl', 'embed'); return false;"   >
-   <img src="/library/image/transparent.gif" 
-        border="0" 
-        title="${rlb.jsp_toolb_image}" 
-        alt="${rlb.jsp_toolb_image}" /></a> 
+    href="#"
+    id="toolbarButtonImage"
+    onclick="addAttachment('wiki-textarea-content','editForm', 'editControl', 'embed'); return false;"
+    title="${rlb.jsp_toolb_image}" 
+    alt="${rlb.jsp_toolb_image}" >
+</a>
 </div>
 #end
 

--- a/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
+++ b/rwiki/rwiki-tool/tool/src/webapp/styles/wikiStyle.css
@@ -137,10 +137,7 @@ li.autoSaveOffClass { display: none }
 .editToolBarContainer select { zoom: 1; font-size: .9em; border: 1px solid #efeffe }
 a.editToolBar,a.editToolBar:visited,a.previewToolBar,a.previewToolBar:visited,a.autosaveToolBar,a.autosaveToolBar:visited  {
 	border: 1px solid #efefde;
-	padding-top: 2px;
-	padding-bottom: 3px;
-	padding-left: 8px;
-	padding-right: 8px
+	padding: 2px 13px 3px;
 }
 a.editToolBar:hover,a.editToolBar:active,a.previewToolBar:hover,a.previewToolBar:active,a.autosaveToolBar:hover,a.autosaveToolBar:active {
 	border: 1px solid #316ac5;


### PR DESCRIPTION
Previously the tool tips were only present on a 5x5px transparent GIF contained within the button, resulting in people not being aware of what the buttons do until they try to use them.