### PR TITLE
SAK-45999 samigo > adjustment/'apply this score' functions throw stack trace with negative values

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoLRSStatements.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/SamigoLRSStatements.java
@@ -19,8 +19,6 @@ import java.util.HashMap;
 
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.event.api.EventTrackingService;
-import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Actor;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Object;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Result;
 import org.sakaiproject.event.api.LearningResourceStoreService.LRS_Statement;
@@ -169,7 +167,7 @@ public class SamigoLRSStatements {
     
     private static LRS_Result getLRS_Result(AssessmentGradingData gradingData, PublishedAssessmentIfc publishedAssessment) {
         double score = gradingData.getFinalScore();
-        LRS_Result result = new LRS_Result(score, 0.0, publishedAssessment.getTotalScore(), null);
+        LRS_Result result = new LRS_Result(score, null, publishedAssessment.getTotalScore(), null);
         result.setCompletion(true);
         return result;
     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45999

If you try to apply a negative score to students using either the "Adjustment" column for those with submissions, or the "Apply This Score" component for those without submissions, you'll notice a stack trace go through the logs and you'll be punted back to the assessment list UI.  Stack trace is like:

> Caused by: java.lang.IllegalArgumentException: score raw (-0.5) must not be less than min (0.0)
>         at org.sakaiproject.event.api.LearningResourceStoreService$LRS_Result.setRawScore(LearningResourceStoreService.java:947)
>         at org.sakaiproject.event.api.LearningResourceStoreService$LRS_Result.setScore(LearningResourceStoreService.java:975)
>         at org.sakaiproject.event.api.LearningResourceStoreService$LRS_Result.<init>(LearningResourceStoreService.java:907)
>         at org.sakaiproject.tool.assessment.util.SamigoLRSStatements.getLRS_Result(SamigoLRSStatements.java:172)
>         at org.sakaiproject.tool.assessment.util.SamigoLRSStatements.getStatementForTotalScoreUpdate(SamigoLRSStatements.java:112)
>         at org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreUpdateListener.saveTotalScores(TotalScoreUpdateListener.java:289)
>         at org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreUpdateListener.processAction(TotalScoreUpdateListener.java:102)

In fact, if you go back to the Scores UI for the quiz in question, you'll see that the adjustment/override was actually applied successfully, despite the stack trace and the confusing behaviour.

This issue was introduced in SAK-39566, where the `LRS_Result` object was hard-coded with "0.0" as the minimum score. Thus, any score passed which is less than 1.0 will always trigger an `IllegalArgumentException`.

This was an erroneous implementation decision, as negative scores are perfectly legitimate in both Samigo and Gradebook. Funnily, the JavaDocs for the `LRS_Result` even state that you can pass `null` as the minimum to bypass that check:

```
         * @param min Minimum score (range) - any number (can be null)
         * @param max Maximum score (range) - any number (can be null)
```