### PR TITLE
SAK-46012 Points for calculated and matrix questions can be changed if drawn from pool

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/item/calculatedQuestion.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/item/calculatedQuestion.jsp
@@ -107,7 +107,7 @@ confirmation dialog
 		<h:outputLabel for="answerptr" value="#{authorMessages.answer_point_value}" styleClass="col-md-4 form-control-label"/>
 		<div class="col-md-2">
 			<h:inputText id="answerptr" label="#{authorMessages.pt}" value="#{itemauthor.currentItem.itemScore}" 
-							required="true" styleClass="form-control">
+							required="true" disabled="#{author.isEditPoolFlow}" styleClass="form-control">
 				<f:validateDoubleRange/>
 			</h:inputText>			
 			<h:message for="answerptr" styleClass="validate"/>

--- a/samigo/samigo-app/src/webapp/jsf/author/item/matrixChoicesSurvey.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/item/matrixChoicesSurvey.jsp
@@ -91,7 +91,7 @@
         <h:outputLabel for="answerptr" value="#{authorMessages.answer_point_value}" styleClass="col-md-4 col-lg-2 form-control-label"/>
         <div class="col-md-2">
             <h:inputText id="answerptr" label="#{authorMessages.pt}" value="#{itemauthor.currentItem.itemScore}" 
-                        required="true" size="6" styleClass="form-control ConvertPoint">
+                        required="true" disabled="#{author.isEditPoolFlow}" size="6" styleClass="form-control ConvertPoint">
                 <f:validateDoubleRange />
             </h:inputText>
             <h:message for="answerptr" styleClass="validate" />


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46012

When using the random draw from pool option in a quiz, the questions are supposed to all have the same value. For most question types, the points value is locked down, but for calculated and matrix of choices questions, it can be edited. This should not be possible.

This PR adds the disabled condition to these question types to match the rest of the types.