### PR TITLE
SAK-46025 remove info text from 19 about manage participants being moved

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -428,7 +428,6 @@ sinfo.list.desc.ellipse=...
 sinfo.list.desc.more=(More)
 sinfo.language = Site Language
 sinfo.language.defaultUserLanguage = User Language (default)
-sinfo.manage.participants.moved = The Participant List (previously located here) has moved to its own page called <a href="{0}">Manage Participants</a>, linked in the tabs above.
 
 sitedicla.alert  = Alert:
 sitedicla.can    = Cancel

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_ar.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_ar.properties
@@ -428,7 +428,6 @@ sinfo.list.desc.ellipse=...
 sinfo.list.desc.more=(More)
 sinfo.language=Site Language
 sinfo.language.defaultUserLanguage=User Language (default)
-sinfo.manage.participants.moved=The Participant List (previously located here) has moved to its own page called <a href\="{0}">Manage Participants</a>, linked in the tabs above.
 
 sitedicla.alert=\u0625\u0646\u0630\u0627\u0631\:
 sitedicla.can=\u0625\u0644\u063a\u0627\u0621

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_ca.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_ca.properties
@@ -428,7 +428,6 @@ sinfo.list.desc.ellipse=...
 sinfo.list.desc.more=(M\u00e9s)
 sinfo.language=Idioma de l\u2019espai
 sinfo.language.defaultUserLanguage=Idioma de l\u2019usuari (predeterminat)
-sinfo.manage.participants.moved=La llista de participants (que anteriorment estava aqu\u00ed) ha estat reubicada a una p\u00e0gina pr\u00f2pia anomenada <a href\="{0}">Gestiona els participants</a>, trobareu l\u2019enlla\u00e7 a la part superior.
 
 sitedicla.alert=Av\u00eds\:
 sitedicla.can=Cancel\u00b7la

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_de_DE.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_de_DE.properties
@@ -381,7 +381,6 @@ sinfo.list.desc.ellipse=...
 sinfo.list.desc.more=(Mehr)
 sinfo.language=Seiten-Sprache
 sinfo.language.defaultUserLanguage=Benutzersprache (Standard)
-sinfo.manage.participants.moved=Die Teilnehmerliste ist hier zu finden\:  <a href\="{0}">Teilnehmer verwalten</a>, (siehe Tabs oben).
 sitedicla.alert=Achtung\:
 sitedicla.can=Abbrechen
 sitedicla.class=Verzeichnis

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_es.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_es.properties
@@ -428,7 +428,6 @@ sinfo.list.desc.ellipse=...
 sinfo.list.desc.more=(M\u00e1s)
 sinfo.language=Idioma del sitio
 sinfo.language.defaultUserLanguage=Definido por el usuario (defecto)
-sinfo.manage.participants.moved=La lista de participantes (que estaba aqu\u00ed anteriormente) se ha movido a su propia p\u00e1gina llamada <a href\="{0}">Gestionar participantes</a>, enlazada en la tabla superior. 
 
 sitedicla.alert=Alerta\:
 sitedicla.can=Cancelar

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_fr_FR.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_fr_FR.properties
@@ -428,7 +428,6 @@ sinfo.list.desc.ellipse=......
 sinfo.list.desc.more=(Plus)
 sinfo.language=Langue de l'espace
 sinfo.language.defaultUserLanguage=Langue de l'utilisateur (par d\u00e9faut)
-sinfo.manage.participants.moved=The Participant List (previously located here) has moved to its own page called <a href\="{0}">Manage Participants</a>, linked in the tabs above.
 
 sitedicla.alert=Alerte \:
 sitedicla.can=Annuler

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_tr_TR.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_tr_TR.properties
@@ -381,7 +381,6 @@ sinfo.list.desc.ellipse=...
 sinfo.list.desc.more=(Daha fazla)
 sinfo.language=Site dili
 sinfo.language.defaultUserLanguage=Kullan\u0131c\u0131 dili (varsay\u0131lan)
-sinfo.manage.participants.moved=Daha \u00f6nce burada g\u00f6r\u00fcnt\u00fcledi\u011finiz kat\u0131l\u0131mc\u0131 listesi yukar\u0131daki <a href\="{0}">Kat\u0131l\u0131mc\u0131lar\u0131 Y\u00f6net</a> sekmesine ta\u015f\u0131nd\u0131.
 sitedicla.alert=Uyar\u0131\:
 sitedicla.can=\u0130ptal
 sitedicla.class=S\u0131n\u0131f Listesi

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -453,9 +453,4 @@
 		</div>
 		<div style="clear:both"> </div>
 		#end
-	#if ($!viewRoster && !$!isMyWorkspace) 
-		<div class="sak-banner-info"> 
-			$tlang.getFormattedMessage("sinfo.manage.participants.moved","?sakai_action=doMenu_siteInfo_manageParticipants") 
-		</div>
-	#end
 </div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46025

This message has been present for 3 major versions: 19, 20, and 21. This is ample time for people to get used to the new location of the manage participants list, so lets remove this text for 22.