### PR TITLE
SAK-46857 Eclipse IDE the package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml

### DIFF
--- a/chat/chat-tool/tool/pom.xml
+++ b/chat/chat-tool/tool/pom.xml
@@ -73,6 +73,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Needed by MyFaces ExtensionsFilter -->

--- a/help/help-tool/pom.xml
+++ b/help/help-tool/pom.xml
@@ -37,6 +37,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/jobscheduler/scheduler-tool/pom.xml
+++ b/jobscheduler/scheduler-tool/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>commons-collections</artifactId>
         </dependency>
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/jsf/jsf-tool-sun/pom.xml
+++ b/jsf/jsf-tool-sun/pom.xml
@@ -83,9 +83,5 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/jsf/jsf-widgets/pom.xml
+++ b/jsf/jsf-widgets/pom.xml
@@ -67,6 +67,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/jsf/myfaces-tool/pom.xml
+++ b/jsf/myfaces-tool/pom.xml
@@ -81,9 +81,5 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/jsf/myfaces-widgets/pom.xml
+++ b/jsf/myfaces-widgets/pom.xml
@@ -44,6 +44,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/jsf2/jsf2-tool-sun/pom.xml
+++ b/jsf2/jsf2-tool-sun/pom.xml
@@ -72,9 +72,5 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/jsf2/jsf2-widgets/pom.xml
+++ b/jsf2/jsf2-widgets/pom.xml
@@ -67,6 +67,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!--

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -305,10 +305,6 @@
             <version>1.6.8</version>
         </dependency>
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <type>jar</type>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -408,19 +408,6 @@
         <version>2.6.2</version>
         <scope>provided</scope>
       </dependency>
-      <!-- block these versions if the user really wants them they will have to be specific -->
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xmlParserAPIs</artifactId>
-        <version>2.0.2</version>
-        <scope>provided</scope>
-      </dependency>
       <!-- shared/lib -->
       <!-- 3rd party APIs/Implementations -->
       <dependency>

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -53,7 +53,7 @@
 					<groupId>xml-apis</groupId>
 					<artifactId>xmlParserAPIs</artifactId>
 				</exclusion>
-            </exclusions>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>

--- a/msgcntr/messageforums-app/pom.xml
+++ b/msgcntr/messageforums-app/pom.xml
@@ -49,7 +49,11 @@
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
-			</exclusions>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xmlParserAPIs</artifactId>
+				</exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -173,6 +173,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -211,10 +215,6 @@
             <artifactId>sakai-rsf-core</artifactId>
             <version>${project.version}</version>
             <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/sections/sections-app/pom.xml
+++ b/sections/sections-app/pom.xml
@@ -84,6 +84,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/signup/tool/pom.xml
+++ b/signup/tool/pom.xml
@@ -92,6 +92,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/syllabus/syllabus-app/pom.xml
+++ b/syllabus/syllabus-app/pom.xml
@@ -74,6 +74,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/user/user-tool-prefs/tool/pom.xml
+++ b/user/user-tool-prefs/tool/pom.xml
@@ -38,6 +38,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- pull through the JSF tool dependencies -->

--- a/userauditservice/tool/pom.xml
+++ b/userauditservice/tool/pom.xml
@@ -77,6 +77,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/usermembership/tool/pom.xml
+++ b/usermembership/tool/pom.xml
@@ -101,6 +101,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
I'm still testing this locally but haven't seen any issue yet without these dependencies. 

I was basically running `mvn dependency:tree` and looking for any instances of  `xml-apis:xmlParserAPIs:jar:2.0.2:compile` to exclude. 

There are other xml-apis like `xerces:xmlParserAPIs:jar:2.6.2:compile` but they don't *seem* to cause an issue with this.

Though looking at the xerces:xmlParserAPIs, it seems like that's really old too and we shouldn't need that one either anymore. That appears to be used directly by rwiki and announcement. And indirectly included a few other places by these other old dependencies. 

* `org.apache.pluto:pluto-descriptor-impl:jar:1.1.7:compile`
* `org.apache.pluto:pluto-container:jar:1.1.7:provided`
* `xom:xom:jar:1.1:compile`

It seems like since these are included in Java 11 it makes Eclipse a lot more picky about them and flags them as errors now. 