### PR TITLE
SAK-33118 mailsend: add plain text only option

### DIFF
--- a/mailsender/api/src/bundle/mailsender.properties
+++ b/mailsender/api/src/bundle/mailsender.properties
@@ -9,6 +9,7 @@ otherrecipients_instruction=Separate additional email addresses with commas or s
 message_subject=Subject:
 attachlink=Attach a file
 attachmorelink=Attach another file
+onlyplaintext=Send only as plain text
 sendmeacopy=Send me a copy
 appendrecipientlist=Append list of recipients to message
 addtoemailarchive=Add to Email Archive, visible to all site participants

--- a/mailsender/api/src/bundle/mailsender_de_DE.properties
+++ b/mailsender/api/src/bundle/mailsender_de_DE.properties
@@ -8,6 +8,7 @@ otherrecipients_instruction=Weitere Empf\u00e4nger durch Komma oder Semicolon ge
 message_subject=Betreff\:
 attachlink=Datei anh\u00e4ngen
 attachmorelink=Weitere Datei anh\u00e4ngen
+onlyplaintext=Nur als Plaintext senden
 sendmeacopy=Eine Kopie an mich senden
 appendrecipientlist=Liste aller Empf\u00e4nger an Nachricht anh\u00e4ngen
 addtoemailarchive=Email archivieren (Sichtbar f\u00fcr alle Benutzer dieser Seite)

--- a/mailsender/api/src/java/org/sakaiproject/mailsender/model/ConfigEntry.java
+++ b/mailsender/api/src/java/org/sakaiproject/mailsender/model/ConfigEntry.java
@@ -16,9 +16,13 @@
  **********************************************************************************/
 package org.sakaiproject.mailsender.model;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Programmatic view of the "Options" page in Mail Sender
  */
+@Getter @Setter
 public class ConfigEntry
 {
 	public static final ConfigEntry DEFAULT_CONFIG = new ConfigEntry(
@@ -37,7 +41,7 @@ public class ConfigEntry
 
 	public enum ConfigParams
 	{
-		replyto, sendmecopy, appendrecipientlist, emailarchive, subjectprefix, displayinvalidemailaddrs, displayemptygroups
+		replyto, sendmecopy, appendrecipientlist, emailarchive, subjectprefix, displayinvalidemailaddrs, displayemptygroups, onlyplaintext
 	}
 
 	private String replyTo;
@@ -48,6 +52,12 @@ public class ConfigEntry
 	private String subjectPrefixType;
 	private String subjectPrefix;
 	private boolean displayEmptyGroups = true;
+	private boolean onlyPlainText;
+
+	public ConfigEntry() {
+		setReplyTo(ReplyTo.no_reply_to.name());
+		setSubjectPrefixType(SubjectPrefixType.system.name());
+	}
 
 	public ConfigEntry(String subjectPrefixType, boolean sendMeACopy, boolean appendRecipientList,
 			boolean addToArchive, String replyTo, boolean displayInvalidEmails,
@@ -63,10 +73,6 @@ public class ConfigEntry
 		setDisplayEmptyGroups(displayEmptyGroups);
 	}
 
-	public String getReplyTo()
-	{
-		return replyTo;
-	}
 
 	public void setReplyTo(String replyTo)
 	{
@@ -84,73 +90,9 @@ public class ConfigEntry
 		}
 	}
 
-	public boolean isDisplayInvalidEmails()
-	{
-		return displayInvalidEmails;
-	}
-
-	public void setDisplayInvalidEmails(boolean displayInvalidEmails)
-	{
-		this.displayInvalidEmails = displayInvalidEmails;
-	}
-
-	public boolean isSendMeACopy()
-	{
-		return sendMeACopy;
-	}
-
-	public void setSendMeACopy(boolean sendMeACopy)
-	{
-		this.sendMeACopy = sendMeACopy;
-	}
-
-	public boolean isAppendRecipientList()
-	{
-		return appendRecipientList;
-	}
-        
-	public void setAppendRecipientList(boolean appendRecipientList)
-	{
-		this.appendRecipientList = appendRecipientList;
-	}
-        
-	public boolean isAddToArchive()
-	{
-		return addToArchive;
-	}
-
-	public void setAddToArchive(boolean addToArchive)
-	{
-		this.addToArchive = addToArchive;
-	}
-
-	public String getSubjectPrefix()
-	{
-		return subjectPrefix;
-	}
-
-	public void setSubjectPrefix(String subjectPrefix)
-	{
-		this.subjectPrefix = subjectPrefix;
-	}
-
-	public String getSubjectPrefixType()
-	{
-		return subjectPrefixType;
-	}
-
 	public void setSubjectPrefixType(String subjectPrefixType)
 	{
 		this.subjectPrefixType = SubjectPrefixType.valueOf(subjectPrefixType).name();
 	}
 
-	public void setDisplayEmptyGroups(boolean displayEmptyGroups)
-	{
-		this.displayEmptyGroups = displayEmptyGroups;
-	}
-
-	public boolean isDisplayEmptyGroups()
-	{
-		return displayEmptyGroups;
-	}
 }

--- a/mailsender/api/src/test/org/sakaiproject/mailsender/model/ConfigEntryTest.java
+++ b/mailsender/api/src/test/org/sakaiproject/mailsender/model/ConfigEntryTest.java
@@ -34,6 +34,7 @@ public class ConfigEntryTest {
 	ConfigEntry entry;
 
 	String subjectPrefixType = SubjectPrefixType.system.toString();
+	boolean onlyPlainText = false;
 	boolean sendMeACopy = false;
 	boolean appendRecipientList = false;
 	boolean addToArchive = false;
@@ -51,6 +52,7 @@ public class ConfigEntryTest {
 	@Test
 	public void getDefaults() {
 		assertEquals(subjectPrefixType, entry.getSubjectPrefixType());
+		assertEquals(onlyPlainText, entry.isOnlyPlainText());
 		assertEquals(sendMeACopy, entry.isSendMeACopy());
 		assertEquals(appendRecipientList, entry.isAppendRecipientList());
 		assertEquals(addToArchive, entry.isAddToArchive());

--- a/mailsender/impl/src/java/org/sakaiproject/mailsender/logic/impl/ExternalLogicImpl.java
+++ b/mailsender/impl/src/java/org/sakaiproject/mailsender/logic/impl/ExternalLogicImpl.java
@@ -280,7 +280,7 @@ public class ExternalLogicImpl implements ExternalLogic
 
 		if (attachments == null)
 		{
-			attachments = Collections.EMPTY_LIST;
+			attachments = Collections.emptyList();
 		}
 
 		boolean retval = true;
@@ -300,8 +300,8 @@ public class ExternalLogicImpl implements ExternalLogic
 
 			return false;
 		}
-		List<String> mailHeaders = new ArrayList<String>();
-		if (useRTE())
+		List<String> mailHeaders = new ArrayList<>();
+		if (useRTE() && !config.isOnlyPlainText())
 		{
 			mailHeaders.add(MailArchiveService.HEADER_OUTER_CONTENT_TYPE
 					+ ": text/html; charset=ISO-8859-1");
@@ -332,7 +332,7 @@ public class ExternalLogicImpl implements ExternalLogic
 			header.setInstantSent(Instant.now());
 			header.setMailHeaders(mailHeaders);
 			// List of references needed.
-			List<Reference> refs = new ArrayList<Reference>();
+			List<Reference> refs = new ArrayList<>();
 			for(Attachment attachment : attachments) {
 				ContentResource resource = createAttachment(channel.getContext(), attachment.getContentTypeHeader(),
 						attachment.getFilename(), attachment.getDataSource().getInputStream(), edit.getId());
@@ -429,7 +429,7 @@ public class ExternalLogicImpl implements ExternalLogic
 
 		msg.setSubject(subject);
 		// set content type based on editor used
-		if (useRTE())
+		if (useRTE() && !config.isOnlyPlainText())
 		{
 			msg.setContentType(ContentType.TEXT_HTML);
 		}

--- a/mailsender/impl/src/test/org/sakaiproject/mailsender/logic/impl/ExternalLogicImplTest.java
+++ b/mailsender/impl/src/test/org/sakaiproject/mailsender/logic/impl/ExternalLogicImplTest.java
@@ -45,6 +45,7 @@ import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.email.api.Attachment;
+import org.sakaiproject.email.api.ContentType;
 import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.Reference;
@@ -60,6 +61,7 @@ import org.sakaiproject.mailarchive.api.MailArchiveMessageHeaderEdit;
 import org.sakaiproject.mailarchive.api.MailArchiveService;
 import org.sakaiproject.mailsender.MailsenderException;
 import org.sakaiproject.mailsender.logic.ExternalLogic;
+import org.sakaiproject.mailsender.model.ConfigEntry;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.SessionManager;
@@ -291,15 +293,27 @@ public class ExternalLogicImplTest {
 	@Test(expected = MailsenderException.class)
 	public void sendMailEmptyTo() throws Exception {
 		impl.sendEmail(null, "from@example.com", null,
-				new HashMap<String, String>(), null, null, null);
+				new HashMap<>(), null, null, null);
 		fail("Must define 'to'");
 	}
 
 	@Test
 	public void sendMailRequiredArgs() throws Exception {
-		HashMap<String, String> to = new HashMap<String, String>();
+		HashMap<String, String> to = new HashMap<>();
 		to.put("test", "test");
 		impl.sendEmail(null, "from@example.com", null, to, null, null, null);
+	}
+
+	@Test
+	public void sendPlainTextOnly() throws Exception {
+		// create config with onlyPlainText
+		ConfigEntry config = new ConfigEntry();
+		config.setOnlyPlainText(true);
+		// sendEmail
+		HashMap<String, String> to = new HashMap<>();
+		to.put("test", "test");
+		impl.sendEmail(null, "from@example.com", null, to, null, null, null);
+		verify(emailService).send(argThat(emailMessage -> ContentType.TEXT_PLAIN.equals(emailMessage.getContentType())), anyBoolean());
 	}
 
 	@Test

--- a/mailsender/tool/src/java/org/sakaiproject/mailsender/tool/controller/MainController.java
+++ b/mailsender/tool/src/java/org/sakaiproject/mailsender/tool/controller/MainController.java
@@ -296,6 +296,7 @@ public class MainController {
         String reqSubject = request.getParameter("subject");
         String rcptsall = request.getParameter("rcptsall");
         //Get checkboxes values
+        String onlyPlainText = request.getParameter("onlyPlainText");
         String reqSendMeACopy = request.getParameter("smac");
         String reqAddToArchive = request.getParameter("addToArchive");
         String reqAppendRecipientList = request.getParameter("appendRecipientList");
@@ -311,9 +312,10 @@ public class MainController {
         if (StringUtils.isNotBlank(rcptsall)) {
             newEmailEntry.setAllIds(Boolean.parseBoolean(rcptsall));
         }
-        config.setSendMeACopy((reqSendMeACopy != null) ? Boolean.parseBoolean(reqSendMeACopy) : false);
-        config.setAddToArchive((reqAddToArchive != null) ? Boolean.parseBoolean(reqAddToArchive) : false);
-        config.setAppendRecipientList((reqAppendRecipientList != null) ? Boolean.parseBoolean(reqAppendRecipientList) : false);
+        config.setOnlyPlainText(Boolean.parseBoolean(onlyPlainText));
+        config.setSendMeACopy(Boolean.parseBoolean(reqSendMeACopy));
+        config.setAddToArchive(Boolean.parseBoolean(reqAddToArchive));
+        config.setAppendRecipientList(Boolean.parseBoolean(reqAppendRecipientList));
 
         newEmailEntry.setConfig(config);
         String reqOtherRecipients= request.getParameter("otherRecipients");

--- a/mailsender/tool/src/webapp/content/templates/compose.html
+++ b/mailsender/tool/src/webapp/content/templates/compose.html
@@ -7,7 +7,7 @@
         <script src="/library/js/headscripts.js"></script>
         <script src="/library/js/spinner.js"></script>
         <script src="/mailsender-tool/content/js/mailsender.js"></script>
-        [(${sakaiHtmlHead})] 
+        [(${sakaiHtmlHead})]
     </head>
     <body>
         <div class="portletBody">
@@ -17,7 +17,7 @@
             <form id="mainForm" method="post" th:action="@{/compose}" enctype="multipart/form-data" data-dirty="false" th:object="${emailEntry}">
                 <div class="page-header">
                     <h1 th:text="#{compose_toolbar}">Compose</h1>
-                </div> 
+                </div>
                 <div class="section">
                     <div class="headerkeyholder">
                         <span th:text="#{from}" class="headerkey">From:</span>
@@ -58,7 +58,7 @@
                                         <input th:id="${user.getId()}" type="checkbox" name="user" th:value="${user.getId()}" onclick="RcptSelect.toggleIndividual(this.id)" th:attrappend="disabled=${user.getEmail().isEmpty()}?@{disabled}"/>
                                         <label th:text="${user.getDisplayName()}+'('+ ${user.getDisplayId()}+')'"/>
                                     </div>
-                                </div> 
+                                </div>
                             </div>
                         </div>
                         <div id="mailsender-sections" class="rolesArea hidden">
@@ -117,7 +117,7 @@
                     <div id="attachOuter" class="headerkeyholder" style="display:none">
                         <span class="headerkey"><img src="/mailsender-tool/content/images/paperclip.gif" alt="attachment_img" height="15" width="15" ></span>
                     </div>
-                    <div id="attachInner" class="headervalue"> 
+                    <div id="attachInner" class="headervalue">
                         <div id="attachmentArea" name="attachmentArea"/>
                         <div id="attachLink"><img src="/mailsender-tool/content/images/paperclip.gif" alt="attachment_img" height="15" width="15" />
                         <a href="#" onclick="MailSender.addAttachment('attachmentArea'); return false;" th:text="#{attachlink}">Attach a file</a>
@@ -134,8 +134,12 @@
 
                     <div class="section">
                         <div class="headervalue">
+                            <input name="onlyPlainText" type="checkbox" id="onlyPlainText" value="true" th:checked="*{config.isOnlyPlainText}"/>
+                            <label th:text="#{onlyplaintext}" for="onlyPlainText">Send only as plain text</label>
+                        </div>
+                        <div class="headervalue">
                             <input name="smac" type="checkbox" id="sendMeACopy" value="true" th:attrappend="checked=*{config.isSendMeACopy() == true}?@{checked}"/>
-                            <label th:text="#{sendmeacopy}" for="sendMeCopy">Send me a copy</label>
+                            <label th:text="#{sendmeacopy}" for="sendMeACopy">Send me a copy</label>
                         </div>
                         <div th:if="${addedTo}" id="addToArchiveDiv" class="headervalue">
                             <input  name="addToArchive" type="checkbox" id="addToArchive" value="true" th:attrappend="checked=*{config.isAddToArchive() == true}?@{checked}" />
@@ -155,8 +159,6 @@
             </form>
             <script>  sakai.editor.launch("editor1", "{noop:0}");
                 CKEDITOR.instances.editor1.setData(/*[[${emailEntry.content}]]*/);
-
-
                 
                 var hroles = document.getElementById("mailsender-rcpt-link-roles");
                 var hsections = document.getElementById("mailsender-rcpt-link-sections");
@@ -213,12 +215,21 @@
                     form.dataset.dirty="true"
                 });
                     
-                    function losedata(msg) {
-                        if (form.dataset.dirty=='true'){
-                            return confirm(msg);
+                function losedata(msg) {
+                    if (form.dataset.dirty=='true'){
+                        return confirm(msg);
+                    }
+                    return true;
+                };
+
+                document.getElementById("onlyPlainText").addEventListener('change', function() {
+                    if (this.checked) {
+                        const editor = CKEDITOR.instances.editor1;
+                        if (editor.mode === 'wysiwyg') {
+                            editor.execCommand('source');
                         }
-                        return true;
-                    };
+                    }
+                });
             </script>
         </div>
     </body>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAK-33118

add a checkbox to the mail compose form for a plain text only option.
When active
- change the CKEditor to source the view
- Emails sent have their `Content-Type` set to `text/plain`

Also contains code cleanup & minor refactoring along the way.