### PR TITLE
SAK-38394 cleanup use of role=menu and menuitem to improve aXe a11y score

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: f2049235-3f10-4142-a26c-fc017211a776
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
       - name: Check number of MySQL statements
         if: ${{ always() }}
         run: |

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
@@ -41,7 +41,7 @@
                             <div class="tab-box">
                                 #foreach($quickLink in $quickLinks)
                                     <li class="Mrphs-quickLinksNav__submenuitem">
-                                        <a role="menuitem" href="${quickLink.url}" title="$quickLink.title" target="_blank">
+                                        <a href="${quickLink.url}" title="$quickLink.title" target="_blank">
                                             #if(${quickLink.iconType} == "image")
                                                 <span id="quicklink-icon" style="background-image:url(${quickLink.imageURI})"></span>
                                             #elseif (${quickLink.iconType} == "icon")
@@ -104,19 +104,19 @@
 
                                 #end ## END of IF (${displayUserloginInfo})
 
-                            <ul class="Mrphs-userNav__subnav is-hidden" role="menu">
+                            <ul class="Mrphs-userNav__subnav is-hidden">
 
                                 <li class="Mrphs-userNav__submenuitem Mrphs-userData">
                                     <div class="Mrphs-userNav__submenuitem--profile-and-image">
                                         #if (${tabsSites.mrphs_profileToolUrl})
                                             <div class="has-avatar">
-                                                <a role="menuitem" class="Mrphs-userNav__submenuitem--profilelink" href="${tabsSites.mrphs_profileToolUrl}" aria-haspopup="dialog">
+                                                <a class="Mrphs-userNav__submenuitem--profilelink" href="${tabsSites.mrphs_profileToolUrl}" aria-haspopup="dialog">
                                                     <span class="Mrphs-userNav__submenuitem--profilepicture Mrphs-userNav__pic-changer" style="background-image:url(/direct/profile/${loginUserId}/image/thumb)"></span>
                                                     <span class="sr-only">${rloader.pic_changer_title}</span>
                                                 </a>
                                             </div>
                                             <div class="Mrphs-userNav__submenuitem--profile">
-                                                <a role="menuitem" href="${tabsSites.mrphs_profileToolUrl}">
+                                                <a href="${tabsSites.mrphs_profileToolUrl}">
                                                     <span>${rloader.sit_profile}</span>
                                                 </a>
                                             </div>
@@ -133,7 +133,7 @@
                                 </li>
 
                                 <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented">
-                                    <a role="menuitem" href="javascript:;" id="Mrphs-userNav__submenuitem--connections" aria-haspopup="dialog">
+                                    <a href="javascript:;" id="Mrphs-userNav__submenuitem--connections" aria-haspopup="dialog">
                                         <span>${rloader.sit_connections}</span>
                                     </a>
                                 </li>
@@ -141,7 +141,7 @@
                                     #if (${tabsSites.calendarToolUrl})
             
                                         <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented">
-                                            <a role="menuitem" href="${tabsSites.calendarToolUrl}" class="Mrphs-userNav__submenuitem--calendar">
+                                            <a href="${tabsSites.calendarToolUrl}" class="Mrphs-userNav__submenuitem--calendar">
                                                 <span>${rloader.sit_calendar}</span>
                                             </a>
                                         </li>
@@ -151,7 +151,7 @@
                                     #if (${tabsSites.prefsToolUrl})
 
                                         <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented">
-                                            <a role="menuitem" href="${tabsSites.prefsToolUrl}" class="Mrphs-userNav__submenuitem--prefs">
+                                            <a href="${tabsSites.prefsToolUrl}" class="Mrphs-userNav__submenuitem--prefs">
                                                 <span>${rloader.sit_preferences}</span>
                                             </a>
                                         </li>
@@ -161,7 +161,7 @@
                                     #if (${tabsSites.tutorial})
 
                                         <li class="Mrphs-userNav__submenuitem Mrphs-userNav__submenuitem-indented">
-                                            <a id="tutorialLink" role="menuitem" href="#" onclick="startTutorial({});" class="Mrphs-userNav__submenuitem--tutorial" aria-haspopup="dialog">
+                                            <a id="tutorialLink" href="#" onclick="startTutorial({});" class="Mrphs-userNav__submenuitem--tutorial" aria-haspopup="dialog">
                                                 <span>${rloader.sit_tutorial}</span>
                                             </a>
                                         </li>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -10,14 +10,14 @@
 
         <div class="hidden" id="max-favorite-entries">${tabsSites.maxFavoritesShown}</div>
 
-        <ul id="otherSitesMenu" role="menu">
+        <ul id="otherSitesMenu" role="menubar">
             #if (${tabsSites.worksiteToolUrl})
 
-                <li><a role="menuitem" id="allSites" href="${tabsSites.mrphs_worksiteToolUrl}"><span>${rloader.sit_allsites}</span></a></li>
+                <li role="menuitem"><a id="allSites" href="${tabsSites.mrphs_worksiteToolUrl}"><span>${rloader.sit_allsites}</span></a></li>
 
                 #if ($allowAddSite)
 
-                    <li><a role="menuitem" id="newSite" href="${tabsSites.mrphs_worksiteToolUrl}?panel=Shortcut&amp;sakai_action=doNew_site&amp"><span>${rloader.sit_newsite}</span></a></li>
+                    <li role="menuitem"><a id="newSite" href="${tabsSites.mrphs_worksiteToolUrl}?panel=Shortcut&amp;sakai_action=doNew_site&amp"><span>${rloader.sit_newsite}</span></a></li>
 
                 #end ## END of IF ($allowAddSite)
 
@@ -25,12 +25,12 @@
 
             #if (${tabsSites.prefsToolUrl})
 
-                <li><a role="menuitem" href="${tabsSites.prefsToolUrl}"><span>${rloader.sit_preferences}</span></a></li>
+                <li role="menuitem"><a href="${tabsSites.prefsToolUrl}"><span>${rloader.sit_preferences}</span></a></li>
 
             #end ## END of IF (${tabsSites.prefsToolUrl})
 
-            <li class="otherSitesMenuClose">
-                <a role="menuitem" href="javascript:void(0);">
+            <li class="otherSitesMenuClose" role="menuitem">
+                <a href="javascript:void(0);">
                     <span class="sr-only">${rloader.sit_othersitesclose}</span>
                     <span class="fa fa-times" aria-hidden="true"></span>
                 </a>

--- a/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/jsf/HideDivisionRenderer.java
+++ b/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/jsf/HideDivisionRenderer.java
@@ -87,7 +87,7 @@ public class HideDivisionRenderer extends Renderer
 		
 		writer.write("<fieldset>");
 		writer.write("<legend>");
-		writer.write("<a role='button' data-toggle='collapse' aria-expanded='true' aria-target='" + id + "' href='#" + id + "' data-target=\"[id='" + id + "']\">" + title + "</a>");
+		writer.write("<a role='button' data-toggle='collapse' aria-expanded='true' href='#" + id + "' data-target=\"[id='" + id + "']\">" + title + "</a>");
 		writer.write("</legend>");
 
 		writer.write("<div class='collapse in' " +


### PR DESCRIPTION
Per accessibility review comment: "list of the expanded item has role of menu and menuitem which is not correct since it does not include the only link but it also includes text information."

Basically: we need to only use the roles of menu/menuitem when it is a pure menu. This upper-right profile is more like a super menu and has information and links so doesn't use the menu/menuitem 

You can do some testing locally with your aXe Chrome console .... open the menu up in upper-right, scan the page, look for errors