### PR TITLE
SAK-44657 providers > add negative cache

### DIFF
--- a/providers/component/src/webapp/WEB-INF/unboundid-ldap.xml
+++ b/providers/component/src/webapp/WEB-INF/unboundid-ldap.xml
@@ -8,6 +8,7 @@
 		destroy-method="destroy">
 
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+		<property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService"/>
 		
 		<!-- Required. Uses Unboundid SingleServerSet by default. Easy to modify code to use FailoverServerSet or RoundRobinServerSet. -->
 		<property name="ldapHost">

--- a/providers/unboundid/src/java/org/sakaiproject/unboundid/UnboundidDirectoryProvider.java
+++ b/providers/unboundid/src/java/org/sakaiproject/unboundid/UnboundidDirectoryProvider.java
@@ -38,6 +38,7 @@ import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.user.api.AuthenticationIdUDP;
 import org.sakaiproject.user.api.DisplayAdvisorUDP;
 import org.sakaiproject.user.api.ExternalUserSearchUDP;
@@ -65,6 +66,7 @@ import com.unboundid.ldap.sdk.migrate.ldapjdk.LDAPConnection;
 import com.unboundid.ldap.sdk.migrate.ldapjdk.LDAPEntry;
 import com.unboundid.ldap.sdk.migrate.ldapjdk.LDAPException;
 import com.unboundid.util.ssl.SSLUtil;
+import org.sakaiproject.memory.api.Cache;
 
 /**
  * <p>
@@ -79,6 +81,9 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 
 	/** Security Service */
 	@Setter private SecurityService securityService;
+
+	/** Memory Service */
+	@Setter private MemoryService memoryService;
 
 	/** Default LDAP connection port */
 	public static final int[] DEFAULT_LDAP_PORT = {389};
@@ -251,6 +256,9 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 	 */
 	private boolean authenticateWithProviderFirst = DEFAULT_AUTHENTICATE_WITH_PROVIDER_FIRST;
 
+	/** Negative cache */
+	private Cache negativeCache;
+
 	public UnboundidDirectoryProvider() {
 		log.debug("instantating UnboundidDirectoryProvider");
 	}
@@ -273,6 +281,9 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 			batchSize = maxResultSize;
 			log.warn("Unboundid batchSize is larger than maxResultSize, batchSize has been reduced from: "+ batchSize + " to: "+ maxResultSize);
 		}
+
+		// setup the negative user cache
+		negativeCache = memoryService.getCache(getClass().getName() + ".negativeCache");
 
 		createConnectionPool();
 		initLdapAttributeMapper();
@@ -379,6 +390,15 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 	 */
 	public void destroy() {
 		log.debug("destroy()");
+		clearCache();
+	}
+
+	/**
+	 * Resets the internal {@link LdapUserData} cache
+	 */
+	public void clearCache() {
+		log.debug("clearCache()");
+		negativeCache.clear();
 	}
 
 	/**
@@ -568,7 +588,19 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 		}
 
 		try {
-			return getUserByEid(edit, edit.getEid());
+			boolean userFound = getUserByEid(edit, edit.getEid());
+
+			// No LDAPException means we have a good connection. Cache a negative result.
+			if (!userFound) {
+				Object o = negativeCache.get(edit.getEid());
+				Integer seenCount = 0;
+				if (o != null) {
+					seenCount = (Integer) o;
+				}
+				negativeCache.put(edit.getEid(), (seenCount + 1));
+			}
+
+			return userFound;
 		} catch ( LDAPException e ) {
 			log.error("getUser() failed [eid: " + edit.getEid() + "]", e);
 			return false;
@@ -673,6 +705,14 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 			for (UserEdit userRemove : usersToRemove) {
 				log.debug("Unboundid getUsers could not find user: {}", userRemove.getEid());
 				users.remove(userRemove);
+
+				// Add eid to negative cache. We are confident the LDAP conn is alive and well here.
+				Integer seenCount = 0;
+				Object o = negativeCache.get(userRemove.getEid());
+				if (o != null) {
+					seenCount = (Integer) o;
+				}
+				negativeCache.put(userRemove.getEid(), (seenCount + 1));
 			}
 			
 		} catch (LDAPException e)	{
@@ -793,6 +833,18 @@ public class UnboundidDirectoryProvider implements UserDirectoryProvider, LdapCo
 	 *   set, or the result of {@link EidValidator#isSearchableEid(String)}
 	 */
 	protected boolean isSearchableEid(String eid) {
+		if (negativeCache == null) {
+			negativeCache = memoryService.getCache(getClass().getName() + ".negativeCache");
+			log.debug("negativeCache initialized in isSearchableEid");
+		}
+		Object o = negativeCache.get(eid);
+		if (o != null) {
+			Integer seenCount = (Integer) o;
+			log.debug("negativeCache count for {}={}", eid, seenCount);
+			if (seenCount > 3) {
+				return false;
+			}
+		}
 		if ( eidValidator == null ) {
 			return true;
 		}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44657

When a user is deleted in LDAP/AD and not also cleaned up in the Sakai database, Sakai will constantly ask the LDAP provider(s) for the deleted user. It cannot be cached normally, because LDAP doesn't return the user details and thus a `User` object cannot be created for storage in the cache.

This can present performance problems on your LDAP server(s) (and consequently may slow down your Sakai nodes) if Sakai is querying constantly for either a lot of deleted users, or the same deleted users repeatedly. In one such instance, our Sakai instance was bombarding our LDAP server with over 75,000 requests per hour.

One solution to this is that when a user record is deleted in LDAP/AD, it must also be cleaned up in Sakai. However, this may not be an option for some institutions who have data retention policies in effect: they may not be legally allowed to clean up the user data in Sakai for various reasons.

Another more progressive solution is to implement a negative cache in Sakai for the `UserDirectoryProvider`. The way a negative cache works is that if the LDAP provider(s) does not return a result for a particular user, we cache this negative return. If the code recognizes that we've queried for the same user and received a negative result 3 or more times from the provider(s), don't ask the provider(s) for this user again until the TTL (time to live) for the cache expires. In effect, LDAP will only be asked 3 times per TTL per user for deleted accounts, rather than every time.

This code was developed by Sam/Longsight.

Set the cache properties via sakai.properties:

> memory.org.sakaiproject.unboundid.UnboundidDirectoryProvider.negativeCache=timeToLiveSeconds=86400,timeToIdleSeconds=0,maxElementsInMemory=100000

**Note:** 20.x has both Unbound and JLDAP. I'll submit a 2nd PR shortly for 20.x JLDAP negative cache exclusively.