### PR TITLE
SAK-46115 assignments > ability to disable setting to send grades to existing gradebook item

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentConstants.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentConstants.java
@@ -315,4 +315,25 @@ public final class AssignmentConstants {
     public static final String PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT = "prop_new_assignment_add_to_gradebook";
 
     public static final String NEW_ASSIGNMENT_ADD_TO_GRADEBOOK = "new_assignment_add_to_gradebook";
+
+	/**
+	 * Sakai property key to change the default value for the 'Add due date to calendar' checkbox
+	 */
+	public static final String SAK_PROP_DUE_DATE_TO_CALENDAR_DEFAULT = "asn.due.date.to.calendar.default";
+
+	/**
+	 * Sakai.property for enable/disable anonymous grading
+	 */
+	public static final String SAK_PROP_ENABLE_ANON_GRADING = "assignment.anon.grading.enabled";
+
+	/**
+	 * Site property for forcing anonymous grading in a site
+	 */
+	public static final String SAK_PROP_FORCE_ANON_GRADING = "assignment.anon.grading.forced";
+
+	/*
+	 * Sakai property for allowing the ability for an assignment to send grades to an existing gradebook item
+	 */
+	public static final String SAK_PROP_ALLOW_LINK_TO_EXISTING_GB_ITEM = "assignment.allowLinkToExistingGBItem";
+	public static final boolean SAK_PROP_ALLOW_LINK_TO_EXISTING_GB_ITEM_DFLT = true;
 }

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -320,10 +320,6 @@ public class AssignmentAction extends PagedResourceActionII {
      */
     private static final String ADDITIONAL_CALENDAR_TOOL_READY = "additional_calendar_tool_ready";
     /**
-     * Sakai property key to change the default value for the 'Add due date to calendar' checkbox
-     */
-    private static final String SAK_PROP_DUE_DATE_TO_CALENDAR_DEFAULT = "asn.due.date.to.calendar.default";
-    /**
      * Default value for the 'Add due date to calendar' checkbox
      */
     private static final boolean DUE_DATE_TO_CALENDAR_DEFAULT = true;
@@ -1027,14 +1023,6 @@ public class AssignmentAction extends PagedResourceActionII {
      * To know if grade_submission go from view_students_assignment view or not
      **/
     private static final String FROM_VIEW = "from_view";
-    /**
-     * Sakai.property for enable/disable anonymous grading
-     */
-    private static final String SAK_PROP_ENABLE_ANON_GRADING = "assignment.anon.grading.enabled";
-    /**
-     * Site property for forcing anonymous grading in a site
-     */
-    private static final String SAK_PROP_FORCE_ANON_GRADING = "assignment.anon.grading.forced";
 
     private static final String FLAG_ON = "on";
     private static final String FLAG_TRUE = "true";
@@ -2739,11 +2727,11 @@ public class AssignmentAction extends PagedResourceActionII {
         initState(state, portlet, (JetspeedRunData) data);
 
         // Anon grading enabled/disabled
-        context.put("enableAnonGrading", serverConfigurationService.getBoolean(SAK_PROP_ENABLE_ANON_GRADING, false));
+        context.put("enableAnonGrading", serverConfigurationService.getBoolean(AssignmentConstants.SAK_PROP_ENABLE_ANON_GRADING, false));
         boolean forceAnonGrading = false;
         try {
             Site site = siteService.getSite((String) state.getAttribute(STATE_CONTEXT_STRING));
-            forceAnonGrading = site.getProperties().getBooleanProperty(SAK_PROP_FORCE_ANON_GRADING);
+            forceAnonGrading = site.getProperties().getBooleanProperty(AssignmentConstants.SAK_PROP_FORCE_ANON_GRADING);
         } catch (EntityPropertyTypeException | EntityPropertyNotDefinedException | SakaiException se) {
             log.debug("Failed to find if anonymous grading is forced.");
         }
@@ -3249,10 +3237,10 @@ public class AssignmentAction extends PagedResourceActionII {
         String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
         // get all assignment
         Collection<Assignment> assignments = assignmentService.getAssignmentsForContext(contextString);
-        HashMap<String, String> gAssignmentIdTitles = new HashMap<String, String>();
+        HashMap<String, String> gAssignmentIdTitles = new HashMap<>();
 
-        HashMap<String, String> gradebookAssignmentsSelectedDisabled = new HashMap<String, String>();
-        HashMap<String, String> gradebookAssignmentsLabel = new HashMap<String, String>();
+        HashMap<String, String> gradebookAssignmentsSelectedDisabled = new HashMap<>();
+        HashMap<String, String> gradebookAssignmentsLabel = new HashMap<>();
 
         for (Assignment a : assignments) {
             String gradebookItem = a.getProperties().get(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
@@ -3310,9 +3298,12 @@ public class AssignmentAction extends PagedResourceActionII {
             // exception
             log.debug(this + ":currentAssignmentGradebookIntegrationIntoContext " + rb.getFormattedMessage("addtogradebook.alertMessage", new Object[]{e.getMessage()}));
         }
-        context.put("gradebookAssignmentsSelectedDisabled", gradebookAssignmentsSelectedDisabled);
 
+        context.put("gradebookAssignmentsSelectedDisabled", gradebookAssignmentsSelectedDisabled);
         context.put("gradebookAssignmentsLabel", gradebookAssignmentsLabel);
+
+        // Determine if we're hiding the option to link to existing gradebook items
+        context.put("allowLinkToExistingGradebookItem", serverConfigurationService.getBoolean(AssignmentConstants.SAK_PROP_ALLOW_LINK_TO_EXISTING_GB_ITEM, AssignmentConstants.SAK_PROP_ALLOW_LINK_TO_EXISTING_GB_ITEM_DFLT));
     }
 
     private void putGradebookCategoryInfoIntoContext(SessionState state, Context context) {
@@ -11534,7 +11525,7 @@ public class AssignmentAction extends PagedResourceActionII {
         state.setAttribute(NEW_ASSIGNMENT_CONTENT_TITLE, null);
         state.setAttribute(NEW_ASSIGNMENT_CONTENT_LAUNCH_NEW_WINDOW, null);
         state.setAttribute(NEW_ASSIGNMENT_DESCRIPTION, "");
-        boolean checkAddDueDate = (state.getAttribute(CALENDAR) != null || state.getAttribute(ADDITIONAL_CALENDAR) != null) && serverConfigurationService.getBoolean(SAK_PROP_DUE_DATE_TO_CALENDAR_DEFAULT, DUE_DATE_TO_CALENDAR_DEFAULT);
+        boolean checkAddDueDate = (state.getAttribute(CALENDAR) != null || state.getAttribute(ADDITIONAL_CALENDAR) != null) && serverConfigurationService.getBoolean(AssignmentConstants.SAK_PROP_DUE_DATE_TO_CALENDAR_DEFAULT, DUE_DATE_TO_CALENDAR_DEFAULT);
         state.setAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_DUE_DATE, Boolean.toString(checkAddDueDate));
         state.setAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE, Boolean.FALSE.toString());
 

--- a/assignment/tool/src/webapp/vm/assignment/instructor_new_edit/grading_section.vm
+++ b/assignment/tool/src/webapp/vm/assignment/instructor_new_edit/grading_section.vm
@@ -119,7 +119,7 @@ This section contains the options for grading this assignment, including rubrics
 
 							## if there are assignment entries in Gradebook
 							#if (!$!gradebookAssignmentsLabel.isEmpty())
-								<div class="radio">  ## Associate with Existing Gradebook Item
+								<div class="radio" #if(!$allowLinkToExistingGradebookItem)style="display: none;"#end>  ## Associate with Existing Gradebook Item
 									<label id="radioAssocWithGbLabel" for="$!gradebookChoice_associate">
 										<input type="radio"	name="$!name_Addtogradebook" id="$!gradebookChoice_associate" value="$!gradebookChoice_associate"
 											#if($!gradebookChoice.equals("$!gradebookChoice_associate"))checked#end
@@ -127,7 +127,7 @@ This section contains the options for grading this assignment, including rubrics
 										$tlang.getString("grading.associate")
 									</label>
 								</div>
-								<div id="gradebookList" class="indnt3">
+								<div id="gradebookList" class="indnt3" #if(!$allowLinkToExistingGradebookItem)style="display: none;"#end>
 									<label for="gradebookItemSelect" class="sr-only">$tlang.getString("grading.select")</label>
 									<select name="$!name_AssociateGradebookAssignment" id="gradebookItemSelect">
 										<option value="">$tlang.getString("grading.select")</option>

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2082,6 +2082,10 @@
 # DEFAULT: 2 (new assignments will use 2 decimal places for grading by default)
 #assignment.grading.decimals=1
 
+# SAK-46115 - enable/disable setting to send grades to an existing gradebook item
+# DEFAULT: true (enabled)
+# assignment.allowLinkToExistingGBItem=false
+
 # ######################################
 # SAK-41821 Student confirmation page
 # ######################################


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46115

We've had multiple issues where users are somehow able to trigger situations where all previously entered grades disappear when the instructor elects to release the grades. Despite how many times this has happened at Western, we've been unable to identify exact steps to reproduce. However, all cases have one thing in common: they're sending grades to an existing gradebook item.

Due to not having solid steps to reproduce, we've historically been in a reactionary cycle, where when this happens it forces us to do a clone and restore to get the grades back into place. This process is extremely cumbersome and time consuming.

As a result, we decided to develop a feature to hide the ability for an Assignment to send grades to an existing gradebook item. In this way, we have dramatically reduced the frequency of this issue cropping up.

Now, we realize that sending grades to an existing gradebook item is a legitimate use case, and some institutions may rely on this workflow. As such, we implemented this feature behind a new sakai.property (`assignment.allowLinkToExistingGBItem`) which defaults to `true` so that original functionality is retained OOTB.