### PR TITLE
SAK-46736 - Admin Workspace: Delegated Access - Dark Theme Makes List Unreadable

### DIFF
--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.html
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.html
@@ -17,34 +17,6 @@
 * limitations under the License.
 -->
 
-<wicket:head>
-    <style>
-		.colDiv{
-			display: inline-block;
-		}
-		
-		.headerText{
-			font-weight: bold;
-		}
-		
-		.inputForm{
-			-webkit-border-radius: 5px;
-			-moz-border-radius: 5px;
-			border-radius: 5px;
-			background: none repeat scroll 0 0 #ddd;
-			padding: 0.7em;
-		}
-		
-		.odd{
-			background: #eee;
-		}
-		
-		.even{
-			background: #FAFAFA;
-		}
-		
-    </style>
-</wicket:head>
 <body>
 <wicket:extend>
 	<form wicket:id="form">

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchUsersPage.html
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchUsersPage.html
@@ -17,21 +17,6 @@
 * limitations under the License.
 -->
 
-<wicket:head>
-    <style>
-    	.headerText{
-			font-weight: bold;
-		}
-		
-		.inputForm{
-			-webkit-border-radius: 5px;
-			-moz-border-radius: 5px;
-			border-radius: 5px;
-			background: none repeat scroll 0 0 #ddd;
-			padding: 0.3em;
-		}
-    </style>
-</wicket:head>
 <body>
 <wicket:extend>
 	<br/>

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/ShoppingEditPage.html
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/ShoppingEditPage.html
@@ -54,6 +54,7 @@
         } 
         div.wicket-tree-table a{
         	float: none !important;
+        	color: black;
         }
         
         div.noRoles div.wicket-tree-table {

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserEditPage.html
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserEditPage.html
@@ -28,6 +28,7 @@
         div.wicket-tree-table{
             margin: 10px 0;
             width: 100%;
+            color: black;
         }
         div.my-tree div.wicket-tree-table-body {
             height: 20em;

--- a/library/src/morpheus-master/sass/modules/tool/delegatedaccess/_delegatedaccess.scss
+++ b/library/src/morpheus-master/sass/modules/tool/delegatedaccess/_delegatedaccess.scss
@@ -13,4 +13,28 @@
     input[name="addAddSites"] {
         margin-top:calc(#{$standard-spacing} / 2)
     }
+
+   	.colDiv{
+		display: inline-block;
+	}
+		
+	.headerText{
+		font-weight: bold;
+	}
+		
+	.inputForm{
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+		background: none repeat scroll 0 0 var(--sakai-background-color-2);
+		padding: 0.3em;
+	}
+	
+	.odd{
+    	background: var(--sakai-background-color-2);
+	}
+		
+	.even{
+        background: transparent;
+	}
 }


### PR DESCRIPTION
I moved many of these styles into morpheus-master. There are still some inline styles mostly for the wicket-tree-table component which is deprecated.
These should really all be removed when/if this component is replaced. I did a slight adjustment to make this more useable in darkmode, even though it's got a white background.
Most of the styles for this are internal to the wicket component and not currently overridden.