### PR TITLE
SAK-46087 GBNG > import > item selection > no way to select all

### DIFF
--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -313,6 +313,10 @@ importExport.confirmation.commentsdisplay = {0} (Comments)
 importExport.confirmation.success = Gradebook items imported successfully!
 importExport.confirmation.failure = Errors during gradebook item import.
 
+importExport.label.selectAllNone = Select All / None
+importExport.label.selectItem = Select Item
+importExport.label.selectComment = Select Comment
+
 #ProcessedGradeItem.Status map
 importExport.status.UPDATE = Update
 importExport.status.NEW = New

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.html
@@ -14,7 +14,7 @@
 	    <table id="grade_import_selection" class="table table-condensed">
 	        <thead>
 	            <tr>
-	                <th class="col-xs-1">&nbsp;</th>
+	                <th class="col-xs-1"><input type="checkbox" id="selectAllNone" aria-controls="grade_import_selection" /></th>
 	                <th class="col-xs-6"><wicket:message key="importExport.selection.title" /></th>
 	                <th class="col-xs-2"><wicket:message key="importExport.selection.points" /></th>
 	                <th class="col-xs-3"><wicket:message key="importExport.selection.status" /></th>
@@ -23,14 +23,14 @@
 	        <tbody>
 				<wicket:container wicket:id="items">
 					<tr wicket:id="gb_item" class="gb_item">
-						<td><input type="checkbox" wicket:id="checkbox"/></td>
+						<td><input type="checkbox" wicket:id="checkbox" class="import_selection_item"/></td>
 						<td class="item_title"><wicket:container wicket:id="title">[assignment 1]</wicket:container></td>
 						<td class="item_points"><wicket:container wicket:id="points">[50]</wicket:container></td>
 						<td class="item_status"><wicket:container wicket:id="status">[no changes/new]</wicket:container></td>
 					</tr>
 						
 					<tr wicket:id="comments" class="comment">
-						<td><input type="checkbox" wicket:id="checkbox"/></td>
+						<td><input type="checkbox" wicket:id="checkbox" class="import_selection_comment"/></td>
 						<td class="item_title"><wicket:message key="importExport.commentname" /></td>
 						<td class="item_points">&nbsp;</td>
 						<td class="item_status"><wicket:container wicket:id="status">[no changes/new]</wicket:container></td>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.html
@@ -14,7 +14,7 @@
 	    <table id="grade_import_selection" class="table table-condensed">
 	        <thead>
 	            <tr>
-	                <th class="col-xs-1"><input type="checkbox" id="selectAllNone" aria-controls="grade_import_selection" /></th>
+	                <th class="col-xs-1"><input type="checkbox" id="selectAllNone" aria-controls="grade_import_selection" wicket:message="aria-label:importExport.label.selectAllNone" /></th>
 	                <th class="col-xs-6"><wicket:message key="importExport.selection.title" /></th>
 	                <th class="col-xs-2"><wicket:message key="importExport.selection.points" /></th>
 	                <th class="col-xs-3"><wicket:message key="importExport.selection.status" /></th>
@@ -23,14 +23,14 @@
 	        <tbody>
 				<wicket:container wicket:id="items">
 					<tr wicket:id="gb_item" class="gb_item">
-						<td><input type="checkbox" wicket:id="checkbox" class="import_selection_item"/></td>
+						<td><input type="checkbox" wicket:id="checkbox" class="import_selection_item" wicket:message="aria-label:importExport.label.selectItem" /></td>
 						<td class="item_title"><wicket:container wicket:id="title">[assignment 1]</wicket:container></td>
 						<td class="item_points"><wicket:container wicket:id="points">[50]</wicket:container></td>
 						<td class="item_status"><wicket:container wicket:id="status">[no changes/new]</wicket:container></td>
 					</tr>
 						
 					<tr wicket:id="comments" class="comment">
-						<td><input type="checkbox" wicket:id="checkbox" class="import_selection_comment"/></td>
+						<td><input type="checkbox" wicket:id="checkbox" class="import_selection_comment" wicket:message="aria-label:importExport.label.selectComment" /></td>
 						<td class="item_title"><wicket:message key="importExport.commentname" /></td>
 						<td class="item_points">&nbsp;</td>
 						<td class="item_status"><wicket:container wicket:id="status">[no changes/new]</wicket:container></td>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
@@ -32,6 +32,9 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
@@ -50,6 +53,7 @@ import org.sakaiproject.gradebookng.tool.component.GbStyleableWebMarkupContainer
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 import org.sakaiproject.gradebookng.tool.pages.ImportExportPage;
 import org.sakaiproject.gradebookng.tool.panels.BasePanel;
+import org.sakaiproject.portal.util.PortalUtils;
 
 /**
  * Page to allow the user to select which items in the imported file are to be imported
@@ -299,6 +303,10 @@ public class GradeItemImportSelectionStep extends BasePanel {
 
 						} else {
 							gbItemWrap.removeStyle(GbStyle.SELECTED);
+							if (commentItem.isSelectable()) {
+								commentItem.setSelected(false);
+								commentWrap.removeStyle(GbStyle.SELECTED);
+							}
 						}
 						gbItemWrap.style();
 						commentWrap.style();
@@ -438,5 +446,14 @@ public class GradeItemImportSelectionStep extends BasePanel {
 		rval.setType(Type.COMMENT);
 		rval.setStatus(Status.SKIP);
 		return rval;
+	}
+
+	@Override
+	public void renderHead(final IHeaderResponse response) {
+		super.renderHead(response);
+
+		final String version = PortalUtils.getCDNQuery();
+		response.render(JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/scripts/gradebook-import.js%s", version)));
+		response.render(OnDomReadyHeaderItem.forScript("$('#selectAllNone').click(function(){ GBI.selectAllNone(this); });"));
 	}
 }

--- a/gradebookng/tool/src/webapp/scripts/gradebook-import.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-import.js
@@ -1,0 +1,25 @@
+/**************************************************************************************
+ *                    Gradebook Import Javascript
+ *************************************************************************************/
+var GBI = GBI || {};
+
+GBI.selectAllNone = function( element )
+{
+	const selectAll = $(element).prop( "checked" );
+
+	// Toggling the gradebook item checkbox will also toggle it's corresponding comment checkbox if it has one, but not vice versa; see below comment
+	$(".import_selection_item").each( function() { GBI.toggleCheckBox( selectAll, this ); });
+
+	// This is needed in the case where comment is selected but associated gradebook item is not
+	$(".import_selection_comment").each( function() { GBI.toggleCheckBox( selectAll, this ); });
+};
+
+GBI.toggleCheckBox = function( selectAll, element )
+{
+	const checkbox = $(element);
+	if( (selectAll && !checkbox.prop( "checked" )) || (!selectAll && checkbox.prop( "checked" )) )
+	{
+		// Fire click handler so we don't have to duplicate the handler's logic here
+		checkbox.click();
+	}
+};


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46087

This is a regression compared to Sakai 11 GBNG. There used to be a a select all/none checkbox on this UI. It no longer exists in Sakai 20+.

Users may complain about this, especially those who import lots of new items or lots of changed items.

This PR restores the select all/none checkbox.