### PR TITLE
SAK-46456 Reorder library not working for numerical inputs

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.reorderer.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.reorderer.js
@@ -85,21 +85,23 @@ $PBJQ(document).ready(function(){
         
         //insert the row in new location - if new value is 1, insert before, if it is the last possible
         // insert after, otherwise insert before or after depending on if it is going up or down
+        var thisElement = $PBJQ(this).parents('.reorder-element');
         if (newVal === '1') {
-            $PBJQ($PBJQ(this).parents('.reorder-element')).insertBefore($PBJQ(this).parents('.reorder-element').siblings('.reorder-element').children('span').children('span').children('input[value=' + newVal + ']').parents('.reorder-element'));
+            $PBJQ(thisElement).insertBefore(thisElement.siblings('.reorder-element').find('input[value=' + newVal + ']').parents('.reorder-element'));
         }
-        else 
+        else {
             if (newVal == inputs.length) {
-                $PBJQ($PBJQ(this).parents('.reorder-element')).insertAfter($PBJQ(this).parents('.reorder-element').siblings('.reorder-element').children('span').children('span').children('input[value=' + newVal + ']').parents('.reorder-element'));
+                $PBJQ(thisElement).insertAfter(thisElement.siblings('.reorder-element').find('input[value=' + newVal + ']').parents('.reorder-element'));
             }
             else {
                 if (newVal > oldVal) {
-                    $PBJQ($PBJQ(this).parents('.reorder-element')).insertAfter($PBJQ(this).parents('.reorder-element').siblings('.reorder-element').children('span').children('span').children('input[value=' + newVal + ']').parents('.reorder-element'));
+                    $PBJQ(thisElement).insertAfter(thisElement.siblings('.reorder-element').find('input[value=' + newVal + ']').parents('.reorder-element'));
                 }
                 else {
-                    $PBJQ($PBJQ(this).parents('.reorder-element')).insertBefore($PBJQ(this).parents('.reorder-element').siblings('.reorder-element').children('span').children('span').children('input[value=' + newVal + ']').parents('.reorder-element'));
+                    $PBJQ(thisElement).insertBefore(thisElement.siblings('.reorder-element').find('input[value=' + newVal + ']').parents('.reorder-element'));
                 }
             }
+        }
         registerChange('notfluid', $PBJQ(this).parents('.reorder-element'));
     });
 


### PR DESCRIPTION
I've changed the code for the reorder script in the library. Before, the code was searching only in the children nodes of the "reorder-element". Using the ".find()" function from JQuery we can search properly in all the nodes beneath the DOM tree, independently of the structure of DOM elements.