### PR TITLE
SAK-47117 Gradebook import fails if 2 or more users have the same name with different IDs

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UserIdentificationReport.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UserIdentificationReport.java
@@ -21,6 +21,7 @@ import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 import lombok.Getter;
+import org.sakaiproject.gradebookng.business.model.GbUnidentifiedUser;
 
 import org.sakaiproject.gradebookng.business.model.GbUser;
 
@@ -38,7 +39,7 @@ public class UserIdentificationReport implements Serializable
     private final SortedSet<GbUser> missingUsers; // users that could have been matched against an id but weren't
 
     @Getter
-    private final SortedSet<GbUser> unknownUsers; // ids that couldn't be matched against a user
+    private final SortedSet<GbUnidentifiedUser> unknownUsers; // ids that couldn't be matched against a user
 
     @Getter
     private final SortedSet<GbUser> duplicateUsers; // users that have more than one entry in the sheet
@@ -67,7 +68,7 @@ public class UserIdentificationReport implements Serializable
         }
     }
 
-    public void addUnknownUser(GbUser user)
+    public void addUnknownUser(GbUnidentifiedUser user)
     {
         if (user != null)
         {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/importExport/UsernameIdentifier.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.sakaiproject.gradebookng.business.model.GbUnidentifiedUser;
 import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.business.model.GbUserBase;
 import org.sakaiproject.gradebookng.business.model.ImportedRow;
 
 /**
@@ -51,7 +53,7 @@ public class UsernameIdentifier implements Serializable
      * @param row - the row data 
      * @return the user
      */
-    private GbUser getUser(ImportedRow row)
+    private GbUserBase getUser(ImportedRow row)
     {
         String userEID = row.getStudentEid();
         GbUser user = userEidMap.get(userEID);
@@ -59,15 +61,15 @@ public class UsernameIdentifier implements Serializable
         {
             report.addIdentifiedUser(user);
             log.debug("User {} identified as UUID: {}", userEID, user.getUserUuid());
+            return user;
         }
         else
         {
-            user = GbUser.forDisplayOnly(userEID, row.getStudentName());
-            report.addUnknownUser(user);
+            GbUnidentifiedUser unidentifiedUser = new GbUnidentifiedUser(userEID, row.getStudentName());
+            report.addUnknownUser(unidentifiedUser);
             log.debug("User {} is unknown to this gradebook", userEID);
+            return unidentifiedUser;
         }
-
-        return user;
     }
 
     /**
@@ -81,7 +83,7 @@ public class UsernameIdentifier implements Serializable
     {
         for (ImportedRow row : rows)
         {
-            GbUser user = getUser(row);
+            GbUserBase user = getUser(row);
             if (user != null)
             {
                 row.setUser(user);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUnidentifiedUser.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUnidentifiedUser.java
@@ -1,0 +1,41 @@
+package org.sakaiproject.gradebookng.business.model;
+
+import java.io.Serializable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This is a minimal class representing an unidentified user, containing only the display ID (EID) and display name.
+ * @author bjones86
+ */
+@Getter
+@EqualsAndHashCode
+public class GbUnidentifiedUser implements GbUserBase, Serializable, Comparable<GbUnidentifiedUser>
+{
+	private static final long serialVersionUID = 5006775569057810645L;
+
+	private final String displayId;
+	private final String displayName;
+
+	public GbUnidentifiedUser( final String displayId, final String displayName )
+	{
+		this.displayId = displayId;
+		this.displayName = displayName;
+	}
+
+	@Override
+	public int compareTo( GbUnidentifiedUser other )
+	{
+		String prop1 = displayId;
+		String prop2 = other.displayId;
+		if( (StringUtils.isBlank( prop1 ) && StringUtils.isBlank( prop2 )) || StringUtils.equalsIgnoreCase( prop1, prop2 ) )
+		{
+			prop1 = displayName;
+			prop2 = other.displayName;
+		}
+
+		return StringUtils.compareIgnoreCase( prop1, prop2 );
+	}
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUnidentifiedUser.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUnidentifiedUser.java
@@ -25,6 +25,15 @@ public class GbUnidentifiedUser implements GbUserBase, Serializable, Comparable<
 		this.displayName = displayName;
 	}
 
+	/**
+	 * Unidentified users are always considered invalid (they have no UUID).
+	 * @return false
+	 */
+	public boolean isValid()
+	{
+		return false;
+	}
+
 	@Override
 	public int compareTo( GbUnidentifiedUser other )
 	{

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUser.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUser.java
@@ -28,6 +28,7 @@ import org.sakaiproject.gradebookng.business.util.FormatHelper;
 
 import java.util.Collections;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 
 /**
  * DTO for a user. Enhance as required.
@@ -36,10 +37,12 @@ import java.util.List;
  *
  */
 @Getter
-public class GbUser implements Serializable, Comparable<GbUser> {
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class GbUser implements GbUserBase, Serializable, Comparable<GbUser> {
 
 	private static final long serialVersionUID = 1L;
 
+	@EqualsAndHashCode.Include
 	private final String userUuid;
 
 	/**
@@ -76,21 +79,6 @@ public class GbUser implements Serializable, Comparable<GbUser> {
 		this.sortName = u.getSortName();
 	}
 
-	public GbUser(final String userUUID, final String displayID, final String displayName, final String firstName, final String lastName, final String studentNumber, final String sortName) {
-		this.userUuid = userUUID;
-		this.displayId = displayID;
-		this.displayName = FormatHelper.htmlEscape(displayName);
-		this.firstName = FormatHelper.htmlEscape(firstName);
-		this.lastName = FormatHelper.htmlEscape(lastName);
-		this.studentNumber = FormatHelper.htmlEscape(studentNumber);
-		this.sections = Collections.emptyList();
-		this.sortName = sortName;
-	}
-
-	public static GbUser forDisplayOnly(final String displayID, final String displayName) {
-		return new GbUser("", displayID, displayName, "", "", "", "");
-	}
-
 	public boolean isValid() {
 		return StringUtils.isNotBlank(userUuid);
 	}
@@ -98,10 +86,18 @@ public class GbUser implements Serializable, Comparable<GbUser> {
 	@Override
 	public int compareTo(GbUser other)
 	{
-		if (StringUtils.isBlank(sortName) && StringUtils.isBlank(other.getSortName())) {
-			return StringUtils.compareIgnoreCase(displayName, other.getDisplayName());
+		String prop1 = sortName;
+		String prop2 = other.getSortName();
+		if (StringUtils.isBlank(prop1) && StringUtils.isBlank(prop2)) {
+			prop1 = displayName;
+			prop2 = other.getDisplayName();
 		}
-		return StringUtils.compareIgnoreCase(sortName, other.getSortName());
+		if (StringUtils.equalsIgnoreCase(prop1, prop2)) {
+			prop1 = displayId;
+			prop2 = other.getDisplayId();
+		}
+
+		return StringUtils.compareIgnoreCase(prop1, prop2);
 	}
 
 	@Override

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUserBase.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUserBase.java
@@ -8,4 +8,5 @@ public interface GbUserBase
 {
 	public String getDisplayId();
 	public String getDisplayName();
+	public boolean isValid();
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUserBase.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/GbUserBase.java
@@ -1,0 +1,11 @@
+package org.sakaiproject.gradebookng.business.model;
+
+/**
+ *
+ * @author bjones86
+ */
+public interface GbUserBase
+{
+	public String getDisplayId();
+	public String getDisplayName();
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedRow.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/model/ImportedRow.java
@@ -42,7 +42,7 @@ public class ImportedRow implements Serializable {
 	private String studentName;
 
 	@Getter
-	private GbUser user;
+	private GbUserBase user;
 
 	@Getter
 	@Setter
@@ -52,7 +52,7 @@ public class ImportedRow implements Serializable {
 		this.cellMap = new HashMap<>();
 	}
 
-	public void setUser(GbUser gbUser) {
+	public void setUser(GbUserBase gbUser) {
 		user = gbUser;
 	}
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -78,6 +78,8 @@ import java.util.Collections;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.gradebookng.business.model.GbUnidentifiedUser;
+import org.sakaiproject.gradebookng.business.model.GbUserBase;
 
 /**
  * Helper to handling parsing and processing of an imported gradebook file
@@ -624,9 +626,10 @@ public class ImportGradesHelper {
 
 				if (cell != null) {
 					// Only process the grade item if the user is valid (present in the site/gradebook)
-					if (row.getUser().isValid()) {
+					GbUserBase user = row.getUser();
+					if (user instanceof GbUser && ((GbUser) user).isValid()) {
 						final ProcessedGradeItemDetail processedGradeItemDetail = new ProcessedGradeItemDetail();
-						processedGradeItemDetail.setUser(row.getUser());
+						processedGradeItemDetail.setUser((GbUser) user);
 						processedGradeItemDetail.setGrade(cell.getScore());
 						processedGradeItemDetail.setComment(cell.getComment());
 						processedGradeItemDetails.add(processedGradeItemDetail);
@@ -694,12 +697,11 @@ public class ImportGradesHelper {
 
 		// for grade items, only need to check if we dont already have a status, as grade items are always imported for NEW and MODIFIED items
 		// for comments we always check unless external as we might have a NEW item but with no data which means SKIP
-		SortedSet<GbUser> usersInGradebook = importedGradeWrapper.getUserIdentifier().getReport().getIdentifiedUsers();
 		if ((column.isGradeItem() && status == null) || (column.isComment() && status != Status.EXTERNAL)) {
 			for (final ImportedRow row : importedGradeWrapper.getRows()) {
 
 				// if the user is not a member of the site/gradebook, we don't need to consider the data for the column's status
-				if (!usersInGradebook.contains(row.getUser())) {
+				if (row.getUser() instanceof GbUnidentifiedUser) {
 					continue;
 				}
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/ImportGradesHelper.java
@@ -79,7 +79,6 @@ import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.gradebookng.business.model.GbUnidentifiedUser;
-import org.sakaiproject.gradebookng.business.model.GbUserBase;
 
 /**
  * Helper to handling parsing and processing of an imported gradebook file
@@ -626,10 +625,9 @@ public class ImportGradesHelper {
 
 				if (cell != null) {
 					// Only process the grade item if the user is valid (present in the site/gradebook)
-					GbUserBase user = row.getUser();
-					if (user instanceof GbUser && ((GbUser) user).isValid()) {
+					if (row.getUser().isValid()) {
 						final ProcessedGradeItemDetail processedGradeItemDetail = new ProcessedGradeItemDetail();
-						processedGradeItemDetail.setUser((GbUser) user);
+						processedGradeItemDetail.setUser((GbUser) row.getUser());
 						processedGradeItemDetail.setGrade(cell.getScore());
 						processedGradeItemDetail.setComment(cell.getComment());
 						processedGradeItemDetails.add(processedGradeItemDetail);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.java
@@ -32,6 +32,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.StringResourceModel;
 
 import org.sakaiproject.gradebookng.business.importExport.UserIdentificationReport;
+import org.sakaiproject.gradebookng.business.model.GbUnidentifiedUser;
 import org.sakaiproject.gradebookng.business.model.GbUser;
 import org.sakaiproject.gradebookng.tool.model.ImportWizardModel;
 
@@ -121,7 +122,7 @@ public class GradeItemImportOmissionsPanel extends Panel
 
         // Sort the omission lists alphabetically
         List<GbUser> missingUsersSorted = new ArrayList<>( report.getMissingUsers() );
-        List<GbUser> unknownUsersSorted = new ArrayList<>( report.getUnknownUsers() );
+        List<GbUnidentifiedUser> unknownUsersSorted = new ArrayList<>( report.getUnknownUsers() );
         Collections.sort( missingUsersSorted );
         Collections.sort( unknownUsersSorted );
 
@@ -137,12 +138,12 @@ public class GradeItemImportOmissionsPanel extends Panel
         };
 
         // Create and populate the list of unknown users
-        final ListView<GbUser> unknownUsers = new ListView<GbUser>( "unknownUsers", unknownUsersSorted )
+        final ListView<GbUnidentifiedUser> unknownUsers = new ListView<GbUnidentifiedUser>( "unknownUsers", unknownUsersSorted )
         {
             @Override
-            protected void populateItem( final ListItem<GbUser> item )
+            protected void populateItem( final ListItem<GbUnidentifiedUser> item )
             {
-                final GbUser user = item.getModelObject();
+                final GbUnidentifiedUser user = item.getModelObject();
                 String userDisplay = user.getDisplayId();
                 String displayName = user.getDisplayName().trim();
                 if( StringUtils.isNotBlank( displayName ))


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47117

JDK seems to be calling `compareTo` now for the sorted set. I tried implemented equals/hash on the existing `GbUser` object, but due to complexities with how we use this object, it became difficult to keep equals and hashcode in sync.

Instead, I decided to split the usage of `GbUser` into a new class, so we use `GbUser` when we know we have UUID etc, and we use the new `GbUnidentifiedUser` for when we don't have a UUID. This makes the equals/hash on each consistent and easy to implement.

Really we are only using the new object to report on users contained within the file who are not members of the site, so it was a small refactor.

Also added fallback logic to the EID in the compareTo.