### PR TITLE
SAK-45432 - Cannot change student permisisons in polls, console error

### DIFF
--- a/polls/api/src/java/org/sakaiproject/poll/logic/ExternalLogic.java
+++ b/polls/api/src/java/org/sakaiproject/poll/logic/ExternalLogic.java
@@ -122,8 +122,9 @@ public interface ExternalLogic {
 	/**
 	 * Register a function with the Sakai Function manager
 	 * @param function
+     * @param userMutable
 	 */
-	public void registerFunction(String function);
+	public void registerFunction(String function, boolean userMutable);
 	
 	/** 
 	 *  get the correct Timezone for the the current user

--- a/polls/impl/src/java/org/sakaiproject/poll/logic/impl/ExternalLogicImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/logic/impl/ExternalLogicImpl.java
@@ -213,8 +213,8 @@ public class ExternalLogicImpl implements ExternalLogic {
 		
 	}
 
-	public void registerFunction(String function) {
-		functionManager.registerFunction(function);
+	public void registerFunction(String function, boolean userMutable) {
+		functionManager.registerFunction(function, userMutable);
 		
 	}
 

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -82,12 +82,12 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
             log.warn("init(): ", t);
         }
 
-        externalLogic.registerFunction(PERMISSION_VOTE);
-        externalLogic.registerFunction(PERMISSION_ADD);
-        externalLogic.registerFunction(PERMISSION_DELETE_OWN);
-        externalLogic.registerFunction(PERMISSION_DELETE_ANY);
-        externalLogic.registerFunction(PERMISSION_EDIT_ANY);
-        externalLogic.registerFunction(PERMISSION_EDIT_OWN);
+        externalLogic.registerFunction(PERMISSION_VOTE, true);
+        externalLogic.registerFunction(PERMISSION_ADD, true);
+        externalLogic.registerFunction(PERMISSION_DELETE_OWN, true);
+        externalLogic.registerFunction(PERMISSION_DELETE_ANY, true);
+        externalLogic.registerFunction(PERMISSION_EDIT_ANY, true);
+        externalLogic.registerFunction(PERMISSION_EDIT_OWN, true);
         log.info(this + " init()");
     }
 

--- a/polls/impl/src/test/org/sakaiproject/poll/logic/test/stubs/ExternalLogicStubb.java
+++ b/polls/impl/src/test/org/sakaiproject/poll/logic/test/stubs/ExternalLogicStubb.java
@@ -119,7 +119,7 @@ public class ExternalLogicStubb implements ExternalLogic {
 		
 	}
 
-	public void registerFunction(String function) {
+	public void registerFunction(String function, boolean userMutable) {
 		// TODO Auto-generated method stub
 		
 	}


### PR DESCRIPTION
Looks like when switching to the permission widget these functions were set as not mutable. (By default)

Just flipped them here.