### PR TITLE
SAK-44785 Add "direct-upload" endpoint to content entity provider

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -648,6 +648,15 @@
 # DEFAULT: video/mp4,video/webm,video/quicktime,audio/mpeg,video/x-m4v
 # content.mime.inline=video/mp4,video/quicktime,video/3gpp,video/x-ms-wmv,audio/mpeg,audio/wav,audio/x-wav,video/x-m4v
 
+# SAK-44785 Allow direct upload endpoint
+# DEFAULT: true
+# content.direct.upload.enabled=false
+
+# SAK-44785 Override the names for the folders automatically created for direct-upload
+# DEFAULT: See below
+# content.direct.upload.instructors=instructor-uploads
+# content.direct.upload.students=student-uploads
+
 # #######################################################################
 # CLOUD-CONTENT
 # #######################################################################

--- a/content/content-tool/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/content/content-tool/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -23,6 +23,7 @@
         <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
         <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
         <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
+        <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
     </bean>
 
     <bean parent="org.sakaiproject.entitybroker.entityprovider.AbstractEntityProvider"

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ContentHostingService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ContentHostingService.java
@@ -261,6 +261,12 @@ public interface ContentHostingService extends EntityProducer
 	public static final String PREVIEW = "PREVIEW";
 
 	/**
+	 * The default names for the direct-upload folders.
+	 */
+	public static final String DEFAULT_INSTRUCTOR_FOLDER = "instructor-uploads";
+	public static final String DEFAULT_STUDENT_FOLDER = "student-uploads";
+
+	/**
     * For a given id, return its UUID (creating it if it does not already exist)
     */
    public String getUuid(String id);
@@ -2097,4 +2103,22 @@ public interface ContentHostingService extends EntityProducer
 	public String expandMacros(String url);
 
 	public Optional<String> getHtmlForRef(String ref);
+
+	/**
+	 * Get the name of the "instructor" upload folder name for direct-upload.
+	 * This is the folder for users that have addCollection permission in the
+	 * site.
+	 *
+	 * @return String - The name of the folder.
+	 */
+	public String getInstructorUploadFolderName();
+
+	/**
+	 * Get the name of the "student" upload folder name for direct-upload.
+	 * This is the folder for users that do not have addCollection permission
+	 * in the site.
+	 *
+	 * @return String - The name of the folder.
+	 */
+	public String getStudentUploadFolderName();
 }

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/ResourceProperties.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/ResourceProperties.java
@@ -182,6 +182,11 @@ public interface ResourceProperties extends Serializable
 	/** Property name on a ContentEntity indicating if the item is hidden but it's content is public.*/
 	static final String PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT = "SAKAI:hidden_accessible_content";
 
+	/** Property name on a ContentEntity indicating that it should not be imported when duplicating
+	 *  a site or importing from a site.
+	 */
+	static final String PROP_DO_NOT_DUPLICATE = "SAKAI:do_not_duplicate";
+
 	/**
 	 * Property name on a Resource or Collection which will allow resources with
 	 * a text/html content type to be output with an inline content-disposition

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -8362,6 +8362,10 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 						}
 
 						ResourceProperties oProperties = oResource.getProperties();
+						if (StringUtils.equals((String)oProperties.get(ResourceProperties.PROP_DO_NOT_DUPLICATE), Boolean.TRUE.toString())) {
+							// This resource has been marked as do not duplicate. Skip it.
+							continue;
+						}
 						boolean isCollection = false;
 						try {
 							isCollection = oProperties.getBooleanProperty(ResourceProperties.PROP_IS_COLLECTION);
@@ -14513,6 +14517,15 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 		}
     }
 
+	@Override
+	public String getInstructorUploadFolderName() {
+		return m_serverConfigurationService.getString("content.direct.upload.instructors", DEFAULT_INSTRUCTOR_FOLDER);
+	}
+
+	@Override
+	public String getStudentUploadFolderName() {
+		return m_serverConfigurationService.getString("content.direct.upload.students", DEFAULT_STUDENT_FOLDER);
+	}
 
 	private String getDisplayName(User userIn) {
 		User user = (userIn== null)?userDirectoryService.getCurrentUser():userIn ;

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -150,6 +150,15 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         };
     }
 
+    let siteId = "";
+    if (collectionId) {
+        if (collectionId.startsWith('/user/') && portal && portal.siteId) {
+            siteId = portal.siteId;
+        } else {
+            siteId = collectionId.split('/')[2];
+        }
+    }
+
     var ckconfig = {
 	//Some defaults for audio recorder
         audiorecorder : {
@@ -184,6 +193,10 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         filebrowserBrowseUrl :      filebrowser.browseUrl,
         filebrowserImageBrowseUrl : filebrowser.imageBrowseUrl,
         filebrowserFlashBrowseUrl : filebrowser.flashBrowseUrl,
+
+        filebrowserUploadUrl: '/direct/content/direct-upload.json?context=${siteId}',
+        uploadUrl: '/direct/content/direct-upload.json?context=${siteId}',
+        imageUploadUrl: '/direct/content/direct-upload.json?context=${siteId}',
 
         extraPlugins: (sakai.editor.enableResourceSearch ? 'resourcesearch,' : '')+'',
 
@@ -328,7 +341,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         //ckconfig.extraPlugins+="atd-ckeditor,";
         //ckconfig.contentsCss = [basePath+'atd-ckeditor/atd.css'];
 
-        ckconfig.extraPlugins+="${ckeditor-extra-plugins}${ckeditor-a11y-extra-plugins}";
+        ckconfig.extraPlugins += "${ckeditor-extra-plugins}${ckeditor-a11y-extra-plugins}, uploadimage";
 
         // Load FontAwesome CSS in case a user wants to manually add FA markup
         ckconfig.contentsCss.push(webJars+'fontawesome/4.7.0/css/font-awesome.min.css');

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -33,7 +33,8 @@
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
       <head><%= request.getAttribute("html.head") %>
       <title> <h:outputText value="#{delivery.assessmentTitle}"/> </title>
-      <%@ include file="/jsf/delivery/deliveryjQuery.jsp" %>
+          <script>var portal = portal || { siteId: '#{delivery.siteId}' };</script>
+          <%@ include file="/jsf/delivery/deliveryjQuery.jsp" %>
       <script src="/sakai-editor/editor-bootstrap.js"></script>
       <script src="/sakai-editor/editor.js"></script>
       <script src="/sakai-editor/editor-launch.js"></script>


### PR DESCRIPTION
This adds a new endpoint that allows members of a site to upload a file
to resources whether or not they have permission to do so. Those without
permission will have their file sent to a folder called by default
student-uploads. Those with permission to add a resource will be have theirs
sent to instructor-uploads.

This endpoint is diabled by default and can be enabled by setting the sakai
property content.direct.upload.enabled=true. Additionally, the direct-upload
folder names can be overriden in sakai.properties.

This new endpoint integrates with the CKEditor to provide drag and drop embedding
and image upload capabilities.