### PR TITLE
SAK-47281 Assignments - Checked is missing when grading using grader on another language using Grader

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/grader/sakai-grader.js
+++ b/webcomponents/tool/src/main/frontend/js/grader/sakai-grader.js
@@ -13,6 +13,8 @@ import { Submission } from "./submission.js";
 import "/webcomponents/rubrics/rubric-association-requirements.js";
 import "/webcomponents/rubrics/sakai-rubric-grading-button.js";
 
+const GRADE_CHECKED = "Checked";
+
 export class SakaiGrader extends gradableDataMixin(SakaiElement) {
 
   constructor() {
@@ -106,7 +108,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
     this.modified = false;
     this.rubricParams = new Map();
     this.showResubmission = this._submission.resubmitsAllowed === -1 || this._submission.resubmitsAllowed > 0;
-    this.isChecked = newValue.grade === this.assignmentsI18n["gen.checked"];
+    this.isChecked = newValue.grade === this.assignmentsI18n["gen.checked"] || newValue.grade === GRADE_CHECKED;
     this.allowExtension = this._submission.extensionAllowed;
     this.submittedTextMode = this._submission.submittedText;
 
@@ -439,7 +441,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
                     type="checkbox"
                     aria-label="${this.i18n.checkgrade_label}"
                     @click=${this.gradeSelected}
-                    value="${this.assignmentsI18n["gen.checked"]}"
+                    value=${GRADE_CHECKED}
                     .checked=${this.isChecked}>
             </input>
             <span>${this.assignmentsI18n["gen.gra2"]} ${this.assignmentsI18n["gen.checked"]}</span>
@@ -1050,7 +1052,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
         break;
       } case "CHECK_GRADE_TYPE": {
         const input = document.getElementById("check-grade-input");
-        input && (input.checked = this.submission.grade === this.assignmentsI18n["gen.checked"]);
+        input && (input.checked = this.submission.grade === this.assignmentsI18n["gen.checked"] || this.submission.grade === GRADE_CHECKED);
         break;
       }
       default:
@@ -1111,7 +1113,7 @@ export class SakaiGrader extends gradableDataMixin(SakaiElement) {
 
     if (this.gradeScale === "CHECK_GRADE_TYPE") {
       if (e.target.checked) {
-        this.submission.grade = e.target.value;
+        this.submission.grade = GRADE_CHECKED;
       } else {
         this.submission.grade = "Unchecked";
       }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47281

The issue here is that Grader is storing the "Checked" string into database in the language that the Grader is displayed. In the old grader, "Checked" is always stored in english. So in the submissions list, if language is different of english, "Checked" is not displayed.
With this fix, now we are going to send to the endpoint the english value, but checks has to be done in both languages, because values comes in user's language to the new grader.