### PR TITLE
SAK-44573 When adding comments to a rubric, automatically set focus to text box

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading-comment.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading-comment.js
@@ -120,6 +120,7 @@ export class SakaiRubricGradingComment extends RubricsElement {
 
     try {
       var commentEditor = CKEDITOR.replace(editorKey, {
+        startupFocus: true,
         toolbar: [['Bold', 'Italic', 'Underline'], ['NumberedList', 'BulletedList', 'Blockquote']],
         height: 40
       });


### PR DESCRIPTION
Use CKEditor's "startupFocus" property to put the cursor in the editor when it loads. There is a caveat to this property, as it places the cursor at the beginning of the text even if there is already text in the editor. There is an option to put the cursor at the end by setting startupFocus = "end" instead of "true", but this causes unwanted behaviour in Firefox (such as inserting blank lines at the beginning of the text and scrolling it offscreen), and it does not appear to work at all in Chromium.