### PR TITLE
SAK-47200 Site Info > Manage Groups > all buttons lack spinners

### DIFF
--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -49,7 +49,7 @@ SPNR.insertSpinnerAfter = function( clickedElement, escapeList, overrideSpinnerL
     SPNR.disableControlsAndSpin( clickedElement, escapeList );
 
     // Create the spinner graphic in a div
-    var spinner = document.createElement( "div" );
+    const spinner = document.createElement( "div" );
     spinner.className = "spinPlaceholder";
 
     // If an override location for the spinner is desired, append it as a child...
@@ -62,7 +62,7 @@ SPNR.insertSpinnerAfter = function( clickedElement, escapeList, overrideSpinnerL
     // Otherwise, insert the spinner div as a sibling to the element being interacted with
     else
     {
-        var parent = clickedElement.parentNode;
+        const parent = clickedElement.parentNode;
         parent.insertBefore( spinner, clickedElement.nextSibling );
     }
 };
@@ -87,7 +87,7 @@ SPNR.insertSpinnerAfter = function( clickedElement, escapeList, overrideSpinnerL
 SPNR.insertSpinnerInPreallocated = function( clickedElement, escapeList, allocatedID )
 {
     // Get the pre-allocated div for the spinner
-    var div = document.getElementById( allocatedID );
+    const div = document.getElementById( allocatedID );
     if( div !== null )
     {
         // Clone and disable all controls, passing the escape list
@@ -121,6 +121,9 @@ SPNR.disableControlsAndSpin = function( clickedElement, escapeList )
         escapeList = [];
     }
 
+    // We want to disable buttons first, because when we clone inputs we make them buttons so the original inputs are still submitted with the form
+    // (disabled inputs do not have their values sent to server on form submission)
+    SPNR.disableButtons( clickedElement, escapeList );
     SPNR.disableInputs( clickedElement, escapeList );
     SPNR.disableLinkPointers( escapeList );
     SPNR.disableSelects( clickedElement, escapeList );
@@ -139,7 +142,7 @@ SPNR.disableControlsAndSpin = function( clickedElement, escapeList )
 SPNR.disableLinkPointers = function( escapeList )
 {
     // Remove cursor pointers for all links (rendering them unclickable)
-    var links = document.getElementsByTagName( "a" );
+    const links = document.getElementsByTagName( "a" );
     for( i = 0; i < links.length; i++ )
     {
         // Remove the pointer if it's not in the escape list
@@ -165,7 +168,7 @@ SPNR.disableLinkPointers = function( escapeList )
 SPNR.disableInputs = function( clickedElement, escapeList )
 {
     // Get all the input elements, separate into lists by type
-    var allInputs = SPNR.nodeListToArray( document.getElementsByTagName( "input" ) );
+    const allInputs = SPNR.nodeListToArray( document.getElementsByTagName( "input" ) );
     for( i = 0; i < allInputs.length; i++ )
     {
         if( (allInputs[i].type === "submit" || allInputs[i].type === "button" || allInputs[i].type === "checkbox" || allInputs[i].type === "radio") 
@@ -189,6 +192,31 @@ SPNR.disableInputs = function( clickedElement, escapeList )
 };
 
 /**
+ * This function will 'disable' all button elements. The element that's being interacted with is passed
+ * into the function, and a spinner will be overlayed on top of the element.
+ *
+ * If no escapes are needed, pass in null for the escapeList parameter.
+ *
+ * @param {DOM Element} clickedElement - the element being interacted with
+ * @param {Array[String]} escapeList - array of IDs you do not wish to be disabled
+ */
+SPNR.disableButtons = function( clickedElement, escapeList )
+{
+    // Get all the button elements
+    const buttons = SPNR.nodeListToArray( document.getElementsByTagName( "button" ) );
+    for( i = 0; i < buttons.length; i++ )
+    {
+        // Only disable if the button is not in the escape list
+        if( escapeList.indexOf( buttons[i].id ) === -1 )
+        {
+            // If this is the clicked button, activate the spinner on it; otherwise just disable the button
+            const activateSpinner = buttons[i] === clickedElement ? true : false;
+            SPNR.disableElementAndSpin( "", buttons[i], activateSpinner );
+        }
+    }
+};
+
+/**
  * This function clones and disables all 'select' elements on the page.
  * 
  * @param {DOM Element} clickedElement - the element being interacted with
@@ -197,20 +225,20 @@ SPNR.disableInputs = function( clickedElement, escapeList )
 SPNR.disableSelects = function( clickedElement, escapeList )
 {
     // Clone and disable all drop downs (disable the clone, hide the original)
-    var dropDowns = SPNR.nodeListToArray( document.getElementsByTagName( "select" ) );
+    const dropDowns = SPNR.nodeListToArray( document.getElementsByTagName( "select" ) );
     for( i = 0; i < dropDowns.length; i++ )
     {
         // Only clone/disable if it's not in the escape list
         if( escapeList.indexOf( dropDowns[i].id ) === -1 )
         {
             // Hide the original drop down
-            var select = dropDowns[i];
+            const select = dropDowns[i];
             select.style.display = "none";
 
             // Create the cloned element and disable it
-            var newSelect = document.createElement( "select" );
-            var oldId = select.getAttribute( "id" );
-            var newId = (oldId !== null) ? oldId : Math.random().toString(36).substring(2, 15);
+            const newSelect = document.createElement( "select" );
+            const oldId = select.getAttribute( "id" );
+            let newId = (oldId !== null) ? oldId : Math.random().toString(36).substring(2, 15);
             newSelect.setAttribute( "id", newId + "Disabled" );
             newSelect.setAttribute( "name", select.getAttribute( "name" ) + "Disabled" );
             newSelect.setAttribute( "className", select.getAttribute( "className" ) );
@@ -223,7 +251,7 @@ SPNR.disableSelects = function( clickedElement, escapeList )
             if (select === clickedElement)
             {
                 // wrap it
-                var wrapper = document.createElement("span");
+                const wrapper = document.createElement("span");
                 wrapper.className = "spinSelect";
                 wrapper.appendChild(newSelect);
                 // transfer any margins from the original select to the wrapper
@@ -249,7 +277,7 @@ SPNR.disableSelects = function( clickedElement, escapeList )
  */
 SPNR.disableTextAreas = function( escapeList )
 {
-    var allAreas = SPNR.nodeListToArray( document.getElementsByTagName( "textarea" ) );
+    const allAreas = SPNR.nodeListToArray( document.getElementsByTagName( "textarea" ) );
     for( i = 0; i < allAreas.length; ++i )
     {
         if( escapeList.indexOf( allAreas[i].id ) === -1 )
@@ -270,7 +298,7 @@ SPNR.disableTextAreas = function( escapeList )
  */
 SPNR.nodeListToArray = function( nodeList )
 {
-    var array = [];
+    let array = [];
     for( var i = nodeList.length >>> 0; i--; )
     {
         array[i] = nodeList[i];
@@ -291,11 +319,11 @@ SPNR.nodeListToArray = function( nodeList )
 SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
 {
     // First set the button to be invisible
-    var origDisplay = element.style.display;
+    const origDisplay = element.style.display;
     element.style.display = "none";
 
     // Now create a new disabled button with the same attributes as the existing button
-    var newElement;
+    let newElement;
     if( element.type === "submit" || element.type === "button" )
     {
         newElement = document.createElement( "button" );
@@ -306,8 +334,8 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
         newElement.setAttribute( "type", element.type );
     }
 
-    var oldId = element.getAttribute( "id" );
-    var newId = (oldId !== null) ? oldId : Math.random().toString(36).substring(2, 15);
+    const oldId = element.getAttribute( "id" );
+    let newId = (oldId !== null) ? oldId : Math.random().toString(36).substring(2, 15);
     newElement.setAttribute( "id", newId + "Disabled" );
     newElement.setAttribute( "name", element.getAttribute( "name" ) + "Disabled" );
     newElement.setAttribute( "value", element.getAttribute( "value" ) );
@@ -320,18 +348,22 @@ SPNR.disableElementAndSpin = function( divID, element, activateSpinner )
     }
     else
     {
-        newElement.textContent = element.getAttribute( "value" );
+        // <input>                --> localName = "input", nodeName="INPUT", tagName="INPUT", type="text"
+        // <input type="submit">  --> localName = "input", nodeName="INPUT", tagName="INPUT", type="submit"
+        // <button>               --> localName = "button", nodeName="button", tagName="BUTTON", type="submit"
+        // <button type="button"> --> localName = "button", nodeName="button", tagName="BUTTON", type="button"
+        element.tagName === "BUTTON" ? newElement.innerHTML = element.innerHTML : newElement.textContent = element.getAttribute( "value" );
         newElement.className = activateSpinner ? "spinButton formButtonDisabled" : "formButtonDisabled";
     }
 
     if( "" !== divID )
     {
-        var div = document.getElementById( divID ); 
+        const div = document.getElementById( divID );
         div.insertBefore( newElement, element );
     }
     else
     {
-        var parent = element.parentNode;
+        const parent = element.parentNode;
         parent.insertBefore( newElement, element );
     }
 };

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step1.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step1.html
@@ -36,8 +36,8 @@
             </tbody>
             </table>
             <div class="act">
-              <input accesskey="x" type="submit" class="active" id="autogroups-continue-button" th:value="#{autogroups.button.continue}" onclick="SPNR.disableControlsAndSpin( this, null );">
-              <a th:href="@{/}" accesskey="x" id="autogroups-cancel-button" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</a>
+              <input accesskey="x" type="submit" class="active" id="autogroups-continue-button" th:value="#{autogroups.button.continue}" />
+              <button type="button" th:data-url="@{/}" accesskey="x" id="autogroups-cancel-button" th:text="#{autogroups.button.cancel}">Cancel</button>
             </div>
           </form>
       </div>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step2.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step2.html
@@ -31,12 +31,12 @@
       <div class="col-sm-8">
         <form id="autogroups-wizard-step2-form" class="autogroups-wizard-form" th:action="@{/autogroups/submitStep2}" th:object="${autoGroupsForm}" method="post">
           <input type="hidden" name="wizardAction" id="wizardAction" value=""/>
-          <input type="hidden" th:field="*{selectedRoleList}" name="selectedRoleList">
+          <input type="hidden" th:field="*{selectedRoleList}" name="selectedRoleList"/>
           <div class="radio">
-            <label for="sectionOptionDontUseSections"><input id="sectionOptionDontUseSections" type="radio" name="sectionOption" checked value="0" th:field="*{sectionsOption}"><span th:utext="#{autogroups.step2.no.section}">No - (Include all site participants, regardless of section/roster, who fit the role(s) selected in Step 1)</span></label>
+            <label for="sectionOptionDontUseSections"><input id="sectionOptionDontUseSections" type="radio" name="sectionOption" checked="checked" value="0" th:field="*{sectionsOption}"><span th:utext="#{autogroups.step2.no.section}">No - (Include all site participants, regardless of section/roster, who fit the role(s) selected in Step 1)</span></label>
           </div>
           <div class="radio" th:if="${!sectionList.isEmpty()}">
-            <label for="sectionOptionUseSections"><input id="sectionOptionUseSections" type="radio" name="sectionOption" value="1" th:field="*{sectionsOption}"><span th:utext="#{autogroups.step2.choose.section}">Yes - (Select members from specific section/rosters, who fit the role(s) selected in Step 1)</span></label>
+            <label for="sectionOptionUseSections"><input id="sectionOptionUseSections" type="radio" name="sectionOption" value="1" th:field="*{sectionsOption}"/><span th:utext="#{autogroups.step2.choose.section}">Yes - (Select members from specific section/rosters, who fit the role(s) selected in Step 1)</span></label>
           </div>
           <div id="selectSectionDiv" class="selectSectionDiv" th:if="${!sectionList.isEmpty()}" th:style="${autoGroupsForm.sectionsOption == 0 ? 'display:none' : 'display:block'}">
             <p th:text="#{autogroups.step2.info2}">Which section(s)/roster(s) should be included in the groups?</p>
@@ -60,9 +60,9 @@
             </table>
           </div>
           <div class="act">
-            <input accesskey="c" type="submit" class="active" id="autogroups-continue-button" th:value="#{autogroups.button.continue}" onclick="SPNR.disableControlsAndSpin( this, null );">
-            <a accesskey="b" id="autogroups-back-button" class="btn btn-default" th:text="#{autogroups.button.back}">Back</a>&nbsp;
-            <a th:href="@{/}" accesskey="x" id="autogroups-cancel-button" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</a>
+            <input accesskey="c" type="submit" class="active" id="autogroups-continue-button" th:value="#{autogroups.button.continue}" />
+            <button type="button" accesskey="b" id="autogroups-back-button" th:text="#{autogroups.button.back}">Back</button>
+            <button type="button" th:data-url="@{/}" accesskey="x" id="autogroups-cancel-button" cth:text="#{autogroups.button.cancel}">Cancel</button>
           </div>
         </form>
       </div>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step3.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step3.html
@@ -31,17 +31,17 @@
       <div class="col-sm-8">
         <form id="autogroups-wizard-step3-form" class="autogroups-wizard-form" th:action="@{/autogroups/submitStep3}" th:object="${autoGroupsForm}" method="post">
           <input type="hidden" name="wizardAction" id="wizardAction" value=""/>
-          <input type="hidden" th:field="*{selectedRoleList}" name="selectedRoleList">
-          <input type="hidden" th:field="*{selectedSectionList}" name="selectedSectionList">
-          <input type="hidden" th:field="*{sectionsOption}" name="sectionsOption">
-          <input type="hidden" th:field="*{useManuallyAddedUsers}" name="useManuallyAddedUsers">
+          <input type="hidden" th:field="*{selectedRoleList}" name="selectedRoleList"/>
+          <input type="hidden" th:field="*{selectedSectionList}" name="selectedSectionList"/>
+          <input type="hidden" th:field="*{sectionsOption}" name="sectionsOption"/>
+          <input type="hidden" th:field="*{useManuallyAddedUsers}" name="useManuallyAddedUsers"/>
           <div class="radio">
-            <label for="pureConfiguration"><input id="mixtureConfiguration" type="radio" name="structureConfigurationOption" checked value="0" th:field="*{structureConfigurationOption}"><span th:text="#{autogroups.step3.option.mixture}">Create groups containing a random mixture of users with the role XX, YY and ZZ </label>
+            <label for="pureConfiguration"><input id="pureConfiguration" type="radio" name="structureConfigurationOption" checked="checked" value="0" th:field="*{structureConfigurationOption}"/><span th:text="#{autogroups.step3.option.mixture}">Create groups containing a random mixture of users with the role XX, YY and ZZ</span></label>
           </div>
           <div id="mixtureStructureOptions" class="col-sm-offset-1" th:style="${autoGroupsForm.structureConfigurationOption == 1 ? 'display:none': 'display:block'}">
             <div id="splitByGroups" th:class="${autoGroupsForm.splitOptions == 0 ? 'optGroupSelect optGroupSelectSelected' : 'optGroupSelect'}">
               <div class="radio">
-                <label for="splitByGroup"><input id="splitByGroup" type="radio" name="splitOptions" checked value="0" th:field="*{splitOptions}"><span th:text="#{autogroups.step3.split.by.groups}">Split by number of groups needed</label>
+                <label for="splitByGroup"><input id="splitByGroup" type="radio" name="splitOptions" checked="checked" value="0" th:field="*{splitOptions}"/><span th:text="#{autogroups.step3.split.by.groups}">Split by number of groups needed</span></label>
               </div>
               <div id="splitByGroupsOptions" th:style="${autoGroupsForm.splitOptions == 0 ? 'display:block' : 'display:none'}">
                 <div th:if="${autoGroupsForm.splitOptions == 0 && splitOptionsError != null}" class="sak-banner-error" th:text="${splitOptionsError}">Error message.</div>
@@ -79,8 +79,8 @@
           </div>
           <div class="act">
             <input accesskey="c" type="submit" class="active" id="autogroups-continue-button" th:value="#{autogroups.button.continue}">
-            <a accesskey="b" id="autogroups-back-button" class="btn btn-default" th:text="#{autogroups.button.back}">Back</a>&nbsp;
-            <a th:href="@{/}" accesskey="x" id="autogroups-cancel-button" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</a>
+            <button type="button" accesskey="b" id="autogroups-back-button" class="btn btn-default" th:text="#{autogroups.button.back}">Back</button>
+            <button type="button" th:data-url="@{/}" accesskey="x" id="autogroups-cancel-button" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</button>
           </div>
         </form>
       </div>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step4.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step4.html
@@ -17,24 +17,24 @@
       <div class="col-sm-8">
         <form id="autogroups-wizard-step4-form" class="autogroups-wizard-form" th:action="@{/autogroups/confirmAutoGroups}" th:object="${autoGroupsForm}" method="post">
           <input type="hidden" name="wizardAction" id="wizardAction" value=""/>
-          <input type="hidden" th:field="*{selectedRoleList}" name="selectedRoleList">
-          <input type="hidden" th:field="*{selectedSectionList}" name="selectedSectionList">
-          <input type="hidden" th:field="*{sectionsOption}" name="sectionsOption">
-          <input type="hidden" th:field="*{splitOptions}" name="splitOptions">
-          <input type="hidden" th:field="*{structureConfigurationOption}" name="structureConfigurationOption">
-          <input type="hidden" th:field="*{groupTitleByGroup}" name="sgroupTitleByGroup">
-          <input type="hidden" th:field="*{groupNumberByGroup}" name="groupNumberByGroup">
-          <input type="hidden" th:field="*{groupTitleByUser}" name="sgroupTitleByUser">
-          <input type="hidden" th:field="*{groupNumberByUser}" name="groupNumberByUser">
-          <input type="hidden" th:field="*{useManuallyAddedUsers}" name="useManuallyAddedUsers">
-          <input type="hidden" th:value="${serializedAutoGroupsMap}" name="serializedAutoGroupsMap">
+          <input type="hidden" th:field="*{selectedRoleList}" name="selectedRoleList"/>
+          <input type="hidden" th:field="*{selectedSectionList}" name="selectedSectionList"/>
+          <input type="hidden" th:field="*{sectionsOption}" name="sectionsOption"/>
+          <input type="hidden" th:field="*{splitOptions}" name="splitOptions"/>
+          <input type="hidden" th:field="*{structureConfigurationOption}" name="structureConfigurationOption"/>
+          <input type="hidden" th:field="*{groupTitleByGroup}" name="sgroupTitleByGroup"/>
+          <input type="hidden" th:field="*{groupNumberByGroup}" name="groupNumberByGroup"/>
+          <input type="hidden" th:field="*{groupTitleByUser}" name="sgroupTitleByUser"/>
+          <input type="hidden" th:field="*{groupNumberByUser}" name="groupNumberByUser"/>
+          <input type="hidden" th:field="*{useManuallyAddedUsers}" name="useManuallyAddedUsers"/>
+          <input type="hidden" th:value="${serializedAutoGroupsMap}" name="serializedAutoGroupsMap"/>
           <div class="form-row">
-            <label for="allowViewMembership"><input id="allowViewMembership" type="checkbox" name="allowViewMembership" th:field="*{allowViewMembership}"><span th:text="#{autogroups.step4.allow.membership}">Allow members to see who else is in their Group.</span></label>
+            <label for="allowViewMembership"><input id="allowViewMembership" type="checkbox" name="allowViewMembership" th:field="*{allowViewMembership}"/><span th:text="#{autogroups.step4.allow.membership}">Allow members to see who else is in their Group.</span></label>
           </div>
           <div class="act">
-            <input accesskey="c" type="submit" class="active" id="autogroups-creategroups-button-top" th:value="#{autogroups.button.create}" onclick="SPNR.disableControlsAndSpin( this, null );">
-            <a accesskey="b" id="autogroups-back-button-top" class="btn btn-default" th:text="#{autogroups.button.back}">Back</a>&nbsp;
-            <a th:href="@{/}" accesskey="x" id="autogroups-cancel-button-top" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</a>&nbsp;
+            <input accesskey="c" type="submit" class="active" id="autogroups-creategroups-button-top" th:value="#{autogroups.button.create}" />
+            <button type="button" accesskey="b" id="autogroups-back-button-top" class="btn btn-default" th:text="#{autogroups.button.back}">Back</button>
+            <button type="button" th:data-url="@{/}" accesskey="x" id="autogroups-cancel-button-top" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</button>
            </div>
            <div th:each="autoGroup : ${autoGroupsMap.entrySet()}">
              <h3 th:text="#{autogroups.step4.group.label(${autoGroup.key}, ${autoGroup.value.size()})}">Group title (X Members)</h3>
@@ -59,9 +59,9 @@
               </table>
           </div>
           <div class="act">
-            <input accesskey="c" type="submit" class="active" id="autogroups-creategroups-button" th:value="#{autogroups.button.create}" onclick="SPNR.disableControlsAndSpin( this, null );">
-            <a accesskey="b" id="autogroups-back-button" class="btn btn-default" th:text="#{autogroups.button.back}">Back</a>&nbsp;
-            <a th:href="@{/}" accesskey="x" id="autogroups-cancel-button" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</a>
+            <input accesskey="c" type="submit" class="active" id="autogroups-creategroups-button" th:value="#{autogroups.button.create}" />
+            <button type="button" accesskey="b" id="autogroups-back-button" class="btn btn-default" th:text="#{autogroups.button.back}">Back</button>
+            <button type="button" th:data-url="@{/}" accesskey="x" id="autogroups-cancel-button" class="btn btn-default" th:text="#{autogroups.button.cancel}">Cancel</button>
           </div>
         </form>
       </div>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/javascript.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/javascript.html
@@ -15,6 +15,39 @@
   };
   /*]]>*/
 </script>
+<script th:fragment="importJs" th:inline="javascript">
+    /*<![CDATA[*/
+    $(document).ready(function() {
+        // Button spinners
+        const bulkCreateButton = document.getElementById("bulk-creation-submit-button");
+        bulkCreateButton && bulkCreateButton.addEventListener("click", e => {
+            SPNR.disableControlsAndSpin(bulkCreateButton, null);
+        });
+        const bulkCreateCancelButton = document.getElementById("bulk-creation-cancel-button");
+        bulkCreateCancelButton && bulkCreateCancelButton.addEventListener("click", e => {
+            SPNR.disableControlsAndSpin(bulkCreateCancelButton, null);
+            window.location.href = bulkCreateCancelButton.getAttribute('data-url');
+        });
+    });
+    /*]]>*/
+</script>
+<script th:fragment="importConfirmJs" th:inline="javascript">
+    /*<![CDATA[*/
+    $(document).ready(function() {
+        // Button spinners
+        const bulkCreateButton = document.getElementById("bulk-creation-submit-button");
+        bulkCreateButton && bulkCreateButton.addEventListener("click", e => {
+            SPNR.disableControlsAndSpin(bulkCreateButton, null);
+        });
+        document.querySelectorAll("#bulk-creation-back-button, #bulk-creation-cancel-button").forEach(el => {
+            el.addEventListener("click", () => {
+                SPNR.disableControlsAndSpin(el, null);
+                window.location.href = el.getAttribute('data-url');
+            });
+        });
+    });
+    /*]]>*/
+</script>
 <script th:fragment="indexJs" th:inline="javascript">
   /*<![CDATA[*/
 
@@ -33,6 +66,7 @@
   gmCancelButton && gmCancelButton.addEventListener("click", e => {
 
     e.preventDefault;
+    SPNR.disableControlsAndSpin(gmCancelButton, null);
     window.location = window.location.href.replace("/sakai-site-group-manager.helper", "");
   });
 
@@ -99,6 +133,18 @@
             submit.disabled = !groupTitle.value || groupNumber.value <= 0 || groupMaxMembers.value <= 0;
         });
       });
+    });
+
+    // Button spinners
+    document.querySelectorAll("#create-joinableset-submit-button, #save-joinableset-submit-button").forEach(el => {
+        el.addEventListener("click", () => {
+            SPNR.disableControlsAndSpin(el, null);
+        });
+    });
+    const joinableSetCancelButton = document.getElementById("create-joinableset-cancel-button");
+    joinableSetCancelButton && joinableSetCancelButton.addEventListener("click", e => {
+        SPNR.disableControlsAndSpin(joinableSetCancelButton, null);
+        window.location.href = joinableSetCancelButton.getAttribute('data-url');
     });
   });
 
@@ -193,6 +239,18 @@
       allowClear: true
     });
 
+    // Button spinners
+    document.querySelectorAll("#create-group-submit-button, #save-group-submit-button").forEach(el => {
+        el.addEventListener("click", () => {
+            SPNR.disableControlsAndSpin(el, null);
+        });
+    });
+    const cancelGroupButton = document.getElementById("create-group-cancel-button");
+    cancelGroupButton && cancelGroupButton.addEventListener("click", e => {
+        SPNR.disableControlsAndSpin(cancelGroupButton, null);
+        window.location.href = cancelGroupButton.getAttribute('data-url');
+    });
+
   });
   /*]]>*/
 </script>
@@ -204,6 +262,16 @@
 
     document.querySelectorAll(".group-manager-role-checkbox")
       .forEach(box => box.checked = e.target.checked);
+  });
+
+  const autoGroupsContinueButton = document.getElementById("autogroups-continue-button");
+  autoGroupsContinueButton && autoGroupsContinueButton.addEventListener("click", e => {
+    SPNR.disableControlsAndSpin(autoGroupsContinueButton, null);
+  });
+  const autoGroupsCancelButton = document.getElementById("autogroups-cancel-button");
+  autoGroupsCancelButton && autoGroupsCancelButton.addEventListener("click", e => {
+    SPNR.disableControlsAndSpin(autoGroupsCancelButton, null);
+    window.location.href = autoGroupsCancelButton.getAttribute('data-url');
   });
   /*]]>*/
 </script>
@@ -230,9 +298,20 @@
 
   const backButton = document.getElementById("autogroups-back-button");
   backButton && backButton.addEventListener("click", () => {
-
+    SPNR.disableControlsAndSpin(backButton, null);
     document.getElementById("wizardAction").value = "back";
     document.getElementById("autogroups-wizard-step2-form").submit();
+  });
+
+  // Button spinners
+  const autoGroupsContinueButton = document.getElementById("autogroups-continue-button");
+  autoGroupsContinueButton && autoGroupsContinueButton.addEventListener("click", e => {
+    SPNR.disableControlsAndSpin(autoGroupsContinueButton, null);
+  });
+  const autoGroupsCancelButton = document.getElementById("autogroups-cancel-button");
+  autoGroupsCancelButton && autoGroupsCancelButton.addEventListener("click", e => {
+    SPNR.disableControlsAndSpin(autoGroupsCancelButton, null);
+    window.location.href = autoGroupsCancelButton.getAttribute('data-url');
   });
   /*]]>*/
 </script>
@@ -274,9 +353,20 @@
 
   const backButton = document.getElementById("autogroups-back-button");
   backButton && backButton.addEventListener("click", () => {
-
+    SPNR.disableControlsAndSpin(backButton, null);
     document.getElementById('wizardAction').value = "back";
     document.getElementById("autogroups-wizard-step3-form").submit();
+  });
+
+  // Button spinners
+  const autoGroupsContinueButton = document.getElementById("autogroups-continue-button");
+  autoGroupsContinueButton && autoGroupsContinueButton.addEventListener("click", e => {
+    SPNR.disableControlsAndSpin(autoGroupsContinueButton, null);
+  });
+  const autoGroupsCancelButton = document.getElementById("autogroups-cancel-button");
+  autoGroupsCancelButton && autoGroupsCancelButton.addEventListener("click", e => {
+    SPNR.disableControlsAndSpin(autoGroupsCancelButton, null);
+    window.location.href = autoGroupsCancelButton.getAttribute('data-url');
   });
   /*]]>*/
 </script>
@@ -286,9 +376,22 @@
   document.querySelectorAll("#autogroups-back-button-top, #autogroups-back-button").forEach(el => {
 
     el.addEventListener("click", () => {
-
+      SPNR.disableControlsAndSpin(el, null);
       document.getElementById("wizardAction").value = "back";
       document.getElementById("autogroups-wizard-step4-form").submit();
+    });
+  });
+
+  // Button spinners
+  document.querySelectorAll("#autogroups-creategroups-button, #autogroups-creategroups-button-top").forEach(el => {
+    el.addEventListener("click", () => {
+      SPNR.disableControlsAndSpin(el, null);
+    });
+  });
+  document.querySelectorAll("#autogroups-cancel-button, #autogroups-cancel-button-top").forEach(el => {
+    el.addEventListener("click", () => {
+      SPNR.disableControlsAndSpin(el, null);
+      window.location.href = el.getAttribute('data-url');
     });
   });
   /*]]>*/

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html
@@ -21,7 +21,7 @@
       <div class="form-group row">
         <div class="col-sm-8">
           <label for="groupTitle" class="form-control-label block" th:text="|* #{groups.title}|">* Group Title</label>
-          <input name="groupTitle" id="groupTitle" type="text" th:field="*{groupTitle}" size="50" maxlength="99" class="form-control" th:placeholder="#{groups.title}" required/>
+          <input name="groupTitle" id="groupTitle" type="text" th:field="*{groupTitle}" size="50" maxlength="99" class="form-control" th:placeholder="#{groups.title}" required="required"/>
         </div>
       </div>
       <div class="form-group row">
@@ -100,7 +100,7 @@
       <div class="act">
         <input th:if="${groupForm.groupId == null}" accesskey="s" disabled="disabled" id="create-group-submit-button" type="submit" class="active" th:value="#{groups.button.create}">
         <input th:if="${groupForm.groupId != null}" accesskey="s" id="save-group-submit-button" type="submit" class="active" th:value="#{groups.button.save}">
-        <a th:href="@{/}" accesskey="x" id="create-group-cancel-button" class="btn btn-default" th:text="#{groups.button.cancel}">Cancel</a>
+        <button type="button" th:data-url="@{/}" accesskey="x" id="create-group-cancel-button" th:text="#{groups.button.cancel}">Cancel</button>
       </div>
     </form>
   </div>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import.html
@@ -34,14 +34,15 @@
         </div>
         <div class="col-sm-6">
           <label for="groupUploadFile" th:text="#{import.chooseone}">Or choose a file</label>
-          <input class="form-control" id="groupUploadFile" name="groupUploadFile" type="file">
+          <input class="form-control" id="groupUploadFile" name="groupUploadFile" type="file"/>
         </div>
       </div>
       <div class="act">
-        <input accesskey="s" onclick="SPNR.disableControlsAndSpin( this, null );" id="bulk-creation-submit-button" type="submit" class="active" th:value="#{import.button.submit}">
-        <a th:href="@{/}" accesskey="x" id="bulk-creation-cancel-button" class="btn btn-default" th:text="#{import.button.cancel}">Cancel</a>
+        <input accesskey="s" id="bulk-creation-submit-button" type="submit" class="active" th:value="#{import.button.submit}"/>
+        <button type="button" th:data-url="@{/}" accesskey="x" id="bulk-creation-cancel-button" th:text="#{import.button.cancel}">Cancel</button>
       </div>
     </form>
   </div>
+  <script th:replace="fragments/javascript :: importJs" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import_confirmation.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import_confirmation.html
@@ -29,11 +29,12 @@
     <form id="bulkcreation-confirmation-form" action="#" th:action="@{/confirmImport}" method="post">
       <input type="hidden" th:value="${importedGroupMap}" name="importedGroupMap" id="importedGroupMap"/>
         <div class="act">
-          <input th:if="${!membershipErrors}" accesskey="s" onclick="SPNR.disableControlsAndSpin( this, null );" id="bulk-creation-submit-button" type="submit" class="active" th:value="#{import.button.create.bulk}">
-          <a th:href="@{/import}" accesskey="b" href="#" id="bulk-creation-back-button" class="btn btn-default" th:text="#{import.button.back}">back</a>&nbsp;
-          <a th:href="@{/}" accesskey="x" id="bulk-creation-cancel-button" class="btn btn-default" th:text="#{import.button.cancel}">Cancel</a>
+          <input th:if="${!membershipErrors}" accesskey="s" id="bulk-creation-submit-button" type="submit" class="active" th:value="#{import.button.create.bulk}"/>
+          <button type="button" th:data-url="@{/import}" accesskey="b" id="bulk-creation-back-button" th:text="#{import.button.back}">Back</button>
+          <button type="button" th:data-url="@{/}" accesskey="x" id="bulk-creation-cancel-button" th:text="#{import.button.cancel}">Cancel</button>
         </div>
       </form>
   </div>
+  <script th:replace="fragments/javascript :: importConfirmJs" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
@@ -61,8 +61,8 @@
         </tbody>
       </table>
       <div class="act">
-        <input accesskey="s" disabled="disabled" id="delete-groups-submit-button" type="submit" class="active" th:value="#{index.button.removechecked}">
-        <a accesskey="x" href="#" id="delete-groups-cancel-button" class="btn btn-default" th:text="#{index.button.cancel}">Cancel</a>
+        <input accesskey="s" disabled="disabled" id="delete-groups-submit-button" type="submit" class="active" th:value="#{index.button.removechecked}"/>
+        <button type="button" accesskey="x" id="delete-groups-cancel-button" th:text="#{index.button.cancel}">Cancel</button>
       </div>
       <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true" id="confirmation-modal">
         <div class="modal-dialog modal-md">
@@ -77,7 +77,7 @@
             </div>
             <div class="modal-footer act">
               <button type="button" class="active" id="modal-btn-confirm" th:text="#{index.modal.button.delete}" onclick="SPNR.disableControlsAndSpin( this, null );">Delete these groups</button>
-              <button type="button" class="btn btn-default" id="modal-btn-cancel" th:text="#{index.button.cancel}">Cancel</button>
+              <button type="button" id="modal-btn-cancel" th:text="#{index.button.cancel}">Cancel</button>
             </div>
           </div>
         </div>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/joinable_set.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/joinable_set.html
@@ -16,11 +16,11 @@
       </div>
     </div>
     <form id="createnewjoinableset-form" action="#" th:action="@{/saveJoinableSet}" th:object="${joinableSetForm}" method="post">
-      <input type="hidden" th:if="${joinableSetForm.joinableSetId != null}" name="joinableSetId" th:value="${joinableSetForm.joinableSetId}">
+      <input type="hidden" th:if="${joinableSetForm.joinableSetId != null}" name="joinableSetId" th:value="${joinableSetForm.joinableSetId}"/>
         <div class="form-group row" id="setName">
           <div class="col-sm-6"> 
             <label for="groupTitle" class="form-control-label" th:text="|* #{joinableset.setname}|">Set name:</label>
-            <input class="form-control" name="groupTitle" id="groupTitle" type="text" th:placeholder="#{joinableset.setname}" th:field="*{groupTitle}" required/>
+            <input class="form-control" name="groupTitle" id="groupTitle" type="text" th:placeholder="#{joinableset.setname}" th:field="*{groupTitle}" required="required"/>
           </div>
         </div>
         <div class="form-group row" th:if="${joinableSetForm.joinableSetId == null}">
@@ -37,19 +37,19 @@
         </div>
         <div class="checkbox" th:if="${joinableSetForm.joinableSetId == null}">
           <label for="allowPreviewMembership">
-            <input class="form-control" name="allowPreviewMembership" id="allowPreviewMembership" type="checkbox" th:field="*{allowPreviewMembership}">
+            <input class="form-control" name="allowPreviewMembership" id="allowPreviewMembership" type="checkbox" th:field="*{allowPreviewMembership}"/>
             <span th:text="#{joinableset.allow.previewmembership}">Allow user to see group membership before joining</span>
           </label>
         </div>
         <div class="checkbox" th:if="${joinableSetForm.joinableSetId == null}">
           <label for="allowViewMembership">
-            <input class="form-control" name="allowViewMembership" id="allowViewMembership" type="checkbox" th:field="*{allowViewMembership}">
+            <input class="form-control" name="allowViewMembership" id="allowViewMembership" type="checkbox" th:field="*{allowViewMembership}"/>
             <span th:text="#{joinableset.allow.viewmembership}">Allow members to see the other members of these groups after joining</span>
           </label>
         </div>
         <div class="checkbox">
           <label for="allowUnjoin">
-            <input class="form-control" name="allowUnjoin" id="allowUnjoin" type="checkbox" th:field="*{allowUnjoin}">
+            <input class="form-control" name="allowUnjoin" id="allowUnjoin" type="checkbox" th:field="*{allowUnjoin}"/>
             <span th:text="#{joinableset.allow.unjoin}">Allow members to unjoin (leave) groups in this set after joining</span>
           </label>
         </div>
@@ -83,13 +83,13 @@
                     <input class="form-control" name="groupMaxMembers" id="groupMaxMembers" type="number" min="1" max="999" th:field="*{groupMaxMembers}" />
                     <div class="checkbox">
                       <label for="allowPreviewMembership">
-                        <input class="form-control" name="allowPreviewMembership" id="allowPreviewMembership" type="checkbox" th:field="*{allowPreviewMembership}">
+                        <input class="form-control" name="allowPreviewMembership" id="allowPreviewMembership" type="checkbox" th:field="*{allowPreviewMembership}"/>
                         <span th:text="#{joinableset.allow.previewmembership}">Allow user to see group membership before joining</span>
                       </label>
                     </div>
                     <div class="checkbox">
                       <label for="allowViewMembership">
-                        <input class="form-control" name="allowViewMembership" id="allowViewMembership" type="checkbox" th:field="*{allowViewMembership}">
+                        <input class="form-control" name="allowViewMembership" id="allowViewMembership" type="checkbox" th:field="*{allowViewMembership}"/>
                         <span th:text="#{joinableset.allow.viewmembership}">Allow members to see the other members of these groups after joining</span>
                       </label>
                     </div>
@@ -113,10 +113,10 @@
           </div>
         </div>
         <div class="act">
-          <input th:if="${joinableSetForm.joinableSetId == null}" accesskey="s" disabled="disabled" id="create-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.add}">
-          <input th:if="${joinableSetForm.joinableSetId != null}" accesskey="s" id="save-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.save}">
+          <input th:if="${joinableSetForm.joinableSetId == null}" accesskey="s" disabled="disabled" id="create-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.add}"/>
+          <input th:if="${joinableSetForm.joinableSetId != null}" accesskey="s" id="save-joinableset-submit-button" type="submit" class="active" th:value="#{joinableset.button.save}"/>
           <a th:href="@{/deleteJoinableSet(joinableSetId=${joinableSetForm.joinableSetId})}" th:if="${joinableSetForm.joinableSetId != null}" accesskey="d" id="delete-joinableset-submit-button" type="submit" class="btn btn-default" th:value="#{joinableset.button.delete}">Delete Joinable Set</a>
-          <a th:href="@{/}" accesskey="x" id="create-joinableset-cancel-button" class="btn btn-default" th:text="#{joinableset.button.cancel}">Cancel</a>
+          <button type="button" th:data-url="@{/}" accesskey="x" id="create-joinableset-cancel-button" th:text="#{joinableset.button.cancel}">Cancel</button>
         </div>
         <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true" id="confirmation-modal">
           <div class="modal-dialog modal-md">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47200

Buttons within the Manage Groups interfaces lack spinners and disabling after clicking. This can lead to users mashing the buttons multiple times, which can result in duplicate groups being created.

This PR will also introduce support for `<button>` tags in `spinner.js`