### PR TITLE
SAK-45486 lessons replace more tools gif with font awesome

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -221,7 +221,7 @@
 					<span>
 					    <a aria-haspopup="true" aria-controls="moreDiv" role="button" href="#" onclick="return false;">
 					        <span rsf:id="msg=simplepage.more-tools" ></span>
-                            &nbsp;&nbsp;<img rsf:id="icondrop" src="/library/image/sakai/icon-dropdn.gif" style="height:15px" alt="" />
+                            &nbsp;&nbsp;<span aria-hidden="true" class="fa-button-text fa-chevron-circle-down"></span>
 					    </a>				
 					</span>
 				</li>


### PR DESCRIPTION
[/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java#L4245-L4245](https://github.com/profmikegreene/sakai/blob/6c209ab8b6c3d6d539342597ee8516c8c0d5926a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java#L4245-L4245) Also contains that icondrop id. Can that line be deleted as well?