### PR TITLE
SAK-45930: Discussions > Any Topic > "Forums" shows as breadcrumb

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
@@ -105,7 +105,7 @@
 		<h3 class="specialLink">
 			<h:commandLink immediate="true" action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 				rendered="#{ForumTool.messagesandForums}" />
-			<h:commandLink immediate="true" action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			<h:commandLink immediate="true" action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 				rendered="#{ForumTool.forumsTool}" />
 			<h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 			<h:commandLink immediate="true" action="#{ForumTool.processActionDisplayForum}" title=" #{ForumTool.selectedForum.forum.title}" rendered="#{ForumTool.showForumLinksInNav}">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/forum/dfForumDetail.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/forum/dfForumDetail.jsp
@@ -34,7 +34,7 @@
           		<%-- Display the proper home page link: either Messages & Forums OR Forums --%>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
 			      <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 			      <h:outputText value="#{ForumTool.selectedForum.forum.title}" />

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/menu/forumsMenu.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/menu/forumsMenu.jsp
@@ -18,7 +18,7 @@
   <ul class="navIntraTool actionToolbar" role="menu">
     <li role="menuitem">
       <span id="forumsMainMenuLink">
-        <h:commandLink value="#{msgs.cdfm_discussion_forums}" action="forumsMain" immediate="true"/>
+        <h:commandLink value="#{msgs.cdfm_discussions}" action="forumsMain" immediate="true"/>
       </span>
     </li>
     <h:panelGroup rendered="#{ForumTool.newForum}">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
@@ -152,7 +152,7 @@
 			      <h:commandLink action="#{ForumTool.processActionHome}" title=" #{msgs.cdfm_message_forums}" rendered="#{ForumTool.messagesandForums}">
 						<h:outputText value="#{msgs.cdfm_message_forums}"/>
 					</h:commandLink>
-			      <h:commandLink action="#{ForumTool.processActionHome}" title=" #{msgs.cdfm_discussion_forums}" rendered="#{ForumTool.forumsTool}" >
+			      <h:commandLink action="#{ForumTool.processActionHome}" title=" #{msgs.cdfm_discussions}" rendered="#{ForumTool.forumsTool}" >
 							<h:outputText value="#{msgs.cdfm_discussion_forums}"/>
 						</h:commandLink>
       			  <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfFlatView.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfFlatView.jsp
@@ -71,7 +71,7 @@
 					<f:verbatim><div class="breadCrumb specialLink"><h3></f:verbatim>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
       			  <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 					  <h:commandLink action="#{ForumTool.processActionDisplayForum}" title=" #{ForumTool.selectedForum.forum.title}">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfPendingMessages.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfPendingMessages.jsp
@@ -20,7 +20,7 @@
 			<h3>
 				<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
       	<h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 				<h:outputText value="#{msgs.cdfm_msg_pending_queue_title}" />

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewMessage.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewMessage.jsp
@@ -60,7 +60,7 @@
 					<h3>
 						<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 							rendered="#{ForumTool.messagesandForums}" />
-						<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+						<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 							rendered="#{ForumTool.forumsTool}" />
 						<h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 						<h:commandLink action="#{ForumTool.processActionDisplayForum}" 

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThread.jsp
@@ -77,7 +77,7 @@
 					<f:verbatim><div class="specialLink"><h3></f:verbatim>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
       			  <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 					  <h:commandLink action="#{ForumTool.processActionDisplayForum}" title=" #{ForumTool.selectedForum.forum.title}" rendered="#{ForumTool.showForumLinksInNav}">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
@@ -155,7 +155,7 @@
           	 <h:panelGroup layout="block" styleClass="breadCrumb" rendered="#{ForumTool.instructor}"><h3>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
 			      <h:outputText value=" / "/>
 			      <h:commandLink action="#{ForumTool.processActionStatistics}" value="#{msgs.stat_list}" title="#{msgs.stat_list}" rendered="#{empty mfStatisticsBean.selectedAllTopicsTopicId && empty mfStatisticsBean.selectedAllTopicsForumId}"/>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsDisplayInThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsDisplayInThread.jsp
@@ -32,7 +32,7 @@
 		<h:panelGroup layout="block" styleClass="breadCrumb" rendered="#{ForumTool.instructor}"><h3>
 		<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      	rendered="#{ForumTool.messagesandForums}" />
-		<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+		<h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      	rendered="#{ForumTool.forumsTool}" />
 		<h:outputText value=" / "/>
 		<h:commandLink action="#{ForumTool.processActionStatistics}" value="#{msgs.stat_list}" title="#{msgs.stat_list}" rendered="#{empty mfStatisticsBean.selectedAllTopicsTopicId && empty mfStatisticsBean.selectedAllTopicsForumId}"/>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsFullTextForOne.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsFullTextForOne.jsp
@@ -35,7 +35,7 @@
           	 <f:verbatim><div class="breadCrumb"><h3></f:verbatim>
 			 <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			 <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			 <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
 			 <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 			 <h:commandLink action="#{ForumTool.processActionStatistics}" value="#{msgs.stat_list}" title="#{msgs.stat_list}"/>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsList.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsList.jsp
@@ -27,7 +27,7 @@
 			 	<f:verbatim><h1></f:verbatim>
 				  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 						rendered="#{ForumTool.messagesandForums}" />
-				  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+				  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 						rendered="#{ForumTool.forumsTool}" />
 				  <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 				  <h:outputText value="#{msgs.stat_list}" />

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsListByAllTopics.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsListByAllTopics.jsp
@@ -27,7 +27,7 @@
 			 	<f:verbatim><h1></f:verbatim>
 				  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 						rendered="#{ForumTool.messagesandForums}" />
-				  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+				  <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 						rendered="#{ForumTool.forumsTool}" />
 				  <h:outputText value=" " />
 				  <h:outputText value=" / " /><h:outputText value=" " />

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsListByTopic.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsListByTopic.jsp
@@ -184,7 +184,7 @@
           	 <f:verbatim><h3></f:verbatim>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
 			      <h:outputText value=" " /><h:outputText value=" / " /><h:outputText value=" " />
 			      <h:commandLink action="#{mfStatisticsBean.processActionStatisticsByAllTopics}" value="#{msgs.stat_list}" title="#{msgs.stat_list}"/>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
@@ -133,7 +133,7 @@
           	 <f:verbatim><h3></f:verbatim>
 			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_message_forums}" title=" #{msgs.cdfm_message_forums}"
 			      		rendered="#{ForumTool.messagesandForums}" />
-			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussion_forums}" title=" #{msgs.cdfm_discussion_forums}"
+			      <h:commandLink action="#{ForumTool.processActionHome}" value="#{msgs.cdfm_discussions}" title=" #{msgs.cdfm_discussions}"
 			      		rendered="#{ForumTool.forumsTool}" />
 			      <h:outputText value=" / "/>
 			      <h:commandLink action="#{ForumTool.processActionStatistics}" value="#{msgs.stat_list}" title="#{msgs.stat_list}" rendered="#{empty mfStatisticsBean.selectedAllTopicsTopicId && empty mfStatisticsBean.selectedAllTopicsForumId}"/>


### PR DESCRIPTION
Replace occurecnces of Forums in breadcrumps with Discussions

I didn't just change the value of the propertue **cdfm_discussion_forums** because **cdfm_discussion** already exists and when all occurences of "Forums" are replaces this propertie can be deleted together with others.