### PR TITLE
SAK-44839 - CKEditor 4 preview can't handle apostrophes or HTML

### DIFF
--- a/library/src/webapp/editor/ckextraplugins/sakaipreview/plugin.js
+++ b/library/src/webapp/editor/ckextraplugins/sakaipreview/plugin.js
@@ -87,7 +87,7 @@
         var previewHighlightedOnly = false;
         function getEditorContent() {
           //Available since CKEditor 4.5.0 to get selected Html. True to return html.
-          var selectedHtml = editor.getSelectedHtml(true)
+          var selectedHtml = editor.getSelectedHtml(true);
 
           if (selectedHtml) {
             previewHighlightedOnly = true;

--- a/library/src/webapp/editor/ckextraplugins/sakaipreview/plugin.js
+++ b/library/src/webapp/editor/ckextraplugins/sakaipreview/plugin.js
@@ -58,32 +58,6 @@
           baseURL = baseURL + ":" + location.port
         }
 
-        var highlightedText = false;
-        function getHighlightedText() {
-          if (typeof highlightedText == 'string') {
-            return highlightedText;
-          }
-
-          var selection = editor.getSelection();
-          if (selection && selection.getType() == CKEDITOR.SELECTION_TEXT) {
-            if (CKEDITOR.env.ie) {
-              selection.unlock(true);
-              highlightedText = selection.getNative().createRange().text;
-            } else {
-              highlightedText = selection.getNative().toString();
-            }
-          }
-
-          return highlightedText;
-        }
-
-        function isHighlight() {
-          return getHighlightedText().length > 0;
-        }
-        // Content to preview: the entire document or just what is highlighted?
-        var previewHighlightedOnly = isHighlight();
-
-
         function getPreviewContentHTML(contentToPreview) {
             let darkThemeEnabled = document.firstElementChild.classList.contains('sakai-dark-theme') ? 'sakai-dark-theme' : '';
 
@@ -103,22 +77,24 @@
 
         function getIframe(html) {
             var $iframe = $PBJQ('<iframe>');
-            $iframe.attr('src', 'data:text/html;charset=utf-8,' + encodeURI(html));
+            $iframe.attr('srcdoc', html);
             $iframe.attr('frameborder', '0');
             $iframe.attr('width', '100%');
             $iframe.attr('height', $PBJQ(window).height() - 240 + "px");
             return $iframe;
         }
 
+        var previewHighlightedOnly = false;
         function getEditorContent() {
-          var selectedText = "";
-          var selection = editor.getSelection();
+          //Available since CKEditor 4.5.0 to get selected Html. True to return html.
+          var selectedHtml = editor.getSelectedHtml(true)
 
-          if (previewHighlightedOnly && isHighlight()) {
-            return getHighlightedText();
+          if (selectedHtml) {
+            previewHighlightedOnly = true;
+            return selectedHtml;
           }
 
-          return editor.getData();
+          return editor.editable().getHtml();
         }
 
         sHTML = getPreviewContentHTML(getEditorContent());


### PR DESCRIPTION
This had a few fixes here to the Javascript.

First I changed the preview both selection and non to return HTML. editable().getHtml() looked to work better.

Then I had to change the iframe to use the html5 srcdoc instead of the encoded src string. T[his is supported by all modern browsers.](https://caniuse.com/iframe-srcdoc). src had length and other limitations that made this really not work well with this already long text.