### PR TITLE
SAK-44890 - Problem running Quartz job "Configurable Job Test"

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutowiringSpringBeanJobFactory.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/AutowiringSpringBeanJobFactory.java
@@ -39,7 +39,8 @@ public final class AutowiringSpringBeanJobFactory extends SpringBeanJobFactory i
     	
         final Object job = super.createJobInstance(bundle);
         beanFactory.autowireBean(job);
-        beanFactory.autowireBeanProperties(job, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, true);
+        // This is set to disable dependency checking, otherwise some bean properties throw an error here
+        beanFactory.autowireBeanProperties(job, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, false);
         return job;
     }
 }

--- a/jobscheduler/scheduler-test-component-shared/pom.xml
+++ b/jobscheduler/scheduler-test-component-shared/pom.xml
@@ -30,7 +30,10 @@
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-kernel-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>

--- a/jobscheduler/scheduler-test-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/TestConfigurableJob.java
+++ b/jobscheduler/scheduler-test-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/TestConfigurableJob.java
@@ -39,7 +39,7 @@ public class TestConfigurableJob extends AbstractConfigurableJob
         throws JobExecutionException
     {
 
-        log.debug ("running TestConfigurableJob");
+        log.info ("running TestConfigurableJob");
 
         readIntegerProperty();
         readStringProperty();
@@ -54,13 +54,13 @@ public class TestConfigurableJob extends AbstractConfigurableJob
 
         if (temp == null)
         {
-            log.debug ("integer property is null");
+            log.info ("integer property is null");
         }
         else
         {
             try
             {
-                log.debug ("integer property is set to integer value: '" + Integer.parseInt(temp) + "'");
+                log.info ("integer property is set to integer value: '" + Integer.parseInt(temp) + "'");
             }
             catch (NumberFormatException nfe)
             {
@@ -76,15 +76,15 @@ public class TestConfigurableJob extends AbstractConfigurableJob
 
         if (temp == null)
         {
-            log.debug ("string property is null");
+            log.info ("string property is null");
         }
         else if (temp.trim().length() == 0)
         {
-            log.debug ("string property is empty");
+            log.info ("string property is empty");
         }
         else
         {
-            log.debug ("string property is set to: '" + temp + "'");
+            log.info ("string property is set to: '" + temp + "'");
         }
     }
 
@@ -95,11 +95,11 @@ public class TestConfigurableJob extends AbstractConfigurableJob
 
         if (temp == null)
         {
-            log.debug ("boolean property is null");
+            log.info ("boolean property is null");
         }
         else
         {
-            log.debug ("boolean property is set to boolean value: '" + Boolean.parseBoolean(temp) + "'");
+            log.info ("boolean property is set to boolean value: '" + Boolean.parseBoolean(temp) + "'");
         }
     }
 }

--- a/jobscheduler/scheduler-test-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/TestConfigurableJob.java
+++ b/jobscheduler/scheduler-test-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/TestConfigurableJob.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.component.app.scheduler.jobs;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import org.quartz.JobExecutionException;
 
@@ -60,11 +61,11 @@ public class TestConfigurableJob extends AbstractConfigurableJob
         {
             try
             {
-                log.info ("integer property is set to integer value: '" + Integer.parseInt(temp) + "'");
+                log.info ("integer property is set to integer value: '{}'", temp);
             }
             catch (NumberFormatException nfe)
             {
-                log.error ("integer property is set to a non-integer value: '" + temp + "'");
+                log.error ("integer property is set to a non-integer value: '{}'", temp);
             }
         }
     }
@@ -74,17 +75,13 @@ public class TestConfigurableJob extends AbstractConfigurableJob
     {
         String temp = getConfiguredProperty(STRING_PROPERTY);
 
-        if (temp == null)
+        if (StringUtils.isBlank(temp))
         {
-            log.info ("string property is null");
-        }
-        else if (temp.trim().length() == 0)
-        {
-            log.info ("string property is empty");
+            log.info ("string property is blank");
         }
         else
         {
-            log.info ("string property is set to: '" + temp + "'");
+            log.info ("string property is set to: '{}'", temp);
         }
     }
 
@@ -99,7 +96,7 @@ public class TestConfigurableJob extends AbstractConfigurableJob
         }
         else
         {
-            log.info ("boolean property is set to boolean value: '" + Boolean.parseBoolean(temp) + "'");
+            log.info ("boolean property is set to boolean value: '{}'", temp);
         }
     }
 }


### PR DESCRIPTION
The fix here seemed to be to disable dependency checking in the new method added in SAK-44246. I tested that SAK-44246 still passes fine with this.
Also changed the logging in Configurable Job Test to info, as I figured if someones actually running this test they'll want to see what it outputs.