### PR TITLE
SAK-46160 - Assignments - clean up content-review items when assignments are hard deleted

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1028,6 +1028,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_REMOVE_ASSIGNMENT, null);
         }
 
+        String context = assignment.getContext();
+
         assignmentDueReminderService.removeScheduledReminder(assignment.getId());
         assignmentRepository.deleteAssignment(assignment.getId());
 
@@ -1052,6 +1054,9 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         } catch (AuthzRealmLockException arle) {
             log.warn("GROUP LOCK REGRESSION: {}", arle.toString());
         }
+
+        // clean up content-review items
+        contentReviewService.deleteAssignment(context, reference);
     }
 
     @Override

--- a/content-review/api/src/main/java/org/sakaiproject/contentreview/service/ContentReviewService.java
+++ b/content-review/api/src/main/java/org/sakaiproject/contentreview/service/ContentReviewService.java
@@ -348,6 +348,14 @@ public interface ContentReviewService {
 	throws SubmissionException, TransientSubmissionException;
 
 	/**
+	 * For the given taskId, does any necessary cleanup when an assignment is hard deleted
+	 *
+	 * @param siteId
+	 * @param taskId
+	 */
+	public void deleteAssignment(String siteId, String taskId);
+
+	/**
 	 * This method returns all the information related with a ContentReviewItem encapsulated as a ContentReviewResult
 	 * Using this method will likely tie you to a particular Content Review implementation.
 	 * 

--- a/content-review/impl/compilatio/src/main/java/org/sakaiproject/contentreview/compilatio/CompilatioReviewServiceImpl.java
+++ b/content-review/impl/compilatio/src/main/java/org/sakaiproject/contentreview/compilatio/CompilatioReviewServiceImpl.java
@@ -51,7 +51,6 @@ import org.sakaiproject.contentreview.exception.ReportException;
 import org.sakaiproject.contentreview.exception.SubmissionException;
 import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
-import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entitybroker.EntityReference;
 import org.sakaiproject.exception.IdUnusedException;
@@ -193,7 +192,6 @@ public class CompilatioReviewServiceImpl extends BaseContentReviewService {
 	@Setter protected CompilatioAccountConnection compilatioConn;
 	@Setter protected CompilatioContentValidator compilatioContentValidator;
 	@Setter protected ContentReviewSiteAdvisor siteAdvisor;
-	@Setter	ContentReviewQueueService crqs;
 	
 	public void init() {		
 	}

--- a/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/ContentReviewFederatedServiceImpl.java
+++ b/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/ContentReviewFederatedServiceImpl.java
@@ -167,6 +167,11 @@ public class ContentReviewFederatedServiceImpl extends BaseContentReviewService 
 		getSelectedProvider().createAssignment(arg0, arg1, arg2);
 	}
 
+	@Override
+	public void deleteAssignment(String siteId, String taskId) {
+		getSelectedProvider().deleteAssignment(siteId, taskId);
+	}
+
 	public List<ContentReviewItem> getAllContentReviewItems(String arg0, String arg1)
 			throws QueueException, SubmissionException, ReportException {
 		return getSelectedProvider().getAllContentReviewItems(arg0, arg1);

--- a/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/NoOpContentReviewService.java
+++ b/content-review/impl/service/src/main/java/org/sakaiproject/contentreview/service/NoOpContentReviewService.java
@@ -245,6 +245,11 @@ public class NoOpContentReviewService extends BaseContentReviewService {
 	}
 
 	@Override
+	public void deleteAssignment(String siteId, String taskId) {
+		log.debug("void deleteAssignment {} {}", siteId, taskId);
+	}
+
+	@Override
 	public ContentReviewItem getContentReviewItemByContentId(String contentId) {
 		ContentReviewItem ret = null;
 		log.debug("{} getContentReviewItemByContentId {}", ret, contentId);

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -72,7 +72,6 @@ import org.sakaiproject.contentreview.exception.ReportException;
 import org.sakaiproject.contentreview.exception.SubmissionException;
 import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
-import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
@@ -108,9 +107,6 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	
 	@Setter
 	private SiteService siteService;
-
-	@Setter
-	private ContentReviewQueueService crqs;
 
 	@Setter
 	private ContentHostingService contentHostingService;

--- a/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
+++ b/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
@@ -58,7 +58,6 @@ import org.sakaiproject.contentreview.exception.ReportException;
 import org.sakaiproject.contentreview.exception.SubmissionException;
 import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
-import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.contentreview.turnitin.util.TurnitinAPIUtil;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
@@ -251,9 +250,6 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 	
 	@Setter
 	private ToolManager toolManager;
-
-	@Setter
-	ContentReviewQueueService crqs;
 
 	public void init() {
 

--- a/content-review/impl/urkund/src/main/java/org/sakaiproject/contentreview/urkund/UrkundReviewServiceImpl.java
+++ b/content-review/impl/urkund/src/main/java/org/sakaiproject/contentreview/urkund/UrkundReviewServiceImpl.java
@@ -55,7 +55,6 @@ import org.sakaiproject.contentreview.advisors.ContentReviewSiteAdvisor;
 import org.sakaiproject.contentreview.dao.ContentReviewConstants;
 import org.sakaiproject.contentreview.dao.ContentReviewItem;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
-import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.contentreview.service.ContentReviewService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entitybroker.EntityReference;
@@ -140,7 +139,6 @@ public class UrkundReviewServiceImpl extends BaseContentReviewService {
 	@Setter	protected UrkundAccountConnection urkundConn;
 	@Setter	protected UrkundContentValidator urkundContentValidator;
 	@Setter protected ContentReviewSiteAdvisor siteAdvisor;
-	@Setter	protected ContentReviewQueueService crqs;
 	
 	public void init() {
 		maxRetry = Long.valueOf(serverConfigurationService.getInt("urkund.maxRetry", 20));

--- a/content-review/impl/vericite/src/main/java/org/sakaiproject/contentreview/vericite/ContentReviewServiceVeriCite.java
+++ b/content-review/impl/vericite/src/main/java/org/sakaiproject/contentreview/vericite/ContentReviewServiceVeriCite.java
@@ -55,7 +55,6 @@ import org.sakaiproject.contentreview.exception.ReportException;
 import org.sakaiproject.contentreview.exception.SubmissionException;
 import org.sakaiproject.contentreview.exception.TransientSubmissionException;
 import org.sakaiproject.contentreview.service.BaseContentReviewService;
-import org.sakaiproject.contentreview.service.ContentReviewQueueService;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.Reference;
@@ -97,9 +96,6 @@ public class ContentReviewServiceVeriCite extends BaseContentReviewService {
 	
 	@Setter
 	private SiteService siteService;
-	
-	@Setter
-	private ContentReviewQueueService crqs;
 	
 	@Setter
 	private ContentHostingService contentHostingService;

--- a/content-review/pack/src/webapp/WEB-INF/compilatio.xml
+++ b/content-review/pack/src/webapp/WEB-INF/compilatio.xml
@@ -20,7 +20,6 @@
 		<property name="compilatioContentValidator" ref="org.sakaiproject.contentreview.compilatio.CompilatioContentValidator" />
 		<property name="compilatioConn" ref="org.sakaiproject.contentreview.compilatio.CompilatioAccountConnection" />
 		<property name="siteAdvisor" ref="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" />
-		<property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
 	</bean>
 
 	<!-- Default to allow all sites to use Compilatio regardless of site type or property -->

--- a/content-review/pack/src/webapp/WEB-INF/components.xml
+++ b/content-review/pack/src/webapp/WEB-INF/components.xml
@@ -19,6 +19,7 @@
 			class="org.sakaiproject.contentreview.service.BaseContentReviewService"
 			abstract="true">
 		<property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService" />
+		<property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
 		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
 		<property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService" />
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />

--- a/content-review/pack/src/webapp/WEB-INF/turnitin-oc.xml
+++ b/content-review/pack/src/webapp/WEB-INF/turnitin-oc.xml
@@ -13,7 +13,6 @@
          <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
          <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
          <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
-         <property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
          <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
          <property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService" />
          <property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService" />

--- a/content-review/pack/src/webapp/WEB-INF/turnitin.xml
+++ b/content-review/pack/src/webapp/WEB-INF/turnitin.xml
@@ -26,7 +26,6 @@
 		<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 		<property name="siteAdvisor" ref="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" />
-		<property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
 	</bean>
 
 	<!-- Default to allow all sites to use Turnitin regardless of site type or property -->

--- a/content-review/pack/src/webapp/WEB-INF/urkund.xml
+++ b/content-review/pack/src/webapp/WEB-INF/urkund.xml
@@ -25,7 +25,6 @@
 		class="org.sakaiproject.contentreview.urkund.UrkundReviewServiceImpl"
 		parent="org.sakaiproject.contentreview.service.BaseContentReviewService"
 		init-method="init">
-		<property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
 
 		<property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />

--- a/content-review/pack/src/webapp/WEB-INF/vericite.xml
+++ b/content-review/pack/src/webapp/WEB-INF/vericite.xml
@@ -12,7 +12,6 @@
          <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
          <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
          <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
-         <property name="crqs" ref="org.sakaiproject.contentreview.service.ContentReviewQueueService" />
          <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
          <property name="memoryService" ref="org.sakaiproject.memory.api.MemoryService" />
     </bean>


### PR DESCRIPTION
When an assignment is hard deleted, it leaves behind content-review items that still refer to the assignment. When these items are in the content-review queue, they can produce errors since their associated assignment no longer exists.

These items should be deleted from the queue.