### PR TITLE
SAK-46140 Add simple date shifter to provide some level of automation for Date Manager

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -125,6 +125,11 @@
 		}
 	}
 
+	#dateShifterDays {
+		box-sizing: content-box;
+		width: 5ch;
+	}
+
   /*Start of Site Group Manager*/
   .wizard-step-active {
     background-color: var(--sakai-primary-color-1);

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -27,3 +27,9 @@ modal.confirm.instruction = You are about to modify the following course dates:
 page.instructions = Edit dates in batch
 
 success.message = The dates were updated successfully.
+
+dateshifter.label.before=Shift dates by
+dateshifter.label.after=day(s). Remember to click Save Changes at the bottom of the page to save your adjustments.
+dateshifter.all.button=Apply to all dates
+dateshifter.visible.button=Apply to expanded sections only
+dateshifter.error.nonnumeric=Please enter a non-zero whole number between -9999 and 9999.

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -25,6 +25,21 @@
 			<h1 th:text="#{page.instructions}">Add/Edit Options in batch</h1>
 		</div>
 
+		<div class="date-manager-shifter panel-group">
+			<p>
+				<div class="sak-banner-error hidden" id="dateShifterError">
+					<span th:text="#{dateshifter.error.nonnumeric}"></span>
+				</div>
+				<label>
+					<span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
+					<input id="dateShifterDays" type="text"></input>
+					<span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
+				</label>
+			</p>
+			<button id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
+			<button id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
+		</div>
+
 		<form class="panel-group" id="date-manager-form" method="POST">
 			<div class="sak-banner-error hidden" id="form-errors">
 				<span th:text="#{errors.instruction}">Your update could not be saved due to the following errors:</span>
@@ -234,6 +249,7 @@
 					var notModified = [];
 
 					DTMN.initDatePicker(updates, notModified);
+					DTMN.initShifter(updates, notModified);
 
 					function printErrors() {
 						$('.errors').empty();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46140

Date Manager is useful but date adjustments are entirely manual. A basic level of automation should be provided, allowing for users to shift all dates by a certain number of days. For example, an instructor may want to shift all dates from last year's imported course by 365 days, to put them in the ballpark of the desired dates for the current year's course. This could save a lot of clicks by avoiding manual changes to year.

See UI screenshot on SAK ticket.
