### PR TITLE
SAK-46027 soft delete warning does not provide info on how to remove yourself from the site

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -754,7 +754,8 @@ sitegen.sitedel.remove = Remove
 sitegen.sitedel.cancel = Cancel
 sitegen.sitedel.remov.soft = Softly Deleting Site...
 sitegen.sitedel.soft = This site will be 'softly deleted' but will remain accessible to you via the "View softly deleted Sites" option in the Worksite Setup tool which is found in Home. It will eventually be purged as per the schedule set by your System Administrator.\
-<p>Participants will no longer be able to access the site, however the contents of the site will be preserved and you can restore access to the site at any time before it is purged.</p>
+<br><br>Participants will no longer be able to access the site, however the contents of the site will be preserved and you can restore access to the site at any time before it is purged.\
+<br><br>If you are trying to remove yourself from the site, use the Membership tool in your Home to unjoin the site.
 sitegen.sitedel.you.soft = You have selected the following site for soft deletion:
 sitegen.sitedel.you2.soft=You have selected the following sites for soft deletion:
 sitegen.sitedel.softly.delete = Mark for deletion


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46027

As an admin when hard deleting you are presented with the following warning:

> Deleting a site removes the entire site's content and is not recoverable - no one else will be able to access the deleted site. If you are trying to remove yourself from the site, use the Membership tool in your Home to unjoin the site.
> 
> NOTE: You chose Hard Delete so these sites will have their tool content purged from the system.

The information about removing yourself from the site should also be presented to the maintainer when they elect to softly delete a site. Currently, they see the following message:

> This site will be 'softly deleted' but will remain accessible to you via the "View softly deleted Sites" option in the Worksite Setup tool which is found in Home. It will eventually be purged as per the schedule set by your System Administrator.
> 
> Participants will no longer be able to access the site, however the contents of the site will be preserved and you can restore access to the site at any time before it is purged.

This PR proposes adding the bit about removing yourself from the site to the message displayed to the maintainer on soft delete.