### PR TITLE
SAK-40409 forums > allow students to access their own stats

### DIFF
--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -59,6 +59,7 @@ cdfm_moderate = Moderate
 cdfm_mark_as_read=Mark as Read
 cdfm_readby= - Read by: 
 stat_list = Statistics & Grading
+stat_list_student = Statistics
 stat_name = Name
 stat_anon_user = User
 stat_authored = Authored

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -158,6 +158,7 @@ import net.sf.json.JSONSerializer;
 import net.sf.json.JsonConfig;
 import org.sakaiproject.api.app.messageforums.events.ForumsMessageEventParams;
 import org.sakaiproject.api.app.messageforums.events.ForumsTopicEventParams;
+import static org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl.DATE_COMPARATOR;
 
 /**
  * @author <a href="mailto:rshastri@iupui.edu">Rashmi Shastri</a>
@@ -7274,6 +7275,9 @@ public class DiscussionForumTool {
 		 setSelectedForumForCurrentTopic(topic);		
 		 selectedTopic = getDecoratedTopic(topic);
 		 selectedForum = getDecoratedForum(forum);
+		 if (!isInstructor()) {
+			 Collections.sort(selectedTopic.getMessages(), DATE_COMPARATOR);
+		 }
 
 		 if (uiPermissionsManager.isRead((DiscussionTopic)topic, forum)) {
 			 List messageList = messageManager.findMessagesByTopicId(topic.getId());

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/menu/forumsMenu.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/menu/forumsMenu.jsp
@@ -49,6 +49,15 @@
         </span>
       </li>
     </h:panelGroup>
+    <h:panelGroup rendered="#{!ForumTool.instructor}">
+      <li role="menuitem">
+        <span id="forumsStatisticsMenuLink">
+          <h:commandLink value="#{msgs.stat_list_student}" id="statListStudent" action="#{mfStatisticsBean.processActionStatisticsUser}" immediate="true">
+              <f:param value="#{ForumTool.userId}" name="siteUserId"/>
+          </h:commandLink>
+        </span>
+      </li>
+    </h:panelGroup>
     <h:panelGroup rendered="#{ForumTool.displayPendingMsgQueue}">
       <li role="menuitem">
         <span id="forumsQueueMenuLink">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
@@ -41,7 +41,7 @@
 
 <f:view>
   <sakai:view toolCssHref="/messageforums-tool/css/msgcntr.css">
-  	<h:form id="dfStatisticsForm" rendered="#{ForumTool.instructor}">
+  	<h:form id="dfStatisticsForm">
   	<!-- discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp-->
   		<script>
 			var iframeId = '<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>';
@@ -152,7 +152,7 @@
 					</h:panelGroup>
 				</h:panelGroup>
 			<% }else {%>
-          	 <h:panelGroup layout="block" styleClass="breadCrumb"><h3>
+          	 <h:panelGroup layout="block" styleClass="breadCrumb" rendered="#{ForumTool.instructor}"><h3>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
@@ -242,7 +242,7 @@
 						<% if(!isDialogBox){ %>
 						<h:panelGroup style="display:block;float:right;width:25%;text-align:right">
 							<h:outputLink value="/tool/#{ForumTool.currentToolId}/discussionForum/message/dfMsgGrade" target="dialogFrame"
-								onclick="dialogLinkClick(this);">
+								onclick="dialogLinkClick(this);" rendered="#{ForumTool.instructor}">
 								<f:param value="#{stat.forumId}" name="forumId"/>
 								<f:param value="#{stat.topicId}" name="topicId"/>
 								<f:param value="#{stat.msgId}" name="messageId"/>
@@ -253,7 +253,7 @@
 								<h:graphicImage value="/../../library/image/silk/award_star_gold_1.png" alt="#{msgs.cdfm_button_bar_grade}" />
 								<h:outputText value=" #{msgs.cdfm_button_bar_grade}" />
 							</h:outputLink>
-							<h:outputText value=" #{msgs.cdfm_toolbar_separator} " />
+							<h:outputText value=" #{msgs.cdfm_toolbar_separator} " rendered="#{ForumTool.instructor}" />
 							<h:commandLink action="#{ForumTool.processActionDisplayInThread}" title=" #{msgs.stat_display_in_thread}" >
 								<f:param value="#{stat.forumId}" name="forumId"/>
 		  				  		<f:param value="#{stat.topicId}" name="topicId"/>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsDisplayInThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsDisplayInThread.jsp
@@ -7,7 +7,7 @@
 </jsp:useBean>
 <f:view>
   <sakai:view toolCssHref="/messageforums-tool/css/msgcntr.css">
-  	<h:form id="dfStatisticsForm" rendered="#{ForumTool.instructor}">
+  	<h:form id="dfStatisticsForm">
 				<!-- discussionForum/statistics/dfStatisticsDisplayInThread.jsp -->
   	    <script>includeLatestJQuery("msgcntr");</script>
        	<script src="/messageforums-tool/js/sak-10625.js"></script>
@@ -29,7 +29,7 @@
 		<link rel="stylesheet" type="text/css" href="/messageforums-tool/css/msgcntr_statistics.css" />
 		<%@ include file="/jsp/discussionForum/menu/forumsMenu.jsp" %>
 
-        <f:verbatim><div class="breadCrumb"><h3></f:verbatim>
+		<h:panelGroup layout="block" styleClass="breadCrumb" rendered="#{ForumTool.instructor}"><h3>
 		<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      	rendered="#{ForumTool.messagesandForums}" />
 		<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
@@ -63,7 +63,7 @@
 		<h:outputText value="#{ForumTool.selectedForum.forum.title}" />
 		<h:outputText value=" / "/>
 		<h:outputText value="#{ForumTool.selectedTopic.topic.title}" />
-		<f:verbatim></h3></div></f:verbatim>
+		</h3></h:panelGroup>
 
 		<h:panelGroup id="forumsAction">
 			<h:outputLink styleClass="button" id="print" value="javascript:printFriendly('#{ForumTool.printFriendlyDisplayInThread}');" title="#{msgs.cdfm_print}">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
@@ -17,7 +17,7 @@
 
 <f:view>
   <sakai:view>
-  	<h:form id="dfStatisticsForm" rendered="#{ForumTool.instructor}">
+  	<h:form id="dfStatisticsForm">
 		<!--discussionForum/statistics/dfStatisticsUser.jsp-->
 		<script>
 
@@ -128,7 +128,7 @@
 			<iframe id="dialogFrame" name="dialogFrame" width="100%" height="100%" frameborder="0"></iframe>
 		</div>
 
-  		<h:panelGrid columns="2" width="100%" styleClass="navPanel  specialLink">
+  		<h:panelGrid columns="2" width="100%" styleClass="navPanel  specialLink" rendered="#{ForumTool.instructor}">
           <h:panelGroup>
           	 <f:verbatim><h3></f:verbatim>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
@@ -262,7 +262,7 @@
 
   				 <h:column>
   					<h:outputLink value="/tool/#{ForumTool.currentToolId}/discussionForum/message/dfMsgGrade" target="dialogFrame"
-						onclick="dialogLinkClick(this);">
+						onclick="dialogLinkClick(this);" rendered="#{ForumTool.instructor}">
 						<f:param value="#{stat.forumId}" name="forumId"/>
 						<f:param value="#{stat.topicId}" name="topicId"/>
 						<f:param value="#{stat.msgId}" name="messageId"/>
@@ -273,7 +273,7 @@
 						<h:graphicImage value="/../../library/image/silk/award_star_gold_1.png" alt="#{msgs.cdfm_button_bar_grade}" />
 						<h:outputText value=" #{msgs.cdfm_button_bar_grade}" />
 					</h:outputLink>
-					<h:outputText value=" #{msgs.cdfm_toolbar_separator} " />
+					<h:outputText value=" #{msgs.cdfm_toolbar_separator} " rendered="#{ForumTool.instructor}" />
 					<h:commandLink action="#{ForumTool.processActionDisplayInThread}" value="#{msgs.stat_display_in_thread}" title=" #{msgs.stat_display_in_thread}">	
 		  				  		<f:param value="#{stat.topicId}" name="topicId"/>
 		  				  		<f:param value="#{stat.forumId}" name="forumId"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-40409

Via the _Forums_' *Statistics and Grading* screen, instructors/project site administrators can access individual participants' posting statistics.  The page for a specific user includes all messages the user posted (with the subjects linked to access those posts in context) and a list of messages the user marked as Read.  There's also an option to jump to a page showing the Full text of all posts the student authored.

This information is not available to students/members, and often students are assigned to post a certain number of times each week or respond to a certain number of posts.  Each site participant should be able to access their own view of the page containing their individual statistics.