### PR TITLE
SAK-45127 - Editing a link to an assignment in Lessons duplicates the open/close information in title

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -4024,7 +4024,8 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 			if (i.getType() == SimplePageItem.ASSIGNMENT) {
 				linkText = getLinkText(linkText, i.getSakaiId());
 			}
-			UIOutput.make(container, ID + "-text", linkText);
+			UIOutput.make(container, ID + "-text", linkText).decorate
+				(new UIFreeAttributeDecorator("data-original-name", i.getName()));
 		}
 
 		if (note != null) {

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -1773,7 +1773,13 @@ $(document).ready(function() {
 			var row = $(this).parent().parent().parent();
 			var itemid = row.find(".current-item-id2").text();
 
-			$("#name").val(row.find(".link-text").text());
+			var linkTextTag = row.find(".link-text");
+
+			// If data-original-name attr is present, use that instead
+			var linkText = 	linkTextTag.attr("data-original-name") 
+			linkText = linkText || linkTextTag.text();
+
+			$("#name").val(linkText);
 			$("#description").val(row.find(".rowdescription").text());
 
 			$("select[name=indent-level-selection]").val(row.find(".indentLevel").text());


### PR DESCRIPTION
I had this idea of just saving the original name as a data-* attribute. 

This seems to work as expected now. This also could have been another inside a hidden tag on the page. 

I left in a check to see if it was undefined and set it to the text default as I'm not 100% sure this is set on every page and will work, but might not be necessary.