### PR TITLE
SAK-46042 request account's email should indicate the user's login id

### DIFF
--- a/reset-pass/account-validator-impl/src/bundle/validate_requestAccount.xml
+++ b/reset-pass/account-validator-impl/src/bundle/validate_requestAccount.xml
@@ -3,12 +3,14 @@
    <emailTemplate>
        <subject>Welcome To ${localSakaiName}!</subject>
        <message>Thank you for requesting an account for ${localSakaiName}, ${institution}'s learning management system. You're almost done!
+Your requested account login is: ${userEid}
 
-To create an account, click on the following link or paste it into your favourite web browser, and fill in the form.
+To create this account, click on the following link or paste it into your favourite web browser, and fill in the form.
 ${url}
 
 If you haven't requested this account, you can safely ignore this message.
         </message>
        <locale></locale>
+       <version>2</version>
    </emailTemplate>
 </emailTemplates>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46042



account-validator-impl/src/bundle/validate_requestAccount.xml has no indication of the user's eid.

Added `<version>2</version>` in the hopes that like our institution, the version in your database is "1", so this will cause the email template to be updated automatically.