### PR TITLE
SAK-45809 Resubmission count always -1 from expected

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6327,7 +6327,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
                     if (NumberUtils.isParsable(properties.get(AssignmentConstants.ALLOW_RESUBMIT_NUMBER))) {
                         // if this submission has been already been submitted previously.
-                        if (submission.getSubmitted() && submission.getDateSubmitted() != null) {
+                        boolean isResub = properties.entrySet().stream().anyMatch(e -> e.getKey().startsWith("log") && e.getValue().contains("submitted"));
+                        if (submission.getSubmitted() && isResub) {
                             // decrease the allow_resubmit_number,
                             int number = Integer.parseInt(properties.get(AssignmentConstants.ALLOW_RESUBMIT_NUMBER));
                             // minus 1 from the submit number, if the number is not -1 (not unlimited)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45809

Assignment items created with a Resubmission quantity will seemingly reduce the quantity by -1.

As an example, instructors which create an assignment that allows for one resubmission might assume that students will have an opportunity to input an initial submission as well as one additional submission for a total of 2 submissions. Current behavior allows for only one in these circumstances.

Similarly, in assignments with 2 resubmissions, students are only provided with the initial submission + 1 resubmission.

--------------------
The code to decrement the resub count is being run on the first submission.

The problem lies with this if statement:
`if (submission.getSubmitted() && submission.getDateSubmitted() != null)`

dateSubmitted is always set regardless of draft or submit, so we can't use it to determine if there is a previous submission or not.

This PR restores the history log check for previous submissions that Assignments used to have for this purpose. This is the only way to reliably determine if this is a resubmission or not.