### PR TITLE
SAK-44545 Rubrics text overlapping/cut off at 500px

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/rubrics/_rubrics.scss
+++ b/library/src/morpheus-master/sass/modules/tool/rubrics/_rubrics.scss
@@ -121,6 +121,84 @@
     }
 
 }
+@media #{$phone} {
+    sakai-rubric,
+    sakai-rubric-readonly,
+    sakai-rubric-grading,
+    sakai-rubric-student {
+        .rubric-title {
+            .actions {
+                @include display-flex;
+                .action-container {
+                    text-align: center;
+                }
+            }
+        }
+        .collapse-details .rubric-details,
+        .rubric-details {
+            .criterion .criterion-row,
+            .criterion.sakai-rubric-criterion-readonly .criterion-row {
+                @include display-flex;
+                @include flex-direction(column);
+                width: 100%;
+                margin-bottom: $standard-spacing;
+                border-width: 1px 0;
+                .criterion-detail {
+                    border-left: 1px solid $rubrics-lightbox-border-color;
+                    width: 100%;
+                    .add-criterion-item {
+                        right: 0px;
+                        top: 8px;
+                    }
+                }
+                .criterion-ratings {
+                    width: 100%;
+                    margin-bottom: 0;
+                    .cr-table,
+                    .cr-table .cr-table-row {
+                        @include display-flex;
+                        @include flex-direction(column);
+                        .rating-item {
+                            border-bottom: 1px solid $rubrics-lightbox-border-color;
+                            border-left: 1px solid $rubrics-lightbox-border-color;
+                            &:last-of-type {
+                                border-bottom: none;
+                            }
+                            .add-criterion-item {
+                                right: 0px;
+                                top: 8px;
+                            }
+                        }
+                    }
+                }
+                .criterion-actions {
+                    width: 100%;
+                    text-align: center;
+                    border-left: 1px solid $rubrics-lightbox-border-color;
+                    border-right: 1px solid $rubrics-lightbox-border-color;
+                    > * {
+                        margin: 0px 8px;
+                    }
+                }
+            }
+            &.grading {
+                .criterion .criterion-row {
+                    .criterion-ratings {
+                        margin-bottom: 0;
+                    }
+                    .criterion-actions {
+                        @include display-flex;
+                        @include flex-direction(row-reverse);
+                        @include align-items(center);
+                        .rubric-grading-points-value {
+                            flex: 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 /** External to the tool **/
 .sakai-rubric-association {
@@ -421,6 +499,23 @@
     }
 }
 
+sakai-rubric-grading {
+    .rubric-details.grading {
+        > h3 {
+            margin-bottom: 10px;
+        }
+        .criterion.sakai-rubric-criteria-grading {
+            margin-bottom: 10px;
+            .criterion-ratings {
+                margin-bottom: 15px;
+            }
+        }
+    }
+    .rubric-totals {
+        margin: 10px 0px 10px 0px;
+    }
+}
+
 sakai-rubric-grading-comment,
 sakai-rubric-student-comment {
 
@@ -430,6 +525,7 @@ sakai-rubric-student-comment {
         width: 100%;
         &.active {
             color: var(--sakai-color-orange);
+            background-color: unset;
         }
     }
 }

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
@@ -83,88 +83,90 @@ export class SakaiRubricGrading extends RubricsElement {
   render() {
 
     return html`
-      <h3 style="margin-bottom: 10px;">${this.rubric.title}</h3>
-      ${this.evaluation && this.evaluation.status === "DRAFT" ? html`
-        <div class="sak-banner-warn">
-          <sr-lang key="draft_evaluation">DRAFT</sr-lang>
-        </div>
-      ` : "" }
-      <div class="criterion grading style-scope sakai-rubric-criteria-grading" style="margin-bottom: 10px;">
-      ${this.criteria.map(c => html`
-        <div id="criterion_row_${c.id}" class="criterion-row">
-          <div class="criterion-detail" tabindex="0">
-            <h4 class="criterion-title">${c.title}</h4>
-            <p>${c.description}</p>
-            ${this.rubric.weighted ?
-              html`
-                <div class="criterion-weight">
-                  <span>
-                    <sr-lang key="weight">Weight</sr-lang>
-                  </span>
-                  <span>${c.weight.toLocaleString(this.locale)}</span>
-                  <span>
-                    <sr-lang key="percent_sign">%</sr-lang>
-                  </span>
-                </div>`
-              : ""
-            }
+      <div class="rubric-details grading">
+        <h3>${this.rubric.title}</h3>
+        ${this.evaluation && this.evaluation.status === "DRAFT" ? html`
+          <div class="sak-banner-warn">
+            <sr-lang key="draft_evaluation">DRAFT</sr-lang>
           </div>
-          <div class="criterion-ratings" style="margin-bottom: 15px !important;">
-            <div class="cr-table">
-              <div class="cr-table-row">
-              ${c.ratings.map(r => html`
-                <div class="rating-item ${r.selected ? "selected" : ""}"
-                      tabindex="0"
-                      data-rating-id="${r.id}"
-                      id="rating-item-${r.id}"
-                      data-criterion-id="${c.id}"
-                      @keypress=${this.toggleRating}
-                      @click=${this.toggleRating}>
-                  <h5 class="criterion-item-title">${r.title}</h5>
-                  <p>${r.description}</p>
-                  <span class="points" data-points="${r.points}">
-                    ${this.rubric.weighted && r.points > 0 ?
-                      html`
-                        <b>
-                          (${parseFloat((r.points * (c.weight / 100)).toFixed(2)).toLocaleString(this.locale)})
-                        </b>`
-                      : ""
-                    }
-                    ${r.points.toLocaleString(this.locale)}
-                    <sr-lang key="points">Points</sr-lang>
-                  </span>
+        ` : "" }
+        <div class="criterion grading style-scope sakai-rubric-criteria-grading">
+        ${this.criteria.map(c => html`
+          <div id="criterion_row_${c.id}" class="criterion-row">
+            <div class="criterion-detail" tabindex="0">
+              <h4 class="criterion-title">${c.title}</h4>
+              <p>${c.description}</p>
+              ${this.rubric.weighted ?
+                html`
+                  <div class="criterion-weight">
+                    <span>
+                      <sr-lang key="weight">Weight</sr-lang>
+                    </span>
+                    <span>${c.weight.toLocaleString(this.locale)}</span>
+                    <span>
+                      <sr-lang key="percent_sign">%</sr-lang>
+                    </span>
+                  </div>`
+                : ""
+              }
+            </div>
+            <div class="criterion-ratings">
+              <div class="cr-table">
+                <div class="cr-table-row">
+                ${c.ratings.map(r => html`
+                  <div class="rating-item ${r.selected ? "selected" : ""}"
+                        tabindex="0"
+                        data-rating-id="${r.id}"
+                        id="rating-item-${r.id}"
+                        data-criterion-id="${c.id}"
+                        @keypress=${this.toggleRating}
+                        @click=${this.toggleRating}>
+                    <h5 class="criterion-item-title">${r.title}</h5>
+                    <p>${r.description}</p>
+                    <span class="points" data-points="${r.points}">
+                      ${this.rubric.weighted && r.points > 0 ?
+                        html`
+                          <b>
+                            (${parseFloat((r.points * (c.weight / 100)).toFixed(2)).toLocaleString(this.locale)})
+                          </b>`
+                        : ""
+                      }
+                      ${r.points.toLocaleString(this.locale)}
+                      <sr-lang key="points">Points</sr-lang>
+                    </span>
+                  </div>
+                `)}
                 </div>
-              `)}
               </div>
             </div>
-          </div>
-          <div class="criterion-actions">
-            <sakai-rubric-grading-comment id="comment-for-${c.id}" @comment-shown=${this.commentShown} @update-comment="${this.updateComment}" criterion="${JSON.stringify(c)}" evaluated-item-id="${this.evaluatedItemId}" entity-id="${this.entityId}"></sakai-rubric-grading-comment>
-            <div>
-              <strong id="points-display-${c.id}" class="points-display ${this.getOverriddenClass(c.pointoverride, c.selectedvalue)}">
-                ${c.selectedvalue.toLocaleString(this.locale)}
-              </strong>
+            <div class="criterion-actions">
+              <sakai-rubric-grading-comment id="comment-for-${c.id}" @comment-shown=${this.commentShown} @update-comment="${this.updateComment}" criterion="${JSON.stringify(c)}" evaluated-item-id="${this.evaluatedItemId}" entity-id="${this.entityId}"></sakai-rubric-grading-comment>
+              <div class="rubric-grading-points-value">
+                <strong id="points-display-${c.id}" class="points-display ${this.getOverriddenClass(c.pointoverride, c.selectedvalue)}">
+                  ${c.selectedvalue.toLocaleString(this.locale)}
+                </strong>
+              </div>
+              ${this.association.parameters.fineTunePoints ? html`
+                  <input
+                      title="${tr("point_override_details")}"
+                      data-criterion-id="${c.id}"
+                      name="rbcs-${this.evaluatedItemId}-${this.entityId}-criterion-override-${c.id}"
+                      class="fine-tune-points form-control hide-input-arrows"
+                      @input=${this.fineTuneRating}
+                      .value="${c.pointoverride.toLocaleString(this.locale)}"
+                  />
+                ` : ""}
+              <input aria-labelledby="${tr("points")}" type="hidden" id="rbcs-${this.evaluatedItemId}-${this.entityId}-criterion-${c.id}" name="rbcs-${this.evaluatedItemId}-${this.entityId}-criterion-${c.id}" .value="${c.selectedvalue}">
+              <input type="hidden" name="rbcs-${this.evaluatedItemId}-${this.entityId}-criterionrating-${c.id}" .value="${c.selectedRatingId}">
             </div>
-            ${this.association.parameters.fineTunePoints ? html`
-                <input
-                    title="${tr("point_override_details")}"
-                    data-criterion-id="${c.id}"
-                    name="rbcs-${this.evaluatedItemId}-${this.entityId}-criterion-override-${c.id}"
-                    class="fine-tune-points form-control hide-input-arrows"
-                    @input=${this.fineTuneRating}
-                    .value="${c.pointoverride.toLocaleString(this.locale)}"
-                />
-              ` : ""}
-            <input aria-labelledby="${tr("points")}" type="hidden" id="rbcs-${this.evaluatedItemId}-${this.entityId}-criterion-${c.id}" name="rbcs-${this.evaluatedItemId}-${this.entityId}-criterion-${c.id}" .value="${c.selectedvalue}">
-            <input type="hidden" name="rbcs-${this.evaluatedItemId}-${this.entityId}-criterionrating-${c.id}" .value="${c.selectedRatingId}">
           </div>
+        `)}
         </div>
-      `)}
-      </div>
-      <div class="rubric-totals" style="margin: 10px 0px 10px 0px;">
-        <input type="hidden" aria-labelledby="${tr("total")}" id="rbcs-${this.evaluatedItemId}-${this.entityId}-totalpoints" name="rbcs-${this.evaluatedItemId}-${this.entityId}-totalpoints" .value="${this.totalPoints}">
-        <div class="total-points">
-          <sr-lang key="total">Total</sr-lang>: <strong id="sakai-rubrics-total-points">${this.totalPoints.toLocaleString(this.locale, {maximumFractionDigits: 2})}</strong>
+        <div class="rubric-totals">
+          <input type="hidden" aria-labelledby="${tr("total")}" id="rbcs-${this.evaluatedItemId}-${this.entityId}-totalpoints" name="rbcs-${this.evaluatedItemId}-${this.entityId}-totalpoints" .value="${this.totalPoints}">
+          <div class="total-points">
+            <sr-lang key="total">Total</sr-lang>: <strong id="sakai-rubrics-total-points">${this.totalPoints.toLocaleString(this.locale, {maximumFractionDigits: 2})}</strong>
+          </div>
         </div>
       </div>
     `;

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student.js
@@ -81,23 +81,25 @@ class SakaiRubricStudent extends RubricsElement {
     return html`
       <hr class="itemSeparator" />
 
-      <h3>${this.rubric.title}</h3>
+      <div class="rubric-details student-view">
+        <h3>${this.rubric.title}</h3>
 
-      ${this.preview || this.forcePreview ? html`
-        <sakai-rubric-criterion-preview
-          criteria="${JSON.stringify(this.rubric.criterions)}"
-          .weighted=${this.rubric.weighted}
-        ></sakai-rubric-criterion-preview>
-        ` : html`
-        <sakai-rubric-criterion-student
-          criteria="${JSON.stringify(this.rubric.criterions)}"
-          rubric-association="${JSON.stringify(this.association)}"
-          evaluation-details="${JSON.stringify(this.evaluation.criterionOutcomes)}"
-          ?preview="${this.preview}"
-          entity-id="${this.entityId}"
-          .weighted=${this.rubric.weighted}
-        ></sakai-rubric-criterion-student>
-      `}
+        ${this.preview || this.forcePreview ? html`
+          <sakai-rubric-criterion-preview
+            criteria="${JSON.stringify(this.rubric.criterions)}"
+            .weighted=${this.rubric.weighted}
+          ></sakai-rubric-criterion-preview>
+          ` : html`
+          <sakai-rubric-criterion-student
+            criteria="${JSON.stringify(this.rubric.criterions)}"
+            rubric-association="${JSON.stringify(this.association)}"
+            evaluation-details="${JSON.stringify(this.evaluation.criterionOutcomes)}"
+            ?preview="${this.preview}"
+            entity-id="${this.entityId}"
+            .weighted=${this.rubric.weighted}
+          ></sakai-rubric-criterion-student>
+        `}
+      </div>
     `;
   }
 


### PR DESCRIPTION
Hi, here are some previews of my proposal to fit rubrics in a mobile viewport

https://jira.sakaiproject.org/browse/SAK-44545

---

<details> 
  <summary>Rubrics tool page (screenshot of the whole page)</summary>

![rubrics tool page](https://user-images.githubusercontent.com/33053368/133993604-9c59d746-cb1f-4ca5-ad1b-69592df1960b.png)

</details>


<details> 
  <summary>Rubrics long text</summary>

![rubrics long-text](https://user-images.githubusercontent.com/33053368/133995220-600c6c8a-36eb-4d4c-a53c-4f4e91df2ff9.png)

</details>


<details> 
  <summary>Rubrics Grading</summary>

![rubrics grading](https://user-images.githubusercontent.com/33053368/133993654-dd92cd0c-b870-4faa-9bd8-f88ab35586c5.png)


</details>

<details> 
  <summary>Rubrics fine tune</summary>

![rubrics fine-tuning](https://user-images.githubusercontent.com/33053368/133993694-f1621ba1-69b4-4bdb-b1b9-33564e7e0c90.png)

</details>

<details> 
  <summary>Rubrics student-view</summary>

![rubrics student](https://user-images.githubusercontent.com/33053368/133993721-fa7d6d3f-4a9a-4c8e-a52d-310eb5887524.png)


</details>
