### PR TITLE
SAK-47357 Assignments: Back to list button is missing when student submits an assignment

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2251,9 +2251,10 @@ public class AssignmentAction extends PagedResourceActionII {
                     
             // Get visibility value of assignments tool
             String isAssignmentsVisible = toolConfig.getConfig().getProperty(ToolManager.PORTAL_VISIBLE);
+            boolean isVisible = StringUtils.isBlank(isAssignmentsVisible) || StringUtils.equalsIgnoreCase(isAssignmentsVisible, Boolean.TRUE.toString());
             
             // Checks if the assignments tool is visible from the LHS Menu.
-            context.put("isAssignmentsToolVisible", StringUtils.equalsIgnoreCase(isAssignmentsVisible, Boolean.TRUE.toString()));
+            context.put("isAssignmentsToolVisible", isVisible);
             
         } catch(IdUnusedException e) {
             log.error(e.getMessage(), e);


### PR DESCRIPTION
There was no default case to show the _Back to list_ button, so I have set it to true when there is no PORTAL_VISIBLE property defined for the tool.