### PR TITLE
SAK-44563 Profile: "Create Worksite" button should not appear

### DIFF
--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/ConfirmedFriends.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/ConfirmedFriends.html
@@ -34,7 +34,6 @@
 
 	<form class="confirmed-friends-button-form" wicket:id="confirmedFriendsButtonForm">
 		<div>
-			<span><input type="submit" wicket:id="createWorksiteButton" value="Create worksite" /></span>
 			<span><input type="submit" wicket:id="searchConnectionsButton" value="Search friends" /></span>
 		</div>
 		<div class="create-worksite" wicket:id="createWorksitePanel"></div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44563

Following the instructions in jira I've removed the "Create worksite" button for any user.