### PR TITLE
SAK-41500 - Lessons - group awareness not working for calendar items

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -3720,7 +3720,7 @@ public class SimplePageBean {
 	       case SimplePageItem.QUESTION:
 	       case SimplePageItem.TWITTER:
 	       case SimplePageItem.STUDENT_CONTENT:
-		   case SimplePageItem.CALENDAR:
+	       case SimplePageItem.CALENDAR:
 		   return getLBItemGroups(i); // for all native LB objects
 	       default:
 	    	   return null;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -3681,7 +3681,8 @@ public class SimplePageBean {
 		         && i.getType() != SimplePageItem.QUESTION
 		         && i.getType() != SimplePageItem.TWITTER
 			 && i.getType() != SimplePageItem.BREAK
-		         && i.getType() != SimplePageItem.STUDENT_CONTENT) {
+		         && i.getType() != SimplePageItem.STUDENT_CONTENT
+		         && i.getType() != SimplePageItem.CALENDAR) {
 	       Object cached = groupCache.get(i.getSakaiId());
 	       if (cached != null) {
 		   if (cached instanceof String)
@@ -3719,6 +3720,7 @@ public class SimplePageBean {
 	       case SimplePageItem.QUESTION:
 	       case SimplePageItem.TWITTER:
 	       case SimplePageItem.STUDENT_CONTENT:
+		   case SimplePageItem.CALENDAR:
 		   return getLBItemGroups(i); // for all native LB objects
 	       default:
 	    	   return null;
@@ -3950,6 +3952,7 @@ public class SimplePageBean {
 	   case SimplePageItem.TWITTER:
 	   case SimplePageItem.QUESTION:
 	   case SimplePageItem.STUDENT_CONTENT:
+	   case SimplePageItem.CALENDAR:
 	       return setLBItemGroups(i, groups);
 	   case SimplePageItem.BREAK:
 	       return null;  // better not actually happen

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -3169,7 +3169,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 							itemGroupTitles = "[" + itemGroupTitles + "]";
 						}
 						if (canEditPage) {
-							UIOutput.make(tableRow, "item-groups", itemGroupString);
+							UIOutput.make(tableRow, "calendar-item-groups", itemGroupString);
 							String name = i.getName()!= null ? i.getName() : "" ;
 							UIOutput.make(tableRow, "calendar-name", name);
 							String description = i.getDescription()!= null ? i.getDescription() : "" ;

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -507,7 +507,7 @@ $(document).ready(function() {
 			$("#customCssClass").val($(".calendar-custom-css-class").text());
 			$("#item-id").val(row.find(".calendar-item-id").text());
 
-			var groups = row.find(".item-groups").text();
+			var groups = row.find(".calendar-item-groups").text();
 			var grouplist = $("#grouplist");
 			if ($('#grouplist input').size() > 0) {
 			    $("#editgroups-student").show();

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -510,11 +510,11 @@ $(document).ready(function() {
 			var groups = row.find(".calendar-item-groups").text();
 			var grouplist = $("#grouplist");
 			if ($('#grouplist input').size() > 0) {
-			    $("#editgroups-student").show();
-			    $("#grouplist").show();
-			    if (groups !== null) {
+				$("#editgroups-student").show();
+				$("#grouplist").show();
+				if (groups !== null) {
 					checkgroups(grouplist, groups);
-			    }
+				}
 			}
 
 			$("#edit-item-error-container").hide();

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -506,6 +506,17 @@ $(document).ready(function() {
 			$("select[name=indent-level-selection]").val($(".calendar-indentLevel").text());
 			$("#customCssClass").val($(".calendar-custom-css-class").text());
 			$("#item-id").val(row.find(".calendar-item-id").text());
+
+			var groups = row.find(".item-groups").text();
+			var grouplist = $("#grouplist");
+			if ($('#grouplist input').size() > 0) {
+			    $("#editgroups-student").show();
+			    $("#grouplist").show();
+			    if (groups !== null) {
+					checkgroups(grouplist, groups);
+			    }
+			}
+
 			$("#edit-item-error-container").hide();
 			$("#edit-item-dialog").dialog('open');
 			setupdialog($("#edit-item-dialog"));

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -630,7 +630,7 @@
                     <div rsf:id="calendarSpan" class="right-col">
                         <div rsf:id="calendar-td" class="edit-col"><div><a href="#" class="usebutton edit-calendar" onclick="return false" rsf:id="edit-calendar"><span aria-hidden="true" class="fa-edit fa-edit-icon"></span></a><a aria-hidden="true" href="#" class="usebutton del-item-link" onclick="return false"><span class="fa-trash-o fa-edit-icon"></span></a><a href="#" class="usebutton add-link" onclick="return false"><span class="fa-plus fa-edit-icon plus-edit-icon"></span></a></div></div>
                         <span style="display:none" rsf:id="calendar-groups-titles" class="item-group-titles"></span>
-                        <span style="display:none" rsf:id="item-groups" class="item-groups"></span>
+                        <span style="display:none" rsf:id="calendar-item-groups" class="calendar-item-groups"></span>
                         <div rsf:id="content" class="textbox"></div>
                         <span style="display:none" rsf:id="calendar-item-id" class="calendar-item-id"></span>
                         <span style="display:none" rsf:id="site-events-url" class="site-events-url"></span>

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -629,7 +629,8 @@
                     <div rsf:id="calendargroup-td" aria-hidden="true" class="group-col"><div><a href="#" class="usebutton" rsf:id="groupcalendar-link"><span rsf:id="groupcalendar-icon"></span></a></div></div>
                     <div rsf:id="calendarSpan" class="right-col">
                         <div rsf:id="calendar-td" class="edit-col"><div><a href="#" class="usebutton edit-calendar" onclick="return false" rsf:id="edit-calendar"><span aria-hidden="true" class="fa-edit fa-edit-icon"></span></a><a aria-hidden="true" href="#" class="usebutton del-item-link" onclick="return false"><span class="fa-trash-o fa-edit-icon"></span></a><a href="#" class="usebutton add-link" onclick="return false"><span class="fa-plus fa-edit-icon plus-edit-icon"></span></a></div></div>
-                        <div rsf:id="calendar-groups-titles" class="item-group-titles"></div>
+                        <span style="display:none" rsf:id="calendar-groups-titles" class="item-group-titles"></span>
+                        <span style="display:none" rsf:id="item-groups" class="item-groups"></span>
                         <div rsf:id="content" class="textbox"></div>
                         <span style="display:none" rsf:id="calendar-item-id" class="calendar-item-id"></span>
                         <span style="display:none" rsf:id="site-events-url" class="site-events-url"></span>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41500

Group awareness within Lessons for embedded calendars does not work.

To replicate:

Create a site with Lessons and Calendar
Create a group in the site
Within Lessons, embed the calendar
Edit the calendar item and select the option to release it to group and save
Edit the calendar item again and you'll see the group option is no longer checked.
Logging in and viewing the Lesson as someone not in the group will still show the embedded calendar.