### PR TITLE
SAK-46098 GBNG > Item Order > Cancel button needlessly refreshes the page

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsPanel.html
@@ -12,7 +12,7 @@
 					<button wicket:id="submit" class="active">
 						<wicket:container wicket:id="label"/>
 					</button>
-					<button class="button_color">
+					<button class="button_color" type="submit" wicket:id="cancel">
 						<wicket:message key="button.cancel"/>
 					</button>
 				</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsPanel.java
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.markup.html.basic.Label;
@@ -37,6 +36,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
+import org.sakaiproject.wicket.component.SakaiAjaxButton;
 
 @Slf4j
 public class SortGradeItemsPanel extends Panel {
@@ -64,7 +64,7 @@ public class SortGradeItemsPanel extends Panel {
 
 		final Form<Void> form = new Form<>("form");
 
-		final AjaxButton submit = new AjaxButton("submit") {
+		final SakaiAjaxButton submit = new SakaiAjaxButton("submit") {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -119,6 +119,7 @@ public class SortGradeItemsPanel extends Panel {
 				setResponsePage(getPage().getPageClass());
 			}
 		};
+		submit.setWillRenderOnClick(true);
 
 		if (categoriesEnabled) {
 			tabs.add(new AbstractTab(new Model<String>(getString("sortgradeitems.bycategory"))) {
@@ -160,6 +161,16 @@ public class SortGradeItemsPanel extends Panel {
 			}
 		});
 
+		SakaiAjaxButton cancel = new SakaiAjaxButton("cancel") {
+			@Override
+			public void onSubmit(final AjaxRequestTarget target, final Form<?> form) {
+				SortGradeItemsPanel.this.window.close(target);
+			}
+		};
+		cancel.setDefaultFormProcessing(false);
+		cancel.setWillRenderOnClick(true);
+
+		form.add(cancel);
 		form.add(submit);
 		add(form);
 	}

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/components/paging/infinite/InfinitePagingNavigationIncrementButton.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/components/paging/infinite/InfinitePagingNavigationIncrementButton.java
@@ -18,7 +18,7 @@ package org.sakaiproject.sitestats.tool.wicket.components.paging.infinite;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.form.Form;
-import org.sakaiproject.sitestats.tool.wicket.components.SakaiAjaxButton;
+import org.sakaiproject.wicket.component.SakaiAjaxButton;
 
 /**
  * Button for navigating between pages of the SakaiInfinitePagingDataTable

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/components/useractivity/EventRefDetailsButtonPanel.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/components/useractivity/EventRefDetailsButtonPanel.java
@@ -23,7 +23,7 @@ import org.apache.wicket.model.IModel;
 import org.sakaiproject.sitestats.api.event.detailed.DetailedEvent;
 import org.sakaiproject.sitestats.api.event.detailed.DetailedEventsManager;
 import org.sakaiproject.sitestats.tool.facade.Locator;
-import org.sakaiproject.sitestats.tool.wicket.components.SakaiAjaxButton;
+import org.sakaiproject.wicket.component.SakaiAjaxButton;
 
 /**
  * A panel showing a button that can be clicked to show more details about an event

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/UserActivityPage.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/UserActivityPage.java
@@ -47,11 +47,11 @@ import org.sakaiproject.sitestats.tool.facade.Locator;
 import org.sakaiproject.sitestats.tool.util.Tools;
 import org.sakaiproject.sitestats.tool.wicket.components.LastJobRun;
 import org.sakaiproject.sitestats.tool.wicket.components.Menus;
-import org.sakaiproject.sitestats.tool.wicket.components.SakaiAjaxButton;
 import org.sakaiproject.sitestats.tool.wicket.components.useractivity.UserTrackingResultsPanel;
 import org.sakaiproject.sitestats.tool.wicket.models.LoadableDisplayUserListModel;
 import org.sakaiproject.sitestats.tool.wicket.models.LoadableDisplayUserListModel.DisplayUser;
 import org.sakaiproject.sitestats.tool.wicket.models.LoadableToolIdListModel;
+import org.sakaiproject.wicket.component.SakaiAjaxButton;
 import org.sakaiproject.wicket.component.SakaiDateTimeField;
 
 /**

--- a/wicket/wicket6/src/java/org/sakaiproject/wicket/component/AbstractSakaiSpinnerAjaxCallListener.java
+++ b/wicket/wicket6/src/java/org/sakaiproject/wicket/component/AbstractSakaiSpinnerAjaxCallListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006-2018 The Apereo Foundation
+ * Copyright (c) 2006-2021 The Apereo Foundation
  *
  * Licensed under the Educational Community License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sakaiproject.sitestats.tool.wicket.components;
+package org.sakaiproject.wicket.component;
 
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
 

--- a/wicket/wicket6/src/java/org/sakaiproject/wicket/component/SakaiAjaxButton.java
+++ b/wicket/wicket6/src/java/org/sakaiproject/wicket/component/SakaiAjaxButton.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006-2018 The Apereo Foundation
+ * Copyright (c) 2006-2021 The Apereo Foundation
  *
  * Licensed under the Educational Community License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sakaiproject.sitestats.tool.wicket.components;
+package org.sakaiproject.wicket.component;
 
 import org.apache.wicket.ajax.AjaxChannel;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;

--- a/wicket/wicket6/src/java/org/sakaiproject/wicket/component/SakaiSpinnerAjaxCallListener.java
+++ b/wicket/wicket6/src/java/org/sakaiproject/wicket/component/SakaiSpinnerAjaxCallListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006-2019 The Apereo Foundation
+ * Copyright (c) 2006-2021 The Apereo Foundation
  *
  * Licensed under the Educational Community License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sakaiproject.sitestats.tool.wicket.components;
+package org.sakaiproject.wicket.component;
 
 /**
  * Adds the Sakai overlay spinner to the component making the Ajax call

--- a/wicket/wicket8/src/java/org/sakaiproject/wicket/component/AbstractSakaiSpinnerAjaxCallListener.java
+++ b/wicket/wicket8/src/java/org/sakaiproject/wicket/component/AbstractSakaiSpinnerAjaxCallListener.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2006-2021 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.wicket.component;
+
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+
+/**
+ * Abstract base class for AjaxCallListeners used to apply a spinner overlay to the component while Ajax call in progress
+ * @author plukasew
+ */
+public abstract class AbstractSakaiSpinnerAjaxCallListener extends AjaxCallListener
+{
+	private static final long serialVersionUID = 1L;
+	protected static final String SPINNER_CLASS = "spinButton";
+	protected static final String DISABLED = "$('#%s').prop('disabled', true);";
+	protected static final String ENABLED = "$('#%s').prop('disabled', false);";
+
+	protected boolean willRender = false;
+	protected String id = "";
+
+	/**
+	 * Call listener to overlay a spinner and disable the a clicked component
+	 * @param componentMarkupId the markup id for the component
+	 * @param componentWillRender whether or not the component will be re-rendered as a result of the ajax update
+	 */
+	public AbstractSakaiSpinnerAjaxCallListener(String componentMarkupId, boolean componentWillRender)
+	{
+		id = componentMarkupId;
+		willRender = componentWillRender;
+	}
+}

--- a/wicket/wicket8/src/java/org/sakaiproject/wicket/component/SakaiAjaxButton.java
+++ b/wicket/wicket8/src/java/org/sakaiproject/wicket/component/SakaiAjaxButton.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2006-2021 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.wicket.component;
+
+import org.apache.wicket.ajax.AjaxChannel;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.markup.html.form.Form;
+
+/**
+ * Disables the button on click, sets the standard Sakai spinner on it, and removes it/re-enables the button after the Ajax call completes.
+ *
+ * @author plukasew
+ */
+public class SakaiAjaxButton extends AjaxButton
+{
+	private static final long serialVersionUID = 1L;
+	protected boolean willRenderOnClick = false;
+
+	public SakaiAjaxButton(String id) {
+		super(id);
+	}
+
+	public SakaiAjaxButton(String id, Form<?> form) {
+		super(id, form);
+	}
+
+	/**
+	 * Whether or not the button itself will be re-rendered as part of the ajax update
+	 * @param value true if button will be re-rendered
+	 * @return the button, for method chaining
+	 */
+	public SakaiAjaxButton setWillRenderOnClick(boolean value)
+	{
+		willRenderOnClick = value;
+		return this;
+	}
+
+	@Override
+	protected void updateAjaxAttributes(AjaxRequestAttributes attributes)
+	{
+		super.updateAjaxAttributes(attributes);
+		attributes.setChannel(new AjaxChannel("blocking", AjaxChannel.Type.ACTIVE));
+
+		AjaxCallListener listener = new SakaiSpinnerAjaxCallListener(getMarkupId(), willRenderOnClick);
+		attributes.getAjaxCallListeners().add(listener);
+	}
+}

--- a/wicket/wicket8/src/java/org/sakaiproject/wicket/component/SakaiSpinnerAjaxCallListener.java
+++ b/wicket/wicket8/src/java/org/sakaiproject/wicket/component/SakaiSpinnerAjaxCallListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006-2018 The Apereo Foundation
+ * Copyright (c) 2006-2021 The Apereo Foundation
  *
  * Licensed under the Educational Community License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sakaiproject.sitestats.tool.wicket.components.dropdown;
-
-import org.sakaiproject.wicket.component.AbstractSakaiSpinnerAjaxCallListener;
+package org.sakaiproject.wicket.component;
 
 /**
- * Adds the Sakai overlay spinner to the component
+ * Adds the Sakai overlay spinner to the component making the Ajax call
  * @author plukasew
  */
-public class SakaiSpinningSelectAjaxCallListener extends AbstractSakaiSpinnerAjaxCallListener
+public class SakaiSpinnerAjaxCallListener extends AbstractSakaiSpinnerAjaxCallListener
 {
 	private static final long serialVersionUID = 1L;
-	private static final String SPIN = "$('#%s').parent().addClass('" + SPINNER_CLASS + "');";
-	private static final String STOP = "$('#%s').parent().removeClass('" + SPINNER_CLASS + "');";
+	private static final String SPIN = "$('#%s').addClass('" + SPINNER_CLASS + "');";
+	private static final String STOP = "$('#%s').removeClass('" + SPINNER_CLASS + "');";
 	private static final String DISABLE_AND_SPIN = DISABLED + SPIN;
 	private static final String ENABLE_AND_STOP = ENABLED + STOP;
 
@@ -33,7 +31,7 @@ public class SakaiSpinningSelectAjaxCallListener extends AbstractSakaiSpinnerAja
 	 * Constructor
 	 * @param componentMarkupId the markup id of the component making the ajax call
 	 */
-	public SakaiSpinningSelectAjaxCallListener(String componentMarkupId)
+	public SakaiSpinnerAjaxCallListener(String componentMarkupId)
 	{
 		this(componentMarkupId, false);
 	}
@@ -43,16 +41,15 @@ public class SakaiSpinningSelectAjaxCallListener extends AbstractSakaiSpinnerAja
 	 * @param componentMarkupId the markup id of the component making the ajax call
 	 * @param componentWillRender whether the ajax call will result in the component being re-rendered
 	 */
-	public SakaiSpinningSelectAjaxCallListener(String componentMarkupId, boolean componentWillRender)
+	public SakaiSpinnerAjaxCallListener(String componentMarkupId, boolean componentWillRender)
 	{
 		super(componentMarkupId, componentWillRender);
 
-		// on the client side, disable the control and show the spinner after the ajax request is initiated
-		// so that the value of the select can be sent as part of the request
-		onAfter(String.format(DISABLE_AND_SPIN, id, id));
+		// on the client side, disable the control and show the spinner after click
+		onBefore(String.format(DISABLE_AND_SPIN, id, id));
 
 		// if the control is re-rendered the disabled property will be set by wicket and the spinner
-		// class will not be on the control as wicket doesn't know about it
+		// class will not be on the component as wicket doesn't know about it
 		if (!willRender)
 		{
 			onComplete(String.format(ENABLE_AND_STOP, id, id));


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46098

Clicking "Cancel" on the Item Order modal causes the Gradebook to reload, which is annoying to have to wait on for large gradebooks when nothing has changed.

The linked PR also adds spinners to both buttons in the modal. To accomplish the spinners, the `SakaiAjaxButton` component (and related classes) were lifted out of sitestats and put into both the Wicket 6 and 8 libraries for use among all Wicket tools.