### PR TITLE
SAK-44598 allow promotion of users to provided despite role matching

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4318,6 +4318,11 @@
 # same role, then the user's site membership should be promoted to provided.
 # DEFAULT: true
 # promoteUsersToProvided@org.sakaiproject.authz.api.AuthzGroupService=false
+# Additional refinement to allow promoting users to their provided role even if non-provided role does not match
+# Example: Teaching Assistant is manually added to site, but is now a provided user as Student. Setting this to 
+# true would move the user from Teaching Assistant to Student
+# DEFAULT: false
+# promoteUsersToProvidedRole@org.sakaiproject.authz.api.AuthzGroupService=true
 
 # Comma separated list of permissions that shouldn't be possessed by roles for site joiner.
 # DEFAULT: site.upd 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -124,6 +124,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 	 * and role to provided
 	 */
 	protected boolean m_promoteUsersToProvided = true;
+	protected boolean m_promoteUsersToProvidedRole = false;
 	private MemoryService m_memoryService;
 	// KNL-600 CACHING for the realm role groups
 	private Cache m_realmRoleGRCache;
@@ -226,6 +227,18 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 	public void setPromoteUsersToProvided(boolean promoteUsersToProvided)
 	{
 		m_promoteUsersToProvided = promoteUsersToProvided;
+	}
+
+	/**
+	 * Configuration: Whether or not to automatically promote non-provided users with same status
+	 * to their provided role
+	 *
+	 * @param promoteUsersToProvidedRole
+	 * 	'true' to promote non-provided users to their provided role, 'false' to maintain their non-provided status or to prevent a role change
+	 */
+	public void setPromoteUsersToProvidedRole(boolean promoteUsersToProvidedRole)
+	{
+		m_promoteUsersToProvidedRole = promoteUsersToProvidedRole;
 	}
 	
 	public void setRefreshTaskInterval(long refreshTaskInterval) {
@@ -333,6 +346,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 	{
 		DbStorage storage = new DbStorage(entityManager(), siteService);
 		storage.setPromoteUsersToProvided(m_promoteUsersToProvided);
+		storage.setPromoteUsersToProvidedRole(m_promoteUsersToProvidedRole);
 		return storage;
 
 	} // newStorage
@@ -750,6 +764,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 		private static final String REALM_USER_GRANTS_CACHE = "REALM_USER_GRANTS_CACHE";
 		private static final String REALM_ROLES_CACHE = "REALM_ROLES_CACHE";
 		private boolean promoteUsersToProvided = true;
+		private boolean promoteUsersToProvidedRole = false;
 		private EntityManager entityManager;
 		private SiteService siteService;
 
@@ -779,6 +794,16 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 		 */
 		public void setPromoteUsersToProvided(boolean promoteUsersToProvided) {
 			this.promoteUsersToProvided = promoteUsersToProvided;
+		}
+
+		/**
+		 * Configure whether or not users with same status will be "promoted" to their provided role.
+		 *
+		 * @param promoteUsersToProvidedRole Whether or not to promote non-provided users to their provided role
+		 * with no consideration of whether the role is identical.
+		 */
+		public void setPromoteUsersToProvidedRole(boolean promoteUsersToProvidedRole) {
+			this.promoteUsersToProvidedRole = promoteUsersToProvidedRole;
 		}
 
 		public boolean check(String id)
@@ -2916,7 +2941,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 						String userEid = userDirectoryService().getUserEid(userId);
 						String targetRole = (String) target.get(userEid);
 
-						if (role.equals(targetRole))
+						if (promoteUsersToProvidedRole || role.equals(targetRole))
 						{
 							// remove from non-provided and add as provided
 							toDelete.add(userId);

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/authz-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/authz-components.xml
@@ -27,6 +27,7 @@
 
  		<property name="autoDdl"><value>${auto.ddl}</value></property>
  		<property name="promoteUsersToProvided"><value>true</value></property>
+ 		<property name="promoteUsersToProvidedRole"><value>false</value></property>
         <property name="databaseBeans">
            <map>
               <entry key="default"><ref bean="org.sakaiproject.authz.impl.DbAuthzGroupSqlDefault"/></entry>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44598

Question for @smarquard : is there a use case for not promoting a user to their proper CMAPI role?

