### PR TITLE
SAK-44733 LESSONS - Bad style on tool bar navigation if there are some subpages on lessons and subpage navigation is enable

### DIFF
--- a/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -70,7 +70,6 @@ body.is-logged-out{
 						text-align: center;
 						border-radius: $tool-menu-item-collapsed-border-radius;
 						margin: $tool-menu-item-collapsed-margin; 
-						padding: $tool-menu-item-collapsed-padding;
 						&:hover, &:focus {
 							position: relative;
 							.#{$namespace}toolsNav__menuitem--title{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44733