### PR TITLE
SAK-44674 lessons > non-null, blank width or height causes Fatal Internal Error on student pages

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1960,16 +1960,16 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 
 					if (mmDisplayType == null && simplePageBean.isImageType(i)) {
 						// a wide default for images would produce completely wrong effect
-					    	if (widthSt != null && !widthSt.equals("")) 
+					    	if (StringUtils.isNotBlank(widthSt))
 						    width = new Length(widthSt);
-					} else if (widthSt == null || widthSt.equals("")) {
+					} else if (StringUtils.isBlank(widthSt)) {
 						width = new Length(DEFAULT_WIDTH);
 					} else {
 						width = new Length(widthSt);
 					}
 
 					Length height = null;
-					if (i.getHeight() != null) {
+					if (StringUtils.isNotBlank(i.getHeight())) {
 						height = new Length(i.getHeight());
 					}
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44674

Steps to reproduce not identified. We saw an instance in our production environment where an item on a student page had a non-null, blank string (" ") for the width field. Given the following code, it presents opportunities for a `NumberFormatException` when parsing the blank String to a `Double`.

```
					String widthSt = i.getWidth();
					Length width = null;

					if (mmDisplayType == null && simplePageBean.isImageType(i)) {
						// a wide default for images would produce completely wrong effect
					    	if (widthSt != null && !widthSt.equals("")) 
						    width = new Length(widthSt);
					} else if (widthSt == null || widthSt.equals("")) {
						width = new Length(DEFAULT_WIDTH);
					} else {
						width = new Length(widthSt);
					}
...
...
...
                Double h = new Double(width.getOld()) * 0.75;
```

Simple solution is to use `StringUtils.isBlank()` and `StringUtils.isNotBlank()` where appropriate, rather than explicitly checking for `null` and `""`.