### PR TITLE
SAK-43911 Drag and Drop Reorder lists should display a grabbing cursor

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-reorder.vm
@@ -105,7 +105,7 @@
 				#set($count = 1)
 				#foreach ($ann_item in $showMessagesList)
 					#set($ann_item_props=$ann_item.getProperties())
-					<li #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft true) id="listitem.orderable$count" tabindex="0">
+					<li class="row reorder-element grab_cursor" id="listitem.orderable$count" tabindex="0" onmouseup="grab(this)" onmousedown="grabbing(this);">
 						<span class="title col-md-4 col-sm-4 col-xs-12">
 							<span style="display:none" class="grabHandle">
 								<input type="text" size="3" value="$count" id="index$count" style="z-index:5"/>
@@ -157,3 +157,19 @@
 		</div>
 #end	##end of for each loop
 </div>
+
+<script>
+
+	function grabbing(selectedItem) {
+		li = $(selectedItem);
+		$(li).removeClass("grab_cursor");
+		$(li).addClass("grabbing_cursor");
+	}
+
+	function grab(selectedItem) {
+		li = $(selectedItem);
+		$(li).removeClass("grabbing_cursor");
+		$(li).addClass("grab_cursor");
+	}
+
+</script>

--- a/assignment/tool/src/webapp/js/assignments.js
+++ b/assignment/tool/src/webapp/js/assignments.js
@@ -986,3 +986,16 @@ $(document).ready(() => {
     Promise.all(promises).then(() => ASN.submitForm('viewForm', 'releaseGrades', null, null));
   });
 });
+
+// SAK-43911 (grab_cursor for reordering items)
+ASN.grabbing = function (selectedItem) {
+    li = $(selectedItem);
+    $(li).removeClass("grab_cursor");
+    $(li).addClass("grabbing_cursor");
+}
+
+ASN.grab = function (selectedItem) {
+    li = $(selectedItem);
+    $(li).removeClass("grabbing_cursor");
+    $(li).addClass("grab_cursor");
+}

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_reorder_assignment.vm
@@ -85,7 +85,7 @@
 			#set($count = 1)
 			#foreach($assignment in $assignments)
 
-			<li class="sortable row reorder-element" tabindex="0" id="listitem.orderable$count">
+			<li class="sortable row reorder-element grab_cursor" tabindex="0" id="listitem.orderable$count" onmousedown="ASN.grabbing(this)" onmouseup="ASN.grab(this)">
 				<span class="col-md-6 col-sm-6 col-xs-12" title="$formattedText.escapeHtml($!assignment.Title)">
 					<span style="display:none" class="grabHandle">
 						<input type="text" size="3" value="$count" id="index$count"/>

--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -566,3 +566,11 @@ div.wicket-modal div.w_blue a.w_close {
 .close {
 	opacity: 1;
 }
+
+.grab_cursor {
+	cursor: grab;
+}
+
+.grabbing_cursor {
+	cursor: grabbing;
+} 

--- a/site-manage/pageorder/tool/src/webapp/content/js/orderUtil.js
+++ b/site-manage/pageorder/tool/src/webapp/content/js/orderUtil.js
@@ -266,3 +266,15 @@ function addTool(draggable, manual) {
 	return false;
 }
 
+function grabbing(selectedItem) {
+	li = $(selectedItem).closest(".sortable_item");
+	$(li).removeClass("grab_cursor");
+	$(li).addClass("grabbing_cursor");
+}
+
+function grab(selectedItem) {
+	li = $(selectedItem).closest(".sortable_item");
+	$(li).removeClass("grabbing_cursor");
+	$(li).addClass("grab_cursor");
+}
+ 

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -31,7 +31,7 @@
 								<strong rsf:id="msg=curr_pages">Current Pages</strong>
 							</div>
 							<ul class="sortable" id="reorder-list">
-								<li rsf:id="page-row:" id="content:::page-row::" class="sortable_item reorder-element" tabindex="0">
+								<li rsf:id="page-row:" id="content:::page-row::" class="sortable_item reorder-element grab_cursor" tabindex="0" onmousedown="grabbing(this);" onmouseup="grab(this)">
 									<div rsf:id="tool-icon"></div>
 									<div class="item_edit_box" style="display: none;">
 										<div>


### PR DESCRIPTION
A `cursor: grab;` when you hover over the items, that turns into a `cursor: grabbing;` when you click and drag one of them to another position, for a more intuitive rearrange.

Defined in the CSS, used for the html element classes and managed with JS functions.

Affects: 
- Announcements -> Reorder
- Assignments -> Reorder
- Site Info -> Tool Order

> A full restart of tomcat is needed for the desired behavior.
