### PR TITLE
SAK-47176 AssignmentEventObserver logs a warning for every Gradebook grade update

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -796,11 +796,11 @@ public interface AssignmentService extends EntityProducer {
      * Get an assignment that is linked with a gradebook item
      * @param context the context (site id)
      * @param linkId the link id of the gradebook item, usually the gradebook item name or id
-     * @return the matching assignment if found or null if none
+     * @return the matching assignment if found or empty if none
      * @throws IdUnusedException if the assignment doesn't exist
      * @throws PermissionException if the current user is not allowed to access the assignment
      */
-    Assignment getAssignmentForGradebookLink(String context, String linkId) throws IdUnusedException, PermissionException;
+    Optional<Assignment> getAssignmentForGradebookLink(String context, String linkId) throws IdUnusedException, PermissionException;
 
     /**
      * Returns a list of users that belong to multiple groups, if the user is considered a "student" in the group

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
@@ -88,9 +88,9 @@ public interface AssignmentRepository extends SerializableRepository<Assignment,
      * Find an assignment that is linked with to a gradebook item
      * @param context the context the assignment is in
      * @param linkId the linked id or name of the gradebook item
-     * @return the assignment id or null if none is found
+     * @return the assignment id or empty if none is found
      */
-    String findAssignmentIdForGradebookLink(String context, String linkId);
+    Optional<String> findAssignmentIdForGradebookLink(String context, String linkId);
 
     Collection<String> findGroupsForAssignmentById(String assignmentId);
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentEventObserver.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentEventObserver.java
@@ -76,7 +76,7 @@ public class AssignmentEventObserver implements Observer {
                                 // Assignments stores the gradebook item name and not the id :(, so we need to look it up
                                 try {
                                     org.sakaiproject.grading.api.Assignment gradebookAssignment = gradingService.getAssignmentByNameOrId(event.getContext(), itemId);
-                                    assignment = Optional.ofNullable(assignmentService.getAssignmentForGradebookLink(event.getContext(), gradebookAssignment.getName()));
+                                    assignment = assignmentService.getAssignmentForGradebookLink(event.getContext(), gradebookAssignment.getName());
                                     if (assignment.isPresent()) {
                                         final Assignment a = assignment.get();
                                         final User user = userDirectoryService.getUser(studentId);
@@ -116,7 +116,7 @@ public class AssignmentEventObserver implements Observer {
                                             log.warn("Submission not found for assignment {} and student {}, ", itemId, studentId);
                                         }
                                     } else {
-                                        log.warn("No matching assignment found with gradebook item id, {}", itemId);
+                                        log.debug("No matching assignment found with gradebook item id, {}", itemId);
                                     }
                                 } catch (IdUnusedException | PermissionException e) {
                                     if (!assignment.isPresent()) {

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -4930,16 +4930,16 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     @Override
-    public Assignment getAssignmentForGradebookLink(String context, String linkId) throws IdUnusedException, PermissionException {
+    public Optional<Assignment> getAssignmentForGradebookLink(String context, String linkId) throws IdUnusedException, PermissionException {
         if (StringUtils.isNoneBlank(context, linkId)) {
-            String assignmentId = assignmentRepository.findAssignmentIdForGradebookLink(context, linkId);
-            if (assignmentId != null) {
-                return getAssignment(assignmentId);
+            Optional<String> assignmentId = assignmentRepository.findAssignmentIdForGradebookLink(context, linkId);
+            if (assignmentId.isPresent()) {
+                return Optional.of(getAssignment(assignmentId.get()));
             } else {
-                log.warn("No assignment id could be found for context {} and link {}", context, linkId);
+                log.debug("No assignment id could be found for context {} and link {}", context, linkId);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     @Override

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
@@ -295,14 +295,15 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
     }
 
     @Override
-    public String findAssignmentIdForGradebookLink(String context, String linkId) {
-        return String.valueOf(startCriteriaQuery()
+    public Optional<String> findAssignmentIdForGradebookLink(String context, String linkId) {
+        Object result = startCriteriaQuery()
                 .createAlias("properties", "p")
                 .add(Restrictions.eq("context", context))
                 .add(Restrictions.eq("p." + CollectionPropertyNames.COLLECTION_INDICES, AssignmentConstants.PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT))
                 .add(Restrictions.eq("p." + CollectionPropertyNames.COLLECTION_ELEMENTS, linkId))
                 .setProjection(Projections.property("id"))
-                .uniqueResult());
+                .uniqueResult();
+        return result == null ? Optional.empty() : Optional.of(String.valueOf(result));
     }
 
     @Override


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47176

AssignmentEventObserver watches for Gradebook grade updates for non-external items to sync up the grades with the ones in Assignments that use the “link to existing Gradebook item” option. In most cases, a Gradebook item will not be linked to any assignment, and in these cases, every gradebook update results in a warn message in the logs. This is unnecessary log bloat.

There are really two problems here. The root problem is that the Assignments service will return the String “null” for the assignment id when there is no assignment linked to the Gradebook item, causing it to log a warning when it shouldn’t. The second problem is that this scenario is too common to be logged at the warn level, and so the logging that does get properly triggered after fixing the “null” issue should instead be logged at something like debug.