### PR TITLE
SAK-47233 - TurnitinOC - introduce a sakai.property to disable indexing (e.g. for non-production environments)

### DIFF
--- a/content-review/impl/turnitin-oc/README.md
+++ b/content-review/impl/turnitin-oc/README.md
@@ -32,12 +32,12 @@ assignment.useContentReview=true
 # turnitin.oc.skip.delays=false
 
 
-# Determines whether indexing is enabled. Recommended to set this to false in test environments, and true in production.
-# Rationale: consider a test environment whose database is cloned from a production snapshot when items existed in the content-review queue.
-# The QAT environment will submit these items to Turnitin. If the papers are indexed, the production items will be updated to 100% matches.
-# By disabling indexing, the test environment papers will match against the production papers, but not vice versa.
-# default: true
-# turnitin.oc.indexing.enabled=true
+# Disables indexing when submitting papers. Recommended to set this to true in QA / restore environments, and false in production.
+# Rationale: consider a QA or restore environment whose database is cloned from a production snapshot when items existed in the content-review queue.
+# The cloned environment will submit these items to Turnitin. If the papers are indexed, the production items will be updated to 100% matches.
+# By disabling indexing, the QA / restore environment papers will match against the production papers, but not vice versa.
+# Default: false
+# turnitin.oc.disable.all.indexing=false
 
 # turnitin.oc.accept.all.files (Optional)
 # If true, any file type will be accepted by Sakai. Invalid file types will still be rejected by Turnitin.

--- a/content-review/impl/turnitin-oc/README.md
+++ b/content-review/impl/turnitin-oc/README.md
@@ -31,6 +31,14 @@ assignment.useContentReview=true
 # default: false
 # turnitin.oc.skip.delays=false
 
+
+# Determines whether indexing is enabled. Recommended to set this to false in test environments, and true in production.
+# Rationale: consider a test environment whose database is cloned from a production snapshot when items existed in the content-review queue.
+# The QAT environment will submit these items to Turnitin. If the papers are indexed, the production items will be updated to 100% matches.
+# By disabling indexing, the test environment papers will match against the production papers, but not vice versa.
+# default: true
+# turnitin.oc.indexing.enabled=true
+
 # turnitin.oc.accept.all.files (Optional)
 # If true, any file type will be accepted by Sakai. Invalid file types will still be rejected by Turnitin.
 # default: false

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -303,6 +303,13 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	private Boolean mayViewMatchSubmissionInfoOverrideStudent = null;
 	private Boolean mayViewSubmissionFullSourceOverrideInstructor = null;
 	private Boolean mayViewMatchSubmissionInfoOverrideInstructor = null;
+
+	/**
+	  * Sakai property that determines whether indexing is enabled. Default: true.
+	  * Set to false to disable indexing on QA nodes to prevent production papers from having 100% matches.
+	  */
+	private String PROP_INDEXING_ENABLED = "turnitin.oc.indexing.enabled";
+	private boolean indexingEnabled = true;
 	
 	private CloseableHttpAsyncClient client;
 	private ObjectMapper objectMapper;
@@ -340,7 +347,9 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		mayViewMatchSubmissionInfoOverrideInstructor = StringUtils.isNotEmpty(serverConfigurationService.getString("turnitin.oc.may_view_match_submission_info.instructor")) 
 				? serverConfigurationService.getBoolean("turnitin.oc.may_view_match_submission_info.instructor", false)
 				: null;
-				
+
+		indexingEnabled = serverConfigurationService.getBoolean(PROP_INDEXING_ENABLED, true);
+
 		// Override default Sakai->Turnitin roles mapping
 		for(ROLES role : ROLES.values()) {
 			//map Sakai roles to Turnitin roles
@@ -793,6 +802,10 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	}
 	
 	private void indexSubmission(String reportId) throws Exception {
+		if (!indexingEnabled) {
+			return;
+		}
+
 		HashMap<String, Object> response = makeHttpCall("PUT",
 				getNormalizedServiceUrl() + "submissions/" + reportId + "/index",
 				SIMILARITY_REPORT_HEADERS,
@@ -833,7 +846,8 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 		reportData.put("view_settings", viewSettings);
 		
 		Map<String, Object> indexingSettings = new HashMap<>();
-		indexingSettings.put("add_to_index", "true".equals(assignmentSettings.get("store_inst_index")));
+		boolean addToIndex = indexingEnabled && "true".equals(assignmentSettings.get("store_inst_index"));
+		indexingSettings.put("add_to_index", addToIndex);
 		reportData.put("indexing_settings", indexingSettings);
 
 		HashMap<String, Object> response = makeHttpCall("PUT",
@@ -1426,7 +1440,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 						Map<String, String> assignmentSettings = assignment.getProperties();
 						//set item retryTime to due date
 						cal.setTime(getDueDateRetryTime(assignmentDueDate));
-						if("true".equals(assignmentSettings.get("store_inst_index"))){
+						if(indexingEnabled && "true".equals(assignmentSettings.get("store_inst_index"))){
 							indexSubmission(item.getExternalId());
 						}
 					}catch (Exception e) {


### PR DESCRIPTION
When configuring a Turnitin assignment, you can choose whether or not papers should be indexed.
Indexing a paper means that it can be matched against by other papers.

The ability to index can be unsuitable in non-production environments. E.g. if a production Sakai instance is cloned to a restore environment while papers are still in the content-review queue, end-user papers will be marked as fully plagiarized against their own clone.