### PR TITLE
SAK-47190 Assignments > Success banners do not display when sending feedback to multiple students

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4751,6 +4751,20 @@ public class AssignmentAction extends PagedResourceActionII {
             state.removeAttribute(STATE_DOWNLOAD_URL);
         }
 
+        // show "feedback saved" success messages if appropriate
+        if (state.getAttribute(SAVED_FEEDBACK) != null) {
+            context.put("savedFeedback", Boolean.TRUE);
+            state.removeAttribute(SAVED_FEEDBACK);
+        }
+        if (state.getAttribute(OW_FEEDBACK) != null) {
+            context.put("overwriteFeedback", Boolean.TRUE);
+            state.removeAttribute(OW_FEEDBACK);
+        }
+        if (state.getAttribute(RETURNED_FEEDBACK) != null) {
+            context.put("returnedFeedback", Boolean.TRUE);
+            state.removeAttribute(RETURNED_FEEDBACK);
+        }
+
         String template = (String) getContext(data).get("template");
 
         return template + TEMPLATE_INSTRUCTOR_GRADE_ASSIGNMENT;

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -161,17 +161,17 @@ function printView(url) {
 				</p>
 				#if ($!savedFeedback)
 					#if ($!overwriteFeedback)
-						<div class="success">
+						<div class="sak-banner-success">
 							$!tlang.getString("sendFeedback.savedow")
 						</div>
 					#else
-						<div class="success">
+						<div class="sak-banner-success">
 							$!tlang.getString("sendFeedback.saved")
 						</div>
 					#end
 				#end
 				#if ($!returnedFeedback)
-					<div class="success">
+					<div class="sak-banner-success">
 						$!tlang.getString("sendFeedback.returned")
 					</div>
 				#end


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47190

Assignments has success messages that should be displayed when sending feedback to multiple students. At some point after Sakai 11 these went missing, even though the markup for them remains in the Velocity templates. The messages need to be added back into the Velocity context.