### PR TITLE
KNL-1089 - Remove unused property from the documentation

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1441,12 +1441,6 @@
 # DEFAULT: true
 # sessions.size.check=false
 
-# Limits the maximum number of session on a per user basis 
-# If a user exceeds this number of sessions then the oldest ones will be expired 
-# when a new one is established until the total is at the max again 
-# DEFAULT: 0 (no limit)
-# session.max.per.user=100
-
 ## Session Replication settings
 ## WARNING: This requires a distribution mechanism of some kind (currently requires a distributed cache)
 ## NOTES:


### PR DESCRIPTION
I searched this property in the entire code and looks like it's not used and the functionality is not implemented, I don't know cases of institutions limiting the number of single user sessions.