### PR TITLE
SAK-46130 assignments > duplicate doesn't copy model answer

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -69,7 +69,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.sakaiproject.announcement.api.AnnouncementChannel;
-import org.sakaiproject.announcement.api.AnnouncementMessage;
 import org.sakaiproject.announcement.api.AnnouncementService;
 import org.sakaiproject.assignment.api.AssignmentConstants;
 import org.sakaiproject.assignment.api.AssignmentConstants.SubmissionStatus;
@@ -974,6 +973,31 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
                 assignmentRepository.newAssignment(assignment);
                 log.debug("Created duplicate assignment {} from {}", assignment.getId(), assignmentId);
+
+                // Copy model answer
+                AssignmentModelAnswerItem existingModelAnswer = assignmentSupplementItemService.getModelAnswer(assignmentId);
+                if (existingModelAnswer != null) {
+                    AssignmentModelAnswerItem copy = assignmentSupplementItemService.newModelAnswer();
+                    copy.setAssignmentId(assignment.getId());
+                    copy.setText(existingModelAnswer.getText());
+                    copy.setShowTo(existingModelAnswer.getShowTo());
+
+                    // We have to save the model answer so it exists before it can have attachments; otherwise we get a Hibernate exception
+                    assignmentSupplementItemService.saveModelAnswer(copy);
+
+                    Set<AssignmentSupplementItemAttachment> attachments = new HashSet<>();
+                    List<String> attachmentIDs = assignmentSupplementItemService.getAttachmentListForSupplementItem(existingModelAnswer);
+                    for (String attachmentID : attachmentIDs) {
+                        AssignmentSupplementItemAttachment attachment = assignmentSupplementItemService.newAttachment();
+                        attachment.setAssignmentSupplementItemWithAttachment(copy);
+                        attachment.setAttachmentId(attachmentID);
+                        assignmentSupplementItemService.saveAttachment(attachment);
+                        attachments.add(attachment);
+                    }
+
+                    copy.setAttachmentSet(attachments);
+                    assignmentSupplementItemService.saveModelAnswer(copy); // save again to persist attachments
+                }
 
                 //copy rubric
                 try {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46130

Duplicating an assignment which contains a model answer does not copy said model answer into the duplicate.