### PR TITLE
SAK-46094 SiteStats > User Activity > Some calendar events can't be resolved

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/detailed/refresolvers/CalendarReferenceResolver.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/event/detailed/refresolvers/CalendarReferenceResolver.java
@@ -62,7 +62,7 @@ public class CalendarReferenceResolver
         }
 
         GenericRefParser.GenericEventRef ref = CalendarRefParser.parse( eventType, eventRef, tips );
-        String calendarRef = "/calendar/calendar/" + ref.contextId + "/";
+        String calendarRef = "/calendar/calendar/" + ref.contextId + "/" + ref.subContextId;
         try
         {
             // 1. some calendar.read refs do not contain an event id and details can't be retrieved


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46094

Calendar events calendar.new and calendar.revise can't be resolved due to a missing calendar id.