### PR TITLE
SAK-47049: Disable property: Add 'direct-upload' endpoint to content entity provider

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -650,8 +650,8 @@
 # content.mime.inline=video/mp4,video/quicktime,video/3gpp,video/x-ms-wmv,audio/mpeg,audio/wav,audio/x-wav,video/x-m4v
 
 # SAK-44785 Allow direct upload endpoint
-# DEFAULT: true
-# content.direct.upload.enabled=false
+# DEFAULT: false
+# content.direct.upload.enabled=true
 
 # SAK-44785 Override the names for the folders automatically created for direct-upload
 # DEFAULT: See below

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/entityproviders/ContentEntityProvider.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/entityproviders/ContentEntityProvider.java
@@ -289,7 +289,7 @@ public class ContentEntityProvider extends AbstractEntityProvider implements Ent
 	 */
 	@EntityCustomAction(action = "direct-upload", viewKey = EntityView.VIEW_NEW)
 	public String uploadFileToSite(EntityView view,  Map<String, Object> params) {
-		if (!serverConfigurationService.getBoolean("content.direct.upload.enabled", Boolean.TRUE)) {
+		if (!serverConfigurationService.getBoolean("content.direct.upload.enabled", Boolean.FALSE)) {
 			throw new SecurityException("The direct-upload service is not enabled for your instance.");
 		}
 		User currentUser = userDirectoryService.getCurrentUser();


### PR DESCRIPTION
This should be disabled by default.

@feralvarez95 is working on https://sakaiproject.atlassian.net/browse/SAK-47024 try uploading resources to Content Hosting instead of Resources tool on a site.