### PR TITLE
SAK-46053 Assignments > Save Draft Doesn't Save Grading Options

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -8822,19 +8822,22 @@ public class AssignmentAction extends PagedResourceActionII {
 
         properties.put(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING, Boolean.toString(checkAnonymousGrading));
 
-        if (post) {
-            switch (addtoGradebook) {
-                case GRADEBOOK_INTEGRATION_ADD:
-                    associateGradebookAssignment = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
-                case GRADEBOOK_INTEGRATION_ASSOCIATE:
-                    properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ASSOCIATE);
+        switch (addtoGradebook) {
+            case GRADEBOOK_INTEGRATION_ADD:
+                if (!post) {  // save as draft, retain original values for now
+                    properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ADD);
                     properties.put(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT, associateGradebookAssignment);
                     break;
-                case GRADEBOOK_INTEGRATION_NO:
-                default:
-                    properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_NO);
-                    properties.remove(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
-            }
+                }
+                associateGradebookAssignment = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+            case GRADEBOOK_INTEGRATION_ASSOCIATE:
+                properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ASSOCIATE);
+                properties.put(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT, associateGradebookAssignment);
+                break;
+            case GRADEBOOK_INTEGRATION_NO:
+            default:
+                properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_NO);
+                properties.remove(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
         }
 
         // allow resubmit number and default assignment resubmit closeTime (dueTime)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46053

Create a new assignment that will be sent to the gradebook. Save as Draft. Edit the draft assignment, notice that your gradebook settings are not saved.

This happens because the gradebook integration settings were only being saved when posting the assignment due to the if (post) statement around the entire block.

