### PR TITLE
SAK-45053 Add Discussions items to Tasks widget

### DIFF
--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -382,6 +382,8 @@ cdfm_points_possible=({0} points possible)
 cdfm_null_points= - 
 cdfm_no_gb_perm=You do not have permission to view or grade the selected Gradebook item for this student.
 
+cdfm_cant_create_task=An error has occurred while trying to create a new task.
+
 #Permissions 
 perm_level=Permission Level 
 perm_role=Role
@@ -415,6 +417,8 @@ perm_choose_instruction_topic=This will be the default when grading in this topi
 perm_choose_instruction_more_link=(More?)
 perm_choose_instruction_forum_more=You can override this association in the child topics by changing it in the Topic settings.
 perm_choose_instruction_topic_more=You can assign any entry from the Gradebook to contributions in this topic. This is just setting the default.
+perm_create_task_forum=Create forum task in Dashboard tasks widget.
+perm_create_task_topic=Create topic task in Dashboard tasks widget.
 
 perm_own=Own
 perm_all=All

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es.properties
@@ -378,6 +378,8 @@ cdfm_points_possible=(de {0} puntos posibles)
 cdfm_null_points=-
 cdfm_no_gb_perm=No tiene permiso para ver o calificar el \u00edtem de calificaciones seleccionado de este estudiante.
 
+cdfm_cant_create_task=Se ha producido un error al intentar crear la tarea.
+
 #Permissions 
 perm_level=Nivel de permisos\: 
 perm_role=Rol
@@ -411,6 +413,8 @@ perm_choose_instruction_topic=Esta ser\u00e1 la opci\u00f3n predeterminada para 
 perm_choose_instruction_more_link=(M\u00e1s)
 perm_choose_instruction_forum_more=Puede anular esta asociaci\u00f3n en los temas subordinados modific\u00e1ndola en la configuraci\u00f3n del tema.
 perm_choose_instruction_topic_more=Puede asignar cualquier entrada del bolet\u00edn de calificaciones a las colaboraciones en este tema. \u00c9sta solo es la configuraci\u00f3n predeterminada.
+perm_create_task_forum=Crear tarea a los estudiantes para este foro en el widget de tareas.
+perm_create_task_topic=Crear tarea a los estudiantes para este tema en el widget de tareas.
 
 perm_own=Propios
 perm_all=Todos

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es_ES_Pearson.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es_ES_Pearson.properties
@@ -347,6 +347,8 @@ cdfm_points_possible=(de {0} puntos posibles)
 cdfm_null_points= - 
 cdfm_no_gb_perm=No tiene permiso para ver o calificar el elemento del bolet\u00edn de calificaciones seleccionado para este alumno.
 
+cdfm_cant_create_task=Se ha producido un error al intentar crear la tarea.
+
 #Permissions 
 perm_level=Nivel de permisos: 
 perm_role=Rol
@@ -379,6 +381,8 @@ perm_choose_instruction_topic=Esta ser\u00e1 la opci\u00f3n predeterminada para 
 perm_choose_instruction_more_link=(M\u00e1s)
 perm_choose_instruction_forum_more=Puede anular esta asociaci\u00f3n en los temas subordinados modific\u00e1ndola en la configuraci\u00f3n del tema.
 perm_choose_instruction_topic_more=Puede asignar cualquier entrada del bolet\u00edn de calificaciones a las colaboraciones en este tema. \u00c9sta solo es la configuraci\u00f3n predeterminada.
+perm_create_task_forum=Crear tarea a los estudiantes para este foro en el widget de tareas.
+perm_create_task_topic=Crear tarea a los estudiantes para este tema en el widget de tareas.
 
 perm_own=Propios
 perm_all=Todos

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -59,6 +59,7 @@ public class DiscussionForumBean
   private List<String> accessorList = null;
   private String gradeAssign;
   private Boolean nonePermission = null;
+  private boolean createTask = true;
   
   private boolean newTopic = false;
   private boolean changeSettings = false;

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
@@ -25,19 +25,27 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javax.faces.context.FacesContext;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.api.app.messageforums.DiscussionForum;
+import org.sakaiproject.api.app.messageforums.DiscussionForumService;
 import org.sakaiproject.api.app.messageforums.DiscussionTopic;
 import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.rubrics.logic.RubricsConstants;
 import org.sakaiproject.rubrics.logic.RubricsService;
+import org.sakaiproject.tasks.api.Task;
+import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.time.api.UserTimeService;
+import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.util.ResourceLoader;
 
 /**
@@ -64,6 +72,7 @@ public class DiscussionTopicBean
   private String gradeAssign;
   private Boolean nonePermission = null;
   private boolean sorted = false;
+  @Getter @Setter private boolean createTask = true;
 
   
   private Boolean isRead = null;
@@ -113,6 +122,10 @@ public class DiscussionTopicBean
     this.userTimeService = userTimeService;
     datetimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
     datetimeFormat.setTimeZone(userTimeService.getLocalTimeZone());
+    TaskService taskService = (TaskService) ComponentManager.get("org.sakaiproject.tasks.api.TaskService");
+    ToolManager toolManager = (ToolManager) ComponentManager.get("org.sakaiproject.tool.api.ToolManager");
+    String reference = DiscussionForumService.REFERENCE_ROOT + "/" + toolManager.getCurrentPlacement().getContext() + "/" + this.topic.getBaseForum().getId();
+    this.createTask = !taskService.getTask(reference).isPresent();
   }
 
   /**

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
@@ -49,15 +49,18 @@
 	function updateGradeAssignment(){
 		var elems = document.getElementsByTagName('sakai-rubric-association');
 		var forumAssignments = document.getElementById("revise:forum_assignments");
-		if( forumAssignments != null && forumAssignments.value != null && forumAssignments.value != 'Default_0'){
+		const createTaskGroup = document.getElementById("revise:createTaskGroup");
+		if (forumAssignments?.value && forumAssignments.value !== "Default_0") {
 			for (var i = 0; i<elems.length; i++) {
                 elems[i].setAttribute("entity-id", forumAssignments.value);
 				elems[i].style.display = 'inline';
 			}
+			createTaskGroup.style.display = 'inline';
 		} else {
 			for (var i = 0; i<elems.length; i++) {
 				elems[i].style.display = 'none';
 			}
+			createTaskGroup.style.display = 'none';
 		}
 	}
 
@@ -322,22 +325,28 @@
 				<h:panelGroup layout="block" styleClass="row form-group" id="forum_grading">
 					<h:outputLabel for="forum_assignments" value="#{msgs.perm_choose_assignment}" styleClass="col-md-2 col-sm-2"></h:outputLabel>  
 					<h:panelGroup layout="block" styleClass="col-md-10 col-sm-10">
-						<h:panelGroup layout="block" styleClass="row">
-				  		<h:panelGroup  styleClass="gradeSelector  itemAction actionItem"> 
-							<h:selectOneMenu id="forum_assignments" onchange="updateGradeAssignment()" value="#{ForumTool.selectedForum.gradeAssign}" disabled="#{not ForumTool.editMode}">
-			   	    			<f:selectItems value="#{ForumTool.assignments}" />
-			      			</h:selectOneMenu>
-							<h:outputText value="#{msgs.perm_choose_assignment_none_f}" styleClass="instrWOGrades" style="display:none;margin-left:0"/>
-							<h:outputText value=" #{msgs.perm_choose_instruction_forum} " styleClass="instrWithGrades" style="margin-left:0;"/>
-							<h:outputLink value="#" style="text-decoration:none" styleClass="instrWithGrades"><h:outputText styleClass="displayMore" value="#{msgs.perm_choose_instruction_more_link}"/></h:outputLink>
-			    		</h:panelGroup>
-			    		</h:panelGroup>
-			    		<h:panelGroup layout="block" styleClass="row"> 
-							<h:panelGroup styleClass="displayMorePanel" style="display:none" ></h:panelGroup>
-							<h:panelGroup styleClass="itemAction actionItem displayMorePanel" style="display:none" >
-								<h:outputText styleClass="displayMorePanel" value="#{msgs.perm_choose_instruction_forum_more}"/>
-			    			</h:panelGroup>
-			    		</h:panelGroup>
+						<h:panelGrid>
+							<h:panelGroup layout="block" styleClass="row">
+								<h:panelGroup  styleClass="gradeSelector  itemAction actionItem"> 
+									<h:selectOneMenu id="forum_assignments" onchange="updateGradeAssignment()" value="#{ForumTool.selectedForum.gradeAssign}" disabled="#{not ForumTool.editMode}">
+										<f:selectItems value="#{ForumTool.assignments}" />
+									</h:selectOneMenu>
+									<h:outputText value="#{msgs.perm_choose_assignment_none_f}" styleClass="instrWOGrades" style="display:none;margin-left:0"/>
+									<h:outputText value=" #{msgs.perm_choose_instruction_forum} " styleClass="instrWithGrades" style="margin-left:0;"/>
+									<h:outputLink value="#" style="text-decoration:none" styleClass="instrWithGrades"><h:outputText styleClass="displayMore" value="#{msgs.perm_choose_instruction_more_link}"/></h:outputLink>
+								</h:panelGroup>
+							</h:panelGroup>
+							<h:panelGroup layout="block" styleClass="row"> 
+								<h:panelGroup styleClass="displayMorePanel" style="display:none" ></h:panelGroup>
+								<h:panelGroup styleClass="itemAction actionItem displayMorePanel" style="display:none" >
+									<h:outputText styleClass="displayMorePanel" value="#{msgs.perm_choose_instruction_forum_more}"/>
+								</h:panelGroup>
+							</h:panelGroup>
+							<h:panelGroup id="createTaskGroup" style="display:#{((ForumTool.selectedForum.gradeAssign != null && ForumTool.selectedForum.gradeAssign != 'Default_0') ? 'block' : 'none')}">
+								<h:selectBooleanCheckbox id="createTask" title="createTask" value="#{ForumTool.selectedForum.createTask}"/>
+								<h:outputLabel for="createTask" value="#{msgs.perm_create_task_forum}" style="margin-left:5px"/>
+							</h:panelGroup>
+						</h:panelGrid>
 					</h:panelGroup>
 				</h:panelGroup>
 			

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
@@ -50,15 +50,21 @@
 
 			var elems = document.getElementsByTagName('sakai-rubric-association');
 			var topicAssignments = document.getElementById("revise:topic_assignments");
+			const createTaskGroup = document.getElementById("revise:createTaskGroup");
+			const createTaskEmptyPanel = document.getElementById("revise:createTaskEmptyPanel");
 			if ( topicAssignments !== null && topicAssignments.value != null && topicAssignments.value != 'Default_0') {
 				for (var i = 0; i < elems.length; i++) {
 					elems[i].setAttribute("entity-id", topicAssignments.value);
 					elems[i].style.display = 'inline';
 				}
+				createTaskGroup.style.display = 'inline';
+				createTaskEmptyPanel.style.display = 'inline';
 			} else {
 				for (var i = 0; i < elems.length; i++) {
 					elems[i].style.display = 'none';
 				}
+				createTaskGroup.style.display = 'none';
+				createTaskEmptyPanel.style.display = 'none';
 			}
 		}
 
@@ -337,12 +343,17 @@
 				<h:outputText value="#{msgs.perm_choose_assignment_none_t}" styleClass="instrWOGrades" style="display:none;margin-left:0"/>
 				<h:outputText value=" #{msgs.perm_choose_instruction_topic} " styleClass="instrWithGrades" style="margin-left:0;"/>
 				<h:outputLink value="#" style="text-decoration:none"  styleClass="instrWithGrades">
-                    <h:outputText styleClass="displayMore" value="#{msgs.perm_choose_instruction_more_link}" />
-                </h:outputLink>
+					<h:outputText styleClass="displayMore" value="#{msgs.perm_choose_instruction_more_link}" />
+				</h:outputLink>
 			</h:panelGroup>
 			<h:panelGroup styleClass="displayMorePanel" style="display:none"></h:panelGroup>
 			<h:panelGroup styleClass="itemAction actionItem displayMorePanel" style="display:none">
 				<h:outputText styleClass="displayMorePanel" value="#{msgs.perm_choose_instruction_topic_more}"/>
+			</h:panelGroup>
+			<h:panelGroup id="createTaskEmptyPanel" style="display:#{((ForumTool.selectedTopic.gradeAssign != null && ForumTool.selectedTopic.gradeAssign != 'Default_0') ? 'block' : 'none')}"></h:panelGroup>
+			<h:panelGroup id="createTaskGroup" style="display:#{((ForumTool.selectedTopic.gradeAssign != null && ForumTool.selectedTopic.gradeAssign != 'Default_0') ? 'block' : 'none')}">
+				<h:selectBooleanCheckbox id="createTask" title="createTask" value="#{ForumTool.selectedTopic.createTask}"/>
+				<h:outputLabel for="createTask" value="#{msgs.perm_create_task_topic}" style="margin-left:5px"/>
 			</h:panelGroup>
 		</h:panelGrid>
 		<sakai-rubric-association style="margin-left:20px;display:none"

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
@@ -74,6 +74,7 @@ import org.sakaiproject.component.app.messageforums.dao.hibernate.ActorPermissio
 import org.sakaiproject.component.app.messageforums.dao.hibernate.DBMembershipItemImpl;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.MessageForumsUserImpl;
 import org.sakaiproject.component.app.messageforums.ui.delegates.LRSDelegate;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.content.api.ContentResource;
@@ -89,6 +90,8 @@ import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tasks.api.Task;
+import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.tool.api.ToolManager;
@@ -483,6 +486,16 @@ public class DiscussionForumManagerImpl extends HibernateDaoSupport implements
                 NotificationService.NOTI_OPTIONAL, params.lrsStatement);
         eventTrackingService.post(event);
     }
+
+    TaskService taskService = (TaskService) ComponentManager.get("org.sakaiproject.tasks.api.TaskService");
+    List<String> userList = new ArrayList<>();
+    userList.add(message.getAuthorId());
+    // Complete task related to forum 
+    String referenceForum = DiscussionForumService.REFERENCE_ROOT + "/" + getCurrentContext() + "/" + message.getTopic().getBaseForum().getId();
+    taskService.completeUserTaskByReference(referenceForum, userList);
+    // Complete task related to topic 
+    String referenceTopic = DiscussionForumService.REFERENCE_ROOT + "/" + getCurrentContext() + "/" + message.getTopic().getBaseForum().getId() + "/topic/" + message.getTopic().getId();
+    taskService.completeUserTaskByReference(referenceTopic, userList);
 
     return persistedMessage;
   }

--- a/msgcntr/messageforums-component-impl/src/webapp/WEB-INF/components.xml
+++ b/msgcntr/messageforums-component-impl/src/webapp/WEB-INF/components.xml
@@ -74,6 +74,7 @@
         <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
         <property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager"/>
         <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
+        <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
     </bean>
         
     <bean id="org.sakaiproject.api.app.messageforums.MessageForumsTypeManager" 


### PR DESCRIPTION
This pull request includes changes into Discussions tools in order to feed the tasks widget on the dashboard. It includes a new option in forum/topic settings to create a task for students when you add grading to a forum or topic. When students post a comment on a graded forum/topic that has a task related to it, this task will be marked as being completed automatically. Also, when you edit a forum or a topic, if there is a task related to it, this task will be updated as well.
@bgarciaentornos, @mpellicer, will you take a look?