### PR TITLE
SAK-45314 - Gradebook: Grade statistics graphs show fractional students.

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-chart.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-chart.js
@@ -59,6 +59,15 @@ function renderChart(gbChartData) {
 						autoSkip: true,
 						maxRotation: 0,
 						fontColor: getComputedStyle(document.documentElement).getPropertyValue('--sakai-text-color-1'),
+						callback: function(value, index, values) {
+						    if (isNaN(value)) {
+							return value;
+						    }
+						    // Display student values only as integers
+						    else if (Math.floor(value) === value) {
+							return value;
+						    }
+						}
 					},
 					scaleLabel: {
 						display: true,
@@ -77,9 +86,15 @@ function renderChart(gbChartData) {
 						fontColor: getComputedStyle(document.documentElement).getPropertyValue('--sakai-text-color-1'),
 						autoskip: true,
 						maxRotation: 0,
-						// Include a space to even out the plusses and minuses
 						callback: function(value, index, values) {
+						    if (isNaN(value)) {
+							// Include a space to even out the plusses and minuses
 							return value + (value.length < 2 ? ' ' : '');
+						    }
+						    // Display student values only as integers
+						    else if (Math.floor(value) === value) {
+							return value;
+						    }
 						}
 					},
 					scaleLabel: {


### PR DESCRIPTION
My working solution is based the top answer from the following stackoverflow post:

https://stackoverflow.com/questions/37699485/skip-decimal-points-on-y-axis-in-chartjs

An important adaptation to the solution in that post that I make here attends to the different contexts in which X and Y axes are used in Gradebook-- namely between the course grade stats graph and a gradebook item stats graph. For the former, the X axis displays the Number of Students. For the former, the Y axis displays the Number of Students. Thus, callback functions for each axis use isNaN() to distinguish whether or not the axis variable is a number. If it is, then the axis is for Number of Students, and for such cases, I filter out all fractional values to display only whole number values in the graph.