### PR TITLE
SAK-46018 Samigo wrong password page returns student to Home rather than assessment Begin page

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/passwordAccessError.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/passwordAccessError.jsp
@@ -48,15 +48,17 @@
 
    <f:verbatim><p class="act"></f:verbatim>
        <h:commandButton value="#{deliveryMessages.button_return}" type="submit"
-          style="act" action="select" 
-          rendered="#{delivery.actionString=='takeAssessment'}">
-         <f:actionListener
-            type="org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener" />
+           style="act" action="beginAssessment"
+           rendered="#{delivery.actionString=='takeAssessment'}">
+           <f:param name="publishedId" value="#{delivery.assessmentId}" />
+           <f:param name="actionString" value="takeAssessment"/>
+           <f:actionListener
+            type="org.sakaiproject.tool.assessment.ui.listener.delivery.BeginDeliveryActionListener" />
        </h:commandButton>
    <f:verbatim></p></f:verbatim>
-  <h:commandButton value="#{deliveryMessages.button_return}" type="button" 
-     rendered="#{delivery.actionString=='takeAssessmentViaUrl'}"
-     style="act" onclick="javascript:window.open('login.faces','_top')" onkeypress="javascript:window.open('login.faces','_top')" />
+   <h:outputLink rendered="#{delivery.actionString == 'takeAssessmentViaUrl'}" value="#{delivery.getPublishedURL()}">
+       <h:outputText value="#{deliveryMessages.button_return}" />
+   </h:outputLink>
 
  </h:form>
   <!-- end content -->


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46018

When a student enters the wrong password for a quiz they are taken to an error page with a Return button. This returns them to either the quiz list (if taken through Samigo), or their Home site (if taken via URL). Intuitively, the "Return" button should return them to the previous page so they can try entering the password in again.