### PR TITLE
SAK-47188 - Lessons-T&Q: Numeric Response popups/warnings not working

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverFillInNumeric.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverFillInNumeric.jsp
@@ -24,6 +24,9 @@ should be included in file importing DeliveryMessages
 **********************************************************************************/
 --%>
 -->
+<script>includeWebjarLibrary("qtip2");</script>
+<script>includeWebjarLibrary("bootstrap");</script>
+
 <!-- ATTACHMENTS -->
 <%@ include file="/jsf/delivery/item/attachment.jsp" %>
 


### PR DESCRIPTION
The qtip and popover libraries are missing the T&Q Numeric Response question type when it is invoked from within Lessons.