### PR TITLE
SAK-45857: Only render 'More details' column for instructors

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsUser.jsp
@@ -259,7 +259,7 @@
   				</h:commandLink>
   			</h:column>
 
-  			<h:column>
+			<h:column rendered="#{ForumTool.instructor}">
 				<f:facet name="header">
 					<h:outputText value="#{msgs.stat_forum_more_details}"  />
 				</f:facet>


### PR DESCRIPTION
Only render 'More details' column for instructors.

The linked View is not set up with permissions for students. they would see hidden topics as well.