### PR TITLE
SAK-47462 Rubrics: Don't set weight for criterion groups

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
@@ -286,8 +286,13 @@ export class SakaiRubric extends RubricsElement {
     this.rubric.weighted = !this.rubric.weighted;
     if (this.rubric.weighted) {
       this.rubric.criteria.forEach(cr => cr.weight = 0);
-      this.rubric.criteria[0].weight = 100;
-      this.handleSaveWeights(e);
+      //Try to get first criterion, that is not a criterion group
+      const firstCriterion = this.rubric.criteria.find(criteria => criteria.ratings?.length > 0);
+      if (firstCriterion) {
+        //Set weight of first criterion to 100 (%)
+        firstCriterion.weight = 100;
+        this.handleSaveWeights(e);
+      }
       this.handleRefreshTotalWeight();
     }
 


### PR DESCRIPTION
When switching a rubric to weighted the weight for the first criterion get’s set to 100%. If there is a criterion group before other criteria, the criterion group get’s the weight value instead (hidden). The weight should only be set for “real” criteria.
This also fixes console errors when changing to weighted for a rubric without criteria.