### PR TITLE
SAK-47217 Samigo > Skip confirmation page if quiz is already retracted, and improve banner consistency

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ActionSelectListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ActionSelectListener.java
@@ -27,6 +27,9 @@ import javax.faces.event.ActionListener;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
+import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
+import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.DeliveryBean;
 import org.sakaiproject.tool.assessment.ui.bean.print.PDFAssessmentBean;
@@ -150,6 +153,15 @@ public class ActionSelectListener implements ActionListener {
 			author.setFromPage("author");
 			author.setEditPublishedAssessmentID( publishedID );
 			author.setJustPublishedAnAssessment(true);
+
+			PublishedAssessmentService pas = new PublishedAssessmentService();
+			PublishedAssessmentFacade paf = pas.getPublishedAssessmentQuick(publishedID);
+			if (PublishedAssessmentIfc.RETRACT_FOR_EDIT_STATUS.equals(paf.getStatus())) {
+				// quiz has already been retracted, no need to present the confirmation page again,
+				// just run the EditAssessmentListener as if the user had clicked Edit on the confirmation page
+				EditAssessmentListener editAssessmentListener = new EditAssessmentListener();
+				editAssessmentListener.processAction(null);
+			}
 		}
 		else if ("preview_published".equals(action)) {
 			delivery.setActionString("previewAssessment");

--- a/samigo/samigo-app/src/webapp/jsf/author/confirmEditPublishedAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/confirmEditPublishedAssessment.jsp
@@ -38,7 +38,7 @@
  <div class="portletBody">
   <h3><h:outputText value="#{authorMessages.edit_published_assessment_heading_conf}"/></h3>
  <h:form id="editPublishedAssessmentForm">
-     <div class="sak-banner-error tier1">
+     <div class="sak-banner-warn tier1">
        <h:outputText value="#{authorMessages.warning}" />
    	   <br/>
        <h:outputText value="#{authorMessages.edit_published_assessment_heading_conf_info_1}" />

--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -522,7 +522,7 @@ $(window).load( function() {
 	    <f:param value="#{author.editPoolName}" />
 	</h:outputFormat>
 </h:panelGrid>
-<h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow}" styleClass="sak-banner-error">
+<h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow}" styleClass="sak-banner-warn">
     <h:panelGrid  columns="1">
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_1}" />
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_21}" rendered="#{assessmentBean.hasGradingData}"/>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47217

When editing a published quiz, you will see a confirmation page first. If the quiz is already retracted, it is not necessary to show this page again, and the wording on it is somewhat inaccurate the second time, so it can just be skipped.

Also, some banners related to retracted quizzes are styled as errors when they should be warnings.