### PR TITLE
SAK-38240 Do not allow access to all Assignments from Lessons

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2224,6 +2224,24 @@ public class AssignmentAction extends PagedResourceActionII {
         context.put("value_ASSIGNMENT_INPUT_ADD_TIME_SPENT", state.getAttribute(ResourceProperties.ASSIGNMENT_INPUT_ADD_TIME_SPENT));
         context.put("isTimesheet", assignmentService.isTimeSheetEnabled((String) state.getAttribute(STATE_CONTEXT_STRING)));
 
+        try {
+            // Get site ID
+            String siteId = toolManager.getCurrentPlacement().getContext();
+            Optional<Site> site = Optional.of(siteService.getSite(siteId));
+            Site currentSite = site.get();
+            // Assignments Tool Configuration
+            ToolConfiguration toolConfig = currentSite.getToolForCommonId(TOOL_ID);
+                    
+            // Get visibility value of assignments tool
+            String isAssignmentsVisible = toolConfig.getConfig().getProperty(ToolManager.PORTAL_VISIBLE);
+            
+            // Checks if the assignments tool is visible from the LHS Menu.
+            context.put("isAssignmentsToolVisible", StringUtils.equalsIgnoreCase(isAssignmentsVisible, Boolean.TRUE.toString()));
+            
+        } catch(IdUnusedException e) {
+            log.error(e.getMessage(), e);
+        }
+                    
         state.removeAttribute(STATE_SUBMITTER);
         String template = (String) getContext(data).get("template");
         return template + TEMPLATE_STUDENT_VIEW_SUBMISSION_CONFIRMATION;

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -205,9 +205,11 @@
 
         #if (!$!linkInvoked)
             <p class="act">
-                <input type="submit" accesskey="x" name="eventSubmit_doConfirm_assignment_submission"
-                       value="$tlang.getString('gen.backtolist')" class="active"
-                       onclick="SPNR.disableControlsAndSpin( this, null );"/>
+                #if ($isAssignmentsToolVisible)
+                    <input type="submit" accesskey="x" name="eventSubmit_doConfirm_assignment_submission"
+                           value="$tlang.getString('gen.backtolist')" class="active"
+                           onclick="SPNR.disableControlsAndSpin( this, null );"/>
+                #end
             </p>
         #end
         <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token"/>


### PR DESCRIPTION
Before, if a instructor made assignments invisible to students, after a student submitted an assignment in lessons could access the rest of assignments of the site pressing "back to list" button. In order to accomplish the features described in this Jira, I have taken into account if assignments tool is visible. In case it is visible, the button "back to list" will be shown whereas if it isn't visible it won't be shown avoiding to see assignments list.