### PR TITLE
SAK-43829 Forums: Create new forum without a title

### DIFF
--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -775,7 +775,7 @@ synoptic_no_activity=No recent activity has occurred in your sites.
 
 # JSF Override
 javax.faces.validator.LengthValidator.MAXIMUM=Validation Error: Field has more characters than allowable maximum ({0} characters)
-javax.faces.validator.LengthValidator.MINIMUM=Validation Error: Field does not have minimum number of allowable characters
+javax.faces.validator.LengthValidator.MINIMUM=Please enter a valid forum title.
 
 all_participants_desc=All Participants
 participants_group_desc={0} Group

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_ar.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_ar.properties
@@ -764,7 +764,6 @@ synoptic_no_activity=No recent activity has occurred in your sites.
 
 # JSF Override
 javax.faces.validator.LengthValidator.MAXIMUM=Validation Error\: Field has more characters than allowable maximum ({0} characters)
-javax.faces.validator.LengthValidator.MINIMUM=Validation Error\: Field does not have minimum number of allowable characters
 
 all_participants_desc=All Participants
 participants_group_desc={0} Group

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_fr_FR.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_fr_FR.properties
@@ -764,7 +764,6 @@ synoptic_no_activity=Aucune activit\u00e9 r\u00e9cente dans vos espaces.
 
 # JSF Override
 javax.faces.validator.LengthValidator.MAXIMUM=Validation Error\: Field has more characters than allowable maximum ({0} characters)
-javax.faces.validator.LengthValidator.MINIMUM=Validation Error\: Field does not have minimum number of allowable characters
 
 all_participants_desc=Tous les participants
 participants_group_desc=Groupe {0}

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -475,6 +475,7 @@ sitediinf.sittit    = Site Title
 sitediinf.term      = Term
 sitediinf.addurl  = Add Site URL
 sitediinf.editurl  = Site URL
+sitediinf.textmaxchar = The short description text has been trimmed because has exceeded the maximum 80 characters.
 
 sitetype.acater    = Academic term:
 sitetype.alert     = Alert:

--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -1228,6 +1228,9 @@ function LimitText(fieldObj,maxChars) {
   if (fieldObj.value.length >= maxChars) {
     fieldObj.value = fieldObj.value.substring(0,maxChars);
     result = false;
+    document.getElementById("exceededTextAlert").style.display = 'block'; 
+  } else {
+    document.getElementById("exceededTextAlert").style.display = 'none';
   }
 
   if (window.event) {

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -218,6 +218,12 @@
 			<div class="col-sm-6">
 				<textarea  name="short_description" id="short_description" rows="2" cols="45" onkeyup="LimitText(this,80)">$validator.escapeHtmlTextarea($!short_description)</textarea>
 			</div>
+			<div class="col-sm-6">
+				<span id="exceededTextAlert" class="sak-banner-error">
+					$tlang.getString("sitediinf.textmaxchar")
+				</span>	
+				<script type="text/javascript">document.getElementById('exceededTextAlert').style.display='none'</script>
+			</div>
 		</div>	
 		## Skin & Site Icon ##
 		#if($allowSkinChoice && !$!skins.isEmpty())


### PR DESCRIPTION
As I have tested, the previous error message does not appear writting only one character and only affects to the title field.

So, as the Jira petition ask I have change this message to another one more clear:
Expected Behavior: An error message appears to warn the user to enter a title. For example: "Please enter a valid forum title."

I also have removed the same lines in english from the other non-english internationalization files.

Thanks.