### PR TITLE
SAK-46544 Kernel : warn log message shouldn't appear

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -1639,7 +1639,7 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		}
 		catch (GroupNotDefinedException gnde)
 		{
-			log.warn(gnde.getMessage());
+			log.debug("removeUser: GroupNotDefinedException: {}", gnde.getMessage());
 		}
 		catch (AuthzRealmLockException arle)
 		{


### PR DESCRIPTION
This seem to come from an "ignore" exception that was changed to WARN (see https://github.com/sakaiproject/sakai/pull/6536), where they were converted to DEBUG for BaseCalendar.. and BaseMessage but not for BaseUser..).