### PR TITLE
SAK-47236 T&Q calculated questions grading: clear answerList map

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -3047,11 +3047,11 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    *    placed in the text where the {{..}}'s appear.
    * <br>2. It will call methods to swap out the defined variables with randomly generated values
    *    within the ranges defined by the user.
-   * <br>3. It updates the HashMap answerList with the calculated answers in sequence. It will 
+   * <br>3. It populates the HashMap answerList with the calculated answers in sequence. It will
    *    parse and calculate what each answer needs to be.
-   * <p>Note: If a divide by zero occurs. We change the random values and try again. It gets limited chances to
+   * <p>Note: If a divide by zero occurs, we change the random values and try again. It gets limited chances to
    *    get valid values and then will return "infinity" as the answer.
-   * @param answerList will enter the method empty and be filled with sequential answers to the question
+   * @param answerList is cleared and filled with sequential answers to the question
    * @return ArrayList of the pieces of text to display surrounding input boxes
    */
   public List<String> extractCalcQAnswersArray(Map<Integer, String> answerList, ItemDataIfc item, Long gradingId, String agentId) {
@@ -3078,10 +3078,11 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
                   instructionSegments = extractInstructionSegments(instructions);
                   hasErrors = false;
               } catch (SamigoExpressionError e1) {
-                  log.warn("Samigo calculated item ("+item.getItemId()+") calculation invalid: "+e1.get());
+                  log.warn("Samigo calculated item ({}) calculation invalid: {}", item.getItemId(), e1.get());
                   attemptCount++;
               }
           } catch (Exception e) {
+              // possible division by zero error
               attemptCount++;
           }
       }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -3058,6 +3058,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
       boolean hasErrors = true;
       Map<String, String> variableRangeMap = buildVariableRangeMap(item);
       List<String> instructionSegments = new ArrayList<>(0);
+      answerList.clear();
 
       int attemptCount = 1;
       while (hasErrors && attemptCount <= MAX_ERROR_TRIES) {


### PR DESCRIPTION
Although answerList should be empty on entering this function according to the javadoc, changes elsewhere have led to a case where it's not always empty. 

This can lead to an answerList that is sized larger than it should be, depending on previous questions in the assessment, leading to item scores being divided by the wrong number of items for a question.
