### PR TITLE
TRINITY-52 Extend Announcements API

### DIFF
--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
@@ -161,6 +161,13 @@ public interface AnnouncementService extends MessageService
 	public Reference getAnnouncementReference(String context);
 	
 	/**
+	* Get announcement's range/scope
+	* @param message announcement message (site-id)
+	* @return String describing announcement's scope (public, site, list of groups)
+	*/
+	public String getAnnouncementRange(AnnouncementMessage message);
+
+	/**
 	* Get URL to access the announcement rss feed
 	* @param ref The announcement entity reference
 	* @return URL for announcement rss feed

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
@@ -186,7 +186,7 @@ public interface AnnouncementService extends MessageService
 	 *        Channel's reference String
 	 * @param filter
 	 *        A filtering object to accept messages, or null if no filtering is desired.
-	 * @param order
+	 * @param ascending
 	 *        Order of messages, ascending if true, descending if false
 	 * @param merged
 	 * 		  flag to include merged channel messages, true returns ALL messages including merged sites/channels
@@ -197,7 +197,7 @@ public interface AnnouncementService extends MessageService
 	 *            if the user does not have read permission to the channel.
 	 * @exception NullPointerException
 	 */
-	public List getMessages(String channelReference, Filter filter, boolean order, boolean merged) throws IdUnusedException, PermissionException, NullPointerException;
+	public List getMessages(String channelReference, Filter filter, boolean ascending, boolean merged) throws IdUnusedException, PermissionException, NullPointerException;
 
 	public Map<String, List<AnnouncementMessage>> getViewableAnnouncementsForCurrentUser(Integer maxAgeInDays);
 }

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -1046,7 +1046,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 	 *        Channel's reference String
 	 * @param filter
 	 *        A filtering object to accept messages, or null if no filtering is desired.
-	 * @param order
+	 * @param ascending
 	 *        Order of messages, ascending if true, descending if false
 	 * @param merged
 	 * 		  flag to include merged channel messages, true returns ALL messages including merged sites/channels
@@ -1057,7 +1057,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 	 *            if the user does not have read permission to the channel.
 	 * @exception NullPointerException
 	 */
-	public List getMessages(String channelReference,Filter filter, boolean order, boolean merged) throws IdUnusedException, PermissionException, NullPointerException
+	public List getMessages(String channelReference,Filter filter, boolean ascending, boolean merged) throws IdUnusedException, PermissionException, NullPointerException
 	{
 		List<Message> messageList = new Vector();	
 		filter = new PrivacyFilter(filter);  		// filter out drafts this user cannot see
@@ -1089,14 +1089,14 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 						//merged flag = true then add all channel's messages
 						//merged flag = false only add the calling channel's messages
 						if(merged || siteChannel.getContext().equals(site.getId()))
-								messageList.addAll(siteChannel.getMessages(filter,order));
+								messageList.addAll(siteChannel.getMessages(filter, ascending));
 					}
 				}
 			}
 			
 			//sort messages
 			Collections.sort(messageList);
-			if (!order)
+			if (!ascending)
 			{
 				Collections.reverse(messageList);
 			}			

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -668,7 +668,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 				return allGroupString;
 			}
 			catch (IdUnusedException e) {
-				log.error("Site could not be loaded: {}", e.getMessage());
+				log.error("Site could not be loaded: {}", e.toString());
 			}
 			return "";
 		}
@@ -1128,7 +1128,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 			}			
 		}
 		catch (NullPointerException e) {
-			log.warn(e.getMessage());
+			log.warn(e.toString());
 		}
 		return messageList;
 
@@ -1408,7 +1408,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 					}
 					catch(Exception e)
 					{
-						log.debug("Unable to remove Announcements ", e.getMessage(), e);
+						log.debug("Unable to remove Announcements ", e.toString(), e);
 					}
 				}
 
@@ -1956,7 +1956,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 					}
 					catch(Exception e)
 					{
-						log.debug("Unable to remove Announcements {}", e.getMessage(), e);
+						log.debug("Unable to remove Announcements {}", e.toString(), e);
 					}
 				}
 			}

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -454,6 +454,7 @@ public class AnnouncementAction extends PagedResourceActionII
 
 	}
 
+	//TODO: Can be removed in the process of refactoring, as this method is also in AnnouncementService 
 	/**
 	 * get announcement range information
 	 */

--- a/webapi/src/main/java/org/sakaiproject/webapi/beans/AnnouncementRestBean.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/beans/AnnouncementRestBean.java
@@ -39,7 +39,7 @@ public class AnnouncementRestBean {
     private String subject;
     private String author;
     private String access;
-    private boolean hasAtachment;
+    private boolean hasAttachment;
     private long date;
     private Long release;
     private Long retract;
@@ -54,15 +54,15 @@ public class AnnouncementRestBean {
         subject = header.getSubject();
         author = header.getFrom().getDisplayName();
         date = header.getInstant().toEpochMilli();
-        hasAtachment = !header.getAttachments().isEmpty();
+        hasAttachment = !header.getAttachments().isEmpty();
         ResourceProperties resourceProperties = am.getProperties();
         try {
             release = resourceProperties.getInstantProperty(AnnouncementService.RELEASE_DATE).toEpochMilli();
             date = release;
-        } catch (EntityPropertyTypeException|EntityPropertyNotDefinedException e) { /*No action needed*/ }
+        } catch (EntityPropertyTypeException | EntityPropertyNotDefinedException e) { /*No action needed*/ }
         try {
             retract = resourceProperties.getInstantProperty(AnnouncementService.RETRACT_DATE).toEpochMilli();
-        } catch (EntityPropertyTypeException|EntityPropertyNotDefinedException e) { /*No action needed*/ }
+        } catch (EntityPropertyTypeException | EntityPropertyNotDefinedException e) { /*No action needed*/ }
         links = new ArrayList<Link>();
         links.add(Link.of(url));
         links.add(getActionLink(url, "doReviseannouncement"));

--- a/webapi/src/main/java/org/sakaiproject/webapi/beans/AnnouncementRestBean.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/beans/AnnouncementRestBean.java
@@ -15,6 +15,8 @@ package org.sakaiproject.webapi.beans;
 
 import org.sakaiproject.announcement.api.AnnouncementMessage;
 import org.sakaiproject.announcement.api.AnnouncementService;
+import org.sakaiproject.entity.api.EntityPropertyNotDefinedException;
+import org.sakaiproject.entity.api.EntityPropertyTypeException;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.site.api.Site;
 
@@ -42,8 +44,9 @@ public class AnnouncementRestBean {
         author = am.getAnnouncementHeader().getFrom().getDisplayName();
         date = am.getAnnouncementHeader().getInstant().toEpochMilli();
         ResourceProperties props = am.getProperties();
-        String release = props.getProperty(AnnouncementService.RELEASE_DATE);
-        if (release != null) date = Long.parseLong(release);
+        try {
+            date = props.getInstantProperty(AnnouncementService.RELEASE_DATE).toEpochMilli();
+        } catch (EntityPropertyTypeException|EntityPropertyNotDefinedException e) { /*No action needed*/ }
         this.url = url;
     }
 }

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
@@ -81,7 +81,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
                     Site site = siteService.getSite(e.getKey());
                     return e.getValue().stream().map(am -> {
                         Optional<String> optionalUrl = entityManager.getUrl(am.getReference(), Entity.UrlType.PORTAL);
-                        return new AnnouncementRestBean(site, am, optionalUrl.get());
+                        return new AnnouncementRestBean(site, am, optionalUrl.get(), announcementService.getAnnouncementRange(am));
                     }).collect(Collectors.toList());
                 } catch (Exception ex) {
                     return null;
@@ -104,7 +104,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
                 .stream()
                 .map(am -> {
                     Optional<String> optionalUrl = entityManager.getUrl(am.getReference(), Entity.UrlType.PORTAL);
-                    return new AnnouncementRestBean(site, am, optionalUrl.get());
+                    return new AnnouncementRestBean(site, am, optionalUrl.get(), announcementService.getAnnouncementRange(am));
                 }).collect(Collectors.toList());
         } catch (IdUnusedException idue) {
             log.error("No announcements for id {}", siteId);

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
@@ -100,7 +100,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
         try {
             Site site = siteService.getSite(siteId);
             String channelRef = announcementService.channelReference(siteId, "main");
-            return ((List<AnnouncementMessage>)announcementService.getMessages(channelRef, null, true, true))
+            return ((List<AnnouncementMessage>) announcementService.getMessages(channelRef, null, false, true))
                 .stream()
                 .map(am -> {
                     Optional<String> optionalUrl = entityManager.getUrl(am.getReference(), Entity.UrlType.PORTAL);

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/SitesController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/SitesController.java
@@ -187,7 +187,7 @@ public class SitesController extends AbstractSakaiApiController {
                 }).collect(Collectors.toList());
                 siteMap.put("pages", pageList);
             } catch (IdUnusedException e) {
-                log.error(e.getMessage());
+                log.error(e.toString());
             }
             return siteMap;
         }).collect(Collectors.toList());

--- a/webcomponents/tool/src/main/frontend/js/announcements/sakai-announcements.js
+++ b/webcomponents/tool/src/main/frontend/js/announcements/sakai-announcements.js
@@ -123,10 +123,10 @@ export class SakaiAnnouncements extends SakaiPageableElement {
           <div class="site cell ${i % 2 === 0 ? "even" : "odd"}">${a.siteTitle}</div>
         ` : ""}
         <div class="url cell ${i % 2 === 0 ? "even" : "odd"}">
-          <a href="${a.url}"
+          <a href="${a.links.find(link => link.rel == "self").href}"
               title="${this.i18n.url_tooltip}"
               aria-label="${this.i18n.url_tooltip}">
-            <sakai-icon type="right" size="small">
+            <sakai-icon type="right" size="small"></sakai-icon>
           </a>
         </div>
       `)}


### PR DESCRIPTION
Added related commit from Adrian, which is on master, but not on the trinity branch yet.

I wanted to remove `getAnnouncementRange` from AnnouncementActions in favor of having it in the AnnouncementService, but found myself to deep in that rabbit hole.