### PR TITLE
SAK-46665 Scheduler: Filter Events page not displaying, stack traces on the server

### DIFF
--- a/jobscheduler/scheduler-tool/src/java/org/sakaiproject/tool/app/scheduler/SchedulerTool.java
+++ b/jobscheduler/scheduler-tool/src/java/org/sakaiproject/tool/app/scheduler/SchedulerTool.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.tool.app.scheduler;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import javax.faces.application.FacesMessage;
@@ -30,6 +31,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.ActionEvent;
 import javax.faces.model.SelectItem;
 import javax.faces.validator.ValidatorException;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +73,10 @@ public class SchedulerTool
   private static final int TRIGGER_NAME_LENGTH_LIMIT = 80;
   /** The maximum length of a job name. */
   private static final int JOB_NAME_LENGTH_LIMIT = 80;
+  
+  private static String BEFORE = "before";
+  private static String AFTER = "after";
+  private static String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm";
 
   private SchedulerManager schedulerManager;
   private String jobName;
@@ -1459,6 +1465,22 @@ public class SchedulerTool
 
    public String processSetFilters()
    {
+       Map<String, String> req = FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap();
+       String beforeText = req.get(BEFORE);
+       String afterText = req.get(AFTER);
+       SimpleDateFormat sdf = new SimpleDateFormat(DATE_PATTERN);
+       try {
+           if (StringUtils.isNotBlank(beforeText)) {
+               getEventPager().setBefore(sdf.parse(beforeText));
+           }
+           if (StringUtils.isNotBlank(afterText)) {
+               getEventPager().setAfter(sdf.parse(afterText));
+           }
+       } catch (ParseException error) {
+           FacesMessage message = new FacesMessage(rb.getFormattedMessage("parse_exception", error));
+           message.setSeverity(FacesMessage.SEVERITY_ERROR);
+           throw new ValidatorException(message);
+       }
        getEventPager().setFilterEnabled(true);
 
        return "events";

--- a/jobscheduler/scheduler-tool/src/webapp/scheduler/filter_events.jsp
+++ b/jobscheduler/scheduler-tool/src/webapp/scheduler/filter_events.jsp
@@ -8,10 +8,6 @@
 <f:view>
 	<sakai:view_container title="#{msgs.title_trigger}">
 
-        <sakai:script contextBase="/jsf-resource" path="/inputDate/inputDate.js"/>
-        <sakai:script contextBase="/jsf-resource" path="/inputDate/calendar1.js"/>
-        <sakai:script contextBase="/jsf-resource" path="/inputDate/calendar2.js"/>
-
 	  <h:form id="filterForm">
   	    <h:graphicImage value="/images/quartz.jpg" alt="#{msgs.powered_by} Quartz"/>
 
@@ -25,13 +21,13 @@
             </h2>
             <h:outputText value="#{msgs.filter_date_instructions}" styleClass="instructions"/><br/>
             <h3>
-                <h:outputText value="#{msgs.filter_before_title}"/>
+                <label for="beforeFilter"><h:outputText value="#{msgs.filter_before_title}"/></label>
             </h3>
-            <sakai:input_date value="#{schedulerTool.eventPager.before}" showDate="true" showTime="false"/><br/>
+            <input type="datetime-local" name="before" id="beforeFilter"/>
             <h3>
-                <h:outputText value="#{msgs.filter_after_title}"/>
+                <label for="afterFilter"><h:outputText value="#{msgs.filter_after_title}"/></label>
             </h3>
-            <sakai:input_date value="#{schedulerTool.eventPager.after}" showDate="true" showTime="false"/>
+            <input type="datetime-local" name="after" id="afterFilter"/>
 
             <h2>
                 <h:outputText value="#{msgs.filter_job_title}"/>


### PR DESCRIPTION
There was a problem with the migration of this tool to JSF2, since the tag <sakai:script> wasn't recognized. That was the reason of the crash and the exceptions being printed on the console. I removed those unnecessary scripts and changed the input date fields of the form to the standard input type "datetime-local". Now we receive that data on the bean manager to configure the filters properly.