### PR TITLE
SAK-47170 Assignments > Students see stack trace on assignments and submissions with attachments if read resources permission is removed

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -383,7 +383,7 @@
                     #if ($reference)
                         #set ($props = false)
                         #set ($props = $reference.Properties)
-                        #if ($!props && $!props.PropertyNames.hasNext())
+                        #if ($!props && !$!props.isEmpty())
                             <li>
                                 #if ($props.getBooleanProperty($props.NamePropIsCollection))
                                     <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -383,7 +383,7 @@
                     #if ($reference)
                         #set ($props = false)
                         #set ($props = $reference.Properties)
-                        #if ($!props)
+                        #if ($!props && $!props.PropertyNames.hasNext())
                             <li>
                                 #if ($props.getBooleanProperty($props.NamePropIsCollection))
                                     <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
@@ -95,7 +95,7 @@
                         #if ($reference)
                             #set ($props = false)
                             #set ($props = $reference.Properties)
-                            #if ($!props && $!props.PropertyNames.hasNext())
+                            #if ($!props && !$!props.isEmpty())
                                 <li>
                                     #if ($props.getBooleanProperty($props.NamePropIsCollection))
                                         <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
@@ -95,7 +95,7 @@
                         #if ($reference)
                             #set ($props = false)
                             #set ($props = $reference.Properties)
-                            #if ($!props)
+                            #if ($!props && $!props.PropertyNames.hasNext())
                                 <li>
                                     #if ($props.getBooleanProperty($props.NamePropIsCollection))
                                         <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
@@ -140,7 +140,7 @@
 									#if ($reference)
 										#set ($props = false)
 										#set ($props = $reference.Properties)
-										#if ($!props && $!props.PropertyNames.hasNext())
+										#if ($!props && !$!props.isEmpty())
 											<li>
 												#if ($props.getBooleanProperty($props.NamePropIsCollection))
 													<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_review_edit.vm
@@ -140,7 +140,7 @@
 									#if ($reference)
 										#set ($props = false)
 										#set ($props = $reference.Properties)
-										#if ($!props)
+										#if ($!props && $!props.PropertyNames.hasNext())
 											<li>
 												#if ($props.getBooleanProperty($props.NamePropIsCollection))
 													<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_feedback_attachments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_feedback_attachments.vm
@@ -12,7 +12,7 @@
 					#if ($reference)
 						#set ($props = false)
 						#set ($props = $reference.Properties)
-						#if ($!props && $!props.PropertyNames.hasNext())
+						#if ($!props && !$!props.isEmpty())
 							<li>
 								#if ($props.getBooleanProperty($props.NamePropIsCollection))
 									<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_feedback_attachments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_feedback_attachments.vm
@@ -12,7 +12,7 @@
 					#if ($reference)
 						#set ($props = false)
 						#set ($props = $reference.Properties)
-						#if ($!props)
+						#if ($!props && $!props.PropertyNames.hasNext())
 							<li>
 								#if ($props.getBooleanProperty($props.NamePropIsCollection))
 									<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -287,7 +287,7 @@
                             #if ($reference)
                                 #set ($props = false)
                                 #set ($props = $reference.Properties)
-                                #if ($!props)
+                                #if ($!props && $!props.PropertyNames.hasNext())
                                     <li>
                                         #if ($props.getBooleanProperty($props.NamePropIsCollection))
                                                 <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -287,7 +287,7 @@
                             #if ($reference)
                                 #set ($props = false)
                                 #set ($props = $reference.Properties)
-                                #if ($!props && $!props.PropertyNames.hasNext())
+                                #if ($!props && !$!props.isEmpty())
                                     <li>
                                         #if ($props.getBooleanProperty($props.NamePropIsCollection))
                                                 <img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -735,7 +735,7 @@ $(document).ready(function(){
 							#foreach ($attachment in $attachments) 
 								#set ($props = false)
 								#set ($props = $attachment.Properties) 
-								#if ($!props)
+								#if ($!props && $!props.PropertyNames.hasNext())
 									<tr>
 										<td>
 											#if ($props.getBooleanProperty($props.NamePropIsCollection))

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -735,7 +735,7 @@ $(document).ready(function(){
 							#foreach ($attachment in $attachments) 
 								#set ($props = false)
 								#set ($props = $attachment.Properties) 
-								#if ($!props && $!props.PropertyNames.hasNext())
+								#if ($!props && !$!props.isEmpty())
 									<tr>
 										<td>
 											#if ($props.getBooleanProperty($props.NamePropIsCollection))

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -191,7 +191,7 @@
                             #if ($reference)
                                 #set ($props = false)
                                 #set ($props = $reference.Properties)
-                                #if ($!props)
+                                #if ($!props && $!props.PropertyNames.hasNext())
                                     <li>$formattedText.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
 										#propertyDetails($props)
                                     </li>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -191,7 +191,7 @@
                             #if ($reference)
                                 #set ($props = false)
                                 #set ($props = $reference.Properties)
-                                #if ($!props && $!props.PropertyNames.hasNext())
+                                #if ($!props && !$!props.isEmpty())
                                     <li>$formattedText.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
 										#propertyDetails($props)
                                     </li>

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/ResourceProperties.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/ResourceProperties.java
@@ -212,6 +212,20 @@ public interface ResourceProperties extends Serializable
 	Iterator<String> getPropertyNames();
 
 	/**
+	 * Returns the number of defined properties
+	 *
+	 * @return the number of defined properties
+	 */
+	int size();
+
+	/**
+	 * Returns true if there are no defined properties
+	 *
+	 * @return true if there are no defined properties
+	 */
+	boolean isEmpty();
+
+	/**
 	 * Access a named property as a string (won't find multi-valued ones.)
 	 * 
 	 * @param name

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/BaseResourceProperties.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/BaseResourceProperties.java
@@ -237,6 +237,18 @@ public class BaseResourceProperties implements ResourceProperties, SerializableP
 		return new EnumerationIterator(m_props.keys());
 	}
 
+	@Override
+	public int size()
+	{
+		return m_props.size();
+	}
+
+	@Override
+	public boolean isEmpty()
+	{
+		return m_props.isEmpty();
+	}
+
 	/**
 	 * Access a named property as a string (won't find multi-valued ones.)
 	 * 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47170

Instructors will sometimes remove the read resources permission from the student role if they upload files they don’t want students to see. While this causes numerous problems throughout Sakai, one in particular is that in Assignments, student will see a stack trace on the submission page if the assignment has attachments, or if they have previously submitted attachments to the assignment. This happens whether or not they have more submissions for the assignment available.

In previous versions of Sakai, a stack trace would only be shown if the student had previously submitted attachments (due to NullPointerException that is was what I was actually intending to fix here), and any attachments on the assignment itself would simply not be shown. I believe the current manifestation of the problem stems from recent work where a change was made so that empty properties were returned instead of null. Calling code may have been relying on the null check to determine if it was safe to access the properties, as was happening in the Velocity templates here. Some of the getters on ResourceProperties will throw exceptions if the property can’t be found, and this is what happens in Assignments and the uncaught exception is printed on the page instead.

This ticket address only the stack trace display issue, and instead will display nothing in the attachments section for the assignment and/or submission. This is how Assignments in previous Sakai versions would handle cases where the attachment properties could not be read.