### PR TITLE
SAK-44905 Clean up name and description form field styling

### DIFF
--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -2205,13 +2205,12 @@ legend.noBottomSpacing {
     padding-left: 0px !important; /* important needed to override bootstrap grid-layout */
 }
 
-.edit-form-input.description{
-    width: 99%;
+.edit-form-input {
     margin-bottom: 10px;
 }
-.edit-form-input.col-sm-2 {
-    padding-left: 0;
-    padding-right: 0;
+
+textarea.edit-form-input {
+    padding: 8px;
 }
 
 p.checkbox{

--- a/lessonbuilder/tool/src/webapp/css/checklist.css
+++ b/lessonbuilder/tool/src/webapp/css/checklist.css
@@ -36,7 +36,6 @@
     display: block;
 }
 #description{
-    height: 80px;
     width: 90%;
     max-width: 500px;
 }

--- a/lessonbuilder/tool/src/webapp/templates/Checklist.html
+++ b/lessonbuilder/tool/src/webapp/templates/Checklist.html
@@ -51,7 +51,7 @@
             <p class="checklistFormInput">
                 <label class="checklistDescription" rsf:id="msg=simplepage.new-checklist-description" for="description"></label>
                 <br />
-                <textarea rsf:id="description" id="description"></textarea>
+                <textarea rsf:id="description" id="description" rows="6"></textarea>
             </p>
 
             <hr />

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -1237,15 +1237,14 @@
                       </p>
 
                       <p class="shorttext required row">
-                          <label rsf:id="name-label" class="col-sm-1" for="name"></label>
-                          <input type="text" name="name" rsf:id="name" id="name" size="30" maxlength="255" class="edit-form-input col-sm-2" /><br />
+                          <label rsf:id="name-label" class="col-sm-2" for="name"></label>
+                          <input type="text" name="name" rsf:id="name" id="name" size="30" maxlength="255" class="edit-form-input col-sm-6" /><br />
                       </p>
 
-                      <p class="shorttext required">
-                      <div rsf:id="description-label" for="description" class="col-sm-1 itemDesc"></div>
-                      <textarea name="description" id="description" rsf:id="description" class="edit-form-input col-sm-2 description" rows="5" cols ="25">
-                            </textarea>
-                      </p>
+                      <div class="shorttext required row">
+                        <div rsf:id="description-label" for="description" class="col-sm-2 itemDesc"></div>
+                        <textarea name="description" id="description" rsf:id="description" class="edit-form-input" rows="6"></textarea>
+                      </div>
 
                       <div rsf:id="changeDiv">
                           <p class="shorttext required" id="change-assignment-p">


### PR DESCRIPTION
Improve the styling of the name and description form fields in the
edit dialog and on the checklist page by adding spacing and making
them wider.