### PR TITLE
SAK-45224: Upgrading Mathjax to v.2.7.9

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4895,7 +4895,7 @@
 # See https://jira.sakaiproject.org/browse/SAK-22384 for more details and a demo.
 
 # URL to MathJax.js, you can use the one on the mathjax CDN or put one locally. Currently this is not included with Sakai.
-# As of KNL-1519 The current default is the CDNJS (https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=default,Safe)
+# As of KNL-1519 The current default is the CDNJS (https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=default,Safe)
 #portal.mathjax.src.path=
 
 # Whether to allow useres to enable or disable MathJAX, this still has to be enabled on a per site basis (default is true)

--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -266,7 +266,7 @@ memory.org.sakaiproject.user.api.UserDirectoryService=maxElementsInMemory=100000
 content.mimeMagic.ignorecontent.extensions=js
 
 # KNL-1234 Enable MathJax on content in resources
-portal.mathjax.src.path=https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=default,Safe
+portal.mathjax.src.path=https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=default,Safe
 
 # Limit grantable permissions to some roles. SAK-29403
 realm.allowed.roles=.auth,.anon


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45224

We have 2.7.9 in our production instance from 3 months ago and no problems have been detected.