### PR TITLE
SAK-42265 samigo > improve text of warning confirmation when deleting quizzes

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -187,6 +187,7 @@ samigo_formula_error_402=402: Result is infinity (Infinity)
 samigo_formula_error_500=500: Unknown Error
 
 cert_rem_assmt=Are you sure you want to remove these assessments?
+cert_rem_assmt2=It is not recommended to delete Draft assessments that you plan to edit, export, or reuse in other sites. You cannot export published assessments.
 button_edit_questions=Edit Questions
 button_return_to_main=Return to Main Questions Screen
 cert_rem_q=Are you sure you would like to remove this question?

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex_content.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex_content.jsp
@@ -217,13 +217,15 @@
         function removeSelectedButtonAction() {
             if (!$("#authorIndexForm\\:remove-selected").hasClass("disabled")) {
                 var message = <h:outputText value="'#{authorMessages.cert_rem_assmt}'" />;
+                message += "\n\n";
+                message += <h:outputText value="'#{authorMessages.cert_rem_assmt2}'" />;
                 var elem = document.createElement('div');
                 elem.innerHTML = message;
                 if(!confirm(elem.textContent)) {
                     event.preventDefault();
                     return false;
                 }
-                return true   
+                return true;
             }
         }
     </script>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-42265

There's no warning about the implications of deleting a Draft quiz, namely, that you can't duplicate/export/reuse published copies. 