### PR TITLE
SAK-46243 - Gradebook: "Set Score for Empty Cells" Does Not Allow Decimal-Only Entry

### DIFF
--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/NumberUtil.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/NumberUtil.java
@@ -45,15 +45,15 @@ public class NumberUtil {
         final DecimalFormatSymbols fs = df.getDecimalFormatSymbols();
         final String doublePattern =
                 new StringBuilder()
-                        .append("\\d+\\")
+                        .append("\\d{1,3}(\\")
                         .append(fs.getGroupingSeparator())
-                        .append("\\d\\d\\d\\")
+                        .append("\\d{3})+")
                         .append(fs.getDecimalSeparator())
-                        .append("\\d+|\\d+\\")
+                        .append("\\d+|\\d*\\")
                         .append(fs.getDecimalSeparator())
-                        .append("\\d+|\\d+\\")
+                        .append("\\d+|\\d{1,3}(\\")
                         .append(fs.getGroupingSeparator())
-                        .append("\\d\\d\\d|\\d+")
+                        .append("\\d{3})+|\\d+")
                         .toString();
         return origin.matches(doublePattern);
     }

--- a/kernel/kernel-util/src/test/java/org/sakaiproject/util/NumberUtilTest.java
+++ b/kernel/kernel-util/src/test/java/org/sakaiproject/util/NumberUtilTest.java
@@ -58,11 +58,15 @@ public class NumberUtilTest {
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("456457546"));
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("3524,055"));
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("2.300"));
+        // No integer part
+        Assert.assertTrue(NumberUtil.isValidLocaleDouble(",01"));
+        // Longer numbers with separators
+        Assert.assertTrue(NumberUtil.isValidLocaleDouble("1.234.456,00"));
 
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("2.00"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("3,520.55"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("3.4561,00"));
-        Assert.assertFalse(NumberUtil.isValidLocaleDouble(",01"));
+        Assert.assertFalse(NumberUtil.isValidLocaleDouble("1234.567,00"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble(".02"));
 
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("A4FC9"));
@@ -78,11 +82,15 @@ public class NumberUtilTest {
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("456457546"));
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("3524.055"));
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("2,300"));
+        // No integer part
+        Assert.assertTrue(NumberUtil.isValidLocaleDouble(".01"));
+        // Longer numbers with separators
+        Assert.assertTrue(NumberUtil.isValidLocaleDouble("1,234,567.00"));
 
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("2,00"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("3.520,55"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("3,4561.00"));
-        Assert.assertFalse(NumberUtil.isValidLocaleDouble(".01"));
+        Assert.assertFalse(NumberUtil.isValidLocaleDouble("1234,567.00"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble(",02"));
 
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("A4FC9"));
@@ -103,11 +111,12 @@ public class NumberUtilTest {
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("456457546"));
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("3524" + arabicDecimal + "055"));
         Assert.assertTrue(NumberUtil.isValidLocaleDouble("2" + arabicGroup + "300"));
+        // No integer part
+        Assert.assertTrue(NumberUtil.isValidLocaleDouble(arabicDecimal + "02"));
 
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("3" + arabicDecimal + "520" + arabicGroup + "55"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("3" + arabicDecimal + "4561" + arabicGroup + "00"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble(arabicGroup + "01"));
-        Assert.assertFalse(NumberUtil.isValidLocaleDouble(arabicDecimal + "02"));
 
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("A4FC9"));
         Assert.assertFalse(NumberUtil.isValidLocaleDouble("0x42"));


### PR DESCRIPTION
I also fixed an issue here where you couldn't have longer formatted values like
1,234,567,890.00

I believe it's valid to have a decimal without an integer part in Spanish too but I wasn't sure. This should be reviewed by someone who uses those decimals. 