### PR TITLE
SAK-44703: Samigo calculated questions do not evaluate large E expressions correctly

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoExpressionParser.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoExpressionParser.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.mariuszgromada.math.mxparser.Expression;
+import org.mariuszgromada.math.mxparser.mXparser;
 import org.sakaiproject.tool.assessment.services.GradingService;
 
 
@@ -46,6 +47,7 @@ public class SamigoExpressionParser
   public SamigoExpressionParser()
   {
     expr = "";
+    mXparser.setEpsilon(1.0E-99);
   }
 
   /**
@@ -81,12 +83,18 @@ public class SamigoExpressionParser
       Expression e = null;
       try {
           e = new Expression(expr);
+          if (expr.contains("E")) {
+              mXparser.disableUlpRounding();
+          }
           double d = e.calculate();
           ans = new BigDecimal(d, MathContext.DECIMAL64);
       }
       catch (NumberFormatException nfe) {
           String errorMessage = e != null ? e.getErrorMessage() : expr;
           throw new SamigoExpressionError(401, errorMessage);
+      }
+      finally {
+          mXparser.enableUlpRounding();
       }
 
       GradingService service = new GradingService();

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceTest.java
@@ -512,6 +512,14 @@ public class GradingServiceTest {
         result = gradingService.processFormulaIntoValue("1.5*((6^2*tan(rad(90-50))+4*6)*80)/27", 0);
         Assert.assertNotNull(result);
         Assert.assertEquals("241", result);
+
+        // E
+        result = gradingService.processFormulaIntoValue("(1.44e-34) * (1.44E15)", 2);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("2.07E-19", result);
+        result = gradingService.processFormulaIntoValue("(5e-49) * (6E28)", 2);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("3E-20", result);
     }
 
     @Test(expected = SamigoExpressionError.class)


### PR DESCRIPTION
I'm not really an expert on this... but it seems working.

Maybe with only setting the epsilon with a small number could be enough...
but Mariusz Gromada (Mathparser's creator) recommend us using
mXparser.disableUlpRounding() before the calculate call.
https://mathparser.org/probability-theory/why-this-formula-gives-approximation-of-e/

@austin48, pls, could you check this one? Thanks!
