### PR TITLE
SAK-47185 warn users of the consequences of locking resources

### DIFF
--- a/admin-tools/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
+++ b/admin-tools/src/java/org/sakaiproject/authz/tool/PermissionsHelperAction.java
@@ -95,6 +95,9 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 	/** State attribute for the description of what's being edited - users should set before starting. */
 	public static final String STATE_DESCRIPTION = "permission.description";
 
+	/** State attribute for the text content of the warning banner - if not set, banner is not displayed. */
+	public static final String STATE_WARNING = "permission.warning";
+
 	/** State attribute for the lock/ability string prefix to be presented / edited - users should set before starting. */
 	public static final String STATE_PREFIX = "permission.prefix";
 
@@ -212,6 +215,7 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 		String prefix = (String) toolSession.getAttribute(PermissionsHelper.PREFIX);
 		String targetRef = (String) toolSession.getAttribute(PermissionsHelper.TARGET_REF);
 		String description = (String) toolSession.getAttribute(PermissionsHelper.DESCRIPTION);
+		String warning = (String) toolSession.getAttribute(PermissionsHelper.WARNING);
 		Object rolesRef = toolSession.getAttribute(PermissionsHelper.ROLES_REF);
 		if (rolesRef == null) rolesRef = targetRef;
 
@@ -232,6 +236,9 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 
 		// ... with this description
 		state.setAttribute(STATE_DESCRIPTION, description);
+
+		// ... with this warning
+		state.setAttribute(STATE_WARNING, warning);
 
 		// ... showing only locks that are prpefixed with this
 		state.setAttribute(STATE_PREFIX, prefix);
@@ -492,6 +499,7 @@ public class PermissionsHelperAction extends VelocityPortletPaneledAction
 		context.put("realm", viewEdit != null ? viewEdit : edit);
 		context.put("prefix", prefix);
 		context.put("description", description);
+		context.put("warning", (String) state.getAttribute(STATE_WARNING));
 		if (roles.size() > 0)
 		{
 			context.put("roles", roles);

--- a/admin-tools/src/webapp/vm/authz-helper/chef_permissions.vm
+++ b/admin-tools/src/webapp/vm/authz-helper/chef_permissions.vm
@@ -14,6 +14,9 @@
 	<div class="instruction">
 		$formattedText.escapeHtml($!description)
 	</div>
+	#if ($!warning)
+		<div class="sak-banner-warn">$warning</div>
+	#end
 	## no need to show the drop down menu if there is no group defined for the site
 	<div class="navPanel">
 		#if ($!groups && $groups.size()>0)

--- a/content/content-bundles/resources/content.properties
+++ b/content/content-bundles/resources/content.properties
@@ -445,7 +445,7 @@ setpermis = Set permissions for resources in folder
 
 setpermis1 = Set permissions for resources in worksite 
 
-permissions.warning = Removing the "Read resources" permission may prevent other tools from functioning correctly, and taking it away from any role is not recommended.
+permissions.warning = Removing the "Read resources" permission will prevent the role from viewing or uploading files and may prevent other tools from functioning correctly. To hide specific files, use "Edit Details" in the Actions menu.
 
 sh.check        = Check box
 sh.close        = Close this folder

--- a/content/content-bundles/resources/content.properties
+++ b/content/content-bundles/resources/content.properties
@@ -445,6 +445,8 @@ setpermis = Set permissions for resources in folder
 
 setpermis1 = Set permissions for resources in worksite 
 
+permissions.warning = Removing the "Read resources" permission may prevent other tools from functioning correctly, and taking it away from any role is not recommended.
+
 sh.check        = Check box
 sh.close        = Close this folder
 sh.closed       = Closed folder

--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -7320,6 +7320,9 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 		state.setAttribute(PermissionsHelper.DESCRIPTION, rb.getString("setpermis1")
 				+ siteService.getSiteDisplay(ref.getContext()));
 
+		// ... with this warning
+		state.setAttribute(PermissionsHelper.WARNING, rb.getString("permissions.warning"));
+
 		// ... showing only locks that are prpefixed with this
 		state.setAttribute(PermissionsHelper.PREFIX, "content.");
 

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/PermissionsHelper.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/PermissionsHelper.java
@@ -34,6 +34,9 @@ public interface PermissionsHelper
 	/** Set this tool state attribute with descriptive text for the editor. */
 	static final String DESCRIPTION = "sakaiproject.permissions.description";
 
+	/** Set this tool state attribute for permissions warning banner */
+	public static final String WARNING = "sakaiproject.permissions.warning";
+
 	/** Set this tool state attribute to the entity reference of the entity whose AuthzGroup is to be edited. */
 	static final String TARGET_REF = "sakaiproject.permissions.targetRef";
 

--- a/site-manage/pageorder/tool/src/bundle/org/sakaiproject/tool/pageorder/bundle/Messages.properties
+++ b/site-manage/pageorder/tool/src/bundle/org/sakaiproject/tool/pageorder/bundle/Messages.properties
@@ -48,6 +48,8 @@ error_pageid=A valid 'page ID' is required
 welcome=Changes to tool order will take effect upon 'Save'. When deleting or editing a tool name, changes will take effect immediately. Click and move tool in list below, or use the keyboard to focus on the tool then use U or D keys.
 warning=Warning: Making tools invisible does not prevent access to the tool items through direct links. To prevent all access, lock the tool.
 
+warn_lockResources=Locking the Resources tool may prevent other tools from functioning correctly, and is not recommended.
+
 add_prompt=Revising site tools for {0} ...
 add_inst=Select the tools you would like added to your site.
 add_select-title=Select

--- a/site-manage/pageorder/tool/src/bundle/org/sakaiproject/tool/pageorder/bundle/Messages.properties
+++ b/site-manage/pageorder/tool/src/bundle/org/sakaiproject/tool/pageorder/bundle/Messages.properties
@@ -48,7 +48,7 @@ error_pageid=A valid 'page ID' is required
 welcome=Changes to tool order will take effect upon 'Save'. When deleting or editing a tool name, changes will take effect immediately. Click and move tool in list below, or use the keyboard to focus on the tool then use U or D keys.
 warning=Warning: Making tools invisible does not prevent access to the tool items through direct links. To prevent all access, lock the tool.
 
-warn_lockResources=Locking the Resources tool may prevent other tools from functioning correctly, and is not recommended.
+warn_lockResources=Locking the Resources tool may prevent other tools from functioning correctly.
 
 add_prompt=Revising site tools for {0} ...
 add_inst=Select the tools you would like added to your site.

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -126,7 +126,7 @@
 					<div class="sak-banner-warn" id="call-results">
 						<span rsf:id="msg=warning">Warning: Hiding tools does not prevent access to their items through links. If you want them inaccessible to students, you must configure them directly in the tool.</span>
 					</div>
-                    <div class="sak-banner-warn">
+					<div class="sak-banner-warn">
 						<span rsf:id="msg=warn_lockResources">Locking the Resources tool may prevent other tools from functioning correctly, and is not recommended.</span>
 					</div>
 				</div>

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -126,6 +126,9 @@
 					<div class="sak-banner-warn" id="call-results">
 						<span rsf:id="msg=warning">Warning: Hiding tools does not prevent access to their items through links. If you want them inaccessible to students, you must configure them directly in the tool.</span>
 					</div>
+                    <div class="sak-banner-warn">
+						<span rsf:id="msg=warn_lockResources">Locking the Resources tool may prevent other tools from functioning correctly, and is not recommended.</span>
+					</div>
 				</div>
 				<p class="act">
 					<input accesskey ="s" class="active" rsf:id="save" value="Save" type="submit" onclick="SPNR.disableControlsAndSpin( this, null ); serialize('reorder-list');"/>

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -127,7 +127,7 @@
 						<span rsf:id="msg=warning">Warning: Hiding tools does not prevent access to their items through links. If you want them inaccessible to students, you must configure them directly in the tool.</span>
 					</div>
 					<div class="sak-banner-warn">
-						<span rsf:id="msg=warn_lockResources">Locking the Resources tool may prevent other tools from functioning correctly, and is not recommended.</span>
+						<span rsf:id="msg=warn_lockResources">Locking the Resources tool may prevent other tools from functioning correctly.</span>
 					</div>
 				</div>
 				<p class="act">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47185

We know instructors like to remove content.read permissions thinking it will secure all their secret exam files from students in one click. What they don't realize is that doing this breaks other tools.

Locking Resources in Site Info > Tool Order is another way instructors can inadvertently cause issues in other tools, as this takes away the "Resource resources" permission.

They should be warned of the consequences of this action in both locations.

The linked PR introduces a new function for the permissions widget: if you supply `permissionWarning` in the state context, the permission widget will render this message inside a `sak-banner-warn`, so that this can be utilized in all tools generically. If no warning is supplied, the banner is not displayed.