### PR TITLE
SAK-44557 Remove section and column merge link id from href

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1330,9 +1330,11 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 				    UIOutput.make(columnContainer, "section3").decorate(new UIFreeAttributeDecorator("title", messageLocator.getMessage("simplepage.columnopen")));
 				    UIOutput.make(columnContainer, "addbottom");
 				    UIOutput.make(columnContainer, "addbottom2").decorate(new UIFreeAttributeDecorator("title", messageLocator.getMessage("simplepage.add-item-column")));
-				    UILink link = UILink.make(columnContainer, "section-del-link", (String)null, "/" + i.getId());
-				    link.decorate(new UIFreeAttributeDecorator("title", messageLocator.getMessage("simplepage.join-items")));
-				    link.decorate(new UIStyleDecorator(sectionbreak?"section-merge-link":"column-merge-link"));
+				    UIOutput mergeLink = UIOutput.make(columnContainer, "section-del-link");
+				    mergeLink.decorate(new UIFreeAttributeDecorator("data-merge-id", String.valueOf(i.getId())));
+				    mergeLink.decorate(new UIFreeAttributeDecorator("title", messageLocator.getMessage("simplepage.join-items")));
+				    mergeLink.decorate(new UIFreeAttributeDecorator("aria-label", messageLocator.getMessage("simplepage.join-items")));
+				    mergeLink.decorate(new UIStyleDecorator(sectionbreak?"section-merge-link":"column-merge-link"));
 				    }
 
 				    UIBranchContainer tableRow = UIBranchContainer.make(tableContainer, "item:");

--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -1849,7 +1849,7 @@ span.nextprev {
 .fa-edit-icon{
   font-size:16px;
   font-weight: normal;
-  color: #aaa;
+  color: #666;
   font-family:FontAwesome;
 }
 .fa-group-icon {

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -2557,7 +2557,7 @@ $(document).ready(function() {
 		var tail_cols = addAboveLI.parent().parent().nextAll();
 		var section = addAboveLI.parent().parent().parent();
 		var sectionId = "sectionid" + (nextid++);
-		section.prev('.sectionHeader').parent().after('<div><h3 class="sectionHeader skip"><span aria-hidden="true" class="collapseIcon fa-caret-down"></span><span class="sectionHeaderText"></span><span class="toggleCollapse">' + msg('simplepage.clickToCollapse') + '</span></h3><div class="section"><div class="column"><div class="editsection"><span class="sectionedit"><h3 class="offscreen">' + msg('simplepage.break-here') + '</h3><a href="/' + newitem + '" title="' + msg('simplepage.join-items') + '" class="section-merge-link" onclick="return false"><span aria-hidden="true" class="fa-compress fa-edit-icon sectioneditfont"></span></a></span><span class="sectionedit sectionedit2"><a href="/lessonbuilder-tool/templates/#" title="' + msg('simplepage.columnopen') + '" class="columnopen" style="text-decoration: none;"><span aria-hidden="true" class="fa-cog fa-edit-icon sectioneditfont"></span></a></span></div><span class="sectionedit addbottom"><a href="#" title="Add new item at bottom of this column" class="add-bottom"><span aria-hidden="true" class="fa-plus fa-edit-icon plus-edit-icon"></span></a></span><div border="0" role="list" style="z-index: 1;" class="indent mainList"><div class="breakitem breaksection" role="listitem"><span style="display:none" class="itemid">' + newitem + '</span></div></div></div></div></div>');
+		section.prev('.sectionHeader').parent().after('<div><h3 class="sectionHeader skip"><span aria-hidden="true" class="collapseIcon fa-caret-down"></span><span class="sectionHeaderText"></span><span class="toggleCollapse">' + msg('simplepage.clickToCollapse') + '</span></h3><div class="section"><div class="column"><div class="editsection"><span class="sectionedit"><h3 class="offscreen">' + msg('simplepage.break-here') + '</h3><button type="button" data-merge-id="' + newitem + '" aria-label="' + msg('simplepage.join-items') + '" title="' + msg('simplepage.join-items') + '" class="section-merge-link"><span aria-hidden="true" class="fa-compress fa-edit-icon sectioneditfont"></span></button></span><span class="sectionedit sectionedit2"><a href="/lessonbuilder-tool/templates/#" title="' + msg('simplepage.columnopen') + '" class="columnopen" style="text-decoration: none;"><span aria-hidden="true" class="fa-cog fa-edit-icon sectioneditfont"></span></a></span></div><span class="sectionedit addbottom"><a href="#" title="Add new item at bottom of this column" class="add-bottom"><span aria-hidden="true" class="fa-plus fa-edit-icon plus-edit-icon"></span></a></span><div border="0" role="list" style="z-index: 1;" class="indent mainList"><div class="breakitem breaksection" role="listitem"><span style="display:none" class="itemid">' + newitem + '</span></div></div></div></div></div>');
 		// now go to new section
 		section = section.prev('.sectionHeader').parent().next().children(".section");
 
@@ -2595,7 +2595,7 @@ $(document).ready(function() {
 		// current section DIV
 		var tail_uls = addAboveLI.parent().nextAll();
 		var column = addAboveLI.parent().parent();
-		column.after('<div class="column"><div class="editsection"><span class="sectionedit"><h3 class="offscreen">' + msg('simplepage.break-column-here') + '</h3><a href="/' + newitem + '" title="' + msg('simplepage.join-items') + '" class="column-merge-link" onclick="return false"><span aria-hidden="true" class="fa-compress fa-edit-icon sectioneditfont"></span></a></span><span class="sectionedit sectionedit2"><a href="/lessonbuilder-tool/templates/#" title="' + msg('simplepage.columnopen') + '" class="columnopen" style="text-decoration: none;"><span aria-hidden="true" class="fa-cog fa-edit-icon sectioneditfont"></span></a></span></div><span class="sectionedit addbottom"><a href="#" title="Add new item at bottom of this column" class="add-bottom"><span aria-hidden="true" class="fa-plus fa-edit-icon plus-edit-icon"></span></a></span><div border="0" role="list" style="z-index: 1;" class="indent mainList"><div class="breakitem breakcolumn" role="listcolumn"><span style="display:none" class="itemid">' + newitem + '</span></div></div></div>');
+		column.after('<div class="column"><div class="editsection"><span class="sectionedit"><h3 class="offscreen">' + msg('simplepage.break-column-here') + '</h3><button type="button" data-merge-id="' + newitem + '" aria-label="' + msg('simplepage.join-items') + '" title="' + msg('simplepage.join-items') + '" class="column-merge-link"><span aria-hidden="true" class="fa-compress fa-edit-icon sectioneditfont"></span></button></span><span class="sectionedit sectionedit2"><a href="/lessonbuilder-tool/templates/#" title="' + msg('simplepage.columnopen') + '" class="columnopen" style="text-decoration: none;"><span aria-hidden="true" class="fa-cog fa-edit-icon sectioneditfont"></span></a></span></div><span class="sectionedit addbottom"><a href="#" title="Add new item at bottom of this column" class="add-bottom"><span aria-hidden="true" class="fa-plus fa-edit-icon plus-edit-icon"></span></a></span><div border="0" role="list" style="z-index: 1;" class="indent mainList"><div class="breakitem breakcolumn" role="listcolumn"><span style="display:none" class="itemid">' + newitem + '</span></div></div></div>');
 
 		// now go to new section
 		column = column.next();
@@ -2617,7 +2617,7 @@ $(document).ready(function() {
 
 	function sectionMergeLink(e) {
 		e.preventDefault();
-		deleteBreak($(this).attr('href').substring(1));
+		deleteBreak($(this).data('merge-id'));
 		var thisCol = $(this).parents('.column');
 		// in first column all li's except the break
 		var tail_lis = thisCol.find('.mainList').children().first().nextAll();
@@ -2645,7 +2645,7 @@ $(document).ready(function() {
 
 	function columnMergeLink(e) {
 		e.preventDefault();
-		deleteBreak($(this).attr('href').substring(1));
+		deleteBreak($(this).data("merge-id"));
 		var thisCol = $(this).parents('.column');
 		// all li's expect break
 		var tail_lis = thisCol.find('.mainList').children().first().nextAll();
@@ -2662,7 +2662,7 @@ $(document).ready(function() {
 
 	$('.columnopen').click(columnOpenLink);
 	function columnOpenLink(e) {
-	    var itemid = $(this).closest('.editsection').find('.column-merge-link,.section-merge-link').attr('href').substring(1);
+	    var itemid = $(this).closest('.editsection').find('.column-merge-link,.section-merge-link').data("merge-id");
 	    var sectionSettings = $('#sectionSettings');
 	    var columnLabel = $('#columnColorLabel');
 	    var sectionLabel = $('#sectionColorLabel');

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -512,7 +512,7 @@
 			  <div class="editsection">
 			  <span rsf:id="section-td" class="sectionedit">
                   <h3 class="offscreen" rsf:id="break-msg"></h3>
-                  <a role="button" rsf:id="section-del-link" href="#"  onclick="return false"><span aria-hidden="true" class="fa-compress fa-edit-icon"></span></a>
+                  <button type="button" rsf:id="section-del-link"><span aria-hidden="true" class="fa-compress fa-edit-icon"></span></button>
               </span>
 			  <span rsf:id="section2" class="sectionedit sectionedit2">
                   <a role="button" aria-haspopup="dialog" aria-controls="column-dialog" rsf:id="section3" href="#" class="columnopen" style="text-decoration: none;"><span aria-hidden="true" class="fa-cog fa-edit-icon sectioneditfont"></span></a>

--- a/library/src/morpheus-master/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/morpheus-master/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -473,6 +473,13 @@
 			top: 2em;	
 		}	
 	}
+	button.section-merge-link, button.column-merge-link {
+		padding: 0;
+		margin: 0;
+		line-height: 24px;
+		border: 0;
+		background: transparent;
+	}
 }
 
 .#{$namespace}multipleTools {


### PR DESCRIPTION
Section and column break item id is needed in javascript to remove the
section or column. This was added to the href of the link but should instead
be added to a data attribute on the link.