### PR TITLE
SAK-45006 Control dark theme with a property separate of the theme toggle

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -887,7 +887,6 @@
 # DEFAULT: - (a dash)
 # portal.mutable.sitename=
 
-
 # Determines whether search should be enable in the portal login nav bar
 # https://jira.sakaiproject.org/browse/SAK-42443
 # DEFAULT: true
@@ -901,9 +900,18 @@
 # DEFAULT: none (null)
 # portlet.support=stealth
 
-# If set to true, the dark/light mode theme switcher will be available in the user dropdown
+# Portal Themes: 
+# Enable/disable the availability of user theme preferences, functionality, and controls
 # DEFAULT: true
-# portal.themeswitcher=true
+# portal.themes=false
+
+# If set to true, the dark/light theme switcher will be available in the user dropdown
+# DEFAULT: false
+# portal.themes.switcher=true
+
+# Enable/disable the OS dark theme auto-detect mode
+# DEFAULT: false
+# portal.themes.autoDetectDark=true
 
 # Display the help icon
 # DEFAULT: true

--- a/login/login-render-engine-impl/impl/src/webapp/vm/defaultskin/xlogin.vm
+++ b/login/login-render-engine-impl/impl/src/webapp/vm/defaultskin/xlogin.vm
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">        
         <link href="${pageSkinRepo}/${pageSkin}/tool.css" type="text/css" rel="stylesheet" media="all" />
         <script src="${pageSkinRepo}/${pageSkin}/js/lib/modernizr.js$!{portalCDNQuery}"></script>
-    #if (${themeSwitcher})
+    #if (${sakaiThemesEnabled})
         <script src="$!{portalCDNPath}/portal/scripts/themeswitcher.js$!{portalCDNQuery}"></script>
     #end
     </head>

--- a/portal/portal-charon/charon/src/webapp/scripts/themeswitcher.js
+++ b/portal/portal-charon/charon/src/webapp/scripts/themeswitcher.js
@@ -12,22 +12,23 @@ function sakaiThemeSwitcher(){
         // if the dark theme switch is on the page, attach listener to dark theme toggle switch
         darkThemeSwitcher && darkThemeSwitcher.addEventListener('click', toggleDarkTheme, false);
 
-        if (isLoggedIn()) {
-            // only check for unset theme preference because light and dark themes are already set by Java
-            if (isPortalThemeUserPrefUnset()) {
-                // if the user has dark mode set on their OS, enable dark mode
-                if (isOsDarkThemeSet()) {
-                    enableDarkTheme();
-                } else {
-                    // to define a user preference:
-                    setPortalThemeUserPref(lightThemeClass);
+        if (portal.userThemeAutoDetectDark) {
+            if (isLoggedIn()) {
+                // only check for unset theme preference because light and dark themes are already set by Java
+                if (isPortalThemeUserPrefUnset()) {
+                    // if the user has dark mode set on their OS, enable dark mode
+                    if (isOsDarkThemeSet()) {
+                        enableDarkTheme();
+                    } else {
+                        // to define a user preference:
+                        setPortalThemeUserPref(lightThemeClass);
+                    }
                 }
+            } else if (isOsDarkThemeSet()) {
+                // just add the dark theme to the markup if not logged in and the user has dark mode set on their OS (no prefs to save)
+                addCssClassToMarkup(darkThemeClass);
             }
-        } else if (isOsDarkThemeSet()) {
-            // just add the dark theme to the markup if not logged in and the user has dark mode set on their OS (no prefs to save)
-            addCssClassToMarkup(darkThemeClass);
         }
-        
         if (document.documentElement.classList.contains(darkThemeClass)) {
             // the dark theme switch toggle is off by default, so toggle it to on if dark theme is enabled
             setDarkThemeSwitcherToggle(true);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -228,7 +228,9 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 
 	private boolean sakaiTutorialEnabled = true;
 	
-	private boolean sakaiThemeSwitcherEnabled = true;
+	private boolean sakaiThemesEnabled = true;
+	private boolean sakaiThemeSwitcherEnabled = false;
+	private boolean sakaiThemesAutoDetectDarkEnabled = false;
 
 	private String handlerPrefix;
 
@@ -1737,12 +1739,19 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
                         	}
                         }
 
-                        if(sakaiThemeSwitcherEnabled) {
-                            rcontext.put("themeSwitcher", true);
-                            
-                            String userTheme = StringUtils.defaultIfEmpty(prefs.getProperties(org.sakaiproject.user.api.PreferencesService.USER_SELECTED_UI_THEME_PREFS).getProperty("theme"), "sakaiUserTheme-notSet");
-                            rcontext.put("userTheme", userTheme);
-                        }
+			if(sakaiThemesEnabled) {
+				rcontext.put("sakaiThemesEnabled", true);
+
+				if(sakaiThemeSwitcherEnabled) {
+					rcontext.put("themeSwitcher", true);
+				}
+				
+				if(sakaiThemesAutoDetectDarkEnabled) {
+					rcontext.put("themesAutoDetectDark", true);
+				}
+				String userTheme = StringUtils.defaultIfEmpty(prefs.getProperties(org.sakaiproject.user.api.PreferencesService.USER_SELECTED_UI_THEME_PREFS).getProperty("theme"), "sakaiUserTheme-notSet");
+				rcontext.put("userTheme", userTheme);
+			}
 
 			if ((poweredByUrl != null) && (poweredByImage != null)
 					&& (poweredByAltText != null)
@@ -2030,7 +2039,9 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		
 		sakaiTutorialEnabled = ServerConfigurationService.getBoolean("portal.use.tutorial", true);
 
-		sakaiThemeSwitcherEnabled = ServerConfigurationService.getBoolean("portal.themeswitcher", true);
+		sakaiThemesEnabled = ServerConfigurationService.getBoolean("portal.themes", true);
+		sakaiThemeSwitcherEnabled = ServerConfigurationService.getBoolean("portal.themes.switcher", false);
+		sakaiThemesAutoDetectDarkEnabled = ServerConfigurationService.getBoolean("portal.themes.autoDetectDark", false);
 
 		basicAuth = new BasicAuth();
 		basicAuth.init();

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
@@ -165,7 +165,7 @@ public class DefaultSiteViewImpl extends AbstractSiteViewImpl
 			renderContextMap.put("tutorial", false);
 		}
 
-		renderContextMap.put("themeSwitcher", serverConfigurationService.getBoolean("portal.themeswitcher", true));
+		renderContextMap.put("themeSwitcher", serverConfigurationService.getBoolean("portal.themes.switcher", false));
 
 		List<Map> l = siteHelper.convertSitesToMaps(request, mySites, prefix,
 				currentSiteId, myWorkspaceSiteId,

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
@@ -182,7 +182,7 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 			renderContextMap.put("tutorial", false);
 		}
 
-		renderContextMap.put("themeSwitcher", serverConfigurationService.getBoolean("portal.themeswitcher", true));
+		renderContextMap.put("themeSwitcher", serverConfigurationService.getBoolean("portal.themes.switcher", false));
 
 		List<Map> l = siteHelper.convertSitesToMaps(request, mySites, prefix,
 				currentSiteId, myWorkspaceSiteId,

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
@@ -168,7 +168,7 @@
 
                                     #end ## END of IF (${tabsSites.tutorial})
 
-                                    #if (${themeSwitcher})
+                                    #if (${sakaiThemesEnabled} && ${themeSwitcher})
 
                                         <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented Mrphs-userNav__submenuitem-toggle">
                                             <label for="sakai-darkThemeSwitcher" class="sakaiThemeSwitch">${rloader.sit_themeSwitcher}</label>
@@ -179,7 +179,7 @@
                                             </button>
                                         </li>
 
-                                    #end ## END of IF (${themeSwitcher})
+                                    #end ## END of IF (${sakaiThemesEnabled} && ${themeSwitcher})
 
                             #end ## END of IF (${site.isMyWorkspace})
 

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -59,6 +59,9 @@
                 },
                 "portalCDNQuery" : "$!{portalCDNQuery}",
                 "userTheme" : "$!{userTheme}"
+                #if ($themesAutoDetectDark)
+                ,"userThemeAutoDetectDark" : true
+                #end
             };
         </script>
 

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
@@ -220,7 +220,7 @@
         <script src="${pageScriptPath}caps-lock-checker.js$!{portalCDNQuery}"></script>
 
         <script src="$!{portalCDNPath}/portal/scripts/jumptotop.js$!{portalCDNQuery}"></script>
-    #if (${themeSwitcher})
+    #if (${sakaiThemesEnabled})
         <script src="$!{portalCDNPath}/portal/scripts/themeswitcher.js$!{portalCDNQuery}"></script>
     #end
         #parse("/vm/morpheus/includeAnalytics.vm")

--- a/user/user-tool-prefs/tool/src/bundle/user-tool-prefs.properties
+++ b/user/user-tool-prefs/tool/src/bundle/user-tool-prefs.properties
@@ -143,6 +143,5 @@ hidden_title=Hide From Site Drawer
 
 theme_prefs_title=Theme
 theme_prefs_instructions=Select a theme to customize the look of your {0} experience.
-theme_prefs_autoTheme=Auto
 theme_prefs_lightTheme=Light Theme
 theme_prefs_darkTheme=Dark Theme

--- a/user/user-tool-prefs/tool/src/bundle/user-tool-prefs_tr_TR.properties
+++ b/user/user-tool-prefs/tool/src/bundle/user-tool-prefs_tr_TR.properties
@@ -105,6 +105,5 @@ hidden_instructions=Ders Listesinde gizlemek i\u00e7in bir ders ya da bir grup d
 hidden_title=Siteyi Gizle
 theme_prefs_title=Tema
 theme_prefs_instructions={0} deneyiminizin g\u00f6r\u00fcn\u00fcm\u00fcn\u00fc \u00f6zelle\u015ftirmek i\u00e7in bir tema se\u00e7in.
-theme_prefs_autoTheme=Otomatik
 theme_prefs_lightTheme=A\u00e7\u0131k Tema
 theme_prefs_darkTheme=Koyu Tema

--- a/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/tool/UserPrefsTool.java
+++ b/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/tool/UserPrefsTool.java
@@ -225,10 +225,17 @@ public class UserPrefsTool
 	// SAK-23895
 	private boolean prefShowTabLabelOption = true;
 	
+	// SAK-45006: only show Themes preference page if themes are enabled
+	private boolean prefShowThemePreferences = false;
+	
 	// //////////////////////////////// PROPERTY GETTER AND SETTER ////////////////////////////////////////////
 
 	public boolean isPrefShowTabLabelOption() {
 	    return prefShowTabLabelOption;
+	}
+	
+	public boolean isPrefShowThemePreferences() {
+	    return prefShowThemePreferences;
 	}
 
 	/**
@@ -498,6 +505,8 @@ public class UserPrefsTool
 		// do we show the option to display by site title or short description?
 		boolean show_tab_label_option = ServerConfigurationService.getBoolean("preference.show.tab.label.option", true);
 		setPrefShowTabLabelOption(show_tab_label_option);
+		
+		setPrefShowThemePreferences(ServerConfigurationService.getBoolean("portal.themes", false));
 
 		//To indicate that it is in the refresh mode
 		refreshMode=true;

--- a/user/user-tool-prefs/tool/src/webapp/prefs/theme.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/theme.jsp
@@ -12,7 +12,7 @@
 	<sakai:view_container title="#{msgs.prefs_title}">
 	<sakai:stylesheet path="/css/prefs.css"/>
 	<sakai:view_content>
-		<h:form id="theme_form">
+		<h:form id="theme_form" rendered="#{UserPrefsTool.prefShowThemePreferences==true}">
 
 			<h:outputText value="#{Portal.latestJQuery}" escape="false"/>
 
@@ -39,7 +39,6 @@
 			<p class="instruction"><h:outputFormat value="#{msgs.theme_prefs_instructions}"><f:param value="#{UserPrefsTool.serviceName}"/></h:outputFormat></p>
 
 			<t:selectOneRadio id="themeOptions" value="#{UserPrefsTool.selectedTheme}" layout="spread">
-				<f:selectItem itemValue="sakaiUserTheme-notSet" itemLabel="#{msgs.theme_prefs_autoTheme}"/>
 				<f:selectItem itemValue="sakaiUserTheme-light" itemLabel="#{msgs.theme_prefs_lightTheme}"/>
 				<f:selectItem itemValue="sakaiUserTheme-dark" itemLabel="#{msgs.theme_prefs_darkTheme}"/>
 			</t:selectOneRadio>
@@ -47,7 +46,6 @@
 			<ul class="prefs-themeSelection">
 				<li><t:radio for="themeOptions" index="0" /></li>
 				<li><t:radio for="themeOptions" index="1" /></li>
-				<li><t:radio for="themeOptions" index="2" /></li>
 			</ul>
 
 			<div class="submit-buttons act">

--- a/user/user-tool-prefs/tool/src/webapp/prefs/toolbar.jspf
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/toolbar.jspf
@@ -13,7 +13,7 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 1}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 1}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 1}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 1}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 1 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionNotiFrmEdit}" value="#{msgs.prefs_noti_title}" rendered="#{UserPrefsTool.noti_selection == 2}" current="#{cTemplate == 'noti' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionTZFrmEdit}" value="#{msgs.prefs_timezone_title}" rendered="#{UserPrefsTool.timezone_selection == 2}" current="#{cTemplate == 'timezone' ? true : false}" />
@@ -21,7 +21,7 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 2}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 2}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 2}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 2}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 2 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionNotiFrmEdit}" value="#{msgs.prefs_noti_title}" rendered="#{UserPrefsTool.noti_selection == 3}" current="#{cTemplate == 'noti' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionTZFrmEdit}" value="#{msgs.prefs_timezone_title}" rendered="#{UserPrefsTool.timezone_selection == 3}" current="#{cTemplate == 'timezone' ? true : false}" />
@@ -29,7 +29,7 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 3}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 3}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 3}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 3}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 3 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionNotiFrmEdit}" value="#{msgs.prefs_noti_title}" rendered="#{UserPrefsTool.noti_selection == 4}" current="#{cTemplate == 'noti' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionTZFrmEdit}" value="#{msgs.prefs_timezone_title}" rendered="#{UserPrefsTool.timezone_selection == 4}" current="#{cTemplate == 'timezone' ? true : false}" />
@@ -37,7 +37,7 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 4}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 4}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 4}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 4}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 4 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionNotiFrmEdit}" value="#{msgs.prefs_noti_title}" rendered="#{UserPrefsTool.noti_selection == 5}" current="#{cTemplate == 'noti' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionTZFrmEdit}" value="#{msgs.prefs_timezone_title}" rendered="#{UserPrefsTool.timezone_selection == 5}" current="#{cTemplate == 'timezone' ? true : false}" />
@@ -45,7 +45,7 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 5}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 5}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 5}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 5}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 5 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionNotiFrmEdit}" value="#{msgs.prefs_noti_title}" rendered="#{UserPrefsTool.noti_selection == 6}" current="#{cTemplate == 'noti' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionTZFrmEdit}" value="#{msgs.prefs_timezone_title}" rendered="#{UserPrefsTool.timezone_selection == 6}" current="#{cTemplate == 'timezone' ? true : false}" />
@@ -53,7 +53,7 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 6}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 6}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 6}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 6}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 6 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionNotiFrmEdit}" value="#{msgs.prefs_noti_title}" rendered="#{UserPrefsTool.noti_selection == 7}" current="#{cTemplate == 'noti' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionTZFrmEdit}" value="#{msgs.prefs_timezone_title}" rendered="#{UserPrefsTool.timezone_selection == 7}" current="#{cTemplate == 'timezone' ? true : false}" />
@@ -61,5 +61,5 @@
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionPrivFrmEdit}" value="#{msgs.prefs_privacy}"  rendered="#{UserPrefsTool.privacy_selection == 7}" current="#{cTemplate == 'privacy' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionHiddenFrmEdit}" value="#{msgs.prefs_sites}"  rendered="#{UserPrefsTool.hidden_selection == 7}" current="#{cTemplate == 'hidden' ? true : false}" />
 		<sakai:tool_bar_item action="#{UserPrefsTool.processActionEditorFrmEdit}" value="#{msgs.prefs_editor}"  rendered="#{UserPrefsTool.editor_selection == 7}" current="#{cTemplate == 'editor' ? true : false}" />
-		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 7}" current="#{cTemplate == 'theme' ? true : false}" />
+		<sakai:tool_bar_item action="#{UserPrefsTool.processActionThemeFrmEdit}" value="#{msgs.prefs_theme}"  rendered="#{UserPrefsTool.theme_selection == 7 and UserPrefsTool.prefShowThemePreferences==true}" current="#{cTemplate == 'theme' ? true : false}" />
 </sakai:tool_bar>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45006

This changes the controlling sakai.property of the dark theme to a generic "sakai.themes" property separate of the existing "sakai.theme.switcher", which just controls the dark theme toggle visibility in the account menu.

This new "sakai.themes" property controls whether the JavaScript is enabled, whether the Preferences tab exists, and whether themes will display. 

Themes are enabled by default, but the theme switcher in the account menu is disabled by default. 

This also removes the "Auto" option from the Preferences page, which doesn't work with the current theme implementation and intention. 

A new option to detect users' OS dark mode can be enabled using "portal.themes.autoDetectDark=true", which is disabled by default. 