### PR TITLE
SAK-45646 Gradebook: In mobile, column headings cover user menu

### DIFF
--- a/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -104,7 +104,7 @@ body.is-logged-out{
 		position: fixed;
 		top: 0;
 		width: 100%;
-		z-index: 20;
+		z-index: 97;
 	}
 }
 


### PR DESCRIPTION
Hi, this is a small UI change, only visible for small devices

The problem was caused because a parent of the popover element had a z-index lower than the gradebook header

![image](https://user-images.githubusercontent.com/33053368/130951386-be804749-86dd-4e40-852f-cc096f803eb5.png)
