### PR TITLE
SAK-45691 re-do the way FileConversionService creates attachment names

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/FileConversionServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/FileConversionServiceImpl.java
@@ -103,6 +103,7 @@ public class FileConversionServiceImpl implements FileConversionService {
 
             if (ContentHostingService.AUTH_RESOURCE_READ.equals(function)
                     || ContentHostingService.AUTH_RESOURCE_ADD.equals(function)
+                    || ContentHostingService.AUTH_RESOURCE_HIDDEN.equals(function)
                     || ContentHostingService.AUTH_RESOURCE_WRITE_ANY.equals(function)) {
                 return SecurityAdvisor.SecurityAdvice.ALLOWED;
             } else {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/FileConversionServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/FileConversionServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FilenameUtils;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
@@ -138,26 +139,20 @@ public class FileConversionServiceImpl implements FileConversionService {
                             FileConversionQueueItem inProgressItem = repository.save(item);
 
                             try {
-                                String sourceFileName = ref.substring(ref.lastIndexOf("/") + 1);
-                                log.debug("Source Filename: {}", sourceFileName);
-                                String convertedFileName = "";
-                                if (sourceFileName.contains(".")) {
-                                    convertedFileName = sourceFileName.split("\\.")[0] + ".pdf";
-                                } else {
-                                    convertedFileName = sourceFileName + ".pdf";
-                                }
+                                String convertedFileName = FilenameUtils.getBaseName(ref) + ".pdf";
+                                String fullPath = FilenameUtils.getPath(ref);
+                                String[] splitPath = fullPath.split("/");
+                                String siteId = splitPath[1];
+                                log.debug("Converted file id: {}, site id: {} ", convertedFileName, siteId);
 
                                 byte[] convertedFileBytes = LoolFileConverter.convert(converterBaseUrl, source.streamContent());
 
-                                String previewId = ref.substring(0, ref.lastIndexOf("/")) + convertedFileName;
-
-                                log.debug("Converted file id: {}", previewId);
                                 ResourcePropertiesEdit properties = contentHostingService.newResourceProperties();
                                 properties.addProperty(ResourceProperties.PROP_DISPLAY_NAME, convertedFileName);
 
                                 securityService.pushAdvisor(securityAdvisor);
                                 ContentResource previewResource
-                                        = contentHostingService.addAttachmentResource(convertedFileName, "application/pdf", convertedFileBytes, properties);
+                                        = contentHostingService.addAttachmentResource(convertedFileName, siteId, ContentHostingService.PREVIEW, ContentHostingService.PDF_MIMETYPE, convertedFileBytes, properties);
 
                                 contentHostingService.addProperty(ref, ContentHostingService.PREVIEW, previewResource.getId());
 


### PR DESCRIPTION
I haven't tested, but does this seem correct?

Here is the call from Assignments for reference:

`contentHostingService.addAttachmentResource(resourceId, siteId, "Assignments", contentType, fileContentStream, props);`