### PR TITLE
SAK-44845 samigo > ToC and Show Feedback tabs give opportunity to trigger data discrepancy error

### DIFF
--- a/samigo/samigo-app/src/webapp/js/questionProgress.js
+++ b/samigo/samigo-app/src/webapp/js/questionProgress.js
@@ -192,4 +192,10 @@
 		$.blockUI({ message: '<h3>' + please_wait + ' <img src="/library/image/sakai/spinner.gif" /></h3>', overlayCSS: { backgroundColor: '#ccc', opacity: 0.25} });
 		return true;
 	};
+
+	questionProgress.blockLink = function(link) {
+		link.style.pointerEvents = 'none';
+		link.disabled = true;
+		return true;
+	};
 }( window.questionProgress = window.questionProgress || {}, jQuery )) ;

--- a/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryHeading.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryHeading.jsp
@@ -37,7 +37,7 @@ Headings for delivery pages, needs to have msg=DeliveryMessages.properties, etc.
 
 <!-- SHOW FEEDBACK LINK FOR TAKE ASSESSMENT AND TAKE ASSESSMENT VIA URL -->
     <h:commandLink title="#{commonMessages.feedback}" action="#{delivery.getOutcome}" 
-       id="showFeedback" onmouseup="saveTime(); serializeImagePoints();" 
+       id="showFeedback" onclick="questionProgress.blockLink(this); saveTime(); serializeImagePoints();"
        rendered="#{(delivery.actionString=='takeAssessment'
                 || delivery.actionString=='takeAssessmentViaUrl') && !(delivery.pageContents.isNoParts && delivery.navigation eq '1')}" >
      <h:outputText value="#{deliveryMessages.show_feedback}" />
@@ -56,7 +56,7 @@ Headings for delivery pages, needs to have msg=DeliveryMessages.properties, etc.
 <!-- TABLE OF CONTENT LINK FOR TAKE ASSESSMENT AND TAKE ASSESSMENT VIA URL -->
   <li role="menuitem"><span>
   <h:commandLink title="#{deliveryMessages.t_tableOfContents}" action="#{delivery.getOutcome}" 
-     id="showTOC" onmouseup="saveTime(); serializeImagePoints();"
+     id="showTOC" onclick="questionProgress.blockLink(this); saveTime(); serializeImagePoints();"
      rendered="#{(delivery.actionString=='takeAssessment'
                    || delivery.actionString=='takeAssessmentViaUrl')
                && delivery.navigation ne '1'}">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-44845

Easy to trigger DD error by getting click-happy on the ToC and Show Feedback tabs.

Using the same method Sam did in SAK-44248 is not appropriate here, as it blocks the transfer to the TOC page and displays a pop-up message saying "use the next links..."

Instead, I created a new JavaScript method that simply disables the link and sets pointerEvents to none so that it cannot receive further clicks after the first one.