### PR TITLE
SAK-47145 Profile: Status section fixes & A11y improvements

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/profile2/_profile2.scss
+++ b/library/src/morpheus-master/sass/modules/tool/profile2/_profile2.scss
@@ -91,7 +91,19 @@
 
 	/* generic styles */
 	.tiny {
-		font-size: 70%;
+		font-size: 80%;
+	}
+
+	button.tiny {
+		padding: 1px 4px;
+		margin-bottom: 4px;
+	}
+
+	.status-divider {
+		span:first-child {
+			padding-right: 4px;
+			border-right: 1px solid #000;
+		}
 	}
 
 	.right {

--- a/profile2/api/src/resources/ProfileApplication.properties
+++ b/profile2/api/src/resources/ProfileApplication.properties
@@ -237,6 +237,7 @@ heading.social                    = Social Networking
 heading.social.edit               = Social Networking
 heading.staff                     = Staff Information
 heading.staff.edit                = Staff Information
+heading.status                    = Status
 heading.student                   = Student Information
 heading.student.edit              = Student Information
 heading.widget.my.friends         = My connections

--- a/profile2/api/src/resources/ProfileApplication_es.properties
+++ b/profile2/api/src/resources/ProfileApplication_es.properties
@@ -237,6 +237,7 @@ heading.social=Redes sociales
 heading.social.edit=Redes sociales
 heading.staff=Informaci\u00f3n institucional
 heading.staff.edit=Informaci\u00f3n institucional
+heading.status=Estado
 heading.student=Informaci\u00f3n de estudiante
 heading.student.edit=Informaci\u00f3n de estudiante
 heading.widget.my.friends=Mis contactos

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/components/ProfileStatusRenderer.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/components/ProfileStatusRenderer.java
@@ -15,6 +15,7 @@
  */
 package org.sakaiproject.profile2.tool.components;
 
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.basic.Label;
@@ -45,7 +46,7 @@ public class ProfileStatusRenderer extends Panel {
 	private String msgClass;
 	private String dateClass;
 	
-	private boolean hasStatusSet = false;
+	@Setter private boolean hasStatusSet = false;
 	
 	@SpringBean(name="org.sakaiproject.profile2.logic.ProfilePrivacyLogic")
 	private ProfilePrivacyLogic privacyLogic;

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStatusPanel.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStatusPanel.html
@@ -29,71 +29,67 @@
 	
     <div id="profileHeading">
     	<span id="profileHeadingName" wicket:id="profileName">[profileName]</span>&nbsp;
-    	<span wicket:id="status" class="status-msg">[status here]</span>
-    	<a wicket:id="clearLink" class="tiny" wicket:message="title:accessibility.profile.status.clear">
+    	<span wicket:id="status" class="status-msg status-divider">[status here]</span>		
+    	<button wicket:id="clearBtn" class="tiny">
 			<span wicket:id="clearLabel">[clearLabel]</span>
-    	</a>
+    	</button>
     </div>
     <div wicket:id="statusFormContainer" class="panel panel-default">
     	<form wicket:id="form" class="panel-content panel-profile-message">
-			<label for="messageinput" class="accessibility-label">
-				<wicket:message key="accessibility.profile.status.input">Enter your current status</wicket:message>
+			<label for="messageinput">
+				<wicket:message key="heading.status">Status</wicket:message>
 			</label>
-			<input type="text" wicket:id="message" class="form-control" wicket:message="title:text.no.status"/>
-                        <div class="profileSayItActionBar">
-                            <p class="act">
-                                <input type="submit" class="active" wicket:id="submit" value="Say it" />
-                            </p>
-                            <span id="tracker" class="text-counter"></span>
-                        </div>
+			<input type="text" wicket:id="message" class="form-control"/>
+				<div class="profileSayItActionBar">
+					<p class="act">
+						<input type="submit" class="active" wicket:id="submit" value="Say it" />
+					</p>
+					<span id="tracker" class="text-counter"></span>
+				</div>
 		</form>
     </div>
     
     
-	<script type="text/javascript">
+	<script>
 
-		//the complementary function for autoFill is dynamically added in the Class
-		function autoFill(id, v){
-			$(id).css({ color: "#5D5D5D" }).attr({ value: v }).focus(function(){
-				if($(this).val()==v){
-					$(this).val("").css({ color: "#000000" });
-					$("#tracker").show();
-				} 
-			}).blur(function(){
-				if($(this).val()==""){
-					$(this).css({ color: "#5D5D5D" }).val(v);
-					$("#tracker").hide();
-				}
-			});
+		let statusInput = document.getElementById('messageinput');
+		const message = statusInput.getAttribute('placeholder');
+		let tracker = document.getElementById('tracker');
 
-		}
+		statusInput.addEventListener('focus', function() {
+			// remove placeholder on focus 
+			statusInput.removeAttribute('placeholder');
 
-		//character counter
-		function countChars(id) {
-			$("#tracker").hide();
-			
-			$(id).apTextCounter({
-				maxCharacters: 140,
-				direction: 'down',
-				tracker: '#tracker',
-				onTrackerUpdated: function(msg) {
-					if (msg.count <= 10) {
-						$(msg.config.tracker).css("color", "red");
-					} else if (msg.count <= 20) {
-						$(msg.config.tracker).css("color", "maroon");
-					} else {
-						$(msg.config.tracker).css("color", "#999999");
+			// show character counter
+			tracker.style.display = "block";
+			if(statusInput.value<1){
+				$(this).apTextCounter({
+					maxCharacters: 140,
+					direction: 'down',
+					tracker: '#tracker',
+					onTrackerUpdated: function(msg) {
+						if (msg.count <= 10) {
+							$(msg.config.tracker).css("color", "red");
+						} else if (msg.count <= 20) {
+							$(msg.config.tracker).css("color", "maroon");
+						} else {
+							$(msg.config.tracker).css("color", "#999999");
+						}
 					}
-				}
-			});
-		}
+				});
+			}
+		});
+		statusInput.addEventListener('blur', function() {
+			statusInput.setAttribute('placeholder', message);
+
+			if(statusInput.value<1){
+				tracker.style.display = "none";
+			}
+		});
 
 	</script>
-	
 
-</wicket:panel>
-	
-	
+</wicket:panel>	
+
 </body>
 </html>
-


### PR DESCRIPTION
Jira: [SAK-47145](https://sakaiproject.atlassian.net/browse/SAK-47145)

Fixes
- `placeholder` and `char counter` weren't showing until a status was submitted.
  now they are completely managed from the script, and a proper placeholder in beeing used.
- After refreshing the page, the "Clear status" link wasn't working (till reloading again).

Accessibility
- Added a "Status" header and aria-labels.
- Clear link is now a button, improved text readability.

