### PR TITLE
SAK-34596 Samigo : remove drafts when publishing

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3698,6 +3698,10 @@
 # DEFAULT: false
 # samigo.removeSubmission.restricted=true
 
+# Remove drafts after being published
+# DEFAULT: true
+# samigo.remove.drafts=false
+
 #########################################
 # MEMBERSHIP TOOL
 #########################################

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
@@ -211,6 +211,12 @@ public class PublishAssessmentListener
       assessment.addAssessmentMetaData("ALIAS", assessmentSettings.getAlias());
       pub = publishedAssessmentService.publishAssessment(assessment);
 
+      boolean removePublishedDrafts = ServerConfigurationService.getBoolean("samigo.remove.drafts", true);
+      if (removePublishedDrafts) {
+        AssessmentService assessmentService = new AssessmentService();
+        assessmentService.removeAssessment(assessment.getAssessmentBaseId().toString());
+      }
+
       //Lock the groups for deletion if the assessment is released to groups, students can lose submissions if the group is deleted.
       boolean groupRelease = AssessmentAccessControlIfc.RELEASE_TO_SELECTED_GROUPS.equals(assessmentSettings.getReleaseTo());
 


### PR DESCRIPTION
This is in order to improve consistency comparing to what's done on other tools.

There are some subtasks (subjiras?) that will be required: duplicate, export and transfer published assessments.