### PR TITLE
SAK-45733 allow substitution of user timezone

### DIFF
--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletRequest;
@@ -70,6 +71,7 @@ import org.sakaiproject.service.gradebook.shared.GradebookService;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.site.cover.SiteService;
+import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.tool.api.Placement;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -516,6 +518,12 @@ public class SakaiBLTIUtil {
 			setProperty(ltiProps, BasicLTIConstants.LIS_PERSON_SOURCEDID, user.getEid());
 			setProperty(lti13subst, LTICustomVars.USER_USERNAME, user.getEid());
 			setProperty(lti13subst, LTICustomVars.PERSON_SOURCEDID, user.getEid());
+
+			UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
+			TimeZone tz = userTimeService.getLocalTimeZone(user.getId());
+			if (tz != null) {
+				setProperty(lti13subst, LTICustomVars.PERSON_ADDRESS_TIMEZONE, tz.getID());
+			}
 
 			if (releasename == 1) {
 				setProperty(ltiProps, BasicLTIConstants.LIS_PERSON_NAME_GIVEN, user.getFirstName());


### PR DESCRIPTION
Hi @csev, this is untested, I'm just looking for guidance. Is this where it should go? 

Schools like Duke, want to use this for LTI:

`custom_person_address_timezone=$Person.address.timezone`