### PR TITLE
SAK-46352: Discussions: Remove [display in thread] links for students

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
@@ -240,7 +240,7 @@
 						</h:outputText>
 						<f:verbatim></p></f:verbatim>
 						<% if(!isDialogBox){ %>
-						<h:panelGroup style="display:block;float:right;width:25%;text-align:right">
+						<h:panelGroup rendered="#{ForumTool.instructor}" style="display:block;float:right;width:25%;text-align:right">
 							<h:outputLink value="/tool/#{ForumTool.currentToolId}/discussionForum/message/dfMsgGrade" target="dialogFrame"
 								onclick="dialogLinkClick(this);" rendered="#{ForumTool.instructor}">
 								<f:param value="#{stat.forumId}" name="forumId"/>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsFullTextForOne.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsFullTextForOne.jsp
@@ -96,7 +96,7 @@
 								<f:convertDateTime pattern="#{msgs.date_format_paren}" timeZone="#{ForumTool.userTimeZone}" locale="#{ForumTool.userLocale}"/>
 							</h:outputText>
 						<f:verbatim></p></f:verbatim>						
-						<h:panelGroup style="display:block;float:right;width:15%;text-align:right;font-weight:bold">
+						<h:panelGroup rendered="#{ForumTool.instructor}" style="display:block;float:right;width:15%;text-align:right;font-weight:bold">
 							<h:commandLink action="#{ForumTool.processActionDisplayInThread}" title=" #{msgs.stat_display_in_thread}" >
 								<f:param value="#{stat.forumId}" name="forumId"/>
 		  				  		<f:param value="#{stat.topicId}" name="topicId"/>


### PR DESCRIPTION
Removed this links for students because display in thread view is broken for students. When there is a fix for [SAK-46353](https://jira.sakaiproject.org/browse/SAK-46353), this can be removed.