### PR TITLE
SAK-42266 lessons > add open date to assignment links which are not yet open

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/AssignmentEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/AssignmentEntity.java
@@ -270,6 +270,16 @@ public class AssignmentEntity implements LessonEntity, AssignmentInterface {
 	return Date.from(assignment.getDueDate());
     }
 
+	public Date getOpenDate() {
+		if (assignment == null) {
+			assignment = getAssignment(id);
+		}
+		if (assignment == null) {
+			return null;
+		}
+		return Date.from(assignment.getOpenDate());
+	}
+
     // the following methods all take references. So they're in effect static.
     // They ignore the entity from which they're called.
     // The reason for not making them a normal method is that many of the

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -128,6 +128,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.*;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.lessonbuildertool.service.AssignmentEntity;
 
 /**
  * This produces the primary view of the page. It also handles the editing of
@@ -3713,7 +3715,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		return makeLink(container, ID, i, simplePageBean, simplePageToolDao, messageLocator, canEditPage, currentPage, notDone, status, forceButtonColor, color);
 	}
 
-	protected static boolean makeLink(UIContainer container, String ID, SimplePageItem i, SimplePageBean simplePageBean, SimplePageToolDao simplePageToolDao, MessageLocator messageLocator,
+	protected boolean makeLink(UIContainer container, String ID, SimplePageItem i, SimplePageBean simplePageBean, SimplePageToolDao simplePageToolDao, MessageLocator messageLocator,
 									  boolean canEditPage, SimplePage currentPage, boolean notDone, Status status) {
 		return makeLink(container, ID, i, simplePageBean, simplePageToolDao, messageLocator, canEditPage, currentPage, notDone, status, false, null);
 	}
@@ -3727,7 +3729,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 	 * @param simplePageToolDao
 	 * @return Whether or not this item is available.
 	 */
-	protected static boolean makeLink(UIContainer container, String ID, SimplePageItem i, SimplePageBean simplePageBean, SimplePageToolDao simplePageToolDao, MessageLocator messageLocator,
+	protected boolean makeLink(UIContainer container, String ID, SimplePageItem i, SimplePageBean simplePageBean, SimplePageToolDao simplePageToolDao, MessageLocator messageLocator,
 			boolean canEditPage, SimplePage currentPage, boolean notDone, Status status, boolean forceButtonColor, String color) {
 		String URL = "";
 		boolean available = simplePageBean.isItemAvailable(i);
@@ -4004,7 +4006,19 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 
 		if (fake) {
 			ID = ID + "-fake";
-			UIOutput link = UIOutput.make(container, ID, i.getName());
+			String linkText = i.getName();
+			if (i.getType() == SimplePageItem.ASSIGNMENT) {
+				SecurityAdvisor yesMan = (String arg0, String arg1, String agr2) -> SecurityAdvisor.SecurityAdvice.ALLOWED;
+				securityService.pushAdvisor(yesMan);
+				try {
+					AssignmentEntity assignment = (AssignmentEntity) assignmentEntity.getEntity(i.getSakaiId(), simplePageBean);
+					linkText += " " + messageLocator.getMessage("simplepage.assignment.open_date", new Object[] {assignment.getOpenDate()});
+				} catch (Exception ex) {}
+				finally {
+					securityService.popAdvisor(yesMan);
+				}
+			}
+			UIOutput link = UIOutput.make(container, ID, linkText);
 			link.decorate(new UIFreeAttributeDecorator("lessonbuilderitem", itemString));
 			// fake and available occurs when prerequisites aren't the issue (it's avaiable)
 			// so the item must be nonexistent or otherwise unavalable.

--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -475,7 +475,8 @@ simplepage.page.releasedate2=Date release page on the following date (the page w
 simplepage.error=Error
 simplepage.error_colon=Error:
 simplepage.complete_required=Please complete all of the above required items before viewing this item.
-simplepage.not_usable=Item is not available
+simplepage.not_usable=Item is not yet available
+simplepage.assignment.open_date=[Open on: {0}]
 simplepage.prerequisites_tag=Has prerequisites
 
 simplepage.editpermissions=Set permissions for

--- a/lessonbuilder/tool/src/resources/messages_ar.properties
+++ b/lessonbuilder/tool/src/resources/messages_ar.properties
@@ -417,7 +417,6 @@ simplepage.page.releasedate=Hide page until the following date (the page will be
 simplepage.page.releasedate2=Hide page until the following date (the page will be listed with the release date)
 simplepage.error=Error
 simplepage.complete_required=Please complete all of the above required items before viewing this item.
-simplepage.not_usable=Item is not available
 simplepage.prerequisites_tag=Has prerequisites
 
 simplepage.editpermissions=Set permissions for

--- a/lessonbuilder/tool/src/resources/messages_de_DE.properties
+++ b/lessonbuilder/tool/src/resources/messages_de_DE.properties
@@ -380,7 +380,6 @@ simplepage.page.releasedate=Die Seite bis zum n\u00e4chsten Tag ausblenden (die 
 simplepage.page.releasedate2=Element bis zum folgenden Zeitpunkt ausblenden:
 simplepage.error=Fehler
 simplepage.complete_required=Bitte bearbeiten Sie alle oben genannten erforderlichen Elemente, bevor Sie dieses Element anzeigen.
-simplepage.not_usable=Item is not available
 simplepage.prerequisites_tag=Has prerequisites
 simplepage.editpermissions=Berechtigungen festlegen f\u00fcr
 simplepage.ownerpermissions=Unless specifically set on a page-by-page basis in Settings, pages are not owned by individual users.

--- a/lessonbuilder/tool/src/resources/messages_fr_FR.properties
+++ b/lessonbuilder/tool/src/resources/messages_fr_FR.properties
@@ -417,7 +417,6 @@ simplepage.page.releasedate=Hide page until the following date (the page will be
 simplepage.page.releasedate2=Hide page until the following date (the page will be listed with the release date)
 simplepage.error=Erreur
 simplepage.complete_required=Please complete all of the above required items before viewing this item.
-simplepage.not_usable=Item is not available
 simplepage.prerequisites_tag=A des pr\u00e9requis
 
 simplepage.editpermissions=Placer les permissions pour


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42266

If an instructor links an assignment into a lesson, but the assignment is not yet open, the link is grey. There is only a hover tool-tip which says "Item is not available", which can easily be missed or not discovered at all.

Let's add the open date in parenthesis beside the assignment title if it's not open for submission, so that the student quickly understands why they can't click the link.