### PR TITLE
SAK-45370 Update calc q regex to avoid catastrophic backtracking

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -133,7 +133,7 @@ public class GradingService
   public static final Pattern CALCQ_ANSWER_PATTERN = Pattern.compile("(?<!\\{)" + CALCQ_VAR_FORM_NAME_EXPRESSION_FORMATTED + "(?!\\})");
   public static final Pattern CALCQ_FORMULA_PATTERN = Pattern.compile(OPEN_BRACKET + CALCQ_VAR_FORM_NAME_EXPRESSION_FORMATTED + CLOSE_BRACKET);
   public static final Pattern CALCQ_FORMULA_SPLIT_PATTERN = Pattern.compile("(" + OPEN_BRACKET + OPEN_BRACKET + CALCQ_VAR_FORM_NAME + CLOSE_BRACKET + CLOSE_BRACKET + ")");
-  public static final Pattern CALCQ_CALCULATION_PATTERN = Pattern.compile("\\[\\[((([^\\[\\]])*?(\\[([^\\[\\]])*?\\])*?)*?)\\]\\]"); // non-greedy
+  public static final Pattern CALCQ_CALCULATION_PATTERN = Pattern.compile("\\[\\[((([^\\[\\]])*+(\\[([^\\[\\]])*+\\])*+)*+)\\]\\]"); // possessive
   // SAK-39922 - Support (or at least watch for support) for binary/unary calculated question (-1--1)
   public static final Pattern CALCQ_ANSWER_AVOID_DOUBLE_MINUS = Pattern.compile("--");
   public static final Pattern CALCQ_ANSWER_AVOID_PLUS_MINUS = Pattern.compile("\\+-");

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceTest.java
@@ -220,6 +220,28 @@ public class GradingServiceTest {
         Assert.assertEquals("D", results.get(0));
     }
 
+    @Test(timeout = 5000)
+    public void testRegexBacktracking() {
+        List<String> results;
+        String text;
+
+        // Test backtracking with properly formatted text
+        text = "{A}+{B}*{C}={{D}} Hint: [[{B}*{C}]]+{A} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus consequat non enim eget dapibus. Etiam dictum nisi eget pharetra facilisis. Aliquam augue nisi, ornare at scelerisque sit amet, ornare sit amet justo. Proin egestas, nisi sit amet sagittis ullamcorper, ex felis interdum ipsum, sit amet scelerisque mauris erat id mauris. Aenean in mollis turpis. Sed dapibus massa quis iaculis pulvinar. Vestibulum mi enim, suscipit nec placerat ac, tincidunt lacinia neque. Sed et eleifend purus. Sed imperdiet neque arcu, ut porttitor elit ultrices ut. Praesent et risus enim. [[({B}*{C})+{A}]]";
+        results = gradingService.extractCalculations(text);
+        Assert.assertNotNull(results);
+        Assert.assertEquals(2, results.size());
+        Assert.assertEquals("{B}*{C}", results.get(0));
+        Assert.assertEquals("({B}*{C})+{A}", results.get(1));
+
+        // Test backtracking with improperly formatted text i.e. missing ending to [[{B}*{C}+{A}
+        // This should return one result (success) or will timeout after 5 seconds (failure)
+        text = "{A}+{B}*{C}={{D}} Hint: [[{B}*{C}+{A} Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus consequat non enim eget dapibus. Etiam dictum nisi eget pharetra facilisis. Aliquam augue nisi, ornare at scelerisque sit amet, ornare sit amet justo. Proin egestas, nisi sit amet sagittis ullamcorper, ex felis interdum ipsum, sit amet scelerisque mauris erat id mauris. Aenean in mollis turpis. Sed dapibus massa quis iaculis pulvinar. Vestibulum mi enim, suscipit nec placerat ac, tincidunt lacinia neque. Sed et eleifend purus. Sed imperdiet neque arcu, ut porttitor elit ultrices ut. Praesent et risus enim. [[({B}*{C})+{A}]]";
+        results = gradingService.extractCalculations(text);
+        Assert.assertNotNull(results);
+        Assert.assertEquals(1, results.size());
+        Assert.assertEquals("({B}*{C})+{A}", results.get(0));
+    }
+
     @Test
     public void testExtractInstructionSegments() {
         List<String> results = null;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45370

Convert non-greedy regular expression pattern for a calculated question
calculation to possessive version to avoid backtracking that can cause
stackoverflow errors or CPU load that brings down the system.