### PR TITLE
SAK-47025 Student-uploads folder should be owned by admin

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/entityproviders/ContentEntityProvider.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/entityproviders/ContentEntityProvider.java
@@ -381,8 +381,8 @@ public class ContentEntityProvider extends AbstractEntityProvider implements Ent
 				props.addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
 				if (StringUtils.equals(uploadFolderName, contentHostingService.getStudentUploadFolderName())) {
 					// Properties for student folder only
-					props.addProperty(ResourceProperties.PROP_CREATOR, developerHelperService.getCurrentUserId());
-					props.addProperty(ResourceProperties.PROP_MODIFIED_BY, developerHelperService.getCurrentUserId());
+					props.addProperty(ResourceProperties.PROP_CREATOR, developerHelperService.ADMIN_USER_ID);
+					props.addProperty(ResourceProperties.PROP_MODIFIED_BY, developerHelperService.ADMIN_USER_ID);
 					props.addProperty(ResourceProperties.PROP_DO_NOT_DUPLICATE, Boolean.TRUE.toString());
 				}
 				contentHostingService.commitCollection(uploadsFolder);


### PR DESCRIPTION
The first student to upload a file through the CKEditor using the direct-uploads
feature will be the owner of the student-uploads folder. This allows that
student to see all of the contents of that folder in Resources.