### PR TITLE
SAK-47417 LIB switch to glassfish JAXB runtime

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -91,8 +91,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -366,9 +366,9 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>2.3.3</version>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>2.3.6</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
There are some systems on which the com.sun.xml.bind:jaxb-impl jar does
not work properly, throwing startup errors. Using the Glassfish jar
appears to resolve this. Later versions move fully to the jakarta.xml
namespace.

Resolves: https://sakaiproject.atlassian.net/browse/SAK-47417