### PR TITLE
SAK-43868 Site Info - Groups: Triangle beside locked tool does not change for expand/collapse

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -143,7 +143,7 @@
     background: none repeat scroll 0 0 #ccc;
   }
 
-  .group-locked-info-collapsed::before {
+  .group-locked-info.collapsed::before {
     content: '\f0da';
     font-family: 'FontAwesome';
     font-size: 18px;
@@ -151,12 +151,16 @@
     cursor: pointer;
   }
 
-  .group-locked-info-expanded::before {
+  .group-locked-info::before {
     content: '\f0d7';
     font-family: 'FontAwesome';
     font-size: 18px;
     font-weight: bold;
     cursor: pointer;
+  }
+
+  .group-locked-info + .collapsing {
+    transition: none !important;
   }
 
   .selectSectionDiv {

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
@@ -30,7 +30,7 @@
             <td class="hidden-xs" th:if="${anyGroupLocked}">
               <div th:if="${lockedGroupsEntityMap.get(group.id) != null }">
                 <div th:if="${!lockedGroupsEntityMap.get(group.id).get('assignments').isEmpty()}">
-                  <span class="group-locked-info-collapsed" data-toggle="collapse" th:data-target="|#lockingassignments-${group.id}|" tabindex="0" role="button" th:text="#{index.table.assignments}"></span>
+                  <span class="group-locked-info collapsed" data-toggle="collapse" th:data-target="|#lockingassignments-${group.id}|" tabindex="0" role="button" th:text="#{index.table.assignments}"></span>
                   <div th:id="|lockingassignments-${group.id}|" class="collapse">
                     <ul th:each=" assigment : ${lockedGroupsEntityMap.get(group.id).get('assignments')}">
                       <li th:text="${assigment}"></li>
@@ -39,7 +39,7 @@
                 </div>
                 <div class="clearfix"></div>
                 <div th:if="${!lockedGroupsEntityMap.get(group.id).get('assessments').isEmpty()}">
-                <span class="group-locked-info-collapsed" data-toggle="collapse" th:data-target="|#lockingassessments-${group.id}|" tabindex="0" role="button" th:text="#{index.table.assessments}"></span>
+                <span class="group-locked-info collapsed" data-toggle="collapse" th:data-target="|#lockingassessments-${group.id}|" tabindex="0" role="button" th:text="#{index.table.assessments}"></span>
                   <div th:id="|lockingassessments-${group.id}|" class="collapse">
                     <ul th:each=" assessment : ${lockedGroupsEntityMap.get(group.id).get('assessments')}">
                       <li th:text="${assessment}"></li>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43868

Also removes the expand/collapse animation because it becomes slow and choppy as the amount of data in the groups table grows