### PR TITLE
SAK-47198 Worksite Setup > Edit Site > Some tabs show data from Home site rather than selected site

### DIFF
--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
@@ -21,6 +21,9 @@ import org.json.simple.JSONArray;
 import org.sakaiproject.datemanager.api.model.DateManagerValidation;
 
 public interface DateManagerService {
+
+	public final String STATE_SITE_ID = "site.instance.id";
+
 	// Global methods
 	public String getCurrentUserId();
 	public String getCurrentSiteId();

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -85,6 +85,7 @@ import org.sakaiproject.util.api.FormattedText;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.tool.api.ToolSession;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentFeedbackIfc;
 
 @Slf4j
@@ -118,12 +119,22 @@ public class DateManagerServiceImpl implements DateManagerService {
 		setPubAssessmentServiceQueries(assessmentPersistenceService.getPublishedAssessmentFacadeQueries());
 	}
 
+	private String getCurrentToolSessionAttribute(String name) {
+		ToolSession session = sessionManager.getCurrentToolSession();
+		return session != null ? session.getAttribute(name).toString() : "";
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public String getCurrentSiteId() {
-		return toolManager.getCurrentPlacement().getContext();
+		String siteID = getCurrentToolSessionAttribute(STATE_SITE_ID);
+		if (StringUtils.isEmpty(siteID)) {
+			siteID = toolManager.getCurrentPlacement().getContext();
+		}
+
+		return siteID;
 	}
 
 	/**

--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/service/SakaiService.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/service/SakaiService.java
@@ -76,8 +76,20 @@ public class SakaiService  {
     @Inject
     private UserDirectoryService userDirectoryService;
 
+    private final String STATE_SITE_ID = "site.instance.id";
+
     public Optional<Site> getCurrentSite() {
-        String siteId = toolManager.getCurrentPlacement().getContext();
+        String siteId;
+
+        // Try to get site ID from session context first
+        try {
+            siteId = sessionManager.getCurrentToolSession().getAttribute(STATE_SITE_ID).toString();
+        } catch (NullPointerException ex) {
+            // Site ID wasn't set in the helper call, get the current site ID
+            log.debug("Site ID not found in session data");
+            siteId = toolManager.getCurrentPlacement().getContext();
+        }
+
         try {
             return Optional.of(siteService.getSite(siteId));
         } catch (Exception ex) {

--- a/userauditservice/tool/src/java/org/sakaiproject/userauditservice/tool/UserAuditEventLog.java
+++ b/userauditservice/tool/src/java/org/sakaiproject/userauditservice/tool/UserAuditEventLog.java
@@ -44,6 +44,7 @@ import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.db.api.SqlService;
 import org.sakaiproject.jsf2.util.LocaleUtil;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.userauditservice.api.UserAuditRegistration;
 import org.sakaiproject.userauditservice.api.UserAuditService;
@@ -69,8 +70,10 @@ public class UserAuditEventLog {
 	private transient UserAuditService userAuditService = (UserAuditService) ComponentManager.get(UserAuditService.class.getName());
 	private transient SiteService siteService = (SiteService) ComponentManager.get(SiteService.class.getName());
 	private transient ToolManager toolManager = (ToolManager) ComponentManager.get(ToolManager.class.getName());
+	private transient SessionManager sessionManager = (SessionManager) ComponentManager.get(SessionManager.class.getName());
 
 	private ResourceLoader rb = new ResourceLoader("UserAuditMessages");
+	private final String STATE_SITE_ID = "site.instance.id";
 	
 	static {
 
@@ -229,7 +232,12 @@ public class UserAuditEventLog {
 			Connection conn = null;
 			PreparedStatement statement = null;
 			ResultSet result = null;
-			String siteId = toolManager.getCurrentPlacement().getContext();
+			String siteId;
+			try {
+				siteId = sessionManager.getCurrentToolSession().getAttribute(STATE_SITE_ID).toString();
+			} catch (Exception ex) {
+				siteId = toolManager.getCurrentPlacement().getContext();
+			}
 			try
 			{
 				conn = sqlService.borrowConnection();


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47198

When editing a site from Worksite Setup, if you go to some tabs you will not see the data from the site you selected to edit, but rather from the user’s home site (which likely contains no data, or very little data, and certainly not the data from the site the user selected to edit).

This appears to be a regression introduced when certain aspects (tabs) of Site Info were rewritten from RSF to a newer framework, or a new tool was introduced. The affected tabs include:

* Manage Groups
* Date Manager
* User Audit Log