### PR TITLE
SAK-43149 Drop Box - "Lock" icon incorrectly displays in Tool Order

### DIFF
--- a/content/content-tool/tool/src/webapp/WEB-INF/tools/sakai.dropbox.xml
+++ b/content/content-tool/tool/src/webapp/WEB-INF/tools/sakai.dropbox.xml
@@ -16,7 +16,7 @@
 		<!-- This is final because it's being added long after the tool has rolled out so making it final means
 		     all existing placements get this in their configuration without backfilling -->
 		<configuration name="functions.require" type="final"
-					   value="dropbox.own | dropbox.maintain | dropbox.maintain.own.groups" />
+					   value="dropbox.own,dropbox.maintain,dropbox.maintain.own.groups" />
 	</tool>
 
 </registration>


### PR DESCRIPTION
The values should be separated by commas and not by pipes "|".
This way, the logic can read the different values in the file SitePageEditHandler.java
in the line:
return new ArrayList<>(Arrays.asList(StringUtils.split(functions, ',')));
And the permissions are correctly processed.
Thank you.