### PR TITLE
SAK-46402 Move hibernate.properties to use create-only

### DIFF
--- a/assignment/impl/src/test/resources/hibernate.properties
+++ b/assignment/impl/src/test/resources/hibernate.properties
@@ -1,6 +1,6 @@
 # Base Hibernate settings
 hibernate.show_sql=false
-hibernate.hbm2ddl.auto=create
+hibernate.hbm2ddl.auto=create-only
 hibernate.enable_lazy_load_no_trans=true
 hibernate.cache.use_second_level_cache=false
 hibernate.current_session_context_class=org.springframework.orm.hibernate5.SpringSessionContext

--- a/kernel/kernel-impl/src/test/resources/hibernate.properties
+++ b/kernel/kernel-impl/src/test/resources/hibernate.properties
@@ -1,6 +1,6 @@
 # Base Hibernate settings
 hibernate.show_sql=false
-hibernate.hbm2ddl.auto=create
+hibernate.hbm2ddl.auto=create-only
 
 # Connection definition to the HSQLDB database
 hibernate.connection.driver_class=org.hsqldb.jdbcDriver


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-46402

This PR only touches kernel and assignments. The issue only seems to
apply to JPA projects. For instance, sitestats tests run fine with
create set as the auto ddl option.