### PR TITLE
SAK-46050 membership > enrolments > rosters attached to multiple sites get squished together

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/EnrolmentsHandler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/EnrolmentsHandler.java
@@ -50,6 +50,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ParameterParser;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
 
 /**
  * Handles most aspects of the 'My Official Course Enrolments' page in the Membership tool.
@@ -421,6 +422,7 @@ public class EnrolmentsHandler
             this.sectionTitle = sectionTitle;
             this.sessionEID = sessionEID;
             this.siteWrappers = siteWrappers;
+            Collections.sort( siteWrappers, Comparator.comparing( SiteTitleUrlWrapper::getSiteTitle, new AlphaNumericComparator() ) );
         }
 
         // Getters

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership_enrolments.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/membership/chef_membership_enrolments.vm
@@ -75,10 +75,21 @@
                                 <td headers="section">$enrolment.getSectionTitle()</td>
                                 <td headers="worksite">
                                     #if ($enrolment.siteWrappers.size() > 0)
-                                        #foreach( $site in $enrolment.siteWrappers )
+                                        #if ($enrolment.siteWrappers.size() == 1)
+                                            #set ($site = $enrolment.siteWrappers.get(0))
                                             <a href="$site.getSiteURL()" target="_top" title="$tlang.getString( "mb.gotosite" ) $formattedText.escapeHtml( $site.getSiteTitle() )">
                                                 $formattedText.escapeHtml( $site.getSiteTitle() )
                                             </a>
+                                        #else
+                                            <ul>
+                                            #foreach( $site in $enrolment.siteWrappers )
+                                                <li>
+                                                    <a href="$site.getSiteURL()" target="_top" title="$tlang.getString( "mb.gotosite" ) $formattedText.escapeHtml( $site.getSiteTitle() )">
+                                                        $formattedText.escapeHtml( $site.getSiteTitle() )
+                                                    </a>
+                                                </li>
+                                            #end
+                                            </ul>
                                         #end
                                     #else
                                         $tlang.getString('mb.enrolments.siteNotAvailable')


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46050

When a roster is used in multiple sites, My Official Course Enrolments lists each. However, the links are squished together, and appear as one giant link. In fact they are distinct, but could use some better spacing.

This PR employs an unordered list if the roster is attached to more than one site, and also sorts the sites alphabetically.

Before and after screenshots attached to the JIRA ticket.