### PR TITLE
SAK-47438: Calendar: Month and year are wrong on PDF when printing monthly using month instead of actual

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/PDFExportService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/PDFExportService.java
@@ -328,7 +328,7 @@ public class PDFExportService {
 
                 // Use the middle of the month since the start/end ranges
                 // may be in an adjacent month.
-                TimeBreakdown breakDown = actualTimeRange.firstTime().breakdownLocal();
+                TimeBreakdown breakDown = timeRangeList.get(0).firstTime().breakdownLocal();
 
                 monthCalendar.setDay(breakDown.getYear(), breakDown.getMonth(), breakDown.getDay());
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47438