### PR TITLE
SAK-44754 Lessons > Fix NPE on student content when group is deleted and related improvements

### DIFF
--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -604,6 +604,8 @@ simplepage.student-comments-anon=Make these comments anonymous
 simplepage.anonymous=Anonymous
 simplepage.student-missing-prereqs=There is an area for student content, but you must complete all required items above before you can see it.
 simplepage.student-fake-missing-prereqs=If you were a student, you wouldn't be able to see student content, because you haven't completed all required items above.
+simplepage.student-user-deleted=User no longer exists
+simplepage.student-group-deleted=Group no longer exists
 
 simplepage.website=Upload Content from a ZIP File
 simplepage.website.noextension=For this operation to work, the ZIP file must have an extension, typically .zip.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44754

If a Student Content item is added to a page and configured to be for groups instead of individual users, adding content for that group and then deleting the group results in a NPE that renders the entire page containing the student content tool inaccessible.

The fix for this issue will check for null groups and present a message to the user indicating the group no longer exists, while retaining access any content from the deleted group (the instructor may chose to delete the content later if this is desired). The following additional changes are made for consistency:

- deleted users will also now present a message indicating such
- page titles that match the name of the page owner will no longer be surrounded by parentheses (ie. a student page called "John Doe" owned by "John Doe" will now display as "John Doe" instead of "(John Doe)", while a page called "John's Page" owned by "John Doe" will still display as "John's Page (John Doe)")

Also removes some code duplication.