### PR TITLE
SAK-47306 Discussions - Changing word count images by FontAwesome

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsAllAuthoredMsgForOneUser.jsp
@@ -227,7 +227,7 @@
 					<f:verbatim>
 	  					</span>
 						<span>
-							<img src="/library/image/silk/table_add.png" alt="#{msgs.cdfm_message_count}"/>&nbsp;</f:verbatim>
+							<i class="fa fa-plus-square" aria-hidden="true"></i>&nbsp;</f:verbatim>
 							<h:outputText value="#{msgs.cdfm_message_count}" />
 							<f:verbatim>:&nbsp;
 							<span  id="wordCountSpan</f:verbatim>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsDisplayInThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsDisplayInThread.jsp
@@ -115,7 +115,7 @@
 					<f:verbatim>  					
 	  					</span>	
 	  					<span>
-	  						<img src="/library/image/silk/table_add.png" alt="#{msgs.cdfm_message_count}"/>
+	  						<i class="fa fa-plus-square" aria-hidden="true"></i>
 	  						&nbsp;
 	  					</span>
 	  				</f:verbatim>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsFullTextForOne.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsFullTextForOne.jsp
@@ -84,7 +84,7 @@
   					</span>  	
 					<span>
 						</f:verbatim>
-						<img src="/library/image/silk/table_add.png" alt="#{msgs.cdfm_message_count}"/>&nbsp;
+						<i class="fa fa-plus-square" aria-hidden="true"></i>&nbsp;
 						<h:outputText value="#{msgs.cdfm_message_count}" />
 						<f:verbatim>:&nbsp;
 						<span  id="wordCountSpan</f:verbatim><h:outputText value="#{stat.msgId}"/>">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47306

The alternative text inserted to the pictures has broken some views in "Statistics and Grading" tab in Discussions, so to get rid of the images and also correct this problem, I changed the images by FA icons.
Before it looks like this:
![image](https://user-images.githubusercontent.com/19774177/172187274-b4f2517e-c4bf-4d34-9f5d-c332e6036878.png)

And after, using FA:
![image](https://user-images.githubusercontent.com/19774177/172186975-2059a2f0-3f98-4ea5-ab15-9cd03900f95a.png)
