### PR TITLE
TRINITY-42 Add missing config and disable velocity caching

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/bundle/org/sakaiproject/portal/charon/velocity/portalvelocity.config
+++ b/portal/portal-render-engine-impl/impl/src/bundle/org/sakaiproject/portal/charon/velocity/portalvelocity.config
@@ -24,7 +24,8 @@ webapp.resource.loader.modificationCheckInterval=60
 #
 class.resource.loader.description=Velocity Classpath Resource Loader
 class.resource.loader.class=org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
-class.resource.loader.cache=true
+# TODO TRINITY-44 renenable caching 
+class.resource.loader.cache=false
 class.resource.loader.modificationCheckInterval=0
 
 #

--- a/portal/portal-render-engine-impl/impl/src/bundle/trinity/options.config
+++ b/portal/portal-render-engine-impl/impl/src/bundle/trinity/options.config
@@ -1,0 +1,11 @@
+include-bottom: true
+include-worksite: true
+include-tabs: true
+include-site-nav: true
+include-page-nav: true
+include-page: true
+include-login: true
+include-logo: true
+include-gallery-nav: true
+include-gallery-login: true
+include-title: true

--- a/portal/portal-render-engine-impl/impl/src/java/org/sakaiproject/portal/charon/velocity/VelocityPortalRenderEngine.java
+++ b/portal/portal-render-engine-impl/impl/src/java/org/sakaiproject/portal/charon/velocity/VelocityPortalRenderEngine.java
@@ -67,7 +67,7 @@ public class VelocityPortalRenderEngine implements PortalRenderEngine
 
 	private ServletContext context;
 
-	private String defaultSkin = "morpheus";
+	private String defaultSkin = "trinity";
 
 	private boolean styleAble = false;
 
@@ -93,7 +93,7 @@ public class VelocityPortalRenderEngine implements PortalRenderEngine
 			styleAbleContentSummary = serverConfigurationService.getBoolean(
 					"portal.styleable.contentSummary", false);
 			
-			//this is rather the template folder name then what we would refer to as skin
+			//this variable will decide which templates and configs (bundle) are picked
 			defaultSkin = serverConfigurationService.getString("portal.templates", "trinity");
 		}
 		catch (Exception ex)
@@ -201,7 +201,7 @@ public class VelocityPortalRenderEngine implements PortalRenderEngine
 		}
 		catch (Exception ex)
 		{
-			log.info("No options loaded ", ex);
+			log.info("No options loaded. Check options.config for " + defaultSkin, ex);
 
 		} 
 		finally {


### PR DESCRIPTION
Fixes stacktrace on every page load that was caused when VelocityPortalRenderEngine tried to load non existing options for the portal and alsodisabled velocity loader caching (for now) to make switching between morpheus and trinity more possible.