### PR TITLE
SAK-47131 Menu items in assignments tool are too close and need some separation

### DIFF
--- a/assignment/tool/src/webapp/js/assignments.js
+++ b/assignment/tool/src/webapp/js/assignments.js
@@ -479,24 +479,6 @@ ASN.toggleElements = function( elements, disabled )
     }
 };
 
-ASN.enableLinks = function()
-{
-    var links = [
-        document.getElementById( "downloadAll" ),
-        document.getElementById( "uploadAll" ),
-        document.getElementById( "releaseGrades" ),
-        document.getElementById( "helpItems" )
-    ];
-
-    for( i = 0; i < links.length; i++ )
-    {
-        if( links[i] !== null )
-        {
-            links[i].className = "";
-        }
-    }
-};
-
 ASN.checkEnableRemove = function()
 {
     var selected = false;

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -117,12 +117,12 @@ function printView(url) {
 			#else
 				<div class="listNav">
 						## download all
-							<a href="#toolLinkParam("$action" "doPrep_download_all" "view=$!view")" class="button" id="downloadAll" title="$!tlang.getString('downall')">$!tlang.getString('downall')</a>
+							<a href="#toolLinkParam("$action" "doPrep_download_all" "view=$!view")" class="assignment-item" id="downloadAll" title="$!tlang.getString('downall')">$!tlang.getString('downall')</a>
 						#if(!$disableGrade)
 							## upload all
-							<a href="#toolLinkParam("$action" "doPrep_upload_all" "view=$view")" class="button" id="uploadAll" title="$!tlang.getString('uploadall.title')">$!tlang.getString('uploadall.title')</a>
+							<a href="#toolLinkParam("$action" "doPrep_upload_all" "view=$view")" class="assignment-item" id="uploadAll" title="$!tlang.getString('uploadall.title')">$!tlang.getString('uploadall.title')</a>
 							<a href="#"
-								class="button"
+								class="assignment-item" 
  								id="releaseGrades"
 							#if ($withGrade)
 								title="$!tlang.getString('relgrad')">$!tlang.getString('relgrad')</a>
@@ -139,7 +139,7 @@ function printView(url) {
 								#end
 							#end
 						#end
-				</div>	
+				</div>
 				#set ($gradeType = $typeOfGrade)
 			#end
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
@@ -819,7 +819,6 @@ function printView(url) {
 			}
 		});
 
-		ASN.enableLinks();
 
 		var assignmentId ="$assignment.Id";
 		var rubricsToken = "$!rbcs-token";

--- a/library/src/morpheus-master/sass/modules/tool/_menu.scss
+++ b/library/src/morpheus-master/sass/modules/tool/_menu.scss
@@ -146,6 +146,11 @@
 			display:inline-block;
 		}
 	}
+
+	.assignment-item:not(:last-child) {
+		border-right: 1px solid;
+		padding-right: 3px;
+	}
 }
 
 .viewNav{


### PR DESCRIPTION
In Sakai 22, in Assignments tool, when a user is going to grade submissions the menu items (“Download All“,”Upload All” and ”Release Grades”) are too close. A little separation is needed