### PR TITLE
SAK-47154 assignments > remove dedicated column for attachment icon

### DIFF
--- a/assignment/api/src/resources/assignment.properties
+++ b/assignment/api/src/resources/assignment.properties
@@ -88,6 +88,7 @@ gen.asstit        = Assignment Title
 gen.ass.remind    = Send a reminder email {0} hours before the due date
 gen.at            = at
 gen.att           = Attachments
+gen.has.att       = This assignment has attachments
 gen.attfprgra     = Attachments for grading
 gen.atttoret      = Attachments to Return with Grade
 gen.atttoret2      = Attachments to Return with Assignment

--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -19,15 +19,16 @@
     #propertyDetails($props)
 #end
 
-#macro( assignmentTitleIcon $assignment )
+#macro( assignmentIcons $assignment )
     #if ($!assignment.IsGroup)
         <i class="fa fa-users" aria-hidden="true" title="$tlang.getString('gen.groupassignment')"></i>
     #end
-#end
-
-#macro( sectionIcon $group )
-    #if ($!group.getProperties().get("sections_category"))
-        <i class="fa fa-users" aria-hidden="true" title="$tlang.getString('gen.section.info')"></i>
+    #if (!$assignment.getAttachments().isEmpty())
+        <i class="icon-sakai--clip" aria-hidden="true"></i>
+        <span class="sr-only">$tlang.getString("gen.has.att")</span>
+    #end
+    #if ($assignment.getContentReview())
+        <img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" />
     #end
 #end
 

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -50,8 +50,8 @@
         <div class="navPanel">
             <div class="highlight gradingHeader">
                 <h3>
-                    #assignmentTitleIcon($!assignment)
                     $formattedText.escapeHtml($!assignment.Title)
+                    #assignmentIcons($!assignment)
                     <span class="highlight"> -
                         #if ($withGrade)
                             #if (!$!submission.Graded)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
@@ -50,9 +50,7 @@
 								<td headers="title" scope="row">
 											<strong>
 												$formattedText.escapeHtml($!assignment.title)
-												#if ($assignment.getContentReview())
-													<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" />
-												#end
+												#assignmentIcons($assignment)
 											</strong>
 								</td>
 								#if ($!allowRecoverAssignment)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -661,8 +661,8 @@ function printView(url) {
 				$tlang.getString("gen.asstit")
 			</th>
 			<td>
-					#assignmentTitleIcon($assignment)
 					$formattedText.escapeHtml($assignment.Title)
+					#assignmentIcons($assignment)
 			</td>
 		</tr>
 		<tr>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_report_submissions.vm
@@ -155,8 +155,8 @@
 							#end
 							</td>
 							<td headers="assignment">
-								#assignmentTitleIcon($assignment)
 								$formattedText.escapeHtml($!assignment.Title)
+								#assignmentIcons($assignment)
 							</td>
 							#if($!isAdditionalNotesEnabled)
 							<td headers="notes">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -91,10 +91,6 @@
 			<input type="hidden" name="source" value="0" />
 			<table class="table table-hover table-striped table-bordered" summary="$tlang.getString("gen.ass.lis.sum")">
 				<tr>
-					<th id="attachments" class="attach hidden-xs" scope="col"> 
-						&nbsp;
-						<span class="sr-only">$tlang.getString("gen.att")</span>
-					</th>				
 					<th id="title" scope="col">
 						<a href="javascript:void(0)" onclick="location='#toolLinkParam("$action" "doSort" "criteria=title")'; return false;"   title="$tlang.getString("listassig.sorbytit")">
 							$tlang.getString("gen.asstit")
@@ -243,17 +239,9 @@
 					## no need to do permission check again, since it was done when the list was constructed
 						#set ($assignmentCount = $assignmentCount + 1)
 						<tr>
-							<td headers="attachments" class="attach hidden-xs">
-								#if (!$assignment.getAttachments().isEmpty())
-									<i class="icon-sakai--clip"></i>
-								#else
-									&nbsp;
-								#end
-							</td>						
 							<td headers="title" scope="row">
 								#if (($!allowAddAssignment || $!allowUpdateAssignment || $!service.allowGradeSubmission($assignmentReference)) && $!view.equals('lisofass1'))
 									<strong>
-										#assignmentTitleIcon($assignment)
 										## normal instructor view
 										#if ($assignment.Draft && $!allowUpdateAssignment )
 											<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
@@ -266,9 +254,7 @@
 											$formattedText.escapeHtml($!assignment.Title)
 										</a>
 
-										#if ($assignment.getContentReview())
-											<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" />
-										#end
+										#assignmentIcons($assignment)
 
 										#if ($rubricsService.hasAssociatedRubric("sakai.assignment", $assignment.getId()))
 										<sakai-rubric-student-button
@@ -319,7 +305,6 @@
 												#end
 											#end
 											## if not submitted or returned and still allowed to submit within the due time
-											#assignmentTitleIcon($assignment)
 											#if ($service.canSubmit($assignment))
 												## go to view submission page when (1) submission has been returned and allow for resubmit;(2)submission has not been posted yet.
 												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
@@ -327,6 +312,7 @@
 												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$formattedText.escapeUrl($submissionReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
 											#end
 											$formattedText.escapeHtml($assignment.Title)</a>
+											#assignmentIcons($assignment)
 											#if ($rubricsService.hasAssociatedRubric("sakai.assignment", $assignment.getId()))
 												<sakai-rubric-student-button
 													token="$!rbcs-token"
@@ -336,8 +322,8 @@
 												</sakai-rubric-student-button>
 											#end
 										#else
-											#assignmentTitleIcon($assignment)
 											$formattedText.escapeHtml($assignment.Title)
+											#assignmentIcons($assignment)
 											#if ($rubricsService.hasAssociatedRubric("sakai.assignment", $assignment.getId()))
 												<sakai-rubric-student-button
 													token="$!rbcs-token"
@@ -391,22 +377,25 @@
                                                         <a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_honorPledge" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
 													#else
 														## go to view submission page when (1) submission has been returned and allow for resubmit;(2)submission has not been posted yet.
-														<strong>#assignmentTitleIcon($assignment)
+														<strong>
 															<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
+															#assignmentIcons($assignment)
 														</strong>
 													#end
 												#else
-													<strong>#assignmentTitleIcon($assignment)
+													<strong>
 														<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$formattedText.escapeUrl($submissionReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
+														#assignmentIcons($assignment)
 													</strong>
 												#end
 											#else
-												<strong>#assignmentTitleIcon($assignment)
+												<strong>
 													#if ($assignment.HonorPledge && $service.canSubmit($assignment))
 														<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_honorPledge" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
 													#else
                                                     	<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
 													#end
+													#assignmentIcons($assignment)
 												</strong>
 											#end
 											#set($submissionId="undefined")
@@ -589,8 +578,6 @@
 							<!-- only show to "students" -->
 							<!-- peer assessment overview row -->
 							<tr>
-								<!-- attachments col -->
-								<td></td>
 								<!-- title col -->
 								<td class="peer-header">
 									<strong title="$formattedText.escapeHtml($!assignment.Title)"><span class="fa fa-caret-square-o-right" aria-hidden="true"></span> $formattedText.escapeHtml($assignment.Title)</strong>
@@ -685,8 +672,6 @@
 								#foreach ($review in $reviews)
 									#set ($reviewCount = $reviewCount + 1)
 									<tr>
-										<!-- attachments col -->
-										<td></td>
 										<!-- title col -->
 										<td>
 											<span class="indnt2">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_confirm_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_confirm_submission.vm
@@ -34,8 +34,8 @@
                 $tlang.getString("gen.title")
             </th>
             <td>
-                #assignmentTitleIcon($assignment)
 				$formattedText.escapeHtml($assignment.Title)
+                #assignmentIcons($assignment)
             </td>
         </tr>
         <tr>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_preview_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_preview_submission.vm
@@ -16,8 +16,8 @@
                 $tlang.getString("gen.title")
             </th>
             <td>
-                #assignmentTitleIcon($assignment)
 				$formattedText.escapeHtml($assignment.Title)
+                #assignmentIcons($assignment)
             </td>
         </tr>
         <tr>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
@@ -40,8 +40,8 @@
 		         style="width:70%;line-height:1.4em">
 				 		
 				<h3>
-                    #assignmentTitleIcon($assignment)
 					$formattedText.escapeHtml($!assignment.title)
+					#assignmentIcons($assignment)
 					<span class="highlight"> -
 					$tlang.getString("gen.reviewing"):&nbsp;
 					#if(!$view_only && $assignment.getPeerAssessmentAnonEval())

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment_honor_pledge.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_assignment_honor_pledge.vm
@@ -9,8 +9,8 @@
     #else
         <h3>
             $tlang.getString('assignment.title')
-            #assignmentTitleIcon($assignment)
             $formattedText.escapeHtml($!assignment.Title)
+            #assignmentIcons($assignment)
         </h3>
 
         #progressBar($statusMap)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -75,7 +75,7 @@
                 $tlang.getString("gen.title")
             </th>
             <td valign="top">
-                #assignmentTitleIcon($assignment) $formattedText.escapeHtml($assignment.title)
+                $formattedText.escapeHtml($assignment.title) #assignmentIcons($assignment)
             </td>
         </tr>
         #if ($!assignment.IsGroup)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -151,8 +151,8 @@ $(document).ready(function(){
 				</div>
 				<div class="col-lg-4 col-sm-6 col-xs-12">
 					<div class="itemSummaryValue">
-						#assignmentTitleIcon($assignment)
 						$formattedText.escapeHtml($assignment.Title)
+						#assignmentIcons($assignment)
 						#set ($deleted = false)
 						#set ($deleted = $assignment.Deleted)
 						#if ($deleted)

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -82,8 +82,8 @@
                     $tlang.getString('assignment.title')
                 </th>
                 <td>
-                    #assignmentTitleIcon($assignment)
 					$formattedText.escapeHtml($!assignment.Title)
+                    #assignmentIcons($assignment)
                 </td>
             </tr>
             ## submission id


### PR DESCRIPTION
https://github.com/bjones86/sakai/pull/new/SAK-47154

We don't need an entire column for one icon. Also, the column is pointlessly rendered even when no assignments have attachments. All icons should appear to the right of the assignment title, not to the left, so that the text of the assignment names is left aligned in tables, etc.