### PR TITLE
SAK-46111 Gradebook > Add null check during save grade routine

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -834,7 +834,7 @@ public class GradebookNgBusinessService {
 			final Double newGradePoints = FormatHelper.validateDouble(newGradeAdjusted);
 
 			// if over limit, still save but return the warning
-			if (newGradePoints.compareTo(maxPoints) > 0) {
+			if (newGradePoints != null && newGradePoints.compareTo(maxPoints) > 0) {
 				log.debug("over limit. Max: {}", maxPoints);
 				rval = GradeSaveResponse.OVER_LIMIT;
 			}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46111

While it is no longer possible to trigger the NPE in the same way, in previous versions of Sakai we have encountered NPEs in the grade save routine. Adding an extra null check there shouldn't hurt.