### PR TITLE
SAK-47024 Moving CKEditor's attachments into attachments in Content Hosting

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1020,7 +1020,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 ResourceProperties p = contentHostingService.getProperties(tempRefId);
                                 String displayName = p.getProperty(ResourceProperties.PROP_DISPLAY_NAME);
                                 // add another attachment instance
-                                String newItemId = contentHostingService.copyIntoFolder(tempRefId, tempRefCollectionId);
+                                String newItemId = contentHostingService.copyIntoFolder(tempRefId, tempRefCollectionId, false);
                                 ContentResourceEdit copy = contentHostingService.editResource(newItemId);
                                 // with the same display name
                                 ResourcePropertiesEdit pedit = copy.getPropertiesEdit();

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -1558,7 +1558,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 
 			try
 			{
-				String id = contentHostingService.copyIntoFolder(itemId, collectionId);
+				String id = contentHostingService.copyIntoFolder(itemId, collectionId, false);
 				String mode = (String) state.getAttribute(STATE_MODE);
 			}
 			catch (PermissionException e)
@@ -1673,7 +1673,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 				String[] args = { p.getProperty(ResourceProperties.PROP_DISPLAY_NAME) };
 				displayName = rb.getFormattedMessage("copy.name", (Object[]) args);
 
-				String newItemId = contentHostingService.copyIntoFolder(itemId, collectionId);
+				String newItemId = contentHostingService.copyIntoFolder(itemId, collectionId, false);
 
 				ContentResourceEdit copy = contentHostingService.editResource(newItemId);
 				ResourcePropertiesEdit pedit = copy.getPropertiesEdit();
@@ -8628,7 +8628,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 					}
 					else
 					{
-						newId = contentService.copyIntoFolder(entityId, collectionId);
+						newId = contentService.copyIntoFolder(entityId, collectionId, false);
 					}
 					
 					ref = entityManager.newReference(contentService.getReference(newId));

--- a/dav/dav/src/java/org/sakaiproject/dav/DavServlet.java
+++ b/dav/dav/src/java/org/sakaiproject/dav/DavServlet.java
@@ -3806,7 +3806,7 @@ public class DavServlet extends HttpServlet
 	    // this isn't perfect. It only protects the top two levels of directory
 	    if (!(doProtected && member_id.toLowerCase().indexOf("/protected") >= 0 &&
 		  (!contentHostingService.allowAddCollection(adjustId(member_id)))))
-		contentHostingService.copyIntoFolder(member_id, new_id);
+		contentHostingService.copyIntoFolder(member_id, new_id, false);
 	}
 
     }

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ContentHostingService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ContentHostingService.java
@@ -256,6 +256,9 @@ public interface ContentHostingService extends EntityProducer
     /** Enable content compression into zip file (affects resources) */
     public static final String RESOURCES_ZIP_ENABLE_COMPRESS = "content.zip.compress.enabled";
 
+    /** Folder name for CKEditor attachments */
+    public static final String CKEDITOR_ATTACHMENTS_FOLDER = "ckeditor-attachments";
+
 	static final String ID_LENGTH_EXCEPTION = "id_length_exception";
 
 	public static final String DOC_MIMETYPE = "application/msword";
@@ -280,12 +283,6 @@ public interface ContentHostingService extends EntityProducer
     public static final String CONVERSION_NOT_SUPPORTED = "CONVERSION_NOT_SUPPORTED";
 
 	public static final String SAK_PROP_MAX_UPLOAD_FILE_SIZE = "content.upload.max";
-
-	/**
-	 * The default names for the direct-upload folders.
-	 */
-	public static final String DEFAULT_INSTRUCTOR_FOLDER = "instructor-uploads";
-	public static final String DEFAULT_STUDENT_FOLDER = "student-uploads";
 
 	/**
     * For a given id, return its UUID (creating it if it does not already exist)
@@ -1317,6 +1314,8 @@ public interface ContentHostingService extends EntityProducer
 	 *        The id of the resource.
 	 * @param folder_id
 	 *        The id of the folder in which the copy should be created.
+	 * @param merge
+	 *        Indicates if we want to merge existing collection with the previous existing with the same name or not.
 	 * @return The full id of the new copy of the resource.
 	 * @exception PermissionException
 	 *            if the user does not have permissions to read a containing collection, or to remove this resource.
@@ -1337,8 +1336,17 @@ public interface ContentHostingService extends EntityProducer
 	 * @exception ServerOverloadException
 	 *            if the server is configured to write the resource body to the filesystem and the save fails.
 	 */
-	public String copyIntoFolder(String id, String folder_id) throws PermissionException, IdUnusedException, TypeException,
+	public String copyIntoFolder(String id, String folder_id, boolean merge) throws PermissionException, IdUnusedException, TypeException,
 			InUseException, OverQuotaException, IdUsedException, ServerOverloadException, InconsistentException, IdLengthException, IdUniquenessException;
+
+	/**
+	* Method to copy the attachments into destination attachment's folder to have access, for example, to
+	* resources inserted into CKEditor
+	* @param fromSiteId site from we want to import
+	* @param toSiteId site from is going to be imported
+	* @param toSiteTitle human readable title of the site
+	*/
+	public void copyAttachments(String fromSiteId, String toSiteId, String toSiteTitle);
 
 	/**
 	 * Move a resource or collection to a (different) folder. This may be accomplished by renaming the resource or by recursively renaming the collection and all enclosed members (no matter how deep) to effectively change their locations. Alternatively,
@@ -2145,22 +2153,4 @@ public interface ContentHostingService extends EntityProducer
 	public String expandMacros(String url);
 
 	public Map<String,String> getHtmlForRef(String ref);
-
-	/**
-	 * Get the name of the "instructor" upload folder name for direct-upload.
-	 * This is the folder for users that have addCollection permission in the
-	 * site.
-	 *
-	 * @return String - The name of the folder.
-	 */
-	public String getInstructorUploadFolderName();
-
-	/**
-	 * Get the name of the "student" upload folder name for direct-upload.
-	 * This is the folder for users that do not have addCollection permission
-	 * in the site.
-	 *
-	 * @return String - The name of the folder.
-	 */
-	public String getStudentUploadFolderName();
 }

--- a/kernel/api/src/main/java/org/sakaiproject/content/cover/ContentHostingService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/cover/ContentHostingService.java
@@ -663,7 +663,7 @@ public class ContentHostingService
 		return service.copy(param0, param1);
 	}
 
-	public static String copyIntoFolder(java.lang.String param0, java.lang.String param1)
+	public static String copyIntoFolder(java.lang.String param0, java.lang.String param1, boolean param2)
 			throws org.sakaiproject.exception.PermissionException, org.sakaiproject.exception.IdUnusedException,
 			org.sakaiproject.exception.IdLengthException, org.sakaiproject.exception.IdUniquenessException,
 			org.sakaiproject.exception.TypeException, org.sakaiproject.exception.InUseException,
@@ -673,7 +673,7 @@ public class ContentHostingService
 		org.sakaiproject.content.api.ContentHostingService service = getInstance();
 		if (service == null) return null;
 
-		return service.copyIntoFolder(param0, param1);
+		return service.copyIntoFolder(param0, param1, param2);
 	}
 
 	public static void moveIntoFolder(java.lang.String param0, java.lang.String param1)

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
@@ -69,7 +69,6 @@ import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ArrayUtil;
-import org.sakaiproject.util.RequestFilter;
 import org.sakaiproject.util.Web;
 import org.sakaiproject.util.api.LinkMigrationHelper;
 import org.springframework.transaction.TransactionStatus;
@@ -440,6 +439,7 @@ public class SiteManageServiceImpl implements SiteManageService {
                         transversalMap.putAll(getDirectToolUrlEntityReferences(toolId, fromSiteId, toSiteId));
                         siteIds.add(fromSiteId);
                         resourcesImported = true;
+                        contentHostingService.copyAttachments(fromSiteId, site.getId(), site.getTitle());
                     }
                 }
             }

--- a/webservices/cxf/src/java/org/sakaiproject/webservices/ContentHosting.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/ContentHosting.java
@@ -823,7 +823,7 @@ public class ContentHosting extends AbstractWebService {
 
 				} catch (IdUnusedException e) { 
 					// Resource doesn't exist in destination so let's copy it
-					contentHostingService.copyIntoFolder(sourceResource.getId(), destResourceDirectoryPath);
+					contentHostingService.copyIntoFolder(sourceResource.getId(), destResourceDirectoryPath, false);
 				}
 			}
 		


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47024

From our point of view, attachment's collection is probably the indicated folder to store this kind of information.
With this PR, pasted images into CKEditor are stored in /attachments/"site_id"/ckeditor_attachments/"image.png"/"image.png".

Also, before this PR this images was stored in resources of the site, so when you wanted to import Tasks, T&Q or some other tool with CKEditor pasted images you have also to import Resources, so, now, when you import a site into another, we are going to also import the ckeditor-attachments of the site into the destination site.

I think that instructor or student images should not be accesible by any instructor or student (at least as easy as open a resources folder). Also, if a student or instructor send a picture with Messages Tool, this information should be also private or not easy to know. Currently you can paste an image as stundent and see in resources as instructor this image, or see as instructor the other instructor pasted images into any CKEditor component in the site. 