### PR TITLE
SAK-46268 Samigo : button alignment

### DIFF
--- a/library/src/morpheus-master/sass/base/_extendables.scss
+++ b/library/src/morpheus-master/sass/base/_extendables.scss
@@ -405,7 +405,6 @@ a.noPointers, input.noPointers {
 	
 	> input, > button, > a, > .active {
 		margin-right: $standard-space;
-    margin-top: $standard-space;
 		
 		&:last-child {
 			margin-right: 0;


### PR DESCRIPTION
Jira refers to Samigo but other places might be affected too. Apparently this was added for the Conversations tool
(https://github.com/sakaiproject/sakai/commit/4b3c9eba2fce1c0365c6e611e3f71a00d419fa47#diff-faa29a65c68a13ad617cc3fe3bd77df8428756a63f98da8f0388d7b157cba6f6R408), @adrianfish could you please take a look and see if it's actually needed or if it can be done differently? Thanks!