### PR TITLE
SAK-41655 Gradebook: Sorting and filtering students distorts next/previous logic for Grade Summary

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -115,12 +115,15 @@ GradebookGradeSummary.prototype.setupStudentNavigation = function() {
 
   var currentStudentIndex = GbGradeTable.rowForStudent(this.studentId);
 
+  // get the students as they are currently rendered so the sorting/filtering is accurately reflected
+  const studentsAsRendered = GbGradeTable.instance.getDataAtCol(0);
+
   var previousStudentId, nextStudentId;
   if (currentStudentIndex > 0) {
-    previousStudentId = GbGradeTable.students[currentStudentIndex - 1].userId;
+    previousStudentId = studentsAsRendered[currentStudentIndex - 1].userId;
   }
-  if (currentStudentIndex < GbGradeTable.students.length - 1) {
-    nextStudentId = GbGradeTable.students[currentStudentIndex + 1].userId;
+  if (currentStudentIndex < studentsAsRendered.length - 1) {
+    nextStudentId = studentsAsRendered[currentStudentIndex + 1].userId;
   } 
 
   if (previousStudentId) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41655

This doesn't work because it is using the full student list in the original order to determine the prev/next students. This PR changes this so it uses the list of students as they are currently displayed.