### PR TITLE
SAK-43746 No warning message displays when an instructor enters a short description for a site with more than 80 characters

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -1222,21 +1222,6 @@ function submitform(id) {
   }
 }
 
-function LimitText(fieldObj,maxChars) {
-
-  var result = true;
-  if (fieldObj.value.length >= maxChars) {
-    fieldObj.value = fieldObj.value.substring(0,maxChars);
-    result = false;
-  }
-
-  if (window.event) {
-    window.event.returnValue = result;
-  }
-
-  return result;
-}
-
 function submitRemoveSection(index, formID) {
 
   id = "removeSection" + index;

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -216,7 +216,7 @@
 				</span>
 			</label>
 			<div class="col-sm-6">
-				<textarea  name="short_description" id="short_description" rows="2" cols="45" onkeyup="LimitText(this,80)">$validator.escapeHtmlTextarea($!short_description)</textarea>
+				<textarea name="short_description" id="short_description" rows="2" cols="45" maxlength="80">$validator.escapeHtmlTextarea($!short_description)</textarea>
 			</div>
 		</div>	
 		## Skin & Site Icon ##


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-43746

Hi, everyone;

I have revised the issue and added an alert when the text os over 80 characters.

When the text is pasted or written and exceeds 80 characters, the banner appears and is hide when the character are less than 80:

"The short description text has been trimmed because has exceeded the maximum 80 characters."

Thank you.