### PR TITLE
SAK-44527 Lessons Remove findItemsOnPage from QueryResultsCache

### DIFF
--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -197,9 +197,12 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	}
 
 	public List<SimplePageItem> findItemsOnPage(long pageId) {
-	    DetachedCriteria d = DetachedCriteria.forClass(SimplePageItem.class).add(Restrictions.eq("pageId", pageId));
-		List<SimplePageItem> list = (List<SimplePageItem>) getHibernateTemplate().findByCriteria(d);
-		
+		List<SimplePageItem> list = getHibernateTemplate().execute(session -> session.createCriteria(SimplePageItem.class)
+				.setCacheable(false)
+				.add(Restrictions.eq("pageId", pageId))
+				.list()
+		);
+
 		Collections.sort(list, new Comparator<SimplePageItem>() {
 			public int compare(SimplePageItem a, SimplePageItem b) {
 				return Integer.valueOf(a.getSequence()).compareTo(b.getSequence());


### PR DESCRIPTION
This change is only for Sakai 20 and 19 as this is solved in 21 with
Apache Ignite