### PR TITLE
SAK-45722 Assignments / error adding an attachment before points entered

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7287,7 +7287,9 @@ public class AssignmentAction extends PagedResourceActionII {
         // read inputs for supplement items
         setNewAssignmentParametersSupplementItems(validify, state, params);
 
-        if (state.getAttribute(WITH_GRADES) != null && (Boolean) state.getAttribute(WITH_GRADES)) {
+        String option = params.get("option");
+
+        if (!"attach".equals(option) && state.getAttribute(WITH_GRADES) != null && (Boolean) state.getAttribute(WITH_GRADES)) {
             // the grade point
             String gradePoints = params.getString(NEW_ASSIGNMENT_GRADE_POINTS);
             state.setAttribute(NEW_ASSIGNMENT_GRADE_POINTS, gradePoints);


### PR DESCRIPTION
Hi, small change but it was hard to find 😅

I'm removing the points validation when the request is in the "attach" mode
The validation executes when the user tries to save the assignment