### PR TITLE
SAK-46287: Tests & Quizzes: Question pool icons should be caret icons

### DIFF
--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -78,40 +78,19 @@ h4.samigo-category-subhead-2 {
 
 .treefolder, .treefolder-open, .treedoc {
  position: relative;
+ margin-right: 15px;
 }
 
 .treefolder:before {
-  content: "\f061";
+  content: "\f0da";
   position: absolute;
   top: 0;
   font-family: FontAwesome;
 }
 
-.treefolder:after {
-  content: "\f07b";
-  position: absolute;
-  top: 0;
-  font-family: FontAwesome;
-  margin-left: -15px;
-}
 
 .treefolder-open:before {
-  content: "\f063";
-  position: absolute;
-  top: 0;
-  font-family: FontAwesome;
-}
-
-.treefolder-open:after {
-  content: "\f07c";
-  position: absolute;
-  top: 0;
-  font-family: FontAwesome;
-  margin-left: -15px;
-}
-
-.treedoc:before {
-  content: "\f114";
+  content: "\f0d7";
   position: absolute;
   top: 0;
   font-family: FontAwesome;

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/poolTreeTable.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/poolTreeTable.jsp
@@ -48,11 +48,11 @@
 <h:panelGroup styleClass="tier#{questionpool.tree.currentLevel}"  id="firstcolumn">
 <h:inputHidden id="rowid" value="#{questionpool.tree.currentObjectHTMLId}"/>
 <h:outputLink  title="#{questionPoolMessages.t_toggletree}" id="parenttogglelink"  onclick="toggleRows(this)" onkeypress="toggleRows(this)" value="#" styleClass="treefolder" rendered="#{questionpool.tree.hasChildList}" >
-    <h:graphicImage id="spacer_for_mozilla" style="border:0" height="14" width="30" value="/images/delivery/spacer.gif" />
+    <h:graphicImage id="spacer_for_mozilla" style="border:0" height="14" width="5" value="/images/delivery/spacer.gif" />
 </h:outputLink>
-<h:outputLink title="#{questionPoolMessages.t_toggletreeEmpty}" id="togglelink"  value="#" styleClass="treedoc" rendered="#{questionpool.tree.hasNoChildList}" >
-    <h:graphicImage id="spacer_for_mozilla1" style="border:0" width="30" height="14"  value="/images/delivery/spacer.gif" />
-</h:outputLink>
+<h:panelGroup styleClass="treedoc" rendered="#{questionpool.tree.hasNoChildList}" >
+    <h:graphicImage id="spacer_for_mozilla1" style="border:0" width="5" height="14"  value="/images/delivery/spacer.gif" />
+</h:panelGroup>
 
 <h:commandLink title="#{questionPoolMessages.t_editPool}" id="editlink" immediate="true" action="#{questionpool.editPool}" rendered="#{authorization.editOwnQuestionPool}">
   <h:outputText id="poolnametext" value="#{pool.displayName}" escape="false"/>


### PR DESCRIPTION
 Replace icons and fix spacing accordingly. Kept spacing images with smaller width to have a little bit wider focus indicator on the icon.