### PR TITLE
SAK-46148 Gradebook > Bulk Edit has no confirmation for deleting GB items

### DIFF
--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -675,6 +675,11 @@ bulkedit.column.header.include=Include in course grade calculations
 bulkedit.column.header.delete=Delete
 bulkedit.update.success = The gradebook items were successfully updated
 bulkedit.update.error = Some gradebook items could not be updated. Please try again. If the problem persists, contact your System Administrator.
+bulkedit.delete.success = The following gradebook items were deleted: {0}
+bulkedit.confirmation.title=Delete Items Confirmation
+bulkedit.confirmation.warning=Are you sure you want to delete the selected Gradebook items? Please be aware that deleting Gradebook items cannot be undone and scores entered will be removed from the gradebook.
+bulkedit.confirmation.continue=Continue
+bulkedit.confirmation.cancel=Cancel
 
 sections.label.none = None
 label.submission-messager.title=Message Students

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -368,9 +368,11 @@ public class GradebookPage extends BasePage {
 				final String siteId = GradebookPage.this.businessService.getCurrentSiteId();
 
 				window.setTitle(getString("bulkedit.heading"));
-				window.setContent(new BulkEditItemsPanel(window.getContentId(), Model.of(siteId), window));
+				BulkEditItemsPanel panel = new BulkEditItemsPanel(window.getContentId(), Model.of(siteId), window);
+				window.setContent(panel.setOutputMarkupId(true));
 				window.setComponentToReturnFocusTo(this);
 				window.show(target);
+				target.appendJavaScript("GBBE.init('" + panel.getMarkupId() + "');");
 			}
 
 			@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.html
@@ -27,12 +27,32 @@
 			
 				
 			<div class="act">
-				<input type="submit" wicket:id="submit" class="active" wicket:message="value:button.savechanges" />
-				<input type="submit" wicket:id="cancel" wicket:message="value:button.cancel" />
+				<button id="gb-bulk-edit-fake-submit" class="active"><wicket:message key="button.savechanges" /></button>
+				<button id="gb-bulk-edit-real-submit" type="submit" wicket:id="submit" class="hide active"><wicket:message key="button.savechanges" /></button>
+				<button type="submit" wicket:id="cancel"><wicket:message key="button.cancel" /></button>
 			</div>
 
 		</form>
 
+		<script id="bulkEditConfirmationModalTemplate" type="text/template">
+			<div class="modal gb-bulk-edit-confirmation">
+				<div class="modal-dialog">
+					<div class="modal-content">
+						<div class="modal-header">
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+							<h3 class="modal-title"><wicket:message key="bulkedit.confirmation.title" /></h3>
+						</div>
+						<div class="modal-body">
+							<div class="sak-banner-warn"><wicket:message key="bulkedit.confirmation.warning" /></div>
+						</div>
+						<div class="modal-footer act">
+							<button type="button" class="button_color gb-bulk-edit-continue active" data-dismiss="modal"><wicket:message key="bulkedit.confirmation.continue" /></button>
+							<button type="button" class="gb-bulk-edit-cancel" data-dismiss="modal"><wicket:message key="bulkedit.confirmation.cancel" /></button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</script>
 	</wicket:panel>
 </body>
 </html>

--- a/gradebookng/tool/src/webapp/scripts/gradebook-bulk-edit.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-bulk-edit.js
@@ -49,3 +49,59 @@ function disableAndStrikeoutOneRow(deleteBox) {
         titleBox.removeAttribute('style');
     }
 }
+
+var GBBE = GBBE || {};
+
+GBBE.init = function(contentId) {
+    GBBE.$content = $(document.getElementById(contentId));
+    GBBE.$fakeSubmit = $(document.getElementById("gb-bulk-edit-fake-submit"));
+    GBBE.$realSubmit = $(document.getElementById("gb-bulk-edit-real-submit"));
+
+    GBBE.$fakeSubmit.off('click').on('click', GBBE.handleFakeSubmit);
+};
+
+GBBE.showConfirmation = function() {
+    const templateHtml = $("#bulkEditConfirmationModalTemplate").html().trim();
+    const modalTemplate = TrimPath.parseTemplate(templateHtml);
+    const $confirmationModal = $(modalTemplate.process());
+
+    $confirmationModal.one("click", ".gb-bulk-edit-continue", function() {
+        GBBE.performRealSubmit();
+    });
+    $(document.body).append($confirmationModal);
+
+    $confirmationModal.on("hidden.bs.modal", function() {
+        $confirmationModal.remove();
+    });
+    $confirmationModal.on("show.bs.modal", function() {
+        const $formModal = GBBE.$content.closest(".wicket-modal");
+        $confirmationModal.css("marginTop", $formModal.offset().top + 40);
+    });
+
+    $confirmationModal.on("shown.bs.modal", function() {
+        $confirmationModal.find(".gb-bulk-edit-cancel").focus();
+    });
+
+    $confirmationModal.modal().modal('show');
+};
+
+GBBE.performRealSubmit = function() {
+    GBBE.$fakeSubmit.hide();
+    GBBE.$realSubmit.toggleClass("hide");
+    GBBE.$realSubmit.trigger("click");
+    GBBE.$content.find(":input").prop("disabled", true);
+};
+
+GBBE.handleFakeSubmit = function(event) {
+
+    if (document.querySelectorAll(".deleteBox:checked").length > 0) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        GBBE.showConfirmation();
+
+        return false;
+    }
+
+    GBBE.performRealSubmit();
+};


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46148

If you enable the "Delete" checkbox on the Bulk Edit Items modal (Gradebook > Bulk Edit) and then click "Save Changes", the page refreshes, the column is gone, and a success message at the top says "The gradebook items were successfully updated".

Deleting content, particularly when it is unrecoverable, such as in Gradebook, should always have a confirmation for the user, such as:

"Are you sure you want to delete the following Gradebook items?"

Deleting a GB item individually says:

    Are you sure you want to delete ''Item 1''? Please be aware that deleting this Gradebook item cannot be undone and scores entered will be removed from the gradebook.

