### PR TITLE
SAK-47183 Signup > Imported meetings don't preserve sign-up start and end dates

### DIFF
--- a/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/organizer/action/CreateMeetings.java
+++ b/signup/tool/src/java/org/sakaiproject/signup/tool/jsf/organizer/action/CreateMeetings.java
@@ -543,10 +543,8 @@ public class CreateMeetings extends SignupAction implements MeetingTypes, Signup
 		copy.setMeetingType(s.getMeetingType());
 		copy.setSignupTimeSlots(timeSlots);
 		copy.setSignupSites(indivSite); // copy sites
-		Date sBegin = Utilities.subTractTimeToDate(s.getStartTime(), getSignupBegins(), getSignupBeginsType());
-		Date sDeadline = Utilities.subTractTimeToDate(s.getEndTime(), getDeadlineTime(), getDeadlineTimeType());
-		copy.setSignupBegins(sBegin);
-		copy.setSignupDeadline(sDeadline);
+		copy.setSignupBegins(s.getSignupBegins());
+		copy.setSignupDeadline(s.getSignupDeadline());
 		copy.setRepeatType(s.getRepeatType());
 		copy.setRepeatUntil(s.getRepeatUntil());
 		copy.setReceiveEmailByOwner(s.isReceiveEmailByOwner());


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47183

When importing a meeting from another site, the signup begin and end dates are not copied over, and instead are recalculated. Imported meetings should just retain their original signup begin/end dates.
