### PR TITLE
 SAK-46020 site info > import > dont show mysterious (stealthed) tools to maintainers

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2943,7 +2943,7 @@ public class SiteAction extends PagedResourceActionII {
 			List<String> selectedTools = new ArrayList<>();
 			List<String> filteredTools = new ArrayList<>();
 			for (String toolId : toolsToInclude) {
-				if (!filteredTools.contains(toolId)) {
+				if ((!filteredTools.contains(toolId) && !ToolManager.isStealthed(toolId)) || SecurityService.isSuperUser()) {
 					filteredTools.add(toolId);
 				}
 
@@ -3086,19 +3086,20 @@ public class SiteAction extends PagedResourceActionII {
 			if (addMissingTools) {
 				
                 selectedTools = allImportableToolIdsInOriginalSites;
-				
-				context.put("selectedTools", selectedTools); 
+
 				//set tools in destination site into context so we can markup the lists and show which ones are new
 				context.put("toolsInDestinationSite", importableToolsIdsInDestinationSite);
 				
 			} else {
-				
-                selectedTools = importableToolsIdsInDestinationSite;
-
 				//just just the ones in the destination site
-				context.put("selectedTools", selectedTools); 
+                selectedTools = importableToolsIdsInDestinationSite;
 			}
-			
+
+			if (!SecurityService.isSuperUser()) {
+				selectedTools = selectedTools.stream().filter(toolID -> !ToolManager.isStealthed(toolID)).collect(Collectors.toList());
+			}
+			context.put("selectedTools", selectedTools);
+
 			//build a map of sites and tools in those sites that have content
 			Map<String,Set<String>> siteToolsWithContent = this.getSiteImportToolsWithContent(importSites, selectedTools);
 			context.put("siteToolsWithContent", siteToolsWithContent);

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
@@ -78,6 +78,9 @@
 								#if($toolId == "sakai.iframe.site")
 									#set($toolTitle = $siteInfoToolTitle)
 								#end
+								#if($toolTitle == "")
+									#set($toolTitle = $toolId)
+								#end
 
 								<h5>$toolTitle
 									#if ($addMissingTools)

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
@@ -46,6 +46,9 @@
 								#if($toolId == "sakai.iframe.site")
 									#set($toolTitle = $siteInfoToolTitle)
 								#end
+								#if($toolTitle == "")
+										#set($toolTitle = $toolId)
+								#end
 
 								<h5>$toolTitle
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46020

If any of the origin sites contain stealth tools, these tools will appear at the top of the list of tools to migrate, but they won't have a tool name. This is different from past versions of Sakai where stealthed tools would never appear in this list. Example screenshot attached to the JIRA ticket.

The proposed fix here would restore the original functionality for instructors/maintainers (they do not see any stealthed tools in the list), but retains the new functionality for admins only. In the case of an admin viewing the list, they will see the tool ID of the stealthed tool(s) rather than their pretty tool names.

Resolving the tool name for stealthed tools (for both maintainers and admins) requires kernel modifications which are out of scope of this fix. We intended to further extend this in the future to allow maintainers to migrate content for stealthed tools if the stealthed tool exists in both origin and destination sites, and to resolve the pretty name for stealthed tools for both maintainers and admins.