### PR TITLE
SAK-44578: Error 500 when session timeout

### DIFF
--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/URLUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/URLUtils.java
@@ -78,7 +78,7 @@ public class URLUtils
 
 	public static String getSafePathInfo(HttpServletRequest req)
 	{
-		String pathInfo = req.getPathInfo();
+		String pathInfo = req!=null?req.getPathInfo():null;
 		if ( pathInfo == null ) return null;
 		String newPathInfo = pathInfo;
 		for (int i =0; i < pathInfo.length() - 1; i++) {


### PR DESCRIPTION
A lot of error 500 on the log when session timeout related to message of the day because Request is null