### PR TITLE
SAK-45598 Roster: permission issue, avoid image caching

### DIFF
--- a/roster2/tool/src/webapp/js/roster.js
+++ b/roster2/tool/src/webapp/js/roster.js
@@ -398,7 +398,7 @@ roster.renderMembership = function (options) {
         if (roster.officialPictureMode) {
           m.profileImageUrl += "/official";
         }
-        m.profileImageUrl += "?siteId=" + encodeURIComponent(roster.siteId);
+        m.profileImageUrl += "?siteId=" + encodeURIComponent(roster.siteId) + "&v=" + Math.random().toString(36).slice(2);
 
         var groupIds = Object.keys(m.groups);
         m.hasGroups = groupIds.length > 0;


### PR DESCRIPTION
Applying a similar parameter for profile images to what's being done on other spots: see org.sakaiproject.profile2.tool.components.ProfileImage or Roster's PronunciationMap (SakaiProxy).