### PR TITLE
TRINITY-52 Remove links from announcements rest api

### DIFF
--- a/webapi/src/main/java/org/sakaiproject/webapi/beans/AnnouncementRestBean.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/beans/AnnouncementRestBean.java
@@ -23,9 +23,6 @@ import org.sakaiproject.site.api.Site;
 
 import org.springframework.hateoas.Link;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -43,7 +40,7 @@ public class AnnouncementRestBean {
     private long date;
     private Long release;
     private Long retract;
-    private List<Link> links;
+    private Link link;
 
     public AnnouncementRestBean(Site site, AnnouncementMessage am, String url, String access) {
         id = am.getId();
@@ -55,6 +52,7 @@ public class AnnouncementRestBean {
         author = header.getFrom().getDisplayName();
         date = header.getInstant().toEpochMilli();
         hasAttachment = !header.getAttachments().isEmpty();
+        link = Link.of(url);
         ResourceProperties resourceProperties = am.getProperties();
         try {
             release = resourceProperties.getInstantProperty(AnnouncementService.RELEASE_DATE).toEpochMilli();
@@ -63,15 +61,5 @@ public class AnnouncementRestBean {
         try {
             retract = resourceProperties.getInstantProperty(AnnouncementService.RETRACT_DATE).toEpochMilli();
         } catch (EntityPropertyTypeException | EntityPropertyNotDefinedException e) { /*No action needed*/ }
-        links = new ArrayList<Link>();
-        links.add(Link.of(url));
-        links.add(getActionLink(url, "doReviseannouncement"));
-        links.add(getActionLink(url, "doDelete_announcement_link"));
-        links.add(getActionLink(url, "doDuplicateAnnouncement"));
-    }
-
-    private Link getActionLink(String reference, String actionName) {
-
-        return Link.of(reference.replaceFirst("doShowmetadata", actionName), actionName);
     }
 }

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
@@ -72,7 +72,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
 	@GetMapping(value = "/users/{userId}/announcements", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<AnnouncementRestBean> getUserAnnouncements(@PathVariable String userId) throws UserNotDefinedException {
 
-        Session session = checkSakaiSession();
+        checkSakaiSession();
         return announcementService.getViewableAnnouncementsForCurrentUser(10).entrySet()
             .stream()
             .map(e -> {
@@ -95,7 +95,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
 	@GetMapping(value = "/sites/{siteId}/announcements", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<AnnouncementRestBean> getSiteAnnouncements(@PathVariable String siteId) throws UserNotDefinedException {
 
-		Session session = checkSakaiSession();
+		checkSakaiSession();
 
         try {
             Site site = siteService.getSite(siteId);
@@ -112,6 +112,6 @@ public class AnnouncementsController extends AbstractSakaiApiController {
             log.warn("The current user does not have permission to get announcements for this site {}", siteId);
         }
 
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
 	}
 }

--- a/webcomponents/tool/src/main/frontend/js/announcements/sakai-announcements.js
+++ b/webcomponents/tool/src/main/frontend/js/announcements/sakai-announcements.js
@@ -123,7 +123,7 @@ export class SakaiAnnouncements extends SakaiPageableElement {
           <div class="site cell ${i % 2 === 0 ? "even" : "odd"}">${a.siteTitle}</div>
         ` : ""}
         <div class="url cell ${i % 2 === 0 ? "even" : "odd"}">
-          <a href="${a.links.find(link => link.rel == "self").href}"
+          <a href="${a.link.href}"
               title="${this.i18n.url_tooltip}"
               aria-label="${this.i18n.url_tooltip}">
             <sakai-icon type="right" size="small"></sakai-icon>


### PR DESCRIPTION
Removed links except one to view announcement. This is similar to how it was pre TRINITY-52.

Fixed and tested announcement widget webcomponent as well