### PR TITLE
SAK-46976 Job Scheduler date filters are not being applied

### DIFF
--- a/jobscheduler/scheduler-tool/src/java/org/sakaiproject/tool/app/scheduler/SchedulerTool.java
+++ b/jobscheduler/scheduler-tool/src/java/org/sakaiproject/tool/app/scheduler/SchedulerTool.java
@@ -1469,6 +1469,8 @@ public class SchedulerTool
        String beforeText = req.get(BEFORE);
        String afterText = req.get(AFTER);
        SimpleDateFormat sdf = new SimpleDateFormat(DATE_PATTERN);
+       getEventPager().setBefore(null);
+       getEventPager().setAfter(null);
        try {
            if (StringUtils.isNotBlank(beforeText)) {
                getEventPager().setBefore(sdf.parse(beforeText));


### PR DESCRIPTION
Corrected a bug. When filtering two consecutive times, filters where not initialized again to null, so they were handling old values.