### PR TITLE
SAK-43433 - Overview / manage overview updates places user in Site Info tool

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3836,7 +3836,6 @@ public class SiteAction extends PagedResourceActionII {
 			if(fromHome) {
 				context.put("back", page.getId());
 			}
-			state.removeAttribute("fromHome");
 
 			return (String) getContext(data).get("template") + TEMPLATE[65];
 		}
@@ -7679,6 +7678,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		state.removeAttribute("overview");
 		state.removeAttribute("site");
 		state.removeAttribute("allWidgets");
+		state.removeAttribute("fromHome");
 
 		doCancel(data);
 	}
@@ -7772,6 +7772,14 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 			state.removeAttribute(SITE_USER_SEARCH);
 			state.removeAttribute(STATE_SITE_PARTICIPANT_FILTER);
 			state.setAttribute(STATE_TEMPLATE_INDEX, SiteConstants.SITE_INFO_TEMPLATE_INDEX);
+		}
+		else if ("65".equals(currentIndex)) { //after manage overview, go back to where the call was made
+			String pageId = params.getString("back");
+			if(StringUtils.isNotEmpty(pageId) && !"12".equals(pageId)) {
+				String redirectionUrl = getDefaultSiteUrl(ToolManager.getCurrentPlacement().getContext()) + "/" + SiteService.PAGE_SUBTYPE + "/" + pageId;
+				sendParentRedirect((HttpServletResponse) ThreadLocalManager.get(RequestFilter.CURRENT_HTTP_RESPONSE), redirectionUrl);
+			}
+			state.setAttribute(STATE_TEMPLATE_INDEX, "12");
 		}
 		// if all fails to match
 		else if (isTemplateVisited(state, SiteConstants.SITE_INFO_TEMPLATE_INDEX)) {
@@ -16102,6 +16110,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		state.removeAttribute("overview");
 		state.removeAttribute("site");
 		state.removeAttribute("allWidgets");
+		state.removeAttribute("fromHome");
 
 		// TODO: hard coding this frame id is fragile, portal dependent, and needs to be fixed -ggolden
 		schedulePeerFrameRefresh("sitenav");


### PR DESCRIPTION
These were some minor improvments on @bgarciaentornos fix in aaa0757 that didn't seem like it was fully working on the jira.

* It moves clearing the state value to when it's saved/cancelled rather than immediately
* It adds the redirection code to the cancel button

I'm testing this locally and it seems to work better.

I did see one instance where the `sakai_csrf_token ` wasn't set which caused this all not to work, but couldn't reproduce that. I'm not sure if that was related to hot deploying/debugging or something else. 