### PR TITLE
SAK-44978: Error when modifying the final grades in ORACLE

### DIFF
--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradingEvent.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradingEvent.java
@@ -40,10 +40,6 @@ public class GradingEvent implements Comparable<Object>, Serializable {
     private Date dateGraded;
     private GradingEventStatus status;
 
-    public GradingEvent() {
-        this.dateGraded = new Date();
-    }
-
     public GradingEvent(GradableObject gradableObject, String graderId, String studentId, Object grade) {
         this.gradableObject = gradableObject;
         this.graderId = graderId;

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -3479,11 +3479,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		courseGradeRecord.setDateRecorded(new Date());
 
 		// create a grading event
-		final GradingEvent gradingEvent = new GradingEvent();
-		gradingEvent.setGradableObject(courseGradeRecord.getCourseGrade());
-		gradingEvent.setGraderId(getUserUid());
-		gradingEvent.setStudentId(studentUuid);
-		gradingEvent.setGrade(courseGradeRecord.getEnteredGrade());
+		final GradingEvent gradingEvent = new GradingEvent(courseGradeRecord.getCourseGrade(), getUserUid(), studentUuid, courseGradeRecord.getEnteredGrade());
 
 		// save
 		getHibernateTemplate().saveOrUpdate(courseGradeRecord);


### PR DESCRIPTION
When modifying the final grade of a user, it produces a null error in the "IS_EXCLUDED" field of the "GB_GRADING_EVENT_T" table in the ORACLE database.