### PR TITLE
SAK-47269 webapi: candidateDetailProvider is now not required

### DIFF
--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/ProfileController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/ProfileController.java
@@ -41,7 +41,9 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 public class ProfileController extends AbstractSakaiApiController {
 
-    @Autowired private CandidateDetailProvider candidateDetailProvider;
+    @Autowired(required = false)
+    private CandidateDetailProvider candidateDetailProvider;
+
     @Autowired private ProfileLinkLogic profileLinkLogic;
     @Autowired private ProfileLogic profileLogic;
     @Autowired private UserDirectoryService userDirectoryService;


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47269