### PR TITLE
SAK-46118 Samigo: prevented merging of question number and point value for screen readers

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -320,13 +320,13 @@ document.links[newindex].onclick();
    <h:dataTable width="100%" value="#{part.itemContents}" var="question">
      <h:column>
 		<h:panelGroup layout="block" styleClass="input-group col-sm-6">
-			<span class="input-group-addon">
+			<p class="input-group-addon">
 				<h:outputText value="<a name='p#{part.number}q#{question.number}'></a>" escape="false" />
 				<h:outputText value="#{deliveryMessages.q} #{question.sequence} #{deliveryMessages.of} #{part.numbering}"/>
-			</span>
+			</p>
 			<%-- REVIEW ASSESSMENT --%>
 			<h:inputText styleClass="form-control adjustedScore" value="#{question.pointsDisplayString}" disabled="true" rendered="#{delivery.actionString=='reviewAssessment'}"/>
-			<span class="input-group-addon">
+			<p class="input-group-addon">
 				<%-- REVIEW ASSESSMENT --%>
 				<h:outputText value="#{question.roundedMaxPointsToDisplay} #{deliveryMessages.pt}" rendered="#{delivery.actionString=='reviewAssessment'}"/>
 				<%-- DELIVER ASSESSMENT --%>
@@ -337,7 +337,7 @@ document.links[newindex].onclick();
 				<h:outputText value="#{deliveryMessages.discount} #{question.itemData.discount} "  rendered="#{question.itemData.discount!='0.0' && delivery.settings.displayScoreDuringAssessments != '2' && question.itemData.scoreDisplayFlag}"  >
 					<f:convertNumber maxFractionDigits="2" groupingUsed="false"/>
 				</h:outputText>
-			</span>
+			</p>
 			<h:outputText styleClass="extraCreditLabel" rendered="#{question.itemData.isExtraCredit == true}" value="#{deliveryMessages.extra_credit_preview}" />
 		</h:panelGroup>
 

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -194,18 +194,18 @@ function toPoint(id)
       <t:dataList value="#{part.itemContents}" var="question" itemStyleClass="page-header question-box" styleClass="question-wrapper" layout="unorderedList">
         <h:outputText value="<a name=\"#{part.number}_#{question.number}\"></a>" escape="false" />
         <h:panelGroup layout="block" styleClass="input-group col-sm-6">
-            <span class="input-group-addon">
+            <p class="input-group-addon">
               <h:outputText value="#{deliveryMessages.q} #{question.sequence} #{deliveryMessages.of} " />
               <h:outputText value="#{part.numbering}#{deliveryMessages.column}  " />
-            </span>
+            </p>
             <h:inputText styleClass="form-control adjustedScore#{studentScores.assessmentGradingId}.#{question.itemData.itemId}" id="adjustedScore" value="#{question.pointsForEdit}" onchange="toPoint(this.id);"
                          validatorMessage="#{evaluationMessages.number_format_error_adjusted_score}">
               <f:validateDoubleRange/>
             </h:inputText>
-            <span class="input-group-addon">
+            <p class="input-group-addon">
             <h:outputText value=" #{deliveryMessages.splash} #{question.roundedMaxPointsToDisplay} " />
             <h:outputText value="#{deliveryMessages.pt}"/>
-            </span>
+            </p>
             <h:message for="adjustedScore" style="color:red"/>
             <h:outputText styleClass="extraCreditLabel" rendered="#{question.itemData.isExtraCredit == true}" value=" #{deliveryMessages.extra_credit_preview}" />
         </h:panelGroup>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46118

Prevented question numbers and point values from being read as a single number by screen readers (e.g. "Question 1 of 10 2 Points" used to read as "Question 1 of 102 Points" to screen readers). 

No visual change. 