### PR TITLE
SAK-46002 Assessment Attempts Are Limited When User is in Multiple Groups

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -967,7 +967,7 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 			final HibernateCallback<List<AssessmentGradingData>> hcb = session -> {
                 Query q = session.createQuery(
 						"select new AssessmentGradingData("
-								+ " a.publishedAssessmentId, count(a)) "
+								+ " a.publishedAssessmentId, count(distinct a)) "
 								+ " from AssessmentGradingData as a, AuthorizationData as az "
 								+ " where a.agentId=:agentId and a.forGrade=:forGrade and a.status > :status"
 								+ " and (az.agentIdString=:siteId or az.agentIdString in (:groupIds)) "


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46002

If an assessment is released to multiple groups, and a user is in more than one of those groups, they are limited in the amount of times they are able to submit to the assessment, regardless of the amount listed. For example, if the quiz allows 2 submissions and the student is in more than one group the quiz is released to, they will only be able to take the quiz once.

What is happening is there is a query that counts your single submission once for each group that you are in due to the way it is joining tables. Essentially it joins sam_assessmentgrading_t to sam_authzdata_t on assessment id. If the quiz is released to multiple groups, that means there is a row in sam_authzdata_t for each group, and each group gets joined against the one submission for that quiz. It just counts up the rows for each quiz, so if you're in 2 of the groups the assignment is released to, you'll have two rows in the results and samigo will think you submitted twice.

This PR changes the query to count distinct submissions instead of just total rows.