### PR TITLE
SAK-44657 providers > add negative cache (20.x JLDAP)

### DIFF
--- a/providers/component/src/webapp/WEB-INF/jldap-beans.xml
+++ b/providers/component/src/webapp/WEB-INF/jldap-beans.xml
@@ -9,6 +9,10 @@
 		
 		<!-- Setting a MemoryService in JLDAP is deprecated! 
 			Caching is done centrally in the UserDirectoryService.callCache -->
+
+		<property name="memoryService">
+			<ref bean="org.sakaiproject.memory.api.MemoryService"/>
+		</property>
 		
 		<!-- Required. Host name or address of your LDAP server -->
 		<property name="ldapHost">

--- a/providers/jldap/src/test/edu/amc/sakai/user/JLDAPDirectoryProviderTest.java
+++ b/providers/jldap/src/test/edu/amc/sakai/user/JLDAPDirectoryProviderTest.java
@@ -21,20 +21,18 @@
 
 package edu.amc.sakai.user;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Stack;
-
 import org.jmock.Mock;
 import org.jmock.cglib.MockObjectTestCase;
 import org.jmock.core.Invocation;
 import org.jmock.core.Stub;
-import org.sakaiproject.user.api.UserEdit;
 
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
 import com.novell.ldap.LDAPSearchResults;
+
+import org.sakaiproject.memory.mock.MemoryService;
+import org.sakaiproject.user.api.UserEdit;
 
 /**
  * 
@@ -83,6 +81,7 @@ public class JLDAPDirectoryProviderTest extends MockObjectTestCase {
 		searchResults = (LDAPSearchResults) mockSearchResults.proxy();
 		mockEntry = mock(LDAPEntry.class);
 		entry = (LDAPEntry)mockEntry.proxy();
+		provider.setMemoryService(new MemoryService());
 		
 		mockConnManager.expects(once()).method("setConfig").with(same(provider));
 		mockConnManager.expects(once()).method("init");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44657

This is for 20.x exclusively, as JLDAP was removed in 21. See #8802 for more details.