### PR TITLE
SAK-44530: SAMIGO - Error on points on calculated question when a student doesn't fill some answer

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -728,7 +728,7 @@ public class SubmitToGradingActionListener implements ActionListener {
 						adds.add(itemgrading);
 				    }	
 				}
-				else if (StringUtils.isNotBlank(s)) {
+				else if (s != null) {
 					log.debug("New Itemgrading with AnswerText = {}", s);
 					// Change to allow student submissions in rich-text [SAK-17021]
 					itemgrading.setAnswerText(s);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44530

Problem: If a student doesn't fill some answers on a calculated question, later the matching of student's answers with right answers is wrong

Solution: We need add that blank answers to do a right matching.