### PR TITLE
SAK-44981 Samigo : assign items to pools, parts or keep sequence

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemConfigBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemConfigBean.java
@@ -442,14 +442,6 @@ public class ItemConfigBean implements Serializable {
     return list;
   }
 
-  public List<SelectItem> getAddItemTypeSelectList()
-  {
-    List<SelectItem> list = getItemTypeSelectList();
-    list.add(0, new SelectItem("", getResourceDisplayName("select_qtype")));
-
-    return list;
-  }
-
   /**
    * Can we select items from a question pool?
    * If we are in question pools we cannot select items from pool.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
@@ -231,10 +231,6 @@ public class SectionContentsBean extends SpringBeanAutowiringSupport implements 
     return itemContents;
   }
 
-  public int getItemContentsCount() {
-    return itemContents.size();
-  }
-
   public List<ItemContentsBean> getItemContentsForRandomDraw()
   {
     // same ordering for each student

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/StartInsertItemListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/StartInsertItemListener.java
@@ -22,9 +22,7 @@ package org.sakaiproject.tool.assessment.ui.listener.author;
 
 import java.util.List;
 
-import javax.faces.component.UIComponent;
 import javax.faces.component.UISelectItem;
-import javax.faces.component.UISelectItems;
 import javax.faces.component.UISelectOne;
 import javax.faces.event.AbortProcessingException;
 import javax.faces.event.ValueChangeEvent;
@@ -56,10 +54,8 @@ public class StartInsertItemListener implements ValueChangeListener {
   public void processValueChange(ValueChangeEvent ae) throws AbortProcessingException {
     ItemAuthorBean itemauthorbean = (ItemAuthorBean) ContextUtil.lookupBean("itemauthor");
 
-    String olditemtype = (String) ae.getOldValue();
-    log.debug("StartInsertItemListener olditemtype ." + olditemtype);
-    String selectedvalue= (String) ae.getNewValue();
-    log.debug("StartInsertItemListener selecteevalue." + selectedvalue);
+    String selectedvalue = (String) ae.getNewValue();
+    log.debug("StartInsertItemListener selectedvalue " + selectedvalue);
     String newitemtype = null;
     String insertItemPosition = null;
     String insertToSection = null;
@@ -70,6 +66,11 @@ public class StartInsertItemListener implements ValueChangeListener {
 
       try {
         newitemtype = strArray[0].trim();
+
+        if (strArray.length >= 2) {//SAK-44981 skipping default selections
+          return;
+        }
+
         ///////// SAK-3114: ///////////////////////////////////////////
         // note: you must include at least one selectItem in the form
         // type#,p#,q#
@@ -83,16 +84,13 @@ public class StartInsertItemListener implements ValueChangeListener {
           if (children.get(i) instanceof UISelectItem) {
               UISelectItem selectItem = (UISelectItem) children.get(i);
               log.debug("selectItem.getItemValue()="+selectItem.getItemValue());
-              String itemValue =  (String) selectItem.getItemValue();
+              String itemValue = (String) selectItem.getItemValue();
               log.debug("itemValue ="+ itemValue);
               String[] insertArray = itemValue.split(",");
               // add in p#,q#
               insertToSection = insertArray[1].trim();
-
+              insertItemPosition = insertArray[2].trim();
               break;
-          }
-          if (ContextUtil.lookupParam("itemSequence") != null && !ContextUtil.lookupParam("itemSequence").trim().equals("")) {
-        	insertItemPosition = ContextUtil.lookupParam("itemSequence");
           }
         }
       } catch (Exception ex) {

--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -223,7 +223,6 @@ $(window).load( function() {
 
 <h:commandLink id="hiddenlink" action="#{itemauthor.doit}" value="" styleClass="hidden">
   <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.StartCreateItemListener" />
-  <f:param name="itemSequence" value="0"/>
 </h:commandLink>
 
 <h:messages styleClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
@@ -320,13 +319,13 @@ $(window).load( function() {
         <h:outputText value="&#160;" escape="false" />
         <!-- each selectItem stores the itemtype, current sequence -->
         <h:selectOneMenu id="changeQType" onchange="clickInsertLink(this);"  value="#{itemauthor.itemTypeString}">
+             <f:selectItem itemLabel="#{authorMessages.select_qtype}" itemValue="1,#{partBean.number},#{partBean.itemContents.size()}"/>
              <f:valueChangeListener type="org.sakaiproject.tool.assessment.ui.listener.author.StartInsertItemListener" />
-             <f:selectItems value="#{itemConfig.addItemTypeSelectList}" />
+             <f:selectItems value="#{itemConfig.itemTypeSelectList}" />
         </h:selectOneMenu>
       </div>
     </div>
     <h:commandLink id="hiddenlink" action="#{itemauthor.doit}" value="" styleClass="hidden">
-      <f:param name="itemSequence" value="#{partBean.itemContentsCount}"/>
     </h:commandLink>
 </h:panelGroup>
 
@@ -464,10 +463,10 @@ $(window).load( function() {
           <!-- each selectItem stores the itemtype, current sequence -->
           <h:selectOneMenu id="changeQType" onchange="clickInsertLink(this);" value="#{itemauthor.itemTypeString}" >
             <f:valueChangeListener type="org.sakaiproject.tool.assessment.ui.listener.author.StartInsertItemListener" />
-            <f:selectItems value="#{itemConfig.addItemTypeSelectList}" />
+            <f:selectItem itemLabel="#{authorMessages.select_qtype}" itemValue="1,#{partBean.number},#{question.itemData.sequence}"/>
+            <f:selectItems value="#{itemConfig.itemTypeSelectList}" />
           </h:selectOneMenu>
           <h:commandLink id="hiddenlink" styleClass="hidden" action="#{itemauthor.doit}" value="">
-            <f:param name="itemSequence" value="#{question.itemData.sequence}"/>
           </h:commandLink>
         </div>
       </h:panelGroup>
@@ -539,4 +538,3 @@ $(window).load( function() {
       </body>
     </html>
   </f:view>
-


### PR DESCRIPTION
This bug was originally introduced on https://jira.sakaiproject.org/browse/SAK-42865 so I'm putting back some of what was removed back then. For that reason I'm also overriding the changes from https://jira.sakaiproject.org/browse/SAK-46039 (as now they won't be needed).