### PR TITLE
SAK-46095 GBNG > export > external gb items should be marked with the ignore prefix

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -355,11 +355,15 @@ public class ExportPanel extends BasePanel {
 						final Assignment a2 = ((i + 1) < assignments.size()) ? assignments.get(i + 1) : null;
 
 						final String assignmentPoints = FormatHelper.formatGradeForDisplay(a1.getPoints().toString());
+						String externalPrefix = "";
+						if (a1.isExternallyMaintained()) {
+							externalPrefix = IGNORE_COLUMN_PREFIX;
+						}
 						if (!isCustomExport || this.includeGradeItemScores) {
-							header.add(a1.getName() + " [" + StringUtils.removeEnd(assignmentPoints, formattedText.getDecimalSeparator() + "0") + "]");
+							header.add(externalPrefix + a1.getName() + " [" + StringUtils.removeEnd(assignmentPoints, formattedText.getDecimalSeparator() + "0") + "]");
 						}
 						if (!isCustomExport || this.includeGradeItemComments) {
-							header.add(String.join(" ", COMMENTS_COLUMN_PREFIX, a1.getName()));
+							header.add(String.join(" ", externalPrefix, COMMENTS_COLUMN_PREFIX, a1.getName()));
 						}
 						
 						if (isCustomExport && this.includeCategoryAverages


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46095

Since re-importing external gradebook items is not allowed, external items should be marked with the ignore prefix when exporting the gradebook.