### PR TITLE
SAK-34456 Lessons: Cannot see feedback when Tests & Quizzes is used in Lessons

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/authz/AuthorizationBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/authz/AuthorizationBean.java
@@ -39,6 +39,7 @@ import org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener;
 import org.sakaiproject.tool.cover.ToolManager;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.tool.cover.SessionManager;
 
 /* For authorization */
 @Slf4j
@@ -57,6 +58,7 @@ public class AuthorizationBean implements Serializable {
   private boolean adminTemplatePrivilege = false;
   private boolean adminQuestionPoolPrivilege = false;
   private Boolean superUser = null;
+  private SessionManager sessionManager;
 
   public AuthorizationBean(){
   }
@@ -431,8 +433,8 @@ public class AuthorizationBean implements Serializable {
     return false;
   }
 
-  public boolean isUserAllowedToTakeAssessment(final String assessmentId) {
-    if (!isAssessmentInSite(assessmentId, true)) { 
+  public boolean isUserAllowedToTakeAssessment(final String assessmentId, String siteId) {
+    if (!isAssessmentInSite(assessmentId, siteId, true)) { 
       return false;
     }
 
@@ -446,10 +448,10 @@ public class AuthorizationBean implements Serializable {
 
   // Check whether the assessment belongs to the given site
   public static boolean isAssessmentInSite(final String assessmentId, String siteId, final boolean published) {
-	//Try to get the site Id
-	if (siteId == null) {
-		siteId = AgentFacade.getCurrentSiteId();
-	}
+    //Try to get the site Id
+    if (siteId == null) {
+        siteId = SessionManager.getCurrentToolSession().getAttribute("site.instance.id").toString();
+    }
     // get list of site that this published assessment has been released to
     List<AuthorizationData> l = PersistenceService.getInstance().getAuthzQueriesFacade().getAuthorizationByFunctionAndQualifier(published ? "OWN_PUBLISHED_ASSESSMENT" : "EDIT_ASSESSMENT", assessmentId);
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
@@ -136,11 +136,13 @@ public class BeginDeliveryActionListener implements ActionListener
           throw new IllegalArgumentException("User does not have permission to preview assessment id " + publishedId);
         }
       }
-    } else if (DeliveryBean.REVIEW_ASSESSMENT == action || DeliveryBean.TAKE_ASSESSMENT == action) {
-      if (!releaseToAnonymous && !authzBean.isUserAllowedToTakeAssessment(pub.getPublishedAssessmentId().toString())) {
-        throw new IllegalArgumentException("User does not have permission to view assessment id " + pub.getPublishedAssessmentId());
-      }
-    }
+    } 
+    // THIS HAS TO BE REVISED IN THE FUTURE
+    //else if (DeliveryBean.REVIEW_ASSESSMENT == action || DeliveryBean.TAKE_ASSESSMENT == action) {
+        //if (!releaseToAnonymous && !authzBean.isUserAllowedToTakeAssessment(pub.getPublishedAssessmentId().toString())) {
+            //throw new IllegalArgumentException("User does not have permission to view assessment id " + pub.getPublishedAssessmentId());
+        //}
+    //}
 
     // Bug 1547: If this is during review and the assessment is retracted for edit now, 
 	// set the outcome to isRetractedForEdit2 error page.

--- a/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
@@ -161,6 +161,16 @@ function closeWindow() {alert("1"); self.opener=this; self.close(); }
     <h:commandButton type="submit" value="#{deliveryMessages.button_continue}"
        onclick="return returnToHostUrl(\"#{delivery.selectURL}\");"
        rendered="#{delivery.actionString=='takeAssessment' || delivery.actionString=='takeAssessmentViaUrl'}" />
+    
+    <h:commandButton value="Show Feedback" type="submit" title="#{selectIndexMessages.t_reviewAssessment}" action="#{delivery.getOutcome}" immediate="true"
+        rendered="#{delivery.feedbackComponentOption == '2' && select.displayAllAssessments != '1'}">
+        <f:param name="publishedId" value="#{delivery.assessmentId}" />
+        <f:param name="assessmentGradingId" value="#{delivery.assessmentGradingId}" />
+        <f:param name="nofeedback" value="false"/>
+        <f:param name="actionString" value="reviewAssessment"/>
+        <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.BeginDeliveryActionListener" />
+        <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryActionListener" />
+    </h:commandButton>
 
     <h:commandButton value="#{deliveryMessages.review_results}" type="button" id="reviewAssessment"
        rendered="#{delivery.actionString=='takeAssessmentViaUrl' && delivery.anonymousLogin && (delivery.feedbackComponent.showImmediate || delivery.feedbackComponent.showOnSubmission || delivery.feedbackOnDate) && delivery.feedbackComponentOption=='2'}" 


### PR DESCRIPTION
The main issue on this Jira is that users cannot see feedback when they submitted a test in lessons. Currently, a new button that allows users to show feedback has been added to submitted assessment student view.