### PR TITLE
SAK-44805 - Fixing up TaskServiceTest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
-    - run: git checkout HEAD^
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,8 @@ jobs:
     # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 2
+    - run: git checkout HEAD
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 2
+	ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
-    - run: git checkout HEAD
+    - run: git checkout HEAD^
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
     - uses: actions/checkout@v2
       with:
-	ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/tasks/impl/test/TaskServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/tasks/impl/test/TaskServiceTest.java
@@ -38,6 +38,8 @@ import org.springframework.test.context.junit4.AbstractTransactionalJUnit4Spring
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.Assert;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {TaskServiceTestConfiguration.class})
 @FixMethodOrder(NAME_ASCENDING)
@@ -57,7 +59,7 @@ public class TaskServiceTest extends AbstractTransactionalJUnit4SpringContextTes
         Task task = new Task();
         task.setSiteId(siteId);
         task.setReference(reference);
-        task.setSystem(true);
+        task.setSystem(false);
         task.setDescription(description);
         return taskService.createTask(task, userIds, Priorities.HIGH);
     }
@@ -65,7 +67,7 @@ public class TaskServiceTest extends AbstractTransactionalJUnit4SpringContextTes
     @Test
     public void testCanCreateSingleUserTask() {
 
-        String description = "This is my task";
+        String description = "Description about my task";
         String notes = "Notes about my task";
         int priority = Priorities.QUITE_HIGH;
         UserTaskAdapterBean bean = new UserTaskAdapterBean();
@@ -82,8 +84,8 @@ public class TaskServiceTest extends AbstractTransactionalJUnit4SpringContextTes
 
         UserTaskAdapterBean userTask = optionalUserTask.get();
 
-        Assert.isTrue(userTask.getDescription().equals(description), "task.description were not the same");
-        Assert.isTrue(userTask.getNotes().equals(notes), "usertask.notes were not the same");
+        assertEquals("task.description were not the same", description, userTask.getDescription());
+        assertEquals("usertask.notes were not the same", notes, userTask.getNotes());
         Assert.isTrue(userTask.getPriority() == priority, "task.priority were not the same");
     }
 
@@ -122,8 +124,8 @@ public class TaskServiceTest extends AbstractTransactionalJUnit4SpringContextTes
 
         userTask = userTasks.get(0);
 
-        Assert.isTrue(userTask.getNotes().equals(newNotes), "Newly saved notes doesn't match");
-        Assert.isTrue(userTask.getDescription().equals(newDescription), "Newly saved description doesn't match");
+        assertEquals("Newly saved notes doesn't match", newNotes, userTask.getNotes());
+        assertEquals("Newly saved description doesn't match", newDescription, userTask.getDescription());
         Assert.isTrue(userTask.getPriority() == 3, "Newly saved priority doesn't match");
         Assert.isTrue(userTask.getComplete(), "Newly saved task should be complete");
     }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/tasks/impl/test/TaskServiceTestConfiguration.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/tasks/impl/test/TaskServiceTestConfiguration.java
@@ -30,7 +30,11 @@ import org.hsqldb.jdbcDriver;
 import org.sakaiproject.tasks.api.Task;
 import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.tasks.api.UserTask;
+import org.sakaiproject.tasks.api.repository.TaskRepository;
+import org.sakaiproject.tasks.api.repository.UserTaskRepository;
 import org.sakaiproject.tasks.impl.TaskServiceImpl;
+import org.sakaiproject.tasks.impl.repository.TaskRepositoryImpl;
+import org.sakaiproject.tasks.impl.repository.UserTaskRepositoryImpl;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.springframework.orm.hibernate.AdditionalHibernateMappings;
 import org.sakaiproject.springframework.orm.hibernate.impl.AdditionalHibernateMappingsImpl;
@@ -114,4 +118,20 @@ public class TaskServiceTestConfiguration {
     public TaskService taskService() {
         return new TaskServiceImpl();
     }
+
+    @Bean
+    public TaskRepository taskRepository(SessionFactory sessionFactory) {
+        TaskRepositoryImpl tr = new TaskRepositoryImpl();
+        tr.setSessionFactory(sessionFactory);
+        return tr;
+    }
+
+    @Bean
+    public UserTaskRepository userTaskRepository(SessionFactory sessionFactory) {
+        UserTaskRepositoryImpl utr = new UserTaskRepositoryImpl();
+        utr.setSessionFactory(sessionFactory);
+        return utr;
+    } 
+
+    
 }


### PR DESCRIPTION
@ern looks like 0170595cf4f48413922dffe26bdb04410c1bb359 broke the TaskServiceTest. 

I researched this a bit.
* Added the missing beans in the `TaskServiceTestConfiguration` that were recently added
Then it was still failing so

* I switched the assertion to use `assertEquals `to display what was actually failing and improved some of the messages.

But it was still showing the old value. I noticed there was a code change
https://github.com/sakaiproject/sakai/blob/df030150d6815c2c72a09d3f918632aa34b6fa71/kernel/kernel-impl/src/main/java/org/sakaiproject/tasks/impl/TaskServiceImpl.java#L120

And this Test had
https://github.com/sakaiproject/sakai/blob/df030150d6815c2c72a09d3f918632aa34b6fa71/kernel/kernel-impl/src/test/java/org/sakaiproject/tasks/impl/test/TaskServiceTest.java#L60

So I switched that to false since this really isn't a system test. Not sure if there was a reason "System" tasks aren't updating or if the test was just wrong to begin with. Perhaps the test could be improved to test this new System test case. 

Thanks!