### PR TITLE
SAK-45119 Fix embedded images with prereqs not showing to students

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderAccessService.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderAccessService.java
@@ -48,10 +48,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.bind.DatatypeConverter;
 
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.io.IOUtils;
 
+import org.sakaiproject.time.api.UserTimeService;
+import org.sakaiproject.user.api.UserDirectoryService;
 import uk.org.ponder.messageutil.MessageLocator;
 import org.apache.commons.io.FilenameUtils;
 import org.sakaiproject.authz.api.AuthzGroupService;
@@ -91,7 +94,6 @@ import org.sakaiproject.memory.api.SimpleConfiguration;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.ToolManager;
-import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
 
@@ -168,6 +170,12 @@ public class LessonBuilderAccessService {
 	public void setSiteService(SiteService s) {
 		siteService = s;
 	}
+
+	@Setter
+	private UserTimeService userTimeService;
+
+	@Setter
+	private UserDirectoryService userDirectoryService;
 
 	LessonEntity forumEntity = null;
 
@@ -519,7 +527,7 @@ public class LessonBuilderAccessService {
 						    usersite = username.substring(0,slash);
 						// normally it is /user/EID, so convert to userid
 						try {
-						    usersite = UserDirectoryService.getUserId(usersite);
+						    usersite = userDirectoryService.getUserId(usersite);
 						} catch (Exception e) {};
 						String itemcreator = item.getAttribute("addedby");
 						// suppose a member of the group adds a resource from another member of
@@ -594,6 +602,9 @@ public class LessonBuilderAccessService {
 						simplePageBean.setCurrentSiteId(currentPage.getSiteId());
 						simplePageBean.setCurrentPage(currentPage);
 						simplePageBean.setCurrentPageId(currentPage.getPageId());
+						simplePageBean.setUserDirectoryService(userDirectoryService);
+						simplePageBean.setUserTimeService(userTimeService);
+						simplePageBean.setAuthzGroupService(authzGroupService);
 						simplePageBean.init();
 
 						if (!simplePageBean.isItemAvailable(item, item.getPageId())) {

--- a/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -320,6 +320,8 @@ simplePageBean.addForumSummary
     <property name="sessionManager"><ref bean="org.sakaiproject.tool.api.SessionManager"/></property>
     <property name="contentFilterService"><ref bean="org.sakaiproject.content.api.ContentFilterService"/></property>
     <property name="authzGroupService"><ref bean="org.sakaiproject.authz.api.AuthzGroupService"/></property>
+    <property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService"/>
+    <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
 
     <property name="messageLocator" ref="messageLocator"/>
     <property name="toolManager" ref="org.sakaiproject.tool.api.ActiveToolManager" />


### PR DESCRIPTION
Explicitly set userdirectoryservice, usertimeservice, and authzgroupservice
in simplepagebean when accessed from lessonbuilderaccessservice to prevent
NPEs and returning a 404 when attempting to load the embedded image.