### PR TITLE
SAK-47222 Samigo > Autosubmit job > Separate transactions and major performance improvement

### DIFF
--- a/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
+++ b/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
@@ -49,6 +49,7 @@
      <property name="publishedSectionFacadeQueries"><ref bean="PublishedSectionFacadeQueries" /></property>
      <property name="publishedItemFacadeQueries"><ref bean="PublishedItemFacadeQueries" /></property>
      <property name="assessmentGradingFacadeQueries"><ref bean="AssessmentGradingFacadeQueries" /></property>
+     <property name="autoSubmitFacadeQueries"><ref bean="AutoSubmitFacadeQueries" /></property>
      <property name="authorizationFacadeQueries"><ref bean="AuthorizationFacadeQueries" /></property>
      <property name="pagingUtilQueries"><ref bean="PagingUtilQueries" /></property>
      <property name="authzQueriesFacade"><ref bean="AuthzQueriesFacade" /></property>
@@ -241,6 +242,21 @@
       <property name="transactionAttributes">
         <props>
           <prop key="*">PROPAGATION_REQUIRED</prop>
+        </props>
+      </property>
+    </bean>
+
+    <bean id="AutoSubmitFacadeQueries"
+          class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+      <property name="transactionManager"><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager"/></property>
+      <property name="target">
+        <bean class="org.sakaiproject.tool.assessment.facade.AutoSubmitFacadeQueries">
+          <property name="sessionFactory"><ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/></property>
+	</bean>
+      </property>
+      <property name="transactionAttributes">
+        <props>
+          <prop key="*">PROPAGATION_REQUIRES_NEW</prop> <!-- ensures every method invocation runs in its own transaction -->
         </props>
       </property>
     </bean>

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -109,6 +109,7 @@ import org.springframework.orm.hibernate5.HibernateCallback;
 import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.tool.assessment.services.PersistenceService;
 
 @Slf4j
 public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implements AssessmentGradingFacadeQueriesAPI {
@@ -2995,123 +2996,34 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
         Iterator iter = list.iterator();
         String lastAgentId = "";
         Long lastPublishedAssessmentId = 0L;
+        PublishedAssessmentFacade assessment = null;
         AssessmentGradingData adata = null;
         Map sectionSetMap = new HashMap();
 
 
         PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
 
-        org.sakaiproject.grading.api.GradingService g = null;
-        boolean updateGrades = false;
-        Map<Long, String> toGradebookPublishedAssessmentSiteIdMap = null;
-        GradebookServiceHelper gbsHelper = null;
-        if (IntegrationContextFactory.getInstance() != null) {
-            boolean integrated = IntegrationContextFactory.getInstance().isIntegrated();
-            if (integrated) {
-                g = (org.sakaiproject.grading.api.GradingService) SpringBeanLocator.getInstance()
-                        .getBean("org.sakaiproject.grading.api.GradingService");
-            }
-            toGradebookPublishedAssessmentSiteIdMap = publishedAssessmentService.getToGradebookPublishedAssessmentSiteIdMap();
-            gbsHelper = IntegrationContextFactory.getInstance().getGradebookServiceHelper();
-            updateGrades = true;
-        }
-        boolean autoSubmitCurrent;
-        Integer scoringType;
+        boolean updateGrades = IntegrationContextFactory.getInstance() != null;
+        AutoSubmitFacadeQueriesAPI autoSubmitFacade = PersistenceService.getInstance().getAutoSubmitFacadeQueries();
         int failures = 0;
         
         while (iter.hasNext()) {
 
-            autoSubmitCurrent = false;
-            scoringType = -1;
-
             try {
                 adata = (AssessmentGradingData) iter.next();
-                adata.setHasAutoSubmissionRun(Boolean.TRUE);
 
-                Date endDate = new Date();
-                if (Boolean.FALSE.equals(adata.getForGrade())) {
+                if (!lastPublishedAssessmentId.equals(adata.getPublishedAssessmentId())) {
+                    assessment = publishedAssessmentService.getPublishedAssessmentQuick(adata.getPublishedAssessmentId().toString());
+                }
 
-                    // SAM-1088 getting the assessment so we can check to see if last user attempt was after due date
-                    PublishedAssessmentFacade assessment = (PublishedAssessmentFacade) publishedAssessmentService.getAssessment(
-                            adata.getPublishedAssessmentId());
-                    scoringType = assessment.getEvaluationModel().getScoringType();
-                    Date dueDate = assessment.getAssessmentAccessControl().getDueDate();
-                    Date retractDate = assessment.getAssessmentAccessControl().getRetractDate();
-                    Integer lateHandling = assessment.getAssessmentAccessControl().getLateHandling();
-                    boolean acceptLate = AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString().equals(lateHandling);
-                    ExtendedTimeDeliveryService assessmentExtended = new ExtendedTimeDeliveryService(assessment,
-                            adata.getAgentId());
-
-                    //If it has extended time, just continue for now, no method to tell if the time is passed
-                    if (assessmentExtended.hasExtendedTime()) {
-                        //Continue on and try to submit it but it may be late, just change the due date
-                        dueDate = assessmentExtended.getDueDate() != null ? assessmentExtended.getDueDate() : dueDate;
-
-                        // If the extended time student received a retract date
-                        if (assessmentExtended.getRetractDate() != null) {
-                        	retractDate =  assessmentExtended.getRetractDate();
-                        	acceptLate = true;
-                        }
-                    }
-
-                    // If the due date or retract date hasn't passed yet, go on to the next one, don't consider it yet
-                    if (acceptLate && retractDate != null && (currentTime.before(retractDate) || adata.getAttemptDate().after(retractDate))) {
-                        continue;
-                    }
-                    else if ( (!acceptLate || retractDate == null) && dueDate != null && currentTime.before(dueDate)) {
-                    	continue;
-                    }
-
-                    adata.setForGrade(Boolean.TRUE);
-                    if (adata.getTotalAutoScore() == null) {
-                        adata.setTotalAutoScore(0d);
-                    }
-                    if (adata.getFinalScore() == null) {
-                        adata.setFinalScore(0d);
-                    }
-
-                    if (adata.getAttemptDate() != null && dueDate != null &&
-                            adata.getAttemptDate().after(dueDate)) {
-                        adata.setIsLate(true);
-                    }
-                    // SAM-1088
-                    else if (adata.getSubmittedDate() != null && dueDate != null &&
-                            adata.getSubmittedDate().after(dueDate)) {
-                        adata.setIsLate(true);
-                    }
-                    // SAM-2729 user probably opened assessment and then never submitted a question
-                    if (adata.getSubmittedDate() == null && adata.getAttemptDate() != null) {
-                        adata.setSubmittedDate(endDate);
-                    }
-
-                    autoSubmitCurrent = true;
-                    adata.setIsAutoSubmitted(Boolean.TRUE);
-                    if (lastPublishedAssessmentId.equals(adata.getPublishedAssessmentId())
-                            && lastAgentId.equals(adata.getAgentId())) {
-                        adata.setStatus(AssessmentGradingData.AUTOSUBMIT_UPDATED);
-                    } else {
-                        adata.setStatus(AssessmentGradingData.SUBMITTED);
-                    }
-                   
-                    completeItemGradingData(adata, sectionSetMap);
+                // this call happens in a separate transaction, so a rollback only affects this iteration
+                boolean success = autoSubmitFacade.processAttempt(adata, updateGrades, this, assessment, currentTime, lastAgentId, lastPublishedAssessmentId, sectionSetMap);
+                if (!success) {
+                    ++failures;
                 }
 
                 lastPublishedAssessmentId = adata.getPublishedAssessmentId();
                 lastAgentId = adata.getAgentId();
-
-                PublishedAssessmentFacade publishedAssessment = publishedAssessmentService.getPublishedAssessment(adata.getPublishedAssessmentId()
-                        .toString());
-                // this call happens in a separate transaction, so a rollback only affects this iteration
-                boolean success = saveOrUpdateAssessmentGrading(adata);
-                
-                if (success && updateGrades && autoSubmitCurrent) {
-                    GradingService gs = new GradingService();
-                    gs.updateAutosubmitEventLog(adata);
-                    gs.notifyGradebookByScoringType(adata, publishedAssessment);
-                }
-                else if (!success) {
-                    ++failures;
-                }
             } catch (Exception e) {
                 ++failures;
                 if (adata != null) {
@@ -3312,8 +3224,8 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
         completeItemGradingData(assessmentGradingData, null);
     }
 
-
-    public void completeItemGradingData(AssessmentGradingData assessmentGradingData, Map sectionSetMap) {
+    @Override
+    public void completeItemGradingData(AssessmentGradingData assessmentGradingData, Map<Long, Set<PublishedSectionData>> sectionSetMap) {
         List answeredPublishedItemIdList = new ArrayList();
         List publishedItemIds = getPublishedItemIds(assessmentGradingData.getAssessmentGradingId());
         Iterator iter = publishedItemIds.iterator();

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueriesAPI.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemData;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingAttachment;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingAttachment;
@@ -278,8 +279,10 @@ public interface AssessmentGradingFacadeQueriesAPI
 
   public HashMap getSubmittedCounts(String siteId);
 
-  public void completeItemGradingData(AssessmentGradingData assessmentGradingData);	
-  
+  public void completeItemGradingData(AssessmentGradingData assessmentGradingData);
+
+  public void completeItemGradingData(AssessmentGradingData assessmentGradingData, Map<Long, Set<PublishedSectionData>> sectionSetMap);
+
   public List getHighestSubmittedAssessmentGradingList(final Long publishedAssessmentId);
   public Double getAverageSubmittedAssessmentGrading( final Long publishedAssessmentId, final String agentId);
   public Map<Long, List<Long>> getAverageAssessmentGradingByPublishedItem(Long publishedAssessmentId);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AutoSubmitFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AutoSubmitFacadeQueries.java
@@ -1,0 +1,112 @@
+package org.sakaiproject.tool.assessment.facade;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData;
+import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
+import org.sakaiproject.tool.assessment.services.GradingService;
+import org.sakaiproject.tool.assessment.util.ExtendedTimeDeliveryService;
+import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
+
+/**
+ *
+ * @author plukasew
+ */
+@Slf4j
+public class AutoSubmitFacadeQueries extends HibernateDaoSupport implements AutoSubmitFacadeQueriesAPI
+{
+	@Override
+	public boolean processAttempt(AssessmentGradingData adata, boolean updateGrades, AssessmentGradingFacadeQueriesAPI agfq, PublishedAssessmentFacade assessment,
+			Date currentTime, String lastAgentId, Long lastPublishedAssessmentId, Map<Long, Set<PublishedSectionData>> sectionSetMap)
+	{
+		boolean autoSubmitCurrent = false;
+		adata.setHasAutoSubmissionRun(Boolean.TRUE);
+
+		Date endDate = new Date();
+		if (Boolean.FALSE.equals(adata.getForGrade())) {
+
+			// SAM-1088 getting the assessment so we can check to see if last user attempt was after due date
+			Date dueDate = assessment.getAssessmentAccessControl().getDueDate();
+			Date retractDate = assessment.getAssessmentAccessControl().getRetractDate();
+			Integer lateHandling = assessment.getAssessmentAccessControl().getLateHandling();
+			boolean acceptLate = AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString().equals(lateHandling);
+			ExtendedTimeDeliveryService assessmentExtended = new ExtendedTimeDeliveryService(assessment,
+					adata.getAgentId());
+
+			//If it has extended time, just continue for now, no method to tell if the time is passed
+			if (assessmentExtended.hasExtendedTime()) {
+				//Continue on and try to submit it but it may be late, just change the due date
+				dueDate = assessmentExtended.getDueDate() != null ? assessmentExtended.getDueDate() : dueDate;
+
+				// If the extended time student received a retract date
+				if (assessmentExtended.getRetractDate() != null) {
+					retractDate =  assessmentExtended.getRetractDate();
+					acceptLate = true;
+				}
+			}
+
+			// If the due date or retract date hasn't passed yet, go on to the next one, don't consider it yet
+			if (acceptLate && retractDate != null && (currentTime.before(retractDate) || adata.getAttemptDate().after(retractDate))) {
+				return true;
+			}
+			else if ( (!acceptLate || retractDate == null) && dueDate != null && currentTime.before(dueDate)) {
+				return true;
+			}
+
+			adata.setForGrade(Boolean.TRUE);
+			if (adata.getTotalAutoScore() == null) {
+				adata.setTotalAutoScore(0d);
+			}
+			if (adata.getFinalScore() == null) {
+				adata.setFinalScore(0d);
+			}
+
+			if (adata.getAttemptDate() != null && dueDate != null &&
+					adata.getAttemptDate().after(dueDate)) {
+				adata.setIsLate(true);
+			}
+			// SAM-1088
+			else if (adata.getSubmittedDate() != null && dueDate != null &&
+					adata.getSubmittedDate().after(dueDate)) {
+				adata.setIsLate(true);
+			}
+			// SAM-2729 user probably opened assessment and then never submitted a question
+			if (adata.getSubmittedDate() == null && adata.getAttemptDate() != null) {
+				adata.setSubmittedDate(endDate);
+			}
+
+			autoSubmitCurrent = true;
+			adata.setIsAutoSubmitted(Boolean.TRUE);
+			if (lastPublishedAssessmentId.equals(adata.getPublishedAssessmentId())
+					&& lastAgentId.equals(adata.getAgentId())) {
+				adata.setStatus(AssessmentGradingData.AUTOSUBMIT_UPDATED);
+			} else {
+				adata.setStatus(AssessmentGradingData.SUBMITTED);
+			}
+
+			agfq.completeItemGradingData(adata, sectionSetMap);
+		}
+
+		boolean success = agfq.saveOrUpdateAssessmentGrading(adata);
+		if (!success) {
+			log.error("Unable to persist assessement grading data for id {}", adata.getAssessmentGradingId());
+			return false;
+		}
+
+		if (autoSubmitCurrent) {
+			GradingService gs = new GradingService();
+			if (updateGrades) {
+				gs.notifyGradebookByScoringType(adata, assessment); // this may throw runtime exceptions triggering a rollback
+			}
+
+			// if we get this far, the processing of this attempt was successful so it is now safe to
+			// update the log and email the student (triggered by the same method)
+			gs.updateAutosubmitEventLog(adata);
+		}
+
+		return true;
+	}
+}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AutoSubmitFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AutoSubmitFacadeQueriesAPI.java
@@ -1,0 +1,33 @@
+package org.sakaiproject.tool.assessment.facade;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData;
+import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
+
+/**
+ * Queries for persisting a single attempt/submission and all related updates in a single transaction. This is important
+ * because exceptions thrown in the autosubmit job can roll back the entire progress of the job. By processing
+ * each attempt in a separate transaction, each successfully processed attempt will still be saved if the job aborts
+ * and rolls back the main transaction.
+ * @author plukasew
+ */
+public interface AutoSubmitFacadeQueriesAPI
+{
+	/**
+	 * Persist updates to a single assessment attempt/submission to the database. This includes updating the attempt,
+	 * the Gradebook integration, and the Samigo event log, as well as firing an event to trigger the email notification system.
+	 * @param adata the data for this attempt/submission
+	 * @param updateGrades if integration with Gradebook is a possibility
+	 * @param agfq service for persisting the attempt
+	 * @param assessment the assessment
+	 * @param currentTime timestamp when the job started
+	 * @param lastAgentId agent id from the previously processed attempt
+	 * @param lastPublishedAssessmentId assessment id from the previously processed attempt
+	 * @param sectionSetMap map of assessment id to assessment sections (aka parts)
+	 * @return true if all processing succeeded
+	 */
+	public boolean processAttempt(AssessmentGradingData adata, boolean updateGrades, AssessmentGradingFacadeQueriesAPI agfq, PublishedAssessmentFacade assessment,
+			Date currentTime, String lastAgentId, Long lastPublishedAssessmentId, Map<Long, Set<PublishedSectionData>> sectionSetMap);
+}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PersistenceService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/PersistenceService.java
@@ -47,6 +47,7 @@ public class PersistenceService{
 	private PublishedSectionFacadeQueriesAPI publishedSectionFacadeQueries;
 	private PublishedItemFacadeQueriesAPI publishedItemFacadeQueries;
 	private AssessmentGradingFacadeQueriesAPI assessmentGradingFacadeQueries;
+	private AutoSubmitFacadeQueriesAPI autoSubmitFacadeQueries;
 	private AuthorizationFacadeQueriesAPI authorizationFacadeQueries;
 	private PagingUtilQueriesAPI pagingUtilQueries;
 	private AuthzQueriesFacadeAPI authzQueriesFacade;
@@ -162,7 +163,14 @@ public class PersistenceService{
 	public void setAssessmentGradingFacadeQueries(AssessmentGradingFacadeQueriesAPI assessmentGradingFacadeQueries){
 	    this.assessmentGradingFacadeQueries = assessmentGradingFacadeQueries;
 	}
-	
+
+	public AutoSubmitFacadeQueriesAPI getAutoSubmitFacadeQueries(){
+	    return autoSubmitFacadeQueries;
+	}
+
+	public void setAutoSubmitFacadeQueries(AutoSubmitFacadeQueriesAPI autoSubmitFacadeQueries){
+	    this.autoSubmitFacadeQueries = autoSubmitFacadeQueries;
+	}
         public AuthorizationFacadeQueriesAPI getAuthorizationFacadeQueries(){
 	  return authorizationFacadeQueries;
         }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47222

Please see the SAK ticket for additional information.

This ticket will address the following two problems with the job:

   1. The whole job is in a single transaction, so any rollback will undo all the processing and effectively reset the queue to its initial state. This can cause the queue to just continue to grow over time. Additionally, each time the queue is reset due to rollback, the autosubmitted attempts that were processed will be processed again and the student will get another email about it.

   2. Performance can be extremely poor. Job runs can take many hours to complete with large queues or “heavy” quizzes, potentially impacting users if the job runs past its expected window and into peak usage times.

The modifications to address these issues are as follows:

  1.  A new class, AutoSubmitFacadeQueries, is created so that Spring can create a separate transaction for each attempt in the queue. This means that any rollback will affect only the attempt that triggered it instead of the entire queue. The body of the queue loop is lifted out and placed into the new class with as little modification as possible to preserve the original logic. A small change was made to delay the email going out until the very end of the processing of the attempt after everything else has succeeded.

   2. The queue loop is modified to retrieve information about each quiz only once, and only the required information for the job using getPublishedAssessmentQuick(). Previously the full quiz, including questions, was being retrieved each loop iteration even though all the attempts for the same quiz are grouped together.