### PR TITLE
SAK-43947 Assignment ASN_ASSIGNMENT_PROPERTIES.VALUE to varchar 4000

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/model/Assignment.java
@@ -179,8 +179,7 @@ public class Assignment {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @ElementCollection
     @MapKeyColumn(name = "NAME")
-    @Lob
-    @Column(name = "VALUE", length = 65535)
+    @Column(name = "VALUE", length = 4000)
     @CollectionTable(name = "ASN_ASSIGNMENT_PROPERTIES", joinColumns = @JoinColumn(name = "ASSIGNMENT_ID"))
     @Fetch(FetchMode.SUBSELECT)
     private Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
This allows Oracle to search this field from a query something not allowed
when using type CLOB