### PR TITLE
SAK-47484 Samigo: Timer may cover title and table of contents

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -434,8 +434,7 @@
 	}
 
 	#delivAssessmentWrapper {
-		width: 96%;
-		float: left;
+		width: calc(100% - 56px);
 	}
 
 	.downloanQuestionCheckbox label {

--- a/samigo/samigo-app/src/webapp/css/timerbar.css
+++ b/samigo/samigo-app/src/webapp/css/timerbar.css
@@ -50,21 +50,10 @@
 }
 
 #timerBlock {
-	position: absolute;
-	top: 0px;
-	width: 75%;
+	position: sticky;
+	top: 52px;
 	background-color: var(--sakai-primary-color-1);
-	margin: 0;
-	margin-left: 15px;
-	padding: 0;
 	z-index: 2;
-}
-
-#timerBlank {
-	height: 110px;
-	border: 0;
-	padding: 0;
-	margin: 0;
 }
 
 #showHide {
@@ -109,14 +98,3 @@ tr.timerSubmission:nth-child(even) {
 	background-color: var(--sakai-background-color-2);
 }
 
-@media only screen and (max-width: 770px) {
-	#timerBlock {
-		position: absolute;
-		top: 0px;
-		width: 100%;
-		margin: 0;
-		padding: 0;
-		z-index: 2;
-		left: 0px;
-	}
-}

--- a/samigo/samigo-app/src/webapp/css/tool_sam.css
+++ b/samigo/samigo-app/src/webapp/css/tool_sam.css
@@ -1158,6 +1158,7 @@ td.feedbackColumn2 {
 	color: var(--sakai-text-color-1);
 	border: 1px solid var(--sakai-border-color);
 	border-bottom-left-radius: 4px;
+	z-index: 3;
 }
 
 div#questionProgressPanel div.tier1 {
@@ -1180,6 +1181,7 @@ div#questionProgressPanel div.tier1 {
 	border-bottom-left-radius: 4px;
 	cursor: pointer;
 	top: 20px;
+	z-index: 3;
 }
 .currentQuestion a {
 	border: 1px solid var(--sakai-active-color-3);

--- a/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryHeading.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryHeading.jsp
@@ -27,6 +27,9 @@ Headings for delivery pages, needs to have msg=DeliveryMessages.properties, etc.
 <h1>
    <h:outputText value="#{delivery.assessmentTitle}" escape="false"/>
 </h1>
+
+<div id="timerPosition"></div>
+
 <%-- NAV BAR --%>
   <ul class="navIntraTool actionToolbar" role="menu">
   <h:panelGroup rendered="#{(delivery.feedbackComponent.showImmediate || delivery.feedbackOnDate) 

--- a/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryTimer.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/assessmentDeliveryTimer.jsp
@@ -66,8 +66,8 @@ function isFromLink() {
 </h:panelGroup>
 
 <h:panelGroup rendered="#{delivery.actionString=='previewAssessment' && delivery.hasTimeLimit}" >
-  <f:verbatim><div style="margin:10px 0px 0px 0px;"><span style="background-color:#bab5b5; padding:5px"></f:verbatim>
+  <f:verbatim><div class="sak-banner-info"></f:verbatim>
   <h:outputText value="#{deliveryMessages.timer_preview_not_available}"/>
-  <f:verbatim></div></span></f:verbatim>
+  <f:verbatim></div></f:verbatim>
 </h:panelGroup>
 </p>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
@@ -119,9 +119,9 @@ function saveTime()
 
 
 <h:panelGroup rendered="#{delivery.actionString=='previewAssessment'&& delivery.hasTimeLimit}" >
-  <f:verbatim><div style="margin:10px 0px 0px 0px;"><span style="background-color:#bab5b5; padding:5px"></f:verbatim>
+  <f:verbatim><div class="sak-banner-info"></f:verbatim>
   <h:outputText value="#{deliveryMessages.timer_preview_not_available}"/>
-  <f:verbatim></div></span></f:verbatim>
+  <f:verbatim></div></f:verbatim>
 </h:panelGroup>
 
 <f:verbatim><br/></span></f:verbatim>

--- a/samigo/samigo-app/src/webapp/jsf/widget/timerBar/timerbar.js
+++ b/samigo/samigo-app/src/webapp/jsf/widget/timerBar/timerbar.js
@@ -47,10 +47,9 @@
           }
       });
 
-      var parnetBlock = $("main").length === 0 ? $("body") : $("main");
-      parnetBlock.prepend(`
+      var parnetBlock = $("#timerPosition");
+      parnetBlock.after(`
           <link href='/samigo-app/css/timerbar.css' type='text/css' rel='stylesheet' media='all' />
-          <div id='timerBlank'></div>
           <div id='timerBlock' aria-hidden='true'>
               <div class="progress-wrapper">
                   <div class="progress">
@@ -129,9 +128,6 @@
                       timerBlock.css("border-radius", "10px");
                   }
               }
-              timerBlock.css({
-                  "top": newTop,
-              });
           }
       }
 
@@ -161,7 +157,8 @@
       var indicator = timeoutDialog.find("#indicator");
       var showTimer = $("input[name$=\\:showTimer]");
 
-      showHide.click(function() {
+      showHide.click(function(e) {
+          e.preventDefault();
           if (progressbar.is(":visible")) {
               progressWrapper.slideUp();
               showHide.find("#showHideText").text(showMessage);


### PR DESCRIPTION
Place timer below the title and instead of placing it in `<main>` and adjust related CSS and JS.
This avoids, that the timer covers the assessment title and table of contents tab.
Also gave the question progress menu a z-index, so it can draw over the timer.