### PR TITLE
SAK-45264 Roster: fix site visits visibility

### DIFF
--- a/roster2/tool/src/handlebars/members_cards.handlebars
+++ b/roster2/tool/src/handlebars/members_cards.handlebars
@@ -78,13 +78,13 @@
             {{/if}}
 
             {{#if ../showVisits}}
-                {{#if ../../viewSiteVisits}}
+                {{#if ../viewSiteVisits}}
                 <div class="roster-card-label">{{tr 'total_visits'}}</div>
                 <div class="roster-card-value roster-total-visits">{{totalSiteVisits}}</div>
-                {{/if}}
-                {{#if formattedLastVisitTime}}
-                <div class="roster-card-label">{{tr 'last_visit'}}</div>
-                <div class="roster-card-value roster-last-visit">{{formattedLastVisitTime}}</div>
+                    {{#if formattedLastVisitTime}}
+                    <div class="roster-card-label">{{tr 'last_visit'}}</div>
+                    <div class="roster-card-value roster-last-visit">{{formattedLastVisitTime}}</div>
+                    {{/if}}
                 {{/if}}
             {{/if}}
 


### PR DESCRIPTION
Copying here the comment I added to the jira https://jira.sakaiproject.org/browse/SAK-45264:

I'd say there are a couple issues here. First there's a discrepancy between the permissions across the tool: on some places last visit and number of visits are tied to the same permission check (see RosterSiteEntityProvider), but on the page rendering side they aren't connected in that way. That means the value isn't filled but the field is shown.

And the second problem I find is the visit count is never displayed, even with the right permissions. I think I'm going to address both on one PR, but this might need some discussion.