### PR TITLE
SAK-46033 resources > edit > no copyright warning when flipping copyright back to 'please select...'

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_properties.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_properties.vm
@@ -5,9 +5,11 @@
 	<h3>
 		$tlang.getString("action.props") 
 	</h3>
-	
+
 	#if ($alertMessage)
-		<div class="sak-banner-error">$tlang.getString("label.alert") $formattedText.escapeHtml($alertMessage)</div>
+		<div id="resourceAlert" class="sak-banner-error">$tlang.getString("label.alert") $formattedText.escapeHtml($alertMessage)</div>
+	#else
+		<div id="resourceAlert" class="sak-banner-error hide"></div>
 	#end
 
 	<p class="instruction">

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
@@ -14,9 +14,9 @@
         #end
     </ol>
     #if ($itemAlertMessage)
-        <div class="sak-banner-success">$itemAlertMessage</div>
+        <div  id="resourceAlert" class="sak-banner-success">$itemAlertMessage</div>
     #else
-        <div class="sak-banner-error" style="display:none"></div>
+        <div  id="resourceAlert" class="sak-banner-error hide"></div>
     #end
     <div id="dragDropWrapper">
     <form name="dropzone-form" action="#toolLink("ResourcesHelperAction" "doPost")&flow=save" class="dropzone" id="file-uploader">

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties_scripts.vm
@@ -1150,9 +1150,8 @@
 		// 'Please select...' is always the first element in the drop down, but only enforce this if configured via sakai.properties
 		if (requireChoice && copyrightSelect !== null && copyrightSelect.selectedIndex < 1)
 		{
-			$('.sak-banner-error').html('$tlang.getString("label.alert") $copyrightError');
-			$('.sak-banner-error').removeClass('hide');
-			$('.sak-banner-error').show();
+			$('#resourceAlert').html('$tlang.getString("label.alert") $copyrightError');
+			$('#resourceAlert').removeClass('hide');
 			window.scrollTo(0, 0);
 			copyrightSelect.focus();
 
@@ -1161,7 +1160,6 @@
 		}
 
 		// Copyright status has been selected; let the calling site submit the necessary form
-		$('.sak-banner-error').hide();
 		submitButton.disabled = true;
 		return true;
 	}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46033

Steps to reproduce:

1. Edit a file in resources/drop box
2. Change the copyright drop down to "Please select a copyright status"
3. Save
4. Notice the form refreshes, but no error message is present at the top
5. Focus is put on the copyright field with no indication as to why the save didn't work

This is a regression introduced in parts by SAK-40422 and SAK-42121