### PR TITLE
SAK-45728 remove clear filter button

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -313,10 +313,6 @@ $PBJQ(document).ready(function(){
     $PBJQ('#txtSearch').focus();
   }
 
-  $PBJQ('#otherSiteSearchClear').on('click', function () {
-      resetSearch();
-  });
-
   //toggle presence panel
   $PBJQ("#presenceToggle").click(function(e){
     e.preventDefault();

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -64,7 +64,6 @@
                     <div id="otherSiteSearch">
                         <label for="txtSearch">${rloader.sit_search}</label>
                         <input type="text" id="txtSearch" name="txtSearch" maxlength="50">
-                        <a id="otherSiteSearchClear" class="other-site-search-clear" href="javascript:void(0);"></a>
                     </div>
                     <div id="noSearchResults" class="is-hidden">${rloader.sit_search_none}</div>
 


### PR DESCRIPTION
This fake button is not accessibility-friendly and provides little value to sighted users. Just use your backspace key.