### PR TITLE
SAK-47442  MathJax: Global configuration using properties.

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4940,6 +4940,12 @@
 # Default : /portal/help/TOCDisplay/content.hlp?docId=howdoiaddlatexlanguagetomycoursesite
 #portal.mathjax.help.url=https://sakai.screenstepslive.com/s/sakai_help/m/68426/l/728838-how-do-i-add-latex-language-to-my-course-site
 
+# Use one or multiple of the following formats for MathJax.
+# DEFAULT: LaTeX
+#mathjax.config.format.count=2
+#mathjax.config.format.1=LaTeX
+#mathjax.config.format.2=AsciiMath
+
 # ######
 # Kerberos Provider
 # ######

--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -267,6 +267,9 @@ content.mimeMagic.ignorecontent.extensions=js
 
 # KNL-1234 Enable MathJax on content in resources
 portal.mathjax.src.path=https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=default,Safe
+# Default format for MathJax
+mathjax.config.format.count=1
+mathjax.config.format.1=LaTeX
 
 # Limit grantable permissions to some roles. SAK-29403
 realm.allowed.roles=.auth,.anon

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -407,10 +407,15 @@
             <artifactId>freemarker</artifactId>
             <version>2.3.31</version>
         </dependency>
-		<dependency>
-			<groupId>org.simpleframework</groupId>
-		    <artifactId>simple-xml</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.simpleframework</groupId>
+            <artifactId>simple-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>${json.simple.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/library/src/webapp/js/mathjax-config.js
+++ b/library/src/webapp/js/mathjax-config.js
@@ -1,0 +1,55 @@
+// Remember to update the Java version on HtmlPageFilter too.
+let scriptTag = document.createElement("script");
+scriptTag.type = "text/x-mathjax-config";
+
+// window.top is needed to get the properties even from an iFrame (for DeliveryBean).
+let format = (window.top.portal.mathJaxConfig.format);
+let ext = [];
+let input = [];
+let defaultDelimiters = false;
+
+function useDefaultFormat(){
+    ext.push("tex2jax.js");
+    input.push("input/TeX");
+    defaultDelimiters = true;
+}
+
+if (format === undefined) {
+    console.error("No property for MathJax config was specified. Using LaTeX as default.");
+    useDefaultFormat();
+} else {
+    format.forEach(extension => {
+        switch (extension) {
+            case "LaTeX":
+                useDefaultFormat();
+                break;
+            case "AsciiMath":
+                ext.push("asciimath2jax.js");
+                input.push("input/AsciiMath");
+                break;
+            default:
+                console.error(extension + " is not a supported format." +
+                " Check available options on Sakai default properties");
+                break;
+        }
+    });
+}
+
+if (ext.length === 0) {
+    console.error("None of the received formats match the supported ones. Using LaTeX as default.");
+    useDefaultFormat();
+}
+
+let confObject = {
+    extensions: ext,
+    jax: [...input, "output/HTML-CSS"],
+    messageStyle: "none"
+}
+
+if (defaultDelimiters) {
+    confObject["tex2jax"] = { inlineMath: [['$$','$$'],['\\(','\\)']] };
+}
+
+// Add the final MathJax config as string inside the script tag to make it work.
+scriptTag.innerHTML = `MathJax.Hub.Config (${JSON.stringify(confObject)});`;
+document.head.appendChild(scriptTag);

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -152,7 +152,11 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-      </dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -41,8 +41,13 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import org.jsoup.nodes.Element;
+
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
@@ -128,13 +133,11 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.util.BasicAuth;
 import org.sakaiproject.util.EditorConfiguration;
+import org.sakaiproject.util.RequestFilter;
 import org.sakaiproject.util.Resource;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
-import org.sakaiproject.util.RequestFilter;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * <p/> Charon is the Sakai Site based portal.
@@ -1110,7 +1113,11 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		
 		//SAK-32224. Ability to disable the animated tool menu by property
 		rcontext.put("scrollingToolbarEnabled", ServerConfigurationService.getBoolean("portal.scrolling.toolbar.enabled",true));
-		
+
+		// Format properties for MathJax.
+		String [] mathJaxFormat = ServerConfigurationService.getStrings("mathjax.config.format");
+		rcontext.put("mathJaxFormat", mathJaxFormat);
+
 		return rcontext;
 	}
 
@@ -1311,24 +1318,6 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		
 		StringBuilder headJs = new StringBuilder();
 
-        // SAK-22384
-        if (site != null && MATHJAX_ENABLED_AT_SYSTEM_LEVEL)
-        {
-                if (site != null)
-                {                           
-                    String strMathJaxEnabledForSite = site.getProperties().getProperty(Site.PROP_SITE_MATHJAX_ALLOWED);
-                    if (StringUtils.isNotBlank(strMathJaxEnabledForSite))
-                    {
-                        if (Boolean.valueOf(strMathJaxEnabledForSite))
-                        {
-                            // this call to MathJax.Hub.Config seems to be needed for MathJax to work in IE
-                            headJs.append("<script type=\"text/x-mathjax-config\">\nMathJax.Hub.Config({\nmessageStyle: \"none\",\ntex2jax: { inlineMath: [['\\\\(','\\\\)']] }\n});\n</script>\n");
-                            headJs.append("<script src=\"").append(MATHJAX_SRC_PATH).append("\" type=\"text/javascript\"></script>\n");
-                        }                     
-                    }
-                }
-        }
-
 		String contentItemUrl = portalService.getContentItemUrl(site);
 		headJs.append("<script type=\"text/javascript\" src=\"");
 		headJs.append(PortalUtils.getCDNPath());
@@ -1371,6 +1360,23 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 			headJs.append("if ( window.self !== window.top ) {");
 			headJs.append(" setTimeout(function(){ window.top.portal_check_pnotify() }, 3000);");
 			headJs.append("}</script>");
+		}
+
+		// SAK-22384
+		if (site != null && MATHJAX_ENABLED_AT_SYSTEM_LEVEL)
+		{
+			String strMathJaxEnabledForSite = site.getProperties().getProperty(Site.PROP_SITE_MATHJAX_ALLOWED);
+
+			if (StringUtils.isNotBlank(strMathJaxEnabledForSite) && Boolean.valueOf(strMathJaxEnabledForSite))
+			{
+				// In order to get MathJax to work on the site, the config and source has to be added to the header.
+				Element config = new Element("script");
+				Element srcPath = new Element("script");
+
+				config.attr("src", "/library/js/mathjax-config.js");
+				srcPath.attr("type", "text/javascript").attr("src", MATHJAX_SRC_PATH);
+				headJs.append(config.toString()).append(srcPath.toString());
+			}
 		}
 
 		// TODO: Should we include jquery here?  See includeStandardHead.vm

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -59,10 +59,12 @@
                 },
                 "portalCDNQuery" : "$!{portalCDNQuery}",
                 "sakaiSkin" : "$!{pageSkin}",
-                "userTheme" : "$!{userTheme}"
-                #if ($themesAutoDetectDark)
-                ,"userThemeAutoDetectDark" : true
-                #end
+                "userTheme" : "$!{userTheme}",
+                #if($themesAutoDetectDark)"userThemeAutoDetectDark" : true,
+                #end"mathJaxConfig" : {
+                    "format" : [#foreach( $format in $mathJaxFormat )"${format}",#end]
+                },
+
             };
         </script>
 

--- a/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
+++ b/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
@@ -233,7 +233,6 @@ public class ToolPortal extends HttpServlet
 		}
 
 		// prepare for the forward
-		setupForward(req, res, siteTool, siteTool.getSkin());
 		req.setAttribute(ToolURL.MANAGER, new ToolURLManagerImpl(res));
 
 		// let the tool do the the work (forward)
@@ -265,71 +264,4 @@ public class ToolPortal extends HttpServlet
 		doGet(req, res);
 	}
 
-	/**
-	 * Setup the request attributes with information used by the tools in their
-	 * response.
-	 * 
-	 * @param req
-	 * @param res
-	 * @param p
-	 * @param skin
-	 * @throws ToolException
-	 */
-	// NOTE: This code is duplicated in SkinnableCharonPortal.java
-	// make sure to change code both places
-	protected void setupForward(HttpServletRequest req, HttpServletResponse res,
-			Placement p, String skin) throws ToolException
-	{
-		boolean isInlineReq = ToolUtils.isInlineRequest(req);
-		// setup html information that the tool might need (skin, body on load,
-		// js includes, etc).
-		String headCss = CSSUtils.getCssHead(skin, isInlineReq);
-		String headJs = "<script type=\"text/javascript\" src=\"/library/js/headscripts.js\"></script>\n";
-        
-        Site site=null;
-        // SAK-22384
-        if (p != null && MATHJAX_ENABLED_AT_SYSTEM_LEVEL)
-        {  
-            ToolConfiguration toolConfig = SiteService.findTool(p.getId());
-            if (toolConfig != null) {
-                String siteId = toolConfig.getSiteId();
-                try {
-                    site = SiteService.getSiteVisit(siteId);
-                }
-                catch (IdUnusedException e) {
-                    site = null;
-                }
-                catch (PermissionException e) {
-                    site = null;
-                }
-
-                if (site != null)
-                {                           
-                    boolean mathJaxAllowedForSite = Boolean.parseBoolean(site.getProperties().getProperty(Site.PROP_SITE_MATHJAX_ALLOWED));
-                    if (mathJaxAllowedForSite)
-                    {
-                        // this call to MathJax.Hub.Config seems to be needed for MathJax to work in IE
-                        headJs += "<script type=\"text/x-mathjax-config\">\nMathJax.Hub.Config({\nmessageStyle: \"none\",\ntex2jax: { inlineMath: [['\\\\(','\\\\)']] }\n});\n</script>\n";
-                        headJs += "<script src=\"" + MATHJAX_SRC_PATH + "\" type=\"text/javascript\"></script>\n";
-                    }
-                }
-            }
-        }
-        
-		String head = headCss + headJs;
-		StringBuilder bodyonload = new StringBuilder();
-		if (p != null)
-		{
-			String element = Web.escapeJavascript("Main" + p.getId());
-			bodyonload.append("setMainFrameHeight('" + element + "');");
-		}
-		bodyonload.append("setFocus(focus_path);");
-
-		req.setAttribute("sakai.html.head", head);
-		req.setAttribute("sakai.html.head.css", headCss);
-		req.setAttribute("sakai.html.head.css.base", CSSUtils.getCssToolBaseLink(CSSUtils.getSkinFromSite(site), isInlineReq));
-		req.setAttribute("sakai.html.head.css.skin", CSSUtils.getCssToolSkinLink(CSSUtils.getSkinFromSite(site), isInlineReq));
-		req.setAttribute("sakai.html.head.js", headJs);
-		req.setAttribute("sakai.html.body.onload", bodyonload.toString());
-	}
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -46,7 +46,10 @@ import javax.faces.context.FacesContext;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import org.jsoup.nodes.Document;
+
 import org.apache.commons.lang3.StringUtils;
+
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.event.cover.EventTrackingService;
@@ -2623,21 +2626,21 @@ public class DeliveryBean implements Serializable {
 		return timeLimit;
 	}
 
-	  //SAM-2517
-	  public boolean getIsMathJaxEnabled(){
-		  String siteId = AgentFacade.getCurrentSiteId();
-		  if(siteId == null) {
-		    PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
-		    siteId = publishedAssessmentService.getPublishedAssessmentOwner(Long.parseLong(getAssessmentId()));
-		  }
-		  return Boolean.parseBoolean(getCurrentSite(siteId).getProperties().getProperty(Site.PROP_SITE_MATHJAX_ALLOWED));
-	  }
-	  public String getMathJaxHeader(){
-		  StringBuilder headMJ = new StringBuilder();
-		  headMJ.append("<script type=\"text/x-mathjax-config\">\nMathJax.Hub.Config({\nmessageStyle: \"none\",\ntex2jax: { inlineMath: [['$$','$$'],['\\\\(','\\\\)']] }, TeX: { equationNumbers: { autoNumber: 'AMS' } }\n});\n</script>\n");
-		  headMJ.append("<script src=\"").append(MATHJAX_SRC_PATH).append("\" type=\"text/javascript\"></script>\n");
-		  return headMJ.toString();
-	  }
+    //SAM-2517
+    public boolean getIsMathJaxEnabled(){
+      String siteId = AgentFacade.getCurrentSiteId();
+      if(siteId == null) {
+        PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
+        siteId = publishedAssessmentService.getPublishedAssessmentOwner(Long.parseLong(getAssessmentId()));
+      }
+      return Boolean.parseBoolean(getCurrentSite(siteId).getProperties().getProperty(Site.PROP_SITE_MATHJAX_ALLOWED));
+    }
+    public String getMathJaxHeader(){
+      Document headMJ = new Document("");
+      headMJ.appendElement("script").attr("src", "/library/js/mathjax-config.js");
+      headMJ.appendElement("script").attr("type", "text/javascript").attr("src", MATHJAX_SRC_PATH);
+      return headMJ.toString();
+    }
 
     public String getQuestionProgressUnansweredPath () {
       return questionProgressUnansweredPath;


### PR DESCRIPTION
Jira: [SAK-47442](https://sakaiproject.atlassian.net/browse/SAK-47442)

`mathjax-config.js` generates the "MathJax.Hub.Config" based on the new properties (stored on the portal header).

`SkinnableCharonPortal.java` is where the config is applied for the whole site.

`DeliveryBean.java` applies the config for Tests inside an iFrame on Lessons.

There is an excepcion related to `HtmlPageFilter.java` { Site / Resources / Actions / Create THML Page ) as you can download a html file outside Sakai, where the script wont be called. That's why I implemented a similar method using Java.

