### PR TITLE
SAK-46489: keep throttle() method in validator js files

### DIFF
--- a/samigo/samigo-app/src/webapp/js/calcQuestInputValidator.js
+++ b/samigo/samigo-app/src/webapp/js/calcQuestInputValidator.js
@@ -69,3 +69,14 @@ var validateCalculatedQuestionInput = function(input) {
 
   return true;
 }
+
+function throttle(f, delay) {
+  var timer = null;
+  return function() {
+   var context = this, args = arguments;
+   clearTimeout(timer);
+   timer = window.setTimeout(function() {
+     f.apply(context, args);
+   }, delay || 200);
+  };
+}

--- a/samigo/samigo-app/src/webapp/js/delivery.js
+++ b/samigo/samigo-app/src/webapp/js/delivery.js
@@ -159,16 +159,4 @@ fixImplicitLabeling = function(){
 function disableShowTimeWarning() {
 	document.getElementById('takeAssessmentForm:showTimeWarning').value = "false";
 }
-
-function throttle(f, delay) {
-  var timer = null;
-  return function() {
-   var context = this, args = arguments;
-   clearTimeout(timer);
-   timer = window.setTimeout(function() {
-     f.apply(context, args);
-   }, delay || 200);
-  };
-}
-
 </script>

--- a/samigo/samigo-app/src/webapp/js/finInputValidator.js
+++ b/samigo/samigo-app/src/webapp/js/finInputValidator.js
@@ -107,4 +107,16 @@ var validateFinInput = function(input) {
   }
 
   return true;
+
+}
+
+function throttle(f, delay) {
+  var timer = null;
+  return function() {
+   var context = this, args = arguments;
+   clearTimeout(timer);
+   timer = window.setTimeout(function() {
+     f.apply(context, args);
+   }, delay || 200);
+  };
 }


### PR DESCRIPTION
I think this should fix it, but I'm working on getting a dev environment going locally to test
I didn't realise the throttle() method was used during grading, the finInputValidator.js file was included in gradeStudentResult.jsp since 21.0 ([SAK-42863](https://github.com/sakaiproject/sakai/commit/dbd430898ac5551e6c92b53db6c518882825d32e))

