### PR TITLE
SAK-44758 Remove empty column from filepicker

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_filepicker_select.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_filepicker_select.vm
@@ -244,8 +244,6 @@ $(document).ready(function() {
 				<th id="actions">
 					$tlang.getString("gen.actions")
 				</th>
-				<th id="actionsspacer">
-				</th>	
 			</tr>
 			#set($itemcount = 0)
 			#set ($unit = "em")
@@ -364,9 +362,6 @@ $(document).ready(function() {
 							#end
 						#end
 					</td>
-					<td style="width:12em">
-						
-					</td>					
 				</tr>
 			#end ## foreach $item in $this_site
 			


### PR DESCRIPTION
I've tried to find out why it was added in the first place but not sure I understand it (see https://jira.sakaiproject.org/browse/SAK-13259)