### PR TITLE
SAK-41363 remove 're-use material...' from site creation process

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -406,6 +406,7 @@ feat.remove.alert.yes = Yes
 feat.remove.alert.no = No
 feat.removeHeading=Remove
 
+feat.notAvail=Please use the Site Import page in Site Info to import content from existing sites once this site has been created.
 
 #SiteInfo VM
 sinfo.other = Site Information

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-editToolGroupFeatures.vm
@@ -16,6 +16,7 @@
         #end
 
         #if ($alertMessage)<div class="sak-banner-error">$tlang.getString("gen.alert") $alertMessage</div>#end
+        #if (!$existSite)<div class="sak-banner-info">$tlang.getString("feat.notAvail")</div>#end
 
         <form name="featuresForm" action="#toolForm("$action")" method="post">
             <input type="hidden" name="option" value="add" />
@@ -23,42 +24,6 @@
 
                 #parse("/vm/sitesetup/toolGroupMultipleDisplay.vm")
 
-                #if (!$existSite && !$createFromArchive && $sites.size() > 0)
-                <fieldset style="clear: both">
-                    <legend>
-                        <h4>$tlang.getString("feat.reuse")</h4>
-                    </legend>
-                    <p class="checkbox">
-                        <input type="radio" id="import_no" name="import" value="FALSE" #if(!$import)checked="checked"#end onclick="document.featuresForm.importSites.disabled=true;" />
-                        <label for="import_no">
-                            $tlang.getString("feat.thanks")
-                        </label>
-                    </p>
-                    <p class="checkbox">
-                        <input type="radio" id="import_yes" name="import" value="TRUE" #if($import)checked="checked"#end onclick="document.featuresForm.importSites.disabled=false;" />
-                        <label for="import_yes">
-                            $tlang.getString("feat.yesfrom")
-                        </label>
-                    </p>
-                    <p class="indnt3">
-                    <span class="reqStar" style="display:none" id="importSitesReq">*</span>
-                    <select title="$tlang.getString("feat.select.title")" name="importSites" id="importSites" size="5" multiple="multiple" #if(!$import)disabled="disabled"#end style="min-width: 10em " aria-describedby="importSelectInstructions">
-                        #foreach    ($site in $sites)
-                            #set($siteSelected = false)
-                            #foreach($s in $importSites.keys())
-                                #if ($s.Id == $site.Id)
-                                    #set($siteSelected = true)
-                                #end
-                            #end
-                            <option value="$site.getId()" #if ($siteSelected)selected="selected"#end>$formattedText.escapeHtml($site.getTitle())</option>
-                        #end
-                    </select>
-                    </p>
-                </fieldset>
-                <p class="instruction" id="importSelectInstructions">
-                    $tlang.getString("feat.note")
-                </p>
-            #end
             <input type="hidden" name="back" value="$!backIndex" />
             <input type="hidden" name="templateIndex" value="$!templateIndex" />
             <p class="act" style="float: none;clear:both">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-41363

The "Re-use material..." feature has many issues, most of which have never been addressed. According to T&L, this feature is rarely used and even more rarely is it recommended to be used. T&L supports removing this feature entirely.

At Western, we have already removed this feature. The linked PR introduces a message displaying at the top of the page where the component used to live:

> Please use the Site Import page in Site Info to import content from existing sites once this site has been created.

This message can likely be removed after a few major versions have been released.