### PR TITLE
SAK-45995 GBNG > selecting 'hide this category' for a partially shown category will actually 'show this category'

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -1784,6 +1784,8 @@ GbGradeTable.setupToggleGradeItems = function() {
     var $group = $itemFilter.closest(".gb-item-filter-group");
     var $label = $group.find(".gb-item-category-filter label");
     var $input = $group.find(".gb-item-category-filter input");
+    const $hideThisCategory = $group.find(".gb-hide-this-category");
+    const $showThisCategory = $group.find(".gb-show-this-category");
 
     var checkedItemFilters = $group.find(".gb-item-filter :input:checked, .gb-item-category-score-filter :input:checked").length;
     var itemFilters = $group.find(".gb-item-filter :input, .gb-item-category-score-filter :input").length;
@@ -1793,16 +1795,19 @@ GbGradeTable.setupToggleGradeItems = function() {
       removeClass("off").
       find(".gb-filter-partial-signal").remove();
 
-    if (checkedItemFilters == 0) {
+    if (checkedItemFilters === 0) {
       $input.prop("checked", false);
       $label.addClass("off");
-    } else if (checkedItemFilters == itemFilters) {
+      $hideThisCategory.hide();
+    } else if (checkedItemFilters === itemFilters) {
       $input.prop("checked", true);
+      $showThisCategory.hide();
     } else {
       $input.prop("checked", false);
       $label.addClass("partial");
-      $label.find(".gb-item-filter-signal").
-        append($("<span>").addClass("gb-filter-partial-signal"));
+      $label.find(".gb-item-filter-signal").append($("<span>").addClass("gb-filter-partial-signal"));
+      $hideThisCategory.show();
+      $showThisCategory.show();
     }
   };
 
@@ -1879,6 +1884,10 @@ GbGradeTable.setupToggleGradeItems = function() {
         .attr("data-suppress-update-view-preferences", "true")
         .trigger("click");
 
+    // Everything in every category is shown, so we should hide the "show this category" menu options
+    $panel.find(".gb-show-this-category").hide();
+    $panel.find(".gb-hide-this-category").show();
+
     GbGradeTable.updateViewPreferences();
   };
 
@@ -1888,6 +1897,10 @@ GbGradeTable.setupToggleGradeItems = function() {
     $panel.find(".gb-item-filter :input:checked, .gb-item-category-score-filter :input:checked")
         .attr("data-suppress-update-view-preferences", "true")
         .trigger("click");
+
+    // Everything in every category is hidden, so we should hide the "hide this category" menu options
+    $panel.find(".gb-hide-this-category").hide();
+    $panel.find(".gb-show-this-category").show();
 
     GbGradeTable.updateViewPreferences();
   };
@@ -2034,8 +2047,17 @@ GbGradeTable.setupToggleGradeItems = function() {
         on("click", ".gb-toggle-this-category", function(event) {
           event.preventDefault();
 
-          var $filter = $(event.target).closest(".gb-item-category-filter");
-          $filter.find(":input").trigger("click");
+          const hide = event.target.className.includes("hide");
+          const $filter = $(event.target).closest(".gb-item-filter-group");
+          if (hide) {
+            $filter.find("div.gb-filter").not(".off").find(":input").trigger("click");
+            $filter.find(".gb-hide-this-category").hide();
+            $filter.find(".gb-show-this-category").show();
+          } else {
+            $filter.find("div.off").find(":input").trigger("click");
+            $filter.find(".gb-hide-this-category").show();
+            $filter.find(".gb-show-this-category").hide();
+          }
           $(this).focus();
         }).
         on("click", ".gb-toggle-this-item", function(event) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45995

Issues:

* 'Hide this category' on a partially shown category will actually 'Show this category'
* 'Hide this category' menu item never gets updated
* 'Show All'/'Hide All' does not update menu items

These issues are related to the fact that there's only one algorithm to do the hide/show, and it's a toggle:

```
        on("click", ".gb-toggle-this-category", function(event) {
          event.preventDefault();

          var $filter = $(event.target).closest(".gb-item-category-filter");
          $filter.find(":input").trigger("click");
          $(this).focus();
        })
```

This ticket fixes some of the issues described in SAK-33740, but does not address the last issue described there: "Show Only this Category" does not hide individual items within other categories; it will only hide other categories if all items within that category are already visible.