### PR TITLE
SAK-46052 Difficulty creating a quiz through Lessons

### DIFF
--- a/library/src/webapp/js/lang-datepicker/lang-datepicker.js
+++ b/library/src/webapp/js/lang-datepicker/lang-datepicker.js
@@ -1438,10 +1438,12 @@ if(c&&c._defaults.timeOnly&&b.input.val()!==b.lastVal)try{$.datepicker._updateDa
 
 $.datepicker._getPreferredSakaiDatetime = function () {
 
-  if (portal.serverTimeMillis && portal.user && portal.user.offsetFromServerMillis) {
+    const p = typeof portal !== "undefined" ? portal : parent.portal;  // we might be inside an iframe (ie. Lessons)
+
+    if (p && p.serverTimeMillis && p.user && p.user.offsetFromServerMillis) {
     let osTzOffset = (new Date()).getTimezoneOffset();
-    return moment(parseInt(portal.serverTimeMillis))
-      .add(portal.user.offsetFromServerMillis, 'ms')
+    return moment(parseInt(p.serverTimeMillis))
+      .add(p.user.offsetFromServerMillis, 'ms')
 	  //Add in the number of ms since this page was loaded
 	  .add(Date.now() - this._initTime, 'ms')
       .add(osTzOffset, 'm')


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46052

The date picker doesn't appear when creating a Tests & Quizzes assessment through Lessons. Since dates are required field, you are unable to create an assessment through Lessons, unless you type the date format into the input field correctly.

The issue is that when embedded in the Lessons iframe, Samigo doesn't have direct access to the portal object and therefore lang-datepicker.js can't find it.