### PR TITLE
SAK-44702 Long img alt text with linebreaks can cause StackOverflowError

### DIFF
--- a/kernel/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
+++ b/kernel/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
@@ -38,6 +38,7 @@
 
 
     <regexp name="anything" value=".*" />
+    <regexp name="anyWithPara" value="(?s).*" />
     <regexp name="numberOrPercent" value="(\d)+(%{0,1})" />
     <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)\?]|&amp;[0-9]{2};)*" />
     <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+" />
@@ -193,7 +194,7 @@
          
          <attribute name="alt" description="The 'alt' attribute provides alternative text to users when its visual representation is not available">
             <regexp-list>
-                <regexp name="paragraph"/>
+                <regexp name="anyWithPara"/>
             </regexp-list>
          </attribute>
 

--- a/kernel/kernel-impl/src/main/resources/antisamy/low-security-policy.xml
+++ b/kernel/kernel-impl/src/main/resources/antisamy/low-security-policy.xml
@@ -38,6 +38,7 @@
 
 
     <regexp name="anything" value=".*" />
+    <regexp name="anyWithPara" value="(?s).*" />
     <regexp name="numberOrPercent" value="(\d)+(%{0,1})" />
     <regexp name="paragraph" value="([\p{L}\p{N},'\.\s\-_\(\)\?]|&amp;[0-9]{2};)*" />
     <regexp name="htmlId" value="[a-zA-Z0-9\:\-_\.]+" />
@@ -188,7 +189,7 @@
          
          <attribute name="alt" description="The 'alt' attribute provides alternative text to users when its visual representation is not available">
             <regexp-list>
-                <regexp name="paragraph"/>
+                <regexp name="anyWithPara"/>
             </regexp-list>
          </attribute>
 


### PR DESCRIPTION
The paragraph regexp is too complex for long img alt text which includes linebreaks. This uses a simpler regexp for alt text.

However, I'm not totally sure whether it's ok to simplify to this extent and this should be reviewed to see if there's anything that actually should not be permitted in alt text, in which case an intermediate regexp may be required that's simpler than paragraph but more complex than anyWithPara.
