### PR TITLE
SAK-37763 Update points in grading pane of lessons tool

### DIFF
--- a/lessonbuilder/tool/src/webapp/js/commentGrading.js
+++ b/lessonbuilder/tool/src/webapp/js/commentGrading.js
@@ -1,3 +1,8 @@
+var LSNGRD = LSNGRD || {};
+
+LSNGRD.childClass = ".uuidBox";
+LSNGRD.type = "comment";
+
 // CommentsGradingPane is called by ajax from a URL like
 // /lessonbuilder-tool/faces/CommentsGradingPane
 // however URLs we generate need to be the usual
@@ -22,11 +27,7 @@ function fixurls() {
 }
 
 $(function() {
-	makeButtons();
-	
-	$.ajaxSetup ({
-		cache: false
-	});
+	LSNGRD.initButtonsAndPointBoxes();
 	
 	$(".gradingTable").find(".details-row").hide();
 	
@@ -50,7 +51,7 @@ $(function() {
 						var current = $(value);
 						var next = $(value).next().next();
 						
-						makeButtons();
+						LSNGRD.makeButtons();
 						
 						$(current).show();
 						
@@ -76,62 +77,7 @@ $(function() {
 		
 		return false;
 	});
-	
-	$(".pointsBox").each(function(index, value) {
-		$(value).parent().children("img").attr("id", "statusImg" + index);
-		$(value).val($(value).parent().children(".pointsSpan").text());
-	});
-	
-	$(".pointsBox").on('change', function(){
-		var img = $(this).parent().children("img");
-		img.attr("src", getStrippedImgSrc(img.attr("id")) + "no-status.png");
-		$(this).addClass("unsubmitted");
-	});
-	
-	// cr on individual box, update that box
-	$(".pointsBox").keyup(function(event){
-		if(event.keyCode === 13)
-		    updateGrade($(this));
-        });
-
-	// update points button, do all the need it
-	$("#clickToSubmit").click(function(event){
-		updateGrades();
-	});
-
-	$("#zeroMissing").click(function(event){
-		event.preventDefault();
-		$("#zero").click();
-	});
-
-
 });
-
-function updateGrades() {
-    var unsubs = $(".unsubmitted");
-    if (unsubs.length > 0) {
-	// call back when finished submitted this one
-	if (unsubs.length > 1)
-	    setGradingDoneHook(updateGrades);
-	else
-	    setGradingDoneHook(null);	    
-	updateGrade(unsubs.first());
-    }
-}
-
-
-function updateGrade(item) {
-    var img = item.parent().children("img");
-    item.removeClass("unsubmitted");
-    img.attr("src", getStrippedImgSrc(img.attr("id")) + "loading.gif");
-			
-    $(".idField").val(item.parent().children(".uuidBox").text()).change();
-    $(".jsIdField").val(img.attr("id")).change();
-    $(".typeField").val("comment");
-			
-    // This one triggers the update
-    $(".pointsField").val(item.val()).change();
-}
 
 function prefetchComments(value) {
 	// Prefetch the next one as well, so that it's ready when they need it.
@@ -139,15 +85,6 @@ function prefetchComments(value) {
 		var href=$(value).find(".commentsLink").attr("href");
 		var ci = href.indexOf("Comment");
 		href = "/lessonbuilder-tool/faces/" + href.substring(ci);
-		$(value).find(".replaceWithComments").load(href, makeButtons);
-	}
-}
-
-function makeButtons() {
-	if (!(navigator.userAgent.indexOf("Firefox/2.") > 0)) {
-	    $('.usebutton').button({text:true});
-	} else {
-	    // fake it; can't seem to get rid of underline though
-	    $('.usebutton').css('border', '1px solid black').css('padding', '1px 4px').css('color', 'black');
+		$(value).find(".replaceWithComments").load(href, LSNGRD.makeButtons);
 	}
 }

--- a/lessonbuilder/tool/src/webapp/js/comments.js
+++ b/lessonbuilder/tool/src/webapp/js/comments.js
@@ -12,6 +12,11 @@ var fckEditor = false;
 var ckEditor = false;
 var commentsToLoad = 0;
 
+var LSNGRD = LSNGRD || {};
+
+LSNGRD.childClass = ".uuidBox";
+LSNGRD.type = "comment";
+
 $(function() {
 	
 	noEditor = ($(".using-editor").size() === 0);
@@ -95,32 +100,7 @@ function commentsLoaded() {
 	
 	$(".pointsBox").unbind("keyup");
 	
-	$(".pointsBox").each(function(index, value) {
-		$(value).parent().children("img").attr("id", "statusImg" + index);
-		$(value).val($(value).parent().children(".pointsSpan").text());
-	});
-	
-	$(".pointsBox").on('change', function(){
-		var img = $(this).parent().children("img");
-		img.attr("src", getStrippedImgSrc(img.attr("id")) + "no-status.png");
-		$(this).addClass("unsubmitted");
-	});
-	
-	$(".pointsBox").keyup(function(event){
-		if(event.keyCode === 13) {
-			var img = $(this).parent().children("img");
-			
-			$(this).removeClass("unsubmitted");
-			img.attr("src", getStrippedImgSrc(img.attr("id")) + "loading.gif");
-			
-			$(".idField").val($(this).parent().children(".uuidBox").text()).change();
-			$(".jsIdField").val(img.attr("id")).change();
-			$(".typeField").val("comment");
-			
-			// This one triggers the update
-			$(".pointsField").val($(this).val()).change();
-		}
-	});
+	LSNGRD.initPointBoxes();
 }
 
 function loadMore(link) {

--- a/lessonbuilder/tool/src/webapp/js/commonGrading.js
+++ b/lessonbuilder/tool/src/webapp/js/commonGrading.js
@@ -1,0 +1,77 @@
+var LSNGRD = LSNGRD || {};
+
+LSNGRD.initButtonsAndPointBoxes = function() {
+	LSNGRD.makeButtons();
+
+	$.ajaxSetup ({
+		cache: false
+	});
+
+	LSNGRD.initPointBoxes();
+
+	// update points button, do all that need it
+	$("#clickToSubmit").click(function(event){
+		LSNGRD.updateGrades();
+	});
+
+	$("#zeroMissing").click(function(event){
+		event.preventDefault();
+		$("#zero").click();
+	});
+};
+
+LSNGRD.initPointBoxes = function() {
+	$(".pointsBox").each(function(index, value) {
+		$(value).parent().children("img").attr("id", "statusImg" + index);
+		$(value).val($(value).parent().children(".pointsSpan").text());
+	});
+
+	$(".pointsBox").on('change', function(){
+		var img = $(this).parent().children("img");
+		img.attr("src", getStrippedImgSrc(img.attr("id")) + "no-status.png");
+		$(this).addClass("unsubmitted");
+	});
+
+	// cr on individual box, update that box
+	$(".pointsBox").keyup(function(event){
+		if(event.keyCode === 13) {
+			LSNGRD.updateGrade($(this));
+		}
+	});
+};
+
+LSNGRD.updateGrades = function() {
+	var unsubs = $(".unsubmitted");
+	if (unsubs.length > 0) {
+	// call back when finished submitted this one
+	if (unsubs.length > 1)
+		setGradingDoneHook(LSNGRD.updateGrades);
+	else
+		setGradingDoneHook(null);
+	LSNGRD.updateGrade(unsubs.first());
+	}
+};
+
+LSNGRD.updateGrade = function(item) {
+	var img = item.parent().children("img");
+	item.removeClass("unsubmitted");
+	img.attr("src", getStrippedImgSrc(img.attr("id")) + "loading.gif");
+
+	$(".idField").val(item.parent().children(LSNGRD.childClass).text()).change();
+	$(".jsIdField").val(img.attr("id")).change();
+	$(".typeField").val(LSNGRD.type);
+
+	// This one triggers the update
+	$(".pointsField").val(item.val()).change();
+};
+
+LSNGRD.makeButtons = function() {
+	if (!(navigator.userAgent.indexOf("Firefox/2.") > 0)) {
+		$('.usebutton').button({text:true});
+	} else {
+		// fake it; can't seem to get rid of underline though
+		$('.usebutton').css('border', '1px solid black').css('padding', '1px 4px').css('color', 'black');
+	}
+};
+
+

--- a/lessonbuilder/tool/src/webapp/js/questionGrading.js
+++ b/lessonbuilder/tool/src/webapp/js/questionGrading.js
@@ -1,82 +1,8 @@
-// CommentsGradingPane is called by ajax from a URL like
-// /lessonbuilder-tool/faces/CommentsGradingPane
-// however URLs we generate need to be the usual
-// /portal/pda/xxxx/tool/xxxx/ShowPage
-// it's hard to get RSF to generate specified URLs, so
-// we fix them up in javascript.
+var LSNGRD = LSNGRD || {};
 
-function fixurls() {
-    
-    var pageurl = window.location + "";
-    var pi = pageurl.indexOf("/QuestionsGradingPane");
-
-    pageurl = pageurl.substring(0,pi);
-    $('a[target="_lbquestions"]').each(function(index, value) {
-	    var linkurl = $(this).attr('href');
-	    var li = linkurl.indexOf("/faces/") + 6;
-	    if (li >= 0) {
-		linkurl = pageurl + linkurl.substring(li);
-		$(this).attr('href',linkurl);
-	    }
-	});
-}
+LSNGRD.childClass = ".responseId";
+LSNGRD.type = "question";
 
 $(function() {
-	makeButtons();
-	
-	$.ajaxSetup ({
-		cache: false
-	});
-	
-	$(".pointsBox").each(function(index, value) {
-		$(value).parent().children("img").attr("id", "statusImg" + index);
-		$(value).val($(value).parent().children(".pointsSpan").text());
-	});
-	
-	$(".pointsBox").on('change', function(){
-		var img = $(this).parent().children("img");
-		img.attr("src", getStrippedImgSrc(img.attr("id")) + "no-status.png");
-		$(this).addClass("unsubmitted");
-	});
-	
-	// cr on individual box, update that box
-	$(".pointsBox").keyup(function(event){
-		if(event.keyCode === 13)
-		    updateGrade($(this));
-        });
-
-	// update points button, do all the need it
-	$("#clickToSubmit").click(function(event){
-		$(".unsubmitted").each(function(index) {
-			updateGrade($(this));
-		    });
-	});
-
-	$("#zeroMissing").click(function(event){
-		event.preventDefault();
-		$("#zero").click();
-	});
-
+	LSNGRD.initButtonsAndPointBoxes();
 });
-
-function updateGrade(item) {
-    var img = item.parent().children("img");
-    item.removeClass("unsubmitted");
-    img.attr("src", getStrippedImgSrc(img.attr("id")) + "loading.gif");
-			
-    $(".idField").val(item.parent().children(".responseId").text()).change();
-    $(".jsIdField").val(img.attr("id")).change();
-    $(".typeField").val("question");
-			
-    // This one triggers the update
-    $(".pointsField").val(item.val()).change();
-}
-
-function makeButtons() {
-	if (!(navigator.userAgent.indexOf("Firefox/2.") > 0)) {
-	    $('.usebutton').button({text:true});
-	} else {
-	    // fake it; can't seem to get rid of underline though
-	    $('.usebutton').css('border', '1px solid black').css('padding', '1px 4px').css('color', 'black');
-	}
-}

--- a/lessonbuilder/tool/src/webapp/templates/CommentGradingPane.html
+++ b/lessonbuilder/tool/src/webapp/templates/CommentGradingPane.html
@@ -25,6 +25,7 @@
 
 <body rsf:id="scr=sakai-body">
 <script>includeLatestJQuery('CommentGradingPane.html');</script>
+<script type="text/javascript" language="JavaScript" src="../js/commonGrading.js"></script>
 <script type="text/javascript" language="JavaScript" src="../js/commentGrading.js"></script>
 <script type="text/javascript" language="JavaScript" src="../js/gradingAjax.js"></script>
 

--- a/lessonbuilder/tool/src/webapp/templates/QuestionGradingPane.html
+++ b/lessonbuilder/tool/src/webapp/templates/QuestionGradingPane.html
@@ -25,6 +25,7 @@
 
 <body rsf:id="scr=sakai-body">
 <script>includeLatestJQuery('QuestionGradingPane.html');</script>
+<script type="text/javascript" language="JavaScript" src="../js/commonGrading.js"></script>
 <script type="text/javascript" language="JavaScript" src="../js/questionGrading.js"></script>
 <script type="text/javascript" language="JavaScript" src="../js/gradingAjax.js"></script>
 

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -78,6 +78,7 @@
  <script type="text/javascript" src="$context/js/show-page.js"></script>
  <script type="text/javascript" src="$context/js/twitter.js"></script>
  <script type="text/javascript" src="$context/js/announcements.js"></script>
+ <script type="text/javascript" src="$context/js/commonGrading.js"></script>
  <script type="text/javascript" src="$context/js/gradingAjax.js"></script>
  <script type="text/javascript" src="$context/js/checklistDisplay.js"></script>
  <script type="text/javascript" src="$context/js/forum-summary.js"></script>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-37763

If there are numerous students in the site, only the first and last student grades are updated when pressing "Update Points".

The root cause of the issue is that multiple RSF AJAX calls are being made at the same time and after the first one, the rest get queued. However, the queue can only hold one item so any additional requests added to it will overwrite the previous one. This results in only the first and last requests being sent to the server.

This issue was identified and fixed for comment grading many years ago. Because the logic for doing grading was copied and pasted between the comment grading and question grading, the problem existed in two places but was only fixed in one.

This PR applies the comment grading fix to the question grading, but is mostly about removing the duplication that resulted in the issue being missed in the first place.