### PR TITLE
SAK-45578: Rubric association active column should default to true

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/ToolItemRubricAssociation.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/logic/model/ToolItemRubricAssociation.java
@@ -91,7 +91,7 @@ public class ToolItemRubricAssociation implements Modifiable, Serializable, Clon
     private Metadata metadata;
 
     @Column(name = "active", nullable = false)
-    private boolean active;
+    private Boolean active = Boolean.TRUE;
 
     @ElementCollection
     @CollectionTable(name = "rbc_tool_item_rbc_assoc_conf", joinColumns = @JoinColumn(name = "association_id", referencedColumnName = "id"))


### PR DESCRIPTION
I'm not sure if this is the normal method used to merge a fix made to master back to another branch like 21.x. With that said this fix from SAK-45578 resolves a critical bug in 21.x (also affecting 21.0 & 21.2): 

SAK-46096: On import, Rubric connection to Assignments/Samigo/Gradebook is lost