### PR TITLE
SAK-46029 Additional/Improved wording warning when using QP random draw in quizzes

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -393,8 +393,8 @@ random_draw_from_que_edit_disabled=(Remove existing questions from this part to 
 randow_draw_from_que_no_pools_available=(Add at least one question to an unused pool to enable this feature)
 random_draw_questions_prefix=* Draw
 random_draw_questions_suffix=question(s) from
-random_draw_correct_prefix=* Correct answers are worth
-random_draw_correct_suffix=point(s).
+random_draw_correct_prefix=* Drawn questions are scored out of
+random_draw_correct_suffix=point(s). This overrides the original pool setting and cannot be changed once published.
 random_draw_deduct_prefix=* For 'True False' or 'Multiple Choice, Single Correct' questions, deduct
 random_draw_deduct_suffix=point(s) for incorrect answers. This overrides the original pool setting.
 random_within_p=Random within Part
@@ -544,7 +544,7 @@ update_pool_error_unknown=An error has occurred while updating the random drawn 
 # validate random drawn number for part
 qdrawn_error= Number of questions to draw should be an integer greater than 0 but not more than 
 qdrawn_pt_error= Point values must be numbers greater than or equal to 0.0
-qdrawn_null_error_pos= Please enter a value in the "Correct answers are worth" field
+qdrawn_null_error_pos= Please enter a value in the "Drawn questions are scored out of" field
 qdrawn_null_error_neg= Please enter a value in the "deduct _ point(s)" field
 
 selectedPool_error=Please select a pool under "Random draw from question pool".

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorMessages.properties
@@ -393,7 +393,7 @@ random_draw_from_que_edit_disabled=(Remove existing questions from this part to 
 randow_draw_from_que_no_pools_available=(Add at least one question to an unused pool to enable this feature)
 random_draw_questions_prefix=* Draw
 random_draw_questions_suffix=question(s) from
-random_draw_correct_prefix=* Drawn questions are scored out of
+random_draw_correct_prefix=* Questions are worth
 random_draw_correct_suffix=point(s). This overrides the original pool setting and cannot be changed once published.
 random_draw_deduct_prefix=* For 'True False' or 'Multiple Choice, Single Correct' questions, deduct
 random_draw_deduct_suffix=point(s) for incorrect answers. This overrides the original pool setting.
@@ -544,7 +544,7 @@ update_pool_error_unknown=An error has occurred while updating the random drawn 
 # validate random drawn number for part
 qdrawn_error= Number of questions to draw should be an integer greater than 0 but not more than 
 qdrawn_pt_error= Point values must be numbers greater than or equal to 0.0
-qdrawn_null_error_pos= Please enter a value in the "Drawn questions are scored out of" field
+qdrawn_null_error_pos= Please enter a value in the "Questions are worth" field
 qdrawn_null_error_neg= Please enter a value in the "deduct _ point(s)" field
 
 selectedPool_error=Please select a pool under "Random draw from question pool".


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46029

Instructors at our institution have found the random draw from pool settings to be somewhat unclear. The following change addresses these concerns:

"Correct answers are worth ___ point(s)" becomes "Drawn questions are scored out of ___ point(s). This overrides the original pool setting and cannot be changed once published."
