### PR TITLE
SAK-46106 Library: Added two-tone colours to the Sakai top header bar

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -24,24 +24,34 @@ body.is-logged-out{
 }
 
 .#{$namespace}mainHeader{
-		border-bottom:1px solid var(--sakai-border-color);
-		position: relative;
+	border-bottom:1px solid var(--sakai-border-color);
+	position: relative;
 
-		.#{$namespace}headerLogo{
+	.#{$namespace}headerLogo{
+		display: flex;
+		justify-content: space-between;
 		width: 100%;
-		padding: 0 $standard-spacing;
+		padding: 0;
 		height: $banner-height;
 		background: var(--top-header-background);
 		text-align: center;
-		@include transition( width 0.5s linear 0s );
+		@media #{$phone}{
+			display: inline-block;
+		}
 
 		.#{$namespace}headerLogo--institution{
-			background: var(--logo) no-repeat center center;
-			width: var(--logo-width);
+			width: $tool-menu-width;
 			height: 100%; // align vertically center
-			float: left;
+			background: var(--logo) no-repeat center center;
 			background-size: var(--logo-width) var(--logo-height);
+			background-color: var(--logo-background-color);
 			opacity: var(--logo-opacity);
+
+			@media #{$phone}{
+				float: left;
+				width: calc(#{$standard-spacing} + #{var(--logo-width)});
+				margin-right: $standard-space-2x;
+			}
 		}
 	}
 
@@ -244,6 +254,10 @@ body.is-logged-out{
 		@include display-flex;
 		@include align-items( center );
 		@include justify-content( flex-end );
+		margin-right: $standard-spacing;
+		@media #{$phone}{
+			margin-right: $standard-space-2x;
+		}
 
 		#roleSwitch {
 			@include display-flex;
@@ -381,7 +395,6 @@ body.is-logged-out{
 			top: -4.2em;
 		}
 	}
-
 }
 
 #mastLogin{
@@ -392,10 +405,6 @@ body.is-logged-out{
 		line-height: 2.3em;
 	}
 
-	@media #{$phone}{
-		width: calc(100% - #{var(--logo-width)});
-	}
-
 	ul{
 		display: inline-block;
 		text-align: left;
@@ -403,11 +412,9 @@ body.is-logged-out{
 		margin-bottom:0px;
 	}
 
-
 	.is-hidden{
 		display: none;
 	}
-
 
 	#loginForm{
 

--- a/library/src/morpheus-master/sass/modules/quicklinks/_base.scss
+++ b/library/src/morpheus-master/sass/modules/quicklinks/_base.scss
@@ -1,9 +1,11 @@
+#quickLinks.#{$namespace}quickLinksNav {
+    padding: 0;
+}
 .#{$namespace}quickLinksNav__popup {
   @extend .view-all-sites-btn;
   @include display-flex;
   @include align-items(center);
   height: 100%;
-  border-right: 1px solid var(--topNav-border-color);
 
   .fa-external-link-square{
     @extend .all-sites-icon;

--- a/library/src/morpheus-master/sass/themes/_light.scss
+++ b/library/src/morpheus-master/sass/themes/_light.scss
@@ -46,6 +46,7 @@
     --logo-height: 36px;
     --logo-width: 126px;
     --logo-opacity: 1;
+    --logo-background-color: var(--sakai-primary-color-1);
 
     // Primary branding color. 
     // Suggested: Your institution's main branding color.
@@ -181,7 +182,7 @@
     --tool-tab-active-background-color: var(--sakai-background-color-1);
     --tool-tab-active-highlight-color:var(--sakai-active-color-3);
 
-    --top-header-background: var(--sakai-primary-color-1);
+    --top-header-background: var(--sakai-color-gray--darker-7);
     --top-header-profile-border-color-top: var(--sakai-secondary-color-1);
     --top-header-profile-border-color-right: var(--sakai-secondary-color-1);
     --top-header-profile-border-color-bottom: var(--sakai-tertiary-color-1);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46106

Adding two-tone colours to the top header bar for greater branding customization as well as a visual transition for 22 to act as a transition to the new "Trinity" design coming in a later Sakai version. Also fixed some minor issues with the header bar. 

See SAK-46106 for after screenshots.