### PR TITLE
SAK-46169 - Assignments - submitted attachment lists include "Inline Submission.html" which is an implementation detail

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/EmailUtil.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/EmailUtil.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
 import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.AssignmentConstants;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.assignment.api.model.AssignmentSubmission;
 import org.sakaiproject.assignment.api.model.AssignmentSubmissionSubmitter;
@@ -227,16 +228,18 @@ public class EmailUtil {
             //if this is a archive (zip etc) append the list of files in it
             attachments.stream().map(attachment -> entityManager.newReference(attachment)).forEach(reference -> {
                 ResourceProperties properties = reference.getProperties();
-                boolean isArchiveFile = isArchiveFile(reference);
-                buffer.append(properties.getProperty(ResourceProperties.PROP_DISPLAY_NAME))
-                        .append(" (")
-                        .append(reference.getProperties().getPropertyFormatted(ResourceProperties.PROP_CONTENT_LENGTH))
-                        .append(isArchiveFile ? "):" : ")")
-                        .append(NEW_LINE);
-                if (isArchiveFile(reference)) {
-                    buffer.append("<blockquote>\n");
-                    buffer.append(getArchiveManifest(reference, true));
-                    buffer.append("</blockquote>\n");
+                if (!"true".equals(properties.getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION))) {
+                    boolean isArchiveFile = isArchiveFile(reference);
+                    buffer.append(properties.getProperty(ResourceProperties.PROP_DISPLAY_NAME))
+                            .append(" (")
+                            .append(reference.getProperties().getPropertyFormatted(ResourceProperties.PROP_CONTENT_LENGTH))
+                            .append(isArchiveFile ? "):" : ")")
+                            .append(NEW_LINE);
+                    if (isArchiveFile(reference)) {
+                        buffer.append("<blockquote>\n");
+                        buffer.append(getArchiveManifest(reference, true));
+                        buffer.append("</blockquote>\n");
+                    }
                 }
             });
         }

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2267,9 +2267,9 @@ public class AssignmentAction extends PagedResourceActionII {
             }
         }
 
-        context.put("text", state.getAttribute(PREVIEW_SUBMISSION_TEXT));
+        context.put("text", state.getAttribute(VIEW_SUBMISSION_TEXT));
         Map<String, Reference> submissionAttachmentReferences = new HashMap<>();
-        stripInvisibleAttachments(state.getAttribute(PREVIEW_SUBMISSION_ATTACHMENTS)).forEach(r -> submissionAttachmentReferences.put(r.getId(), r));
+        stripInvisibleAttachments(state.getAttribute(ATTACHMENTS)).forEach(r -> submissionAttachmentReferences.put(r.getId(), r));
         context.put("submissionAttachmentReferences", submissionAttachmentReferences);
         context.put("contentTypeImageService", contentTypeImageService);
 

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -1933,6 +1933,21 @@ public class AssignmentAction extends PagedResourceActionII {
     }
 
     /**
+     * Filters the submission's attachments to include only attachments that should be displayed in the UI,
+     * then returns as a map of attachment reference IDs to their associated references
+     */
+    private Map<String, Reference> getVisibleAttachmentIdsToReferences(AssignmentSubmission submission) {
+        Map<String, Reference> submissionAttachmentReferences = new HashMap<>();
+        submission.getAttachments().forEach(refId -> {
+            Reference reference = entityManager.newReference(refId);
+            if (!"true".equals(reference.getProperties().getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION))) {
+                submissionAttachmentReferences.put(refId, reference);
+            }
+        });
+        return submissionAttachmentReferences;
+    }
+
+    /**
      * Get a list of accepted mime types suitable for an 'accept' attribute in an html file picker
      *
      * @throws IllegalArgumentException if the assignment accepts all attachments
@@ -2085,9 +2100,7 @@ public class AssignmentAction extends PagedResourceActionII {
             if (s != null) {
                 context.put("submission", s);
 
-                Map<String, Reference> attachmentReferences = new HashMap<>();
-                s.getAttachments().forEach(r -> attachmentReferences.put(r, entityManager.newReference(r)));
-                context.put("attachmentReferences", attachmentReferences);
+                context.put("submissionAttachmentReferences", getVisibleAttachmentIdsToReferences(s));
 
                 context.put("submit_text", StringUtils.trimToNull(s.getSubmittedText()));
                 context.put("email_confirmation", serverConfigurationService.getBoolean("assignment.submission.confirmation.email", true));
@@ -2446,9 +2459,7 @@ public class AssignmentAction extends PagedResourceActionII {
             context.put("assignmentAttachmentReferences", assignmentAttachmentReferences);
 
             context.put("submission", submission);
-            Map<String, Reference> submissionAttachmentReferences = new HashMap<>();
-            submission.getAttachments().forEach(r -> submissionAttachmentReferences.put(r, entityManager.newReference(r)));
-            context.put("submissionAttachmentReferences", submissionAttachmentReferences);
+            context.put("submissionAttachmentReferences", getVisibleAttachmentIdsToReferences(submission));
 
             Map<String, Reference> submissionFeedbackAttachmentReferences = new HashMap<>();
             submission.getFeedbackAttachments().forEach(r -> submissionFeedbackAttachmentReferences.put(r, entityManager.newReference(r)));
@@ -3624,9 +3635,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 context.put("isAdditionalNotesEnabled", false);
             }
 
-            Map<String, Reference> attachmentReferences = new HashMap<>();
-            s.getAttachments().forEach(r -> attachmentReferences.put(r, entityManager.newReference(r)));
-            context.put("submissionAttachmentReferences", attachmentReferences);
+            context.put("submissionAttachmentReferences", getVisibleAttachmentIdsToReferences(s));
 
             putSubmissionLogMessagesInContext(context, s);
             rangeAndGroups.buildInstructorGradeSubmissionContextGroupCheck(assignment, s.getGroupId(), state);
@@ -4280,9 +4289,7 @@ public class AssignmentAction extends PagedResourceActionII {
         if (submission != null) {
             context.put("submission", submission);
 
-            Map<String, Reference> submissionAttachmentReferences = new HashMap<>();
-            submission.getAttachments().forEach(r -> submissionAttachmentReferences.put(r, entityManager.newReference(r)));
-            context.put("submissionAttachmentReferences", submissionAttachmentReferences);
+            context.put("submissionAttachmentReferences", getVisibleAttachmentIdsToReferences(submission));
 
             Assignment assignment = submission.getAssignment();
             context.put("assignment", assignment);
@@ -4862,9 +4869,7 @@ public class AssignmentAction extends PagedResourceActionII {
             context.put("value_feedback_attachment", v);
             state.setAttribute(ATTACHMENTS, v);
 
-            Map<String, Reference> attachmentReferences = new HashMap<>();
-            s.getAttachments().forEach(r -> attachmentReferences.put(r, entityManager.newReference(r)));
-            context.put("submissionAttachmentReferences", attachmentReferences);
+            context.put("submissionAttachmentReferences", getVisibleAttachmentIdsToReferences(s));
         }
         if (peerAssessmentItems != null && submissionId != null) {
             //find the peerAssessmentItem for this submission:
@@ -6452,6 +6457,13 @@ public class AssignmentAction extends PagedResourceActionII {
                     properties.remove(AssignmentConstants.SUBMITTER_USER_ID);
                 }
 
+                // SAK-26322 - add inline as an attachment for the content review service
+                if (post && !isHtmlEmpty(text)) {
+                    /* prepares a file representing the inline content;
+                     * needed whether or not content review is used - it will be queued retroactively if we enable content review on the assignment in the future */
+                    prepareInlineForContentReview(text, submission, state, u);
+                }
+
                 // submission log
                 StringBuilder logEntry = new StringBuilder();
                 DateTimeFormatter dtf = DateTimeFormatter.RFC_1123_DATE_TIME
@@ -6482,18 +6494,9 @@ public class AssignmentAction extends PagedResourceActionII {
                     return;
                 }
 
-                // SAK-26322 - add inline as an attachment for the content review service
-                if (post) {
-                    if (!isHtmlEmpty(text)) {
-                        /* prepares a file representing the inline content;
-                         * needed whether or not content review is used - it will be queued retroactively if we enable content review on the assignment in the future */
-                        prepareInlineForContentReview(text, submission, state, u);
-                    }
-
-                    // Check if we need to post the attachments
-                    if (a.getContentReview() && !submission.getAttachments().isEmpty()) {
-                        assignmentService.postReviewableSubmissionAttachments(submission);
-                    }
+                // Check if we need to post the attachments
+                if (post && a.getContentReview() && !submission.getAttachments().isEmpty()) {
+                    assignmentService.postReviewableSubmissionAttachments(submission);
                 }
             }
 
@@ -6577,7 +6580,6 @@ public class AssignmentAction extends PagedResourceActionII {
             try {
                 Reference ref = entityManager.newReference(contentHostingService.getReference(attachment.getId()));
                 attachments.add(ref.getReference());
-                assignmentService.updateSubmission(submission);
             } catch (Exception e) {
                 log.warn(this + "prepareInlineForContentReview() cannot find reference for " + attachment.getId() + e.getMessage());
             }

--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -342,6 +342,7 @@
             #end
             <ul class="attachList">
                 #foreach ($attachmentReference in $attachmentsSet)
+                    #set ($reference = false)
                     #set ($reference = $attachmentReferencesMap.get($attachmentReference))
                     #if ($reference)
                         #set ($props = false)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -252,14 +252,7 @@
         #set($hasInline = !$value_feedback_text.isEmpty())
         #set($size = 0)
         #if ($!submission.Submitted || !$alertGradeDraft)
-            #set ($props = false)
-            #set ($size = $submission.Attachments.size())
-            #foreach ($attachmentReference in $submission.Attachments)
-                #set ($reference = $submissionAttachmentReferences.get($attachmentReference))
-                #if ($reference)
-                    #set ($props = $reference.Properties)
-                #end
-            #end
+            #set ($size = $submissionAttachmentReferences.size())
         #end
         #if ($submissionType == 4 && !$hasInline && $size == 0)
             ## if this is non-electronic submission

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
@@ -79,7 +79,7 @@
         ## Submission Attachments
         #set ($sAttachments = $!submission.Attachments)
         #if ($sAttachments)
-            #set ($size = $sAttachments.size())
+            #set ($size = $submissionAttachmentReferences.size())
             #if ($size > 0)
                 <h4>
                     #if ($!assignment.TypeOfSubmission.ordinal() == 5)
@@ -90,6 +90,7 @@
                 </h4>
                 <ul class="attachList indnt1">
                     #foreach ($attachmentReference in $sAttachments)
+                        #set ($reference = false)
                         #set ($reference = $submissionAttachmentReferences.get($attachmentReference))
                         #if ($reference)
                             #set ($props = false)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
@@ -129,12 +129,13 @@
 					<h3>$tlang.getString("gen.stuatt")</h3>
 					#set ($attachments = $submission.Attachments)
 					#if ($attachments)
-						#set ($size = $attachments.size())
+						#set ($size = $submissionAttachmentReferences.size())
 						#if ($size == 0)
 							<p class="instruction">$tlang.getString("gen.noattsubmitted")</p>
 						#else
 							<ul class="attachList indnt1">
 								#foreach ($attachmentReference in $attachments)
+									#set ($reference = false)
 									#set ($reference = $submissionAttachmentReferences.get($attachmentReference))
 									#if ($reference)
 										#set ($props = false)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -242,7 +242,7 @@
         ## Submission Attachments
         #set ($attachments = $submission.Attachments)
         #if ($attachments)
-            #set ($size = $attachments.size())
+            #set ($size = $submissionAttachmentReferences.size())
             #if ($size < 1)
                 $tlang.getString("gen.noattsubmitted")
             #else
@@ -256,6 +256,7 @@
                 <div class="textPanel borderPanel">
                     <ul class="attachList indnt1">
                         #foreach ($attachmentReference in $attachments)
+                            #set ($reference = false)
                             #set ($reference = $submissionAttachmentReferences.get($attachmentReference))
                             #if ($reference)
                                 #set ($props = false)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -168,7 +168,7 @@
             ## Submission attachments
             #set ($attachments = $submission.Attachments)
             #if ($attachments)
-                #set ($size = $attachments.size())
+                #set ($size = $submissionAttachmentReferences.size())
                 #if ($size < 1)
                     #if ($!assignment.SubmissionType.ordinal() == 5)
                         $tlang.getString("gen.noatt.single")
@@ -178,7 +178,8 @@
                 #else
                     <ul class="attachList indnt2">
                         #foreach ($attachmentReference in $attachments)
-                            #set ($reference = $attachmentReferences.get($attachmentReference))
+                            #set ($reference = false)
+                            #set ($reference = $submissionAttachmentReferences.get($attachmentReference))
                             #if ($reference)
                                 #set ($props = false)
                                 #set ($props = $reference.Properties)


### PR DESCRIPTION
Within submitted attachment lists, "Inline Submission.html" is often included. This attachment is not a user-uploaded attachment; it's an implementation detail required in case the assignment is edited, and content-review is enabled.

Hide this file from all UIs and emails.