### PR TITLE
SAK-46004 Samigo: Access Denied occurrences don't appear in Event Log

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EventLogMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EventLogMessages.properties
@@ -23,6 +23,7 @@ error_access=Access Error
 error_pw_access=Password Access Error
 error_ip_access=IP Access Error
 error_secure_delivery=Secure Delivery Error
+error_access_denied=Access Denied Error
 no_error=No Errors (User submit)
 no_submission=No Submission
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/delivery/LoginServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/delivery/LoginServlet.java
@@ -251,6 +251,10 @@ public class LoginServlet
     	  }
     	  else { //isAuthenticated but not authorized
     		  path = "/jsf/delivery/accessDenied.faces";
+    		  if (releaseTo.contains(AssessmentAccessControl.RELEASE_TO_SELECTED_GROUPS)) {
+    			  // log access denied because they are not in a valid group for the quiz
+    			  delivery.updatEventLog("error_access_denied");
+    		  }
     	  }
       }
       if ("true".equals(req.getParameter("fromDirect"))) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46004

When an assessment is released to a specific group of students and a student who is not in that group accesses the assessment directly (typically, using a direct URL), the student will receive an "Access Denied" message. Getting this error message is not logged in the Event Log like other errors are (e.g. "Password Access Error"), but it would be helpful if it was.