### PR TITLE
SAK-46753 - Signup: NPE with email to potential participants

### DIFF
--- a/signup/tool/src/webapp/signup/newMeeting/step2.jsp
+++ b/signup/tool/src/webapp/signup/newMeeting/step2.jsp
@@ -453,8 +453,8 @@
 								
 								<h:panelGroup id="emailAttendeeOnly">
 									<h:selectOneRadio  value="#{NewSignupMeetingBean.sendEmailToSelectedPeopleOnly}" layout="pageDirection" styleClass="rs" >
-										<f:selectItem id="all_attendees" itemValue="all" itemLabel="#{msgs.label_email_all_people}" itemDisabled="true"/>
-										<f:selectItem id="only_organizers" itemValue="organizers_only" itemLabel="#{msgs.label_email_organizers_only}" itemDisabled="true"/>
+										<f:selectItem id="all_attendees" itemValue="all" itemLabel="#{msgs.label_email_all_people}"/>
+										<f:selectItem id="only_organizers" itemValue="organizers_only" itemLabel="#{msgs.label_email_organizers_only}"/>
 									</h:selectOneRadio>
 								</h:panelGroup>
 							</h:panelGrid>

--- a/signup/tool/src/webapp/signup/organizer/copyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/copyMeeting.jsp
@@ -667,8 +667,8 @@
 							</h:panelGroup>
 							<h:panelGroup id="emailAttendeeOnly" layout="block">
 								<h:selectOneRadio  value="#{CopyMeetingSignupMBean.sendEmailToSelectedPeopleOnly}" layout="pageDirection" styleClass="rs" style="margin-left:20px;">
-									<f:selectItem id="all_attendees" itemValue="all" itemLabel="#{msgs.label_email_all_people}" itemDisabled="true"/>
-									<f:selectItem id="only_organizers" itemValue="organizers_only" itemLabel="#{msgs.label_email_signed_up_ones_Organizers_only}" itemDisabled="true"/>
+									<f:selectItem id="all_attendees" itemValue="all" itemLabel="#{msgs.label_email_all_people}"/>
+									<f:selectItem id="only_organizers" itemValue="organizers_only" itemLabel="#{msgs.label_email_signed_up_ones_Organizers_only}"/>
 								</h:selectOneRadio>
 							</h:panelGroup>
 						</h:panelGroup>

--- a/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
+++ b/signup/tool/src/webapp/signup/organizer/modifyMeeting.jsp
@@ -479,9 +479,9 @@
 								
 							<h:panelGroup layout="block" id="emailAttendeeOnly">
 								<h:selectOneRadio  value="#{EditMeetingSignupMBean.sendEmailToSelectedPeopleOnly}" layout="pageDirection" styleClass="rs" style="margin-left:20px;">
-									<f:selectItem id="all_attendees" itemValue="all" itemLabel="#{msgs.label_email_all_people}" itemDisabled="true"/>
-									<f:selectItem id="only_signedUp_ones" itemValue="signup_only" itemLabel="#{msgs.label_email_signed_up_ones_only}" itemDisabled="true"/>
-									<f:selectItem id="only_organizers" itemValue="organizers_only" itemLabel="#{msgs.label_email_organizers_only}" itemDisabled="true"/>
+									<f:selectItem id="all_attendees" itemValue="all" itemLabel="#{msgs.label_email_all_people}"/>
+									<f:selectItem id="only_signedUp_ones" itemValue="signup_only" itemLabel="#{msgs.label_email_signed_up_ones_only}"/>
+									<f:selectItem id="only_organizers" itemValue="organizers_only" itemLabel="#{msgs.label_email_organizers_only}"/>
 								</h:selectOneRadio>
 							</h:panelGroup>
 						</h:panelGroup>


### PR DESCRIPTION
It seems like having itemDisabled here as the default made it so that JSF wouldn't pass any value through to the bean. I don't know if this is something new with JSF2 or not. I'd have to imagine it was working as this was added back in 11. From what I can tell it doesn't need to be disabled by default as there is code client side to enable or disable and this code isn't processed if the checkbox isn't checked.