### PR TITLE
SAK-46517 replace curly and smart quotes with regular apostrophe and …

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -2530,6 +2530,14 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		 String answer = StringEscapeUtils.unescapeHtml4(rawAnswer);
 		 String input = StringEscapeUtils.unescapeHtml4(rawInput);
 
+		 // User on Mac will use "smart" curly apostrophes by default!!
+		 answer = answer.replaceAll("[\u2018\u2019]", "'");
+		 input = input.replaceAll("[\u2018\u2019]", "'");
+
+		 // User on Mac will use “smart” quotes by default!
+		 answer = answer.replaceAll("[\u201C\u201D]", "\"");
+		 input = input.replaceAll("[\u201C\u201D]", "\"");
+
 		 // Always trim trailing spaces
 		 answer = answer.trim();
 		 input = input.trim();
@@ -2540,9 +2548,8 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 			 input = input.replaceAll("\\p{javaSpaceChar}", "");
 		 }
  		 StringBuilder regex_quotebuf = new StringBuilder();
-		 
-		 String REGEX = answer.replaceAll("\\*", "|*|");
-		 String[] oneblank = REGEX.split("\\|");
+
+		 String[] oneblank = answer.replaceAll("\\*", "|*|").split("\\|");
 		 for (String str : oneblank) {
 			 if ("*".equals(str)) {
 				 regex_quotebuf.append(".+");

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/FibGradingTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/FibGradingTest.java
@@ -15,17 +15,16 @@
  */
 
 
-package org.sakaiproject.assesment.service;
+package org.sakaiproject.tool.assessment.services;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.sakaiproject.tool.assessment.services.GradingService;
-
-public class GradingServiceTest {
+public class FibGradingTest {
 	
 	@Test
 	public void testValidate() {
@@ -101,7 +100,27 @@ public class GradingServiceTest {
 		Assert.assertTrue(gradingService.fibmatch("A > ~T", "A > ~T", false, false));
 		Assert.assertTrue(gradingService.fibmatch("A &gt; ~T", "A &gt; ~T", false, false));
 	}
-	
+
+	@Test
+	public void fibTestUnicodeApostrophes() {
+		GradingService gradingService = new GradingService();
+
+		// Italian course FIB with smart quotes or special keyboard
+		Assert.assertTrue(gradingService.fibmatch("un'", "un'", false, true));
+		Assert.assertTrue(gradingService.fibmatch("un’", "un'", false, true));
+		Assert.assertTrue(gradingService.fibmatch("un’", "un'", true, false));
+		Assert.assertTrue(gradingService.fibmatch("un'", "un’", false, true));
+		Assert.assertTrue(gradingService.fibmatch("un’", "un‘", false, true));
+		Assert.assertFalse(gradingService.fibmatch("un`", "un'", false, true));
+
+		// Mac user with default smart quotes on !!
+		Assert.assertTrue(gradingService.fibmatch("Sylvester \"Sly Stone\" Stewart", "Sylvester \"Sly Stone\" Stewart", true, true));
+		Assert.assertTrue(gradingService.fibmatch("Sylvester “Sly Stone” Stewart", "Sylvester \"Sly Stone\" Stewart", true, true));
+		Assert.assertTrue(gradingService.fibmatch("Sylvester “Sly Stone“ Stewart", "Sylvester \"Sly Stone\" Stewart", true, false));
+		Assert.assertFalse(gradingService.fibmatch("Sylvester 'Sly Stone' Stewart", "Sylvester \"Sly Stone\" Stewart", true, true));
+		Assert.assertFalse(gradingService.fibmatch("Sylvester ’Sly Stone’ Stewart", "Sylvester \"Sly Stone\" Stewart", true, true));
+	}
+
 	@Test
 	public void fibContainsIllegalsTest() {
 		GradingService gradingService = new GradingService();


### PR DESCRIPTION
…regular quotes for accurate FIB scoring

Any issues with foreign languages here? I assume smart quotes are just a Mac/Microsoft invention and should be translated into apostrophes and regular quotes for all languages.

CC: @juanjmerono @mpellicer @jesusmmp 