### PR TITLE
SAK-43378 - Fix CSV reader so event end times are not included

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/CSVReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/CSVReader.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import org.sakaiproject.calendar.impl.GenericCalendarImporter;
 import org.sakaiproject.exception.ImportException;
+import org.sakaiproject.time.api.TimeRange;
 import org.sakaiproject.util.ResourceLoader;
 
 /**
@@ -284,8 +285,9 @@ public class CSVReader extends Reader
 			Duration gapMinutes = Duration.ofMinutes(durationInMinutes);
 			
 			// Time Service will ajust to current user's TZ
-			eventProperties.put(GenericCalendarImporter.ACTUAL_TIMERANGE,
-				getTimeService().newTimeRange(millis, gapMinutes.toMillis()));
+			TimeRange actualTimeRange = getTimeService().newTimeRange(
+					getTimeService().newTime(millis), getTimeService().newTime(millis + gapMinutes.toMillis()), true, false);
+			eventProperties.put(GenericCalendarImporter.ACTUAL_TIMERANGE, actualTimeRange);
 					
 			lineNumber++;
 		}


### PR DESCRIPTION
I'm leaving this as a draft at the moment because I don't love the calls to `getTimeService()` and I also don't love having to use this syntax. This appears to fix the bug though.

I believe the typical intention of an import and also `newTimeRange `is to not have the end time included in the range. It's possible the other imports may also have this problem. 

IcalendarReader, OutlokReader and MeetingMakerReader all use the same version of `newTimeRange`. 