### PR TITLE
SAK-47202 Assignments > history log > time zone format displays offset rather than name

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6740,10 +6740,7 @@ public class AssignmentAction extends PagedResourceActionII {
 
                 // submission log
                 StringBuilder logEntry = new StringBuilder();
-                DateTimeFormatter dtf = DateTimeFormatter.RFC_1123_DATE_TIME
-                        .withZone(userTimeService.getLocalTimeZone(u.getId()).toZoneId())
-                        .withLocale(preferencesService.getLocale(u.getId()));
-                logEntry.append(dtf.format(Instant.now()));
+                logEntry.append(userTimeService.shortLocalizedTimestamp(Instant.now(), userTimeService.getLocalTimeZone(u.getId()), preferencesService.getLocale(u.getId())));
                 boolean anonymousGrading = Boolean.parseBoolean(a.getProperties().get(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING));
                 String subOrDraft = post ? rb.getString("listsub.submitted") : rb.getString("listsub.submitted.draft");
                 if (!anonymousGrading) {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47202

Observe the submission history time zone format

> Sakai 11:
> Wed Feb 10 13:00:59 EST 2021 Albi Tremblay (student01) saved draft
> Sakai 20+:
> Wed, 10 Feb 2021 13:00:57 -0500 Albi Tremblay (student01) saved draft

Time zones are confusing for people, and they don’t want to do have to do math to figure out which time zone the string is referring to. Users who were polled unanimously prefer time zones listed by name (Sakai 11) over their difference to GMT (Sakai 20+).

Sakai 23 before:

> Fri, 22 Apr 2022 12:47:59 -0400 Albi Tremblay (student01) saved draft

Sakai 23 after:

> Apr. 22, 2022, 12:57 p.m. EDT Albi Tremblay (student01) saved draft