### PR TITLE
SAK-43995 Messages: Quick Search box is inconsistent with Search for text box

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/messages/_messages.scss
+++ b/library/src/morpheus-master/sass/modules/tool/messages/_messages.scss
@@ -105,6 +105,13 @@
   			td.bogus{
  				width: 17%;
  			}
+
+ 			&\:pvtmsgs_filter {
+ 				input[type=search] {
+ 					margin-left: $standard-space;
+ 					font-weight: normal;
+				}
+ 			}
  		}
  	}
  	


### PR DESCRIPTION
I've added a margin between the label and input, defining its font-weight as normal, since the text in the searchbar appeared in bold (but not the outline).

I've applied these changes at the .scss as it is part of the DataTables plugin and I can't modify it.
