### PR TITLE
SAK-46781 Added js log message explaining the 404 error

### DIFF
--- a/rubrics/api/src/main/bundle/rubrics.properties
+++ b/rubrics/api/src/main/bundle/rubrics.properties
@@ -66,3 +66,7 @@ adjust_scores_warning=Deselecting the 'Adjust individual student scores' option 
 existing student rubric scores to the default point value for selected ratings. Are you sure?
 public_rubrics_title=Publicly Shared Rubrics
 public_rubrics_info=Rubrics in this section were created by instructors and shared publicly with all users. You can share a rubric publicly by clicking on the "Globe" icon next to the rubric you would like to share. To use one of these rubrics in your course site, expand the "Public Rubrics" section and click on the "Copy" icon located in the "Actions" column.
+grading_404_info=If you can see a GET error above this message, for the returned evaluation, \
+please ignore it as it is expected. Rubrics probes for a potentially non-existent returned \
+evaluation copy and handles the 404. However, some browsers also print an error about the \
+missing resource, and there's not much we can do about that, currently.

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
@@ -579,6 +579,7 @@ export class SakaiRubricGrading extends RubricsElement {
       if (r.ok) {
         return r.json();
       } else if (r.status === 404) {
+        console.info(this.i18nLoaded.grading_404_info);
         return Promise.resolve({ originalEvaluationId });
       }
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-46781

This error is displayed by a browser when a 404 is received. Rubrics
makes a get request for the returned evaluation backup copy when saving,
and it's perfectly valid for this to return a 404. The code handles the
404 returned, but the browser also prints the 404 "error" to the
console.