### PR TITLE
SAK-44781 samigo > remove uses of messageSamigo class in favour of standardized sak-banner-error

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -511,18 +511,6 @@ a.hideDivision {
     COLOR:#860000;
 } 
 
-.messageSamigo {
-	background: #FFEEEE url(../images/exclamation.png) 5px 4px no-repeat;
-	border: 1px solid #b11;
-	display: block;
-	width: 80%;
-	font-size: 1em;
-	clear: both;
-	color: black;
-	margin: 20px 0 10px 0;
-	padding: 1px 5px 1px 25px;
-}
-
 .saCharCount {
     border: 1px solid #bbb;
 }

--- a/samigo/samigo-app/src/webapp/js/authoring-emi.js
+++ b/samigo/samigo-app/src/webapp/js/authoring-emi.js
@@ -64,7 +64,7 @@ $(document).ready(function(){
 	//----------------------------------------------//
 	$("input[value='Save']").bind('click', function(){
 		updateAnswerPointScore();
-		$errorMessageTable.removeClass('messageSamigo');
+		$errorMessageTable.removeClass('sak-banner-error');
 		$('#emiErrorMessageTable > tr').remove();
 		var errorMessages = new Array();
 		var errorNumber=+0;
@@ -165,7 +165,7 @@ $(document).ready(function(){
 				var row = $tableRowElement.clone().appendTo($errorMessageTable);
 				col.appendTo(row);
 			}
-			$errorMessageTable.addClass('messageSamigo');
+			$errorMessageTable.addClass('sak-banner-error');
 			top.window.scrollTo(0,0);
 			return false;
 		}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44781

There are some remaining usages of the class `messageSamigo` for extended matching items. Lets replace them with the standardized `sak-banner-error`.