### PR TITLE
SAK-45685 T&Q: Settings / Layout and Appearance - color text unmatched

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -87,17 +87,15 @@
 
               if (enabled) {
 			$('#assessmentSettingsAction\\:linear_access_warning').hide();
-			$('#assessmentSettingsAction\\:markForReview1').removeAttr("disabled").parent().removeClass("placeholder");
+			$('#assessmentSettingsAction\\:markForReview1').removeAttr("disabled");
 			QuesFormatRadios.forEach( function(v, i, a) {
-                      		$('label[for="' + v + '"]').removeClass("placeholder");
                       		$("#" + v).removeAttr("disabled");
                   	});
               } else {
 			$('#assessmentSettingsAction\\:linear_access_warning').show();
-			$('#assessmentSettingsAction\\:markForReview1').attr("disabled", true).prop("checked", false).parent().addClass("placeholder");
+			$('#assessmentSettingsAction\\:markForReview1').attr("disabled", true).prop("checked", false);
 			QuesFormatRadios.forEach( function(v, i, a) {
                       		$('#assessmentSettingsAction\\:assessmentFormat\\:0').click();
-                      		$('label[for="' + v + '"]').addClass("placeholder");
                       		$("#" + v).attr("disabled", true);
                   	});
               }


### PR DESCRIPTION
Solved this issue by removing the `placeholder` class, as it just overrides the `disabled` color with `color: var(--sakai-text-color-dimmed)`.

It had no effect in the _div_ that contains the checkbox.

![image](https://user-images.githubusercontent.com/81161239/123402245-d08ba700-d5a7-11eb-91bf-df06fbf5cbae.png)
