### PR TITLE
SAK-46590 resolve aXe-identified a11y issues.

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -208,7 +208,7 @@
 								</th>
 							#end
 							#if ($SiteColumnFlag > 0) ## (there are anns from other sites so show what site they are from)
-								<th id="Site" scope="col" class="hidden-xs">
+								<th id="anncSite" scope="col" class="hidden-xs">
 									#if (!$currentSortedBy.equals("channel"))
 										<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbychannel")';return false;"  title ="$tlang.getString('gen.sortchannel')">$tlang.getString('gen.site')</a>
 									#else
@@ -290,7 +290,7 @@
 									</td>
 								#end
 								#if ($SiteColumnFlag > 0)
-									<td headers="channel" class="hidden-xs">
+									<td headers="anncSite" class="hidden-xs">
 										$formattedText.escapeHtml($ann_item.channelDisplayName)
 									</td>
 								#end
@@ -494,7 +494,7 @@
 											</th>
 										#end
 									#end
-									<th id="channel" scope="col" class="hidden-xs">
+									<th id="anncSite" scope="col" class="hidden-xs">
 										#if (!$currentSortedBy.equals("for"))
 											<a href="#" onclick="location='#toolLink("AnnouncementAction" "doSortbyfor")';return false;"  title="$tlang.getString('gen.sortbyfor')">$tlang.getString("gen.visible")</a>
 										#else

--- a/velocity/tool/src/templates/VM_chef_library.vm
+++ b/velocity/tool/src/templates/VM_chef_library.vm
@@ -666,10 +666,9 @@ ${extra}")
 	<input type="button" name="eventSubmit_doList_prev" value="&lt;" title="$tlang.getFormattedMessage('gen.previous.pagesize', $pagesize)"
 		onclick="VM_PP.doPageNav('#toolLink("$action", "doList_prev")', this);" #if ($goPPButton != "true") disabled="disabled" #end />
 
-	<label for="selectPageSize_$panelName">$tlang.getString("gen.select.label")</label>
-	<span class="skip">$tlang.getString("gen.listnavselect")</span>
 	<div class="sakai-table-pagerPageSize">
-		<select id="selectPageSize_$panelName" name="selectPageSize_$panelName" #if ($allMsgNumber == 0) disabled="disabled" #end
+		<span class="skip">$tlang.getString("gen.listnavselect")</span>
+		<select aria-label="$tlang.getString('gen.select.label')" id="selectPageSize_$panelName" name="selectPageSize_$panelName" #if ($allMsgNumber == 0) disabled="disabled" #end
 			onchange="VM_PP.doChangePageSize('#toolLink("$action", "doChange_pagesize")', this);">
 		#foreach ($i in $!pagesizes)
 			<option value="$i" #if($pagesize == $i) selected="selected" #end>$tlang.getFormattedMessage("gen.show", $i)</option>


### PR DESCRIPTION
The label should not be hidden from view. Use aria-label instead.