### PR TITLE
SAK-46092 GBNG > TA with permission to grade empty group can see non-roster students not present in the group

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -238,7 +238,8 @@ public class GradebookNgBusinessService {
 			// note that this list MUST exclude TAs as it is checked in the
 			// GradebookService and will throw a SecurityException if invalid
 			// users are provided
-			final Set<String> userUuids = this.siteService.getSite(givenSiteId).getUsersIsAllowed(GbRole.STUDENT.getValue());
+			Site site = siteService.getSite(givenSiteId);
+			final Set<String> userUuids = site.getUsersIsAllowed(GbRole.STUDENT.getValue());
 
 			// filter the allowed list based on membership
 			if (groupFilter != null && groupFilter.getType() != GbGroup.Type.ALL) {
@@ -295,13 +296,18 @@ public class GradebookNgBusinessService {
 						}
 					}
 
+					// If all group IDs in perms are null, this means TA has permission to view/grade All Sections/Groups.
+					// In this situation, we should add non-provided site members to their viewable list
+					List<String> nonProvidedMembers = site.getMembers().stream().filter(m -> !m.isProvided()).map(Member::getUserId).collect(Collectors.toList());
+					if (perms.stream().allMatch(p -> p.getGroupReference() == null)) {
+						viewableStudents.addAll(nonProvidedMembers);
+					}
+
 					if (!viewableStudents.isEmpty()) {
-						userUuids.retainAll(viewableStudents); // retain only
-																// those that
-																// are visible
-																// to this TA
+						userUuids.retainAll(viewableStudents); // retain only those that are visible to this TA
 					} else {
 						userUuids.removeAll(sectionManager.getSectionEnrollmentsForStudents(givenSiteId, userUuids).getStudentUuids()); // TA can view/grade students without section
+						userUuids.removeAll(nonProvidedMembers); // Filter out non-provided users
 					}
 				}
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46092

This is directly related to SAK-42468. TA's should only see those users who are members of the groups and/or sections they're assigned to. TA's should only see non-provided site members if the TA is assigned to the "All sections/groups" setting.