### PR TITLE
SAK-46375: T&Q: Question Metadata contains a curly brace behind the text

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -223,7 +223,7 @@ metadata_rubrics=Rubrics
 record_metadata=Question Metadata
 metadata_parts=Parts
 metadata_questions=Record question metadata to Statistics
-metadata_questions_info=Enable recording metadata to enter keywords and objectives for individual questions. The percentage of correct answers to all questions with a particular keyword or objective will be available in the Statistics page while grading
+metadata_questions_info=Enable recording metadata to enter keywords and objectives for individual questions. The percentage of correct answers to all questions with a particular keyword or objective will be available in the Statistics page while grading.
 
 
 button_unique_save_and_publish=Save Settings and Publish

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -320,7 +320,7 @@ if (releaseToVal === 'Anonymous Users') {
             value="#{assessmentSettings.valueMap.hasMetaDataForQuestions}"/>
          <h:outputLabel for="metadataQuestions" value="#{assessmentSettingsMessages.metadata_questions}" rendered="#{assessmentSettings.valueMap.metadataQuestions_isInstructorEditable==true}" />
         </div>
-        <h:outputLabel id="metadataQuestionsHelpBlock" styleClass="help-block info-text small" value="#{assessmentSettingsMessages.metadata_questions_info}}" />
+        <h:outputLabel id="metadataQuestionsHelpBlock" styleClass="help-block info-text small" value="#{assessmentSettingsMessages.metadata_questions_info}" />
     </h:panelGroup>
 
 </samigo:hideDivision><!-- End the About this Assessment category -->

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -331,7 +331,7 @@
             value="#{publishedSettings.valueMap.hasMetaDataForQuestions}"/>
          <h:outputLabel for="metadataQuestions" value="#{assessmentSettingsMessages.metadata_questions}" rendered="#{publishedSettings.valueMap.metadataQuestions_isInstructorEditable==true}" />
         </div>
-        <h:outputLabel id="metadataQuestionsHelpBlock" styleClass="help-block info-text small" value="#{assessmentSettingsMessages.metadata_questions_info}}" />
+        <h:outputLabel id="metadataQuestionsHelpBlock" styleClass="help-block info-text small" value="#{assessmentSettingsMessages.metadata_questions_info}" />
     </h:panelGroup>
 
 </samigo:hideDivision><!-- End the About this Assessment category -->


### PR DESCRIPTION
Remove '}' form template and add '.' to text property of info text