### PR TITLE
SAK-45453 Samigo remove samigo.studentRichText property

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2533,11 +2533,6 @@ public class DeliveryBean implements Serializable {
   	    return ServerConfigurationService.getInt("samigo.autoSave.repeat.milliseconds", 300000);
 	  }
 
-	  public boolean getStudentRichText() {
-	      String studentRichText = ServerConfigurationService.getString("samigo.studentRichText", "true");
-		  return Boolean.parseBoolean(studentRichText);
-	  }
-
 	  public String getRecURL() {
   	    if (RECPATH == null || RECPATH.trim().equals("")) {
   	    	return "";

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswer.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswer.jsp
@@ -39,20 +39,12 @@ should be included in file importing DeliveryMessages
 
 <h:outputText value="#{deliveryMessages.sa_invalid_length_error} " escape="false" rendered="#{question.isInvalidSALengthInput}" styleClass="sak-banner-error"/>
 
-<%-- If studentRichText is true, show the rich text answer option --%>
 <h:panelGrid rendered="#{delivery.actionString!='reviewAssessment'
-            && delivery.actionString!='gradeAssessment' && delivery.studentRichText}">
+            && delivery.actionString!='gradeAssessment'}">
 	<samigo:wysiwyg rows="240" value="#{question.responseText}" hasToggle="yes" maxCharCount="32000">
 	</samigo:wysiwyg>
 </h:panelGrid>
 
-<%-- Otherwise, show old-style non-rich text answer input --%>
-
-<h:inputTextarea rows="20" cols="80" value="#{question.responseText}" 
-   rendered="#{delivery.actionString!='reviewAssessment'
-            && delivery.actionString!='gradeAssessment' && !delivery.studentRichText}">
-<f:validateLength maximum="32000"/>
-</h:inputTextarea>
 <h:outputText value="#{question.responseTextForDisplay}" 
    rendered="#{delivery.actionString=='reviewAssessment'
             || delivery.actionString=='gradeAssessment'}" escape="false"/>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswerLink.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverShortAnswerLink.jsp
@@ -37,21 +37,13 @@ should be included in file importing DeliveryMessages
 </h:panelGroup> 
 <f:verbatim><br/></f:verbatim>
 
-<%-- If studentRichText is true, show the rich text answer option --%>
 <h:panelGrid rendered="#{delivery.actionString!='reviewAssessment'
-           && delivery.actionString!='gradeAssessment' && delivery.studentRichText}">
+           && delivery.actionString!='gradeAssessment'}">
 	<samigo:wysiwyg rows="140" value="#{question.responseText}" hasToggle="yes" maxCharCount="32000">
 	    <f:validateLength maximum="32000"/>
 	</samigo:wysiwyg>
 </h:panelGrid>
 
-<%-- Otherwise, show old-style non-rich text answer input --%>
-
-<h:inputTextarea rows="20" cols="80" value="#{question.responseText}" 
-   rendered="#{delivery.actionString!='reviewAssessment'
-            && delivery.actionString!='gradeAssessment' && !delivery.studentRichText}">
-<f:validateLength maximum="32000"/>
-</h:inputTextarea>
 <h:outputText value="#{question.responseTextForDisplay}" 
    rendered="#{delivery.actionString=='reviewAssessment'
             || delivery.actionString=='gradeAssessment'}" escape="false"/>


### PR DESCRIPTION
samigo.studentRichText has been removed, so the current behaviour is always samigo.studentRichText=true

Removing property: Core team

https://jira.sakaiproject.org/browse/SAK-45453
https://github.com/sakaiproject/sakai/pull/9233/files