### PR TITLE
SAK-45826 When creating a new site, there is no longer a default selected

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -177,9 +177,6 @@ sakai.siteTypeSetup = function(){
      //the #courseSiteTypes input[type=text] contains what site types are associated with the course category
      // if there are none associated in sakai.properties, the value will be just one ('course')
      var courseSiteTypes = $('#courseSiteTypes').val().replace('[','').replace(']','').replace(/ /gi, '').split(',');
-     
-    //uncheck site type radio
-    $('input[name="itemType"]').prop('checked', false);
     
     // handles clicking in "Build site from template"
     $('#copy').click(function(e){


### PR DESCRIPTION
Just a small change, that line was there since 2009.
It was causing the "flashy" behavior, where the page loaded with the checkbox activated and after that the js deselected it

Here is a GIF showing the bug

---

![SAK-45826](https://user-images.githubusercontent.com/33053368/128342618-ccf43155-adeb-4931-9707-618c9614e0f0.gif)

