### PR TITLE
SAK-47186 Assignments > ClassCastException in calcPageFromSubmission()

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4370,6 +4370,9 @@ public class AssignmentAction extends PagedResourceActionII {
 
         String submissionId = state.getAttribute(GRADE_SUBMISSION_SUBMISSION_ID).toString();
         List<SubmitterSubmission> subs = (List<SubmitterSubmission>) state.getAttribute(STATE_PAGEING_TOTAL_ITEMS);
+        if (!subs.isEmpty() && !(subs.get(0) instanceof SubmitterSubmission)) {
+            return 1;
+        }
         int subIndex = 0;
 
         for (int i = 0; i < subs.size(); ++i) {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47186

We’ve occasionally seen this in our logs:
Caused by: java.lang.ClassCastException: org.sakaiproject.assignment.api.model.Assignment cannot be cast to org.sakaiproject.assignment.tool.AssignmentAction$SubmitterSubmission
        at org.sakaiproject.assignment.tool.AssignmentAction.calcPageFromSubmission(AssignmentAction.java:3958)
        at org.sakaiproject.assignment.tool.AssignmentAction.doPrev_back_next_submission(AssignmentAction.java:3891)
        at org.sakaiproject.assignment.tool.AssignmentAction.doAssignment_form(AssignmentAction.java:10165)
        at org.sakaiproject.assignment.tool.AssignmentAction.doAssignment_form(AssignmentAction.java:10021)

I don’t know how to reproduce but I’m assuming it is still an issue since the code hasn’t changed. The problem is the state variable can contain different types of objects in the collection. The safe thing to do is just return the value 1 if the class doesn’t match the expected type.