### PR TITLE
SAK-45051 Add Gradebook items to Tasks widget

### DIFF
--- a/edu-services/gradebook-service/hibernate/src/hibernate/org/sakaiproject/tool/gradebook/GradableObject.hbm.xml
+++ b/edu-services/gradebook-service/hibernate/src/hibernate/org/sakaiproject/tool/gradebook/GradableObject.hbm.xml
@@ -45,6 +45,7 @@
 			<property name="countNullsAsZeros" column="IS_NULL_ZERO" type="java.lang.Boolean"/>
 			<property name="hideInAllGradesTable" column="HIDE_IN_ALL_GRADES_TABLE" type="java.lang.Boolean"/>
 			<property name="externalData" column="EXTERNAL_DATA" type="text" />
+                        <property name="createTask" column="CREATE_TASK" type="java.lang.Boolean" />
     </subclass>
 
 		<subclass name="org.sakaiproject.tool.gradebook.CourseGrade" extends="org.sakaiproject.tool.gradebook.GradableObject" discriminator-value="2">

--- a/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradebookAssignment.java
+++ b/edu-services/gradebook-service/hibernate/src/java/org/sakaiproject/tool/gradebook/GradebookAssignment.java
@@ -89,6 +89,7 @@ public class GradebookAssignment extends GradableObject {
 	@Getter @Setter private String externalAppName;
 	@Getter @Setter private String externalData;
 	@Setter @Getter private Boolean released;
+        @Setter @Getter private Boolean createTask;
 	@Getter @Setter private Category category;
 	@Getter @Setter private Double averageTotal;
 	@Setter private Boolean ungraded;
@@ -419,6 +420,18 @@ public class GradebookAssignment extends GradableObject {
 	public Boolean isReleased() {
 		return this.released != null ? this.released : false;
 	}
+        
+        public void setCreateTask(Boolean createTask) {
+            this.createTask = createTask;
+        }
+        
+        /**
+         * 
+         * @return selective createTask true or false
+         */
+        public Boolean isCreateTask() {
+            return this.createTask != null ? this.createTask : false;
+        }
 
 	/**
 	 * Calculate the mean score for students with entered grades.

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/BaseHibernateManager.java
@@ -277,13 +277,13 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
 	}
 
     public Long createAssignment(final Long gradebookId, final String name, final Double points, final Date dueDate, final Boolean isNotCounted,
-           final Boolean isReleased, final Boolean isExtraCredit, final Integer sortOrder) throws ConflictingAssignmentNameException, StaleObjectModificationException
+           final Boolean isReleased, final Boolean createTask, final Boolean isExtraCredit, final Integer sortOrder) throws ConflictingAssignmentNameException, StaleObjectModificationException
     {
-        return createNewAssignment(gradebookId, null, name, points, dueDate, isNotCounted, isReleased, isExtraCredit, sortOrder, null);
+        return createNewAssignment(gradebookId, null, name, points, dueDate, isNotCounted, isReleased, createTask, isExtraCredit, sortOrder, null);
     }
 
     public Long createAssignmentForCategory(final Long gradebookId, final Long categoryId, final String name, final Double points, final Date dueDate, final Boolean isNotCounted, 
-           final Boolean isReleased, final Boolean isExtraCredit, final Integer categorizedSortOrder)
+           final Boolean isReleased, final Boolean createTask, final Boolean isExtraCredit, final Integer categorizedSortOrder)
     throws ConflictingAssignmentNameException, StaleObjectModificationException, IllegalArgumentException
     {
     	if(gradebookId == null || categoryId == null)
@@ -291,20 +291,20 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
     		throw new IllegalArgumentException("gradebookId or categoryId is null in BaseHibernateManager.createAssignmentForCategory");
     	}
 
-        return createNewAssignment(gradebookId, categoryId, name, points, dueDate, isNotCounted, isReleased, isExtraCredit, null, categorizedSortOrder);
+        return createNewAssignment(gradebookId, categoryId, name, points, dueDate, isNotCounted, isReleased, createTask, isExtraCredit, null, categorizedSortOrder);
     }
 
     private Long createNewAssignment(final Long gradebookId, final Long categoryId, final String name, final Double points, final Date dueDate, final Boolean isNotCounted,
-            final Boolean isReleased, final Boolean isExtraCredit, final Integer sortOrder, final Integer categorizedSortOrder) 
+            final Boolean isReleased, final Boolean createTask, final Boolean isExtraCredit, final Integer sortOrder, final Integer categorizedSortOrder) 
                     throws ConflictingAssignmentNameException, StaleObjectModificationException
     {
-        final GradebookAssignment asn = prepareNewAssignment(name, points, dueDate, isNotCounted, isReleased, isExtraCredit, sortOrder, categorizedSortOrder);
+        final GradebookAssignment asn = prepareNewAssignment(name, points, dueDate, isNotCounted, isReleased, createTask, isExtraCredit, sortOrder, categorizedSortOrder);
 
         return saveNewAssignment(gradebookId, categoryId, asn);
     }
 
     private GradebookAssignment prepareNewAssignment(final String name, final Double points, final Date dueDate, final Boolean isNotCounted, final Boolean isReleased, 
-            final Boolean isExtraCredit, final Integer sortOrder, final Integer categorizedSortOrder)
+            final Boolean createTask, final Boolean isExtraCredit, final Integer sortOrder, final Integer categorizedSortOrder)
     {
         // name cannot contain these special chars as they are reserved for special columns in import/export
         final String validatedName = GradebookHelper.validateGradeItemName(name);
@@ -314,6 +314,7 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
         asn.setPointsPossible(points);
         asn.setDueDate(dueDate);
         asn.setUngraded(false);
+        asn.setCreateTask(false);
         if (isNotCounted != null)
         {
             asn.setNotCounted(isNotCounted.booleanValue());
@@ -325,6 +326,10 @@ public abstract class BaseHibernateManager extends HibernateDaoSupport {
         if (isReleased != null)
         {
             asn.setReleased(isReleased.booleanValue());
+        }
+        if(createTask != null)
+        {
+            asn.setCreateTask(createTask.booleanValue());
         }
         if (sortOrder != null)
         {

--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/component/gradebook/GradebookServiceHibernateImpl.java
@@ -350,6 +350,8 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
     	assignmentDefinition.setExternalId(internalAssignment.getExternalId());
     	assignmentDefinition.setExternalData(internalAssignment.getExternalData());
     	assignmentDefinition.setReleased(internalAssignment.isReleased());
+        assignmentDefinition.setCreateTask(internalAssignment.isCreateTask());
+        
     	assignmentDefinition.setId(internalAssignment.getId());
     	assignmentDefinition.setExtraCredit(internalAssignment.isExtraCredit());
     	if (gbUsesCategories && internalAssignment.getCategory() != null) {
@@ -605,7 +607,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 						// create the assignment for the current category
 						try {
 							Long newId = createAssignmentForCategory(gradebook.getId(), categoriesCreated.get(c.getName()), a.getName(), a.getPoints(),
-									a.getDueDate(), !a.isCounted(), a.isReleased(), a.isExtraCredit(), a.getCategorizedSortOrder());
+									a.getDueDate(), !a.isCounted(), a.isReleased(), a.isCreateTask(), a.isExtraCredit(), a.getCategorizedSortOrder());
 							transversalMap.put("gb/"+a.getId(),"gb/"+newId);
 						} catch (final ConflictingAssignmentNameException e) {
 							// assignment already exists. Could be from a merge.
@@ -637,7 +639,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		assignments.removeIf(a -> assignmentsCreated.contains(a.getName()));
 		assignments.forEach(a -> {
 			try {
-				Long newId = createAssignment(gradebook.getId(), a.getName(), a.getPoints(), a.getDueDate(), !a.isCounted(), a.isReleased(), a.isExtraCredit(), a.getSortOrder());
+				Long newId = createAssignment(gradebook.getId(), a.getName(), a.getPoints(), a.getDueDate(), !a.isCounted(), a.isReleased(), a.isCreateTask(), a.isExtraCredit(), a.getSortOrder());
 				transversalMap.put("gb/"+a.getId(),"gb/"+newId);
 			} catch (final ConflictingAssignmentNameException e) {
 				// assignment already exists. Could be from a merge.
@@ -718,11 +720,11 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 		if (assignmentDefinition.getCategoryId() != null) {
 			return createAssignmentForCategory(gradebook.getId(), assignmentDefinition.getCategoryId(), validatedName,
 					assignmentDefinition.getPoints(), assignmentDefinition.getDueDate(), !assignmentDefinition.isCounted(), assignmentDefinition.isReleased(),
-					assignmentDefinition.isExtraCredit(), assignmentDefinition.getCategorizedSortOrder());
+					assignmentDefinition.isCreateTask(), assignmentDefinition.isExtraCredit(), assignmentDefinition.getCategorizedSortOrder());
 		}
 
 		return createAssignment(gradebook.getId(), validatedName, assignmentDefinition.getPoints(), assignmentDefinition.getDueDate(),
-				!assignmentDefinition.isCounted(), assignmentDefinition.isReleased(), assignmentDefinition.isExtraCredit(), assignmentDefinition.getSortOrder());
+				!assignmentDefinition.isCounted(), assignmentDefinition.isReleased(), assignmentDefinition.isCreateTask(), assignmentDefinition.isExtraCredit(), assignmentDefinition.getSortOrder());
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -769,6 +771,7 @@ public class GradebookServiceHibernateImpl extends BaseHibernateManager implemen
 				assignment.setExtraCredit(assignmentDefinition.isExtraCredit());
 				assignment.setCounted(assignmentDefinition.isCounted());
 				assignment.setReleased(assignmentDefinition.isReleased());
+                                assignment.setCreateTask(assignmentDefinition.isCreateTask());
 
 				assignment.setExternalAppName(assignmentDefinition.getExternalAppName());
 				assignment.setExternallyMaintained(assignmentDefinition.isExternallyMaintained());

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -112,6 +112,7 @@ public class GbGradebookData {
 		private String dueDate;
 
 		private boolean isReleased;
+                private boolean createTask;
 		private boolean isIncludedInCourseGrade;
 		private boolean isExtraCredit;
 		private boolean isExternallyMaintained;
@@ -543,6 +544,7 @@ public class GbGradebookData {
 					FormatHelper.formatDate(a1.getDueDate(), getString("label.studentsummary.noduedate")),
 
 					a1.isReleased(),
+                                        a1.isCreateTask(),
 					counted,
 					a1.isExtraCredit(),
 					a1.isExternallyMaintained(),

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanel.java
@@ -86,6 +86,8 @@ public class AddOrEditGradeItemPanel extends BasePanel {
 			assignment = new Assignment();
 			// Default released to true
 			assignment.setReleased(true);
+                        // Default createTask to true
+                        assignment.setCreateTask(true);
 			// If no categories, then default counted to true
 			final Gradebook gradebook = this.businessService.getGradebook();
 			assignment.setCounted(GradebookService.CATEGORY_TYPE_NO_CATEGORY == gradebook.getCategory_type());

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/AddOrEditGradeItemPanelContent.java
@@ -68,6 +68,7 @@ public class AddOrEditGradeItemPanelContent extends BasePanel {
 
 	private CheckBox counted;
 	private CheckBox released;
+        private CheckBox createTask;
 
 	private boolean categoriesEnabled;
 
@@ -306,10 +307,10 @@ public class AddOrEditGradeItemPanelContent extends BasePanel {
 		
 		// create task
 		final WebMarkupContainer taskWrap = new WebMarkupContainer("taskWrap");
-		final CheckBox createTask = new CheckBox("createTask", new PropertyModel<Boolean>(assignmentModel, "createTask"));
-		createTask.setOutputMarkupId(true);
-		createTask.setModelObject(true);
-		add(createTask);
+		this.createTask = new CheckBox("createTask", new PropertyModel<Boolean>(assignmentModel, "createTask"));
+		this.createTask.setOutputMarkupId(true);
+		add(this.createTask);
+                
 		final WebMarkupContainer createTaskLabel = new WebMarkupContainer("createTaskLabel");
 		add(createTaskLabel);
 		taskWrap.add(createTask);
@@ -342,14 +343,18 @@ public class AddOrEditGradeItemPanelContent extends BasePanel {
 					if (category == null) {
 						AddOrEditGradeItemPanelContent.this.counted.setEnabled(false);
 						AddOrEditGradeItemPanelContent.this.counted.setModelObject(false);
+                                                AddOrEditGradeItemPanelContent.this.released.setModelObject(false);
+                                                AddOrEditGradeItemPanelContent.this.createTask.setModelObject(false);
 					} else {
 						AddOrEditGradeItemPanelContent.this.counted.setEnabled(true);
 						AddOrEditGradeItemPanelContent.this.counted.setModelObject(true);
 						AddOrEditGradeItemPanelContent.this.released.setModelObject(true);
+                                                AddOrEditGradeItemPanelContent.this.createTask.setModelObject(true);
 					}
 
 					target.add(AddOrEditGradeItemPanelContent.this.counted);
 					target.add(AddOrEditGradeItemPanelContent.this.released);
+                                        target.add(AddOrEditGradeItemPanelContent.this.createTask);
 				}
 			}
 		});


### PR DESCRIPTION
The reason of why the checkbox wasn't checked before if I created a new gradebook item is due to the fact that the information about its state wasn't stored in the database. So, I have added a new column ( in the table gb_gradable_object_t) called CREATED_TASK for storing the information about the state of the checkbox that allows to create a task. I have also added some methods and made some changes to fix this issue. Now, everyone can update the state of the checkbox without any problem. By default, when you create a new gradebook item the checkbox's state is true. 