### PR TITLE
SAK-43946: Lessons-TQ: cc_import skips or does not import some questions correctly

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/SamigoExport.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/SamigoExport.java
@@ -404,7 +404,7 @@ public class SamigoExport {
                 if (type.equals(TypeIfc.MULTIPLE_CHOICE) || type.equals(TypeIfc.TRUE_FALSE)) {
                     int remaining = -1; // default to allow all correct answers
                     if (correctSet.size() > 1) {
-                        if (ccVersion.greaterThan(V12)) {
+                        if (ccVersion.lessThan(V12)) {
                             ccConfig.getResults().add(messageSource.getMessage("simplepage.exportcc-sam-mcss", null, ccConfig.getLocale()).replace("{1}", title).replace("{2}", assessmentTitle));
                             remaining = 1;
                         } else


### PR DESCRIPTION
This one only solves:

**Multiple Choice: Multiple correct, single selection
v1.1 - imports correctly
v1.3 - imports as single correct**

from: https://jira.sakaiproject.org/browse/SAK-43946

Regression from:
https://github.com/sakaiproject/sakai/blame/f67bafcb1ac3f22c1c78ab76f6b41f87269427df/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/SamigoExport.java#L502

![image](https://user-images.githubusercontent.com/15141743/115731089-231dcc80-a387-11eb-8a12-63f1a0314d3a.png)

At the top, here it says: https://github.com/sakaiproject/sakai/commit/8cdb4c81efae04eab09d0a34ad415aa569f176b1#

**Don't try MCSS equestions for version 1.1**