### PR TITLE
SAK-46156 Improve gradebook JS rendering time in some browsers

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -688,6 +688,10 @@ GbGradeTable.renderTable = function (elementId, tableData) {
   GbGradeTable.COURSE_GRADE_COLUMN_INDEX = GbGradeTable.FIXED_COLUMN_OFFSET - 1; // course grade is always the last fixed column
   GbGradeTable.domElement.addClass('gb-fixed-columns-' + GbGradeTable.FIXED_COLUMN_OFFSET);
 
+  if (sakai && sakai.locale && sakai.locale.userLanguage) {
+    GbGradeTable.numFmt = new Intl.NumberFormat(sakai.locale.userLanguage);
+  }
+
   GbGradeTable.grades = GbGradeTable.mergeColumns(GbGradeTable.unpack(tableData.serializedGrades,
                                                                       tableData.rowCount,
                                                                       tableData.columnCount),
@@ -3121,8 +3125,8 @@ GbGradeTable.localizeNumber = function(number) {
         return;
     }
 
-    if (sakai && sakai.locale && sakai.locale.userLanguage) {
-        return parseFloat(number).toLocaleString(sakai.locale.userLanguage);
+    if (GbGradeTable.numFmt) {
+        return GbGradeTable.numFmt.format(parseFloat(number));
     }
 
     return '' + number;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46156



Gradebook uses toLocaleString() for each grade it renders. During an investigation into client-side rendering performance I noted that this was taking a long time in Firefox. I found the following MDN article that recommends a different approach for performance reasons:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#performance

Anecdotally, after making this change locally I measured a reduction in JS rendering time for a large gradebook of approximately 1000ms, taking the entire time from 2200ms to 1100ms, so this is a noticeable improvement in this scenario. This was in Firefox. There was no real improvement in Chromium, so I assume it already makes this optimization under the hood. Still, for Firefox users with large gradebooks this will be a benefit.
