### PR TITLE
SAK-43909 Update oAuth admin styling and rights

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/oauthadmin/_oauthadmin.scss
+++ b/library/src/morpheus-master/sass/modules/tool/oauthadmin/_oauthadmin.scss
@@ -1,0 +1,52 @@
+.#{$namespace}sakai-oauth-admin{
+
+    .flex-container {
+        display: flex;
+     }
+
+    .configuration {
+        width:60%;	
+    }
+
+    .permissions {
+        width:40%;	
+    }
+
+    fieldset {
+        border-radius: 10px;
+        background: #eee;
+        margin: 20px 10px !important;
+        padding: 16px !important;
+        box-shadow: 0 0 10px rgba(0,0,0,.3);
+        position: relative;
+        border: 2px groove threedface !important;
+        width: 80%;
+    }
+
+    .sectionFieldSet {
+        margin:10px;	
+    }
+
+    input[type=submit] {
+        margin-top: 20px !important;
+    }
+
+    input[type="checkbox"] {
+        margin-right: 5px !important;
+    }
+
+    label {
+        font-weight: normal !important;
+        display: inline !important;
+    }
+
+    .permissions label {
+        cursor: pointer !important;
+    }
+
+    label::after { 
+        content: "\A"; 
+        white-space: pre; 
+    } 
+
+}

--- a/library/src/morpheus-master/sass/tool.scss
+++ b/library/src/morpheus-master/sass/tool.scss
@@ -54,6 +54,7 @@
 @import "modules/tool/roster/roster";
 @import "modules/tool/tagservice/tagservice";
 @import "modules/tool/rubrics/rubrics";
+@import "modules/tool/oauthadmin/oauthadmin";
 @import "modules/tool/authz/authz";
 @import "modules/tool/delegatedaccess/delegatedaccess";
 @import "modules/tool/simplerss/simplerss";

--- a/oauth/tool/src/java/org/sakaiproject/oauth/tool/pages/SakaiPage.java
+++ b/oauth/tool/src/java/org/sakaiproject/oauth/tool/pages/SakaiPage.java
@@ -130,7 +130,6 @@ public abstract class SakaiPage extends WebPage implements IHeaderContributor {
 
         // Tool additions (at end so we can override if required)
         response.render(new MetaDataHeaderItem(MetaDataHeaderItem.META_TAG).addTagAttribute("http-equiv", "Content-Type").addTagAttribute("content", "text/html; charset=UTF-8"));
-        response.render(CssReferenceHeaderItem.forReference(new CssResourceReference(getClass(), "style.css")));
     }
 
     /**

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ConsumerAdministration.html
@@ -32,50 +32,64 @@
     <h3><span wicket:id="consumerName">Consumer name</span></h3>
 
     <form wicket:id="consumerForm" action="post">
-        <h2><wicket:message key="section.settings">Settings</wicket:message></h2>
+      <div class="flex-container">
+        <div class="configuration">
+          <fieldset>
+          <div class="sectionFieldSet">
+            <h2><wicket:message key="section.settings">Settings</wicket:message></h2>
 
-        <div>
-            <label wicket:for="id"><wicket:message key="consumer.id">Unique identifier (consumer's key)</wicket:message></label>
-            <input type="text" id="id" value="consumer's key" wicket:id="id"/>
-        </div>
-        <div>
-            <label wicket:for="name"><wicket:message key="consumer.name">Consumer's name (used for display)</wicket:message></label>
-            <input type="text" id="name" value="consumer's name" wicket:id="name"/>
-        </div>
-        <div>
-            <label wicket:for="description"><wicket:message key="consumer.description">Description</wicket:message></label>
-            <textarea id="description" cols="0" rows="0" wicket:id="description">Consumer's description</textarea>
-        </div>
-        <div>
-            <label wicket:for="url"><wicket:message key="consumer.url">URL (website, homepage)</wicket:message></label>
-            <input type="text" id="url" value="http://www.consumersite.com/" wicket:id="url"/>
-        </div>
-        <div>
-            <label wicket:for="callbackUrl"><wicket:message key="consumer.callbackUrl">Callback URL (used during the authorisation phase)</wicket:message></label>
-            <input type="text" id="callbackUrl" value="http://www.consumersite.com/oauth/callback"
-                   wicket:id="callbackUrl"/>
-        </div>
-        <div>
-            <label wicket:for="secret"><wicket:message key="consumer.secret">Consumer's secret (password), used to sign oauth messages</wicket:message></label>
-            <input type="text" id="secret" value="sEcre7/p@s$W0rd" wicket:id="secret"/>
-        </div>
-        <div>
-            <label wicket:for="accessorSecret"><wicket:message key="consumer.accessorSecret">Accessor's secret</wicket:message></label>
-            <input type="text" id="accessorSecret" value="sEcre7/p@s$W0rd" wicket:id="accessorSecret"/>
-        </div>
-        <div>
-            <label wicket:for="defaultValidity"><wicket:message key="consumer.defaultValidity">Default validity (in minutes)</wicket:message></label>
-            <input type="text" id="defaultValidity" value="42" wicket:id="defaultValidity"/>
+            <div>
+                <label wicket:for="id"><wicket:message key="consumer.id">Unique identifier (consumer's key)</wicket:message></label>
+                <input type="text" id="id" value="consumer's key" wicket:id="id"/>
+            </div>
+            <div>
+                <label wicket:for="name"><wicket:message key="consumer.name">Consumer's name (used for display)</wicket:message></label>
+                <input type="text" id="name" value="consumer's name" wicket:id="name"/>
+            </div>
+            <div>
+                <label wicket:for="description"><wicket:message key="consumer.description">Description</wicket:message></label>
+                <textarea id="description" cols="50" rows="4" wicket:id="description">Consumer's description</textarea>
+            </div>
+            <div>
+                <label wicket:for="url"><wicket:message key="consumer.url">URL (website, homepage)</wicket:message></label>
+                <input type="text" id="url" value="http://www.consumersite.com/" wicket:id="url"/>
+            </div>
+            <div>
+                <label wicket:for="callbackUrl"><wicket:message key="consumer.callbackUrl">Callback URL (used during the authorisation phase)</wicket:message></label>
+                <input type="text" id="callbackUrl" value="http://www.consumersite.com/oauth/callback"
+                       wicket:id="callbackUrl"/>
+            </div>
+            <div>
+                <label wicket:for="secret"><wicket:message key="consumer.secret">Consumer's secret (password), used to sign oauth messages</wicket:message></label>
+                <input type="text" id="secret" value="sEcre7/p@s$W0rd" wicket:id="secret"/>
+            </div>
+            <div>
+                <label wicket:for="accessorSecret"><wicket:message key="consumer.accessorSecret">Accessor's secret</wicket:message></label>
+                <input type="text" id="accessorSecret" value="sEcre7/p@s$W0rd" wicket:id="accessorSecret"/>
+            </div>
+            <div>
+                <label wicket:for="defaultValidity"><wicket:message key="consumer.defaultValidity">Default validity (in minutes)</wicket:message></label>
+                <input type="text" id="defaultValidity" value="42" wicket:id="defaultValidity"/>
+            </div>
+	
+            <input type="submit" value="Save" wicket:message="value:consumer.save"/>
+            </div>
+          </fieldset>
         </div>
 
-        <input type="submit" value="Save" wicket:message="value:consumer.save"/>
-
-        <h2><wicket:message key="section.rights">Rights</wicket:message></h2>
-        <span wicket:id="rights">
-            <input type="checkbox" id="right.name" checked="checked"/><label for="right.name">Right's name</label><br/>
-            <input type="checkbox" id="otherright.name"/><label for="otherright.name">Other right's name</label>
-        </span>
-        <input type="submit" value="Save" wicket:message="value:consumer.save"/>
+        <div class="permissions">
+          <fieldset>
+            <div class="sectionFieldSet">
+              <h2><wicket:message key="section.rights">Rights</wicket:message></h2>
+              <span wicket:id="rights">
+                <input type="checkbox" id="right.name" checked="checked"/><label for="right.name">Right's name</label>
+                <input type="checkbox" id="otherright.name"/><label for="otherright.name">Other right's name</label>
+              </span>
+              <input type="submit" value="Save" wicket:message="value:consumer.save"/>
+           </div>
+          </fieldset>
+        </div>
+      </div>
     </form>
 
 </wicket:extend>

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/admin/pages/ListConsumers.html
@@ -39,7 +39,7 @@
             <a href="#" wicket:id="record"><span wicket:id="recordLink">enable/disable record mode</span></a>
         </div>
     </div>
-    <span class="no-consumer" wicket:id="noConsumer">There is no consumer to administrate</span>
+    <span class="instructions clear" wicket:id="noConsumer">There is no consumer to administrate</span>
 
 </wicket:extend>
 </body>

--- a/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage.html
+++ b/oauth/tool/src/resources/org/sakaiproject/oauth/tool/pages/SakaiPage.html
@@ -29,7 +29,9 @@
 <div class="portletBody">
     <ul class="navIntraTool actionToolbar" role="menu" wicket:enclosure="menu">
         <li role="menuitem" wicket:id="menu">
-            <a wicket:id="menuItem"><span wicket:id="menuItemText">Link Label</span></a>
+            <span>
+              <a wicket:id="menuItem"><span wicket:id="menuItemText">Link Label</span></a>
+            </span>
         </li>
     </ul>
 


### PR DESCRIPTION
Greetings;

I have been working on creating styles for this tool.
I will write down the tasks performed.

In the first place I have eliminated the console error that was produced when trying to load a non-existent file "style.css".
Second, I have formatted the tool's tabs for easier navigation.
And thirdly, I have created styles for the "Add a consumer" view.
I have followed the style of the "Admin Site Perms" tool as it was similar.

The new "css" are in a new file included in the "Library" module; the file is called "_oauthadmin.scss".

Regarding other changes that imply tasks, not styling, in the logic of this tool, another tour ticket can be opened.

Any comment and opinion for improvement will be well received.

Thank you very much.