### PR TITLE
SAK-46475 Gradebook category columns remain after disabling categories

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -562,7 +562,7 @@ public class GbGradebookData {
 
 			// If we're at the end of the assignment list, or we've just changed
 			// categories, put out a total.
-			if (userSettings.isGroupedByCategory() &&
+			if (userSettings.isGroupedByCategory() && (GbCategoryType.valueOf(this.settings.getCategoryType()) != GbCategoryType.NO_CATEGORY) &&
 					a1.getCategoryId() != null &&
 					(a2 == null || !a1.getCategoryId().equals(a2.getCategoryId()))) {
 				result.add(new CategoryAverageDefinition(a1.getCategoryId(),


### PR DESCRIPTION
Even if I'd say this fixes the issue, that part of code hasn't been modified for years... So I tried to look after the "recent" change that introduced the issue just in case, it might be js? No big deal, mentioning it to see if anyone has any clue.