### PR TITLE
SAK-45135: SAMIGO: Wrong question's order on instructor view when Continuous numbering between parts

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -165,8 +165,8 @@ function toPoint(id)
                   </h:outputText>
                   <h:outputText escape="false" value=" #{deliveryMessages.pt} "/>
                 </span>
-                <h:outputLink value="##{part.sequence}#{deliveryMessages.underscore}#{question.number}"> 
-                  <h:outputText escape="false" value="#{question.number}#{deliveryMessages.dot} #{question.strippedText}"/>
+                <h:outputLink value="##{part.number}#{deliveryMessages.underscore}#{question.number}"> 
+                  <h:outputText escape="false" value="#{question.sequence}#{deliveryMessages.dot} #{question.strippedText}"/>
                 </h:outputLink>
                 <h:outputText styleClass="extraCreditLabel" rendered="#{question.itemData.isExtraCredit==true}" value=" #{deliveryMessages.extra_credit_preview}" />
         </t:dataList>


### PR DESCRIPTION
Please merge. Sorry, I did a mistake when copying the patch from our instance to 22.x

![image](https://user-images.githubusercontent.com/15141743/110764864-d7d6b100-8253-11eb-8e3e-167a33ecafa0.png)
