### PR TITLE
SAK-44770 lessons > page settings does not reflect custom tool title from ToolConfiguration

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -4986,7 +4986,15 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		makeCsrf(form, "csrf14");
 
 		UIOutput.make(form, "pageTitleLabel", messageLocator.getMessage("simplepage.pageTitle_label"));
-		UIInput.make(form, "pageTitle", "#{simplePageBean.pageTitle}");
+
+		String internalPageTitle = page.getTitle();
+		String externalPageTitle = simplePageBean.getCurrentSite().getPage(page.getToolId()).getTools().stream()
+				.filter(t -> t.getId().equals(toolManager.getCurrentPlacement().getId()))
+				.findFirst()
+				.map(t -> t.getTitle())
+				.orElse("");
+		String effectivePageTitle = (StringUtils.isNotBlank(externalPageTitle) && !externalPageTitle.equals(internalPageTitle)) ? externalPageTitle : internalPageTitle;
+		UIInput.make(form, "pageTitle", "#{simplePageBean.pageTitle}", effectivePageTitle);
 
 		if (!simplePageBean.isStudentPage(page)) {
 			UIOutput.make(tofill, "hideContainer");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44770

f you set a custom tool title via Site Info > Tool Order, then view the page settings in the Lessons tool itself, the Lessons modal does not reflect the new tool title set in Tool Order. It instead displays the original name, stored in the Lessons Page object. This can lead to user data loss opportunities, if the user saved the modal without realizing that they're actually reverting the tool title.