### PR TITLE
SAK-25024 forums > use UserDirectoryService to resolve author names dynamically

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionMessageBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionMessageBean.java
@@ -38,6 +38,8 @@ import org.sakaiproject.api.app.messageforums.ui.UIPermissionsManager;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.ToolManager;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
 
 /** 
@@ -503,7 +505,23 @@ log.debug("... before return getAuthorEmail(): userEmail = " + userEmail);
 	 */
 	public String getAnonAwareAuthor()
 	{
-		return isUseAnonymousId() ? getAnonId() : message.getAuthor();
+		if (isUseAnonymousId())
+		{
+			return getAnonId();
+		}
+		else
+		{
+			String authorID = getAuthorEid();
+			try
+			{
+				User author = UserDirectoryService.getUser(authorID);
+				return author.getDisplayName();
+			}
+			catch (UserNotDefinedException e)
+			{
+				return message.getAuthor();
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-25024

Users routinely have name mis-spellings corrected and changed. Users can also have their eid changed during the course of enrolment at an institution (marriage, divorce, etc). With the current behaviour in Forums, the only way to "fix" the "Authored By" in a forum, is editing directly in a DB.