### PR TITLE
SAK-46011 Samigo : can't navigate question pool items

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/shared/api/questionpool/QuestionPoolServiceAPI.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/shared/api/questionpool/QuestionPoolServiceAPI.java
@@ -55,11 +55,11 @@ public interface QuestionPoolServiceAPI
   public QuestionPoolDataIfc getPool(Long poolId, String agentId);
 
   /**
-   * Get a list of pools that have a specific Agent
+   * Get a list of pools that have a specific item
    */
-  public List getPoolIdsByItem(String itemId);
+  public List getPoolIdsByItem(Long itemId);
 
-  public boolean hasItem(String itemId, Long poolId);
+  public boolean hasItem(Long itemId, Long poolId);
 
   /**
    * Get pool id's by agent.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -50,6 +50,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
@@ -706,11 +707,11 @@ public class QuestionPoolBean implements Serializable {
 		sourcePart = s;
 	}
 
-	public List getCurrentItemIds() {
+	public List<Long> getCurrentItemIds() {
 		return currentItemIds;
 	}
 
-	public void setCurrentItemIds(List pstr) {
+	public void setCurrentItemIds(List<Long> pstr) {
 		currentItemIds = pstr;
 	}
 
@@ -1262,29 +1263,26 @@ public String getAddOrEdit()
 	}
   
      public String moveQuestion() {
-		String sourceId = "";
-		String destId = "";
-		sourceId = this.getCurrentPool().getId().toString();
-		List sourceItemIds = this.getCurrentItemIds();
+		Long sourceId = getCurrentPool().getId();
+		List<Long> sourceItemIds = getCurrentItemIds();
 		String originId = Long.toString(ORIGIN_TOP.equals(getOutcome())?0:getOutcomePool());
 
-		destId = ContextUtil.lookupParam("movePool:selectedRadioBtn");
+		Long destId = NumberUtils.toLong(ContextUtil.lookupParam("movePool:selectedRadioBtn"), -1L);
 
-		if ((sourceId != null) && (destId != null) && (sourceItemIds != null)) {
+		if (sourceId != null && !destId.equals(-1L) && sourceItemIds != null) {
 			try {
 				QuestionPoolService delegate = new QuestionPoolService();
 
-				Iterator iter = sourceItemIds.iterator();
+				Iterator<Long> iter = sourceItemIds.iterator();
 				while (iter.hasNext()) {
-					String sourceItemId = (String) iter.next();
+					Long sourceItemId = iter.next();
 					// originally this returned "movePool" if we found it
 					// in dest. This seems wrong. No error message, just
 					// return to an irrelevant screen. I think it's better
 					// just to skip that item. One could argue for a warning
 					// message.
 					if (!hasItemInDestPool(sourceItemId, destId)) {
-						delegate.moveItemToPool(new Long(sourceItemId),
-								new Long(sourceId), new Long(destId));
+						delegate.moveItemToPool(sourceItemId, sourceId, destId);
 					}
 					EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SAVEITEM, "/sam/" + AgentFacade.getCurrentSiteId() + "/moved, itemId=" + sourceItemId, true));
 				}
@@ -1362,11 +1360,11 @@ public String getAddOrEdit()
 		return EDIT_ASSESSMENT;
 	}
      
-  public boolean hasItemInDestPool(String sourceItemId, String destId){
+  public boolean hasItemInDestPool(Long sourceItemId, Long destId){
   
               QuestionPoolService delegate = new QuestionPoolService();
               // check if the item already exists in the destPool
-              if (delegate.hasItem(sourceItemId, new Long(destId))){
+              if (delegate.hasItem(sourceItemId, destId)){
                 // we do not want to add duplicated items, show message
 
                 FacesContext context=FacesContext.getCurrentInstance();
@@ -1385,18 +1383,16 @@ public String getAddOrEdit()
 		if (getSourcePart() != null)
 			return copyQuestionsFromPart();
 
-		// Long sourceId = new Long(0);
-		String destId = "";
 		List sourceItems = this.getCurrentItems();
 
-		List destpools = ContextUtil.paramArrayValueLike("checkboxes");
+		List<String> destpools = ContextUtil.paramArrayValueLike("checkboxes");
 		// sourceId = this.getCurrentPool().getId();
 		String originId = Long.toString(ORIGIN_TOP.equals(getOutcome())?0:getOutcomePool());
-		Iterator iter = destpools.iterator();
+		Iterator<String> iter = destpools.iterator();
 		while (iter.hasNext()) {
 
-			destId = (String) iter.next();
-			if ((sourceItems != null) && (destId != null)) {
+			Long destId = NumberUtils.toLong(iter.next(), -1L);
+			if (sourceItems != null && !destId.equals(-1L)) {
 
 				try {
 					QuestionPoolService questionPoolService = new QuestionPoolService();
@@ -1405,7 +1401,7 @@ public String getAddOrEdit()
 					Iterator iter2 = sourceItems.iterator();
 					while (iter2.hasNext()) {
 						ItemFacade sourceItem = (ItemFacade) iter2.next();
-						String sourceItemId = sourceItem.getItemIdString();
+						Long sourceItemId = sourceItem.getItemId();
 						// originally this returned "copyPool" if we found it
 						// in dest. This seems wrong. No error message, just
 						// return to an irrelevant screen. I think it's better
@@ -1484,7 +1480,7 @@ public String getAddOrEdit()
 
 
        // check to see if any pools are linked to this item
-       List poollist = delegate.getPoolIdsByItem(itemfacade.getItemIdString());
+       List poollist = delegate.getPoolIdsByItem(itemfacade.getItemId());
        if (poollist.isEmpty()) {
 
 	 if (itemfacade.getSection() == null) {
@@ -1525,10 +1521,10 @@ public String getAddOrEdit()
 
   public void getCheckedQuestion()
   {
-	String itemId= ContextUtil.lookupParam("itemid");
+	Long itemId = NumberUtils.toLong(ContextUtil.lookupParam("itemid"), -1L);
 	ItemService delegate = new ItemService();
-	ItemFacade itemfacade= delegate.getItem(new Long(itemId), AgentFacade.getAgentString());
-	List itemIds = new ArrayList();
+	ItemFacade itemfacade= delegate.getItem(itemId, AgentFacade.getAgentString());
+	List<Long> itemIds = new ArrayList<>();
 	itemIds.add(itemId);
 	setCurrentItemIds(itemIds);
 	 
@@ -1539,18 +1535,17 @@ public String getAddOrEdit()
   }
 
   public void getCheckedQuestions() {
-		// String itemId= ContextUtil.lookupParam("itemid");
 
-		List destItems = ContextUtil.paramArrayValueLike("removeCheckbox");
-		List itemIds = new ArrayList();
+		List<String> destItems = ContextUtil.paramArrayValueLike("removeCheckbox");
+		List<Long> itemIds = new ArrayList<>();
 		List itemFacades = new ArrayList();
 
 		ItemService delegate = new ItemService();
-		Iterator iter = destItems.iterator();
+		Iterator<String> iter = destItems.iterator();
 
 		while (iter.hasNext()) {
-			String itemId = (String) iter.next();
-			ItemFacade itemfacade = delegate.getItem(new Long(itemId),
+			Long itemId = NumberUtils.toLong(iter.next(), -1L);
+			ItemFacade itemfacade = delegate.getItem(itemId,
 					AgentFacade.getAgentString());
 			itemFacades.add(itemfacade);
 			itemIds.add(itemId);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ImportQuestionsToAuthoringFromSearch.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ImportQuestionsToAuthoringFromSearch.java
@@ -123,7 +123,7 @@ public class ImportQuestionsToAuthoringFromSearch implements ActionListener
             QuestionPoolService qpdelegate = new QuestionPoolService();
 
             //Save the question in the pool
-            if (!qpdelegate.hasItem(itemfacade.getItemIdString(),
+            if (!qpdelegate.hasItem(itemfacade.getItemId(),
                     Long.valueOf(searchQuestionBean.getSelectedQuestionPool()))) {
               qpdelegate.addItemToPool(itemfacade.getItemId(),
                       Long.valueOf(searchQuestionBean.getSelectedQuestionPool()));

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
@@ -937,8 +937,7 @@ public class ItemAddListener
 
         QuestionPoolService qpdelegate = new QuestionPoolService();
 
-        if (!qpdelegate.hasItem(item.getItemIdString(),
-        		Long.valueOf(itemauthor.getQpoolId()))) {
+        if (!qpdelegate.hasItem(item.getItemId(), Long.valueOf(itemauthor.getQpoolId()))) {
           qpdelegate.addItemToPool(item.getItemId(),
                                    Long.valueOf(itemauthor.getQpoolId()));
 
@@ -1092,13 +1091,13 @@ public class ItemAddListener
 	        if (StringUtils.isNotEmpty(bean.getOrigPool())
 	                && StringUtils.isNotEmpty(bean.getSelectedPool())
 	                && !bean.getSelectedPool().equals(bean.getOrigPool())
-	                && qpdelegate.hasItem(item.getItemIdString(), Long.valueOf(bean.getOrigPool()))) {
+	                && qpdelegate.hasItem(item.getItemId(), Long.valueOf(bean.getOrigPool()))) {
 	            qpdelegate.removeQuestionFromPool(item.getItemId(), Long.valueOf(bean.getOrigPool()));
 	        }
 	
 	        // if assign to pool, add the item to the pool
 	        if (StringUtils.isNotEmpty(bean.getSelectedPool())
-	                && !qpdelegate.hasItem(item.getItemIdString(), Long.valueOf(bean.getSelectedPool()))) {
+	                && !qpdelegate.hasItem(item.getItemId(), Long.valueOf(bean.getSelectedPool()))) {
 	            // if the item is already in the pool then do not add.
 	            qpdelegate.addItemToPool(item.getItemId(), Long.valueOf(bean.getSelectedPool()));
 	        }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
@@ -37,6 +37,7 @@ import javax.faces.event.ActionListener;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.component.cover.ComponentManager;
@@ -182,7 +183,7 @@ public class ItemModifyListener implements ActionListener
               UserDirectoryService userDirectoryService = ComponentManager.get(UserDirectoryService.class);
               String currentUserId = userDirectoryService.getCurrentUser().getId();
               QuestionPoolService qpdelegate = new QuestionPoolService();
-              List<Long> poolIds = qpdelegate.getPoolIdsByItem(itemId);
+              List<Long> poolIds = qpdelegate.getPoolIdsByItem(NumberUtils.toLong(itemId, -1L));
               boolean authorized = false;
               poolloop:
               for (Long poolId : poolIds) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemRemoveListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemRemoveListener.java
@@ -56,8 +56,8 @@ public class ItemRemoveListener implements ActionListener
 		if(item.getItemToDelete() == null) {
 			return;
 		}
-		String deleteId = String.valueOf(item.getItemToDelete().getItemId());
-		ItemFacade itemf = delegate.getItem(deleteId);
+		Long deleteId = item.getItemToDelete().getItemId();
+		ItemFacade itemf = delegate.getItem(String.valueOf(deleteId));
 		// save the currSection before itemf.setSection(null), used to reorder question sequences
 		SectionFacade  currSection = (SectionFacade) itemf.getSection();
 		Integer  currSeq = itemf.getSequence();
@@ -70,13 +70,13 @@ public class ItemRemoveListener implements ActionListener
 			if (!authzBean.isUserAllowedToEditAssessment(af.getAssessmentBaseId().toString(), af.getCreatedBy(), false)) {
 				throw new IllegalArgumentException("User does not have permission to delete item in assessment: " + af.getAssessmentBaseId());
 			}
-			delegate.deleteItem(Long.valueOf(deleteId), AgentFacade.getAgentString());
+			delegate.deleteItem(deleteId, AgentFacade.getAgentString());
 		}
 		else {
 			if (currSection == null) {
 				// if this item is created from question pool
 				QuestionPoolBean  qpoolbean= (QuestionPoolBean) ContextUtil.lookupBean("questionpool");
-				ItemFacade itemfacade= delegate.getItem(deleteId);
+				ItemFacade itemfacade= delegate.getItem(String.valueOf(deleteId));
 				ArrayList<ItemFacade> items = new ArrayList<>();
 				items.add(itemfacade);
 				qpoolbean.setItemsToDelete(items);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/entity/impl/ItemEntityProviderImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/entity/impl/ItemEntityProviderImpl.java
@@ -107,10 +107,8 @@ public class ItemEntityProviderImpl implements ItemEntityProvider,CoreEntityProv
 
 
     public List<String> questionPoolIds(ItemFacade item) {
-        Long itemID = item.getItemId();
-        String itemIdSting = itemID.toString();
-        List questionPoolIdsItem = questionPoolFacadeQueries.getPoolIdsByItem(itemIdSting);
-        List<String> questionPoolIds = new ArrayList<String>();
+        List questionPoolIdsItem = questionPoolFacadeQueries.getPoolIdsByItem(item.getItemId());
+        List<String> questionPoolIds = new ArrayList<>();
         if (!(questionPoolIdsItem).isEmpty()){
             Iterator iterator = questionPoolIdsItem.iterator();
             while (iterator.hasNext()){

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueries.java
@@ -252,8 +252,7 @@ public class QuestionPoolFacadeQueries
     List newlist = new ArrayList();
     for (int i = 0; i < list.size(); i++) {
       ItemData itemdata = (ItemData) list.get(i);
-      String itemId = itemdata.getItemId().toString();
-     if (getPoolIdsByItem(itemId).size() == 1) {
+     if (getPoolIdsByItem(itemdata.getItemId()).size() == 1) {
        newlist.add(itemdata);
      }
      else {
@@ -985,7 +984,7 @@ public class QuestionPoolFacadeQueries
    * @param poolId DOCUMENTATION PENDING
    */
 
-  public List getPoolIdsByItem(final String itemId) {
+  public List getPoolIdsByItem(final Long itemId) {
     List idList = new ArrayList();
     
     final HibernateCallback<List> hcb = session -> {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/QuestionPoolFacadeQueriesAPI.java
@@ -204,7 +204,7 @@ public interface QuestionPoolFacadeQueriesAPI
    * @param poolId DOCUMENTATION PENDING
    */
 
-  public List getPoolIdsByItem(String itemId);
+  public List getPoolIdsByItem(Long itemId);
 
   /**
    * Copy a pool to a new location.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/QuestionPoolService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/QuestionPoolService.java
@@ -121,9 +121,9 @@ import org.sakaiproject.tool.assessment.facade.QuestionPoolIteratorFacade;
   }
 
   /**
-   * Get a list of pools that have a specific Agent
+   * Get a list of pools that have a specific item
    */
-  public List getPoolIdsByItem(String itemId)
+  public List getPoolIdsByItem(Long itemId)
   {
     List idList = null;
     try
@@ -142,7 +142,7 @@ import org.sakaiproject.tool.assessment.facade.QuestionPoolIteratorFacade;
   }
 
 
-  public boolean hasItem(String itemId, Long poolId)
+  public boolean hasItem(Long itemId, Long poolId)
   {
         List poollist = null;
 	boolean found = false;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentService.java
@@ -448,9 +448,8 @@ public class AssessmentService {
 				Iterator itemIter = section.getItemSet().iterator();
 				while (itemIter.hasNext()) {
 					ItemDataIfc item = (ItemDataIfc) itemIter.next();
-					List poolIds = qpService.getPoolIdsByItem(item.getItemId()
-							.toString());
-					if (poolIds.size() == 0) {
+					List poolIds = qpService.getPoolIdsByItem(item.getItemId());
+					if (poolIds.isEmpty()) {
 						Long deleteId = item.getItemId();
 						itemService.deleteItem(deleteId, agentId);
 						EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_ITEM_DELETE, "/sam/" +AgentFacade.getCurrentSiteId() + "/removed itemId=" + deleteId, true));

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/questionpool/QuestionPoolServiceImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/shared/impl/questionpool/QuestionPoolServiceImpl.java
@@ -131,9 +131,9 @@ public class QuestionPoolServiceImpl
   }
 
   /**
-   * Get a list of pools that have a specific Agent
+   * Get a list of pools that have a specific item
    */
-  public List getPoolIdsByItem(String itemId)
+  public List getPoolIdsByItem(Long itemId)
   {
     try
     {
@@ -146,7 +146,7 @@ public class QuestionPoolServiceImpl
     }
   }
 
-  public boolean hasItem(String itemId, Long poolId)
+  public boolean hasItem(Long itemId, Long poolId)
   {
     try
     {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46011

When you try to access a question pool item there's a stacktrace being thrown. In fact, creation generates an exception too, but the item is created in the pool:

`org.sakaiproject.tool.assessment.services.QuestionPoolService.getPoolIdsByItem Parameter value [11] did not match expected type [java.lang.Long (n/a)]`

The problem is that at some point in time the database column in question was a varchar, and now it's a number, but the application code was never updated, still using Strings everywhere. This then surfaced as an issue when setString() was changed to setParameter() in SAK-45813. I'm guessing setString() used to do some internal conversion, because it worked fine when I changed it back locally.

While we could just do a quick conversion to Long when passing the value to setParameter, but this PR changes the application code to use Long instead of String from the beginning. This will improve type safety and remove a bunch of conversions from Long to String that were happening throughout the code.