### PR TITLE
SAK-45940 RUBRICS: You can save a weighted rubric with more than one criterion with 100%

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Criterion.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/Criterion.java
@@ -110,7 +110,6 @@ public class Criterion implements Modifiable, Serializable, Cloneable {
         Criterion clonedCriterion = new Criterion();
         clonedCriterion.setId(null);
         clonedCriterion.setTitle(this.title);
-        clonedCriterion.setWeight(this.weight);
         clonedCriterion.setDescription(this.description);
         clonedCriterion.setRatings(this.getRatings().stream().map(rating -> {
             Rating clonedRating = null;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45940
Currently, criterions are cloned even if its sum of weights is greater than 100, saving this in database. Now, the cloned criterion's weight is set to zero.