### PR TITLE
SAK-45998 Samigo > Points values are cut off in the random draw from pool interface

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -938,7 +938,9 @@ label.inactive
 
 #modifyPartForm fieldset.roundedBorder input[type="text"]
 {
-    width: 30px;
+    box-sizing: content-box; /* content-box is used so we can safely use the "ch" unit to define the number of digits that fit in the field */
+    width: 5ch;
+    text-align: center;
     margin-left: 5px;
     margin-right: 5px;
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45998

Edit a part and select random draw from pool. You are presented with some text fields to enter a number of questions to draw and the points values for these questions. The text fields are not wide enough to fully display more than about 3 characters. This presents a problem even if your points values are relatively small because they are rendered with decimal points when you go back to edit them. If you entered, for example "10" for the points value, you would only see "10." with a cut-off 0 after the decimal point. The fields should be resized to display 2 digits on either side of the decimal, so 5 characters in total. This should be enough to cover most realistic scenarios while still not looking too strange for single-digit values.

See before/after screenshots on the Jira ticket.