### PR TITLE
SAK-46501 - Adding property to the experimental.sakai.properties in order to test assessment order list

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
@@ -147,3 +147,9 @@ oauth.enabled=true
 
 # enable final grade mode
 gradebook.enable.finalgrade=true
+
+# To test SAK-46501
+# SAK-46501 property to select the default sorting column in assessment list view
+# The column by which we want to sort the table
+# DEFAULT: 2
+samigo.assessmentSortingColumn=9


### PR DESCRIPTION
We need to add this property to verify merged changes in https://github.com/sakaiproject/sakai/pull/9976