### PR TITLE
SAK-45553 Cannot uncheck group by category in grade summary

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GradebookUiSettings.java
@@ -61,6 +61,7 @@ public class GradebookUiSettings implements Serializable {
 	private boolean categoriesEnabled;
 
 	@Getter
+	@Setter
 	private boolean groupedByCategory;
 
 	private final Map<Long, Boolean> assignmentVisibility;
@@ -167,11 +168,6 @@ public class GradebookUiSettings implements Serializable {
 	public void setCategoriesEnabled(final boolean categoriesEnabled) {
 		this.categoriesEnabled = categoriesEnabled;
 		this.groupedByCategory = categoriesEnabled;
-		this.gradeSummaryGroupedByCategory = categoriesEnabled;
-	}
-
-	public void setGroupedByCategory(final boolean groupedByCategory) {
-		this.groupedByCategory = groupedByCategory;
 		this.gradeSummaryGroupedByCategory = categoriesEnabled;
 	}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -546,6 +546,7 @@ public class GradebookPage extends BasePage {
 
 		if (settings == null) {
 			settings = new GradebookUiSettings();
+			settings.setCategoriesEnabled(this.businessService.categoriesAreEnabled());
 			settings.initializeCategoryColors(this.businessService.getGradebookCategories());
 			settings.setCategoryColor(getString(GradebookPage.UNCATEGORISED), GradebookUiSettings.generateRandomRGBColorString(null));
 			setUiSettings(settings);
@@ -554,10 +555,7 @@ public class GradebookPage extends BasePage {
 		// See if the user has a database-persisted preference for Group by Category
 		String userGbUiCatPref = this.businessService.getUserGbPreference("GROUP_BY_CAT");
 		if (StringUtils.isNotBlank(userGbUiCatPref)) {
-			settings.setCategoriesEnabled(new Boolean(userGbUiCatPref));
-		}
-		else {
-			settings.setCategoriesEnabled(this.businessService.categoriesAreEnabled());
+			settings.setGroupedByCategory(Boolean.valueOf(userGbUiCatPref));
 		}
  
 		return settings;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45553

The group by category button on the student summary modal does nothing when you click it.