### PR TITLE
SAK-42153: portal: Tools skip link turns screen gray

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.responsive.menus.js
@@ -3,10 +3,19 @@
  */
 
 function toggleToolsNav(event){
+  /*global MorpheusViewportHelper*/
+  /*eslint no-undef: "error"*/
+
   if (event) {
     event.preventDefault();
   }
-    
+  
+  // The DHTML mask is only needed for mobile layouts, where the tool menu
+  // will overlay much of the screen.
+  if (MorpheusViewportHelper.isDesktop()) {
+      return;
+  }
+
   $PBJQ('body').toggleClass('toolsNav--displayed');
   if ($PBJQ('body').hasClass('toolsNav--displayed')) {
     /* Add the mask to grey out the top headers - re-use code in more.sites.js */

--- a/library/src/morpheus-master/js/src/sakai.morpheus.skipnav.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.skipnav.js
@@ -11,7 +11,16 @@ var setupSkipNav = function(){
 };
 
 $PBJQ( document ).ready(function() {
+        /*global $PBJQ*/
+        /*eslint no-undef: "error"*/
 	
+        // Accessibility fix for accesskey-l to display a visible focus applied to the first tool menu link
+        var firstToolMenuLink = $PBJQ("#toolMenu ul li:first a.Mrphs-toolsNav__menuitem--link");
+        var toToolMenuHeading = $PBJQ("h2#totoolmenu");
+        toToolMenuHeading.focus(function() {
+            firstToolMenuLink.focus();
+        });
+
 	var lastScrollTop = 0;
 
 	$PBJQ(document).scroll(function(event){


### PR DESCRIPTION
The layer of gray is a mask that should only be enabled for mobile layouts. It is needed for those layouts because the tool menu will cover most of the screen. Thus, I've added a conditional for desktop layouts.

Furthermore, I've added some jQuery to grant focus to the first tool (an anchor element) in the tool menu so that something visible has focus when the user keystrokes accesskey-l.