### PR TITLE
SAK-45963 Discussions:  rubric property values are missing

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/sakai-i18n.js
+++ b/webcomponents/tool/src/main/frontend/js/sakai-i18n.js
@@ -24,8 +24,9 @@ function loadProperties(suppliedOptions) {
     return;
   }
 
+  const lang = window.parent.portal.locale ? window.parent.portal.locale : "";
   const defaults = {
-    lang: (window.portal && window.portal.locale) ? window.portal.locale : "",
+    lang: (window.portal && window.portal.locale) ? window.portal.locale : lang,
     resourceClass: "org.sakaiproject.i18n.InternationalizedMessages",
     cache: true,
   };


### PR DESCRIPTION
`window.portal` was always undefined in the opened dialog