### PR TITLE
SAK-46005 samigo > make data discrepancy 'return' link/button text configurable

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -460,6 +460,8 @@ data_discrepancy_3=When a user did not save their answers before a timed assessm
 data_discrepancy_4=In both cases, which answers actually got saved depends on when a user last clicked <b> Next </b> or <b> Exit </b>. 
 data_discrepancy_5=If you are taking the assessment in multiple browser windows or tabs, close all windows except one.<br/>Click <b>{0}</b> to return to the assessments list. <b>Retake</b> the assessment if it is still available for you to do so.
 data_discrepancy_5_url=If you are taking the assessment in multiple browser windows or tabs, close all windows except one. Retake the assessment if it is still available for you to do so.
+data_discrepancy_button=Return to assessment list
+data_discrepancy_link=Return to assessment
 
 text_or=or
 text_period=.

--- a/samigo/samigo-app/src/webapp/jsf/delivery/discrepancyInData.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/discrepancyInData.jsp
@@ -58,11 +58,11 @@
 
  <h:form id="discrepancyInData">
  <p class="act">
-       <h:commandButton value="#{deliveryMessages.button_return}" type="submit" styleClass="active" action="select" rendered="#{delivery.actionString=='takeAssessment'}">
+       <h:commandButton value="#{deliveryMessages.data_discrepancy_button}" type="submit" styleClass="active" action="select" rendered="#{delivery.actionString=='takeAssessment'}">
           <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener" />
        </h:commandButton>
        <h:outputLink rendered="#{delivery.actionString == 'takeAssessmentViaUrl'}" value="#{delivery.getPublishedURL()}">
-           <h:outputText value="#{deliveryMessages.button_return}" />
+           <h:outputText value="#{deliveryMessages.data_discrepancy_link}" />
        </h:outputLink>
  </p>
  </h:form>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46005

The "Return" button/link found at the bottom of the Data Discrepancy page uses a generic message key. If we were to customize this through MBM, we would affect all of the other cases of that key in Samigo. Since the DD page has unique keys for the rest of its text, make the following keys for the "Return" link (pub.ass.url) and button (Tests & Quizzes):

* data_discrepancy_button: "Return to assessment list"
* data_discrepancy_link: "Return to assessment"