### PR TITLE
SAK-46091 Location of expansion icon for recurring meetings is inconstent between views

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/signup/_signup.scss
+++ b/library/src/morpheus-master/sass/modules/tool/signup/_signup.scss
@@ -11,11 +11,8 @@
 
 	.toggleMeetings{
 		cursor:pointer;
-		&.toggleDownload{
-			left: 5px;
-			top: -2px;
-			position: relative;
-			margin: 0 0 0 0;
+		&.toggleDownload img{
+			vertical-align: baseline;
 		}
 	}
 

--- a/signup/tool/src/webapp/signup/download/downloadSelections.jsp
+++ b/signup/tool/src/webapp/signup/download/downloadSelections.jsp
@@ -242,6 +242,14 @@
 							</h:panelGroup>
 							<%-- normal checkbox --%>
 							<h:selectBooleanCheckbox id="selectItem" value="#{wrapper.toDownload}" rendered="#{wrapper.recurEventsSize < 1}" styleClass="#{wrapper.recurId}"/>
+						</t:column>
+
+						<t:column defaultSorted="true" sortable="true">
+							<f:facet name="header" >
+								<t:commandSortHeader columnName="#{DownloadEventBean.signupSorter.titleColumn}" immediate="true" arrow="true">
+									<h:outputText value="#{msgs.tab_event_name}" escape="false"/>
+								</t:commandSortHeader>
+							</f:facet>
 							<h:panelGroup rendered="#{wrapper.firstOneRecurMeeting && wrapper.recurEventsSize >1}" styleClass="toggleMeetings toggleDownload">
 								<h:outputText value="<span id='imageOpen_RM_#{wrapper.recurId}' style='display:none'>"  escape="false"/>
 								<h:outputLink value="javascript:showDetails('imageOpen_RM_#{wrapper.recurId}','imageClose_RM_#{wrapper.recurId}');showAllRelatedRecurMeetings('#{wrapper.recurId}','#{DownloadEventBean.iframeId}');">
@@ -257,14 +265,7 @@
 		   	    				
 		   	    				<h:outputText value="&nbsp;" escape="false"/>
 		   	    			</h:panelGroup>
-						</t:column>		
-						
-						<t:column defaultSorted="true" sortable="true">
-							<f:facet name="header" >
-								<t:commandSortHeader columnName="#{DownloadEventBean.signupSorter.titleColumn}" immediate="true" arrow="true">
-									<h:outputText value="#{msgs.tab_event_name}" escape="false"/>
-								</t:commandSortHeader>
-							</f:facet>							
+
 							<h:outputText  value="#{wrapper.meeting.title}" />
 							
 						</t:column>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46091

For recurring meeting, the instances are collapsed by default with an expansion icon that will show them all when clicked. On the Meetings tab, the expansion icon is next to the meeting name, while on the Export tab it is next to the checkbox. This placement is inconsistent and may confuse some users.

In older versions of Sakai, the icon was next to the meeting name in both views. This changed in SAK-31259, but there is no indication it was intentional as the fix did not require changing the location of the icon.

For consistency, restore the icon on the Export tab back to its original location next to the meeting name.
