### PR TITLE
SAK-46837 Assignment submission export should sorting correctly when there are spaces

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
@@ -95,7 +95,7 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
         if (submitters.size() != 1) {
             // On a non-group assignment, there should be precisely one submitter.
             // When instructors submit on behalf of a user, it does not create a new submitter entry; rather it adds a submission property.
-            log.warn("Submission for a non-group assignment has multiple submitters. SubmissionID: " + submission.getId());
+            log.warn("Submission for a non-group assignment has multiple submitters. SubmissionID: {}", submission.getId());
             return Optional.empty();
         }
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
@@ -92,9 +92,12 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
         }
 
         Set<AssignmentSubmissionSubmitter> submitters = submission.getSubmitters();
+        /*
+         * On a non-group assignment, there should be precisely one submitter.
+         * Even when an instructor submits on behalf of a student, they do not create a new submitter entry (rather a submission property is created).
+         * So expect the submitters set to contain only one user: the student. Log and return empty otherwise.
+         */
         if (submitters.size() != 1) {
-            // On a non-group assignment, there should be precisely one submitter.
-            // When instructors submit on behalf of a user, it does not create a new submitter entry; rather it adds a submission property.
             log.warn("Submission for a non-group assignment has multiple submitters. SubmissionID: {}", submission.getId());
             return Optional.empty();
         }

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/sort/AssignmentSubmissionComparator.java
@@ -19,6 +19,8 @@ import java.text.Collator;
 import java.text.ParseException;
 import java.text.RuleBasedCollator;
 import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,6 +32,7 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
  * Sorts assignment submissions by the submitter's sort name.
@@ -41,6 +44,7 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
     private SiteService siteService;
     private AssignmentService assignmentService;
     private UserDirectoryService userDirectoryService;
+    private static final UserSortNameComparator userSortNameComparator = new UserSortNameComparator();
 
     // private to prevent no arg instantiation
     private AssignmentSubmissionComparator() {
@@ -62,11 +66,45 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
 
     @Override
     public int compare(AssignmentSubmission a1, AssignmentSubmission a2) {
-        int result;
+        // Compare by UserSortNameComparator if appropriate
+        Optional<User> u1 = getIndividualSubmitterAsUser(a1);
+        Optional<User> u2 = getIndividualSubmitterAsUser(a2);
+        if (u1.isPresent() && u2.isPresent()) {
+            return userSortNameComparator.compare(u1.get(), u2.get());
+        }
+
         String name1 = getSubmitterSortname(a1);
         String name2 = getSubmitterSortname(a2);
-        result = compareString(name1, name2);
-        return result;
+        return compareString(name1, name2);
+    }
+
+    /**
+     * Gets the submitter of a submission for a non-group assignment.
+     * @return Optional<User> of the submission's submitter.
+     * Returns Optional.empty() if:
+     *     the submission is associated with a group assignment
+     *     the submission does not have exactly 1 associated submitter
+     *     the submitter cannot be retrieved via the UserDirectoryService
+     */
+    private Optional<User> getIndividualSubmitterAsUser(AssignmentSubmission submission) {
+        if (submission.getAssignment().getIsGroup()) {
+            return Optional.empty();
+        }
+
+        Set<AssignmentSubmissionSubmitter> submitters = submission.getSubmitters();
+        if (submitters.size() != 1) {
+            // On a non-group assignment, there should be precisely one submitter.
+            // When instructors submit on behalf of a user, it does not create a new submitter entry; rather it adds a submission property.
+            log.warn("Submission for a non-group assignment has multiple submitters. SubmissionID: " + submission.getId());
+            return Optional.empty();
+        }
+
+        String submitterId = submitters.iterator().next().getSubmitter();
+        try {
+            return Optional.of(userDirectoryService.getUser(submitterId));
+        } catch (UserNotDefinedException e) {
+            return Optional.empty();
+        }
     }
 
     private int compareString(String s1, String s2) {

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
@@ -25,11 +25,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.assignment.api.model.AssignmentSubmission;
@@ -45,6 +49,7 @@ public class AssignmentComparatorTest {
 	private Comparator<String> sortNameComparator;
 	private Comparator<AssignmentSubmission> submitterNameComparator;
 	private AssignmentSubmission assignmentSubmission1, assignmentSubmission2, assignmentSubmission3, assignmentSubmission4;
+	private AssignmentSubmission[] namesWithSpaceSubmissions = new AssignmentSubmission[7];
 
 	@Before
 	public void setUp() throws Exception {
@@ -89,8 +94,47 @@ public class AssignmentComparatorTest {
 		Mockito.when(userDirectoryService.getUser("user4")).thenReturn(user4);
 		Mockito.when(userDirectoryService.getUser("usernull")).thenReturn(null);
 
+		// Adapted from UserSortNameComparatorTest in kernel
+		final String USERS_WITH_SPACE_PREFIX = "usersWithSpace";
+		User[] usersWithSpace = new User[7];
+		for (int i = 0; i < usersWithSpace.length; i++) {
+			usersWithSpace[i] = Mockito.mock(User.class);
+			when(userDirectoryService.getUser(USERS_WITH_SPACE_PREFIX + i)).thenReturn(usersWithSpace[i]);
+		}
+		when(usersWithSpace[0].getSortName()).thenReturn("Dekfort, Apple");
+		when(usersWithSpace[1].getSortName()).thenReturn("Del Fintino, Pear");
+		when(usersWithSpace[2].getSortName()).thenReturn("Dekford", "Orange");
+		when(usersWithSpace[3].getSortName()).thenReturn("De'Leon", "Cactus");
+		when(usersWithSpace[4].getSortName()).thenReturn("Deleverde", "Mango");
+		when(usersWithSpace[5].getSortName()).thenReturn("Martinez Torcal, Apple");
+		when(usersWithSpace[6].getSortName()).thenReturn("Martin Troncoso, X");
+		for (int i = 0; i < namesWithSpaceSubmissions.length; i++) {
+			namesWithSpaceSubmissions[i] = mockSubmissionForUserID(USERS_WITH_SPACE_PREFIX + i);
+		}
+
 		sortNameComparator = new UserIdComparator(userDirectoryService);
 		submitterNameComparator = new AssignmentSubmissionComparator(assignmentService, siteService, userDirectoryService);
+	}
+
+	/**
+	 * Mock a submission object, as well as its assignment and submitters.
+	 * The assignment will not be a group assignment, and the specified userId will be the only submitter.
+	 */
+	public static AssignmentSubmission mockSubmissionForUserID(String userID)
+	{
+		AssignmentSubmission submission = Mockito.mock(AssignmentSubmission.class);
+
+		Assignment assignment = Mockito.mock(Assignment.class);
+		when(submission.getAssignment()).thenReturn(assignment);
+		when(assignment.getIsGroup()).thenReturn(false);
+
+		Set<AssignmentSubmissionSubmitter> submitters = new HashSet<>(1);
+		AssignmentSubmissionSubmitter submitter = Mockito.mock(AssignmentSubmissionSubmitter.class);
+		when(submitter.getSubmitter()).thenReturn(userID);
+		submitters.add(submitter);
+		when(submission.getSubmitters()).thenReturn(submitters);
+
+		return submission;
 	}
 
 	@Test
@@ -157,6 +201,17 @@ public class AssignmentComparatorTest {
 			&& submitterNameComparator.compare(assignmentSubmission1,assignmentSubmission3) == -1
 			&& submitterNameComparator.compare(assignmentSubmission2,assignmentSubmission3) == -1
 			&& submitterNameComparator.compare(assignmentSubmission4,assignmentSubmission3) == -1);
+	}
+
+	@Test
+	public void testSubmitterNamesWithSpaces() {
+		// Adapted from UserSortNameComparatorTest in kernel
+		assertEquals(-1, submitterNameComparator.compare(namesWithSpaceSubmissions[0], namesWithSpaceSubmissions[1]));
+		assertEquals(1, submitterNameComparator.compare(namesWithSpaceSubmissions[1], namesWithSpaceSubmissions[0]));
+		assertEquals(0, submitterNameComparator.compare(namesWithSpaceSubmissions[1], namesWithSpaceSubmissions[1]));
+		assertEquals(-1, submitterNameComparator.compare(namesWithSpaceSubmissions[3], namesWithSpaceSubmissions[2]));
+		assertEquals(-1, submitterNameComparator.compare(namesWithSpaceSubmissions[3], namesWithSpaceSubmissions[4]));
+		assertEquals(1, submitterNameComparator.compare(namesWithSpaceSubmissions[5], namesWithSpaceSubmissions[6]));
 	}
 
 }

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
@@ -109,7 +109,7 @@ public class AssignmentComparatorTest {
 		when(usersWithSpace[5].getSortName()).thenReturn("Martinez Torcal, Apple");
 		when(usersWithSpace[6].getSortName()).thenReturn("Martin Troncoso, X");
 		for (int i = 0; i < namesWithSpaceSubmissions.length; i++) {
-			namesWithSpaceSubmissions[i] = mockSubmissionForUserID(USERS_WITH_SPACE_PREFIX + i);
+			namesWithSpaceSubmissions[i] = createSubmissionForUserID(USERS_WITH_SPACE_PREFIX + i);
 		}
 
 		sortNameComparator = new UserIdComparator(userDirectoryService);
@@ -117,22 +117,22 @@ public class AssignmentComparatorTest {
 	}
 
 	/**
-	 * Mock a submission object, as well as its assignment and submitters.
-	 * The assignment will not be a group assignment, and the specified userId will be the only submitter.
+	 * Create a submission object, as well as its assignment and submitters.
+	 * The assignment will not be a group assignment, and the specified userID will be the only submitter.
 	 */
-	public static AssignmentSubmission mockSubmissionForUserID(String userID)
+	public static AssignmentSubmission createSubmissionForUserID(String userID)
 	{
-		AssignmentSubmission submission = Mockito.mock(AssignmentSubmission.class);
+		AssignmentSubmission submission = new AssignmentSubmission();
 
-		Assignment assignment = Mockito.mock(Assignment.class);
-		when(submission.getAssignment()).thenReturn(assignment);
-		when(assignment.getIsGroup()).thenReturn(false);
+		Assignment assignment = new Assignment();
+		assignment.setIsGroup(false);
+		submission.setAssignment(assignment);
 
 		Set<AssignmentSubmissionSubmitter> submitters = new HashSet<>(1);
-		AssignmentSubmissionSubmitter submitter = Mockito.mock(AssignmentSubmissionSubmitter.class);
-		when(submitter.getSubmitter()).thenReturn(userID);
+		AssignmentSubmissionSubmitter submitter = new AssignmentSubmissionSubmitter();
+		submitter.setSubmitter(userID);
 		submitters.add(submitter);
-		when(submission.getSubmitters()).thenReturn(submitters);
+		submission.setSubmitters(submitters);
 
 		return submission;
 	}


### PR DESCRIPTION
When exporting submissions from an assignment, the grade spreadsheets use AssignmentSubmissionComparator, which has code duplication and minor inconsistencies from comparators used elsewhere in Sakai. Make it use UserSortNameComparator when appropriate.