### PR TITLE
SAK-46139 - Assignments - submitted content should be queued when content-review is enabled on an existing assignment

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.assignment.api.model.AssignmentSubmission;
 import org.sakaiproject.assignment.api.model.AssignmentSubmissionSubmitter;
+import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.Reference;
@@ -781,6 +782,11 @@ public interface AssignmentService extends EntityProducer {
      * @return true if content review results for the given submission can be displayed.
      */
     public boolean isContentReviewVisibleForSubmission(AssignmentSubmission submission);
+
+    /**
+     * Gets all attachments in the submission that are acceptable to the content review service
+     */
+    public List<ContentResource> getAllAcceptableAttachments(AssignmentSubmission submission);
 
     /**
      * Get an assignment that is linked with a gradebook item

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -3775,6 +3775,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         }
     }
 
+    @Transactional
     public String createContentReviewAssignment(Assignment assignment, String assignmentRef, Instant openTime, Instant dueTime, Instant closeTime) {
         Map<String, Object> opts = new HashMap<>();
         Map<String, String> p = assignment.getProperties();
@@ -4563,9 +4564,10 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     /**
-     * Gets all attachments in the submission that are acceptable to the content review service
+     * {@inheritDoc}
      */
-    private List<ContentResource> getAllAcceptableAttachments(AssignmentSubmission s) {
+    @Override
+    public List<ContentResource> getAllAcceptableAttachments(AssignmentSubmission s) {
         List<ContentResource> attachments = new ArrayList<>();
         for (String attachment : s.getAttachments()) {
             Reference attachmentRef = entityManager.newReference(attachment);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6485,12 +6485,15 @@ public class AssignmentAction extends PagedResourceActionII {
                 }
 
                 // SAK-26322 - add inline as an attachment for the content review service
-                if (post && a.getContentReview()) {
+                if (post) {
                     if (!isHtmlEmpty(text)) {
+                        /* prepares a file representing the inline content;
+                         * needed whether or not content review is used - it will be queued retroactively if we enable content review on the assignment in the future */
                         prepareInlineForContentReview(text, submission, state, u);
                     }
+
                     // Check if we need to post the attachments
-                    if (!submission.getAttachments().isEmpty()) {
+                    if (a.getContentReview() && !submission.getAttachments().isEmpty()) {
                         assignmentService.postReviewableSubmissionAttachments(submission);
                     }
                 }

--- a/content-review/impl/compilatio/src/main/java/org/sakaiproject/contentreview/compilatio/CompilatioReviewServiceImpl.java
+++ b/content-review/impl/compilatio/src/main/java/org/sakaiproject/contentreview/compilatio/CompilatioReviewServiceImpl.java
@@ -39,7 +39,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.content.api.ContentResource;
@@ -53,7 +52,6 @@ import org.sakaiproject.contentreview.exception.SubmissionException;
 import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
 import org.sakaiproject.contentreview.service.ContentReviewQueueService;
-import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entitybroker.EntityReference;
 import org.sakaiproject.exception.IdUnusedException;
@@ -192,8 +190,6 @@ public class CompilatioReviewServiceImpl extends BaseContentReviewService {
 	@Setter protected ToolManager toolManager;
 	@Setter protected UserDirectoryService userDirectoryService;
 	@Setter protected ContentHostingService contentHostingService;
-	@Setter protected EntityManager entityManager;
-	@Setter protected AssignmentService assignmentService;
 	@Setter protected CompilatioAccountConnection compilatioConn;
 	@Setter protected CompilatioContentValidator compilatioContentValidator;
 	@Setter protected ContentReviewSiteAdvisor siteAdvisor;

--- a/content-review/impl/service/pom.xml
+++ b/content-review/impl/service/pom.xml
@@ -18,6 +18,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.sakaiproject.assignment</groupId>
+			<artifactId>sakai-assignment-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>

--- a/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/BaseContentReviewService.java
+++ b/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/BaseContentReviewService.java
@@ -17,18 +17,31 @@ package org.sakaiproject.contentreview.service;
 
 import java.time.Instant;
 import java.io.StringReader;
+import java.util.List;
 import java.util.Optional;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.model.Assignment;
+import org.sakaiproject.assignment.api.model.AssignmentSubmission;
+import org.sakaiproject.assignment.api.model.AssignmentSubmissionSubmitter;
+import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.contentreview.exception.SubmissionException;
+import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.contentreview.dao.ContentReviewConstants;
 import org.sakaiproject.contentreview.dao.ContentReviewItem;
 import org.sakaiproject.contentreview.exception.ContentReviewProviderException;
 import org.sakaiproject.contentreview.exception.QueueException;
 import org.sakaiproject.contentreview.exception.ReportException;
+import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityPropertyNotDefinedException;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.user.api.PreferencesEdit;
 import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.util.ResourceLoader;
@@ -42,7 +55,11 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class BaseContentReviewService implements ContentReviewService{
-	
+
+	@Setter
+	protected AssignmentService assignmentService;
+	@Setter
+	protected EntityManager entityManager;
 	@Setter
 	protected PreferencesService preferencesService;
 	@Setter
@@ -113,6 +130,50 @@ public abstract class BaseContentReviewService implements ContentReviewService{
 		}catch(Exception e) {
 			log.error(e.getMessage(), e);
 		}	
+	}
+
+	@Override
+	public void createAssignment(final String contextId, final String taskId, final Map opts)
+		throws SubmissionException, TransientSubmissionException {
+		queueAllSubmissionsForAssignment(taskId);
+	}
+
+	protected void queueAllSubmissionsForAssignment(final String taskId) {
+		try {
+			Assignment assignment;
+			try {
+				// Assume it's from the Assignments tool, support can be added to other tools in the future if there is a need to integrate with content-review
+				assignment = assignmentService.getAssignment(entityManager.newReference(taskId));
+			}
+			catch (IdUnusedException | PermissionException e) {
+				return;
+			}
+
+			Set<AssignmentSubmission> submissions = assignmentService.getSubmissions(assignment);
+			if (submissions != null) {
+				submissions.stream().filter(AssignmentSubmission::getSubmitted).forEach(sub -> {
+					List<ContentResource> attachments = assignmentService.getAllAcceptableAttachments(sub);
+					if (!attachments.isEmpty()) {
+						Optional<AssignmentSubmissionSubmitter> submitter = assignmentService.getSubmissionSubmittee(sub);
+						if (!submitter.isPresent() && allowSubmissionsOnBehalf()) {
+							submitter = sub.getSubmitters().stream().findAny();
+						}
+						if (submitter.isPresent()) {
+							try {
+								queueContent(submitter.get().getSubmitter(), assignment.getContext(), taskId, attachments);
+							}
+							catch (QueueException e) {
+								// Already queued most likely
+							}
+						}
+					}
+				});
+			}
+		}
+		catch (Exception e)
+		{
+			log.error("Unknown excpetion queueing submissions for assessment " + taskId, e);
+		}
 	}
 	
 	@Override

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -56,7 +56,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.assignment.api.AssignmentConstants;
-import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.assignment.api.model.AssignmentSubmission;
 import org.sakaiproject.assignment.api.model.AssignmentSubmissionSubmitter;
@@ -74,7 +73,6 @@ import org.sakaiproject.contentreview.exception.SubmissionException;
 import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
 import org.sakaiproject.contentreview.service.ContentReviewQueueService;
-import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
@@ -106,14 +104,8 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	private UserDirectoryService userDirectoryService;
 
 	@Setter
-	private EntityManager entityManager;
-
-	@Setter
 	private SecurityService securityService;
 	
-	@Setter
-	private AssignmentService assignmentService;
-
 	@Setter
 	private SiteService siteService;
 
@@ -486,12 +478,6 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 
 	@Override
 	public void syncRosters() {
-		// Auto-generated method stub
-	}
-
-	@Override
-	public void createAssignment(final String contextId, final String assignmentRef, final Map opts)
-			throws SubmissionException, TransientSubmissionException {
 		// Auto-generated method stub
 	}
 

--- a/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
+++ b/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
@@ -61,7 +61,6 @@ import org.sakaiproject.contentreview.service.BaseContentReviewService;
 import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.contentreview.turnitin.util.TurnitinAPIUtil;
 import org.sakaiproject.entity.api.Entity;
-import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
@@ -216,9 +215,6 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 
 	@Setter
 	private TurnitinAccountConnection turnitinConn;
-
-	@Setter
-	private EntityManager entityManager;
 
 	@Setter
 	private ContentHostingService contentHostingService;

--- a/content-review/impl/vericite/src/main/java/org/sakaiproject/contentreview/vericite/ContentReviewServiceVeriCite.java
+++ b/content-review/impl/vericite/src/main/java/org/sakaiproject/contentreview/vericite/ContentReviewServiceVeriCite.java
@@ -57,7 +57,6 @@ import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
 import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.entity.api.Entity;
-import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
@@ -92,9 +91,6 @@ public class ContentReviewServiceVeriCite extends BaseContentReviewService {
 	
 	@Setter
 	private UserDirectoryService userDirectoryService;
-	
-	@Setter
-	private EntityManager entityManager;
 	
 	@Setter
 	private SecurityService securityService;

--- a/content-review/pack/src/webapp/WEB-INF/compilatio.xml
+++ b/content-review/pack/src/webapp/WEB-INF/compilatio.xml
@@ -17,8 +17,6 @@
 		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
 		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
-		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
-		<property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService" />
 		<property name="compilatioContentValidator" ref="org.sakaiproject.contentreview.compilatio.CompilatioContentValidator" />
 		<property name="compilatioConn" ref="org.sakaiproject.contentreview.compilatio.CompilatioAccountConnection" />
 		<property name="siteAdvisor" ref="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" />

--- a/content-review/pack/src/webapp/WEB-INF/components.xml
+++ b/content-review/pack/src/webapp/WEB-INF/components.xml
@@ -18,6 +18,8 @@
 	<bean id="org.sakaiproject.contentreview.service.BaseContentReviewService"
 			class="org.sakaiproject.contentreview.service.BaseContentReviewService"
 			abstract="true">
+		<property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService" />
+		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
 		<property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService" />
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 	</bean>

--- a/content-review/pack/src/webapp/WEB-INF/turnitin-oc.xml
+++ b/content-review/pack/src/webapp/WEB-INF/turnitin-oc.xml
@@ -10,10 +10,8 @@
         parent="org.sakaiproject.contentreview.service.BaseContentReviewService"
         init-method="init" lazy-init="true">
          <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
-         <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
          <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
          <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
-         <property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService" />
          <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
          <property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
          <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />

--- a/content-review/pack/src/webapp/WEB-INF/turnitin.xml
+++ b/content-review/pack/src/webapp/WEB-INF/turnitin.xml
@@ -17,7 +17,6 @@
 		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
 		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
-		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
 		<property name="sakaiPersonManager" ref="org.sakaiproject.api.common.edu.person.SakaiPersonManager" />
 		<property name="turnitinContentValidator" ref="org.sakaiproject.contentreview.turnitin.TurnitinContentValidator" />
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />

--- a/content-review/pack/src/webapp/WEB-INF/vericite.xml
+++ b/content-review/pack/src/webapp/WEB-INF/vericite.xml
@@ -10,7 +10,6 @@
         parent="org.sakaiproject.contentreview.service.BaseContentReviewService"
         init-method="init" lazy-init="true">
          <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
-         <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
          <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
          <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
          <property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />


### PR DESCRIPTION
Consider this scenario:

- An assignment is created without content-review
- A student submits to the assignment
- The assignment is edited, using content-review

The system should attempt to queue the student's content with the content-review service for both inline content and attachments.