### PR TITLE
SAK-46279: ERROR: ProfileDaoImpl.invalidateCurrentProfileImage invalidateCurrentProfileImage failed. class java.lang.NullPointerException: null

### DIFF
--- a/profile2/impl/src/java/org/sakaiproject/profile2/dao/impl/ProfileDaoImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/dao/impl/ProfileDaoImpl.java
@@ -1179,9 +1179,13 @@ public class ProfileDaoImpl extends HibernateDaoSupport implements ProfileDao {
 	public boolean invalidateCurrentProfileImage(final String userUuid) {
 		try {
 			final ProfileImageUploaded currentImage = getCurrentProfileImageRecord(userUuid);
-			currentImage.setCurrent(false);
-			getHibernateTemplate().save(currentImage);
-			return true;
+			if (currentImage != null) {
+				currentImage.setCurrent(false);
+				getHibernateTemplate().save(currentImage);
+				return true;
+			} else {
+				return false;
+			}
 		} catch (final Exception e) {
 			log.error("invalidateCurrentProfileImage failed. "+ e.getClass() + ": " + e.getMessage());
 			return false;


### PR DESCRIPTION
currentImage is null when removing an empty profile image.

https://jira.sakaiproject.org/browse/SAK-46279

![image](https://user-images.githubusercontent.com/15141743/134016563-d8b0949f-9f5c-4251-bad8-4f0650a2e7aa.png)
