### PR TITLE
SAK-44898 - Configurable job name and description not being translated

### DIFF
--- a/jobscheduler/scheduler-test-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-test-component/src/webapp/WEB-INF/components.xml
@@ -14,7 +14,7 @@
        <property name="jobName">
           <value>Configurable Job Test</value>
        </property>
-       <property name="resourceBundleBase" value="org.sakaiproject.component.app.scheduler.jobs.Messages"/>
+       <property name="resourceBundleBase" value="org.sakaiproject.component.app.scheduler.jobs.test.Messages"/>
        <property name="configurableJobProperties">
            <set>
                <bean id="integer.property" class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">


### PR DESCRIPTION
Was just using the wrong resource bundle for this bean.
![image](https://user-images.githubusercontent.com/27447/104855286-db942a00-58d9-11eb-94b3-b4b418f8f1aa.png)
