### PR TITLE
SAK-45993 Samigo: Students receive late submissions not allowed message with extensions when taking quiz through URL

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -1694,7 +1694,7 @@ public class DeliveryBean implements Serializable {
   public void setPublishedAssessment(PublishedAssessmentFacade publishedAssessment) {
 	  this.publishedAssessment = publishedAssessment;
 	  //Setup extendedTimeDeliveryService
-	  if (extendedTimeDeliveryService == null && 
+	  if ((extendedTimeDeliveryService == null || StringUtils.isBlank(extendedTimeDeliveryService.getAgentId())) &&
 			  (publishedAssessment != null && publishedAssessment.getPublishedAssessmentId() != null)) {
 		  extendedTimeDeliveryService = new ExtendedTimeDeliveryService(publishedAssessment);
 	  }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/ExtendedTimeDeliveryService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/ExtendedTimeDeliveryService.java
@@ -52,6 +52,8 @@ public class ExtendedTimeDeliveryService {
 
 	@Getter
 	private Long publishedAssessmentId;
+	@Getter
+	private String agentId;
 
 	/**
 	 * Creates an ExtendedTimeService object using the userId in the agentFacade as the current user
@@ -82,6 +84,8 @@ public class ExtendedTimeDeliveryService {
 		String pubId = publishedAssessmentId.toString();
 		siteId = publishedAssessmentService.getPublishedAssessmentSiteId(pubId);
 		PublishedAssessmentData pubData = publishedAssessmentService.getBasicInfoOfPublishedAssessment(pubId);
+
+		this.agentId = agentId;
 
 		ExtendedTimeFacade extendedTimeFacade = PersistenceService.getInstance().getExtendedTimeFacade();
 		List<ExtendedTime> extendedTimes = extendedTimeFacade.getEntriesForPub(pubData);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45993

If a quiz does not allow late submissions, is closed, yet has granted an extension to a student, that student will be able to take the quiz through the normal Samigo interface, but not through a direct URL. The student will instead receive a misleading "late submissions not allowed" error page.

Typically this will happen when the user is not logged in when they hit the URL. This is because an ExtendedTimeDeliveryService object is created before the current user is known, and not replaced after the user is known because the object already exists.  This PR makes sure the object is replaced if the user was unknown at the time.