### PR TITLE
SAK-47211 Discussions: Mark as read button appears when corresponding permission is not granted

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -150,7 +150,7 @@
 
 .Mrphs-sakai-forums #msgForum a.button.markAsReadIcon{
 	cursor: pointer;
-	margin-left:.5em;
+	padding-left: 25px;
 	position:relative;
 }
 

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
@@ -399,20 +399,12 @@
 				</h:panelGroup>
 			</h:column>
 				<%-- author column --%>
-			<h:column>
-				<f:facet name="header">
-						<h:outputText value="&nbsp;" escape="false"/>
-					</f:facet>
-               	
-					<h:graphicImage value="/images/trans.gif" rendered="#{message.read}" style="margin-left:.5em" alt="" />
-					<h:outputLink value="javascript:void(0);"
-								  title="#{msgs.cdfm_mark_as_read}"
-								  rendered="#{!message.read}"
-								  styleClass="markAsReadIcon button"
-								  onclick="doAjax(#{message.message.id}, #{ForumTool.selectedTopic.topic.id}, this);">
-						<h:graphicImage value="/images/trans.gif"/>
-						<h:outputText value="#{msgs.cdfm_mark_as_read}"/>
-					</h:outputLink>
+			<h:column rendered="#{ForumTool.selectedTopic.isMarkAsRead}">
+				<f:facet name="header"><h:outputText value="#{msgs.cdfm_mark_as_read}" escape="false"/></f:facet>
+				<h:outputLink rendered="#{!message.read}" value="javascript:void(0);" title="#{msgs.cdfm_mark_as_read}" styleClass="markAsReadIcon button"
+							  onclick="doAjax(#{message.message.id}, #{ForumTool.selectedTopic.topic.id}, this);">
+					<h:outputText value="#{msgs.cdfm_mark_as_read}"/>
+				</h:outputLink>
 			</h:column>
 			<h:column>
 				<f:facet name="header">

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThreadBodyInclude.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThreadBodyInclude.jsp
@@ -88,10 +88,9 @@
 				<%-- mark as read link --%>
 					<h:outputLink value="javascript:void(0);"
 						title="#{msgs.cdfm_mark_as_read}" 
-						rendered="#{!message.read}"
+						rendered="#{!message.read and ForumTool.selectedTopic.isMarkAsRead}"
 						styleClass="markAsReadIcon button"
 						onclick="doAjax(#{message.message.id}, #{ForumTool.selectedTopic.topic.id}, this);">
-						<h:graphicImage value="/images/trans.gif"/>
 						<h:outputText value="#{msgs.cdfm_mark_as_read}"/>
 					</h:outputLink>
 				<%-- Reply link --%>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47211

Forum topics have a permission “mark as read”, yet when this permission is not granted, mark as read buttons still appear. The only thing the permission seems to actually control is the “Mark All As Read” button on the thread view.

Users without the permission should not see any Mark as Read buttons, nor should the Mark as Read column appear at all for them.