### PR TITLE
SAK-46100 ELFinder > disable 'download' button for all entity types except resources

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/elfinder/ReadOnlyFsVolume.java
+++ b/kernel/api/src/main/java/org/sakaiproject/elfinder/ReadOnlyFsVolume.java
@@ -56,7 +56,7 @@ public abstract class ReadOnlyFsVolume  implements SakaiFsVolume {
 
     @Override
     public void filterOptions(SakaiFsItem item, Map<String, Object> map) {
-        map.put("disabled", Arrays.asList(new String[]{"create", "rm", "duplicate", "rename", "mkfile", "mkdir", "search", "zipdl"}));
+        map.put("disabled", Arrays.asList(new String[]{"create", "rm", "duplicate", "rename", "mkfile", "mkdir", "search", "zipdl", "download"}));
         // Disable chunked uploads.
         map.put("uploadMaxConn", "-1");
     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46100

If you attempt to "Download" (floppy disc icon) any entity other than resources via "Browse Server", it will silently fail and the following stack trace will be present in the log (see stack trace in JIRA).

It doesn't make sense to download any entity types except Resources, so let's disable this button for everything else.

Since resources is the only thing that currently doesn't extend `ReadOnlyFsVolume`, this is a simple change.