### PR TITLE
SAK-46357: CLONE - Reopened - Discussions > Statistics > Student View > Print Buttons do not work

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/printFriendlyAllAuthoredMsg.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/printFriendlyAllAuthoredMsg.jsp
@@ -8,7 +8,7 @@
 
 <f:view>
 <sakai:view toolCssHref="/messageforums-tool/css/msgcntr.css">
-	<h:form id="msgForum" rendered="#{ForumTool.instructor}">
+	<h:form id="msgForum" rendered="#{ForumTool.instructor || mfStatisticsBean.isAuthor}">
 		<!--discussionForum/statistics/printFriendlyAllAuthoredMsg.jsp-->
 		<ul class="navIntraTool actionToolBar">
 			<li class="firstToolBarItem">


### PR DESCRIPTION
Fix print page for students (Discussions -> Statistics -> Show Full Text for All Authored Messages), by not only rendering the view to instructors, but also for the author of the messages.  