### PR TITLE
SAK-43749 Invisible tool cannot be accessed by students via direct link

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/DirectToolHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/DirectToolHandler.java
@@ -60,6 +60,9 @@ public class DirectToolHandler extends BasePortalHandler
 	private static ServerConfigurationService serverConfigurationService = (ServerConfigurationService)ComponentManager.get(ServerConfigurationService.class);
 
 	public static final String URL_FRAGMENT = "directtool";
+	public static final String DIRECT_LINK = "directLink";
+	public static final String DIRECT_LINK_SITE = "directLinkSite";
+	public static final String DIRECT_LINK_PAGE = "directLinkPage";
 
 	public DirectToolHandler()
 	{
@@ -91,6 +94,12 @@ public class DirectToolHandler extends BasePortalHandler
 					return ABORT;
 				}
 				parts[2] = toolPlacement;
+				
+				//To allow direct link to students
+				session.setAttribute(DIRECT_LINK, toolPlacement);
+				ToolConfiguration siteTool = SiteService.findTool(toolPlacement);
+				session.setAttribute(DIRECT_LINK_SITE, siteTool.getSiteId());
+				session.setAttribute(DIRECT_LINK_PAGE, siteTool.getPageId());
 
 				return doDirectTool(req, res, session, parts[2], req.getContextPath()
 						+ req.getServletPath() + Web.makePath(parts, 1, 3), Web.makePath(

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -282,7 +282,7 @@ public class SiteHandler extends WorksiteHandler
 			String commonToolId, String [] parts, String toolContextPath) throws ToolException,
 			IOException
 	{		
-				
+		
 		// default site if not set
 		String userId = session.getUserId();
 		if (siteId == null)


### PR DESCRIPTION
SAK-43749 Invisible tool cannot be accessed by students via direct link

Hi, everyone.

I have been working on this issue.
I know that this request is delicate since it affects the navigation between tools, sites and projects.
I have tested my solution with courses and project sites and various tools.
First of all, I allow access to the tool with direct link even if it is hidden from the student. However, I do not allow the name of the tool to appear in the menu on the left, as it can only be accessed with the link.

Thank you.