### PR TITLE
SAK-45051 Add Gradebook items to Tasks widget

### DIFF
--- a/edu-services/gradebook-service/api/pom.xml
+++ b/edu-services/gradebook-service/api/pom.xml
@@ -21,6 +21,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.sakaiproject.kernel</groupId>
+      <artifactId>sakai-component-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.sakaiproject.kernel</groupId>
+      <artifactId>sakai-kernel-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/Assignment.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/Assignment.java
@@ -144,6 +144,9 @@ public class Assignment implements Serializable, Comparable<Assignment> {
 	@Getter
 	@Setter
 	private Integer categorizedSortOrder;
+	@Getter
+	@Setter
+	private boolean createTask;
 
 	/**
 	 * For editing. Not persisted.
@@ -151,6 +154,13 @@ public class Assignment implements Serializable, Comparable<Assignment> {
 	@Getter
 	@Setter
 	private boolean scaleGrades;
+	@Getter
+	@Setter
+	private String context;
+	@Getter
+	@Setter
+	private String gradebookId;
+	
 
 	@Override
 	public int compareTo(final Assignment o) {

--- a/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
+++ b/edu-services/gradebook-service/api/src/java/org/sakaiproject/service/gradebook/shared/GradebookService.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.entity.api.Entity;
+import org.sakaiproject.entity.api.EntityProducer;
 
 /**
  * This is the externally exposed API of the gradebook application.
@@ -43,7 +45,7 @@ import org.apache.commons.lang3.StringUtils;
  * <p>
  * WARNING: For documentation of the deprecated methods, please see the service interfaces which own them.
  */
-public interface GradebookService {
+public interface GradebookService extends EntityProducer {
 	// Application service hooks.
 
 	// These have been deprecated in favour of the {@link GradingType} enum
@@ -57,6 +59,8 @@ public interface GradebookService {
 	public static final int CATEGORY_TYPE_NO_CATEGORY = 1;
 	public static final int CATEGORY_TYPE_ONLY_CATEGORY = 2;
 	public static final int CATEGORY_TYPE_WEIGHTED_CATEGORY = 3;
+	public static final String REFERENCE_ROOT = "/gbassignment";
+	public static final String SAKAI_GBASSIGNMENT = "sakai:gbassignment";
 
 	public static final String[] validLetterGrade = { "a+", "a", "a-", "b+", "b", "b-",
 			"c+", "c", "c-", "d+", "d", "d-", "f" };
@@ -73,7 +77,7 @@ public interface GradebookService {
 	public static final String enableLetterGradeString = "gradebook_enable_letter_grade";
 
 	public static final MathContext MATH_CONTEXT = new MathContext(10, RoundingMode.HALF_DOWN);
-
+	
 	/**
 	 * An enum for defining valid/invalid information for a points possible/relative weight value for a gradebook item. See
 	 * {@link GradebookService#isPointsPossibleValid(String, Assignment, Double)} for usage
@@ -205,6 +209,17 @@ public interface GradebookService {
 	 * @throws AssessmentNotFoundException
 	 */
 	public Assignment getAssignment(String gradebookUid, Long assignmentId)
+			throws AssessmentNotFoundException;
+
+	/**
+	 * Get an assignment based on its id
+	 *
+	 * @param gradebookUid
+	 * @param assignmentId
+	 * @return the associated Assignment with the given assignmentId
+	 * @throws AssessmentNotFoundException
+	 */
+	public Assignment getAssignmentByID(final Long gradeableObjectID)
 			throws AssessmentNotFoundException;
 
 	/**

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
@@ -236,6 +236,14 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
                 .setParameter("gradebookuid", gradebookUid)
                 .uniqueResult();
 	}
+	
+	protected GradebookAssignment getAssignmentById(final Long assignmentId) throws HibernateException {
+		return (GradebookAssignment) getSessionFactory().getCurrentSession()
+				.createCriteria(GradebookAssignment.class)
+				.add(Restrictions.eq("id", assignmentId))
+				.add(Restrictions.eq("removed", false))
+				.uniqueResult();
+	}
 
 	protected void updateAssignment(final GradebookAssignment assignment) throws ConflictingAssignmentNameException, HibernateException {
 		// Ensure that we don't have the assignment in the session, since

--- a/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
+++ b/edu-services/gradebook-service/sakai-pack/src/webapp/WEB-INF/components.xml
@@ -67,7 +67,8 @@
 
 	<bean id="org_sakaiproject_service_gradebook_GradebookServiceTarget"
 		class="org.sakaiproject.component.gradebook.GradebookServiceHibernateImpl"
-        name="org.sakaiproject.service.gradebook.GradebookServiceTarget">
+		name="org.sakaiproject.service.gradebook.GradebookServiceTarget"
+		init-method="init">
         <property name="sessionFactory"><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/></property>
         <property name="sectionAwareness">
             <ref bean="org.sakaiproject.section.api.SectionAwareness" />
@@ -89,14 +90,15 @@
         </property>
         <property name="serverConfigService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
         <property name="rubricsService" ref="org.sakaiproject.rubrics.logic.RubricsService" />
+        <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager"/>
+        <property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
 	</bean>
 	<bean id="org_sakaiproject_service_gradebook_GradebookPermissionServiceTarget"
           class="org.sakaiproject.component.gradebook.GradebookPermissionServiceImpl"
           name="org.sakaiproject.service.gradebook.GradebookPermissionServiceTarget">
         <property name="sessionFactory"><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/></property>
         <property name="sectionAwareness"><ref bean="org.sakaiproject.section.api.SectionAwareness"/></property>
-	</bean>
-	
+	</bean>	
 
 	<bean id="gradebookServiceTemplate"
 		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean"

--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -160,6 +160,7 @@ label.editgradeitem.due.help = Select a date
 label.editgradeitem.category = Category
 label.editgradeitem.release = Release item to students?
 label.editgradeitem.include = Include item in course grade calculations?
+label.editgradeitem.task = Create task in student dashboard?
 
 #Rubrics
 rubrics.dont_associate_label = Do not use a rubric to grade this assignment

--- a/gradebookng/bundle/src/main/bundle/gradebookng_es.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng_es.properties
@@ -160,6 +160,7 @@ label.editgradeitem.due.help=Seleccionar una fecha
 label.editgradeitem.category=Categor\u00eda
 label.editgradeitem.release=\u00bfPublicar este \u00edtem de calificaci\u00f3n al alumnado?
 label.editgradeitem.include=\u00bfIncluir este \u00edtem en el c\u00e1lculo de la nota final?
+label.editgradeitem.task =\u00bfCrear una tarea en el tablero del estudiante?
 
 #Rubrics
 rubrics.dont_associate_label=No utilizar r\u00fabricas para evaluar esta tarea

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.html
@@ -86,6 +86,16 @@
 					</div>
 				</div>
 			</div>
+			<div class="form-group form-group-sm" wicket:id="taskWrap">
+				<div class="col-xs-offset-3 col-xs-6">
+					<div class="checkbox">
+						<label>
+							<input wicket:id="createTask" type="checkbox" />
+							<span wicket:id="createTaskLabel"><wicket:message key="label.editgradeitem.task" /></span>
+						</label>
+					</div>
+				</div>
+			</div>
 
         </wicket:panel>
     </body>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
@@ -302,8 +302,19 @@ public class AddOrEditGradeItemPanelContent extends BasePanel {
 				this.counted.setModelObject(false);
 			}
 		}
-
 		add(this.counted);
+		
+		// create task
+		final WebMarkupContainer taskWrap = new WebMarkupContainer("taskWrap");
+		final CheckBox createTask = new CheckBox("createTask", new PropertyModel<Boolean>(assignmentModel, "createTask"));
+		createTask.setOutputMarkupId(true);
+		createTask.setModelObject(true);
+		add(createTask);
+		final WebMarkupContainer createTaskLabel = new WebMarkupContainer("createTaskLabel");
+		add(createTaskLabel);
+		taskWrap.add(createTask);
+		taskWrap.add(createTaskLabel);
+		add(taskWrap);
 
 		// behaviour for when a category is chosen. If the category is extra
 		// credit, deselect and disable extra credit checkbox

--- a/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -22,6 +22,7 @@
 		<property name="gradebookExternalAssessmentService" ref="org.sakaiproject.service.gradebook.GradebookExternalAssessmentService"/>
 		<property name="formattedText" ref="org.sakaiproject.util.api.FormattedText" />
 		<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService" />
+		<property name="taskService" ref="org.sakaiproject.tasks.api.TaskService" />
 	</bean>
 
 	<bean


### PR DESCRIPTION
This pull request includes modifications in edu-services to implement an entity to GradebookAssignments, since it was required on task creation to have a reference to the items on the gradebook. The gradebook was also modified to have a new checkbox option when creating gradebook items in order to create new tasks for the widget. Tasks created within the gradebook will be also updaded or deleted when corresponding gradebook items do so.