### PR TITLE
SAK-44856 Dark theme background fix within Manage Tools

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/sitemanage/_sitemanage.scss
+++ b/library/src/morpheus-master/sass/modules/tool/sitemanage/_sitemanage.scss
@@ -318,12 +318,12 @@
       list-style: none;
       margin: 0;
       padding: 0 $standard-spacing;
-      display: none;	
+      display: none;
       > li {
         padding: $standard-spacing 0;
-        border-top: $manageTools-panel-border;  
+        border-top: $manageTools-panel-border;
         &:first-of-type {
-          border-top: 0 none; 
+          border-top: 0 none;
         }
         &.indnt3 {
           padding-top: 0;
@@ -342,17 +342,17 @@
     h3 {
         margin: 0;
         padding: 0;
-		
+
       a {
         border-top: $manageTools-panel-border;
         border-bottom: $manageTools-panel-border;
-        background: $manageTools-heading-background;
+        background: var(--sakai-background-color-2);
         text-decoration: none;
         text-transform: capitalize;
         padding: $standard-spacing;
         display: block;
         margin: 0;
-        
+
         &:hover, &:hover .checkedCount, &:focus, &:focus .checkedCount {
           background: $manageTools-heading-hover-background;
           outline-offset: -#{$focus-outline-width};	// keep outline contained within the element
@@ -398,7 +398,7 @@
       }
     }
     .groupedTools {
-      &:first-of-type a { 
+      &:first-of-type a {
         border-top: 0 none;		// remove extra top border from first item
       }
       a:not(.open) {
@@ -480,7 +480,7 @@
   }
   #toolSelectionListHeader {
     position: relative;
-    background: $manageTools-heading-background;
+    background: var(--sakai-background-color-2);
   }
   #joinLimitByAccountType {
     margin-bottom: 1em;
@@ -624,7 +624,7 @@
     {
       margin: 0 0 0.5em 0;
     }
-  
+
     h4
     {
       margin: 0 10px 0.5em 0;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44856

<img width="869" alt="Screen Shot 2021-01-05 at 3 38 01 PM" src="https://user-images.githubusercontent.com/20628667/103696424-51a8a080-4f6c-11eb-8914-41bd29ee9f18.png">
<img width="918" alt="Screen Shot 2021-01-05 at 3 37 50 PM" src="https://user-images.githubusercontent.com/20628667/103696435-55d4be00-4f6c-11eb-9d72-70709c94371f.png">


WIP: Will also try and remove some of the $manageTools-panel-border variables