### PR TITLE
SAK-46086 GBNG > export > include student #'s by default

### DIFF
--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -348,6 +348,7 @@ importExport.export.advancedOption.includeCategoryAverages = Category Averages
 importExport.export.csv.headers.studentId = Student ID
 importExport.export.csv.headers.studentDisplayId = Student Display ID
 importExport.export.csv.headers.studentName = Name
+importExport.export.csv.headers.studentNumber = Student Number
 importExport.export.csv.headers.points = Total Points
 importExport.export.csv.headers.courseGrade = Course Grade
 importExport.export.csv.headers.calculatedGrade = Calculated Grade

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -72,7 +72,7 @@ public class ExportPanel extends BasePanel {
 	ExportFormat exportFormat = ExportFormat.CSV;
 	boolean includeStudentName = true;
 	boolean includeStudentId = true;
-	boolean includeStudentNumber = false;
+	boolean includeStudentNumber = true;
 	private boolean includeSectionMembership = false;
 	boolean includeStudentDisplayId = false;
 	boolean includeGradeItemScores = true;
@@ -319,8 +319,8 @@ public class ExportPanel extends BasePanel {
 				if (isCustomExport && this.includeStudentDisplayId) {
 					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.studentDisplayId")));
 				}
-				if (isCustomExport && this.includeStudentNumber) {
-					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("column.header.studentNumber")));
+				if (!isCustomExport || this.includeStudentNumber) {
+					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("importExport.export.csv.headers.studentNumber")));
 				}
 				if (isCustomExport && this.includeSectionMembership) {
 					header.add(String.join(" ", IGNORE_COLUMN_PREFIX, getString("column.header.section")));
@@ -420,7 +420,7 @@ public class ExportPanel extends BasePanel {
 					if (isCustomExport && this.includeStudentDisplayId) {
 						line.add(studentGradeInfo.getStudentDisplayId());
 					}
-					if (isCustomExport && this.includeStudentNumber)
+					if (!isCustomExport || this.includeStudentNumber)
 					{
 						line.add(studentGradeInfo.getStudentNumber());
 					}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46086

Student #'s are important for instructors for a variety of reasons. If we have student #'s in the system, we should include them in the export by default for both regular and custom exports. Instructors can still elect to do a custom export without student #'s if they so desire.