### PR TITLE
SAK-46648 - Regression: Accounts: the same email address can be assigned to 2 different users

### DIFF
--- a/admin-tools/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/admin-tools/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -1397,7 +1397,7 @@ public class UsersAction extends PagedResourceActionII
 			}
 
 			// if we validate through email, passwords will be handled in AccountValidator
-			TempUser tempUser = new TempUser(eid, null, null, null, eid, pw, null);
+			TempUser tempUser = new TempUser(eid, email, null, null, eid, pw, null);
 			if (!validateWithAccountValidator)
 			{
 				// if in create mode, make sure we have a password


### PR DESCRIPTION
I'm not sure why this email parameter was removed back in #311 but it breaks this the optional feature of duplicate email checking.

I tried it with and without the property and the email variable doesn't seem to be used by any other code in here. I was going to create a separate tempUser but that didn't seem necessary. 

It's possibly this validation could be cleared up. I also wonder if this should just be enabled as default. 