### PR TITLE
SAK-46003 ArrayIndexOutOfBounds when calculated question cannot be parsed

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -581,6 +581,7 @@ calcq_sr_explanation = What follows is a calculated question with {0} blanks.
 calcq_sr_answer_label_part1 = Blank
 calcq_sr_answer_label_part2 = Calculate the answer by read surrounding text.
 calcq_invalid_characters_error=Please only use allowed characters within calculated question fields. Acceptable inputs are real numbers like "9.3" and scientific notation like "6.32e10" or "6.32E10".
+calc.extract_text_error=ERROR: Unable to extract any question text from this calculated question. The formula may be invalid.
 
 #AJAX Timer
 savedMessage=Work is being saved.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -2337,14 +2337,18 @@ public class DeliveryActionListener
       String agentId = determineCalcQAgentId(delivery, bean);
 
       service.getAnswersMap().clear();
-      service.setTexts(service.extractCalcQAnswersArray(service.getAnswersMap(), item, gradingId, agentId));
+      List<String> texts = service.extractCalcQAnswersArray(service.getAnswersMap(), item, gradingId, agentId);
+      if (texts.isEmpty())
+      {
+          log.error("Unable to extract any question text from calculated question with item id {}. The formula for this question may be invalid.", item.getItemId());
+          texts = Collections.singletonList(rb.get("calc.extract_text_error").toString());
+      }
+      service.setTexts(texts);
       String questionText = service.getTexts().get(0);
 
       ItemTextIfc text = (ItemTextIfc) item.getItemTextArraySorted().toArray()[0];
       List<FinBean> fins = new ArrayList<FinBean>();
       bean.setInstruction(questionText); // will be referenced in table of contents
-
-      int numOfAnswers = service.getAnswersMap().size();
 
       int i = 0;
       List<AnswerIfc> calcQuestionEntities = text.getAnswerArraySorted();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46003

If a calculated question cannot be parsed, it can lead to an index out of bounds exception that can prevent students from taking the quiz and instructors for seeing the scores, even if only one question is affected, an there is no way for a user to figure out what the problem is. This happened to Western a few times during our upgrade from Sakai 11 to Sakai 20, because the underlying parser changed in Sakai 12 and some questions that were valid in 11 were no longer valid in 20.

To better handle this and allow students and instructors to still use the quiz to whatever degree remains possible, an error message can be substituted for the question text when it cannot be parsed. With this message, it is easy to identify the problem question(s) and correct them.
