### PR TITLE
SAK-47362 Content tool: Error uploading pasted images in editor

### DIFF
--- a/content/content-bundles/resources/content.properties
+++ b/content/content-bundles/resources/content.properties
@@ -669,3 +669,11 @@ access.hidden=(Hidden)
 resource.is.hidden=This resource/collection is hidden
 
 resource.is.secured.access=This resource is secured and can only be accessed under specific conditions.
+
+err.unable.get.uploads.folder=Unable to get uploads folder.
+err.quota.exceeded=Resource quota exceeded.
+err.server.busy=Server is busy. Please try again.
+err.permission=You do not have permission to perform this action.
+err.filename.too.long=File name too long.
+err.file.already.exists=A file with that name already exists.
+err.error.uploading=An error occurred trying to upload the file.

--- a/content/content-bundles/resources/content_es.properties
+++ b/content/content-bundles/resources/content_es.properties
@@ -666,3 +666,11 @@ access.hidden=(Oculto)
 resource.is.hidden=Este recurso/colecci\u00f3n esta oculto
 
 resource.is.secured.access=Este recurso est\u00e1 protegido y solamente puede ser accedido bajo unas condiciones espec\u00edficas.
+
+err.unable.get.uploads.folder=Imposible recuperar el directorio de subida de ficheros.
+err.quota.exceeded=L\u00edmite de recursos excedido.
+err.server.busy=El servidor est\u00e1 ocupado. Por favor, int\u00e9ntelo m\u00e1s tarde.
+err.permission=No tiene permisos para realizar esta acción.
+err.filename.too.long=El nombre del fichero es demasiado largo.
+err.file.already.exists=Ya existe un fichero con el mismo nombre.
+err.error.uploading=Hubo un error al intentar subir el fichero.


### PR DESCRIPTION
Fixed a problem when pasting images in the CK editor. When you reached 100 images pasted and then uploaded, you got an error because all images were named the same ("image"). It was being considered as a hundredth attempt to upload the same image, but it was not.

In addition, I have added internationalization of error messages related to these uploads.

Please @josecebe @mpellicer, could you keep an eye out?