### PR TITLE
SAK-47282 Add lti_content to site archive

### DIFF
--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
@@ -833,8 +833,8 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 				List<Map<String,Object>> contents = ltiService.getContentsDao(null, null, 0, 0, siteId, false);
 				for (Map<String,Object> contentItem : contents) {
 					LTIContentArchiveBean ltiContentArchiveBean = new LTIContentArchiveBean(contentItem);
-                                        Node newNode = ltiContentArchiveBean.toNode(doc);
-                                        basicLtiList.appendChild(newNode);
+					Node newNode = ltiContentArchiveBean.toNode(doc);
+					basicLtiList.appendChild(newNode);
 					contentCount++;
 				}
 

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
@@ -803,11 +803,13 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 			StringBuilder results = new StringBuilder("archiving basiclti "+siteId+"\n");
 
 			int count = 0;
+			int contentCount = 0;
 			try {
 				Site site = siteService.getSite(siteId);
 				log.info("SITE: {} : {}", site.getId(), site.getTitle());
 				Element basicLtiList = doc.createElement("org.sakaiproject.basiclti.service.BasicLTISecurityService");
 
+				// Export the LTI tools
 				for (SitePage sitePage : site.getPages()) {
 					for (ToolConfiguration toolConfiguration : sitePage.getTools()) {
 						if ( toolConfiguration.getTool() == null ) continue;
@@ -827,6 +829,16 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 					}
 				}
 
+				// Export the LTI Content Items
+				List<Map<String,Object>> contents = ltiService.getContentsDao(null, null, 0, 0, siteId, false);
+				for (Map<String,Object> contentItem : contents) {
+					LTIContentArchiveBean ltiContentArchiveBean = new LTIContentArchiveBean(contentItem);
+                                        Node newNode = ltiContentArchiveBean.toNode(doc);
+                                        basicLtiList.appendChild(newNode);
+					contentCount++;
+				}
+
+				// Finish
 				((Element) stack.peek()).appendChild(basicLtiList);
 				stack.push(basicLtiList);
 				stack.pop();
@@ -840,7 +852,7 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 				log.warn("Failed to archive: {}, error: {}", siteId, e);
 				results.append("basiclti exception:"+e.getClass().getName()+"\n");
 			}
-			results.append("archiving basiclti ("+count+") tools archived\n");
+			results.append("archiving basiclti: "+count+" tools and " + contentCount + " content items archived\n");
 
 			return results.toString();
 		}

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
@@ -30,13 +30,13 @@ import org.w3c.dom.Node;
 @Slf4j
 public class LTIContentArchiveBean {
 
-        public final static String ALIAS = "LTIContent";
+	public final static String ALIAS = "LTIContent";
 
 	private Map<String,Object> contents;
 
 	private List<String> allowedFields = Arrays.asList(
-		       	"id",
-		       	"tool_id",
+			"id",
+			"tool_id",
 			"title",
 			"description",
 			"contentitem",

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
@@ -48,39 +48,6 @@ public class LTIContentArchiveBean {
 			"newpage",
 			"frameheight" );
 
-	/* 
-+--------------------+---------------+------+-----+---------+----------------+
-| id                 | int(11)       | NO   | PRI | NULL    | auto_increment |
-| tool_id            | int(11)       | YES  |     | NULL    |                |
-| SITE_ID            | varchar(99)   | YES  |     | NULL    |                |
-| title              | varchar(1024) | YES  |     | NULL    |                |
-| frameheight        | int(11)       | YES  |     | NULL    |                |
-| newpage            | tinyint(4)    | YES  |     | 0       |                |
-| debug              | tinyint(4)    | YES  |     | 0       |                |
-| custom             | mediumtext    | YES  |     | NULL    |                |
-| launch             | text          | YES  |     | NULL    |                |
-| xmlimport          | mediumtext    | YES  |     | NULL    |                |
-| placement          | varchar(256)  | YES  |     | NULL    |                |
-| created_at         | datetime      | NO   |     | NULL    |                |
-| updated_at         | datetime      | NO   |     | NULL    |                |
-| pagetitle          | varchar(1024) | YES  |     | NULL    |                |
-| consumerkey        | varchar(1024) | YES  |     | NULL    |                |
-| secret             | varchar(1024) | YES  |     | NULL    |                |
-| settings           | mediumtext    | YES  |     | NULL    |                |
-| placementsecret    | text          | YES  |     | NULL    |                |
-| oldplacementsecret | text          | YES  |     | NULL    |                |
-| resource_handler   | text          | YES  |     | NULL    |                |
-| settings_ext       | mediumtext    | YES  |     | NULL    |                |
-| FA_ICON            | varchar(1024) | YES  |     | NULL    |                |
-| CONTENTITEM        | mediumtext    | YES  |     | NULL    |                |
-| toolorder          | int(11)       | YES  |     | 0       |                |
-| lti13              | tinyint(4)    | YES  |     | 0       |                |
-| lti13_settings     | mediumtext    | YES  |     | NULL    |                |
-| description        | mediumtext    | YES  |     | NULL    |                |
-| protect            | tinyint(4)    | YES  |     | 0       |                |
-+--------------------+---------------+------+-----+---------+----------------+
-*/
-
         public LTIContentArchiveBean(Map<String,Object> itemFields)
         {
 		// Create a new bean with a filtered list of items

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2009-2016 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.basiclti.impl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Properties;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+@Slf4j
+public class LTIContentArchiveBean {
+
+        public final static String ALIAS = "LTIContent";
+
+	private Map<String,Object> contents;
+
+	private List<String> allowedFields = Arrays.asList(
+		       	"id",
+		       	"tool_id",
+			"title",
+			"description",
+			"contentitem",
+			"launch",
+			"custom",
+			"settings",
+			"lti13",
+			"lti13_settings",
+			"newpage",
+			"frameheight" );
+
+	/* 
++--------------------+---------------+------+-----+---------+----------------+
+| id                 | int(11)       | NO   | PRI | NULL    | auto_increment |
+| tool_id            | int(11)       | YES  |     | NULL    |                |
+| SITE_ID            | varchar(99)   | YES  |     | NULL    |                |
+| title              | varchar(1024) | YES  |     | NULL    |                |
+| frameheight        | int(11)       | YES  |     | NULL    |                |
+| newpage            | tinyint(4)    | YES  |     | 0       |                |
+| debug              | tinyint(4)    | YES  |     | 0       |                |
+| custom             | mediumtext    | YES  |     | NULL    |                |
+| launch             | text          | YES  |     | NULL    |                |
+| xmlimport          | mediumtext    | YES  |     | NULL    |                |
+| placement          | varchar(256)  | YES  |     | NULL    |                |
+| created_at         | datetime      | NO   |     | NULL    |                |
+| updated_at         | datetime      | NO   |     | NULL    |                |
+| pagetitle          | varchar(1024) | YES  |     | NULL    |                |
+| consumerkey        | varchar(1024) | YES  |     | NULL    |                |
+| secret             | varchar(1024) | YES  |     | NULL    |                |
+| settings           | mediumtext    | YES  |     | NULL    |                |
+| placementsecret    | text          | YES  |     | NULL    |                |
+| oldplacementsecret | text          | YES  |     | NULL    |                |
+| resource_handler   | text          | YES  |     | NULL    |                |
+| settings_ext       | mediumtext    | YES  |     | NULL    |                |
+| FA_ICON            | varchar(1024) | YES  |     | NULL    |                |
+| CONTENTITEM        | mediumtext    | YES  |     | NULL    |                |
+| toolorder          | int(11)       | YES  |     | 0       |                |
+| lti13              | tinyint(4)    | YES  |     | 0       |                |
+| lti13_settings     | mediumtext    | YES  |     | NULL    |                |
+| description        | mediumtext    | YES  |     | NULL    |                |
+| protect            | tinyint(4)    | YES  |     | 0       |                |
++--------------------+---------------+------+-----+---------+----------------+
+*/
+
+        public LTIContentArchiveBean(Map<String,Object> itemFields)
+        {
+		// Create a new bean with a filtered list of items
+		this.contents = new HashMap();
+
+		for (String key : itemFields.keySet()) {
+			if (allowedFields.contains(key)) {
+				contents.put(key, itemFields.get(key));
+			}
+		}
+        }
+        
+        public LTIContentArchiveBean(Node basicLTI) throws Exception
+        {
+		throw new UnsupportedOperationException("Not implemented");
+        }
+
+        public Node toNode(Document doc)
+        {
+        	Node node = null;
+    		log.debug("Building node");
+
+		// The alias is the name of the root element
+		node = doc.createElement(LTIContentArchiveBean.ALIAS);
+			
+		// Set the id as attribute of the item element
+		if (contents.get("id") != null) {
+			Attr itemId = doc.createAttribute("id");
+			itemId.setValue(contents.get("id").toString());
+			node.getAttributes().setNamedItem(itemId);
+		}
+
+		for (String key: contents.keySet()) {
+			Node property = doc.createElement(key);
+			if (contents.get(key) != null) {
+				property.setTextContent(contents.get(key).toString());
+			}
+			node.appendChild(property);
+		}
+
+        	return node;
+        }
+}

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/LTIContentArchiveBean.java
@@ -30,64 +30,61 @@ import org.w3c.dom.Node;
 @Slf4j
 public class LTIContentArchiveBean {
 
-	public final static String ALIAS = "LTIContent";
+    public final static String ALIAS = "LTIContent";
 
-	private Map<String,Object> contents;
+    private Map < String, Object > contents;
 
-	private List<String> allowedFields = Arrays.asList(
-			"id",
-			"tool_id",
-			"title",
-			"description",
-			"contentitem",
-			"launch",
-			"custom",
-			"settings",
-			"lti13",
-			"lti13_settings",
-			"newpage",
-			"frameheight" );
+    private List < String > allowedFields = Arrays.asList(
+        "id",
+        "tool_id",
+        "title",
+        "description",
+        "contentitem",
+        "launch",
+        "custom",
+        "settings",
+        "lti13",
+        "lti13_settings",
+        "newpage",
+        "frameheight");
 
-        public LTIContentArchiveBean(Map<String,Object> itemFields)
-        {
-		// Create a new bean with a filtered list of items
-		this.contents = new HashMap();
+    public LTIContentArchiveBean(Map < String, Object > itemFields) {
+        // Create a new bean with a filtered list of items
+        this.contents = new HashMap();
 
-		for (String key : itemFields.keySet()) {
-			if (allowedFields.contains(key)) {
-				contents.put(key, itemFields.get(key));
-			}
-		}
+        for (String key: itemFields.keySet()) {
+            if (allowedFields.contains(key)) {
+                contents.put(key, itemFields.get(key));
+            }
         }
-        
-        public LTIContentArchiveBean(Node basicLTI) throws Exception
-        {
-		throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public LTIContentArchiveBean(Node basicLTI) throws Exception {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public Node toNode(Document doc) {
+        Node node = null;
+        log.debug("Building node");
+
+        // The alias is the name of the root element
+        node = doc.createElement(LTIContentArchiveBean.ALIAS);
+
+        // Set the id as attribute of the item element
+        if (contents.get("id") != null) {
+            Attr itemId = doc.createAttribute("id");
+            itemId.setValue(contents.get("id").toString());
+            node.getAttributes().setNamedItem(itemId);
         }
 
-        public Node toNode(Document doc)
-        {
-        	Node node = null;
-    		log.debug("Building node");
-
-		// The alias is the name of the root element
-		node = doc.createElement(LTIContentArchiveBean.ALIAS);
-			
-		// Set the id as attribute of the item element
-		if (contents.get("id") != null) {
-			Attr itemId = doc.createAttribute("id");
-			itemId.setValue(contents.get("id").toString());
-			node.getAttributes().setNamedItem(itemId);
-		}
-
-		for (String key: contents.keySet()) {
-			Node property = doc.createElement(key);
-			if (contents.get(key) != null) {
-				property.setTextContent(contents.get(key).toString());
-			}
-			node.appendChild(property);
-		}
-
-        	return node;
+        for (String key: contents.keySet()) {
+            Node property = doc.createElement(key);
+            if (contents.get(key) != null) {
+                property.setTextContent(contents.get(key).toString());
+            }
+            node.appendChild(property);
         }
+
+        return node;
+    }
 }


### PR DESCRIPTION
This adds the relevant lti_content items into the basiclti.xml file created as part of the site archive.

A filtered list of fields is included, excluding placement info and other site context info which would not be relevant if these were imported into another context.

The exported XML elements look like this:

```
<LTIContent id="12010">
<settings/>
<lti13_settings/>
<newpage>0</newpage>
<custom>tool=/play/67948c69-7a18-4f90-b239-047c8a8cb1dd</custom>
<description/>
<tool_id>228</tool_id>
<launch>https://media.uct.ac.za/lti/player/67948c69-7a18-4f90-b239-047c8a8cb1dd</launch>
<id>12010</id>
<contentitem>{"@graph":[{"thumbnail":{"@id":"https:\/\/media.uct.ac.za\/static\/mh_default_org\/engage-player\/67948c69-7a18-4f90-b239-047c8a8cb1dd\/889af55c-af04-441e-8784-93e899ab0c54\/presenter_5_000s_feed.jpg"},"@type":"LtiLinkItem","custom":{"tool":"\/play\/67948c69-7a18-4f90-b239-047c8a8cb1dd"},"mediaType":"application\/vnd.ims.lti.v1.ltilink","@id":"67948c69-7a18-4f90-b239-047c8a8cb1dd","text":"8\/21\/2019","title":"Thomas King - Take #1","url":"https:\/\/media.uct.ac.za\/lti\/player\/67948c69-7a18-4f90-b239-047c8a8cb1dd"}],"@context":"http:\/\/purl.imsglobal.org\/ctx\/lti\/v1\/ContentItem"}</contentitem>
<lti13>0</lti13>
<frameheight/>
<title>Take #1</title>
</LTIContent>
```