### PR TITLE
SAK-46028 site info > sort section sets alphabetically

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3336,9 +3336,14 @@ public class SiteAction extends PagedResourceActionII {
 					.equalsIgnoreCase(SITE_MODE_SITEINFO)) {
 				context.put("backIndex", "");
 			}
-			List ll = (List) state.getAttribute(STATE_TERM_COURSE_LIST);
-			context.put("termCourseList", state
-					.getAttribute(STATE_TERM_COURSE_LIST));
+
+			// Sort the course offerings if necessary
+			List<CourseObject> courseList = (List) state.getAttribute(STATE_TERM_COURSE_LIST);
+			if (CollectionUtils.isNotEmpty(courseList)) {
+				courseList.sort(Comparator.comparing(CourseObject::getTitle));
+				state.setAttribute(STATE_TERM_COURSE_LIST, courseList);
+			}
+			context.put("termCourseList", state.getAttribute(STATE_TERM_COURSE_LIST));
 
 			Boolean showRosterEIDs = ServerConfigurationService.getBoolean(SAK_PROP_SHOW_ROSTER_EID, SAK_PROP_SHOW_ROSTER_EID_DEFAULT);
 			context.put("showRosterEIDs", showRosterEIDs);
@@ -14008,7 +14013,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 			CourseOffering o = (CourseOffering) j.next();
 			if (!dealtWith.contains(o.getEid())) {
 				// 1. construct list of CourseOfferingObject for CourseObject
-				ArrayList l = new ArrayList();
+				ArrayList<CourseOfferingObject> l = new ArrayList<>();
 				CourseOfferingObject coo = new CourseOfferingObject(o,
 						(ArrayList) sectionHash.get(o.getEid()));
 				l.add(coo);
@@ -14280,9 +14285,9 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		public String eid;
 		public String title;
 		public String description;
-		public List courseOfferingObjects;
+		public List<CourseOfferingObject> courseOfferingObjects;
 
-		public CourseObject(CourseOffering offering, List courseOfferingObjects) {
+		public CourseObject(CourseOffering offering, List<CourseOfferingObject> courseOfferingObjects) {
 			this.eid = offering.getEid();
 			this.title = offering.getTitle();
 			this.description = offering.getDescription();

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3340,7 +3340,7 @@ public class SiteAction extends PagedResourceActionII {
 			// Sort the course offerings if necessary
 			List<CourseObject> courseList = (List) state.getAttribute(STATE_TERM_COURSE_LIST);
 			if (CollectionUtils.isNotEmpty(courseList)) {
-				courseList.sort(Comparator.comparing(CourseObject::getTitle));
+				courseList.sort(Comparator.comparing(CourseObject::getTitle, new AlphaNumericComparator()));
 				state.setAttribute(STATE_TERM_COURSE_LIST, courseList);
 			}
 			context.put("termCourseList", state.getAttribute(STATE_TERM_COURSE_LIST));

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-newSiteCourse.vm
@@ -28,7 +28,7 @@
 					$tlang.getString("nscourse.acad2")
 				</label>	
 				<div class="col-sm-6">
-					<select name="selectTerm" id="selectTerm" onchange="SPNR.insertSpinnerAfter( this, null, null ); document.getElementById('option').value='change';document.addCourseForm.submit();">
+					<select name="selectTerm" id="selectTerm" onchange="SPNR.disableControlsAndSpin(this, null); document.getElementById('option').value='change';document.addCourseForm.submit();">
 						#foreach($t in $termList)
 							<option value ="$t.eid"
 								#if($t.eid == $term.eid)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46028

The UI to select rosters has a sorting issue: the sections within each set are sorted, but the sets themselves are not. Instead, they appear in the order they are retrieved from the database. Example screenshot can be seen on the JIRA ticket.

This PR sorts the sets alphabetically. It also addresses an issue in the Add Roster UI, where the drop down produces two spinners (one on the drop down itself, and one beside it), by retaining only the overlay spinner.