### PR TITLE
SAK-44562 library / portal - ckeditor support dark theme

### DIFF
--- a/library/src/morpheus-master/sass/_defaults.scss
+++ b/library/src/morpheus-master/sass/_defaults.scss
@@ -258,10 +258,11 @@ $active-transition-hover: box-shadow 100ms ease-out !default;
 $active-transition-active: box-shadow 100ms ease-in !default;
 
 :root {
-/* topNav Main Menu */
---header-size: 50px;
+    /* topNav Main Menu */
+    --header-size: 50px;
 
-//Dashboard
---sakai-course-card-border-radius: $button-radius;
---sakai-title-bar-font-weight: $button-font-weight;
+    //Dashboard
+    --sakai-course-card-border-radius: $button-radius;
+    --sakai-title-bar-font-weight: $button-font-weight;
+    --sakai-font-family: #{$font-family};
 }

--- a/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/library/src/morpheus-master/sass/base/_defaults.scss
@@ -257,7 +257,3 @@ span.marker {
     margin: 0;
   }
 }
-html {
-    --sakai-font-family: roboto, arial, sans-serif;
-    --sakai-table-even-color: #f4f4f4;
-}

--- a/library/src/morpheus-master/sass/modules/connection-manager/_base.scss
+++ b/library/src/morpheus-master/sass/modules/connection-manager/_base.scss
@@ -334,8 +334,3 @@
 		height: 375px;
   }
 }
-
-.modal-backdrop {
-  background-color: #FFFFFF !important;
-  opacity: 0.4 !important;
-}

--- a/library/src/morpheus-master/sass/modules/editor/_base.scss
+++ b/library/src/morpheus-master/sass/modules/editor/_base.scss
@@ -13,6 +13,11 @@
 		max-width: 1200px;
 	}
 
+	.modal-content {
+		color: var(--sakai-text-color-1);
+		background: var(--sakai-background-color-1);
+	}
+
 	.sakaipreview-print {
 		@extend .fa;
 		@extend .fa-print;
@@ -32,6 +37,25 @@
 }
 .cke_dialog_contents_body .cke_tpl_list {
 	height: 430px !important;
+	background: var(--sakai-background-color-1);
+	border-color: var(--sakai-border-color);
+
+	.cke_tpl_item {
+		border-color: var(--sakai-border-color);
+		color: var(--sakai-text-color-1);
+	}
+
+	a:focus,
+	a:hover,
+	a:active {
+		.cke_tpl_item {
+			border-color: var(--sakai-border-color);
+			background: var(--sakai-background-color-2);
+		}
+	}
+}
+.cke_dialog_body .cke_dialog_close_button {
+	filter: var(--sakai-image-invert);
 }
 .cke_tpl_preview .cke_tpl_preview_img {
 	width: 50px !important;
@@ -46,7 +70,6 @@
 		text-align: center;
 	}
 }
-
 .cke_dialog_container {
 	z-index: 100010 !important;
 }

--- a/library/src/morpheus-master/sass/properties.scss
+++ b/library/src/morpheus-master/sass/properties.scss
@@ -1,0 +1,8 @@
+// This file should only include rules that output CSS Custom Properties
+// It is used in ckeditor. If you add themes to tool.css, add them here as well
+
+@import "themes/base";
+
+@import "themes/light";
+@import "themes/dark";
+@import "themes/custom";

--- a/library/src/morpheus-master/sass/themes/_custom.scss
+++ b/library/src/morpheus-master/sass/themes/_custom.scss
@@ -1,4 +1,4 @@
-/* Custom Theme */
+// Custom Theme
 
 :root {
     /////////////////////////////////////////////////////////////
@@ -31,7 +31,7 @@
     // More info about defineColorHSL in sass/themes/_base.scss
 
     // Uncomment below to define a custom color
-    // @include defineColorHSL(--custom, 183, 56%, 25%);
+    // @include defineColorHSL(--custom, 173, 46%, 35%);
 
     /////////////////////////////////////////////////////////////
 
@@ -47,34 +47,34 @@
     // Used in the top header, action buttons, etc. Commonly used as the background
     // color with white text color.
     // Uncomment below to set --sakai-primary-color-1
-    // --sakai-primary-color-1:var(--custom-6);
+    // --sakai-primary-color-1:var(--custom);
 
     // Default: A slightly darker shade of --sakai-primary-color-1
     // Used for hover effects and higher contrast with white text color
     // Uncomment below to set --sakai-primary-color-2
-    // --sakai-primary-color-2: var(--custom-7);
+    // --sakai-primary-color-2: var(--custom--darker-2);
 
     // Default: A slightly darker shade of --sakai-primary-color-2
     // Used for active, focus, selected effects
     // Uncomment below to set --sakai-primary-color-3
-    // --sakai-primary-color-3: var(--custom-8);
+    // --sakai-primary-color-3: var(--custom--darker-3);
 
     // Default: A very light tint of --sakai-primary-color-1. 
     // Suggested: A light tint of your institution's main branding color.
     // Used to highlight active/current site in favorites and active/current tool in toolmenu
     // Commonly used with white background color with white text color.
     // Uncomment below to set --sakai-active-color-1
-    // --sakai-active-color-1: var(--custom-1);
+    // --sakai-active-color-1: var(--custom--lighter-5);
 
     // Default: A slightly darker shade of --sakai-active-color-1
     // Used for hover effects and higher contrast with --sakai-text-color-3
     // Uncomment below to set --sakai-active-color-2
-    // --sakai-active-color-2: var(--custom-2);
+    // --sakai-active-color-2: var(--custom--lighter-5);
 
     // Default: A slightly darker shade of --sakai-active-color-2
     // Used for active, focus, selected effects with --sakai-text-color-3
     // Uncomment below to set --sakai-active-color-3
-    // --sakai-active-color-3: var(--custom-3);
+    // --sakai-active-color-3: var(--custom--lighter-4);
 
     // Primary background color. 
     // Suggested: white
@@ -103,7 +103,7 @@
     // what you select for --sakai-primary-color-1
     // Used in new user tutorial, user profile image border
     // Uncomment below to set --sakai-secondary-color-1
-    // --sakai-secondary-color-1: var(--custom-2);
+    // --sakai-secondary-color-1: var(--custom--darker-2);
 
     // Tertiary branding color. 
     // Suggested: A third branding color distinct from
@@ -131,7 +131,7 @@
     // Default: A much darker shade of --sakai-primary-color-1
     // Used as text color of active site in favorites, active tool in toolmenu
     // Uncomment below to set --sakai-text-color-3
-    // --sakai-text-color-3: var(--custom-9);
+    // --sakai-text-color-3: var(--custom--darker-3);
 
     // Default: A lighter shade of --sakai-text-color-1
     // Used to make elements appear disabled or "grayed out"

--- a/library/src/morpheus-master/sass/themes/_dark.scss
+++ b/library/src/morpheus-master/sass/themes/_dark.scss
@@ -131,6 +131,9 @@
 
     /////////////////////End main theme definition/////////////////////
 
+    // Additional dark mode variables
+    --sakai-image-invert: grayscale(100%) invert(100%);
+
     // Overrides _light.scss variables when necessary
     --top-header-background: var(--sakai-background-color-1);
     --breadcrumbs-tool-color: var(--sakai-text-color-color-3);

--- a/library/src/webapp-filtered/editor/ckeditor.css
+++ b/library/src/webapp-filtered/editor/ckeditor.css
@@ -1,0 +1,21 @@
+html,
+body.cke_editable {
+    background: var(--sakai-background-color-1);
+    color: var(--sakai-text-color-1);
+}
+
+caption {
+    color: var(--sakai-text-color-2);
+}
+
+.table th {
+    background-color: var(--sakai-active-color-1);
+}
+
+.table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: var(--sakai-background-color-2);
+}
+
+.table-hover > tbody > tr:hover {
+    background-color: var(--sakai-background-color-3);
+}

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -124,8 +124,8 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
             "attemptsRemaining": Number.MAX_VALUE
         },
         skin: 'moono-lisa',
+        uiColor: 'themeswitcher',
         defaultLanguage: 'en',
-        
         // SAK-31829, SAK-33279 Disable functionality in table plugin
         //https://docs.ckeditor.com/#!/guide/dev_disallowed_content-section-how-to-allow-everything-except...
         allowedContent: {
@@ -228,7 +228,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         //SAK-29598 - Add more templates to CK Editor
         templates_files: [basePath+"templates/default.js"],
         templates: 'customtemplates',
-        templates_replaceContent: false
+        templates_replaceContent: false,
     };
 
     // Merge config values into ckconfig
@@ -301,15 +301,265 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         //If the siteskin is defined, add the print.css
         if (sakai.editor.sitePrintSkin) {
             ckconfig.contentsCss.push(sakai.editor.sitePrintSkin);
-        } 
+        }
         CKEDITOR.dtd.$removeEmpty.span = false;
         CKEDITOR.dtd.$removeEmpty['i'] = false;
         //Add greek special characters to set
         ckconfig.specialChars = CKEDITOR.config.specialChars.concat([ ["&alpha;","alpha"],["&beta;","beta"],["&gamma;","gamma"],["&delta;","delta"],["&epsilon;","epsilon"],["&zeta;","zeta"],["&eta;","eta"],["&theta;","theta"], ["&iota;","iota"],["&kappa;","kappa"],["&lambda;","lambda"],["&mu;","mu"],["&nu;","nu"],["&xi;","xi"],["&omicron;","omnicron"],["&pi;","pi"],["&rho;","rho"],["&sigma;","sigma"],["&tau;","tau"],["&upsilon;","upsilon"], ["&phi;","phi"],["&chi;","chi"],["&psi;","psi"],["&omega;","omega"],["&Alpha;","Alpha"],["&Beta;","Beta"],["&Gamma;","Gamma"],["&Delta;","Delta"],["&Epsilon;","Epsilon"],["&Zeta;","Zeta"],["&Eta;","Eta"],["&Theta;","Theta"], ["&Iota;","Iota"],["&Kappa;","Kappa"],["&Lambda;","Lambda"],["&Mu;","Mu"],["&Nu;","Nu"],["&Xi;","Xi"],["&Omicron;","Omnicron"],["&Pi;","Pi"],["&Rho;","Rho"],["&Sigma;","Sigma"],["&Tau;","Tau"],["&Upsilon;","Upsilon"], ["&Phi;","Phi"],["&Chi;","Chi"],["&Psi;","Psi"],["&Omega;","Omega"] ]);
 
+        //SAK-44562 Dark Mode
+        //Add styles to the content in CKeditor
+        if (sakai.editor.sitePropertiesSkin) {
+            ckconfig.contentsCss.push(sakai.editor.sitePropertiesSkin);
+            ckconfig.contentsCss.push('/library/editor/ckeditor.css');
+        }
+        //CKEditor doesn't have a method to add classes to the HTML element
+        //so we manually add the class on load and when exiting source mode
+        CKEDITOR.on('instanceLoaded', function(editor){
+            if (document.firstElementChild.classList.contains('sakai-dark-theme')){
+                if (typeof editor.editor.document.$ !== 'undefined'){
+                    editor.editor.document.$.firstElementChild.classList.add('sakai-dark-theme');
+                }
+                editor.editor.on('afterCommandExec', function(evt){
+                    if (evt.data.name === 'source'
+                        && typeof evt.editor.document !== 'undefined'
+                        && typeof evt.editor.document.$ !== 'undefined') {
+                            evt.editor.document.$.firstElementChild.classList.add('sakai-dark-theme');
+                    }
+                })
+            }
+        });
+
+        //Enable ckeditor to reflect themeswitcher changes. Overrides:
+        //https://github.com/ckeditor/ckeditor4/blob/a786d6f43c17ef90c13b1cf001dbd00204a622b1/skins/moono-lisa/skin.js
+        CKEDITOR.skin.chameleon = ( function() {
+
+        templates = {
+            editor: new CKEDITOR.template(
+                `.cke_reset_all, .cke_reset_all *, .cke_reset_all a, .cke_reset_all textarea [
+                    color:{defaultTextColor};
+                ]
+                {id}.cke_chrome [
+                    color:{defaultTextColor};
+                    border-color:{defaultBorder};
+                ]
+                {id} .cke_top [ 
+                    background-color:{defaultBackground};
+                    border-bottom-color:{defaultBorder};
+                ] 
+                {id} .cke_bottom [
+                    background-color:{defaultBackground};
+                    border-top-color:{defaultBorder};
+                ] 
+                {id} .cke_resizer [
+                    border-right-color:{ckeResizer}
+                ] 
+                {id} .cke_wysiwyg_frame,
+                {id} .cke_wysiwyg_div [
+                    background:{defaultBackground}
+                ] 
+                {id} textarea.cke_source [
+                    background-color: {lightBackground};
+                    color: {defaultTextColor};
+                ]` +
+                // Dialogs.
+                `{id} .cke_dialog_title [
+                    color:{defaultTextColor};
+                    background-color:{defaultBackground};
+                    border-bottom-color:{defaultBorder};
+                ] 
+                {id} .cke_dialog_footer [
+                    color:{defaultTextColor};
+                    background-color:{defaultBackground};
+                    outline-color:{defaultBorder};
+                ] 
+                {id} .cke_dialog_tab [
+                    color:{defaultTextColor};
+                    background-color:{dialogTab};
+                    border-color:{defaultBorder};
+                ] 
+                {id} .cke_dialog_tab:hover, {id} .cke_dialog_tab_selected:hover [
+                    color:{menubuttonTextHover};
+                    background-color:{lightBackground};
+                ] 
+                {id} .cke_dialog_contents [
+                    color:{defaultTextColor};
+                    background-color:{lightBackground};
+                    border-top-color:{defaultBorder};
+                ] 
+                {id} .cke_dialog_tab_selected [
+                    color:{defaultTextColor};
+                    background:{dialogTabSelected};
+                    border-bottom-color:{dialogTabSelectedBorder};
+                ] 
+                {id} .cke_dialog_body [
+                    color:{defaultTextColor};
+                    background:{dialogBody};
+                    border-color:{defaultBorder};
+                ] 
+                .cke_dialog a.cke_dialog_ui_button [
+                    background:{menubutton};
+                    color: {menubuttonIcon};
+                ] 
+                .cke_dialog a.cke_dialog_ui_button:hover [
+                    background:{menubuttonHover};
+                    color:{menubuttonTextHover};
+                ] 
+                .cke_dialog a.cke_dialog_ui_button.cke_dialog_ui_button_ok [
+                    background:{okBackground};
+                    border-color:{okBorderColor};
+                    color: {okColor};
+                ] 
+                {id} input.cke_dialog_ui_input_text, {id} input.cke_dialog_ui_input_password, {id} input.cke_dialog_ui_input_tel, {id} textarea.cke_dialog_ui_input_textarea, {id} select.cke_dialog_ui_input_select [
+                    background:{dialogBody};
+                    border-color:{defaultBorder};
+                    color:{defaultTextColor};
+                ]` +
+                // Toolbars, buttons.
+                `{id} a.cke_button .cke_button_icon [
+                    filter: {invertIfDarkMode}
+                ]
+                {id} a.cke_button_off:hover,
+                {id} a.cke_button_off:focus,
+                {id} a.cke_button_off:active [
+                    background-color:{darkBackground};
+                    border-color:{toolbarElementsBorder};
+                    color:{defaultTextColor};
+                ] 
+                {id} .cke_button_label,
+                {id} a.cke_button_off:hover .cke_button_label,
+                {id} a.cke_button_off:focus .cke_button_label,
+                {id} a.cke_button_off:active .cke_button_label [
+                    color:{defaultTextColor};
+                ] 
+                {id} .cke_button_on [
+                    background-color:{ckeButtonOn};
+                    border-color:{toolbarElementsBorder};
+                ] 
+                {id} .cke_toolbar_separator,
+                {id} .cke_toolgroup a.cke_button:last-child:after,
+                {id} .cke_toolgroup a.cke_button.cke_button_disabled:hover:last-child:after [
+                    background-color: {toolbarElementsBorder};
+                    border-color: {toolbarElementsBorder};
+                ] 
+                {id} .cke_button_arrow [
+                    border--top-color: {toolbarElementsBorder};
+                ]` +
+                // Combo buttons.
+                `{id} a.cke_combo_button:hover,
+                {id} a.cke_combo_button:focus,
+                {id} .cke_combo_on a.cke_combo_button [
+                    border-color:{toolbarElementsBorder};
+                    color:{menubuttonTextHover};
+                    background-color:{darkBackground};
+                ] 
+                {id} .cke_combo_arrow,
+                {id} .cke_combo:after [
+                    border-top-color:{defaultTextColor};
+                ] 
+                {id} .cke_combo_text [
+                    color:{defaultTextColor};
+                ]`+
+                // Elementspath.
+                `{id} .cke_path_item [
+                    color:{elementsPathColor};
+                ] 
+                {id} a.cke_path_item:hover,
+                {id} a.cke_path_item:focus,
+                {id} a.cke_path_item:active [
+                    color:{menubuttonTextHover};
+                    background-color:{darkBackground};
+                ] 
+                {id}.cke_panel [
+                    border-color:{defaultBorder};
+                ]`
+            ),
+            panel: new CKEDITOR.template(
+                // Context menus.
+                `.cke_menubutton_icon [
+                    background-color:{menubuttonIcon};
+                ] 
+                .cke_menubutton:hover,
+                .cke_menubutton:focus,
+                .cke_menubutton:active [
+                    color:{menubuttonTextHover};
+                    background-color:{menubuttonHover};
+                ] 
+                .cke_menubutton:hover .cke_menubutton_icon, 
+                .cke_menubutton:focus .cke_menubutton_icon, 
+                .cke_menubutton:active .cke_menubutton_icon [
+                    color:{menubuttonTextHover};
+                    background-color:{menubuttonIconHover};
+                ] 
+                .cke_menubutton_disabled:hover .cke_menubutton_icon,
+                .cke_menubutton_disabled:focus .cke_menubutton_icon,
+                .cke_menubutton_disabled:active .cke_menubutton_icon [
+                    background-color:{menubuttonIcon};
+                ] 
+                .cke_menuseparator [
+                    background-color:{menubuttonIcon};
+                ] ` +
+                // Color boxes.
+                `a:hover.cke_colorbox, 
+                a:active.cke_colorbox [
+                    border-color:{defaultBorder};
+                ] 
+                a:hover.cke_colorauto, 
+                a:hover.cke_colormore, 
+                a:active.cke_colorauto, 
+                a:active.cke_colormore [
+                    background-color:{ckeColorauto};
+                    border-color:{defaultBorder};
+                ] `
+            )
+        };
+            return function( editor, part ) {
+                // CKEditor instances have a unique ID, which is used as class name into
+                // the outer container of the editor UI (e.g. ".cke_1").
+                //
+                // The Chameleon feature is available for each CKEditor instance,
+                // independently. Because of this, we need to prefix all CSS selectors with
+                // the unique class name of the instance.
+                uiColor = getComputedStyle(document.firstElementChild);
+                templateStyles = {
+                id: '.' + editor.id,
+                invertIfDarkMode: (document.firstElementChild.classList.contains('sakai-dark-theme')) ? uiColor.getPropertyValue("--sakai-image-invert") : '',
+                // These styles are used by various UI elements.
+                defaultBorder: uiColor.getPropertyValue("--sakai-border-color"),
+                toolbarElementsBorder: uiColor.getPropertyValue("--sakai-border-color"),
+                defaultBackground: uiColor.getPropertyValue("--sakai-background-color-2"),
+                lightBackground: uiColor.getPropertyValue("--sakai-background-color-1"),
+                darkBackground: uiColor.getPropertyValue("--sakai-background-color-3"),
+                defaultTextColor: uiColor.getPropertyValue("--sakai-text-color-1"),
+
+                // These are for specific UI elements.
+                ckeButtonColor: uiColor.getPropertyValue("--sakai-text-color-1"),
+                ckeButtonOn: uiColor.getPropertyValue("--sakai-active-color-1"),
+                ckeResizer: uiColor.getPropertyValue("--sakai-text-color-1"),
+                ckeColorauto: uiColor.getPropertyValue("--sakai-background-color-3"),
+                dialogBody: uiColor.getPropertyValue("--sakai-background-color-2"),
+                dialogTab: uiColor.getPropertyValue("--sakai-background-color-2"),
+                dialogTabSelected: uiColor.getPropertyValue("--sakai-active-color-1"),
+                dialogTabSelectedBorder: uiColor.getPropertyValue("--sakai-border-color"),
+                elementsPathColor: uiColor.getPropertyValue("--sakai-text-color-1"),
+                menubutton: uiColor.getPropertyValue("--button-background"),
+                menubuttonHover: uiColor.getPropertyValue("--button-hover-background"),
+                menubuttonTextHover: uiColor.getPropertyValue("--button-hover-text-color"),
+                menubuttonIcon: uiColor.getPropertyValue("--button-text-color"),
+                menubuttonIconHover: uiColor.getPropertyValue("--button-hover-background"),
+                okBackground: uiColor.getPropertyValue("--sakai-color-green--darker-3"),
+                okBorderColor: uiColor.getPropertyValue("--sakai-color-green--darker-4"),
+                okColor: uiColor.getPropertyValue("--sakai-color-green--lighter-7"),
+                }
+                return templates[ part ]
+                    .output(templateStyles)
+                    .replace( /\[/g, '{' )// Replace brackets with braces.
+                    .replace( /\]/g, '}' );
+            };
+        } )();
     })();
 
-	  CKEDITOR.replace(targetId, ckconfig);
+      CKEDITOR.replace(targetId, ckconfig);
       //SAK-22505
       CKEDITOR.on('dialogDefinition', function(e) {
           // Take the dialog name and its definition from the event
@@ -341,7 +591,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
           }
 
       });
+
 }
 
 sakai.editor.launch = sakai.editor.editors.ckeditor.launch;
-

--- a/library/src/webapp/editor/ckextraplugins/sakaipreview/plugin.js
+++ b/library/src/webapp/editor/ckextraplugins/sakaipreview/plugin.js
@@ -85,7 +85,9 @@
 
 
         function getPreviewContentHTML(contentToPreview) {
-            return editor.config.docType + '<html dir="' + editor.config.contentsLangDirection + '">' +
+            let darkThemeEnabled = document.firstElementChild.classList.contains('sakai-dark-theme') ? 'sakai-dark-theme' : '';
+
+            return editor.config.docType + '<html dir="' + editor.config.contentsLangDirection + '" class="' + darkThemeEnabled + '">' +
                     '<head>' +
                         baseTag +
                         '<title>' + editor.lang.sakaipreview.preview + '</title>' +

--- a/library/src/webapp/editor/ckextraplugins/templates/default.js
+++ b/library/src/webapp/editor/ckextraplugins/templates/default.js
@@ -4,58 +4,247 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 */
 CKEDITOR.addTemplates('customtemplates', {imagesPath: CKEDITOR.getUrl(CKEDITOR.basePath.substr(0, CKEDITOR.basePath.indexOf("ckeditor/"))+"../editor/ckextraplugins/" + 'templates/images/'), templates: [
         {
-            title:'<span class="fa fa-id-card template-icon" style="color:#3177b5;"></span>Instructor Insight Panel',
+            title:'<span class="fa fa-id-card template-icon" style="color:var(--sakai-color-blue--lighter-2);"></span>Instructor Insight Panel',
             description:'Panel box with photo where you can share a personal message.',
-            html:'<style type="text/css">*.panel-insight-speaker { display: block; max-width: 130.0px; max-height: 130.0px; width: auto; height: auto; margin-right: 10.0px; float: left; } *.panel-insight-title { margin: 0 0 0 0; } </style> <div class="panel panel-primary"> <div class="panel-heading"> <h3 class="panel-insight-title">Professor Last Name&#39;s Insight</h3>  <p>Subtitle</p> </div>  <div class="panel-body"><img alt="Instructors Photo" class="panel-insight-speaker" src="/library/image/genericProf.png" /><span class="fa fa-quote-left"></span> Replace this text, the title, the subtitle, and the picture to create a personal message you would like to communicate to your students. It should be no more than a short paragraph or two. An image size of <b>130px x 130px</b> would fit best with this template.<span class="fa fa-quote-right"></span><span></span></div>  <div class="panel-body"><em>Here&#39;s an extra bit of instruction can can optionally add.</em></div> </div>'
+            html:`
+                <style type="text/css">
+                    *.panel-insight-speaker { 
+                        display: block; 
+                        max-width: 130.0px; 
+                        max-height: 130.0px; 
+                        width: auto; 
+                        height: auto; 
+                        margin-right: 10.0px; 
+                        float: left;
+                    } 
+                    *.panel-insight-title { 
+                        margin: 0 0 0 0; 
+                    } 
+                </style> 
+                <div class="panel">
+                    <div class="panel-heading sakai-colorize--sakai-color-blue--lighter-4">
+                        <h3 class="panel-insight-title">Professor Last Name&#39;s Insight</h3>
+                        <p>Subtitle</p>
+                    </div>
+                    <div class="panel-body sakai-colorize--sakai-color-gray--lighter-7">
+                        <img alt="Instructors Photo" class="panel-insight-speaker" src="/library/image/genericProf.png" />
+                        <span class="fa fa-quote-left"></span> Replace this text, the title, the subtitle, and the picture to create a personal message you would like to communicate to your students. It should be no more than a short paragraph or two. An image size of <b>130px x 130px</b> would fit best with this template.<span class="fa fa-quote-right"></span>
+                        <span></span>
+                    </div>
+                    <div class="panel-body sakai-colorize--sakai-color-gray--lighter-7"><em>Here&#39;s an extra bit of instruction can can optionally add.</em></div>
+                </div>
+                `
         },
         {
-            title:'<span class="fa fa-comment template-icon" style="color:#90b193;"></span>Instructor Insight Conversation',
+            title:'<span class="fa fa-comment template-icon" style="color:var(--sakai-color-green--lighter-2);"></span>Instructor Insight Conversation',
             description:'Text message styled box with photo on the left.',
-            html:'<style type="text/css">*.insight-section ul li { list-style: none; margin-top: 10.0px; } *.insight-section ul { padding: 0.0px; } *.left-insight img, *.right-insight img { width: 70.0px; height: 70.0px; float: left; margin: 0.0px 5.0px; border-radius: 50.0%; } *.right-insight img { float: right; } *.left-insight, *.right-insight { overflow: hidden; } *.left-insight p, *.right-insight p { background-color: rgb(200,230,201); padding: 10.0px; color: black; border-radius: 5.0px; float: left; width: 60.0%; margin-bottom: 20.0px; margin-left: 0.0px; } *.right-insight p { float: right; background-color: rgb(153,194,255); color: black; margin-right: 2.0px; } </style> <div class="insight-section"> <ul> <li> <div class="left-insight"><img alt="Instructor speaking" src="/library/image/genericProf.png" /> <p>Replace this text and photo to create a casual personal message you would like to communicate to your students. It should be no more than a short paragraph or two. An image size of <b>70px x 70px</b> would fit best with this template.</p> </div> </li> </ul> </div>'
+            html:`
+                <style type="text/css">
+                    *.insight-section ul li {
+                        list-style: none;
+                        margin-top: 10.0px;
+                    }
+                    *.insight-section ul {
+                        padding: 0.0px;
+                    }
+                    *.left-insight img,
+                    *.right-insight img {
+                        width: 70.0px;
+                        height: 70.0px;
+                        float: left;
+                        margin: 0.0px 5.0px;
+                        border-radius: 50.0%;
+                    }
+                    *.right-insight img {
+                        float: right;
+                    }
+                    *.left-insight,
+                    *.right-insight {
+                        overflow: hidden;
+                    }
+                    *.left-insight p,
+                    *.right-insight p {
+                        padding: 10.0px;
+                        border-radius: 5.0px;
+                        float: left;
+                        width: 60.0%;
+                        margin-bottom: 20.0px;
+                        margin-left: 0.0px;
+                    }
+                    *.right-insight p {
+                        float: right;
+                        margin-right: 2.0px;
+                    } 
+                </style>
+                <div class="insight-section">
+                    <ul>
+                        <li>
+                            <div class="left-insight">
+                                <img alt="Instructor speaking" src="/library/image/genericProf.png" />
+                                <p class="sakai-colorize--sakai-color-green--lighter-4">Replace this text and photo to create a casual personal message you would like to communicate to your students. It should be no more than a short paragraph or two. An image size of <b>70px x 70px</b> would fit best with this template.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                `
         },
         {
-            title:'<span class="fa fa-comments template-icon" style="color:#9bbeff;"></span>Instructor Insight Reply',
+            title:'<span class="fa fa-comments template-icon" style="color:var(--sakai-color-purple--lighter-2);"></span>Instructor Insight Reply',
             description:'Text message styled box with photo on the right.',
-            html:'<style type="text/css">*.insight-section ul li { list-style: none; margin-top: 10.0px; } *.insight-section ul { padding: 0.0px; } *.left-insight img, *.right-insight img { width: 70.0px; height: 70.0px; float: left; margin: 0.0px 5.0px; border-radius: 50.0%; } *.right-insight img { float: right; } *.left-insight, *.right-insight { overflow: hidden; } *.left-insight p, *.right-insight p { background-color: rgb(128,255,138); padding: 10.0px; color: black; border-radius: 5.0px; float: left; width: 60.0%; margin-bottom: 20.0px; margin-left: 0.0px; } *.right-insight p { float: right; background-color: rgb(153,194,255); color: black; margin-right: 2.0px; } </style> <div class="insight-section"> <ul> <li> <div class="right-insight"><img alt="Student" src="/library/image/genericProf.png" /> <p>Replace this text and maybe the photo to create the effect of another side of a conversation or of a student responding to an instructor insight. It should be no more than a short paragraph or two. <b>An image size of 70px x 70px</b> would fit best with this template.</p> </div> </li> </ul> </div>'
+            html:`
+                <style type="text/css">
+                *.insight-section ul li {
+                    list-style: none;
+                    margin-top: 10.0px;
+                }
+                *.insight-section ul {
+                    padding: 0.0px;
+                }
+                *.left-insight img,
+                *.right-insight img {
+                    width: 70.0px;
+                    height: 70.0px;
+                    float: left;
+                    margin: 0.0px 5.0px;
+                    border-radius: 50.0%;
+                }
+                *.right-insight img,
+                *.right-insight span {
+                    float: right;
+                }
+                *.left-insight,
+                *.right-insight {
+                    overflow: hidden;
+                }
+                *.left-insight p,
+                *.right-insight p {
+                    padding: 10.0px;
+                    border-radius: 5.0px;
+                    float: left;
+                    width: 60.0%;
+                    margin-bottom: 20.0px;
+                    margin-left: 0.0px;
+                }
+                *.right-insight p {
+                    float: right;
+                    margin-right: 2.0px;
+                }
+                </style>
+                <div class="insight-section">
+                    <ul>
+                        <li>
+                            <div class="right-insight">
+                                <img alt="Student" src="/library/image/genericProf.png" />
+                                <p class="sakai-colorize--sakai-color-purple--lighter-4">Replace this text and maybe the photo to create the effect of another side of a conversation or of a student responding to an instructor insight. It should be no more than a short paragraph or two. <b>An image size of 70px x 70px</b> would fit best with this template.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                `
         },
         {
-            title:'<span class="fa fa-lightbulb-o template-icon" style="color:#E3BC2E;"></span>Key Idea',
+            title:'<span class="fa fa-lightbulb-o template-icon" style="color:var(--sakai-color-gold--lighter-2);"></span>Key Idea',
             description:'Yellow box with lightbulb and key idea text.',
-            html:'<div class="alert alert-warning"><div style="float:left"><span class="fa fa-3x fa-lightbulb-o"></span></div> <div style="margin-left:35.0px"><strong>Enter a statement that highlights a key idea.</strong></div></div>'
+            html:`
+                <div class="alert sakai-colorize--sakai-color-gold--lighter-4">
+                    <div style="float:left"><span class="fa fa-3x fa-lightbulb-o" style="margin-top:-10px;"></span></div>
+                    <div style="margin-left:35.0px"><strong>Enter a statement that highlights a key idea.</strong></div>
+                </div>
+                `
         },
         {
-            title:'<span class="fa fa-exclamation-triangle template-icon" style="color:#a84843;"></span>Warning',
+            title:'<span class="fa fa-exclamation-triangle template-icon" style="color:var(--sakai-color-red--lighter-2);"></span>Warning',
             description:'Red panel box containing a warning message.',
-            html:'<div class="panel panel-danger"> <div class="panel-heading"> <h3 class="callout-title"><span class="fa fa-exclamation-triangle"></span> Warning!</h3> </div>  <div class="panel-body">Use this to give your students a very noticeable warning. Don&#39;t overuse these, or your students will stop noticing them. </div> </div>'
+            html:`
+                <div class="panel">
+                    <div class="panel-heading sakai-colorize--sakai-color-red--lighter-4">
+                        <h3 class="callout-title"><span class="fa fa-exclamation-triangle"></span> Warning!</h3>
+                    </div>
+                    <div class="panel-body sakai-colorize--sakai-color-gray--lighter-7">Use this to give your students a very noticeable warning. Don&#39;t overuse these, or your students will stop noticing them. </div>
+                </div>
+                `
         },
         {
-            title:'<span class="fa fa-star template-icon" style="color:#E3BC2E;"></span>Alert with Star',
+            title:'<span class="fa fa-star template-icon" style="color:var(--sakai-color-gold--lighter-2);"></span>Alert with Star',
             description:'Yellow box with a star and text',
-            html:'<div class="alert alert-warning"> <div style="float:left"><span class="fa fa-star" style="font-size:26.0px"></span></div>  <div style="margin-left:35.0px"><strong>Replace this with appropriate text to alert your students about something important.</strong></div> </div>'
+            html:`
+                <div class="alert sakai-colorize--sakai-color-gold--lighter-4">
+                    <div style="float:left"><span class="fa fa-star" style="font-size:26.0px"></span></div>
+                    <div style="margin-left:35.0px"><strong>Replace this with appropriate text to alert your students about something important.</strong></div>
+                </div>
+                `
         },
         {
-            title:'<span class="fa fa-lightbulb-o template-icon" style="color:#444;"></span>Learning Outcomes',
+            title:'<span class="fa fa-lightbulb-o template-icon" style="color:var(--sakai-text-color)"></span>Learning Outcomes',
             description:'Organized list of learning outcomes with icon',
-            html:'<h2><span class="fa fa-fw fa-lightbulb-o" style="color:#000000; font-size:25.0px"></span>&nbsp; Learning Outcomes</h2>  <p style="margin-left:40.0px">After completing this module, students will be able to:</p>  <ol> <li style="margin-left: 40.0px;">Construct learning outcomes using Bloom&#39;s Taxonomy.</li> <li style="margin-left: 40.0px;">Explain why each learning outcome must be measurable.</li> <li style="margin-left: 40.0px;">Revise this list as the course content changes.</li> <li style="margin-left: 40.0px;">State the contact information for E-Learning to get help with learning outcomes.</li> </ol>'
+            html:`
+                <h2><span class="fa fa-fw fa-lightbulb-o" style="color:var(--sakai-text-color); font-size:25.0px"></span>&nbsp; Learning Outcomes</h2>
+                <p style="margin-left:40.0px">After completing this module, students will be able to:</p>
+                <ol>
+                    <li style="margin-left: 40.0px;">Construct learning outcomes using Bloom&#39;s Taxonomy.</li>
+                    <li style="margin-left: 40.0px;">Explain why each learning outcome must be measurable.</li>
+                    <li style="margin-left: 40.0px;">Revise this list as the course content changes.</li>
+                    <li style="margin-left: 40.0px;">State the contact information for E-Learning to get help with learning outcomes.</li>
+                </ol>
+                `
         },
         {
-            title:'<span class="fa fa-file-text template-icon" style="color:#444;"></span>Assignment Task',
+            title:'<span class="fa fa-file-text template-icon" style="color:var(--sakai-text-color);"></span>Assignment Task',
             description:'Instructions for an assignment',
-            html:'<h3><span class="fa fa-file-text"></span>&nbsp;Assignment Title</h3>  <p><strong>Due:</strong> Thursday, July 5<br /> <strong>Estimated Time:</strong> 2.5 hours<br /> <strong>Value:</strong> 100 points</p>  <h4>Instructions</h4>  <p>Replace this with appropriate assignment instructions. Detail all expectations including content and format. Your goal should be to write instructions so clearly that students do not need to ask you questions. The assignment title may not be necessary if you are providing the title in a Section in the Lessons tool.&nbsp;Also&nbsp;in the Lessons tool, you can add a link to submit to an assignment immediately below this element.</p> '
+            html:`
+                <h3><span class="fa fa-file-text"></span>&nbsp;Assignment Title</h3>
+                <p> <strong>Due:</strong> Thursday, July 5<br />
+                    <strong>Estimated Time:</strong> 2.5 hours<br />
+                    <strong>Value:</strong> 100 points
+                </p>
+                <h4>Instructions</h4>
+                <p>Replace this with appropriate assignment instructions. Detail all expectations including content and format. Your goal should be to write instructions so clearly that students do not need to ask you questions. The assignment title may not be necessary if you are providing the title in a Section in the Lessons tool.&nbsp;Also&nbsp;in the Lessons tool, you can add a link to submit to an assignment immediately below this element.</p>
+                `
         },
         {
-            title:'<span class="fa fa-comments template-icon" style="color:#444;"></span>Discussion Forum Task',
+            title:'<span class="fa fa-comments template-icon" style="color:var(--sakai-text-color);"></span>Discussion Forum Task',
             description:'Instructions for a discussion forum task',
-            html:'<h3><span class="fa fa-comments"></span>&nbsp;Discussion Forum</h3>  <p><strong>Initial Post Due:</strong> Thursday, July 5<br /> <strong>Response Post Due:</strong> Sunday, July 8<br /> <strong>Estimated Time:</strong> 45 minutes<br /> <strong>Value:</strong> 20 points</p>  <h4>Step 1</h4>  <p>Post a response to the following prompt. Your contribution should be complete while staying under 100 words.</p>  <p style="margin-left:40.0px"><strong>Prompt:</strong>&nbsp;All of the &quot;#1 Dad&quot; mugs in the world suddenly change to show the actual ranking of Dads. Project what effect this would have on society.</p>  <h4>Step 2</h4>  <p>Respond to two classmates\' posts by politely pointing out how their projections may be off-base.&nbsp;</p>  <p>Replace all this text with the appropriate text for your discussion forum exercise. The Lessons tool allows you to link to a forum topic directly below this text.</p>'
+            html:`
+                <h3><span class="fa fa-comments"></span>&nbsp;Discussion Forum</h3>
+                <p> 
+                    <strong>Initial Post Due:</strong> Thursday, July 5<br />
+                    <strong>Response Post Due:</strong> Sunday, July 8<br />
+                    <strong>Estimated Time:</strong> 45 minutes<br />
+                    <strong>Value:</strong> 20 points
+                </p>
+                <h4>Step 1</h4>
+                <p>Post a response to the following prompt. Your contribution should be complete while staying under 100 words.</p>
+                <p style="margin-left:40.0px"><strong>Prompt:</strong>&nbsp;All of the &quot;#1 Dad&quot; mugs in the world suddenly change to show the actual ranking of Dads. Project what effect this would have on society.</p>
+                <h4>Step 2</h4>
+                <p>Respond to two classmates\' posts by politely pointing out how their projections may be off-base.&nbsp;</p>
+                <p>Replace all this text with the appropriate text for your discussion forum exercise. The Lessons tool allows you to link to a forum topic directly below this text.</p>
+                `
         },
         {
-            title:'<span class="fa fa-book template-icon" style="color:#444;"></span>Reading Assignment',
+            title:'<span class="fa fa-book template-icon" style="color:var(--sakai-text-color);"></span>Reading Assignment',
             description:'Instructions for a reading assignment',
-            html:'<h3><span class="fa fa-book"></span>&nbsp;Reading Assignment</h3>  <p><strong>Due:</strong> Thursday, July 5<br /> <strong>Estimated Time:</strong> 30 minutes</p>  <h4>Instructions</h4>  <p>Read chapters 1 and 2 from <em>Opening Up Education</em> by Iiyoshi and Kumar. As you read, pay close attention to how traditional models of education have become less appropriate, and consider what this means for the future.</p>'
+            html:`
+                <h3><span class="fa fa-book"></span>&nbsp;Reading Assignment</h3>
+                <p>
+                    <strong>Due:</strong> Thursday, July 5<br />
+                    <strong>Estimated Time:</strong> 30 minutes
+                </p>
+                <h4>Instructions</h4>
+                <p>Read chapters 1 and 2 from <em>Opening Up Education</em> by Iiyoshi and Kumar. As you read, pay close attention to how traditional models of education have become less appropriate, and consider what this means for the future.</p>
+                `
         },
         {
-            title:'<span class="fa fa-play-circle template-icon" style="color:#444;"></span>Video Assignment',
+            title:'<span class="fa fa-play-circle template-icon" style="color:var(--sakai-text-color);"></span>Video Assignment',
             description:'Instructions for a video assignment',
-            html:'<h3><span class="fa fa-play-circle"></span>&nbsp;Video Assignment</h3>  <p><strong>Due:</strong> Thursday, July 5<br /> <strong>Estimated Time:</strong> 30 minutes</p>  <h4>Instructions</h4>  <p>Watch the following video. The speaker presents a compelling case for why wind turbines should be abandoned as a primary municipal power source. You will be expected to reference this video in the upcoming assignments.</p>  <p style="margin-left:40.0px"><em>Embed your video here using the video links in the editor tool bar.</em></p> '
+            html:`
+                <h3><span class="fa fa-play-circle"></span>&nbsp;Video Assignment</h3>
+                <p>
+                    <strong>Due:</strong> Thursday, July 5<br />
+                    <strong>Estimated Time:</strong> 30 minutes
+                </p>
+                <h4>Instructions</h4>
+                <p>Watch the following video. The speaker presents a compelling case for why wind turbines should be abandoned as a primary municipal power source. You will be expected to reference this video in the upcoming assignments.</p>
+                <p style="margin-left:40.0px"><em>Embed your video here using the video links in the editor tool bar.</em></p>
+                `
         }
 ]});

--- a/portal/editor-tool/tool/src/java/org/sakaiproject/editor/EditorServlet.java
+++ b/portal/editor-tool/tool/src/java/org/sakaiproject/editor/EditorServlet.java
@@ -167,6 +167,7 @@ public class EditorServlet extends HttpServlet
 				out.print("sakai.editor.editors.ckeditor.browser = '" + EditorConfiguration.getCKEditorFileBrowser() + "';\n");
 				out.print("sakai.editor.siteToolSkin = '" + CSSUtils.getCssToolSkin(skin) + "';\n");
 				out.print("sakai.editor.sitePrintSkin = '" + CSSUtils.getCssPrintSkin(skin) + "';\n");
+				out.print("sakai.editor.sitePropertiesSkin = '" + CSSUtils.getCssPropertiesSkin(skin) + "';\n");
 
 				out.print(editor.getPreloadScript());
 			}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1359,6 +1359,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		}
 		headJs.append("sakai.editor.siteToolSkin = '" + CSSUtils.getCssToolSkin(skin) + "';\n");
 		headJs.append("sakai.editor.sitePrintSkin = '" + CSSUtils.getCssPrintSkin(skin) + "';\n");
+		headJs.append("sakai.editor.sitePropertiesSkin = '" + CSSUtils.getCssPropertiesSkin(skin) + "';\n");
 		headJs.append("sakai.editor.editors.ckeditor.browser = '"+ EditorConfiguration.getCKEditorFileBrowser()+ "';\n");
 		headJs.append("</script>\n");
 		headJs.append(preloadScript);

--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/CSSUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/CSSUtils.java
@@ -99,6 +99,21 @@ public class CSSUtils
 		String cssPrintSkin = skinRepo + "/" + skinFolder + "/print.css";
 		return cssPrintSkin;
 	}
+
+	/**
+	 * Returns a URL for the properties.css suitable for putting in an href= field.
+	 *
+	 * @param <code>skinFolder</code>
+	 *		where the properties.css skin lives for this site.
+	 * @return <code>cssPrintSkin</code> URL for the properties.css
+	 */
+	public static String getCssPropertiesSkin(String skinFolder)
+	{
+		skinFolder = adjustCssSkinFolder(skinFolder);
+		String skinRepo = ServerConfigurationService.getString("skin.repo");
+		String cssPropertiesSkin = skinRepo + "/" + skinFolder + "/properties.css";
+		return cssPropertiesSkin;
+	}
 	
 	/**
 	 * Returns a URL for the portal.css suitable for putting in an href= field.
@@ -163,6 +178,22 @@ public class CSSUtils
 		return cssPrintSkin;
 	}
 
+	/**
+	 * Returns a URL for the properties.css suitable for putting in an href= field
+	 *
+	 * @param <code>skinFolder</code>
+	 *		where the properties.css skin lives for this site.
+	 * @return <code>cssPropertiesSkin</code> URL for the properties.css
+	 */
+	public static String getCssPropertiesSkinCDN(String skinFolder)
+	{
+		String cssPropertiesSkin = getCssPropertiesSkin(skinFolder);
+		if ( cssPropertiesSkin.startsWith("/") ) {
+			cssPropertiesSkin = PortalUtils.getCDNPath() + cssPropertiesSkin + PortalUtils.getCDNQuery();
+		}
+		return cssPropertiesSkin;
+	}
+
 	/** 
 	 * Convenience method to retrieve the skin folder from a site
 	 * @param site
@@ -224,8 +255,12 @@ public class CSSUtils
 		String headCssPrintSkin = "<link href=\"" 
 				+ getCssPrintSkinCDN(skin)
 				+ "\" type=\"text/css\" rel=\"stylesheet\" media=\"print\" />\n";
+
+		String headCssPropertiesSkin = "<link href=\"" 
+				+ getCssPropertiesSkinCDN(skin)
+				+ "\" type=\"text/css\" rel=\"stylesheet\" media=\"screen, tty, tv, handheld, projection\" />\n";
 		
-		return headCssToolSkin + headCssPrintSkin;
+		return headCssToolSkin + headCssPrintSkin + headCssPropertiesSkin;
 	}
 
 	public static String getCssHead(String skin, boolean isInlineRequest) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44562 - several screenshots included on the JIRA

This enables dark theme support in ckeditor, but what it **also** does is set ckeditor to inherit the theme variables set in light mode as well. Overall, CKeditor fits in with Sakai's ui more closely and adapts to the themes set in the skin.

A new `skinname/properties.css` file is now generated from `library/src/morpheus-master/sass/properties.scss` which can be used by CKeditor or other parts of the app. It only contains the css custom properties and not the entire skin in an effort to reduce potential conflicts and download size.

`library/src/webapp-filtered/editor/ckeditor.css` contains CSS that affects HTML written by ckeditor or the user.

The `CKEDITOR.skin.chameleon` function is included in our moono-lisa skin and overridden to make use of our CSS Custom Properties. The out of the box function did not work with CSS Custom Properties and ran them through color functions resulting in different than expected values.

`library/src/webapp/editor/ckextraplugins/templates/default.js` was rewritten to make use of CSS Custom properties and increase readability.

Remaining issues
* the dropdown menus on the bottom row still have white backgrounds
* the autosave plugin injects code that does not retain dark mode