### PR TITLE
SAK-47439 Gradebook - Grades with decimal comma are not sorted properly

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -2227,10 +2227,10 @@ GbGradeTable.setupColumnSorting = function() {
 };
 
 GbGradeTable.defaultSortCompare = function(a, b) {
-    if (a == null || a == "") {
+    if (a == null || a === "") {
       return -1;
     }
-    if (b == null || b == "") {
+    if (b == null || b === "") {
       return 1;
     }
     if (parseFloat(a) > parseFloat(b)) {
@@ -2267,8 +2267,8 @@ GbGradeTable.sort = function(colIndex, direction) {
   }
 
   clone.sort(function(row_a, row_b) {
-    var a = isNaN(row_a[colIndex]) ? row_a[colIndex] : GbGradeTable.localizedStringToNumber(row_a[colIndex]);
-    var b = isNaN(row_b[colIndex]) ? row_b[colIndex] : GbGradeTable.localizedStringToNumber(row_b[colIndex]);
+    var a = isNaN(parseFloat(row_a[colIndex])) ? row_a[colIndex] : GbGradeTable.localizedStringToNumber(row_a[colIndex]);
+    var b = isNaN(parseFloat(row_b[colIndex])) ? row_b[colIndex] : GbGradeTable.localizedStringToNumber(row_b[colIndex]);
 
     return sortCompareFunction(a, b);
   });


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47439
Just two fixes:
- 0 == "" -> true, so I changed by the strict equality operator (===)
- Decimal with comma is interpreted as NaN when it comes as String, so now we check if isNaN with the parsed float and not with the raw value.