### PR TITLE
SAK-45605 - fix syllabus ckeditor parsing and saving

### DIFF
--- a/syllabus/syllabus-app/src/java/org/sakaiproject/tool/syllabus/entityproviders/SyllabusEntityProvider.java
+++ b/syllabus/syllabus-app/src/java/org/sakaiproject/tool/syllabus/entityproviders/SyllabusEntityProvider.java
@@ -326,6 +326,7 @@ public class SyllabusEntityProvider extends AbstractEntityProvider implements En
 								} else {
 									if (StringUtils.isNotEmpty(cleanedText)) {
 										data.setAsset(cleanedText);
+										syllabusManager.saveSyllabus(data);
 									}
 								}
 							}

--- a/syllabus/syllabus-app/src/webapp/js/syllabus.js
+++ b/syllabus/syllabus-app/src/webapp/js/syllabus.js
@@ -363,9 +363,6 @@ function doAddItemButtonClick( msgs, published )
 	}
 	else
 	{
-		// Fetch the content from the new wysiwyg
-		$("#newContentTextAreaWysiwyg").val($('#newContentDiv').find('iframe').contents().find('body').html()).change();
-
 		// ID doesn't exist since we're adding a new one
 		var id = "0";
 		params = 
@@ -374,7 +371,7 @@ function doAddItemButtonClick( msgs, published )
 			"title": title,
 			"siteId": $("#siteId").val(),
 			"published": published,
-			"content": $("#newContentTextAreaWysiwyg").val()
+			"content": CKEDITOR.instances.newContentTextAreaWysiwyg.getData()
 		};
 
 		postAjax( id, params, msgs );


### PR DESCRIPTION
Using a better way to get fckeditor content so it can be submitted.  The old way seemed to be getting additional markup that we don't want.

Also, there was an issue actually saving the new syllabus data.  Possibly related to changes that came in with SAK-44784?