### PR TITLE
SAK-44069 fix for invalid deferred EL method syntax.

### DIFF
--- a/sections/sections-app/src/webapp/roster.jsp
+++ b/sections/sections-app/src/webapp/roster.jsp
@@ -56,7 +56,7 @@
         binding="#{rosterBean.rosterDataTable}"
         sortColumn="#{preferencesBean.rosterSortColumn}"
         sortAscending="#{preferencesBean.rosterSortAscending}"
-        rendered="#{rosterBean.enrollments.size() > 0}"
+        rendered="#{rosterBean.enrollmentsSize > 0}"
         styleClass="listHier rosterTable">
         <h:column>
             <f:facet name="header">


### PR DESCRIPTION
Fix for https://github.com/sakaiproject/sakai/commit/316b5b828172f89a9d3f5a1e7d62063aa304ebd8  breaking the "Student Memberships" tab as reported on the dev list and here: https://sakaiproject.atlassian.net/browse/SAK-44069?focusedCommentId=202098    

Clicking the "Student Memberships" tab resulted in an exception, because using "()" to call a method as done in "#{rosterBean.enrollments.size()" isn't allowed.
                 
=> Using the already existing "enrollmentsSize" property for consistency (instead of just removing the "()", which should also work)