### PR TITLE
SAK-44873 Multiple issues with assignments released to deleted groups

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2710,7 +2710,7 @@ public class AssignmentAction extends PagedResourceActionII {
     } // build_list_assignments_context
 
     private List<String> getSortedAsnGroupTitles(Assignment asn, Site site, AssignmentComparator groupComparator) {
-        List<Group> asnGroups = asn.getGroups().stream().map(id -> site.getGroup(id)).collect(Collectors.toList());
+        List<Group> asnGroups = asn.getGroups().stream().map(id -> site.getGroup(id)).filter(Objects::nonNull).collect(Collectors.toList());
         asnGroups.sort(groupComparator);
         return asnGroups.stream().map(Group::getTitle).collect(Collectors.toList());
     }

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -447,30 +447,25 @@
 							<td headers="for" class="hidden-xs">
 								#if($assignment.TypeOfAccess == "SITE")
 									$tlang.getString("gen.viewallgroupssections")
-								#elseif($assignment.TypeOfAccess == "GROUP")
-									#set($groupTitleList = $asnGroupTitleMap.get($assignment.Id))
-                                    <div class="groupsContainer">
-                                        <strong class="collapse" onclick="ASN.toggleGroups( this ); ASN.resizeFrame();">
-											$groupTitleList.size()
-											#if($groupTitleList.size() == 1)
-												$tlang.getString( "selected.group" )
-											#else
-												$tlang.getString( "selected.groups" )
-											#end
-                                        </strong>
-
-                                        <div id="groupsPanel" style="display: none;">
-                                            <ul>
-												#foreach($title in $groupTitleList)
-                                                    <li>$formattedText.escapeHtml($title)</li>
-												#end
-                                            </ul>
-                                        </div>
-                                    </div>
 								#else
-                                    <div class="sak-banner-warn">
-										$tlang.getString( "assignment.inaccessible" )
-                                    </div>
+									#set($groupTitleList = $asnGroupTitleMap.get($assignment.Id))
+									#if(!$groupTitleList.isEmpty())
+										<div class="groupsContainer">
+											<strong class="collapse" onclick="ASN.toggleGroups(this);">
+												$groupTitleList.size() #if($groupTitleList.size() == 1) $tlang.getString("selected.group") #else $tlang.getString("selected.groups") #end
+											</strong>
+
+											<div id="groupsPanel" style="display: none;">
+												<ul>
+													#foreach($title in $groupTitleList)
+														<li>$formattedText.escapeHtml($title)</li>
+													#end
+												</ul>
+											</div>
+										</div>
+									#else
+										<div class="sak-banner-warn">$tlang.getString("assignment.inaccessible")</div>
+									#end
 								#end
 							</td>
 							#end


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44873

See the ticket for full description of the issues.

Regarding the change to the .vm:

Here is the original from Sakai 11 where the message would appear:
```
#if( $siteRelease )
    $tlang.getString("gen.viewallgroupssections")
#elseif( $groupTitleList.size() > 0 )
```

And in Sakai 12+:
```
#if($assignment.TypeOfAccess == "SITE")
    $tlang.getString("gen.viewallgroupssections")
#elseif($assignment.TypeOfAccess == "GROUP")
```
Following these is an #else that displays the warning message.

The new #elseif might look equivalent to the old one, but it is not, and as a result the #else is now unreachable.