### PR TITLE
SAK-46123 assignments > add/edit > emails on grade release too sticky

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11655,6 +11655,7 @@ public class AssignmentAction extends PagedResourceActionII {
         state.removeAttribute(NEW_ASSIGNMENT_ATTACHMENT);
         state.removeAttribute(NEW_ASSIGNMENT_FOCUS);
         state.removeAttribute(NEW_ASSIGNMENT_DESCRIPTION_EMPTY);
+        state.removeAttribute(AssignmentConstants.ASSIGNMENT_RELEASEGRADE_NOTIFICATION_VALUE);
 
         // reset the global navigaion alert flag
         if (state.getAttribute(ALERT_GLOBAL_NAVIGATION) != null) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46123

At first, the default is to not send emails. However, once you've added an assignment, or edited an existing assignment and switched it to send emails on grades being released, for the rest of your session the default selection will then be to send emails. This can potentially lead to emails being sent out when the instructor did not intend to do so.

Someone started using the state for more state management and forgot to do the necessary cleanup of the new param in `resetAssignment()`.