### PR TITLE
SAK-46255 Messages: Unable to access replies saved as drafts

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -1182,7 +1182,9 @@ public void processChangeSelectView(ValueChangeEvent eve)
 	  selectedComposeToList = selectedLists.to;
 	  selectedComposeBccList = selectedLists.bcc;
 
-	  setBooleanEmailOut(draft.getExternalEmail());
+	  if (draft.getExternalEmail() != null) {
+		  setBooleanEmailOut(draft.getExternalEmail());
+	  }
 
 	  //go to compose page
 	  setFromMainOrHp();


### PR DESCRIPTION
This fixes the critical issue with the NPE, however, the approach is suboptimal since the EXTERNAL_EMAIL column in the MFR_MESSAGE_T table is nullable and doesn't have a default false value.