### PR TITLE
SAK-45315 feedback-tool: don't load recaptcha script if disabled

### DIFF
--- a/feedback/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
+++ b/feedback/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
@@ -120,7 +120,9 @@ public class FeedbackTool extends HttpServlet {
         if (userId != null) {
             setMapAttribute(request, "siteUpdaters", emailRecipients);
         } else {
-            if (sakaiProxy.getConfigBoolean("user.recaptcha.enabled", false)) {
+            boolean recaptchaEnabled = sakaiProxy.getConfigBoolean("user.recaptcha.enabled", false);
+            request.setAttribute("recaptchaEnabled", recaptchaEnabled);
+            if (recaptchaEnabled) {
                 String publicKey = sakaiProxy.getConfigString("user.recaptcha.public-key", "");
                 setStringAttribute(request, "recaptchaPublicKey", publicKey);
             }

--- a/feedback/src/webapp/WEB-INF/bootstrap.jsp
+++ b/feedback/src/webapp/WEB-INF/bootstrap.jsp
@@ -10,9 +10,12 @@
         <script src="/library/webjars/jquery/1.12.4/jquery.min.js"></script>
         <script src="/feedback-tool/lib/jquery.form.min.js"></script>
         <script src="/library/webjars/multifile/2.2.2/jquery.MultiFile.min.js"></script>
-        <script src="//www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script>
         <script src="/feedback-tool/lib/handlebars.runtime-v1.3.0.js"></script>
         <script src="/feedback-tool/templates/all.handlebars"></script>
+
+        <c:if test="${recaptchaEnabled}">
+            <script src="//www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script>
+        </c:if>
 
         <script>
 


### PR DESCRIPTION
Simple fix to include Google's recaptcha script only if recaptcha is enabled and used.

https://jira.sakaiproject.org/browse/SAK-45315