### PR TITLE
SAK-41584 Fix text indentations on Site Info > Manage Access page

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/sitemanage/_sitemanage.scss
+++ b/library/src/morpheus-master/sass/modules/tool/sitemanage/_sitemanage.scss
@@ -587,6 +587,7 @@
   }
   legend {
     font-size: 16px;
+    padding-left: 0;
 
     &.nopad {
       padding: 0.5em 0;


### PR DESCRIPTION
Titles correctly aligned by removing the `<legend>` label.