### PR TITLE
SAK-46099 GBNG > Set Score for Empty Cells > no primary action button

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/UpdateUngradedItemsPanel.html
@@ -37,9 +37,9 @@
 					</div>
 				</div>
 
-				<div class="col-xs-offset-4 col-xs-5">
-					<button class="button_color gb-update-ungraded-fake-submit"><wicket:message key="button.done" /></button>
-					<input type="submit" class="hide gb-update-ungraded-real-submit" wicket:id="submit" wicket:message="value:button.update" />
+				<div class="col-xs-offset-4 col-xs-5 act">
+					<button class="button_color gb-update-ungraded-fake-submit active"><wicket:message key="button.done" /></button>
+					<input type="submit" class="hide gb-update-ungraded-real-submit active" wicket:id="submit" wicket:message="value:button.update" />
 					<button wicket:id="cancel"><wicket:message key="button.cancel"/></button>
 				</div>
 				
@@ -62,8 +62,8 @@
 								<p><wicket:message key="label.updateungradeditems.confirmation.extracredit" /></p>
 							{/if}
 						</div>
-						<div class="modal-footer">
-							<button type="button" class="button_color gb-update-ungraded-continue" data-dismiss="modal"><wicket:message key="label.updateungradeditems.confirmation.continue" /></button>
+						<div class="modal-footer act">
+							<button type="button" class="button_color gb-update-ungraded-continue active" data-dismiss="modal"><wicket:message key="label.updateungradeditems.confirmation.continue" /></button>
 							<button type="button" class="gb-update-ungraded-cancel" data-dismiss="modal"><wicket:message key="label.updateungradeditems.confirmation.cancel" /></button>
 						</div>
 					</div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46099

The modal produced when setting score for empty cells lacks primary buttons, as does the secondary confirmation modal.