### PR TITLE
SAK-46754 refactor to avoid scanning entire MFR_PERMISSION_LEVEL table

### DIFF
--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsMessageManager.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsMessageManager.java
@@ -263,11 +263,11 @@ public interface MessageForumsMessageManager {
 	public Map<Long, Boolean> getReadStatusForMessagesWithId(List<Long> msgIds, String userId);
 	
 	/**
-	 * Returns list of all messages in site with Pending approval for which
+	 * Returns list of all messages from a given set of topics with Pending approval for which
 	 * at least one of the given memberships has moderate perm
 	 * @return
 	 */
-	public List getPendingMsgsInSiteByMembership(final List membershipList);
+	public List getPendingMsgsInSiteByMembership(final List<String> membershipList, final List<Topic> moderatedTopics);
 	
 	/**
 	 * Retrieves all pending messages in a given topic

--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/ui/DiscussionForumManager.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/ui/DiscussionForumManager.java
@@ -175,10 +175,10 @@ public interface DiscussionForumManager
   public void approveAllPendingMessages(Long topicId);
   
   /**
-   * Returns pending msgs in site according to user's memberships
+   * Returns pending msgs of available moderated topics according to user's memberships
    * @return
    */
-  List getPendingMsgsInSiteByMembership(List membershipList);
+  List<Message> getPendingMsgsInSiteByMembership(List<String> membershipList, List<Topic> moderatedTopics);
   
   /**
    * 

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -4873,7 +4873,7 @@ public class DiscussionForumTool {
 		  Map<String, List<DiscussionMessageBean>> userIdAnonMessagesMap = new HashMap<>();
 	  
 		  for (Message msg : messages)
-          {
+		  {
 			  // Determine if we should display anonIds in the context of this message's topic, keep track of this in a map to minimize redundant permission checks, etc.
 			  Topic topic = msg.getTopic();
 			  Boolean useAnonId = topicUseAnonIdMap.get(topic);

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -4824,11 +4824,12 @@ public class DiscussionForumTool {
    */
   public boolean isDisplayPendingMsgQueue() {
     if (displayPendingMsgQueue == null) {
+      List<String> membershipList = new ArrayList<>();
       List<Topic> moderatedTopics = forumManager.getModeratedTopicsInSite();
 
       // Avoid the expensive queries below if there are no moderated topics
       if (moderatedTopics != null && !moderatedTopics.isEmpty()) {
-        List<String> membershipList = uiPermissionsManager.getCurrentUserMemberships();
+        membershipList = uiPermissionsManager.getCurrentUserMemberships();
         int numModTopicWithPerm = forumManager.getNumModTopicsWithModPermissionByPermissionLevel(membershipList, moderatedTopics);
 
         if (numModTopicWithPerm < 1) {
@@ -4840,23 +4841,26 @@ public class DiscussionForumTool {
       else {
         displayPendingMsgQueue = false;
       }
+
+      if (refreshPendingMsgs && displayPendingMsgQueue) {
+        refreshPendingMessages(membershipList, moderatedTopics);
+      }
     }
 
-    if (refreshPendingMsgs && displayPendingMsgQueue.booleanValue()) {
-      refreshPendingMessages();
-    }
-    return displayPendingMsgQueue.booleanValue();
+    return displayPendingMsgQueue;
   }
   
   /**
    * Retrieve pending msgs from db and make DiscussionMessageBeans
    *
+   * @param membershipList
+   * @param moderatedTopics
    */
-  private void refreshPendingMessages()
+  private void refreshPendingMessages(List<String> membershipList, List<Topic> moderatedTopics)
   {
 	  pendingMsgs = new ArrayList();
 	  numPendingMessages = 0;
-	  List messages = forumManager.getPendingMsgsInSiteByMembership(uiPermissionsManager.getCurrentUserMemberships());
+	  List<Message> messages = forumManager.getPendingMsgsInSiteByMembership(membershipList, moderatedTopics);
 	  
 	  if (messages != null && !messages.isEmpty())
 	  {
@@ -4868,11 +4872,8 @@ public class DiscussionForumTool {
 		  // Maps userIds to all the messages that are within an anonymous context
 		  Map<String, List<DiscussionMessageBean>> userIdAnonMessagesMap = new HashMap<>();
 	  
-		  Iterator msgIter = messages.iterator();
-		  while (msgIter.hasNext())
-		  {
-			  Message msg = (Message) msgIter.next();
-
+		  for (Message msg : messages)
+          {
 			  // Determine if we should display anonIds in the context of this message's topic, keep track of this in a map to minimize redundant permission checks, etc.
 			  Topic topic = msg.getTopic();
 			  Boolean useAnonId = topicUseAnonIdMap.get(topic);
@@ -4932,11 +4933,6 @@ public class DiscussionForumTool {
    */
   public List getPendingMessages()
   {
-	  if (refreshPendingMsgs)
-	  {
-	  	refreshPendingMessages();
-	  }
-	  
 	  return pendingMsgs;
   }
   

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -1859,9 +1859,9 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
 
     public List<Message> getPendingMsgsInSiteByMembership(final List<String> membershipList, final List<Topic> moderatedTopics)
     {
-        if (membershipList == null || moderatedTopics == null) {
-            log.error("getPendingMsgsInSiteByMembership failed with membershipList: null or moderatedTopics: null");
-            throw new IllegalArgumentException("Null Argument");
+        if (membershipList == null || membershipList.isEmpty() || moderatedTopics == null || moderatedTopics.isEmpty()) {
+            log.debug("membershipList is null or empty | moderatedTopics is null or empty");
+            return Collections.emptyList();
         }
 
         // First, check by permissionLevel (custom permissions)

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -38,6 +38,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.query.Query;
 import org.hibernate.type.LongType;
 import org.hibernate.type.StringType;
+import org.sakaiproject.api.app.messageforums.PermissionLevel;
+import org.sakaiproject.api.app.messageforums.PermissionLevelManager;
 import org.springframework.orm.hibernate5.HibernateCallback;
 import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException;
 import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
@@ -106,6 +108,8 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
 
     private MessageForumsTypeManager typeManager;
 
+    private PermissionLevelManager permissionLevelManager;
+
     private SessionManager sessionManager;
 
     private EventTrackingService eventTrackingService;
@@ -136,6 +140,8 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
     public void setTypeManager(MessageForumsTypeManager typeManager) {
         this.typeManager = typeManager;
     }
+
+    public void setPermissionLevelManager(PermissionLevelManager permissionLevelManager) { this.permissionLevelManager = permissionLevelManager; }
     
     public void setSessionManager(SessionManager sessionManager) {
         this.sessionManager = sessionManager;
@@ -1850,62 +1856,62 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
 		}
 		return statusMap;
 	}
-	
-	public List getPendingMsgsInSiteByMembership(final List membershipList)
-	{   	
-		if (membershipList == null) {
-            log.error("getPendingMsgsInSiteByMembership failed with membershipList: null");
+
+    public List<Message> getPendingMsgsInSiteByMembership(final List<String> membershipList, final List<Topic> moderatedTopics)
+    {
+        if (membershipList == null || moderatedTopics == null) {
+            log.error("getPendingMsgsInSiteByMembership failed with membershipList: null or moderatedTopics: null");
             throw new IllegalArgumentException("Null Argument");
         }
-		
-		// First, check by permissionLevel (custom permissions)
-		HibernateCallback<List> hcb = session -> {
-            Query q = session.getNamedQuery(QUERY_FIND_PENDING_MSGS_BY_CONTEXT_AND_USER_AND_PERMISSION_LEVEL);
-            q.setParameter("contextId", getContextId(), StringType.INSTANCE);
-            q.setParameterList("membershipList", membershipList);
 
+        // First, check by permissionLevel (custom permissions)
+        HibernateCallback<List> hcb = session -> {
+            Query q = session.getNamedQuery(QUERY_FIND_PENDING_MSGS_BY_CONTEXT_AND_USER_AND_PERMISSION_LEVEL);
+            q.setParameterList("membershipList", membershipList);
+            q.setParameterList("topicList", moderatedTopics);
             return q.list();
         };
-		
-		Message tempMsg = null;
-        Set resultSet = new HashSet();      
+
+        Message tempMsg = null;
+        Set<Message> resultSet = new HashSet<>();
         List temp = getHibernateTemplate().execute(hcb);
         for (Iterator i = temp.iterator(); i.hasNext();)
         {
           Object[] results = (Object[]) i.next();        
               
-          if (results != null) {
-            if (results[0] instanceof Message) {
+          if (results != null && results[0] instanceof Message)
+          {
               tempMsg = (Message)results[0];
-              tempMsg.setTopic((Topic)results[1]); 
+              tempMsg.setTopic((Topic)results[1]);
               tempMsg.getTopic().setBaseForum((BaseForum)results[2]);
-            }
-            resultSet.add(tempMsg);
+              resultSet.add(tempMsg);
           }
         }
         
         // Second, check by PermissionLevelName (non-custom permissions)
         HibernateCallback<List> hcb2 = session -> {
             Query q = session.getNamedQuery(QUERY_FIND_PENDING_MSGS_BY_CONTEXT_AND_USER_AND_PERMISSION_LEVEL_NAME);
-            q.setParameter("contextId", getContextId(), StringType.INSTANCE);
             q.setParameterList("membershipList", membershipList);
-            q.setParameter("customTypeUuid", typeManager.getCustomLevelType(), StringType.INSTANCE);
-
+            q.setParameterList("topicList", moderatedTopics);
             return q.list();
         };
-		   
+
         temp = getHibernateTemplate().execute(hcb2);
         for (Iterator i = temp.iterator(); i.hasNext();)
         {
           Object[] results = (Object[]) i.next();        
               
-          if (results != null) {
-            if (results[0] instanceof Message) {
+          if (results != null && results[0] instanceof Message)
+          {
               tempMsg = (Message)results[0];
               tempMsg.setTopic((Topic)results[1]); 
               tempMsg.getTopic().setBaseForum((BaseForum)results[2]);
-            }
-            resultSet.add(tempMsg);
+
+              // See if the permission level has ability to moderate
+              PermissionLevel permLevel = permissionLevelManager.getPermissionLevelByName((String)results[3]);
+              if (permLevel.getModeratePostings()) {
+                  resultSet.add(tempMsg);
+              }
           }
         }
         

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
@@ -603,9 +603,9 @@ public class DiscussionForumManagerImpl extends HibernateDaoSupport implements
    * (non-Javadoc)
    * @see org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager#getTotalNoPendingMessages()
    */
-  public List getPendingMsgsInSiteByMembership(List membershipList)
+  public List<Message> getPendingMsgsInSiteByMembership(List<String> membershipList, List<Topic> moderatedTopics)
   {
-	  return messageManager.getPendingMsgsInSiteByMembership(membershipList);
+	  return messageManager.getPendingMsgsInSiteByMembership(membershipList, moderatedTopics);
   }
 
   /*

--- a/msgcntr/messageforums-component-impl/src/webapp/WEB-INF/components.xml
+++ b/msgcntr/messageforums-component-impl/src/webapp/WEB-INF/components.xml
@@ -213,6 +213,7 @@
                 <property name="idManager" ref="org.sakaiproject.id.api.IdManager" />
                 <property name="sessionManager"  ref="org.sakaiproject.tool.api.SessionManager" />
                 <property name="typeManager" ref="org.sakaiproject.api.app.messageforums.MessageForumsTypeManager"/>
+                <property name="permissionLevelManager" ref="org.sakaiproject.api.app.messageforums.PermissionLevelManager"/>
                 <property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
                 <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
                 <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>

--- a/msgcntr/messageforums-hbm/src/java/org/sakaiproject/component/app/messageforums/dao/hibernate/MessageImpl.hbm.xml
+++ b/msgcntr/messageforums-hbm/src/java/org/sakaiproject/component/app/messageforums/dao/hibernate/MessageImpl.hbm.xml
@@ -756,14 +756,13 @@
   <query name="findAllPendingMsgsByContextByMembershipByPermissionLevel">
     <![CDATA[select message, topic, forum from org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl as message,
     					org.sakaiproject.component.app.messageforums.dao.hibernate.PermissionLevelImpl as pl
-    				 join message.topic as topic
+             join message.topic as topic
              join topic.openForum as forum
-             join forum.area as area
              join topic.membershipItemSet as membershipItem   
-             where area.contextId = :contextId and
+             where topic in ( :topicList ) and
              membershipItem.name in ( :membershipList ) and
              message.deleted = false and
-             message.approved = null and
+             message.approved is null and
              membershipItem.permissionLevel = pl.id and
              pl.moderatePostings = true
     ]]>    
@@ -771,30 +770,28 @@
   
   <!--  second check by permissionLevelName (non-custom permission) -->
   <query name="findAllPendingMsgsByContextByMembershipByPermissionLevelName">
-    <![CDATA[select message, topic, forum from org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl as message,
-    					org.sakaiproject.component.app.messageforums.dao.hibernate.PermissionLevelImpl as pl
-    				 join message.topic as topic
+    <![CDATA[select message, topic, forum, membershipItem.permissionLevelName
+             from org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl as message
+             join message.topic as topic
              join topic.openForum as forum
-             join forum.area as area
              join topic.membershipItemSet as membershipItem   
-             where area.contextId = :contextId and
+             where topic in ( :topicList ) and
              membershipItem.name in ( :membershipList ) and
+             membershipItem.permissionLevel is null and
              message.deleted = false and
-             message.approved = null and
-             (pl.typeUuid != :customTypeUuid and pl.name = membershipItem.permissionLevelName) and
-             pl.moderatePostings = true
+             message.approved is null
     ]]>    
   </query>
   
   <query name="findPendingMsgsByTopicId">
-    <![CDATA[select message, topic, forum from org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl as message      
+    <![CDATA[select message, topic, forum from org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl as message
     				 join message.topic as topic
     				 join topic.openForum as forum    
              where topic.id = :topicId and
              topic.draft = false and
              forum.draft = false and
              message.deleted = false and
-             message.approved = null
+             message.approved is null
     ]]>    
   </query>
   


### PR DESCRIPTION
when looking for ability to moderate a topic

It looks like all topics to create in modern Sakai create a set of custom permissions. But very old topics in Sakai may use a default permission level. These changes make this querying much more efficient.