### PR TITLE
SAK-44602 - embed calendar broken in master

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1262,10 +1262,16 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 			String color = null;
 			for (SimplePageItem i : itemList) {
 				
-				//If the content is not released or is hidden will not be rendered on the page
-				boolean isContentAvailable = contentHostingService.isAvailable(String.valueOf(i.getSakaiId()));
-				if(!isContentAvailable) {
-					continue;
+				switch (i.getType())
+				{
+					case SimplePageItem.RESOURCE:
+					case SimplePageItem.RESOURCE_FOLDER:
+						//If the content is not released or is hidden will not be rendered on the page
+						if (!contentHostingService.isAvailable(String.valueOf(i.getSakaiId())))
+						{
+							continue;
+						}
+					default:
 				}
 				
 				// break is not a normal item. handle it first


### PR DESCRIPTION
Issue introduced in https://github.com/sakaiproject/sakai/pull/8754
Used ContentHostingService to check the availability of all Lesson item types (so this affects more than calendar).