### PR TITLE
SAK-46145 Add spinners to Group By Category buttons

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -36,11 +36,9 @@ import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.form.HiddenField;
 import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
@@ -84,6 +82,7 @@ import org.sakaiproject.service.gradebook.shared.GradingType;
 import org.sakaiproject.service.gradebook.shared.PermissionDefinition;
 import org.sakaiproject.service.gradebook.shared.SortType;
 import org.sakaiproject.tool.gradebook.Gradebook;
+import org.sakaiproject.wicket.component.SakaiAjaxButton;
 
 /**
  * Grades page. Instructors and TAs see this one. Students see the {@link StudentPage}.
@@ -310,7 +309,7 @@ public class GradebookPage extends BasePage {
 
 		this.tableArea.add(this.gradeTable);
 
-		final Button toggleCategoriesToolbarItem = new Button("toggleCategoriesToolbarItem") {
+		final SakaiAjaxButton toggleCategoriesToolbarItem = new SakaiAjaxButton("toggleCategoriesToolbarItem") {
 			@Override
 			protected void onInitialize() {
 				super.onInitialize();
@@ -318,10 +317,11 @@ public class GradebookPage extends BasePage {
 					add(new AttributeAppender("class", " on"));
 				}
 				add(new AttributeModifier("aria-pressed", settings.isGroupedByCategory()));
+				setWillRenderOnClick(true);
 			}
 
 			@Override
-			public void onSubmit() {
+			public void onSubmit(AjaxRequestTarget target, Form<?> form) {
 				settings.setGroupedByCategory(!settings.isGroupedByCategory());
 				setUiSettings(settings, true);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
@@ -6,7 +6,7 @@
 <wicket:panel>
 	<wicket:enclosure child="categoriesList">
 		<div wicket:id="toggleActions" class="pull-right">
-			<a href="javascript:void(0);" class="button" id="toggleCategories" wicket:id="toggleCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.toolbar.togglecategories"></wicket:message></a>
+			<button class="button" id="toggleCategories" wicket:id="toggleCategoriesBtn" aria-controls="gradeSummaryTable"><wicket:message key="label.toolbar.togglecategories"></wicket:message></button>
 			<a href="javascript:void(0);" class="gb-summary-expand-all" wicket:id="expandCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.expandall"></wicket:message></a>
 			<a href="javascript:void(0);" class="gb-summary-collapse-all" wicket:id="collapseCategoriesLink" aria-controls="gradeSummaryTable"><wicket:message key="label.studentsummary.collapseall"></wicket:message></a>
 		</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -30,6 +30,7 @@ import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.StringHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.IModel;
@@ -49,6 +50,7 @@ import org.sakaiproject.service.gradebook.shared.CategoryDefinition;
 import org.sakaiproject.service.gradebook.shared.GradebookInformation;
 import org.sakaiproject.service.gradebook.shared.GradeDefinition;
 import org.sakaiproject.service.gradebook.shared.GradingType;
+import org.sakaiproject.wicket.component.SakaiAjaxButton;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -109,7 +111,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 		final WebMarkupContainer toggleActions = new WebMarkupContainer("toggleActions");
 		toggleActions.setVisible(categoriesEnabled);
 
-		final GbAjaxLink toggleCategoriesLink = new GbAjaxLink("toggleCategoriesLink") {
+		final SakaiAjaxButton toggleCategoriesBtn = new SakaiAjaxButton("toggleCategoriesBtn") {
 			@Override
 			protected void onInitialize() {
 				super.onInitialize();
@@ -120,7 +122,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 			}
 
 			@Override
-			public void onClick(final AjaxRequestTarget target) {
+			public void onSubmit(final AjaxRequestTarget target, Form<?> form) {
 				if (getPage() instanceof GradebookPage) {
 					final GradebookPage page = (GradebookPage) getPage();
 					final GradebookUiSettings settings = page.getUiSettings();
@@ -137,7 +139,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 								showingStudentView));
 			}
 		};
-		toggleActions.add(toggleCategoriesLink);
+		toggleActions.add(toggleCategoriesBtn);
 		toggleActions.addOrReplace(new WebMarkupContainer("expandCategoriesLink").setVisible(this.isGroupedByCategory));
 		toggleActions.addOrReplace(new WebMarkupContainer("collapseCategoriesLink").setVisible(this.isGroupedByCategory));
 		addOrReplace(toggleActions);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46145

The Group by Category action can be a bit slow to respond due to triggering a full page refresh. Adding spinners to the buttons will let users know their action is processing.