### PR TITLE
SAK-46722 Feedback tool: When setting the 'X-Content-Type-Options' header the tool does not load.

### DIFF
--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -132,7 +132,7 @@
                                     <goal>precompile</goal>
                                 </goals>
                                 <configuration>
-                                    <output>${basedir}/src/webapp/templates/all.handlebars</output>
+                                    <output>${basedir}/src/webapp/templates/all.handlebars.js</output>
                                     <prefix>${basedir}/src/webapp/WEB-INF/templates/</prefix>
                                     <suffix>.handlebars</suffix>
                                     <minimize>false</minimize>
@@ -168,7 +168,7 @@
                             <goal>precompile</goal>
                         </goals>
                         <configuration>
-                            <output>${project.build.directory}/${project.build.finalName}/templates/all.handlebars</output>
+                            <output>${project.build.directory}/${project.build.finalName}/templates/all.handlebars.js</output>
                             <prefix>${basedir}/src/webapp/WEB-INF/templates/</prefix>
                             <suffix>.handlebars</suffix>
                             <minimize>false</minimize>

--- a/feedback/src/webapp/WEB-INF/bootstrap.jsp
+++ b/feedback/src/webapp/WEB-INF/bootstrap.jsp
@@ -11,7 +11,7 @@
         <script src="/feedback-tool/lib/jquery.form.min.js"></script>
         <script src="/library/webjars/multifile/2.2.2/jquery.MultiFile.min.js"></script>
         <script src="/feedback-tool/lib/handlebars.runtime-v1.3.0.js"></script>
-        <script src="/feedback-tool/templates/all.handlebars"></script>
+        <script src="/feedback-tool/templates/all.handlebars.js"></script>
 
         <c:if test="${recaptchaEnabled}">
             <script src="//www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script>


### PR DESCRIPTION
The Handlebars plugin was creating a compiled file with a ".handlebars" extension that wasn't recognized as a valid mimetype when using security configuration in the server side. I changed the name of the output file on the "handlebars-maven-plugin" properties of the pom.xml to use a valid ".js" extension.