### PR TITLE
SAK-46151 Categories using equal weighting or extra credit are not indicated to students

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -164,6 +164,9 @@
                 {if extraCredit}
                     <span class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracreditcategory"></span>
                 {/if}
+                {if equalWeight}
+                    <span class="gb-flag-equal-weight" wicket:message="title:label.gradeitem.equalweightcategory"></span>
+                {/if}
                 {var tooltip = title.replace(/"/g, '&quot;')}
                 <a class="gb-title" title="${tooltip}">
                     <span class="gb-category">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -232,15 +232,20 @@ public class BasePage extends WebPage {
 	 * Helper to build a notification flag with a Bootstrap popover
 	 */
 	public WebMarkupContainer buildFlagWithPopover(final String componentId, final String message) {
+		return buildFlagWithPopover(componentId, message, "manual", "#gradebookGrades");
+	}
+
+	public WebMarkupContainer buildFlagWithPopover(final String componentId, final String message,
+			final String trigger, final String container) {
 		final WebMarkupContainer flagWithPopover = new WebMarkupContainer(componentId);
 
 		flagWithPopover.add(new AttributeModifier("title", message));
 		flagWithPopover.add(new AttributeModifier("aria-label", message));
 		flagWithPopover.add(new AttributeModifier("data-toggle", "popover"));
-		flagWithPopover.add(new AttributeModifier("data-trigger", "manual"));
+		flagWithPopover.add(new AttributeModifier("data-trigger", trigger));
 		flagWithPopover.add(new AttributeModifier("data-placement", "bottom"));
 		flagWithPopover.add(new AttributeModifier("data-html", "true"));
-		flagWithPopover.add(new AttributeModifier("data-container", "#gradebookGrades"));
+		flagWithPopover.add(new AttributeModifier("data-container", container));
 		flagWithPopover.add(new AttributeModifier("data-template",
 				"<div class=\"gb-popover popover\" role=\"tooltip\"><div class=\"arrow\"></div><div class=\"popover-content\"></div></div>"));
 		flagWithPopover.add(new AttributeModifier("data-content", generatePopoverContent(message)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.html
@@ -28,7 +28,13 @@
 					<tbody class="gb-summary-category-tbody">
 						<tr wicket:id="categoryRow" class="gb-summary-category-row" wicket:message="aria-label:studentsummary.categoryrow">
 							<th scope="rowgroup">
-								<a href="javascript:void(0);" class="gb-summary-category-toggle" wicket:message="title:studentsummary.categorytoggle"><span wicket:id="category" class="gb-summary-category-name"></span></a>
+								<div class="gb-summary-category-toggle-container">
+									<a href="javascript:void(0);" class="gb-summary-category-toggle" wicket:message="title:studentsummary.categorytoggle"><span wicket:id="category" class="gb-summary-category-name"></span></a>
+									<span class="gb-summary-grade-flags" wicket:id="flags">
+										<span wicket:id="isExtraCredit" class="gb-flag-extra-credit"></span>
+										<span wicket:id="isEqualWeight" class="gb-flag-equal-weight"></span>
+									</span>
+								</div>
 								<p wicket:id="categoryDropInfo" class="gb-summary-grade-category-dropInfo">
 									<span wicket:id="categoryDropInfo1">Drop Highest: 1 & </span><wbr><span wicket:id="categoryDropInfo2">Drop Lowest: 1</span>
 								</p>
@@ -65,7 +71,13 @@
 						<td class="gb-summary-grade-duedate" wicket:id="dueDate"></td>
 						<td class="gb-summary-grade-comments"><div wicket:id="comments"></div></td>
 						<td class="gb-summary-grade-category" wicket:id="category">
-							<div wicket:id="categoryName"></div>
+							<div>
+								<span wicket:id="categoryName"></span>
+								<span class="gb-summary-grade-category-flags" wicket:id="cflags">
+									<span wicket:id="isExtraCredit" class="gb-flag-extra-credit"></span>
+									<span wicket:id="isEqualWeight" class="gb-flag-equal-weight"></span>
+								</span>
+							</div>
 							<p wicket:id="categoryDropInfo" class="gb-summary-grade-category-col-dropInfo">Drop Highest: 1</p>
 							<p wicket:id="categoryDropInfo2" class="gb-summary-grade-category-col-dropInfo">Drop Lowest: 1</p>
 						</td>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -15,6 +15,7 @@
  */
 package org.sakaiproject.gradebookng.tool.panels;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.IAjaxIndicatorAware;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -180,6 +182,13 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 				categoryItem.add(categoryRow);
 				categoryRow.add(new Label("category", categoryName));
 
+				// popover flags
+				final CategoryFlags cf = getCategoryFlags(categoryName, categoriesMap);
+				final WebMarkupContainer flags = new WebMarkupContainer("flags");
+				flags.add(newPopoverFlag("isExtraCredit", getString("label.gradeitem.extracreditcategory"), cf.extraCredit));
+				flags.add(newPopoverFlag("isEqualWeight", getString("label.gradeitem.equalweightcategory"), cf.equalWeight));
+				categoryRow.add(flags.setVisible(cf.hasFlags()));
+
 				final DropInfoPair pair = getDropInfo(categoryName, categoriesMap);
 				if (!pair.second.isEmpty()) {
 					pair.first += " " + getString("label.category.dropSeparator") + " ";
@@ -305,31 +314,13 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 
 						// popover flags
 						final WebMarkupContainer flags = new WebMarkupContainer("flags");
-						flags.add(page.buildFlagWithPopover("isExtraCredit", getString("label.gradeitem.extracredit"))
-								.add(new AttributeModifier("data-trigger", "focus"))
-								.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
-								.setVisible(assignment.isExtraCredit()));
-						flags.add(page.buildFlagWithPopover("isNotCounted", getString("label.gradeitem.notcounted"))
-								.add(new AttributeModifier("data-trigger", "focus"))
-								.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
-								.setVisible(!assignment.isCounted()));
-						flags.add(page.buildFlagWithPopover("isNotReleased", getString("label.gradeitem.notreleased"))
-								.add(new AttributeModifier("data-trigger", "focus"))
-								.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
-								.setVisible(!assignment.isReleased()));
-						flags.add(page.buildFlagWithPopover("isExcused", getString("grade.notifications.excused"))
-								.add(new AttributeModifier("data-trigger", "focus"))
-								.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
-								.setVisible(excused));
-						flags.add(page
-								.buildFlagWithPopover("isExternal",
-										new StringResourceModel("label.gradeitem.externalapplabel", null,
-												new Object[] { assignment.getExternalAppName() }).getString())
-								.add(new AttributeModifier("data-trigger", "focus"))
-								.add(new AttributeModifier("data-container", "#gradeSummaryTable"))
-								.add(new AttributeModifier("class",
-										"gb-external-app-flag " + GradeSummaryTablePanel.this.businessService.getIconClass(assignment)))
-								.setVisible(assignment.isExternallyMaintained()));
+						flags.add(newPopoverFlag("isExtraCredit", getString("label.gradeitem.extracredit"), assignment.isExtraCredit()));
+						flags.add(newPopoverFlag("isNotCounted", getString("label.gradeitem.notcounted"), !assignment.isCounted()));
+						flags.add(newPopoverFlag("isNotReleased", getString("label.gradeitem.notreleased"), !assignment.isReleased()));
+						flags.add(newPopoverFlag("isExcused", getString("grade.notifications.excused"), excused));
+						String extAppName = new StringResourceModel("label.gradeitem.externalapplabel", null, new Object[] { assignment.getExternalAppName() }).getString();
+						flags.add(newPopoverFlag("isExternal", extAppName, assignment.isExternallyMaintained())
+								.add(new AttributeModifier("class", "gb-external-app-flag " + GradeSummaryTablePanel.this.businessService.getIconClass(assignment))));
 						flags.setVisible(
 								assignment.isExtraCredit() ||
 								!assignment.isCounted() ||
@@ -421,6 +412,13 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 						final WebMarkupContainer catCon = new WebMarkupContainer("category");
 						catCon.setVisible(categoriesEnabled && !GradeSummaryTablePanel.this.isGroupedByCategory);
 						catCon.add(new Label("categoryName", assignment.getCategoryName()));
+
+						final CategoryFlags cf = getCategoryFlags(assignment.getCategoryName(), categoriesMap);
+						final WebMarkupContainer cflags = new WebMarkupContainer("cflags");
+						cflags.add(newPopoverFlag("isExtraCredit", getString("label.gradeitem.extracreditcategory"), cf.extraCredit));
+						cflags.add(newPopoverFlag("isEqualWeight", getString("label.gradeitem.equalweightcategory"), cf.equalWeight));
+						catCon.add(cflags.setVisible(cf.hasFlags()));
+
 						final DropInfoPair pair = getDropInfo(assignment.getCategoryName(), categoriesMap);
 						catCon.add(new Label("categoryDropInfo", pair.first).setVisible(!pair.first.isEmpty()));
 						catCon.add(new Label("categoryDropInfo2", pair.second).setVisible(!pair.second.isEmpty()));
@@ -444,7 +442,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 		}
 	}
 
-	private final class DropInfoPair {
+	private final class DropInfoPair implements Serializable {
 		public String first = "";
 		public String second = "";
 	}
@@ -476,5 +474,30 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 			"<script src=\"/webcomponents/rubrics/sakai-rubrics-utils.js" + version + "\"></script>"));
 		response.render(StringHeaderItem.forString(
 			"<script type=\"module\" src=\"/webcomponents/rubrics/rubric-association-requirements.js" + version + "\"></script>"));
+	}
+
+	private Component newPopoverFlag(String id, String msg, boolean visible) {
+		final BasePage page = (BasePage) getPage();
+		return page.buildFlagWithPopover(id, msg, "focus", "#gradeSummaryTable").setVisible(visible);
+	}
+
+	private final class CategoryFlags implements Serializable {
+		public boolean extraCredit = false;
+		public boolean equalWeight = false;
+
+		public boolean hasFlags() {
+			return extraCredit || equalWeight;
+		}
+	}
+
+	private CategoryFlags getCategoryFlags(String catName, final Map<String, CategoryDefinition> categoriesMap) {
+		CategoryFlags flags = new CategoryFlags();
+		if (catName != null && !catName.equals(getString(GradebookPage.UNCATEGORISED))) {
+			CategoryDefinition cat = categoriesMap.get(catName);
+			flags.extraCredit = cat != null && Boolean.TRUE.equals(cat.getExtraCredit());
+			flags.equalWeight = cat != null && Boolean.TRUE.equals(cat.getEqualWeight());
+		}
+
+		return flags;
 	}
 }

--- a/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-gbgrade-table.css
@@ -298,10 +298,11 @@
 }
 .gb-flag-equal-weight:before {
   content: '\2696';
-  color:var(--sakai-color-gold--darker-1);
 }
 .gb-flag-extra-credit:before {
   content: '\f0fe';
+}
+#gradeTableWrapper .gb-notification.gb-flag-extra-credit:before {
   color:var(--sakai-color-gold--darker-1);
 }
 #gradeTableWrapper .gb-excused {

--- a/gradebookng/tool/src/webapp/styles/gradebook-grades.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-grades.css
@@ -448,6 +448,11 @@ div.wicket-modal .w_blue div.w_content
 .gb-summary-grade-panel .gb-summary-category-toggle:active {
   text-decoration: none;
   display: flex;
+  flex-grow: 2;
+}
+.gb-summary-grade-panel .gb-summary-category-toggle-container {
+  display: flex;
+  justify-content: space-between;
 }
 .gb-summary-grade-title {
   font-weight: normal;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46151

When a category is set to use the equal weighting feature, this is indicated with a small icon so the instructor can easily recognize why the calculation doesn't reflect the raw point values. However, no such indication is given in the student view, which could be very confusing for students trying to understand how their category score was derived. Equal weight categories are also not indicated for instructors on the category column header itself, only in the item headers. This contrasts with extra credit, which is indicated in both places.

Additionally, students are also given no indication that a category is extra credit.

-----------

The styling colour changes are needed because by default both the extra credit and equal weight icons are gold. This gold colour is only needed in the grade cells for extra credit, and not needed at all for equal weight, so I refined the styles to only apply the gold colour in the appropriate situation.
