### PR TITLE
SAK-46869 - Admin Site Permissions:  No mapping for GET /adminsiteperms/sitePerms.htm

### DIFF
--- a/site/admin-perms-tool/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/site/admin-perms-tool/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -29,6 +29,7 @@
         <property name="mappings">
             <value>
                 /sitePerms.htm=sitePermsController
+                /*/sitePerms.htm=sitePermsController
             </value>
         </property>
     </bean>


### PR DESCRIPTION
Added additional wildcard map for this file. I'm not 100% sure why this was needed in Sakai 21 now. I was just [reading through this guide](https://www.baeldung.com/spring-handler-mappings) and noticed the difference which fixed it and makes sense.