### PR TITLE
SAK-41588 Show warning if switching from adjusted scores

### DIFF
--- a/rubrics/api/src/main/bundle/rubrics.properties
+++ b/rubrics/api/src/main/bundle/rubrics.properties
@@ -62,3 +62,5 @@ draft_evaluation=Draft rubric evaluation. Save in the tool to publish the rubric
 locked_message=This tool, when locked (the default), can NOT be seen by students. Students can \
 still, however, see their rubric evaluations in tools like Assignments, Gradebook and Tests and \
 Quizzes. You DO NOT need to unlock this tool for students to see their rubric evaluations.
+adjust_scores_warning=Deselecting the 'Adjust individual student scores' option will reset \
+existing student rubric scores to the default point value for selected ratings. Are you sure?

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-association.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-association.js
@@ -53,6 +53,15 @@ class SakaiRubricAssociation extends RubricsElement {
     }
   }
 
+  toggleFineTunePoints(e) {
+
+    if (!e.target.checked) {
+      if (!confirm(this.i18n["adjust_scores_warning"])) {
+        e.preventDefault();
+      }
+    }
+  }
+
   shouldUpdate() {
     return this.i18n && this.rubrics && this.rubrics.length > 0;
   }
@@ -93,7 +102,13 @@ class SakaiRubricAssociation extends RubricsElement {
             <div class="rubric-options">
               <div class="checkbox">
                 <label>
-                  <input name="rbcs-config-fineTunePoints" type="checkbox" ?checked=${this.selectedConfigOptions["fineTunePoints"]} value="1" ?disabled=${!this.isAssociated || this.readOnly}>${this.fineTunePoints}
+                  <input
+                      name="rbcs-config-fineTunePoints"
+                      type="checkbox"
+                      @click=${this.toggleFineTunePoints}
+                      ?checked=${this.selectedConfigOptions["fineTunePoints"]}
+                      value="1"
+                      ?disabled=${!this.isAssociated || this.readOnly}>${this.fineTunePoints}
                 </label>
               </div>
               <div class="checkbox">


### PR DESCRIPTION
When modifying graded rubric from adjust to default, scores and cells do not match. Issue a
warning informing the user.