### PR TITLE
SAK-47184 samigo > add messaging when beginning an assessment warning of multiple tab dangers

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -507,7 +507,7 @@ begin_assessment_msg_latest=If multiple submissions are allowed, answers from pr
 begin_assessment_msg_average=If multiple submissions are allowed, your average score will be recorded.
 begin_assessment_msg_attempt_autosubmit_warn_average=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be averaged with all previous attempts to determine your overall assessment score.  Do you want to begin a new attempt of this assessment?
 begin_assessment_msg_attempt_autosubmit_warn_last=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be recorded as your overall score for this assessment.  Do you want to begin a new attempt of this assessment?
-begin_assessment_msg_warn_tabs=To prevent issues, please use only one browser window and tab when taking this assessment and only take one assessment at a time.
+begin_assessment_msg_warn_tabs=To prevent issues, open only one assessment at a time. Opening multiple assessments or reviewing older assessments at the same time may cause issues with your current submission.
 
 submission_allowed_1=You can submit this assessment {0} time(s).
 submission_allowed_2=You can submit this assessment {0} more time(s).

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -507,6 +507,7 @@ begin_assessment_msg_latest=If multiple submissions are allowed, answers from pr
 begin_assessment_msg_average=If multiple submissions are allowed, your average score will be recorded.
 begin_assessment_msg_attempt_autosubmit_warn_average=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be averaged with all previous attempts to determine your overall assessment score.  Do you want to begin a new attempt of this assessment?
 begin_assessment_msg_attempt_autosubmit_warn_last=You have already submitted this assessment.  If you start another attempt it will be automatically submitted even if you do not answer all questions.  If you start a new attempt now, your score from this attempt will be recorded as your overall score for this assessment.  Do you want to begin a new attempt of this assessment?
+begin_assessment_msg_warn_tabs=To prevent issues, please use only one browser window and tab when taking this assessment and only take one assessment at a time.
 
 submission_allowed_1=You can submit this assessment {0} time(s).
 submission_allowed_2=You can submit this assessment {0} more time(s).

--- a/samigo/samigo-app/src/webapp/jsf/delivery/beginTakingAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/beginTakingAssessment.jsp
@@ -204,6 +204,10 @@
 </h:panelGrid>
 
  </div></div>
+
+ <h:panelGroup layout="block" styleClass="sak-banner-warn">
+	<h:outputText value="#{deliveryMessages.begin_assessment_msg_warn_tabs}" />
+ </h:panelGroup>
  
  <h:panelGroup layout="block" styleClass="honor-container" rendered="#{delivery.honorPledge && delivery.firstTimeTaking}">
 	<h:selectBooleanCheckbox id="honor_pledge" />


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47184

Students often attempt to take multiple quizzes in multiple tabs, all at the same time. This leads to data discrepancy errors. Students are not warned about the dangers of this practise, and therefore aren’t aware that their behaviour is causing the problem.

Add a warning on the begin assessment page explaining the potential danger of doing so.