### PR TITLE
SAK-44477 File naming when compressing top-level folder

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -963,7 +963,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		context.put ("id", entityId);
 		String collectionId = (String) state.getAttribute(STATE_MORE_COLLECTION_ID);
 		context.put ("collectionId", collectionId);
-		String homeCollectionId = (String) (String) state.getAttribute (STATE_HOME_COLLECTION_ID);
+		String homeCollectionId = (String) state.getAttribute (STATE_HOME_COLLECTION_ID);
 		context.put("homeCollectionId", homeCollectionId);
 		//List cPath = getCollectionPath(state);
 		//context.put ("collectionPath", cPath);
@@ -8350,11 +8350,11 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 			if ((home == null) || (home.length() == 0))
 			{
 				home = contentHostingService.getSiteCollection(toolManager.getCurrentPlacement().getContext());
-
-				// TODO: what's the 'name' of the context? -ggolden
-				// we'll need this to create the home collection if needed
-				state.setAttribute (STATE_HOME_COLLECTION_DISPLAY_NAME, toolManager.getCurrentPlacement().getContext()
-						/*siteService.getSiteDisplay(toolManager.getCurrentPlacement().getContext()) */);
+				try {
+					state.setAttribute(STATE_HOME_COLLECTION_DISPLAY_NAME, ((Site) siteService.getSite(toolManager.getCurrentPlacement().getContext())).getTitle());
+				} catch (IdUnusedException e) {
+					log.warn("Error while trying to set {} attribute for site {}", STATE_HOME_COLLECTION_DISPLAY_NAME, toolManager.getCurrentPlacement().getContext());
+				}
 			}
 		}
 		state.setAttribute (STATE_HOME_COLLECTION_ID, home);

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -181,13 +181,12 @@ public class ZipContentUtil {
 			String resourceName = extractName(resourceId);			
 			String homeCollectionId = (String) toolSession.getAttribute(STATE_HOME_COLLECTION_ID);
 			if(homeCollectionId != null && homeCollectionId.equals(reference.getId())){
-				//place the zip file into the home folder of the resource tool
-				resourceId = reference.getId() + resourceName;
-				
 				String homeName = (String) toolSession.getAttribute(STATE_HOME_COLLECTION_DISPLAY_NAME);
 				if(homeName != null){
-					resourceName = homeName;
-				}				
+					resourceName = homeName + ZIP_EXTENSION;
+				}
+				//place the zip file into the home folder of the resource tool
+				resourceId = reference.getId() + homeName;
 			}
 			int count = 0;
 			ContentResourceEdit resourceEdit = null;


### PR DESCRIPTION
It seems the STATE_HOME_COLLECTION_DISPLAY_NAME attributte had a wrong value since the early times, probably not used elsewhere though