### PR TITLE
SAK-44280 T&Qs : Fix MCSC default settings on edit

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
@@ -237,10 +237,13 @@ public class ItemModifyListener implements ActionListener
       bean.setItemDiscount(discount);
 
       // partical credit flag
-      String partialCreditFlag= "FALSE";
+      String partialCreditFlag = "Default";
       Boolean hasPartialCredit = itemfacade.getPartialCreditFlag();
       if (hasPartialCredit != null) {
-    	  partialCreditFlag = hasPartialCredit.toString();
+        partialCreditFlag = hasPartialCredit.toString();
+        if(!itemfacade.getPartialCreditFlag() && itemfacade.getDiscount() == 0) {
+          partialCreditFlag = "Default";
+        }
       } 
       bean.setPartialCreditFlag(partialCreditFlag);
            


### PR DESCRIPTION
The way it's being saved right now, the value can't ever be null. But if it is false with no discount, then it means no option was selected (or the discount would have no effect).
I researched a bit about the possibility of storing an actual null but it could create regression errors and I feel it doesn't make sense for such a specific case.