### PR TITLE
SAK-44778 Regression: Assignment List > Selected Groups no longer sorted

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2673,6 +2673,15 @@ public class AssignmentAction extends PagedResourceActionII {
             if (realm != null) {
                 context.put("activeUserIds", realm.getUsers());
             }
+
+            // for sorting assignment groups using the standard comparator
+            Map<String, List<String>> groupTitleMap = new HashMap<>(assignments.size());
+            AssignmentComparator groupComparator = new AssignmentComparator(null, SORTED_BY_GROUP_TITLE, Boolean.TRUE.toString());
+            for (Assignment asn : assignments) {
+                groupTitleMap.put(asn.getId(), getSortedAsnGroupTitles(asn, site, groupComparator));
+            }
+            context.put("asnGroupTitleMap", groupTitleMap);
+
         } catch (Exception ignore) {
             log.warn(this + ":build_list_assignments_context " + ignore.getMessage());
             log.warn(this + ignore.getMessage() + " siteId= " + contextString);
@@ -2699,6 +2708,12 @@ public class AssignmentAction extends PagedResourceActionII {
         return template + TEMPLATE_LIST_ASSIGNMENTS;
 
     } // build_list_assignments_context
+
+    private List<String> getSortedAsnGroupTitles(Assignment asn, Site site, AssignmentComparator groupComparator) {
+        List<Group> asnGroups = asn.getGroups().stream().map(id -> site.getGroup(id)).collect(Collectors.toList());
+        asnGroups.sort(groupComparator);
+        return asnGroups.stream().map(Group::getTitle).collect(Collectors.toList());
+    }
 
     private Set<String> getSubmittersIdSet(List<AssignmentSubmission> submissions) {
         return submissions.stream().map(AssignmentSubmission::getSubmitters).flatMap(Set::stream).map(AssignmentSubmissionSubmitter::getSubmitter).collect(Collectors.toSet());
@@ -4674,6 +4689,18 @@ public class AssignmentAction extends PagedResourceActionII {
             context.put("attachmentReferences", attachmentReferences);
 
             supplementItemIntoContext(state, context, assignment, null);
+
+            // for sorting assignment groups using the standard comparator
+            String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
+            try {
+                Site site = siteService.getSite(contextString);
+                AssignmentComparator groupComparator = new AssignmentComparator(null, SORTED_BY_GROUP_TITLE, Boolean.TRUE.toString());
+                String groupTitles = StringUtils.join(getSortedAsnGroupTitles(assignment, site, groupComparator), ", ");
+                context.put("asnGroupTitles", groupTitles.isEmpty() ? rb.getString("gen.viewallgroupssections") : groupTitles);
+            }
+            catch (IdUnusedException e) {
+                // ignore
+            }
         }
 
         if (taggingManager.isTaggable() && assignment != null) {

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_view_assignment.vm
@@ -107,23 +107,7 @@
 					$tlang.getString("gen.visible")
 				</th>
 				<td>
-					#set($count=1)
-					#set($for="")
-					#foreach ($group in $assignment.Groups)
-						#set($groupFound=false)
-						#set($groupFound=$!site.getGroup($group))
-						#if($!groupFound)
-							#if ($count>1)
-								#set($for=$for.concat(", "))
-							#end
-							#set($for= $for.concat($groupFound.Title))
-							#set($count=$count+1)
-						#end
-					#end
-					#if($count==1)
-						#set($for=$tlang.getString("gen.viewallgroupssections"))
-					#end
-					$formattedText.escapeHtml($!for)
+					$formattedText.escapeHtml($!asnGroupTitles)
 				</td>
 			</tr>
 			<tr> 

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -448,14 +448,7 @@
 								#if($assignment.TypeOfAccess == "SITE")
 									$tlang.getString("gen.viewallgroupssections")
 								#elseif($assignment.TypeOfAccess == "GROUP")
-									#set($groupTitleList = [])
-									#foreach($groupID in $assignment.Groups)
-										#set($group = $!site.getGroup($groupID))
-										#if($!group)
-											#set($success = $groupTitleList.add($formattedText.escapeHtml($group.Title)))
-											#set($group = false)
-										#end
-									#end
+									#set($groupTitleList = $asnGroupTitleMap.get($assignment.Id))
                                     <div class="groupsContainer">
                                         <strong class="collapse" onclick="ASN.toggleGroups( this ); ASN.resizeFrame();">
 											$groupTitleList.size()
@@ -468,8 +461,8 @@
 
                                         <div id="groupsPanel" style="display: none;">
                                             <ul>
-												#foreach( $title in $groupTitleList )
-                                                    <li>$title</li>
+												#foreach($title in $groupTitleList)
+                                                    <li>$formattedText.escapeHtml($title)</li>
 												#end
                                             </ul>
                                         </div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44778

When an assignment is released to selected groups, the groups are listed on the main assignments page. They used to be sorted alphabetically, they no longer are.

Regarding sorting outside of the stream operations, the compiler doesn't like the type of the AssignmentComparator so it doesn't allow the sort in the stream itself, so I had to do it separately.