### PR TITLE
SAK-46159 Site Info > Improve layout of tool selection page when importing content

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -213,7 +213,6 @@ site.create = Create Site
 #Import Vm
 import.reuse = Re-use Material from Other Sites
 import.of = of
-import.reuse2 = Re-use material from other sites you own...
 import.choose = Choose the material you want to re-use from these sites. You can combine material from  more than one site (for example, Resources from several sites).
 import.choose.list.summary = Table holds a grid of tools and sites. First column: tool name. Subsequent columns the sites. Some of these may have checkboxes. Selecting them will import the contents of that tool (the row) in that site (the column)
 import.choose.label1 = Select
@@ -1015,7 +1014,7 @@ java.delete.hard = Hard Delete Selected
 sitegen.sitedel.hard = NOTE: You chose Hard Delete so these sites will have their tool content purged from the system.
 sitegen.sitedel.hard.button = Hard delete
 
-import.newtool = Note: If you choose to import content from the tools marked with a +, the tools will be added to your site.
+import.newtool = Note: If you choose to import content from the tools marked with a <strong><sup>+</sup></strong>, the tools will be added to your site.
 
 sinfo.lessonbuildersubnav.name=Lessons subpage navigation
 sinfo.lessonbuildersubnav.allowForSite=Enable <strong>Lessons subpage navigation</strong> in the left tool menu.

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSites.vm
@@ -17,6 +17,12 @@
 			#end
 		#end
 	#end
+
+	<h3>$tlang.getString("import.reuse")</h3>
+	#if ($alertMessage)
+		<div class="sak-banner-error">$tlang.getString("gen.alert") $alertMessage</div>
+	#end
+
 	#if ($materialFound)
 		<div class="sak-banner-warn">
 			#if ($hideImportedContent)
@@ -25,16 +31,9 @@
 				$tlang.getString("sitinfimp.material.visible.warn")
 			#end
 		</div>
-		<div class="clear"></div>
 	#end
-	<h3>
-		$tlang.getString("import.reuse")
-	</h3>
-	<p class="step">
-		$tlang.getString("import.reuse2")
-	</p>
-	#if ($alertMessage)
-		<div class="sak-banner-error">$tlang.getString("gen.alert") $alertMessage</div>
+	#if ($addMissingTools)
+		<p class="sak-banner-info">$tlang.getString("import.newtool")</p>
 	#end
 	<p class="instruction">
 	$tlang.getString("import.choose")
@@ -153,10 +152,6 @@
 				#end
 			</table>
 		</div>
-		
-		#if ($addMissingTools)
-			<p class="sak-banner-warn">$tlang.getString("import.newtool")</p>
-		#end
 		
 		<input type="hidden" name="back" value="$!backIndex" />
 		<input type="hidden" name="templateIndex" value="$!templateIndex" />

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-importSitesMigrate.vm
@@ -4,11 +4,12 @@
 	<h3>
 		$tlang.getString("import.reuse")
 	</h3>
-	<p class="step">
-		$tlang.getString("import.reuse2")
-	</p>
 	#if ($alertMessage)
 		<div class="sak-banner-error">$tlang.getString("gen.alert") $alertMessage</div>
+	#end
+	<div class="sak-banner-warn">$tlang.getString("import.links.warning")</div>
+	#if ($addMissingTools)
+		<p class="sak-banner-info">$tlang.getString("import.newtool")</p>
 	#end
 	<p class="instruction">
 	$tlang.getString("sitinfimp.choose")
@@ -121,11 +122,7 @@
 				#end
 			</table>
 		</div>
-		
-		#if ($addMissingTools)
-			<p class="sak-banner-warn">$tlang.getString("import.newtool")</p>
-		#end
-		
+
 		<input type="hidden" name="back" value="59" />
 		<input type="hidden" name="templateIndex" value="60" />
 		<input type="hidden" name="continue" value="$continue" />
@@ -133,9 +130,6 @@
 			<input type="submit" accesskey="s" class="active" name="eventSubmit_doContinue" value="$tlang.getString('gen.finish')" onclick="SPNR.disableControlsAndSpin( this, null );" />
 			<input type="submit" accesskey="b" name="eventSubmit_doBack" value="$tlang.getString('gen.back')" onclick="SPNR.disableControlsAndSpin( this, null );" />
 			<input type="submit" accesskey="x" name="eventSubmit_doCancel" value="$tlang.getString('gen.cancel')" onclick="SPNR.disableControlsAndSpin( this, null );" />
-		</p>
-		<p class="alertMessageInline">
-		$tlang.getString("import.links.warning")
 		</p>
 		<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 	</form>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46159

The instructions on the tool selection page when importing content are a little scattered. Moving all the banners to the top of the page and removing redundant messages would help streamline things.
