### PR TITLE
SAK-44949 External Tool (Admin): Show number of entries per page drop-down not displaying properly

### DIFF
--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -179,7 +179,7 @@ input::placeholder {
 	color: var(--sakai-text-color-1);
 	font-family: $font-family;
 	font-size: #{$default-font-size - 1};
-	padding: 0.3em 2.2em 0.3em 0.5em;
+	padding: 0.3em 2.2em 0.3em 0.5em !important;
 	text-align: left;
 	max-width: 100%;
 	@include appearance(none);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44949

I added "!important" to the padding, because the padding of the tablesorter css was 0 and made it look bad.