### PR TITLE
SAK-34456 Lessons: Cannot see feedback when Tests & Quizzes is used in Lessons

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/authz/AuthorizationBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/authz/AuthorizationBean.java
@@ -39,6 +39,7 @@ import org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener;
 import org.sakaiproject.tool.cover.ToolManager;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.tool.cover.SessionManager;
 
 /* For authorization */
 @Slf4j
@@ -57,6 +58,7 @@ public class AuthorizationBean implements Serializable {
   private boolean adminTemplatePrivilege = false;
   private boolean adminQuestionPoolPrivilege = false;
   private Boolean superUser = null;
+  private SessionManager sessionManager;
 
   public AuthorizationBean(){
   }
@@ -431,8 +433,8 @@ public class AuthorizationBean implements Serializable {
     return false;
   }
 
-  public boolean isUserAllowedToTakeAssessment(final String assessmentId) {
-    if (!isAssessmentInSite(assessmentId, true)) { 
+  public boolean isUserAllowedToTakeAssessment(final String assessmentId, String siteId) {
+    if (!isAssessmentInSite(assessmentId, siteId, true)) { 
       return false;
     }
 
@@ -446,10 +448,13 @@ public class AuthorizationBean implements Serializable {
 
   // Check whether the assessment belongs to the given site
   public static boolean isAssessmentInSite(final String assessmentId, String siteId, final boolean published) {
-	//Try to get the site Id
-	if (siteId == null) {
-		siteId = AgentFacade.getCurrentSiteId();
-	}
+    //Try to get the site Id
+    if (StringUtils.isBlank(siteId)) {
+        siteId = AgentFacade.getCurrentSiteId();
+        if (StringUtils.isBlank(siteId)) {
+            siteId = SessionManager.getCurrentToolSession().getAttribute("site.instance.id").toString();
+        }
+    }
     // get list of site that this published assessment has been released to
     List<AuthorizationData> l = PersistenceService.getInstance().getAuthzQueriesFacade().getAuthorizationByFunctionAndQualifier(published ? "OWN_PUBLISHED_ASSESSMENT" : "EDIT_ASSESSMENT", assessmentId);
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -351,6 +351,8 @@ public class DeliveryBean implements Serializable {
   @Getter @Setter
   private boolean anonymousLogin = false;
   @Getter @Setter
+  private boolean accessByUrlAndAuthorized = false;
+  @Getter @Setter
   private String contextPath;
 
   // SAK-6990 daisyf added this for timed assessment, to check if mutiple windows were open during timed assessment

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/delivery/LoginServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/delivery/LoginServlet.java
@@ -194,6 +194,7 @@ public class LoginServlet
           agentIdString = AgentFacade.getAgentString();
         }
         delivery.setAnonymousLogin(false);
+        delivery.setAccessByUrlAndAuthorized(isAuthorized);
         person.setAnonymousId(null);
       }
 

--- a/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/submitted.jsp
@@ -163,10 +163,10 @@ function closeWindow() {alert("1"); self.opener=this; self.close(); }
        rendered="#{delivery.actionString=='takeAssessment' || delivery.actionString=='takeAssessmentViaUrl'}" />
 
     <h:commandButton value="#{deliveryMessages.review_results}" type="button" id="reviewAssessment"
-       rendered="#{delivery.actionString=='takeAssessmentViaUrl' && delivery.anonymousLogin && (delivery.feedbackComponent.showImmediate || delivery.feedbackComponent.showOnSubmission || delivery.feedbackOnDate) && delivery.feedbackComponentOption=='2'}" 
+       rendered="#{delivery.actionString=='takeAssessmentViaUrl' && (delivery.anonymousLogin || delivery.accessByUrlAndAuthorized) && (delivery.feedbackComponent.showImmediate || delivery.feedbackComponent.showOnSubmission || delivery.feedbackOnDate) && delivery.feedbackComponentOption=='2'}" 
        style="act" onclick="reviewAssessment(this);" onkeypress="reviewAssessment(this);" />
 
-    <h:commandLink id="hiddenlink" action="takeAssessment" rendered="#{delivery.actionString=='takeAssessmentViaUrl' && delivery.anonymousLogin && (delivery.feedbackComponent.showImmediate || delivery.feedbackComponent.showOnSubmission || delivery.feedbackOnDate) && delivery.feedbackComponentOption=='2'}">
+    <h:commandLink id="hiddenlink" action="takeAssessment" rendered="#{delivery.actionString=='takeAssessmentViaUrl' && (delivery.anonymousLogin || delivery.accessByUrlAndAuthorized) && (delivery.feedbackComponent.showImmediate || delivery.feedbackComponent.showOnSubmission || delivery.feedbackOnDate) && delivery.feedbackComponentOption=='2'}">
       <f:param name="publishedId" value="#{delivery.assessmentId}" />
       <f:param name="nofeedback" value="false"/>
       <f:param name="actionString" value="reviewAssessment"/>


### PR DESCRIPTION
In this PR I have controlled the visibility of the review results button when exams are accessed from the Lessons tool or through anonymous access (both are done by URL). This should allow students to get feedback from the Lessons tool and from anonymous access as well.
