### PR TITLE
SAK-46127 assignments > add/edit > gradebook > category drop down only shows if 2 or more categories exist

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -3318,7 +3318,7 @@ public class AssignmentAction extends PagedResourceActionII {
     private void putGradebookCategoryInfoIntoContext(SessionState state, Context context) {
         Map<Long, String> categoryTable = categoryTable();
         if (categoryTable != null) {
-            long categoryTableSize = categoryTable.keySet().stream().filter(i -> i >= 0).count();
+            long categoryTableSize = categoryTable.size();
             context.put("value_totalCategories", Long.valueOf(categoryTableSize));
 
             // selected category


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46127

Despite having 1 user defined category in gradebook, the drop down to select the destination category does not appear. If you then add another user defined category (to make 2 user defined categories plus the default "uncategorized" category), then the drop down will appear and display all three category options.

Looking at the code, we have this conditional in the Velocity template:

```
#if ($!value_totalCategories > 1)
... show the drop down
#end
```
And In Java, we populate `value_totalCategories` in the following:

```
Map<Long, String> categoryTable = categoryTable();
long categoryTableSize = categoryTable.keySet().stream().filter(i -> i >= 0).count();
context.put("value_totalCategories", Long.valueOf(categoryTableSize));
```

In effect, the `value_totalCategories` value is always 1 less than the available categories, so the condition in the Velocity template only passes if there are actually 2 or more user defined categories.

The fix is extremely simple: get rid of the stream filtering on the `HashMap`and just count the size of the records within (each map entry represents a category, and there is always at least one "default" (uncategorized) category):

```
long categoryTableSize = categoryTable.size();
```