### PR TITLE
SAK-44400 Students can't view graded forum rubric in Gradebook

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/js/forum.js
+++ b/msgcntr/messageforums-app/src/webapp/js/forum.js
@@ -872,11 +872,11 @@ $(document).ready(function(){
         }
     });
 
-    const saveButton = document.getElementById("msgForum:save");
-    saveButton && saveButton.addEventListener("click", e => {
-
-      const rubricGrading = document.getElementsByTagName("sakai-rubric-grading").item(0);
-      rubricGrading && rubricGrading.save();
-    });
 });
 
+var MFR_RBC = MFR_RBC || {};
+
+MFR_RBC.saveRubric = function() {
+    const rubricGrading = document.getElementsByTagName("sakai-rubric-grading").item(0);
+    rubricGrading && rubricGrading.save();
+};

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfMsgGrade.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfMsgGrade.jsp
@@ -72,6 +72,7 @@
             if (userId == null) userId = forumTool.getUserId();
 
             String rbcsEvaluationId = entityId + "." + userId;
+            String rbcsEvaluationOwnerId = userId;
             %>
 
             <script>
@@ -202,20 +203,20 @@
                     tool-id="sakai.gradebookng"
                     entity-id='<%= entityId %>'
                     evaluated-item-id='<%= rbcsEvaluationId %>'
-                    evaluated-item-owner-id='<h:outputText value="#{ForumTool.selectedMessage.message.authorId}" />'
+                    evaluated-item-owner-id='<%= rbcsEvaluationOwnerId %>'
                 ></sakai-rubric-grading>
             <%}%>
 
             <sakai:button_bar>
                 <% if(isDialogBox){ %>
                     <h:commandButton id="save" action="#{ForumTool.processDfGradeSubmitFromDialog}" value="#{msgs.cdfm_submit_grade}"
-                        accesskey="s" styleClass="active" disabled="#{!ForumTool.allowedToGradeItem}" onclick="SPNR.disableControlsAndSpin( this, null );" />
+                        accesskey="s" styleClass="active" disabled="#{!ForumTool.allowedToGradeItem}" onclick="SPNR.disableControlsAndSpin( this, null );MFR_RBC.saveRubric();" />
                     <h:commandButton action="#{ForumTool.processDfGradeCancelFromDialog}" value="#{msgs.cdfm_cancel}" accesskey="x"
                         onclick="SPNR.disableControlsAndSpin( this, null );closeDialogBoxIfExists();" />
                 <% }else {%>
                     <h:commandButton action="#{ForumTool.processDfGradeSubmit}" value="#{msgs.cdfm_submit_grade}"
                         accesskey="s" styleClass="active" disabled="#{!ForumTool.allowedToGradeItem}"
-                        onclick="SPNR.disableControlsAndSpin( this, null );" />
+                        onclick="SPNR.disableControlsAndSpin( this, null );MFR_RBC.saveRubric();" />
                     <h:commandButton action="#{ForumTool.processDfGradeCancel}" value="#{msgs.cdfm_cancel}" accesskey="x" onclick="SPNR.disableControlsAndSpin( this, null );closeDialogBoxIfExists();" />
                 <%}%>
 


### PR DESCRIPTION
This PR addresses two problems:

1. Forums sets the student on the saved rubric based on the message author of the currently selected message. When grading by topic, there is no selected message so the student is not set.

2. In Firefox, the event handler to save the rubric is called when the button is clicked, but the PATCH request never makes to the server. I'm unsure why this doesn't work, but adding the save call to the onclick attribute of the button does work. I did try removing the onclick attribute entirely but that still did not allow the event handler to function properly.