### PR TITLE
SAK-46016 statistics reveals the existence of stealthed tools

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -1402,4 +1402,17 @@ public interface SiteService extends EntityProducer
 	 * @return {@link SiteTitleValidationStatus}
 	 */
 	public SiteTitleValidationStatus validateSiteTitle(String orig, String stripped);
+
+	/**
+	 * Determine if a stealthed tool is present in the given site.
+	 * NOTE: can't just do "currentSite.getTool(toolID) != null" because getTool() will not
+	 * report on stealthed tools; so we have to do it the long way.
+	 * NOTE: you can technically use this method with non-stealthed tool IDs, but in that case
+	 * it may be easier to just call "currentSite.getTool(toolID) != null"
+	 *
+	 * @param site the current site in question
+	 * @param toolID the ID of the stealthed tool to check for in the current site
+	 * @return true if the stealthed tool is present in the given site; false otherwise
+	 */
+	public boolean isStealthedToolPresent(Site site, String toolID);
 }

--- a/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/cover/SiteService.java
@@ -608,4 +608,15 @@ public class SiteService
 
 		return service.validateSiteTitle(orig, stripped);
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static boolean isStealthedToolPresent(Site site, String toolID)
+	{
+		org.sakaiproject.site.api.SiteService service = getInstance();
+		if (service == null) { return false; }
+
+		return service.isStealthedToolPresent(site, toolID);
+	}
 }

--- a/kernel/api/src/main/java/org/sakaiproject/tool/api/ToolManager.java
+++ b/kernel/api/src/main/java/org/sakaiproject/tool/api/ToolManager.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.sakaiproject.site.api.Site;
-import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.w3c.dom.Document;
@@ -191,7 +190,11 @@ public interface ToolManager
 	 * If the configuration tag is not set or is null, then all users see the tool.
 	 */
 	public boolean allowTool(Site site, Placement placement);
+
+	/**
+	 * Determine if the tool defined by the given tool ID is stealthed globally.
+	 * @param toolID the ID of the tool in question
+	 * @return true if the tool is stealthed globally; false otherwise
+	 */
+	public boolean isStealthed(String toolID);
 }
-
-
-

--- a/kernel/api/src/main/java/org/sakaiproject/tool/cover/ToolManager.java
+++ b/kernel/api/src/main/java/org/sakaiproject/tool/cover/ToolManager.java
@@ -137,5 +137,12 @@ public class ToolManager
 
 		return manager.getLocalizedToolProperty(toolId, key);
 	}	
-	
+
+	public static boolean isStealthed(String toolID)
+	{
+		org.sakaiproject.tool.api.ToolManager manager = getInstance();
+		if (manager == null) return false;
+
+		return manager.isStealthed(toolID);
+	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -3924,4 +3924,21 @@ public abstract class BaseSiteService implements SiteService, Observer
 			return SiteTitleValidationStatus.OK;
 		}
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean isStealthedToolPresent(Site site, String toolID) {
+		List<SitePage> pages = site.getOrderedPages();
+		for (SitePage page : pages) {
+			List<ToolConfiguration> toolConfigs = page.getTools();
+			for (ToolConfiguration toolConfig : toolConfigs) {
+				if (toolConfig.getToolId().equals(toolID)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/tool/impl/ToolComponent.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/tool/impl/ToolComponent.java
@@ -703,7 +703,16 @@ public abstract class ToolComponent implements ToolManager
 			return false;
 		}
 	}
-	
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean isStealthed(String toolID) {
+		Tool tool = getTool(toolID);
+		Set<Tool> tools = findTools(Collections.emptySet(), null);
+		return tool == null || !tools.contains(tool);
+	}
+
 	private boolean arrayContains(Object obj, String item){
 		if(obj != null && obj instanceof String[]){
 			String[] array = (String[]) obj;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MenuBuilder.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MenuBuilder.java
@@ -35,6 +35,7 @@ import org.sakaiproject.site.api.SiteService.SortType;
 import org.sakaiproject.site.util.SiteConstants;
 import org.sakaiproject.site.util.SiteTypeUtil;
 import org.sakaiproject.sitemanage.api.SiteTypeProvider;
+import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.util.ResourceLoader;
 
 /**
@@ -47,6 +48,7 @@ public class MenuBuilder
 {
     // APIs
     private static final SiteService SS = (SiteService) ComponentManager.get( SiteService.class );
+    private static final ToolManager TM = (ToolManager) ComponentManager.get( ToolManager.class );
 
     // sakai.properties
     private static final String     SAK_PROP_SITE_SETUP_IMPORT_FILE                 = "site.setup.import.file";
@@ -222,7 +224,7 @@ public class MenuBuilder
             menu.add( buildMenuEntry( rl.getString( "java.edittools" ), "doMenu_edit_site_tools", activeTab.equals( SiteInfoActiveTab.MANAGE_TOOLS ) ) );
 
             // If the page order helper is available, not stealthed and not hidden, show the link
-            if( SiteAction.notStealthOrHiddenTool( "sakai-site-pageorder-helper" ) )
+            if( !TM.isStealthed("sakai-site-pageorder-helper" ) )
             {
                 // In particular, need to check site types for showing the tool or not
                 if( SiteAction.isPageOrderAllowed( siteType, siteProperties.getProperty( SiteConstants.SITE_PROPERTY_OVERRIDE_HIDE_PAGEORDER_SITE_TYPES ) ) )
@@ -236,7 +238,7 @@ public class MenuBuilder
         }
 
         // If the add participant helper is available, not stealthed and not hidden, show the tab
-        if( allowUpdateSiteMembership && !isMyWorkspace && SiteAction.notStealthOrHiddenTool( SiteAction.getAddUserHelper( site ) ) )
+        if( allowUpdateSiteMembership && !isMyWorkspace && !TM.isStealthed( SiteAction.getAddUserHelper( site ) ) )
         {
             // 'Add Participants'
             menu.add( buildMenuEntry( rl.getString( "java.addp" ), "doParticipantHelper", activeTab.equals( SiteInfoActiveTab.ADD_PARTICIPANTS ) ) );
@@ -269,13 +271,13 @@ public class MenuBuilder
 
         if( allowUpdateSite && !isMyWorkspace )
         {
-            if( SiteAction.notStealthOrHiddenTool( "sakai-site-manage-link-helper" ) )
+            if( !TM.isStealthed( "sakai-site-manage-link-helper" ) )
             {
                 // 'Link to Parent Site'
                 menu.add( buildMenuEntry( rl.getString( "java.link" ), "doLinkHelper", activeTab.equals( SiteInfoActiveTab.LINK_TO_PARENT_SITE ) ) );
             }
 
-            if( SiteAction.notStealthOrHiddenTool( "sakai.basiclti.admin.helper" ) )
+            if( !TM.isStealthed( "sakai.basiclti.admin.helper" ) )
             {
                 // 'External Tools'
                 menu.add( buildMenuEntry( rl.getString( "java.external" ), "doExternalHelper", activeTab.equals( SiteInfoActiveTab.EXTERNAL_TOOLS ) ) );
@@ -320,7 +322,7 @@ public class MenuBuilder
             }
 
             boolean eventLogEnabled = ServerConfigurationService.getBoolean( SAK_PROP_DISPLAY_USER_AUDIT_LOG, SAK_PROP_DISPLAY_USER_AUDIT_LOG_DEFAULT );
-            if( SiteAction.notStealthOrHiddenTool( "sakai.useraudit" ) && eventLogEnabled )
+            if( !TM.isStealthed( "sakai.useraudit" ) && eventLogEnabled )
             {
                 // 'User Audit Log'
                 menu.add( buildMenuEntry( rl.getString( "java.userAuditEventLog" ), "doUserAuditEventLog", activeTab.equals( SiteInfoActiveTab.USER_AUDIT_LOG ) ) );

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -4179,7 +4179,7 @@ public class SiteAction extends PagedResourceActionII {
 	 */
 	private void pageOrderToolTitleIntoContext(Context context, SessionState state, String siteType, boolean newSite, String overrideSitePageOrderSetting) {
 		// check if this is an existing site and PageOrder is enabled for the site. If so, show tool title
-		if (!newSite && notStealthOrHiddenTool("sakai-site-pageorder-helper") && isPageOrderAllowed(siteType, overrideSitePageOrderSetting))
+		if (!newSite && !ToolManager.isStealthed("sakai-site-pageorder-helper") && isPageOrderAllowed(siteType, overrideSitePageOrderSetting))
 		{
 			// the actual page titles
 			context.put(STATE_TOOL_REGISTRATION_TITLE_LIST, state.getAttribute(STATE_TOOL_REGISTRATION_TITLE_LIST));
@@ -4555,7 +4555,7 @@ public class SiteAction extends PagedResourceActionII {
 		{
 			state.setAttribute(stateHelperString, helperId);
 		}
-		if (notStealthOrHiddenTool(helperId)) {
+		if (!ToolManager.isStealthed(helperId)) {
 			return true;
 		}
 		return false;
@@ -6439,7 +6439,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 						if (tr != null) 
 						{
 								String toolId = tr.getId();
-								if (isSiteTypeInToolCategory(SiteTypeUtil.getTargetSiteType(type), tr) && notStealthOrHiddenTool(toolId) ) // SAK 23808
+								if (isSiteTypeInToolCategory(SiteTypeUtil.getTargetSiteType(type), tr) && !ToolManager.isStealthed(toolId) ) // SAK 23808
 								{
 									newTool = new MyTool();
 									newTool.title = tr.getTitle();
@@ -9986,7 +9986,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 														Tool tool = toolConf.getTool();
 														String toolId = StringUtils.trimToEmpty(tool.getId());
 
-														if (StringUtils.isNotBlank(toolId) && !notStealthOrHiddenTool(toolId)) {
+														if (StringUtils.isNotBlank(toolId) && ToolManager.isStealthed(toolId)) {
 															// Found a stealthed tool, queue for removal
 															log.debug("found stealthed tool {}", toolId);
 															rmToolList.add(toolConf);
@@ -11797,20 +11797,6 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 			}
 		}
 	}
-
-	/**
-	 * Is the tool stealthed or hidden
-	 * @param toolId
-	 * @return
-	 */
-	public static boolean notStealthOrHiddenTool(String toolId) {
-		Tool tool = ToolManager.getTool(toolId);
-		Set<Tool> tools = ToolManager.findTools(Collections.emptySet(), null);
-		boolean result =  tool != null && tools.contains(tool);
-		return result;
-
-	}
-
 
 	/**
 	 * Is the siteType listed in the tool properties list of categories?

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsTestConfiguration.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsTestConfiguration.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -291,6 +292,10 @@ public class SiteStatsTestConfiguration {
         when(resourcesTool.getId()).thenReturn(StatsManager.RESOURCES_TOOLID);
         Set<Tool> tools = new HashSet<>(Arrays.asList(chatTool, resourcesTool));
         when(toolManager.findTools(null, null)).thenReturn(tools);
+        when(toolManager.findTools(Collections.EMPTY_SET, null)).thenReturn(tools);
+        when(toolManager.findTools(Collections.emptySet(), null)).thenReturn(tools);
+        when(toolManager.getTool(FakeData.TOOL_CHAT)).thenReturn(chatTool);
+        when(toolManager.getTool(StatsManager.RESOURCES_TOOLID)).thenReturn(resourcesTool);
         return toolManager;
     }
 

--- a/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
+++ b/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
@@ -146,6 +146,7 @@
 		<property name="serverEventIds" ref="org.sakaiproject.sitestats.api.serverevents.List" />
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
 		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager"/>
+		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
 	</bean>
 	<bean id="org.sakaiproject.sitestats.api.event.FileEventRegistry"
 		  class="org.sakaiproject.sitestats.impl.event.FileEventRegistry"


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46016

If you deselect the "Only list tools available in this site" option in Preferences, all the tools in the system will be shown, including stealthed tools.

This PR introduces 2 new service methods, one of which was lifted out of `SiteAction`.