### PR TITLE
SAK-47066 Catch NumberFormatException for invalid revision numbers

### DIFF
--- a/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/bean/helper/ReviewHelperBean.java
+++ b/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/bean/helper/ReviewHelperBean.java
@@ -66,8 +66,12 @@ public class ReviewHelperBean
 	{
 		if (request != null)
 		{
-			interestedRevision = Integer.parseInt(request
+			try {
+				interestedRevision = Integer.parseInt(request
 					.getParameter(HistoryBean.REVISION_PARAM));
+			} catch (NumberFormatException nfe) {
+				interestedRevision = rwikiObject.getRevision().intValue(); 
+			}
 		}
 
 		if (interestedRevision == rwikiObject.getRevision().intValue())


### PR DESCRIPTION
Ignore invalid revision numbers as they're probably generated from fuzzing scripts
