### PR TITLE
SAK-45839 Rubrics: property to hide weighted option

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5466,6 +5466,16 @@
 # The secret shared between Sakai and the rubrics service to secure JWTs
 rubrics.integration.token-secret=12345678900909091234
 
+# SAK-45839 property to show/hide weighted option
+#
+# If you turn the weighted option off and any of your users have already applied weights to rubrics, you
+# will need to update the rbc_rubric table and set weighted to 0 or false. If you don't do this, the rubric
+# will still be weighted in any calculations, even though the weighted option will not be visible in the rubrics
+# UI an longer.
+#
+# DEFAULT: true
+# rubrics.enable.weighted=false
+
 # ###############################
 # Content-Review
 # ###############################

--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/RubricsService.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/RubricsService.java
@@ -60,6 +60,8 @@ public interface RubricsService {
 
     String generateLang();
 
+    Boolean isWeightedEnabled();
+
     String getRubricEvaluationObjectId(String associationId, String userId, String toolId);
 
     void deleteRubricAssociation(String toolId, String itemId);

--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/logic/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/logic/RubricsServiceImpl.java
@@ -1026,6 +1026,10 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
 
         return lines.toString();
     }
+    
+    public Boolean isWeightedEnabled(){
+        return serverConfigurationService.getBoolean("rubrics.enable.weighted", true);
+    }
 
     public String getCurrentSessionId() {
         return sessionManager.getCurrentSession().getId();

--- a/rubrics/tool/src/main/java/org/sakaiproject/rubrics/controller/MainController.java
+++ b/rubrics/tool/src/main/java/org/sakaiproject/rubrics/controller/MainController.java
@@ -39,6 +39,7 @@ public class MainController {
     public String index(ModelMap model) {
         String token = rubricsService.generateJsonWebToken("sakai.rubrics");
         model.addAttribute("token", token);
+        model.addAttribute("weightedEnabled", rubricsService.isWeightedEnabled());
         model.addAttribute("sakaiSessionId", rubricsService.getCurrentSessionId());
         model.addAttribute("cdnQuery", PortalUtils.getCDNQuery());
         return "index";

--- a/rubrics/tool/src/main/resources/templates/index.html
+++ b/rubrics/tool/src/main/resources/templates/index.html
@@ -11,7 +11,7 @@
       <script th:inline="javascript">
           var sakaiSessionId = /*[[${sakaiSessionId}]]*/ null;
       </script>
-      <sakai-rubrics-manager th:attr="token=${token}"></sakai-rubrics-manager>
+      <sakai-rubrics-manager th:attr="token=${token}, weighted-enabled=${weightedEnabled ? true : null}"></sakai-rubrics-manager>
     </div>
   </body>
 </html>

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
@@ -32,7 +32,8 @@ export class SakaiRubric extends RubricsElement {
       shareIcon: { type: String },
       weightedIcon: String,
       totalWeight: String,
-      validWeight: Boolean
+      validWeight: Boolean,
+      weightedIsEnabled: { attribute: "weighted-enabled", type: Boolean },
     };
   }
 
@@ -82,7 +83,7 @@ export class SakaiRubric extends RubricsElement {
         <div class="hidden-xs"><sakai-rubric-modified-date modified="${this.rubric.metadata.modified}"></sakai-rubric-modified-date></div>
 
         <div class="actions">
-          ${!this.rubric.metadata.locked ? html`
+          ${!this.rubric.metadata.locked && this.weightedIsEnabled ? html`
             <div class="action-container">
               <span class="hidden-sm hidden-xs sr-only">
                 ${this.rubric.weighted ?

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubrics-list.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubrics-list.js
@@ -17,6 +17,7 @@ export class SakaiRubricsList extends RubricsElement {
     return {
       token: { type: String },
       rubrics: { type: Array },
+      weightedIsEnabled: { attribute: "weighted-enabled", type: Boolean },
     };
   }
 
@@ -40,7 +41,7 @@ export class SakaiRubricsList extends RubricsElement {
         <div role="tablist">
         ${repeat(this.rubrics, r => r.id, r => html`
           <div class="rubric-item" id="rubric_item_${r.id}">
-            <sakai-rubric @clone-rubric="${this.cloneRubric}" @delete-item="${this.deleteRubric}" token="${this.token}" rubric="${JSON.stringify(r)}"></sakai-rubric>
+            <sakai-rubric @clone-rubric="${this.cloneRubric}" @delete-item="${this.deleteRubric}" token="${this.token}" rubric="${JSON.stringify(r)}" ?weighted-enabled=${this.weightedIsEnabled}></sakai-rubric>
           </div>
         `)}
         </div>

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubrics-manager.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubrics-manager.js
@@ -17,7 +17,11 @@ class SakaiRubricsManager extends RubricsElement {
   }
 
   static get properties() {
-    return { token: String, i18nLoaded: Boolean };
+    return {
+      token: String,
+      i18nLoaded: Boolean,
+      weightedIsEnabled: { attribute: "weighted-enabled", type: Boolean }
+    };
   }
 
   shouldUpdate() {
@@ -57,7 +61,7 @@ class SakaiRubricsManager extends RubricsElement {
           <div class="actions"><sr-lang key="actions">actions</sr-lang></div>
         </div>
         <br>
-        <sakai-rubrics-list id="sakai-rubrics" @sharing-change="${this.handleSharingChange}" @copy-share-site="${this.copyShareSite}" token="Bearer ${this.token}"></sakai-rubrics-list>
+        <sakai-rubrics-list id="sakai-rubrics" @sharing-change="${this.handleSharingChange}" @copy-share-site="${this.copyShareSite}" token="Bearer ${this.token}" ?weighted-enabled=${this.weightedIsEnabled}></sakai-rubrics-list>
       </div>
 
         <div id="shared-rubrics-title" aria-expanded="${this.sharedRubricsExpanded}" role="tab" aria-multiselectable="true" class="manager-collapse-title" title="${tr("toggle_shared_rubrics")}" tabindex="0" @click="${this.toggleSharedRubrics}">


### PR DESCRIPTION
Hi,
this change allows to deactivate the capability to make rubrics weighted, using the server property `rubrics.enable.weighted`

https://jira.sakaiproject.org/browse/SAK-45839

Here are some visual comparisons

Before

---

![image](https://user-images.githubusercontent.com/33053368/128337226-4af380f9-fb67-4266-b271-aaecefa36738.png)

---

After 

![image](https://user-images.githubusercontent.com/33053368/128337271-669083c7-2abc-4a0a-9d45-87564fc4e72c.png)


