### PR TITLE
SAK-47203 update same score site property not respected when taking quiz through lessons or direct link

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1943,6 +1943,11 @@
 # Default: false
 # gradebook.students.use.sorting=true
 
+# Allow gradebook to update the DATE_RECORDED field for an item if the same score is achieved.
+# This property can be set globally for all sites, or for individual sites as a site property of the same name.
+# DEFAULT: false
+# gradebook.externalAssessments.updateSameScore=true
+
 # SAK-33836: control the maximum character length of gradebook item comments.
 # NOTE: this property is not enforced in Gradebook Classic.
 # Default: 20,000


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47203

There is a site property (and sakai.property) one can use to force updating a score in GB when a quiz is taken and the same score is achieved. The site property is not respected when accessing a quiz through the Lessons tool.

The reason this occurs is because we are without portal in this situation, so the site ID cannot be resolved using the normal method. This results in a failure to look up the site property, and then it falls back to the global sakai.property. If the global property is set to false, but the site property is true, it will fail to update the record in GB when the quiz is access through Lessons.

The same issue occurs when accessing a quiz using the direct link from Samigo itself. Ex: `https://<server>/samigo-app/servlet/Login?id=<uuid>`

To work around this we can use the gradebook UUID, which is already known at this point, and by convention is the exact same as the site ID. Considering that this convention has not changed in the entirety of Sakai’s history, we can safely assume that this will continue to be the case in the future.