### PR TITLE
SAK-44510 samigo > fix editing questions with > 26 variables+formulas

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
@@ -2021,11 +2021,11 @@ public class ItemAddListener
 			}
 
 			// loop through all variables and formulas to create all answers for the ItemText object
+			String choiceLabel = AnswerBean.getChoiceLabels()[0]; // choice label doesn't matter for calculated questions; use a static value just to make the constructor happy below
 			for (CalculatedQuestionAnswerIfc curVarFormula : list) {
 				String match = curVarFormula.getMatch();
 				Long curSequence = curVarFormula.getSequence();
 				boolean isCorrect = curSequence.equals(sequence);
-				String choiceLabel = AnswerBean.getChoiceLabels()[curSequence.intValue()];
 				boolean foundAnswer = false;
 				for (AnswerIfc curAnswer : answerSet) {
 					if (curAnswer.getSequence().equals(sequence)) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44510

`IndexOutOfBoundsException` produced when editing a calculated question with more than 26 variables and formulas (combined).  This question type was likely never tested with insane amounts of variables and formulas. This does not affect the initial save of the question, nor does it affect students taking the question, nor grading of the question.

Problem code in question is in `ItemAddListener.preparePublishedTextForCalculatedQuestion()`:

```
			for (CalculatedQuestionAnswerIfc curVarFormula : list) {
				String match = curVarFormula.getMatch();
				Long curSequence = curVarFormula.getSequence();
				boolean isCorrect = curSequence.equals(sequence);
				String choiceLabel = AnswerBean.getChoiceLabels()[curSequence.intValue()];
				boolean foundAnswer = false;
				for (AnswerIfc curAnswer : answerSet) {
					if (curAnswer.getSequence().equals(sequence)) {
						curAnswer.setText(varFormula.getMatch());
						foundAnswer = true;
						break;
					}
				}
				if (!foundAnswer) {
					AnswerIfc answer = new PublishedAnswer(choiceText, match, curSequence, choiceLabel, isCorrect, grade, score, partialCredit, discount);
					answerSet.add(answer);
				}
			}
```

Specifically:

```
String choiceLabel = AnswerBean.getChoiceLabels()[curSequence.intValue()];
```

`AnswerBean.getChoiceLabels()` always returns an array of static choice labels: A,B,C,D,E,F,G.... etc. If there are more than 26 variables and formulas `curSequence` increments beyond 25, presenting `IndexOutOfBoundsException` opportunities.

In the context of calculated questions, the choice label really doesn't matter. Calculated questions are not presented with choice labels like multiple choice questions. They are rendered with text boxes in line.

To fix this, just pass the `PublishedAnswer` constructor a static value; it doesn't matter what it is in this scenario.