### PR TITLE
SAK-47250 Site Info > Manage Tools > allow maintainers to remove stealthed tools present in their site

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -395,11 +395,20 @@ public interface LTIService extends LTISubstitutionsFilter {
     // Tool Retrieval
     List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId);
 
+    List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId, boolean includeStealthed);
+
     /**
      * Gets a list of the launchable tools in the site
      * @param siteId
      */
     List<Map<String, Object>> getToolsLaunch(String siteId);
+
+    /**
+     * Gets a list of the launchable tools in the site, optionally including stealthed LTI tools
+     * @param siteId
+     * @param includeStealthed
+     */
+    List<Map<String, Object>> getToolsLaunch(String siteId, boolean includeStealthed);
 
     /**
      * Gets a list of tools that can configure themselves in the site
@@ -440,6 +449,8 @@ public interface LTIService extends LTISubstitutionsFilter {
     List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId);
 
     List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId, boolean isAdmin);
+
+    List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId, boolean isAdmin, boolean includeStealthed);
 
 
     // --- Content

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -556,22 +556,32 @@ public abstract class BaseLTIService implements LTIService {
 
 	@Override
 	public List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId) {
-		return getToolsDao(search, order, first, last, siteId, isAdmin(siteId));
+		return getTools(search, order, first, last, siteId, false);
 	}
 
 	@Override
-    public List<Map<String, Object>> getToolsLaunch(String siteId) {
+	public List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
+		return getToolsDao(search, order, first, last, siteId, isAdmin(siteId), includeStealthed);
+	}
+
+	@Override
+	public List<Map<String, Object>> getToolsLaunch(String siteId) {
+		return getToolsLaunch(siteId, false);
+	}
+
+	@Override
+	public List<Map<String, Object>> getToolsLaunch(String siteId, boolean includeStealthed) {
 		return getTools( "lti_tools."+LTIService.LTI_PL_LAUNCH+" = 1 OR ( " +
 			"( lti_tools."+LTIService.LTI_PL_LINKSELECTION+" IS NULL OR lti_tools."+LTIService.LTI_PL_LINKSELECTION+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_FILEITEM+" IS NULL OR lti_tools."+LTIService.LTI_PL_FILEITEM+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_IMPORTITEM+" IS NULL OR lti_tools."+LTIService.LTI_PL_IMPORTITEM+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_CONTENTEDITOR+" IS NULL OR lti_tools."+LTIService.LTI_PL_CONTENTEDITOR+" = 0 ) and " + 
 			"( lti_tools."+LTIService.LTI_PL_ASSESSMENTSELECTION+" IS NULL OR lti_tools."+LTIService.LTI_PL_ASSESSMENTSELECTION+" = 0 ) " +
-			" ) ", null, 0, 0, siteId);
+			" ) ", null, 0, 0, siteId, includeStealthed);
 	}
 
 	@Override
-    public List<Map<String, Object>> getToolsLtiLink(String siteId) {
+	public List<Map<String, Object>> getToolsLtiLink(String siteId) {
 		return getTools("lti_tools."+LTIService.LTI_PL_LINKSELECTION+" = 1",null,0,0, siteId);
 	}
 

--- a/kernel/api/src/main/java/org/sakaiproject/tool/api/ToolManager.java
+++ b/kernel/api/src/main/java/org/sakaiproject/tool/api/ToolManager.java
@@ -92,6 +92,23 @@ public interface ToolManager
 	Set<Tool> findTools(Set<String> categories, Set<String> keywords);
 
 	/**
+	 * Find a set of tools that meet the critieria.
+	 * A tool must have a category in the categories criteria (unless it is empty or null) to be returned.
+	 * A tool must have a keyword in the keywords criteria (unless it is empty or null) to be returned.
+	 * If both categories and keywords criteria are specified, the tool must meet both criteria to be returned.
+	 * If neither criteria are specified, all registered tools are returned.
+	 * To retrieve only non-hidden tools (that is, tools which will be displayed as available
+	 * in normal site setup), specify an empty set of categories.
+	 * @param categories A Set (String) of category values, typically corresponding to site types;
+	 *                   if null or empty no category criteria is specified;
+	 *                   if an empty set, then only non-hidden tools are returned.
+	 * @param keywords A Set (String) of keyword values; if null or empty no keyword criteria is specified.
+	 * @param includeStealthed if true, stealthed tools will not be filtered out of the returned list
+	 * @return A Set (Tool) of Tool objects that meet the criteria, or an empty set if none found.
+	 */
+	Set<Tool> findTools(Set<String> categories, Set<String> keywords, boolean includeStealthed);
+
+	/**
 	 * Access the Tool associated with the current request / thread
 	 * @return The current Tool, or null if there is none.
 	 */

--- a/kernel/api/src/main/java/org/sakaiproject/tool/cover/ToolManager.java
+++ b/kernel/api/src/main/java/org/sakaiproject/tool/cover/ToolManager.java
@@ -97,10 +97,15 @@ public class ToolManager
 
 	public static java.util.Set findTools(java.util.Set param0, java.util.Set param1)
 	{
+		return findTools(param0, param1, false);
+	}
+
+	public static java.util.Set findTools(java.util.Set<String> categories, java.util.Set<String> keywords, boolean includeStealthed)
+	{
 		org.sakaiproject.tool.api.ToolManager manager = getInstance();
 		if (manager == null) return null;
 
-		return manager.findTools(param0, param1);
+		return manager.findTools(categories, keywords, includeStealthed);
 	}
 
 	public static org.sakaiproject.tool.api.Tool getCurrentTool()

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/tool/impl/ToolComponent.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/tool/impl/ToolComponent.java
@@ -265,17 +265,24 @@ public abstract class ToolComponent implements ToolManager
 	 * {@inheritDoc}
 	 */
 	@SuppressWarnings("unchecked")
-	public Set<Tool> findTools(Set categories, Set keywords)
+		public Set<Tool> findTools(Set<String> categories, Set<String> keywords)
 	{
-		Set<Tool> rv = new HashSet<Tool>();
+		return findTools(categories, keywords, false);
+	}
 
-		for (Iterator<Tool> i = m_tools.values().iterator(); i.hasNext();)
+	/**
+	 * {@inheritDoc}
+	 */
+	public Set<Tool> findTools(Set<String> categories, Set<String> keywords, boolean includeStealthed)
+	{
+		Set<Tool> rv = new HashSet<>();
+
+		for (Tool tool : m_tools.values())
 		{
-			Tool tool = (Tool) i.next();
 			if (matchCriteria(categories, tool.getCategories()) && matchCriteria(keywords, tool.getKeywords()))
 			{
 				// add if not hidden (requests for no (null) category include all, even hidden items)
-				if ((categories == null) || (m_toolIdsToHide == null) || (Arrays.binarySearch(m_toolIdsToHide, tool.getId()) < 0))
+				if (includeStealthed || ((categories == null) || (m_toolIdsToHide == null) || (Arrays.binarySearch(m_toolIdsToHide, tool.getId()) < 0)))
 				{
 					rv.add(tool);
 				}

--- a/site-manage/site-manage-tool/tool/src/test/org/sakaiproject/site/tool/SiteActionTestTools.java
+++ b/site-manage/site-manage-tool/tool/src/test/org/sakaiproject/site/tool/SiteActionTestTools.java
@@ -78,7 +78,7 @@ public class SiteActionTestTools {
         when(ServerConfigurationService.getString("projectSiteTargetType", "project")).thenReturn("project");
 
         SessionState state = mock(SessionState.class);
-        Set<Tool> project = siteAction.getToolRegistrations(state, "project");
+        Set<Tool> project = siteAction.getToolRegistrations(state, "project", false);
         assertThat(project, IsCollectionContaining.hasItems(projectTool));
     }
 
@@ -86,7 +86,7 @@ public class SiteActionTestTools {
     public void testGetToolRegistrationNone() {
         // Site type that doesn't exist
         SessionState state = mock(SessionState.class);
-        Set<Tool> other = siteAction.getToolRegistrations(state, "other");
+        Set<Tool> other = siteAction.getToolRegistrations(state, "other", false);
         assertTrue(other.isEmpty());
     }
 
@@ -100,7 +100,7 @@ public class SiteActionTestTools {
 
         SessionState state = mock(SessionState.class);
         when(state.getAttribute(STATE_DEFAULT_SITE_TYPE)).thenReturn("project");
-        Set<Tool> tools = siteAction.getToolRegistrations(state, "new");
+        Set<Tool> tools = siteAction.getToolRegistrations(state, "new", false);
         assertThat(tools, IsCollectionContaining.hasItems(projectTool));
     }
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47250

This is a regression compared to 11.x.

After a stealthed LTI tool has been added to a site, it should appear in the Manage Tools list as selected, so the instructor can elect to remove it if necessary.

This is no longer possible. After adding a stealthed LTI tool to a site, it does not appear in Manage Tools. This then requires the instructor to (again) contact support so that an admin can remove it on their behalf.

Restore the ability for maintainers to remove stealthed LTI tools which are already present in their site. The linked PR also allows maintainers to remove regularly stealthed, non-LTI tools from their sites (this is a new feature, as they would have never seen regular stealthed tools in the tool list in previous versions of Sakai).