### PR TITLE
SAK-46438 Gradebook: Item menus are not keyboard accessible when on far left/right of gradebook or category

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -1014,7 +1014,7 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     // Remove "Move left" menu option for the leftmost item and "Move right" for the rightmost item.
     var $header = $link.closest("th.gb-item");
     if ($header.length) {
-	  var menuOption;
+      var menuOption;
       // Retrieve JQuery <a> element
       if (!$header.prev("th.gb-item").length || $header.prev("th").hasClass("gb-item-category")) {
         menuOption = $dropdownMenu.find(".gb-move-left");

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -1011,15 +1011,20 @@ GbGradeTable.renderTable = function (elementId, tableData) {
 
     $('body').append($dropdownMenu.detach());
 
-    // SAK-40644 Hide move left for the leftmost, move right for the rightmost.
+    // Remove "Move left" menu option for the leftmost item and "Move right" for the rightmost item.
     var $header = $link.closest("th.gb-item");
     if ($header.length) {
+	  var menuOption;
+      // Retrieve JQuery <a> element
       if (!$header.prev("th.gb-item").length || $header.prev("th").hasClass("gb-item-category")) {
-        $dropdownMenu.find(".gb-move-left").hide();
+        menuOption = $dropdownMenu.find(".gb-move-left");
       }
-
       if (!$header.next("th.gb-item").length || $header.next("th").hasClass("gb-item-category")) {
-        $dropdownMenu.find(".gb-move-right").hide();
+        menuOption = $dropdownMenu.find(".gb-move-right"); 
+      }
+      // Remove DOM <li> element
+      if (menuOption != null && menuOption.length > 0) {
+        menuOption[0].parentElement.remove();
       }
     }
 


### PR DESCRIPTION
There was a problem related to SAK-40644. When hiding a dropdown menu item on the Gradebook, the keyboard navigation ceased to work properly because the navigator couldn't focus on the hidden item. Those menu items had to be removed from the DOM in order to make the whole menu accessible.