### PR TITLE
SAK-46097 GBNG > Settings > Statistics > change 'assignment' wording to 'gradebook item'

### DIFF
--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -461,7 +461,7 @@ settingspage.gradeentry.percentages = Percentages
 settingspage.graderelease.label = Display released Gradebook items to students
 settingspage.graderelease.instructions = You can release a Gradebook item when creating or editing the Gradebook item. 
 
-settingspage.statistics.assignment.label = Display assignment statistics to students
+settingspage.statistics.assignment.label = Display Gradebook items' statistics to students
 settingspage.statistics.coursegrade.label = Display course grade statistics to students
 
 settingspage.displaycoursegrade.label = Display final course grade to students


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46097

In Gradebook > Settings > Statistics, the option says "Display assignment statistics to students". Even though Gradebook refers to items as "assignments" internally, that terminology isn't used on the frontend and confuses end-users.

Change to "Display Gradebook items' statistics to students"