### PR TITLE
SAK-46119 Samigo: Removed dash from default Part title when not needed

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -300,9 +300,7 @@ document.links[newindex].onclick();
     <h:column>
     <h4 class="part-header">
         <h:outputText value="#{deliveryMessages.p} #{part.number} #{deliveryMessages.of} #{part.numParts}" />
-        <small class="part-text">
-            <h:outputText value=" #{deliveryMessages.dash} #{part.nonDefaultText}" escape="false"/>
-        </small>
+        <h:outputText value=" #{deliveryMessages.dash} #{part.nonDefaultText}" escape="false" rendered="#{! empty part.nonDefaultText}"/>
         <span class="badge"><h:outputText value="#{part.pointsDisplayString} #{deliveryMessages.splash} #{part.roundedMaxPoints} #{deliveryMessages.pt}" rendered="#{delivery.actionString=='reviewAssessment'}"/></span>
     </h4>
     <h4 class="tier1">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46119

When a Samigo assessment's Part title is "Default", it normally doesn't display the title. This fix hides the dash too when the title isn't shown. 

See SAK-46119 for the before and after screenshots. 