### PR TITLE
SAK-46055 membership > joinable sites > filter out sites where user is an inactive member

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MembershipAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MembershipAction.java
@@ -181,22 +181,12 @@ public class MembershipAction extends PagedResourceActionII
 		}
 		else if( JOINABLE_MODE.equals( mode ) )
 		{
-			if (sortAsc)
-			{
-				List<Site> sites = SITE_SERV.getSites(SelectionType.JOINABLE, null, search, null, SortType.TITLE_ASC, page);
+			SortType sort = sortAsc ? SortType.TITLE_ASC : SortType.TITLE_DESC;
+			List<Site> sites = SITE_SERV.getSites(SelectionType.JOINABLE, null, search, null, sort, page);
 
-				// SAK-24423 - filter sites taking into account 'exclude from public list' setting and global toggle
-				JoinableSiteSettings.filterSitesListForMembership( sites );
-				rv = sites;
-			}
-			else
-			{
-				List<Site> sites = SITE_SERV.getSites(SelectionType.JOINABLE, null, search, null, SortType.TITLE_DESC, page);
-
-				// SAK-24423 - filter sites taking into account 'exclude from public list' setting and global toggle
-				JoinableSiteSettings.filterSitesListForMembership( sites );
-				rv = sites;
-			}
+			// SAK-24423 - filter sites taking into account 'exclude from public list' setting and global toggle
+			JoinableSiteSettings.filterSitesListForMembership( sites );
+			rv = sites;
 		}
 		else
 		{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46055

If you are an inactive member of a joinable site, that site will still appear in the list of Joinable Sites in the Membership tool. If you try to join the site from this UI, the page simply refreshes and it looks as if nothing happened.

The user is already a member of this site, but marked as inactive, therefore you cannot join the site again.

Joinable Sites should not display any sites where the user is an inactive member.
