### PR TITLE
SAK-47156 Assignments > late status is not communicated to students

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -494,7 +494,10 @@
 									#if ($submission)
 										#set ($submissionId = $submission.Id)
 									#end
-									<span class="highlight">$!service.getSubmissionStatus($!submissionId, false)</span>
+									$!service.getSubmissionStatus($!submissionId, false)
+									#if ($assignment.DueDate && $submission.DateSubmitted && $submission.DateSubmitted.isAfter($assignment.DueDate))
+										<span class="highlight">$tlang.getString("gen.late2")</span>
+									#end
 								#end
 							</td>
 							<td headers="openDate" class="hidden-xs">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -115,6 +115,9 @@
                     ## get submit time
                     #if ($!submitTime)
                         $!service.getUsersLocalDateTimeString($submitTime)
+                        #if ($submitTime.isAfter($assignment.DueDate))
+                            <span class="highlight">$tlang.getString("gen.late2")</span>
+                        #end
                     #end
                     <br/>
                 </td>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47156

Instructor’s see the “ - late” label applied to late submissions in both the submission list and the submission grading UIs. However, students do not see the late status on any of the UIs (assignment list, nor view submission). This information has meaning for both students and instructors, and should be communicated to both.

Part of this is a regression: the late status used to be displayed to students in the assignment list table. However this doesn’t seem to be the case in 23. Also, the "status" column for the student assignment list should not display the status in red bold text. Only the "late" label is meant to receive this styling.