### PR TITLE
SAK-44938 - Update subetha in mailarchive to newer fork

### DIFF
--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -328,9 +328,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.subethamail</groupId>
+            <groupId>com.github.davidmoten</groupId>
             <artifactId>subethasmtp</artifactId>
-            <version>3.1.7</version>
+            <version>5.2.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/email/impl/test/EmailServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/email/impl/test/EmailServiceTest.java
@@ -123,8 +123,7 @@ public class EmailServiceTest
 
 		if (ALLOW_TRANSPORT) {
 			log.debug("Starting internal mail server...");
-			wiser = new Wiser();
-			wiser.setPort(PORT);
+			wiser =  Wiser.port(PORT);
 			wiser.start();
 			log.debug("Internal mail server started.");
 		}

--- a/mailarchive/mailarchive-subetha/pom.xml
+++ b/mailarchive/mailarchive-subetha/pom.xml
@@ -40,9 +40,9 @@
             <artifactId>sakai-message-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.subethamail</groupId>
+            <groupId>com.github.davidmoten</groupId>
             <artifactId>subethasmtp</artifactId>
-            <version>3.1.7</version>
+            <version>5.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>

--- a/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
+++ b/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
@@ -344,7 +344,7 @@ public class SakaiMessageHandlerTest {
      */
     public SmartClient createClient() throws IOException {
         SMTPServer server = messageHandlerFactory.getServer();
-        return new SmartClient("localhost", server.getPort(), "test");
+        return SmartClient.createAndConnect("localhost", server.getPort(), "test");
     }
 
     public void writeData(SmartClient client, String resource) throws IOException {

--- a/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
+++ b/mailarchive/mailarchive-subetha/src/test/org/sakaiproject/mailarchive/SakaiMessageHandlerTest.java
@@ -344,7 +344,7 @@ public class SakaiMessageHandlerTest {
      */
     public SmartClient createClient() throws IOException {
         SMTPServer server = messageHandlerFactory.getServer();
-        return SmartClient.createAndConnect("localhost", server.getPort(), "test");
+        return SmartClient.createAndConnect("localhost", server.getPortAllocated(), "test");
     }
 
     public void writeData(SmartClient client, String resource) throws IOException {


### PR DESCRIPTION
The version we're using is from

I tried to update to the latest 6.0.0 but it looks like they changed some dependencies on jakarta.mail and doesn't seem to be working with the version we have in master, so just went back a version. There was also an open PR for this so might not be completed.

[Data](https://github.com/davidmoten/subethasmtp/commit/a5376e0dc00779a4f436b04088e17a8e7ca74246) got changed to support a string value of the return. It only suggests returning "OK message received" or null which will just return 250 OK. So there might be better returns we can use here but it seemed to be working okay. 