### PR TITLE
SAK-46075 GBNG > import > no error message when uploading file that exceeds max allowed size

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1982,6 +1982,10 @@
 # DEFAULT: false
 # gradebookng.allowColumnResizing=true
 
+# SAK-46075: max upload file size, defined in megabytes
+# DEFAULT: 2
+# gradebook.import.maxSize=3
+
 # ASSIGNMENT 1
 # Allows an instructor or any user with assignments management permissions to submit the assignment on behalf of a student 
 # who has no submission yet (via the View Assignment list by student)

--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -284,6 +284,7 @@ importExport.error.orphanedComments = The uploaded file contains the following o
 importExport.error.noFileSelected = You have not yet selected a file to upload. Please select the file you wish to import and click the 'Continue' button.
 importExport.error.noValidGrades = The uploaded file contains no grade columns. Please review the file and ensure it contains at least one importable column with valid grades.
 importExport.error.noChanges = The uploaded file contains no changes compared to the existing Gradebook data. Please review the file and ensure it contains at least one change to column or grade data.
+importExport.error.fileTooBig = The selected file is too large to import. Maximum size is {0} megabyte(s).
 
 importExport.selection.hideitems = Hide items with no changes
 importExport.selection.hideitemsallhidden = There are no imported items that have any changes.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46075

Currently if you provide a file which is over the hard coded 2MB limit for uploading in GBNG, nothing happens: the button is not enabled, there's no error on the UI, and you'll see the following in the logs:

> 8-Apr-2020 16:04:26.985 WARN [https-jsse-nio-8443-exec-1] org.sakaiproject.util.ResourceLoader.getString bundle 'org.sakaiproject.gradebookng.GradebookNgApplication'  missing key: 'form.uploadTooLarge'  from: org.sakaiproject.gradebookng.framework.GradebookNgStringResourceLoader.loadString(GradebookNgStringResourceLoader.java:46)

This PR introduces proper error messaging for this condition, as well as providing configuration for the maximum upload file size.

New property: `gradebook.import.maxSize` which defaults to 2 megabytes