### PR TITLE
SAK-47157 assignments, samigo > submission page should display EID

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -15,7 +15,6 @@
  */
 package org.sakaiproject.assignment.entityproviders;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -1458,6 +1457,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
         private String id;
         private String displayName;
         private String sortName;
+        private String displayId;
 
         public SimpleSubmitter(AssignmentSubmissionSubmitter ass, boolean anonymousGrading) throws UserNotDefinedException {
 
@@ -1468,6 +1468,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                 User user = userDirectoryService.getUser(this.id);
                 this.displayName = user.getDisplayName();
                 this.sortName = user.getSortName();
+                this.displayId = user.getDisplayId();
             } else {
                 this.displayName = ass.getSubmission().getId() + " " + rb.getString("grading.anonymous.title");
                 this.sortName = this.displayName;

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2213,7 +2213,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 context.put("email_confirmation", serverConfigurationService.getBoolean("assignment.submission.confirmation.email", true));
 
                 if (assignment.getIsGroup()) {
-					context.put("submitterNames", getSubmitterFormattedNames(submission, "build_student_view_submission_confirmation_context"));
+					context.put("submitterNames", getSubmitterFormattedNames(submission, false));
                 }
 
                 putSubmissionLogMessagesInContext(context, submission);
@@ -2231,10 +2231,15 @@ public class AssignmentAction extends PagedResourceActionII {
     } // build_student_view_submission_confirmation_context
 
     //Get all submitter names from submission, comma separated and processed in formattedText
-	private String getSubmitterFormattedNames(AssignmentSubmission s, String method) {
+	private String getSubmitterFormattedNames(AssignmentSubmission s, boolean includeDisplayID) {
 		final Map<String, User> users = assignmentToolUtils.getSubmitters(s)
 						.collect(Collectors.toMap(User::getId, Function.identity()));
-		final String submitterNames = users.values().stream().map(u -> u.getDisplayName()).collect(Collectors.joining(", "));
+		final String submitterNames;
+		if (includeDisplayID) {
+			submitterNames = users.values().stream().map(u -> u.getDisplayName() + " (" + u.getDisplayId() + ")").collect(Collectors.joining(", "));
+		} else {
+			submitterNames = users.values().stream().map(u -> u.getDisplayName()).collect(Collectors.joining(", "));
+		}
 		return formattedText.escapeHtml(submitterNames);
 	}
 
@@ -2691,7 +2696,7 @@ public class AssignmentAction extends PagedResourceActionII {
             securityService.popAdvisor(asgnAdvisor);
         }
         
-        context.put("submitterNames", getSubmitterFormattedNames(submission, "build_instructor_grade_submission_context"));
+        context.put("submitterNames", getSubmitterFormattedNames(submission, false));
         context.put(RUBRICS_EXPORT_PDF, serverConfigurationService.getBoolean(RUBRICS_EXPORT_PDF_SERVER_PROPERTY, true));
 
         context.put("name_ASSIGNMENT_INPUT_ADD_TIME_SPENT", ResourceProperties.ASSIGNMENT_INPUT_ADD_TIME_SPENT);
@@ -3761,7 +3766,7 @@ public class AssignmentAction extends PagedResourceActionII {
 
             context.put("users", users);
 
-            context.put("submitterNames", getSubmitterFormattedNames(s, "build_instructor_grade_submission_context"));
+            context.put("submitterNames", getSubmitterFormattedNames(s, true));
             context.put("submissionStatus", assignmentService.getSubmissionStatus(s.getId(), true));
             s.getSubmitters().stream().findAny().ifPresent(u -> context.put("submitterId", u.getSubmitter()));
 
@@ -4506,7 +4511,7 @@ public class AssignmentAction extends PagedResourceActionII {
             assignment.getAttachments().forEach(r -> assignmentAttachmentReferences.put(r, entityManager.newReference(r)));
             context.put("assignmentAttachmentReferences", assignmentAttachmentReferences);
 
-            context.put("submitterNames", getSubmitterFormattedNames(submission, "build_instructor_preview_grade_submission_context"));
+            context.put("submitterNames", getSubmitterFormattedNames(submission, false));
 
             setScoringAgentProperties(context, assignment, submission, false);
 
@@ -10344,7 +10349,7 @@ public class AssignmentAction extends PagedResourceActionII {
             AssignmentSubmission s = getSubmission(submissionId, "putSubmissionInfoIntoState", state);
             if (s != null) {
                 state.setAttribute(GRADE_SUBMISSION_FEEDBACK_TEXT, s.getSubmittedText());
-                state.setAttribute(GRADE_SUBMISSION_SUBMITTERS_NAMES, getSubmitterFormattedNames(s, "putSubmissionInfoIntoState"));
+                state.setAttribute(GRADE_SUBMISSION_SUBMITTERS_NAMES, getSubmitterFormattedNames(s, false));
 
                 if ((s.getFeedbackText() == null) || (s.getFeedbackText().length() == 0)) {
                     state.setAttribute(GRADE_SUBMISSION_FEEDBACK_TEXT, s.getSubmittedText());

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/StudentScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/StudentScoresBean.java
@@ -29,6 +29,8 @@ import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
+import lombok.Getter;
+import lombok.Setter;
 
 import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.content.api.FilePickerHelper;
@@ -44,6 +46,7 @@ import org.sakaiproject.tool.cover.SessionManager;
 @Slf4j
 @ManagedBean(name="studentScores")
 @SessionScoped
+@Getter @Setter
 public class StudentScoresBean implements Serializable {
 
   /** Use serialVersionUID for interoperability. */
@@ -55,6 +58,7 @@ public class StudentScoresBean implements Serializable {
   private String comments;
   private String publishedId;
   private String studentId;
+  private String displayId;
   private String assessmentGradingId;
   private String itemId; // ID of the first item; used by QuestionScores
   private String email;
@@ -67,107 +71,6 @@ public class StudentScoresBean implements Serializable {
   {
     log.debug("Creating a new StudentScoresBean");
   }
-  
-  public String getStudentName()
-  {
-    return studentName;
-  }
-
-  public void setStudentName(String studentName)
-  {
-    this.studentName = studentName;
-  }
-
-  public String getFirstName()
-  {
-    return firstName;
-  }
-
-  public void setFirstName(String firstName)
-  {
-    this.firstName = firstName;
-  }
-
-  public String getLastName()
-  {
-    return lastName;
-  }
-
-  public void setLastName(String lastName)
-  {
-    this.lastName = lastName;
-  }
-
-  public String getComments()
-  {
-    return comments;
-  }
-
-  public void setComments(String newcomments)
-  {
-    comments = newcomments;
-  }
-
-  public String getPublishedId()
-  {
-    return publishedId;
-  }
-
-  public void setPublishedId(String newId)
-  {
-    publishedId = newId;
-  }
-
-  public String getStudentId()
-  {
-    return studentId;
-  }
-
-  public void setStudentId(String newId)
-  {
-    studentId = newId;
-  }
-
-  public String getAssessmentGradingId()
-  {
-    return assessmentGradingId;
-  }
-
-  public void setAssessmentGradingId(String newId)
-  {
-    assessmentGradingId = newId;
-  }
-
-  public String getItemId()
-  {
-    return itemId;
-  }
-
-  public void setItemId(String newId)
-  {
-    itemId = newId;
-  }
-  
-  public String getEmail()
-  {
-    return email;
-  }
-
-  public void setEmail(String email)
-  {
-	  this.email = email;
-  }
-  
-
-  public Long getItemGradingIdForFilePicker() {
-	  return itemGradingIdForFilePicker;
-  }
-
-  public void setItemGradingIdForFilePicker(Long itemGradingIdForFilePicker)
-  {
-	  this.itemGradingIdForFilePicker = itemGradingIdForFilePicker;
-  }
-
 
   public String addAttachmentsRedirect() {
 	  // 1. redirect to add attachment

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/StudentScoreListener.java
@@ -115,6 +115,7 @@ import lombok.extern.slf4j.Slf4j;
       bean.setAssessmentGradingId(ContextUtil.lookupParam("gradingData"));
       bean.setItemId(ContextUtil.lookupParam("itemId"));
       bean.setEmail(agent.getEmail());
+      bean.setDisplayId(agent.getDisplayIdString());
       
       DeliveryBean dbean = (DeliveryBean) ContextUtil.lookupBean("delivery");
       dbean.setActionString("gradeAssessment");

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -127,7 +127,7 @@ function toPoint(id)
 
   <h:panelGroup layout="block" styleClass="page-header">
     <h1>
-      <h:outputText value="#{studentScores.studentName}" rendered="#{totalScores.anonymous eq 'false'}"/>
+      <h:outputText value="#{studentScores.studentName} (#{studentScores.displayId})" rendered="#{totalScores.anonymous eq 'false'}"/>
       <small><h:outputText value="#{evaluationMessages.submission_id}#{deliveryMessages.column} #{studentScores.assessmentGradingId}" rendered="#{totalScores.anonymous eq 'true'}"/></small>
     </h1>
   </h:panelGroup>

--- a/webcomponents/tool/src/main/frontend/js/grader/submission.js
+++ b/webcomponents/tool/src/main/frontend/js/grader/submission.js
@@ -52,7 +52,7 @@ export class Submission {
       this.ltiSubmissionLaunch = init.ltiSubmissionLaunch;
 
       if (init.submitters) {
-        this.firstSubmitterName = init.submitters[0].sortName;
+        this.firstSubmitterName = `${init.submitters[0].sortName}${init.submitters[0].displayId !== null ? ` (${init.submitters[0].displayId})` : ''}`;
         this.firstSubmitterId = init.submitters[0].id;
       }
       this.late = init.late;


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47157

Assignments: If two students have the same name  you can't tell them apart when navigating between submissions. Sakai  Grader has the same issue.

Samigo: If two students have the same name and you forget which one  you clicked on, you have to go back a page and click on the right one to  be sure. You could also use the Email link at the bottom but that's  easily overlooked. Not as big a problem as in Assignments since you  can't navigate between students in this view, but for consistency it  should be the same in all tools.