### PR TITLE
SAK-47158 Assignments > trash doesn't indicate draft status

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_deleted_assignments.vm
@@ -49,6 +49,9 @@
 							<tr>
 								<td headers="title" scope="row">
 											<strong>
+												#if ($assignment.draft)
+													<span class="highlight">$tlang.getString("gen.dra2") </span>
+												#end
 												$formattedText.escapeHtml($!assignment.title)
 												#if ($assignment.getContentReview())
 													<img alt="$reviewIndicator" title="$reviewIndicator" src="/library/image/silk/rosette.png" />


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47158

1. Create a draft assignment
2. Return to the assignment list
3. Notice the assignment title is prefixed with “Draft - “
4. Move the assignment to the Trash
5. Go to the Trash list
6. Notice there is no indication that the assignment is a draft

The assignment is restored to draft status. For consistency and clarity, we should apply the draft label to draft assignments in the Trash list. This could cause annoyances if someone has multiple assignments with the same name, but some are draft and some are published.