### PR TITLE
SAK-45796 Accessibility in Forums: Alert not read by screen reader

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
@@ -81,6 +81,7 @@
 				// Improve accessibility in error messages.adding the error as title
 				var errorMessages = $('#revise\\:errorMessages');
 				if (errorMessages !== undefined) {
+					errorMessages.attr("role", "alert");
 					errorMessages.find('td').each(function() {
 						$(this).attr('title', $(this).html());
 					});


### PR DESCRIPTION
Hi, not much to say here 😅

With the role set as "alert" the errors are read by the screen reader

(I'm using NVDA for testing)