### PR TITLE
SAK-45997 Oracle and MySQL treat null differently when ORDER BY used

### DIFF
--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/db-components.xml
@@ -455,6 +455,7 @@
 				<prop key="hibernate.current_session_context_class">org.springframework.orm.hibernate5.SpringSessionContext</prop>
 				<prop key="org.apache.ignite.hibernate.default_access_type">READ_ONLY</prop>
 				<prop key="hibernate.id.new_generator_mappings">false</prop>
+				<prop key="hibernate.order_by.default_null_ordering">last</prop>
 			</props>
 		</property>
 	</bean>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -276,7 +276,7 @@ $(document).ready(function(){
        <h:outputText value="\"></a>" escape="false" />
 
        <h:commandLink styleClass="sam-scoretable-deleteattempt" title="#{commonMessages.delete_attempt}" action="totalScores" immediate="true" rendered="true" >
-         <h:panelGroup rendered="#{description.submittedDate!=null &&  description.assessmentGradingId ne '-1'}">
+         <h:panelGroup rendered="#{description.assessmentGradingId ne '-1'}">
 	     <span class="fa fa-trash" aria-hidden="true"></span>
 	     <span class="sr-only"><h:outputText value="#{commonMessages.delete}" /></span>
          </h:panelGroup>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45997

We discovered this while investigating a support inquiry where a student had 2 submissions to a quiz that was set to record the highest attempted score. In one of the student's attempt, the `submitteddate` and the `finalscore` were both `NULL`. In an Oracle environment this forced the `NULL` score to the top of the query, so that in effect the student got a zero for the quiz instead of their original non-zero attempt.

According to my research:

> Oracle treats NULLs the same way as PostgreSQL. Specifically, Oracle's documentation states that "if the null ordering is not specified, then the handling of the null values is NULLS LAST if the sort is ASC, NULLS FIRST if the sort is DESC." In effect, Oracle considers NULL values larger than any non-NULL values.
> ...
> ...
> Like SQLite, MySQL considers NULL values lower than any non-NULL value. If you use this database, expect the same treatment of NULL values as illustrated above: NULLs will appear first if the values are sorted in ascending order and last if descending order is used.

This explains why the `NULL` floated to the top of the result set in Oracle, but was not reproducible in a MySQL environment.

In order to resolve this, we need to tell Oracle environments to use the same null precidence that MySQL uses, so that results are consistent between the two environments.

Another issue here was that the instructor was not able to delete the "bogus" attempt from the student because the submission lacked a `submitteddate`, which seems to be an invalid constraint on rendering the anchor to delete a submission through the UI.