### PR TITLE
SAK-46146 Gradebook > Extend search filter to student number column

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -1740,6 +1740,9 @@ GbGradeTable.applyStudentFilter = function(data) {
 
       var student = row[GbGradeTable.STUDENT_COLUMN_INDEX];
       var searchableFields = [student.firstName, student.lastName, student.eid];
+      if (GbGradeTable.settings.isStudentNumberVisible) {
+          searchableFields.push(student.studentNumber);
+      }
       var studentSearchString = searchableFields.join(";")
 
       for (var i=0; i<queryStrings.length; i++) {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46146

Instructors may wish to search for students by student number. Extend the search filter to look in the student number column if it exists.