### PR TITLE
SAK-46345: Reopened - Discussions > Statistics > Student View > Print Buttons do not work

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
@@ -2185,7 +2185,7 @@ public class MessageForumStatisticsBean {
 	}
 
 	public boolean getIsAuthor() {
-		return selectedSiteUserId == userDirectoryService.getCurrentUser().getId();
+		return selectedSiteUserId.equals(userDirectoryService.getCurrentUser().getId());
 	}
 
 	public String getButtonUserName() {


### PR DESCRIPTION
Change '==' to equals method to avoid a false false