### PR TITLE
SAK-44069 SECTION INFO: First row shouldn't appear if 0 items found

### DIFF
--- a/sections/sections-app/src/bundle/sections.properties
+++ b/sections/sections-app/src/bundle/sections.properties
@@ -35,6 +35,7 @@ edit_student_successful=Students in {0} were updated successfully\!
 section_max_size=Section Size
 student_view_join=Join
 edit_student_unassigned=Unassigned Students
+students_not_found=No related students found in this site.
 update=Update
 options_automatically_manage=Automatically Manage
 options_manually_manage=Manually Manage

--- a/sections/sections-app/src/webapp/roster.jsp
+++ b/sections/sections-app/src/webapp/roster.jsp
@@ -56,7 +56,7 @@
         binding="#{rosterBean.rosterDataTable}"
         sortColumn="#{preferencesBean.rosterSortColumn}"
         sortAscending="#{preferencesBean.rosterSortAscending}"
-        rendered="#{rosterBean.enrollments.size()>0}"
+        rendered="#{rosterBean.enrollments.size() > 0}"
         styleClass="listHier rosterTable">
         <h:column>
             <f:facet name="header">

--- a/sections/sections-app/src/webapp/roster.jsp
+++ b/sections/sections-app/src/webapp/roster.jsp
@@ -45,6 +45,10 @@
         </t:div>
     </h:panelGrid>
     
+    <h:panelGroup rendered="#{rosterBean.enrollmentsSize<=0}" >
+        <h:outputText styleClass="sak-banner-warn" value="#{msgs.students_not_found}"  />
+    </h:panelGroup>
+
     <t:dataTable cellpadding="0" cellspacing="0"
         id="sectionsTable"
         value="#{rosterBean.enrollments}"
@@ -52,6 +56,7 @@
         binding="#{rosterBean.rosterDataTable}"
         sortColumn="#{preferencesBean.rosterSortColumn}"
         sortAscending="#{preferencesBean.rosterSortAscending}"
+        rendered="#{rosterBean.enrollments.size()>0}"
         styleClass="listHier rosterTable">
         <h:column>
             <f:facet name="header">

--- a/sections/sections-app/src/webapp/roster.jsp
+++ b/sections/sections-app/src/webapp/roster.jsp
@@ -45,7 +45,7 @@
         </t:div>
     </h:panelGrid>
     
-    <h:panelGroup rendered="#{rosterBean.enrollmentsSize<=0}" >
+    <h:panelGroup rendered="#{rosterBean.enrollmentsSize <= 0}" >
         <h:outputText styleClass="sak-banner-warn" value="#{msgs.students_not_found}"  />
     </h:panelGroup>
 


### PR DESCRIPTION
To solve this, a warn banner will be displayed when there are no students to show, instead of the empty table. 

The message will appear in two cases:

- The search result doesn't match with any user.
- There are no students associated with the site.

I wrote it trying to fit both situations. Of course, I'm open for suggestions.


Jira: [SAK-44069](https://jira.sakaiproject.org/browse/SAK-44069)