### PR TITLE
SAK-44783 site info > manage groups > edit joinable set > only 1 primary action button per form

### DIFF
--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -355,6 +355,7 @@
 							var(--button-shadow),
 							var(--button-hover-shadow),
 							var(--button-active-shadow));
+	margin-right: $standard-space;
 }
 
 button.btn-primary, .act .active {

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/joinable_set.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/joinable_set.html
@@ -115,7 +115,7 @@
         <div class="act">
           <input th:if="${joinableSetForm.joinableSetId == null}" accesskey="s" disabled="disabled" id="create-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.add}">
           <input th:if="${joinableSetForm.joinableSetId != null}" accesskey="s" id="save-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.save}">
-          <a th:href="@{/deleteJoinableSet(joinableSetId=${joinableSetForm.joinableSetId})}" th:if="${joinableSetForm.joinableSetId != null}" accesskey="d" id="delete-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.delete}">Delete Joinable Set</a>
+          <a th:href="@{/deleteJoinableSet(joinableSetId=${joinableSetForm.joinableSetId})}" th:if="${joinableSetForm.joinableSetId != null}" accesskey="d" id="delete-joinableset-submit-button" type="submit" class="btn btn-default" th:value="#{joinableset.button.delete}">Delete Joinable Set</a>
           <a th:href="@{/}" accesskey="x" id="create-joinableset-cancel-button" class="btn btn-default" th:text="#{joinableset.button.cancel}">Cancel</a>
         </div>
         <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true" id="confirmation-modal">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44783

When editing a Joinable Set there are 2 primary action buttons present in the UI. There should only be one primary action for a given form.