### PR TITLE
SAK-46049 'This assessment has been modified' message doesn't go away

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/SelectIndexMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/SelectIndexMessages.properties
@@ -70,7 +70,7 @@ highest_note=This assessment allows multiple submissions and has been configured
 last_note=This assessment allows multiple submissions and has been configured to record the last score which is the one listed here.
 
 asterisk_2=**
-has_been_modified=This assessment has been modified since you submitted it. Please consult your instructor if you find any discrepancies.
+has_been_modified=This assessment has been modified since you achieved your recorded score. Please consult your instructor if you find any discrepancies.
 currently_being_edited=This assessment is currently being edited. Access to feedback, if permitted, will be available when editing is done.
 
 immediate=Immediate

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/select/SelectActionListener.java
@@ -350,7 +350,7 @@ public class SelectActionListener implements ActionListener {
     
     /// --mustansar
     List reviewableList=new ArrayList();
-    List recordedList=new ArrayList();
+    List<DeliveryBeanie> recordedList=new ArrayList<>();
     Iterator it=submittedAssessmentGradingList.iterator();
     String assessmentIdNew="";
     while(it.hasNext()){
@@ -413,7 +413,9 @@ public class SelectActionListener implements ActionListener {
     		reviewableList.add(beanie);
     	}  
     }
-    
+
+    // display warning legend if any quizzes have been marked as modified in the review section
+    select.setHasAnyAssessmentBeenModified(recordedList.stream().anyMatch(db -> db.getHasAssessmentBeenModified()));
     
     if ("2".equals(select.getDisplayAllAssessments())){
     	submittedAssessmentGradingList=reviewableList;    
@@ -834,7 +836,6 @@ public class SelectActionListener implements ActionListener {
 	    		log.debug("AssessmentGradingId = " + g.getAssessmentGradingId());
 	    		log.debug("LastModifiedDate = " + p.getLastModifiedDate());
 	    		log.debug("SubmittedDate = " + g.getSubmittedDate());
-	    		select.setHasAnyAssessmentBeenModified(true);
 	    		return true;
 	    	}
 	    }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46049

If an instructor makes a change such as giving the entire class another retake, the student gets the following message:
"This assessment has been modified since you submitted it. Please consult your instructor if you find any discrepancies." (as a legend at the button of their submission list, to explain the icon next to the quiz that was modified).

But if the student retakes the assessment, the message continues to display to them. Visibility of the legend should be conditional so that if there are no marked quizzes, it does not appear.

Additionally, the part "since you submitted it" is not technically accurate. Quizzes are marked as modified if the modificaiton was after the submission with the recorded score, not just the most recent submission. Therefore, in the case of highest submission, if you did worse or the same as your previously recorded score, the quiz will still be marked as modified if you resubmit after the modification. Changing the message to read "since you achieved your recorded score" would be more accurate and explain why the message may persist even after a retake.

NOTE: as of SAK-43208, you need to explicitly set the sakai property "samigo.SelectAssessmentBean.warnUserOfModification" to true to see this message, as it has been turned off by default.