### PR TITLE
SAK-46088 GBNG > improve performance of 'Set Score for Empty Cells' algorithm

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -2247,48 +2247,44 @@ public class GradebookNgBusinessService {
 	public boolean updateUngradedItems(final long assignmentId, final double grade, final GbGroup group) {
 		final String siteId = getCurrentSiteId();
 		final Gradebook gradebook = getGradebook(siteId);
+		final Assignment assignment = getAssignment(assignmentId);
 
 		// get students
 		final List<String> studentUuids = (group == null) ? this.getGradeableUsers() : this.getGradeableUsers(group);
 
-		// get grades (only returns those where there is a grade)
-		final List<GradeDefinition> defs = this.gradebookService.getGradesForStudentsForItem(gradebook.getUid(),
-				assignmentId, studentUuids);
+		// get grades (only returns those where there is a grade, or comment; does not return those where there is no grade AND no comment)
+		final List<GradeDefinition> defs = this.gradebookService.getGradesForStudentsForItem(gradebook.getUid(), assignmentId, studentUuids);
 
-		// iterate and trim the studentUuids list down to those that don't have
-		// grades
-		for (final GradeDefinition def : defs) {
+		// Remove students who already have a grade
+		studentUuids.removeIf(studentUUID -> defs.stream().anyMatch(def -> studentUUID.equals(def.getStudentUid()) && StringUtils.isNotBlank(def.getGrade())));
+		defs.removeIf(def -> StringUtils.isNotBlank(def.getGrade()));
 
-			// don't remove those where the grades are blank, they need to be
-			// updated too
-			if (StringUtils.isNotBlank(def.getGrade())) {
-				studentUuids.remove(def.getStudentUid());
+		// Create new GradeDefinition objects for those students who do not have one
+		for (String studentUUID : studentUuids) {
+			if (defs.stream().noneMatch(def -> studentUUID.equals(def.getStudentUid()))) {
+				GradeDefinition def = new GradeDefinition();
+				def.setStudentUid(studentUUID);
+				def.setGradeEntryType(gradebook.getGrade_type());
+				def.setGradeReleased(gradebook.isAssignmentsDisplayed() && assignment.isReleased());
+				defs.add(def);
 			}
 		}
 
-		if (studentUuids.isEmpty()) {
+		// Short circuit
+		if (defs.isEmpty()) {
 			log.debug("Setting default grade. No students are ungraded.");
 		}
 
+		// Apply the new grade to the GradeDefinitions to be updated
+		for (GradeDefinition def : defs) {
+			def.setGrade(Double.toString(grade));
+			log.debug("Setting default grade. Values of assignmentId: {}, studentUuid: {}, grade: {}", assignmentId, def.getStudentUid(), grade);
+		}
+
+		// Batch update the GradeDefinitions, and post an event on completion
 		try {
-			// for each student remaining, add the grade
-			for (final String studentUuid : studentUuids) {
-
-				log.debug("Setting default grade. Values of assignmentId: {}, studentUuid: {}, grade: {}", assignmentId, studentUuid, grade);
-
-				// TODO if this is slow doing it one by one, might be able to
-				// batch it
-
-				// The service needs it otherwise it will assume 'null'
-				// so pull it back from the service and poke it in there!
-				final String comment = getAssignmentGradeComment(Long.valueOf(assignmentId), studentUuid);
-
-				this.gradebookService.saveGradeAndCommentForStudent(gradebook.getUid(), assignmentId, studentUuid,
-						FormatHelper.formatGradeForDisplay(String.valueOf(grade)), comment);
-			}
-
+			gradebookService.saveGradesAndComments(gradebook.getUid(), assignmentId, defs);
 			EventHelper.postUpdateUngradedEvent(gradebook, assignmentId, String.valueOf(grade), getUserRoleOrNone());
-
 			return true;
 		} catch (final Exception e) {
 			log.error("An error occurred updating the assignment", e);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46088

This algorithm suffers from some design decisions. Mainly, it sets each student's grade for each gradebook item to zero serially, rather than in batch. From GradebookNgBusinessService.updateUngradedItems():

```
			// for each student remaining, add the grade
			for (final String studentUuid : studentUuids) {

				log.debug("Setting default grade. Values of assignmentId: {}, studentUuid: {}, grade: {}", assignmentId, studentUuid, grade);

				// TODO if this is slow doing it one by one, might be able to
				// batch it
				this.gradebookService.saveGradeAndCommentForStudent(gradebook.getUid(), assignmentId, studentUuid, String.valueOf(grade), null);
			}
```

The comment even states that the author was aware of the potential performance problem here.

I tested the performance of this algorithm in a new site with 5000 student users and 20 completely empty gradebook items. It took 11,669 seconds to complete...

Change the algorithm to batch process all student grades for a particular gradebook item in one call to the database (in the same way we did for the gradebook import algorithm).

Also noticed that the original algorithm was loading existing comments twice, once in batch and once serially right before it attempted to save the grade, further reducing the efficiency. This is now abolished.

The performance improvement is sizeable (5-10x faster), and is in place for both a single gradebook item, as well as all gradebook items (course grade set zero score for empty cells) as the latter is just a loop over all gradebook items invoking the same service method.