### PR TITLE
SAK-46102 ELFinder > samigo heading is 'assessments' rather than 'tests & quizzes'

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/elfinder/AssessmentToolFsVolumeFactory.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/elfinder/AssessmentToolFsVolumeFactory.java
@@ -111,7 +111,7 @@ public class AssessmentToolFsVolumeFactory implements ToolFsVolumeFactory {
         @Override
         public String getName() {
             // TODO i18n
-            return "Assessments";
+            return "Tests & Quizzes";
         }
 
         @Override


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46102

This is a regression introduced in SAK-32130. Prior to this change, the heading for samigo when you "Browse Server" was "Tests & Quizzes". Now in 21+ it's titled "Assessments". This is confusing for users who don't know what assessments are, and think it's a duplicate of assignments.

Revert to the naming convention used in the UI, not the naming convention used in code.