### PR TITLE
SAK-46044 preferences > editor > no options, just update and cancel buttons

### DIFF
--- a/user/user-tool-prefs/tool/src/webapp/prefs/editor.jsp
+++ b/user/user-tool-prefs/tool/src/webapp/prefs/editor.jsp
@@ -29,15 +29,15 @@
                         <%@ include file="toolbar.jspf"%>
 
                         <div class="page-header">
-                                <h1><h:outputText rendered="#{UserPrefsTool.prefShowTabLabelOption==true}" value="#{msgs.prefs_editor_tab_title}" /></h1>
+                                <h1><h:outputText value="#{msgs.prefs_editor_tab_title}" /></h1>
                         </div>
 
                         <t:div rendered="#{UserPrefsTool.editorUpdated}">
                                 <jsp:include page="prefUpdatedMsg.jsp"/>
                         </t:div>
 
-                        <p class="instruction"><h:outputText value="#{msgs.editor_prompt}"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}"/></p>
-                        <h:selectOneRadio value="#{UserPrefsTool.selectedEditorType}" layout="pageDirection"  rendered="#{UserPrefsTool.prefShowTabLabelOption==true}" styleClass="addRadioLabelPadding">
+                        <p class="instruction"><h:outputText value="#{msgs.editor_prompt}" /></p>
+                        <h:selectOneRadio value="#{UserPrefsTool.selectedEditorType}" layout="pageDirection" styleClass="addRadioLabelPadding">
                                                 <f:selectItem itemValue="auto" itemLabel="#{msgs.editor_auto}"/>
                                                 <f:selectItem itemValue="basic" itemLabel="#{msgs.editor_basic}"/>
                                                 <f:selectItem itemValue="full" itemLabel="#{msgs.editor_full}"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46044

This is a bug, introduced in SAK-33240.

SAK-23895 created a new sakai.property (preference.show.tab.label.option), which exposes a setting in Preferences to allow users to display the tab text as either the site title or the site short description.

At Western, we do not want users to be able to switch this setting (we only want them seeing the site/roster title as the tab text), so we set this sakai.property explicitly to false.

SAK-33240 then introduced a new UI in Preferences for the CKEditor. For some reason, this UI makes use of conditionals on elements which use the boolean value of what amounts to be an unrelated sakai.property (the one from above that defaults to true and we set to false explicitly).

So this ended up passing QA because it was only tested in the default scenario: where this property was set to true. However, when this property is set to false you get the blank page with two buttons.

It doesn't make sense to have these elements conditional on an unrelated property. The options displayed here are for the CKEditor, and have nothing to do with the ability of users to switch tab text from site title to site short description.
