### PR TITLE
SAK-47204 Update default.sakai.properties Oracle driver class name

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -446,7 +446,7 @@
 
 ## Oracle settings - make sure to alter as appropriate
 # vendor@org.sakaiproject.db.api.SqlService=oracle
-# driverClassName@javax.sql.BaseDataSource=oracle.jdbc.driver.OracleDriver
+# driverClassName@javax.sql.BaseDataSource=oracle.jdbc.OracleDriver
 # hibernate.dialect=org.hibernate.dialect.Oracle9iDialect
 # hibernate.dialect=org.hibernate.dialect.Oracle10gDialect
 # url@javax.sql.BaseDataSource=jdbc:oracle:thin:@your.oracle.dns:1521:SID


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47204

The Oracle driver class name changed a long time ago from oracle.jdbc.driver.OracleDriver to just oracle.jdbc.OracleDriver. HikariCP spits out a warning on startup if using the old name. Update default.sakai.properties with the new name.