### PR TITLE
SAK-44520 samigo > dont validate extended time entries on save of quiz

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -55,7 +55,6 @@ import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.PublishRepublishNotificationBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
-import org.sakaiproject.tool.assessment.util.ExtendedTimeValidator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.util.api.FormattedText;
@@ -187,11 +186,6 @@ public class ConfirmPublishAssessmentListener
 		if(!availableLongerThanTimer) {
 			error = true;
 		}
-	}
-
-	boolean extendedTimesValid = new ExtendedTimeValidator().validateEntries( assessmentSettings.getExtendedTimes(), context, assessmentSettings );
-	if(!extendedTimesValid) {
-		error = true;
 	}
 
     // if due date is null we cannot have late submissions

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -74,7 +74,6 @@ import org.sakaiproject.tool.assessment.ui.bean.author.PublishRepublishNotificat
 import org.sakaiproject.tool.assessment.ui.bean.author.PublishedAssessmentSettingsBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
-import org.sakaiproject.tool.assessment.util.ExtendedTimeValidator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.util.ResourceLoader;
@@ -317,11 +316,6 @@ implements ActionListener
 			if(!availableLongerThanTimer) {
 				error = true;
 			}
-		}
-
-		boolean extendedTimesValid = new ExtendedTimeValidator().validateEntries( assessmentSettings.getExtendedTimes(), context, assessmentSettings );
-		if(!extendedTimesValid) {
-			error = true;
 		}
 
 	    // SAM-1088


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44520

Editing a closed quiz with extended time entries to change unrelated settings (feedback, send to gradebook, etc.) is blocked by extended time validation (because the extensions due dates are now in the past).

When I originally developed SAK-43610, I enforce validation in 4 spots:

1. When adding an extended time entry to a draft quiz (validate single entry)
2. When adding an extended time entry to a published quiz (validate single entry)
3. When saving a draft quiz (validate all entries)
4. When saving a published quiz (validate all entries)

Due to the design of the extended time interface, you must click the "save" button for the extension entry before clicking the "save" button of the quiz itself. If you save the quiz before the extension entry, the changes to the entry are thrown away.

So in effect the validation checks at locations 3 and 4 are duplicates and won't catch anything that wasn't already caught in locations 1 and 2. Further, the checks in 3 and 4 are actually causing the bug described in this ticket.

I think it's safe to just remove the checks at locations 3 and 4, and that should resolve the issue here while retaining the necessary extended time validation on saving individual entries.