### PR TITLE
SAK-46022 Add High-Priority option to Commons posts

### DIFF
--- a/commons/api/src/bundle/commons.properties
+++ b/commons/api/src/bundle/commons.properties
@@ -72,7 +72,6 @@ Example URL: /direct/commons/rss/SITEID.json
 menu_main = Posts
 permissions = Permissions
 
-priority_email_subject = Subject: Email notification for Commons post in site 
-priority_email_forwarded = This forwarded message was sent via Isidore Commons from the 
-priority_email_sitebreak = site.<br>----------------------<br>
-priority_email_view = <br><br>View this message in the Isidore site: 
+priority_email_subject = [{0} - Commons] New high-priority post
+priority_email_added = A high-priority post was added to the Commons tool in the {0} site.
+priority_email_forwarded = This forwarded message was sent by Isidore (<a href="https://isidore.udayton.edu/portal" >https://isidore.udayton.edu/portal</a>) via the Commons tool in the {0} site.

--- a/commons/api/src/bundle/commons.properties
+++ b/commons/api/src/bundle/commons.properties
@@ -8,6 +8,8 @@ like = Like
 people = people liked this
 person = person liked this
 reply = Reply
+priority = Make this post High-Priority
+priorityHelp = When a post is marked as High Priority, an email notification is sent to participants that contains the text of the post and will be flagged as High Priority within the Commons tool.
 post_comment = Post Comment
 delete_post_message = Are you sure you want to delete this post?
 delete_comment_message = Are you sure you want to delete this comment?
@@ -68,3 +70,8 @@ Example URL: /direct/commons/rss/SITEID.json
 # Menu
 menu_main = Posts
 permissions = Permissions
+
+priority_email_subject = Subject: Email notification for Commons post in site 
+priority_email_forwarded = This forwarded message was sent via Isidore Commons from the 
+priority_email_sitebreak = site.<br>----------------------<br>
+priority_email_view = <br><br>View this message in the Isidore site: 

--- a/commons/api/src/bundle/commons.properties
+++ b/commons/api/src/bundle/commons.properties
@@ -10,6 +10,7 @@ person = person liked this
 reply = Reply
 priority = Make this post High-Priority
 priorityHelp = When a post is marked as High Priority, an email notification is sent to participants that contains the text of the post and will be flagged as High Priority within the Commons tool.
+priority_icon = High-Priority Post
 post_comment = Post Comment
 delete_post_message = Are you sure you want to delete this post?
 delete_comment_message = Are you sure you want to delete this comment?

--- a/commons/api/src/java/org/sakaiproject/commons/api/datamodel/Post.java
+++ b/commons/api/src/java/org/sakaiproject/commons/api/datamodel/Post.java
@@ -56,6 +56,7 @@ public class Post implements Entity {
     private String siteId;
     private String commonsId;
     private String url = "";
+    private boolean priority;
 
     public Post() {
 
@@ -73,7 +74,7 @@ public class Post implements Entity {
         this.setSiteId(rs.getString("SITE_ID"));
         this.setContent(rs.getString("CONTENT"));
         this.setCreatorId(rs.getString("CREATOR_ID"));
-
+        this.setPriority(rs.getBoolean("PRIORITY"));
         // retrieve time's in UTC since that's how it's stored
         this.setCreatedDate(rs.getTimestamp("CREATED_DATE", Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("UTC")))).getTime());
         this.setModifiedDate(rs.getTimestamp("MODIFIED_DATE", Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("UTC")))).getTime());

--- a/commons/impl/src/java/org/sakaiproject/commons/impl/PersistenceManagerImpl.java
+++ b/commons/impl/src/java/org/sakaiproject/commons/impl/PersistenceManagerImpl.java
@@ -68,7 +68,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
     private static final String COMMENT_UPDATE = "UPDATE COMMONS_COMMENT SET CONTENT = ?, MODIFIED_DATE = ? WHERE ID = ?";
     private static final String COMMENT_DELETE = "DELETE FROM COMMONS_COMMENT WHERE ID = ?";
     private static final String POST_UPDATE = "UPDATE COMMONS_POST SET CONTENT = ?, MODIFIED_DATE = ?, RELEASE_DATE = ? WHERE ID = ?";
-    private static final String POST_INSERT = "INSERT INTO COMMONS_POST VALUES (?,?,?,?,?,?)";
+    private static final String POST_INSERT = "INSERT INTO COMMONS_POST VALUES (?,?,?,?,?,?,?)";
     private static final String POST_DELETE = "DELETE FROM COMMONS_POST WHERE ID = ?";
     private static final String POST_LIKE = "INSERT INTO COMMONS_LIKE VALUES (?,?,?,?)";
     private static final String LIKE_GET = "SELECT * FROM COMMONS_LIKE WHERE POST_ID = ? AND USER_ID=?";
@@ -229,7 +229,8 @@ public class PersistenceManagerImpl implements PersistenceManager {
                                             , post.getCreatorId()
                                             , new Timestamp(post.getCreatedDate())
                                             , new Timestamp(post.getModifiedDate())
-                                            , new Timestamp(post.getReleaseDate())});
+                                            , new Timestamp(post.getReleaseDate())
+                                            , post.isPriority()});
                     sqlService.dbWrite(COMMONS_POST_INSERT
                         , new Object [] { post.getCommonsId(), post.getId() });
                 }

--- a/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
+++ b/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
@@ -572,7 +572,7 @@ public class CommonsEntityProvider extends AbstractEntityProvider implements Req
             }
             List<String> headers = new ArrayList<String>();
             headers.add(rl.getString("priority_email_subject") + siteService.getSite(siteId).getTitle());
-            headers.add("From: " + userDirectoryService.getCurrentUser().getDisplayName() + " (" + userDirectoryService.getCurrentUser().getEmail() + ')');
+            headers.add("From: " + "\"" + userDirectoryService.getCurrentUser().getDisplayName() + "\" <" + userDirectoryService.getCurrentUser().getEmail() + ">");
             headers.add("Reply-To: " + userDirectoryService.getCurrentUser().getEmail());
             StringBuilder messageText = new StringBuilder();    //make message body
             messageText.append(rl.getString("priority_email_forwarded"));

--- a/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
+++ b/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
@@ -571,15 +571,16 @@ public class CommonsEntityProvider extends AbstractEntityProvider implements Req
                 }
             }
             List<String> headers = new ArrayList<String>();
-            headers.add(rl.getString("priority_email_subject") + siteService.getSite(siteId).getTitle());
+            headers.add("Subject: " + rl.getFormattedMessage("priority_email_subject", siteService.getSite(siteId).getTitle()));
             headers.add("From: " + "\"" + userDirectoryService.getCurrentUser().getDisplayName() + "\" <" + userDirectoryService.getCurrentUser().getEmail() + ">");
             headers.add("Reply-To: " + userDirectoryService.getCurrentUser().getEmail());
+            headers.add("Content-Type: text/html");
             StringBuilder messageText = new StringBuilder();    //make message body
-            messageText.append(rl.getString("priority_email_forwarded"));
-            messageText.append("<a href=\"" + siteService.getSite(siteId).getUrl() + "\" >" + siteService.getSite(siteId).getTitle() + "</a> ");
-            messageText.append(rl.getString("priority_email_sitebreak"));
-            messageText.append(postContent);
-            messageText.append(rl.getString("priority_email_view") + "<a href=\"" + siteService.getSite(siteId).getUrl() + "\" >" + siteService.getSite(siteId).getTitle() + "</a>");
+            messageText.append(rl.getFormattedMessage("priority_email_added", "<a href=\"" + siteService.getSite(siteId).getUrl() + "\" >" + siteService.getSite(siteId).getTitle() + "</a> "));
+            messageText.append("<br><br>" + postContent);
+            messageText.append("<br><br><hr><em>");
+            messageText.append(rl.getFormattedMessage("priority_email_forwarded", "<a href=\"" + siteService.getSite(siteId).getUrl() + "\" >" + siteService.getSite(siteId).getTitle() + "</a> "));
+            messageText.append("</em>");
             emailService.sendToUsers(siteUsers, headers, messageText.toString());
         } catch (IdUnusedException e){
             log.error("Cannot send email; no site with ID " + siteId);

--- a/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
+++ b/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
@@ -562,15 +562,15 @@ public class CommonsEntityProvider extends AbstractEntityProvider implements Req
     private void sendPriorityEmail(String siteId, String postContent){
         try{
             Set<String> siteUserIds = siteService.getSite(siteId).getUsers();
-            Set<User> siteUsers = new HashSet<User>();  //will be list of users to email
+            Set<User> siteUsers = new HashSet<>();  //will be list of users to email
             for(String id: siteUserIds){
                 try{
                     siteUsers.add(userDirectoryService.getUser(id));
                 } catch (UserNotDefinedException u){
-                    log.error("No user found with ID " + id + " while sending Commons Priority email.");
+                    log.error("No user found with ID {} while sending Commons Priority email.", id);
                 }
             }
-            List<String> headers = new ArrayList<String>();
+            List<String> headers = new ArrayList<>();
             headers.add("Subject: " + rl.getFormattedMessage("priority_email_subject", siteService.getSite(siteId).getTitle()));
             headers.add("From: " + "\"" + userDirectoryService.getCurrentUser().getDisplayName() + "\" <" + userDirectoryService.getCurrentUser().getEmail() + ">");
             headers.add("Reply-To: " + userDirectoryService.getCurrentUser().getEmail());
@@ -583,7 +583,7 @@ public class CommonsEntityProvider extends AbstractEntityProvider implements Req
             messageText.append("</em>");
             emailService.sendToUsers(siteUsers, headers, messageText.toString());
         } catch (IdUnusedException e){
-            log.error("Cannot send email; no site with ID " + siteId);
+            log.error("Cannot send email; no site with ID {}", siteId);
         }
     }
 }

--- a/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
+++ b/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
@@ -572,7 +572,7 @@ public class CommonsEntityProvider extends AbstractEntityProvider implements Req
             }
             List<String> headers = new ArrayList<String>();
             headers.add(rl.getString("priority_email_subject") + siteService.getSite(siteId).getTitle());
-            headers.add("From: " + userDirectoryService.getCurrentUser().getDisplayName() + '(' + userDirectoryService.getCurrentUser().getEmail() + ')');
+            headers.add("From: " + userDirectoryService.getCurrentUser().getDisplayName() + " (" + userDirectoryService.getCurrentUser().getEmail() + ')');
             headers.add("Reply-To: " + userDirectoryService.getCurrentUser().getEmail());
             StringBuilder messageText = new StringBuilder();    //make message body
             messageText.append(rl.getString("priority_email_forwarded"));

--- a/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
+++ b/commons/tool/src/java/org/sakaiproject/commons/tool/entityprovider/CommonsEntityProvider.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/commons/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/commons/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -8,6 +8,9 @@
 		<property name="commonsManager"><ref bean="org.sakaiproject.commons.api.CommonsManager"/></property>
         <property name="commonsSecurityManager"><ref bean="org.sakaiproject.commons.api.CommonsSecurityManager"/></property>
         <property name="sakaiProxy"><ref bean="org.sakaiproject.commons.api.SakaiProxy"/></property>
+        <property name="emailService"><ref bean="org.sakaiproject.email.api.EmailService"/></property>
+        <property name="siteService"><ref bean="org.sakaiproject.site.api.SiteService"/></property>
+        <property name="userDirectoryService"><ref bean="org.sakaiproject.user.api.UserDirectoryService"/></property>
     </bean>
 
 </beans>

--- a/commons/tool/src/webapp/WEB-INF/templates/post.hbs
+++ b/commons/tool/src/webapp/WEB-INF/templates/post.hbs
@@ -5,7 +5,11 @@
         <div class="commons-photo" style="background-image:url(/direct/profile/{{creatorId}}/image/thumb)"></div>
         <div class="commons-post-text-container">
             <div class="commons-post-body">
-                <div class="commons-post-content"><a id="commons-author-name-{{id}}" class="commons-post-author-name profile-popup-trigger" data-user-id="{{creatorId}}" href="javascript:;">{{creatorDisplayName}}</a><span id="commons-post-content-{{id}}">{{{content}}}<span></div>
+                <div class="commons-post-content">
+                    <span id="commons-high-priority-{{id}}" class="fa fa-exclamation-circle commons-high-priority" style="display:none;"></span>
+                    <a id="commons-author-name-{{id}}" class="commons-post-author-name profile-popup-trigger" data-user-id="{{creatorId}}" href="javascript:;">{{creatorDisplayName}}</a>
+                    <span id="commons-post-content-{{id}}">{{{content}}}<span>
+                </div>
                 <div id="commons-post-options-{{id}}" class="commons-post-options">
                     <span id="commons-like-section" >
                         <a href="javascript:;" id="commons-like-link-{{id}}" class="commons-like-link" data-post-id="{{id}}" >

--- a/commons/tool/src/webapp/WEB-INF/templates/post.hbs
+++ b/commons/tool/src/webapp/WEB-INF/templates/post.hbs
@@ -1,12 +1,12 @@
 <div id="commons-post-outer-container-{{id}}" class="commons-post-outer-container">
 
-    <div class="commons-post-inner-container">
+    <div class="commons-post-inner-container" id="commons-post-inner-container-{{id}}">
 
         <div class="commons-photo" style="background-image:url(/direct/profile/{{creatorId}}/image/thumb)"></div>
         <div class="commons-post-text-container">
             <div class="commons-post-body">
                 <div class="commons-post-content">
-                    <span id="commons-high-priority-{{id}}" class="fa fa-exclamation-circle commons-high-priority" style="display:none;"></span>
+                    <span id="commons-high-priority-{{id}}" class="fa fa-flag commons-high-priority" title={{tr 'priority_icon'}} style="display:none;"></span>
                     <a id="commons-author-name-{{id}}" class="commons-post-author-name profile-popup-trigger" data-user-id="{{creatorId}}" href="javascript:;">{{creatorDisplayName}}</a>
                     <span id="commons-post-content-{{id}}">{{{content}}}<span>
                 </div>

--- a/commons/tool/src/webapp/WEB-INF/templates/posts.hbs
+++ b/commons/tool/src/webapp/WEB-INF/templates/posts.hbs
@@ -13,7 +13,7 @@
             <span id="commons-editor-priority-container" style="display:none;">
                 <input type="checkbox" id="commons-editor-priority" class="commons-editor-priority"></input>
                 <label for="commons-editor-priority" class="commons-editor-priority-label">{{tr 'priority'}}</label>
-                <a href="javascript://" data-toggle="popover" data-html="true" data-content="{{tr 'priorityHelp'}}" id="commons-editor-priority-help" class="fa fa-question-circle" ></a>
+                <a href="javascript://" data-toggle="popover" data-placement="top" data-trigger="focus" data-html="true" data-content="{{tr 'priorityHelp'}}" id="commons-editor-priority-help" class="fa fa-question-circle" ></a>
                 <br>
             </span>
         </div>

--- a/commons/tool/src/webapp/WEB-INF/templates/posts.hbs
+++ b/commons/tool/src/webapp/WEB-INF/templates/posts.hbs
@@ -10,6 +10,12 @@
             <button id="commons-editor-cancel-button" disabled="true">{{tr 'cancel'}}</button>
             <button id="commons-editor-link-button" class="commons-editor-special-button" title="{{tr 'link_button_tooltip'}}"><span class="fa fa-link"></span></button>
             <button id="commons-editor-image-button" class="commons-editor-special-button" title="{{tr 'image_button_tooltip'}}"><span class="fa fa-picture-o"></span></button>
+            <span id="commons-editor-priority-container" style="display:none;">
+                <input type="checkbox" id="commons-editor-priority" class="commons-editor-priority"></input>
+                <label for="commons-editor-priority" class="commons-editor-priority-label">{{tr 'priority'}}</label>
+                <a href="javascript://" data-toggle="popover" data-html="true" data-content="{{tr 'priorityHelp'}}" id="commons-editor-priority-help" class="fa fa-question-circle" ></a>
+                <br>
+            </span>
         </div>
     </div>
 

--- a/commons/tool/src/webapp/js/commons.js
+++ b/commons/tool/src/webapp/js/commons.js
@@ -130,7 +130,10 @@ commons.switchState = function (state, arg) {
                 commons.selectedText = (document.selection) ? sel.createRange().htmlText : sel.toString();
                 commons.currentRange = sel.getRangeAt(0);
             });
-
+            if(commons.currentUserPermissions.postDeleteAny){   //if the user can delete any post, we will give them access to Hi-Priority posting too.
+                document.getElementById('commons-editor-priority-container').removeAttribute('style');
+                $('[data-toggle="popover"]').popover(); //we need the popover to work only when Hi-Priority is exposed.
+            }
             editorPostButton.click(function (e) {
 
                 commons.utils.savePost('', editor.html(), function (post) {

--- a/commons/tool/src/webapp/js/commons_utils.js
+++ b/commons/tool/src/webapp/js/commons_utils.js
@@ -283,7 +283,8 @@ commons.utils = {
     savePost: function (postId, content, callback) {
 
         var success = false;
-
+        var priority = document.getElementById('commons-editor-priority').checked;
+        document.getElementById('commons-editor-priority').checked = false; //uncheck the box by default, we have what we need from it already.
         if (!postId) postId = '';
 
         if ('' == content) {
@@ -296,7 +297,8 @@ commons.utils = {
                 'content': content,
                 'commonsId': commons.commonsId,
                 'siteId': commons.siteId,
-                'embedder': commons.embedder
+                'embedder': commons.embedder,
+                'priority': priority
             };
 
         $.ajax({
@@ -499,7 +501,9 @@ commons.utils = {
             if (post.comments.length <= 3) {
                 showCommentsLink.hide();
             }
-
+            if(post.priority === true){
+                document.getElementById('commons-high-priority-' + post.id).removeAttribute('style');
+            }
             post.comments.forEach(function (c) { self.addHandlersToComment(c); });
         });
     },

--- a/commons/tool/src/webapp/js/commons_utils.js
+++ b/commons/tool/src/webapp/js/commons_utils.js
@@ -502,6 +502,7 @@ commons.utils = {
                 showCommentsLink.hide();
             }
             if(post.priority === true){
+                document.getElementById('commons-post-inner-container-' + post.id).classList.add('alert-info');
                 document.getElementById('commons-high-priority-' + post.id).removeAttribute('style');
             }
             post.comments.forEach(function (c) { self.addHandlersToComment(c); });

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -266,7 +266,3 @@
 span.commons-high-priority {
     float: right;
 }
-
-span.commons-high-priority {
-    float: right;
-}

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -83,10 +83,10 @@
 
     .commons-post-outer-container {
         border-bottom: 1px solid var(--sakai-border-color);
-        margin-bottom: 20px;
+        margin-bottom: 10px;
     }
         .commons-post-inner-container{
-            margin: 5px;
+            padding: 5px;
             overflow: auto;
         }
             .commons-post-body {
@@ -259,7 +259,4 @@
 }
 #commons-editor-priority-help {
     text-decoration: none;
-}
-.commons-high-priority {
-    color: red;
 }

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -254,12 +254,19 @@
 #commons-like-section {
     margin-right: 1em;
 }
+
 .commons-editor-priority-label {
     margin-top: 7px;
 }
+
 #commons-editor-priority-help {
     text-decoration: none;
 }
+
 span.commons-high-priority {
     float: right;
+}
+
+.commons-high-priority {
+    color: red;
 }

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -260,3 +260,6 @@
 #commons-editor-priority-help {
     text-decoration: none;
 }
+span.commons-high-priority {
+    float: right;
+}

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -267,6 +267,6 @@ span.commons-high-priority {
     float: right;
 }
 
-.commons-high-priority {
-    color: red;
+span.commons-high-priority {
+    float: right;
 }

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -254,3 +254,12 @@
 #commons-like-section {
     margin-right: 1em;
 }
+.commons-editor-priority-label {
+    margin-top: 7px;
+}
+#commons-editor-priority-help {
+    text-decoration: none;
+}
+.commons-high-priority {
+    color: red;
+}


### PR DESCRIPTION
These commits add a checkbox below the main Commons textbox that sets the post to High-Priority. This will highlight the post and add an icon on its right side, and send an email to members of the site when it's added.
This works using a new database column called Priority; I will make a corresponding PR to sakai-reference with that change and link to it here.