### PR TITLE
SAK-46113 Gradebook > Some columns don't sort properly in gradebooks with many columns

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -6,7 +6,7 @@
         </div>
 
         <script id="courseGradeHeaderTemplate" type="text/template">
-            <span class="colHeader hide">${col}</span>
+            <span class="colHeader hide" data-col-index="${col}">${col}</span>
             <div class="relative">
                 <a class="gb-title">
                     <wicket:message key="column.header.coursegrade"/>
@@ -64,7 +64,7 @@
             </div>
         </script>
         <script id="assignmentHeaderTemplate" type="text/template">
-            <span class="colHeader hide">${col}</span>
+            <span class="colHeader hide" data-col-index="${col}">${col}</span>
             <div class="relative">
                 {if extraCredit}
                     <span class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracredit"></span>
@@ -159,7 +159,7 @@
             </div>
         </script>
         <script id="categoryScoreHeaderTemplate" type="text/template">
-            <span class="colHeader hide">${col}</span>
+            <span class="colHeader hide" data-col-index="${col}">${col}</span>
             <div class="relative">
                 {if extraCredit}
                     <span class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracreditcategory"></span>
@@ -206,7 +206,7 @@
         </script>
         <script id="studentHeaderTemplate" type="text/template">
             <div class="relative">
-                <div class="colHeader">
+                <div class="colHeader" data-col-index="${col}">
                     <a class="gb-title">
                         <wicket:message key="column.header.students"/>
                     </a>
@@ -231,7 +231,7 @@
         </script>
         <script id="studentNumberHeaderTemplate" type="text/template">
             <div class="relative">
-                <div class="colHeader">
+                <div class="colHeader" data-col-index="${col}">
                     <a class="gb-title">
                         <wicket:message key="column.header.studentNumber"/>
                     </a>
@@ -249,7 +249,7 @@
         </script>
         <script id="sectionsHeaderTemplate" type="text/template">
             <div class="relative">
-                <div class="colHeader">
+                <div class="colHeader" data-col-index="${col}">
                     <a class="gb-title">
                         <wicket:message key="column.header.sections"/>
                     </a>

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -2163,7 +2163,19 @@ GbGradeTable.setupColumnSorting = function() {
   $table.on("click", ".gb-title", function() {
     var $handle = $(this);
 
-    var colIndex = $handle.closest("th").index();
+    let colIndex = -1;
+    const $colHeader = $handle.closest("th").find(".colHeader");
+    if ($colHeader.length > 0 && "colIndex" in $colHeader[0].dataset) {
+        const index = parseInt($colHeader[0].dataset.colIndex, 10);
+        if (!isNaN(index)) {
+            colIndex = index;
+        }
+    }
+
+    if (colIndex < 0) {
+        log.error("Unable to find column index for sorting.");
+        return;
+    }
 
     if (GbGradeTable.currentSortColumn != colIndex) {
       GbGradeTable.currentSortColumn = colIndex;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46113

In a gradebook with many columns, sorting works for columns that are visible when the Gradebook is loaded. However, columns which you must scroll to see may exhibit incorrect sorting.

This happens because the sorting routine in Gradebook's custom JavaScript is not aware that Handsontable may remove column markup that is not currently visible due to scrolling.

--------------

Columns were sorting using $handle.closest("th").index(). The index() function is jquery that returns the element's position among its siblings. This works fine until you reach the point where Handsontable decides to remove the markup for the columns that aren't shown on screen. I'm not sure what threshold actually triggers this, but if you watch the markup as you scroll a large gradebook to the right, there will come a point where the leftmost columns disappear from the markup. Since they are no longer there, the index that jquery reports is no longer accurate for the overall table data.

This PR adds an explicit column index into the markup for all column headers, and uses that to sort on. 
