### PR TITLE
SAK-45327 Error trying to upload video to Profile gallery

### DIFF
--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/ChangeProfilePictureUpload.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/ChangeProfilePictureUpload.html
@@ -35,7 +35,7 @@
 		<div class="wicket-feedbackpanel-nolist" wicket:id="feedback">[feedback]</div>
 		
 		<label for="pictureupload" class="accessibility-label"><wicket:message key="accessibility.image.upload">Profile image file selector</wicket:message></label>
-		<p><input type="file" wicket:id="picture" size="15"/></p>
+		<p><input type="file" wicket:id="picture" size="15" accept="image/*"/></p>
 			
 		<div wicket:id="editWarning" class="edit-other-warning">[You are editing {other person}'s image]</div>
 		


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-45327

My solution to this is to restrict the allowed file types, to accept only images, so the user is not able to select a video or something else

Also the OS file explorer will only show allowed files

![image](https://user-images.githubusercontent.com/33053368/131644804-9e3fc3a5-52c6-45a6-84d5-961af1cf88b6.png)
