### PR TITLE
SAK-45847 Rubrics > Adjust Individual Scores > Deleting a number after a decimal deletes the decimal too

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
@@ -240,9 +240,9 @@ export class SakaiRubricGrading extends RubricsElement {
 
     const value = e.target.value;
 
-    const parsed = parseFloat(value.replace(/,/g, "."));
+    const parsed = value.replace(/,/g, ".");
 
-    if (isNaN(parsed)) {
+    if (isNaN(parseFloat(parsed))) {
       return;
     }
 
@@ -274,7 +274,7 @@ export class SakaiRubricGrading extends RubricsElement {
 
       return {
         criterionId: c.id,
-        points: c.pointoverride || c.selectedvalue,
+        points: c.pointoverride ? parseFloat(c.pointoverride) : c.selectedvalue,
         comments: c.comments,
         pointsAdjusted: c.pointoverride !== c.selectedvalue,
         selectedRatingId: c.selectedRatingId


### PR DESCRIPTION
Hi,
The problem was caused because after the parseFloat, the dot was removed and that value was set as the input value
I'm moving the parseFloat operation to right before the API update and keeping the value as a string to maintain the dot in the input
