### PR TITLE
SAK-46056 site info > manage access > specific workflows do not enable Continue button when they should

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -1264,7 +1264,7 @@ function doCategoryCheck(clickedElement) {
   }
 }
 
-// Returns true iff the limitByAccountType checkboxes are in a valid state.
+// Returns true if the limitByAccountType checkboxes are in a valid state.
 // Also responsible for the visibility of the "You must select at least one account type below" message
 function limitByAccountTypesValidation() {
 
@@ -1281,21 +1281,18 @@ function limitByAccountTypesValidation() {
 
     // determine if at least one is checked
     var atLeastOneChecked = [].slice.call(chkAccountTypes).some(function (t) { return t.checked; });
-    /*
-    var atLeastOneChecked = false;
-    for (var i = 0; i < chkAccountTypes.length; i++) {
-      if (chkAccountTypes[i].checked) {
-        atLeastOneChecked = true;
-        break;
-      }
-    }
-    */
 
     if (!atLeastOneChecked) {
       // 'Limit join to specific accounts' is checked, but no accounts are checked; the page is invalid
       displayJoinLimitInfo = true;
       valid = false;
     }
+  }
+
+  const unjoinable = document.getElementById("unjoinable");
+  const unpublished = document.getElementById("unpublish");
+  if ((unjoinable && unjoinable.checked) || (unpublished && unpublished.checked)) {
+      valid = true;
   }
 
   // Control the visibility of the "You must select at least one account type below" message

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -93,13 +93,13 @@
 		</p>
 		<div class="radio">			
 			<label for="publish">
-				<input type="radio" name="publishunpublish" id="publish" value="true" #if($published) checked="checked"#end onclick="checkPublish(this.checked);" aria-describedby="site_status_inst" />
+				<input type="radio" name="publishunpublish" id="publish" value="true" #if($published) checked="checked"#end onclick="checkPublish(this.checked); validatePage();" aria-describedby="site_status_inst" />
 				$tlang.getString("ediacc.pubsit")
 			</label>
 		</div>
 		<div class="radio">			
 			<label for="unpublish">
-				<input type="radio" name="publishunpublish" id="unpublish" value="false" #if(!$published) checked="checked"#end onclick="checkUnpublish(this.checked);" aria-describedby="site_status_inst" />
+				<input type="radio" name="publishunpublish" id="unpublish" value="false" #if(!$published) checked="checked"#end onclick="checkUnpublish(this.checked); validatePage();" aria-describedby="site_status_inst" />
 				$tlang.getString("ediacc.unpubsit")
 			</label>
 		</div>
@@ -215,7 +215,7 @@
 			<div class="radio">
 				<label for="unjoinable">
 					<input type="radio" name="joinable" id="unjoinable" value="false" #if (!$joinable) checked="checked"#end 
-				      onclick="this.checked ? document.getElementById('joinerrole').style.display='none' : document.getElementById('joinerrole').style.display='block'; utils.resizeFrame();"
+				      onclick="this.checked ? document.getElementById('joinerrole').style.display='none' : document.getElementById('joinerrole').style.display='block'; validatePage(); utils.resizeFrame();"
 				      aria-describedby="site_glob_inst" />
 					$tlang.getString("ediacc.cannotbejoi")
 				</label>
@@ -223,7 +223,7 @@
 			<div class="radio">
 				<label for="joinable">
 				     <input type="radio" name="joinable" id="joinable" value="true" #if ($joinable) checked="checked"#end 
-				            onclick="this.checked ? document.getElementById('joinerrole').style.display='block' : document.getElementById('joinerrole').style.display='none'; utils.resizeFrame();"
+				            onclick="this.checked ? document.getElementById('joinerrole').style.display='block' : document.getElementById('joinerrole').style.display='none'; validatePage(); utils.resizeFrame();"
 				            aria-describedby="site_glob_inst" />				
 					$tlang.getFormattedMessage("ediacc.canbejoi", $uiService)
 				</label>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46056

If you take specific actions within Manage Access, you can produce a valid state that does not enable the Continue/Update button. This affects both existing sites and the site creation wizard.

For example:

* during the site creation process on the Manage Access page, "Allow any Sakai user to join the site"
* limit join to specific accounts
* don't select any account types
* switch to "Limit to official course members or to those I add manually (recommended)" under "Global Access"
* observe: you have provided valid options, but the Continue button remains disabled

This also happens if you switch "Publish Site (accessible by all participants)" to Draft mode for step 4.