### PR TITLE
SAK-46612 [User] Preferences use correct property for service name

### DIFF
--- a/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/tool/UserPrefsTool.java
+++ b/user/user-tool-prefs/tool/src/java/org/sakaiproject/user/tool/UserPrefsTool.java
@@ -2611,7 +2611,7 @@ public class UserPrefsTool
 	 * @return The name of the service that should be shown to users.
 	 */
 	public String getServiceName() {
-		return ServerConfigurationService.getString("ui.name", "Sakai");
+		return ServerConfigurationService.getString("ui.service", "Sakai");
 	}
 	
 }


### PR DESCRIPTION
Change getServiceName to use the standard sakai property ui.service
to get the local service name to display in the Preferences tool.