### PR TITLE
SAK-45054 Add Lessons items to Tasks widget

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -704,10 +704,15 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
     */
    public String getEntityUrl(Reference ref)
    {
-       //Just return a URL to the top of the page based on the item's pageId and toolId
-       long id = idFromRef(ref.getReference());
-       SimplePageItem item = simplePageToolDao.findItem(id);
        String URL = "";
+       long id = idFromRef(ref.getReference());
+       if ("page".equals(ref.getSubType())) {
+    	   SimplePage currentPage = simplePageToolDao.getPage(id);
+    	   URL = String.format("%s/site/%s/page/%s", ServerConfigurationService.getPortalUrl(), currentPage.getSiteId(), currentPage.getToolId());
+    	   return URL;
+       }
+       //Just return a URL to the top of the page based on the item's pageId and toolId
+       SimplePageItem item = simplePageToolDao.findItem(id);
        if (item != null) {
            URL = item.getURL();
            if (URL == null || "".equals(URL) ) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -5024,6 +5024,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		if (points != null) {
 			pointString = points.toString();
 		}
+		UIBoundBoolean.make(form, "page-task", "#{simplePageBean.createTask}", true);
 		
 		if(!simplePageBean.isStudentPage(page)) {
 			UIOutput.make(form, "csssection");
@@ -5184,7 +5185,9 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		}
 		UIBoundBoolean.make(form, "comments-graded", "#{simplePageBean.graded}");
 		UIInput.make(form, "comments-max", "#{simplePageBean.maxPoints}");
-		
+
+		UIBoundBoolean.make(form, "comments-create-task", "#{simplePageBean.commentsCreateTask}", true);
+
 		UIBoundBoolean.make(form, "comments-required", "#{simplePageBean.required}");
 		UIBoundBoolean.make(form, "comments-prerequisite", "#{simplePageBean.prerequisite}");
 
@@ -5231,6 +5234,8 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 
 		UIBoundBoolean.make(form, "student-graded", "#{simplePageBean.graded}");
 		UIInput.make(form, "student-max", "#{simplePageBean.maxPoints}");
+		
+		UIBoundBoolean.make(form, "student-create-task", "#{simplePageBean.studentContentsCreateTask}", true);
 
 		UIOutput gradeBook = UIOutput.make(form, "gradeBookStudentsDiv");
 		UIOutput gradeBook2 = UIOutput.make(form, "gradeBookStudentCommentsDiv");
@@ -5281,6 +5286,8 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		UIBoundBoolean.make(form, "question-graded", "#{simplePageBean.graded}");
 		UIInput.make(form, "question-gradebook-title", "#{simplePageBean.gradebookTitle}");
 		UIInput.make(form, "question-max", "#{simplePageBean.maxPoints}");
+		
+		UIBoundBoolean.make(form, "question-create-task", "#{simplePageBean.questionCreateTask}", true);
 		
 		UIInput.make(form, "question-multiplechoice-answer-complete", "#{simplePageBean.addAnswerData}");
 		UIInput.make(form, "question-multiplechoice-answer-id", null);

--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -43,6 +43,11 @@ simplepage.notreleased.text=Note: This page will not be available to standard us
 simplepage.page.gradebook=Create Gradebook item when page is completed.
 simplepage.points=points
 simplepage.endmenu=End of menu. Use Escape to close it.
+simplepage.createtask=Create a task on student's dashboard
+simplepage.errorCreatingTask=There was an error when attempting to create a Task.
+simplepage.question-task-title=Answer question
+simplepage.comments-task-title=Add comments
+simplepage.student-contents-task-title=Add contents
 
 simplepage.overquota=Unable to add resource: it would take your site over its quota
 simplepage.resourceerror=Unable to add resource: {}

--- a/lessonbuilder/tool/src/resources/messages_es.properties
+++ b/lessonbuilder/tool/src/resources/messages_es.properties
@@ -43,6 +43,11 @@ simplepage.notreleased.text=Nota\: Esta p\u00e1gina no estar\u00e1 disponible al
 simplepage.page.gradebook=A\u00f1adir \u00edtem en Calificaciones cuando la p\u00e1gina est\u00e9 completada
 simplepage.points=puntos
 simplepage.endmenu=Final del men\u00fa. Use la tecla "Esc" para cerrarlo.
+simplepage.createtask=Crear una tarea en el widget de Tareas.
+simplepage.errorCreatingTask=Hubo un error al intentar crear una tarea.
+simplepage.question-task-title=Responder pregunta
+simplepage.comments-task-title=A\u00f1adir comentarios
+simplepage.student-contents-task-title=A\u00f1adir contenidos
 
 simplepage.overquota=Imposible a\u00f1adir un recurso\: se sobrepasar\u00e1 la cuota de recursos del sitio
 simplepage.resourceerror=Imposible a\u00f1adir el recurso\: {}

--- a/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -207,7 +207,11 @@ simplePageBean.newOwner,
 simplePageBean.forumSummaryHeight,
 simplePageBean.forumSummaryDropDown,
 simplePageBean.addCalendar,
-simplePageBean.addForumSummary
+simplePageBean.addForumSummary,
+simplePageBean.createTask,
+simplePageBean.questionCreateTask,
+simplePageBean.commentsCreateTask,
+simplePageBean.studentContentsCreateTask
 </value>
 </property>
    </bean>

--- a/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
@@ -308,6 +308,7 @@
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
 		<property name="formattedText" ref="org.sakaiproject.util.api.FormattedText" />
 		<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService"/>
+		<property name="taskService" ref="org.sakaiproject.tasks.api.TaskService"/>
 	</bean>
 	
 	<!-- Over-riding the CommonsMultipartResolver to have multiple files incoming under the same form input name  -->

--- a/lessonbuilder/tool/src/webapp/removePage.jsp
+++ b/lessonbuilder/tool/src/webapp/removePage.jsp
@@ -13,7 +13,9 @@
 %><%@ page import="org.sakaiproject.event.cover.EventTrackingService" %><%
 %><%@ page import="org.sakaiproject.lessonbuildertool.api.LessonBuilderEvents" %><%
 %><%@ page import="org.sakaiproject.lessonbuildertool.SimplePage" %><%
-%><%@ page import="org.apache.commons.text.StringEscapeUtils" %>
+%><%@ page import="org.apache.commons.text.StringEscapeUtils" %><%
+%><%@ page import="org.sakaiproject.tasks.api.TaskService" %>
+
 
 
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -40,6 +42,8 @@
 
     SimplePageToolDao dao = (SimplePageToolDao)ComponentManager
     .get(SimplePageToolDao.class);
+    
+    TaskService taskService = (TaskService)ComponentManager.get(TaskService.class);
 
     String siteId = request.getParameter("site");
     Site site = null;
@@ -99,8 +103,8 @@
     }
 		
     EventTrackingService.post(EventTrackingService.newEvent(LessonBuilderEvents.PAGE_REMOVE, "/lessonbuilder/page/" + simplePage.getPageId(), true));
-
-   out.println("<script>parent.location.replace(\"/portal/site/" + URLEncoder.encode(site.getId(), "UTF-8") + "\")</script>");
+    taskService.removeTaskByReference("/lessonbuilder/page/" + simplePage.getPageId());
+    out.println("<script>parent.location.replace(\"/portal/site/" + URLEncoder.encode(site.getId(), "UTF-8") + "\")</script>");
 
 %>
 

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -1798,6 +1798,13 @@
                         </p>
                     </div>
                     
+                    <div id="tasks">
+                        <p class="checkbox">
+                            <input type="checkbox" name="page-task" id="page-task" rsf:id="page-task" />
+                            <label for="page-task"><span rsf:id="msg=simplepage.createtask"></span></label>
+                        </p>
+                    </div>
+                    
                     <div rsf:id="csssection">
 
                     <hr />
@@ -2013,6 +2020,10 @@
                             </p>
                         </div>
                         <p class="checkbox">
+                            <input type="checkbox" name="comments-create-task" id="comments-create-task" rsf:id="comments-create-task" />
+                            <label for="comments-create-task"><span rsf:id="msg=simplepage.createtask"></span></label>
+                        </p>
+                        <p class="checkbox">
                               <input type="checkbox" name="comments-prerequisite" id="comments-prerequisite" rsf:id="comments-prerequisite" />
                               <label for="comments-prerequisite"><span rsf:id="msg=simplepage.prerequisites_label"></span></label>
                         </p>
@@ -2095,7 +2106,10 @@
                         </p>
                         <br /><br />
                     </div>
-
+                    <p class="checkbox">
+                        <input type="checkbox" name="student-create-task" id="student-create-task" rsf:id="student-create-task" />
+                        <label for="student-create-task"><span rsf:id="msg=simplepage.createtask"></span></label>
+                    </p>
                     <p class="checkbox">
                         <input type="checkbox" name="student-comments" id="student-comments" rsf:id="student-comments" />
                         <label for="student-comments"><span rsf:id="msg=simplepage.student-comments"></span></label>
@@ -2379,6 +2393,10 @@
                                     <input type="text" name="question-max" id="question-max" rsf:id="question-max" />
                                 </p>
                             </div>
+                            <p class="checkbox">
+                                <input type="checkbox" name="question-create-task" id="question-create-task" rsf:id="question-create-task" />
+                                <label for="question-create-task"><span rsf:id="msg=simplepage.createtask"></span></label>
+                            </p>
                             <div class="longtext">
                             <label for="question-correct-text"><span rsf:id="msg=simplepage.correct-text"></span></label><br />
                             <textarea rsf:id="question-correct-text" name="question-correct-text" id="question-correct-text" rows="3" columns="30"></textarea>


### PR DESCRIPTION
This change allows the Lessons tool to create tasks when adding new pages, questions, comments or student content. Settings of all of these components have a new checkbox option to create these tasks. Tasks are updated or removed automatically when pages and/or components are changed or deleted. @mpellicer @bgarciaentornos 