### PR TITLE
SAK-47227 Discussions - Sometimes open/close dates are not set properly

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -540,13 +540,15 @@ public class DiscussionForumBean
 	}
 
 	public void setOpenDate(String openDateStr){
-		if (StringUtils.equals(openDateStr, openDateISO)) {
-			try{
+		if (StringUtils.isNotBlank(openDateISO)) {
+			try {
 				Date openDate = (Date) datetimeFormat.parse(openDateISO);
 				forum.setOpenDate(openDate);
-			}catch (ParseException e) {
+			} catch (ParseException e) {
 				log.error("Couldn't convert open date", e);
 			}
+		} else if (StringUtils.isBlank(openDateStr)) {
+			forum.setOpenDate(null);
 		}
 	}
 
@@ -559,13 +561,15 @@ public class DiscussionForumBean
 	}
 
 	public void setCloseDate(String closeDateStr){
-		if (StringUtils.equals(closeDateStr, closeDateISO)) {
-			try{
+		if (StringUtils.isNotBlank(closeDateISO)) {
+			try {
 				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
 				forum.setCloseDate(closeDate);
-			}catch (ParseException e) {
+			} catch (ParseException e) {
 				log.error("Couldn't convert Close date", e);
 			}
+		} else if (StringUtils.isBlank(closeDateStr)) {
+			forum.setCloseDate(null);
 		}
 	}
 
@@ -595,11 +599,15 @@ public class DiscussionForumBean
 
 	public void setOpenDateISO(String openDateISO) {
 		this.openDateISO = openDateISO;
-		setOpenDate(this.openDateISO);
+		if (StringUtils.isNotBlank(openDateISO)) {
+			this.setOpenDate(openDateISO);
+		}
 	}
 
 	public void setCloseDateISO(String closeDateISO) {
 		this.closeDateISO = closeDateISO;
-		setCloseDate(this.closeDateISO);
+		if (StringUtils.isNotBlank(closeDateISO)) {
+			this.setCloseDate(closeDateISO);
+		}
 	}
 }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -540,15 +540,13 @@ public class DiscussionForumBean
 	}
 
 	public void setOpenDate(String openDateStr){
-		if (StringUtils.isNoneBlank(openDateStr, openDateISO)) {
+		if (StringUtils.equals(openDateStr, openDateISO)) {
 			try{
 				Date openDate = (Date) datetimeFormat.parse(openDateISO);
 				forum.setOpenDate(openDate);
 			}catch (ParseException e) {
 				log.error("Couldn't convert open date", e);
 			}
-		}else{
-			forum.setOpenDate(null);
 		}
 	}
 
@@ -561,15 +559,13 @@ public class DiscussionForumBean
 	}
 
 	public void setCloseDate(String closeDateStr){
-		if (StringUtils.isNoneBlank(closeDateStr, closeDateISO)) {
+		if (StringUtils.equals(closeDateStr, closeDateISO)) {
 			try{
 				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
 				forum.setCloseDate(closeDate);
 			}catch (ParseException e) {
 				log.error("Couldn't convert Close date", e);
 			}
-		}else{
-			forum.setCloseDate(null);
 		}
 	}
 

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
@@ -295,20 +295,13 @@
 			<script>
 				function storeOpenDateISO(e) {
 					e.preventDefault();
-					document.getElementsByClassName("openDateISO")[0].value = document.getElementById("openDateISO8601").value;
+					document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
 				}
 
 				function storeCloseDateISO(e) {
 					e.preventDefault();
-					document.getElementsByClassName("closeDateISO")[0].value = document.getElementById("closeDateISO8601").value;
+					document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
 				}
-
-				$(document).ready(function() {
-					if (document.getElementById("openDateISO8601").value != null) {
-						document.getElementsByClassName("openDateISO")[0].value = document.getElementById("openDateISO8601").value;
-						document.getElementsByClassName("closeDateISO")[0].value = document.getElementById("closeDateISO8601").value;
-					}
-				});
 
 				localDatePicker({
 					input: '.openDate',


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47227

- Javascript has been cleaned, removing not necesary functionality
- setCloseDate and setOpenDate was called twice, changing the value both times. Now dates are setted just when open/close dates comes in ISO format. Also, I tried the datetime-local input, but currently is displayed in the browser's languange, not in the user's defined language in the site.