### PR TITLE
SAK-43044 Messages can be sent, can't be read, with single space in subject

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -318,9 +318,9 @@ public class PrivateMessagesTool {
   private String composeSendAsPvtMsg=SET_AS_YES; // currently set as Default as change by user is allowed
   @Getter @Setter
   private boolean booleanEmailOut = ServerConfigurationService.getBoolean("mc.messages.ccEmailDefault", false);
-  @Getter @Setter
-  private String composeSubject ;
-  @Getter @Setter
+  @Getter
+  private String composeSubject;
+  @Getter
   private String composeBody;
   @Getter @Setter
   private String selectedLabel="pvt_priority_normal" ;   //defautl set
@@ -346,20 +346,20 @@ public class PrivateMessagesTool {
   private List selectedMoveToFolderItems;
   
   //reply to 
-  @Getter @Setter
+  @Getter
   private String replyToBody;
-  @Getter @Setter
+  @Getter
   private String replyToSubject;
 
   //forwarding
-  @Getter @Setter
+  @Getter
   private String forwardBody;
-  @Getter @Setter
+  @Getter
   private String forwardSubject;
 
-  @Getter @Setter
+  @Getter
   private String replyToAllBody;
-  @Getter @Setter
+  @Getter
   private String replyToAllSubject;
   
   //Setting Screen
@@ -1440,10 +1440,12 @@ public void processChangeSelectView(ValueChangeEvent eve)
 	    this.setReplyingMessage(pm);
 	    
 	    String title = pm.getTitle();
-    	if(title != null && !title.startsWith(getResourceBundleString(ReplyAll_SUBJECT_PREFIX)))
-    		forwardSubject = getResourceBundleString(ReplyAll_SUBJECT_PREFIX) + ' ' + title;
-    	else
-    		forwardSubject = title;//forwardSubject
+    	if(title != null && !title.startsWith(getResourceBundleString(ReplyAll_SUBJECT_PREFIX))) {
+    		replyToAllSubject = getResourceBundleString(ReplyAll_SUBJECT_PREFIX) + ' ' + title;
+    	}
+    	else {
+    		replyToAllSubject = title;
+    	}
 
 
     	// format the created date according to the setting in the bundle
@@ -1488,7 +1490,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
 	    	}
 	    }
 	    
-	    this.setForwardBody(replyallText.toString());
+	    setReplyToAllBody(replyallText.toString());
 	   	    
 	    String msgautherString=getDetailMsg().getAuthor();
 	    String msgCClistString=getDetailMsg().getRecipientsAsText();
@@ -2789,7 +2791,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
 
 	  //Select Forward Recipients
 	  
-	  if(StringUtils.isEmpty(getForwardSubject())) {
+	  if(StringUtils.isEmpty(getReplyToAllSubject())) {
 		  if(isDraft){
 			  setErrorMessage(getResourceBundleString(MISSING_SUBJECT_DRAFT));
 		  }else{
@@ -2797,7 +2799,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
 		  }
 		  return null ;
 	  }
-	  if(StringUtils.isEmpty(getForwardBody())) {
+	  if(StringUtils.isEmpty(getReplyToAllBody())) {
 		  if(isDraft) {
 			  setErrorMessage(getResourceBundleString(MISSING_BODY_DRAFT));
 		  } else {
@@ -2810,15 +2812,13 @@ public void processChangeSelectView(ValueChangeEvent eve)
 
 
 	  StringBuilder alertMsg = new StringBuilder();
-	  rrepMsg.setTitle(getForwardSubject());
+	  rrepMsg.setTitle(getReplyToAllSubject());
 	  rrepMsg.setDraft(isDraft);
 	  rrepMsg.setDeleted(Boolean.FALSE);
 
 	  rrepMsg.setAuthor(getAuthorString());
 	  rrepMsg.setApproved(Boolean.FALSE);
-	  //add some emty space to the msg composite, by huxt
-	  String replyAllbody="  ";
-	  replyAllbody=getForwardBody();
+	  String replyAllbody=getReplyToAllBody();
 
 
 	  rrepMsg.setBody(formattedText.processFormattedText(replyAllbody, alertMsg));
@@ -4635,4 +4635,37 @@ public void processChangeSelectView(ValueChangeEvent eve)
     public boolean isDisplayDraftRecipientsNotFoundMsg() {
         return drDelegate.isDisplayDraftRecipientsNotFoundMsg();
     }
+
+	public void setComposeSubject(String value) {
+		composeSubject = StringUtils.trimToEmpty(value);
+	}
+
+	public void setComposeBody(String value) {
+		composeBody = StringUtils.trimToEmpty(value);
+	}
+
+	public void setReplyToSubject(String value) {
+		replyToSubject = StringUtils.trimToEmpty(value);
+	}
+
+	public void setReplyToBody(String value) {
+		replyToBody = StringUtils.trimToEmpty(value);
+	}
+
+	public void setForwardSubject(String value) {
+		forwardSubject = StringUtils.trimToEmpty(value);
+	}
+
+	public void setForwardBody(String value) {
+		forwardBody = StringUtils.trimToEmpty(value);
+	}
+
+	public void setReplyToAllSubject(String value) {
+		replyToAllSubject = StringUtils.trimToEmpty(value);
+	}
+
+	public void setReplyToAllBody(String value) {
+		replyToAllBody = StringUtils.trimToEmpty(value);
+	}
+
 }

--- a/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgReplyAll.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/pvtMsgReplyAll.jsp
@@ -267,7 +267,7 @@
 					</div>
 					<div class="col-xs-12 col-sm-10">
 						<h:panelGroup styleClass="shorttext">
-							<h:inputText value="#{PrivateMessagesTool.forwardSubject}" id="subject" size="45" styleClass="form-control">
+							<h:inputText value="#{PrivateMessagesTool.replyToAllSubject}" id="subject" size="45" styleClass="form-control">
 								<f:validateLength maximum="255"/>
 							</h:inputText>
 						</h:panelGroup>
@@ -277,7 +277,7 @@
 
 			<h4><h:outputText value="#{msgs.pvt_star}" styleClass="reqStar"/><h:outputText value="#{msgs.pvt_message}" /></h4>
 
-			<sakai:inputRichText textareaOnly="#{PrivateMessagesTool.mobileSession}" rows="#{ForumTool.editorRows}" cols="132" id="pvt_forward_body" value="#{PrivateMessagesTool.forwardBody}">
+			<sakai:inputRichText textareaOnly="#{PrivateMessagesTool.mobileSession}" rows="#{ForumTool.editorRows}" cols="132" id="pvt_forward_body" value="#{PrivateMessagesTool.replyToAllBody}">
 			</sakai:inputRichText>
 
             <%--********************* Attachment *********************--%>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43044

"A student sent an email to an instructor where the subject appeared blank. Since there was no text in the subject line, the instructor could not open and read the message. I was able to reproduce this by having a space in the subject line. That appeared to count as "not blank" for the subject check, but can't be clicked on by the recipient."

User input should be trimmed when entering the system, as this prevents various issues that could occur later on, including the problem above. This PR trims the input for subject and message body using the setters that JSF calls when mapping the input field values from HTML back to Java.

This PR also cleans up the reply all page, as it was actually using variables for the forward page instead of its own variables.