### PR TITLE
SAK-47209 Set a longer query timeout for T&Q autosubmit

### DIFF
--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
@@ -127,7 +127,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
                 throw new IllegalStateException("Template is null");
             }
             InternetAddress[] to = { new InternetAddress(toAddress) };
-            emailService.sendMail(new InternetAddress(fromAddress), to, template.getRenderedSubject(), template.getRenderedMessage(), null, null, null);
+            emailService.sendMail(new InternetAddress(fromAddress), to, template.getRenderedSubject(), template.getRenderedMessage(), to, null, null);
         }
         catch (Exception e) {
             log.error("Unable to send email notification for AutoSubmit failures.", e);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -2988,6 +2988,7 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	    
 		query.setTimestamp("currentTime",currentTime);
 		query.setParameterList("status", Arrays.asList(AssessmentGradingData.REMOVED, AssessmentGradingData.NO_SUBMISSION) );
+		query.setTimeout(300);
 
 		List<AssessmentGradingData> list = query.list();
 


### PR DESCRIPTION
The query used to identify submissions may be slow and return a large data set on systems with lots of data. Increase the default query time to 300s (5min).

Also add an explicit To: header field for the email message sent if there's a failure in this job.