### PR TITLE
SAK-46173 Samigo > Create/Edit > Settings > User selections lost/changed silently

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -93,6 +93,7 @@ anonymous_users=Anonymous Users
 entire_site=Entire Site
 selected_groups=Selected Group(s)
 select_all_groups=Select All Groups
+released_to_help=Choosing "Anonymous Users" will (if applicable) automatically select anonymous grading and deselect send to Gradebook in the "Grading and Feedback" settings. Switching from "Anonymous Users" to another choice will automatically deselect anonymous grading.
 
 high_security_allow_only_specified_ip=Allow only specified IP Addresses
 high_security_secondary_id_pw=Secondary Password
@@ -177,6 +178,7 @@ gradebook_options=Gradebook Options
 gradebook_options_help=Send assessment score to Gradebook immediately, regardless of options below
 gradebook_category_select=Select a Gradebook category (optional)
 gradebook_uncategorized=Uncategorized
+grading_options_disabled_info=The option(s) below are disabled due to the selection of "Anonymous Users" in the "Availability and Submissions" settings
 
 recorded_score=If multiple submissions, record the
 highest_score=highest score

--- a/samigo/samigo-app/src/webapp/js/authoring.js
+++ b/samigo/samigo-app/src/webapp/js/authoring.js
@@ -671,24 +671,54 @@ function initTimedCheckBox(){
 		if((timedHoursVal != "0") || (timedMinutesVal != "0")) document.getElementById("assessmentSettingsAction\:selTimeAssess").checked=true;
 }
 
-function lockdownAnonyGrading(value) {
-	if (value == 'Anonymous Users') {
-		$('#assessmentSettingsAction\\:anonymousGrading').prop('checked', 'checked');
-		$('#assessmentSettingsAction\\:anonymousGrading').prop('disabled', 'disabled');
-	} 
-	else {
-		$('#assessmentSettingsAction\\:anonymousGrading').prop('checked', '');
-		$('#assessmentSettingsAction\\:anonymousGrading').prop('disabled', '');
+const ANON_USERS = "Anonymous Users";
+function lockdownAnonyGrading(value, prevValue) {
+	const ag = document.getElementById("assessmentSettingsAction:anonymousGrading");
+	if (ag === null) {
+		return;
 	}
+
+	if (value === ANON_USERS) {
+		ag.checked = true;
+	} 
+	else if (prevValue === ANON_USERS) {
+		ag.checked = false;
+	}
+
+	ag.disabled = value === ANON_USERS;
 }
 
 function lockdownGradebook(value) {
-	if (value == 'Anonymous Users') {
-		$('#assessmentSettingsAction\\:toDefaultGradebook').prop('checked', '');
-		$('#assessmentSettingsAction\\:toDefaultGradebook').prop('disabled', 'disabled');
-	} 
-	else {
-		$('#assessmentSettingsAction\\:toDefaultGradebook').prop('disabled', '');
+	const gb = document.getElementById("assessmentSettingsAction:toDefaultGradebook");
+	if (gb === null) {
+		return;
+	}
+
+	if (value === ANON_USERS && gb.checked) {
+		gb.click();  // there is an event handler on the checkbox so we need to click it
+	}
+
+	gb.disabled = value === ANON_USERS;
+}
+
+function handleAnonymousUsers(value, prevValue) {
+	lockdownAnonyGrading(value, prevValue);
+	lockdownGradebook(value);
+	const msg = document.getElementById("assessmentSettingsAction:gradingOptionsDisabledInfo");
+	if (msg !== null) {
+		msg.style.display = value === ANON_USERS ? "block" : "none";
+	}
+}
+
+function handleAnonymousUsersChange(element)
+{
+	const value = element.value; 	// possible values are Anonymous Users, <site title>, Specific Groups
+	const prevValue = "prevValue" in element ? element.prevValue : [...element.options].filter(o => o.defaultSelected)[0].label;
+	element.prevValue = value;
+
+	// only if switching to or from Anonymous Users do we need to take action
+	if (value !== prevValue && (value === ANON_USERS || prevValue === ANON_USERS)) {
+		handleAnonymousUsers(value, prevValue);
 	}
 }
 

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -169,9 +169,8 @@
           });
           
           var releaseToVal = $('#assessmentSettingsAction\\:releaseTo').val();
-          if (releaseToVal == 'Anonymous Users') {
-              lockdownAnonyGrading(releaseToVal);
-              lockdownGradebook(releaseToVal);
+          if (releaseToVal === 'Anonymous Users') {
+              handleAnonymousUsers(releaseToVal, "");
           }
           showHideReleaseGroups();
           initTimedCheckBox();
@@ -355,9 +354,11 @@
   <div class="form-group row">
       <h:outputLabel for="releaseTo" styleClass="col-md-2" value="#{assessmentSettingsMessages.released_to} " />
       <div class="col-md-10">
-          <h:selectOneMenu id="releaseTo" value="#{assessmentSettings.firstTargetSelected}" onclick="setBlockDivs();lockdownAnonyGrading(this.value);lockdownGradebook(this.value);" onchange="showHideReleaseGroups();">
+          <h:selectOneMenu id="releaseTo" value="#{assessmentSettings.firstTargetSelected}" onclick="setBlockDivs();" onchange="handleAnonymousUsersChange(this);showHideReleaseGroups();">
               <f:selectItems value="#{assessmentSettings.publishingTargets}" />
           </h:selectOneMenu>
+          <h:outputLabel rendered="#{assessmentSettings.valueMap.testeeIdentity_isInstructorEditable==true || (assessmentSettings.valueMap.toGradebook_isInstructorEditable==true && assessmentSettings.gradebookExists==true)}"
+                         styleClass="help-block info-text small" value="#{assessmentSettingsMessages.released_to_help}" />
        </div>
   </div>
 
@@ -579,7 +580,13 @@
         </t:selectOneRadio>
       </div>
     </h:panelGroup>
-  
+
+    <!-- info message about the anonymous and gradebook options below, will be shown only if quiz released to "Anonymous Users" -->
+    <h:panelGroup rendered="#{assessmentSettings.valueMap.testeeIdentity_isInstructorEditable==true || (assessmentSettings.valueMap.toGradebook_isInstructorEditable==true && assessmentSettings.gradebookExists==true)}"
+                  layout="block" id="gradingOptionsDisabledInfo" styleClass="row sak-banner-info" style="display: none">
+        <h:outputText value="#{assessmentSettingsMessages.grading_options_disabled_info}" />
+    </h:panelGroup>
+
     <!--  ANONYMOUS OPTION -->
     <h:panelGroup styleClass="row" layout="block" rendered="#{assessmentSettings.valueMap.testeeIdentity_isInstructorEditable==true}">
       <h:outputLabel styleClass="col-md-2" value="#{assessmentSettingsMessages.student_identity_label}"/>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46173

Samigo will run JavaScript that will silently uncheck the anon grading box if you switch "release to" from "Entire Site" to "Selected Groups" or vice-versa. The intention here was to do this when switching from "Anonymous Users" to another selection, but it seems "Selected Groups" was not considered. Furthermore, silently changing settings is not a good practice. Users need to know that this will happen.
