### PR TITLE
SAK-45183 Library datepicker sliders contrast

### DIFF
--- a/library/src/morpheus-master/sass/base/_jquery-ui-defaults.scss
+++ b/library/src/morpheus-master/sass/base/_jquery-ui-defaults.scss
@@ -247,4 +247,14 @@
         -webkit-box-shadow:var(--elevation-4dp);
         box-shadow:var(--elevation-4dp);
     }
+
+    .ui-state-default.ui-slider-handle {
+        background: var(--button-primary-background);
+        border: var(--button-primary-border-color);
+    }
+
+    .ui-widget.ui-slider {
+        border: 1px solid var(--sakai-background-color-3);
+        background: var(--sakai-background-color-3);
+    }
 }


### PR DESCRIPTION
Changes light and dark mode sliders to use the button-primary styles.
https://jira.sakaiproject.org/browse/SAK-45183?filter=-1