### PR TITLE
SAK-46093 GBNG > import > user data loss when navigating backwards through the wizard

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportSelectionStep.java
@@ -17,6 +17,7 @@ package org.sakaiproject.gradebookng.tool.panels.importExport;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,6 +146,28 @@ public class GradeItemImportSelectionStep extends BasePanel {
 		final Map<String, ProcessedGradeItem> commentMap = createCommentMap(allItems);
 		final Map<String, ProcessedGradeItem> gradeItemMap = createGradeItemMap(allItems);
 
+		// Set up the previous selections, if any
+		final List<ProcessedGradeItem> selectedItems = importWizardModel.getSelectedGradeItems() == null ? Collections.emptyList() : importWizardModel.getSelectedGradeItems();
+		for (ProcessedGradeItem prevSelection : selectedItems)
+		{
+			final String title = prevSelection.getItemTitle();
+			ProcessedGradeItem item = null;
+			switch (prevSelection.getType())
+			{
+				case GB_ITEM:
+					item = gradeItemMap.get(title);
+					break;
+				case COMMENT:
+					item = commentMap.get(title);
+					break;
+			}
+
+			if (item != null && item.isSelectable())
+			{
+				item.setSelected(true);
+			}
+		}
+
 		final Form<?> form = new Form("form");
 		add(form);
 
@@ -219,6 +242,7 @@ public class GradeItemImportSelectionStep extends BasePanel {
 				log.debug("Items to modify: {}", itemsToModify.size());
 
 				// set data for next page
+				importWizardModel.setSelectedGradeItems(itemsToProcess); // This is grades and comments now
 				importWizardModel.setItemsToCreate(itemsToCreate);
 				importWizardModel.setItemsToUpdate(itemsToUpdate);
 				importWizardModel.setItemsToModify(itemsToModify);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46093

If you import some items, change the values along the way in the wizard, reach the confirmation page, then navigate all the way back to the item selection stage, then start going forwards through the wizard again, you'll notice that all the changes you made originally have been lost. This is annoying for users. Let's preserve their input as they traverse through the wizard.

There is one known caveat here: if you navigate all the way back to the item selection step, this UI will show the original values from the imported spreadsheet. However, once you start going forwards through the item modification steps, you'll notice that all your previous modifications are still present.