### PR TITLE
SAK-47386 Rubrics: Rubric student preview does not display

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student.js
@@ -141,7 +141,7 @@ class SakaiRubricStudent extends RubricsElement {
           <sakai-rubric-criterion-student
             .criteria="${this.rubric.criteria}"
             rubric-association="${JSON.stringify(this.association)}"
-            .evaluation-details="${this.evaluation.criterionOutcomes}"
+            evaluation-details="${JSON.stringify(this.evaluation.criterionOutcomes)}"
             ?preview="${this.preview}"
             entity-id="${this.entityId}"
             .weighted=${this.rubric.weighted}


### PR DESCRIPTION
This is reverting one change from SAK-45614(#10596) which was not necessary for the fix, but causing the rubrics preview to break