### PR TITLE
SAK-45417: LESSONS: Deleting language=en-US from IMS V1.3

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/CCExport.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/CCExport.java
@@ -544,7 +544,7 @@ public class CCExport {
                     out.println("    <lomimscc:lom>");
                     out.println("      <lomimscc:general>");
                     out.println("        <lomimscc:title>");
-                    out.println("          <lomimscc:string language=\"en-US\">" + StringEscapeUtils.escapeXml11(title) + "</lomimscc:string>");
+                    out.println("          <lomimscc:string>" + StringEscapeUtils.escapeXml11(title) + "</lomimscc:string>");
                     out.println("        </lomimscc:title>");
                     out.println("      </lomimscc:general>");
                     out.println("    </lomimscc:lom>");


### PR DESCRIPTION
Should be the same as V1.1: https://github.com/sakaiproject/sakai/blob/master/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/ccexport/CCExport.java#L522