### PR TITLE
SAK-46610: ORACLE: Assignment Work log, change maxlength from 4096 to 4000

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_estimate.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_estimate.vm
@@ -127,7 +127,7 @@
                                     <label for="timesheet_record_comment" class="col-form-label">$!tlang.getString("ts.modal.field.comment")</label>
                                 </div>
                                 <div class="col-8">
-                                    <textarea class="form-control" id="comment" name="comment" maxlength="4096"></textarea>
+                                    <textarea class="form-control" id="comment" name="comment" maxlength="4000"></textarea>
                                 </div>
                             </div>
                             <div class="form-group form-required">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-46610

ORACLE 11g, for example, does not allow VARCHAR2 bigger than 4000 so we should modify length before anyone can add this feature to their instances.

On other PR I'll change the scripts:
https://github.com/sakaiproject/sakai-reference/pull/143/files