### PR TITLE
SAK-46039 Changing item type to 'select a question type' when editing a question triggers error

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemConfigBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemConfigBean.java
@@ -438,12 +438,16 @@ public class ItemConfigBean implements Serializable {
     if (isSelectFromQuestionPool()) {
       list.add(new SelectItem("10", getResourceDisplayName("import_from_q")));
     }
-
-    List<SelectItem> ret = new ArrayList<SelectItem>();
-    ret.add(new SelectItem("", getResourceDisplayName("select_qtype")));
-    ret.addAll(list);
     
-    return ret;
+    return list;
+  }
+
+  public List<SelectItem> getAddItemTypeSelectList()
+  {
+    List<SelectItem> list = getItemTypeSelectList();
+    list.add(0, new SelectItem("", getResourceDisplayName("select_qtype")));
+
+    return list;
   }
 
   /**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -2045,7 +2045,7 @@ String poolId = ContextUtil.lookupParam("qpid");
 			itemauthorbean.setQpoolId(poolid);
 			itemauthorbean.setTarget(ItemAuthorBean.FROM_QUESTIONPOOL);
 
-			itemauthorbean.setItemType("");
+			itemauthorbean.setItemType(String.valueOf(TypeIfc.MULTIPLE_CHOICE));
 			itemauthorbean.setItemTypeString("");
 
 			//QuestionPoolDataBean pool = new QuestionPoolDataBean();

--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -321,7 +321,7 @@ $(window).load( function() {
         <!-- each selectItem stores the itemtype, current sequence -->
         <h:selectOneMenu id="changeQType" onchange="clickInsertLink(this);"  value="#{itemauthor.itemTypeString}">
              <f:valueChangeListener type="org.sakaiproject.tool.assessment.ui.listener.author.StartInsertItemListener" />
-             <f:selectItems value="#{itemConfig.itemTypeSelectList}" />
+             <f:selectItems value="#{itemConfig.addItemTypeSelectList}" />
         </h:selectOneMenu>
       </div>
     </div>
@@ -464,7 +464,7 @@ $(window).load( function() {
           <!-- each selectItem stores the itemtype, current sequence -->
           <h:selectOneMenu id="changeQType" onchange="clickInsertLink(this);" value="#{itemauthor.itemTypeString}" >
             <f:valueChangeListener type="org.sakaiproject.tool.assessment.ui.listener.author.StartInsertItemListener" />
-            <f:selectItems value="#{itemConfig.itemTypeSelectList}" />
+            <f:selectItems value="#{itemConfig.addItemTypeSelectList}" />
           </h:selectOneMenu>
           <h:commandLink id="hiddenlink" styleClass="hidden" action="#{itemauthor.doit}" value="">
             <f:param name="itemSequence" value="#{question.itemData.sequence}"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46039

When you are editing a question, you can change the question type using the dropdown menu, which contains "select a question type". This triggers a validation error on the page.

There is no reason to include this option when editing an existing question, so it should be removed.

Similarly, when adding a question to a question pool, there is an intermediate page to choose a question type that starts with "select a question type" selected. Since in this case, unlike on the main assessment page, selecting a question type does not trigger any further action, there is no reason to start this form in an invalid state. Instead, it should default to the most common question type, Multiple Choice.
