### PR TITLE
SAK-46058: improved language for locked groups

### DIFF
--- a/site-manage/site-group-manager/src/main/resources/Messages.properties
+++ b/site-manage/site-group-manager/src/main/resources/Messages.properties
@@ -19,7 +19,7 @@ index.table.grouptitle=Group Title
 index.table.groupsize=Size (Max)
 index.table.groupmembers=Members
 index.table.grouplocked=The group is locked because it is being used by a tool. Locked groups cannot be edited or deleted.
-index.table.grouplocked.info=indicates group is locked because it is being used by a tool. Locked groups cannot be edited or deleted.
+index.table.grouplocked.info=indicates the group is locked by a tool. Locked groups cannot be deleted. Groups locked by the Assignments tool cannot be edited if they are used for group assignments.
 index.table.grouplockedby=Locked By
 index.table.assessments=Tests & Quizzes
 index.table.assignments=Assignments
@@ -27,6 +27,7 @@ index.table.joinableset=Joinable set
 index.table.members=members
 index.table.selectallnone=Select All/None
 index.warning.groupempty=There are currently no custom groups defined. You can create new groups using one of the options above.
+index.table.group.locked=Locked Group
 
 # Create new Group
 groups.allowviewmembership=Allow members to see the other members of this group

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
@@ -7,7 +7,7 @@
     <div id="menu" th:include="fragments/menus :: main (index)" />
     <div class="page-header"><h1 th:text="#{index.header.grouplist}"></h1></div>
     <div class="sak-banner-info" th:if="${groupList.isEmpty()}" th:text="#{index.warning.groupempty}">No groups in this site.</div>
-    <div class="instruction" th:if="${anyGroupLocked}"><span class="fa fa-fw fa-lock" aria-hidden="true"></span> - <span th:text="#{index.table.grouplocked.info}"></span></div>
+    <div class="instruction" th:if="${anyGroupLocked}"><span class="fa fa-fw fa-lock" aria-hidden="true"></span> - <span ria-hidden="true" th:text="#{index.table.grouplocked.info}"></span></div>
     <form th:if="${!groupList.isEmpty()}" id="group-manager-form" action="#" th:action="@{/removeGroups}" th:object="${mainForm}" method="post">
       <table id="groupTable" class="table table-striped table-bordered table-hover">
         <thead>
@@ -23,7 +23,8 @@
         <tbody>
           <tr th:each="group : ${groupList}">
             <td>
-              <span th:if="${lockedGroupList.contains(group.id)}" class="fa fa-fw fa-lock" aria-hidden="true" th:title="#{index.table.grouplocked}"></span>
+              <span th:if="${lockedGroupList.contains(group.id)}" class="fa fa-fw fa-lock" aria-hidden="true"></span>
+              <span th:if="${lockedGroupList.contains(group.id)}" class="sr-only" th:text="#{index.table.group.locked}"></span>
               <a th:if="${!lockedGroupList.contains(group.id)}" th:href="@{/group(groupId=${group.id})}" th:text="${group.title}"></a>
               <span th:if="${lockedGroupList.contains(group.id)}" th:text="${group.title}"></span>
             </td>
@@ -53,7 +54,8 @@
             <td class="hidden-xs" th:text="${groupMemberMap.get(group.id)}"></td>
             <td>
               <input th:if="${!lockedForDeletionGroupList.contains(group.id)}" th:attr="groupInfo=|${group.title} - ${group.getMembers().size()} #{index.table.members}|" type="checkbox" name="deletedGroupList" th:field="*{deletedGroupList}" th:value="${group.id}" onchange="indexFunctions.checkSubmitButton();"/>
-              <span th:if="${lockedForDeletionGroupList.contains(group.id)}" class="fa fa-fw fa-lock" aria-hidden="true" th:title="#{index.table.grouplocked}"></span>
+              <span th:if="${lockedForDeletionGroupList.contains(group.id)}" class="fa fa-fw fa-lock" aria-hidden="true"></span>
+              <span th:if="${lockedForDeletionGroupList.contains(group.id)}" class="sr-only" th:text="#{index.table.group.locked}"></span>
             </td>
           </tr>
         </tbody>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
@@ -7,7 +7,7 @@
     <div id="menu" th:include="fragments/menus :: main (index)" />
     <div class="page-header"><h1 th:text="#{index.header.grouplist}"></h1></div>
     <div class="sak-banner-info" th:if="${groupList.isEmpty()}" th:text="#{index.warning.groupempty}">No groups in this site.</div>
-    <div class="instruction" th:if="${anyGroupLocked}"><span class="fa fa-fw fa-lock" aria-hidden="true"></span> - <span ria-hidden="true" th:text="#{index.table.grouplocked.info}"></span></div>
+    <div class="instruction" th:if="${anyGroupLocked}"><span class="fa fa-fw fa-lock" aria-hidden="true"></span> - <span aria-hidden="true" th:text="#{index.table.grouplocked.info}"></span></div>
     <form th:if="${!groupList.isEmpty()}" id="group-manager-form" action="#" th:action="@{/removeGroups}" th:object="${mainForm}" method="post">
       <table id="groupTable" class="table table-striped table-bordered table-hover">
         <thead>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46058

Users are routinely confused by the intention and purpose of locked groups, and we've had several support inquiries related to this. We were requested to update the information provided in Manage Groups to better explain the current state of group locking and how it interacts with certain tools.

The linked PR introduces some new information for the legend, as well as improving some a11y pieces around the lock icons, etc.

This may need to be expanded in the future as more tools utilize group locking, and more types of group locking are employed (currently there are 4 supported locking modes, but only 2 of them are actually utilized).