### PR TITLE
SAK-47489 this disables SSE for Bullhorns and modifies the fetch to the /direct/ endpoint

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5405,13 +5405,6 @@
 #portal.bullhorns.enabled=false
 
 # ###############################################################
-# SAK-30461 Add academic and social alerts icons to portal topbar
-# Set this to the number of milliseconds between polls
-# Defaults to 240000
-# ###############################################################
-#portal.bullhorns.poll.interval=60000
-
-# ###############################################################
 # SAK-43903 Configurable Favicon
 # Defaults to /library/icon/favicon.ico
 # ###############################################################

--- a/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
@@ -269,7 +269,7 @@
     horn.append('<span id="bullhorn-counter" class="bullhorn-counter-red">' + count + '</span>');
   };
 
-  let updateBullhornCounter = function (count) {
+  const updateBullhornCounter = function (count) {
 
       if (count > 0) {
         portal.setBullhornCounter(count);

--- a/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
@@ -220,10 +220,8 @@
       events: {
         visible: function (event, api) {
 
-          var firstBunch = document.querySelector("#bullhorn-alerts button");
-          if (firstBunch) {
-            firstBunch.focus();
-          }
+          const firstBunch = document.querySelector("#bullhorn-alerts button");
+          firstBunch && firstBunch.focus();
         }
       }
     });

--- a/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.bullhorns.js
@@ -217,42 +217,6 @@
       show: { event: 'click', delay: 0, solo: portal.socialBullhorn },
       style: { classes: 'portal-bullhorns' },
       hide: { event: 'click unfocus' },
-      content: {
-        text: function (event, api) {
-
-          if (portal.bullhornAlerts && portal.bullhornAlerts.length <= 0) {
-            return portal.wrapNoAlertsString(portal.bullhornsI18n.noAlerts);
-          } else {
-            var markup = '<div id="portal-bullhorn-alerts" class="accordion">';
-
-            var allBunches = [];
-            createBunches(portal.bullhornAlerts, "annc").forEach(alerts => allBunches.push({ type: "announcements", alerts: alerts }));
-            createBunches(portal.bullhornAlerts, "asn").forEach(alerts => allBunches.push({ type: "assignments", alerts: alerts }));
-            createBunches(portal.bullhornAlerts, "commons").forEach(alerts => allBunches.push({ type: "commons", alerts: alerts }));
-            createBunches(portal.bullhornAlerts, "lessonbuilder").forEach(alerts => allBunches.push({ type: "lessonbuilder", alerts: alerts }));
-            createBunches(portal.bullhornAlerts, "profile").forEach(alerts => allBunches.push({ type: "profile", alerts: alerts }));
-
-            allBunches.forEach(b => {
-              b.alerts.sort((first, second) => first.eventDate.epochSecond - second.eventDate.epochSecond);
-              b.latest = b.alerts[0].eventDate.epochSecond;
-              b.bunchDate = b.alerts[0].formattedEventDate;
-            });
-
-            allBunches.sort((a,b) => { return b.latest - a.latest; });
-
-            allBunches.forEach(b => { markup += getBunchMarkup(b, portal.bullhornsI18n) });
-
-            markup += `
-                <div id="portal-bullhorn-clear-all">
-                  <a href="javascript:;" onclick="portal.clearAllBullhornAlerts('${portal.bullhornsI18n.noAlerts}');">${portal.bullhornsI18n.clearAll}</a>
-                </div>
-              </div>
-            `;
-
-            return markup;
-          }
-        }
-      },
       events: {
         visible: function (event, api) {
 
@@ -265,6 +229,40 @@
     });
   });
 
+  var updateBullhornQtipContent = function(alertCount) {
+          if (alertCount <= 0) {
+             portal.bullhorn.qtip('option', 'content.text', portal.wrapNoAlertsString(portal.bullhorns.i18n.noAlerts));
+          } else {
+            let markup = '<div id="portal-bullhorn-alerts" class="accordion">';
+
+            let allBunches = [];
+            createBunches(portal.bullhorns.alerts, "annc").forEach(alerts => allBunches.push({ type: "announcements", alerts: alerts }));
+            createBunches(portal.bullhorns.alerts, "asn").forEach(alerts => allBunches.push({ type: "assignments", alerts: alerts }));
+            createBunches(portal.bullhorns.alerts, "commons").forEach(alerts => allBunches.push({ type: "commons", alerts: alerts }));
+            createBunches(portal.bullhorns.alerts, "lessonbuilder").forEach(alerts => allBunches.push({ type: "lessonbuilder", alerts: alerts }));
+            createBunches(portal.bullhorns.alerts, "profile").forEach(alerts => allBunches.push({ type: "profile", alerts: alerts }));
+
+            allBunches.forEach(b => {
+              b.alerts.sort((first, second) => first.eventDate.epochSecond - second.eventDate.epochSecond);
+              b.latest = b.alerts[0].eventDate.epochSecond;
+              b.bunchDate = b.alerts[0].formattedEventDate;
+            });
+
+            allBunches.sort((a,b) => { return b.latest - a.latest; });
+
+            allBunches.forEach(b => { markup += getBunchMarkup(b, portal.bullhorns.i18n) });
+
+            markup += `
+                <div id="portal-bullhorn-clear-all">
+                  <a href="javascript:;" onclick="portal.clearAllBullhornAlerts('${portal.bullhorns.i18n.noAlerts}');">${portal.bullhorns.i18n.clearAll}</a>
+                </div>
+              </div>
+            `;
+
+            portal.bullhorn.qtip('option', 'content.text', markup);
+          }
+  }
+
   portal.setBullhornCounter = function (count) {
 
     var horn = $('#Mrphs-bullhorn');
@@ -273,7 +271,7 @@
     horn.append('<span id="bullhorn-counter" class="bullhorn-counter-red">' + count + '</span>');
   };
 
-  var updateCount = function (count) {
+  let updateBullhornCounter = function (count) {
 
       if (count > 0) {
         portal.setBullhornCounter(count);
@@ -282,8 +280,19 @@
       }
   };
 
-  if (portal.loggedIn && portal.bullhorns && portal.bullhorns.enabled) {
-    portal.bullhornAlerts = [];
+  if (portal.loggedIn && portal.bullhorns && portal.bullhorns.enabled && portal.bullhorns.alertCount) {
+    updateBullhornCounter(portal.bullhorns.alertCount);
+  }
+
+  document.getElementById('Mrphs-bullhorn').onclick = function(e) {
+    portal.bullhorns.alerts = [];
+
+    // Dont fetch more than once per minute
+    if (portal.bullhorns.lastFetch && (Date.now() - portal.bullhorns.lastFetch) < 60000) {
+      return false;
+    }
+
+    portal.bullhorns.lastFetch = Date.now();
 
     fetch("/direct/portal/bullhornAlerts.json", {
         credentials: "include",
@@ -293,16 +302,18 @@
       .then(r => r.json())
       .then(data => {
 
-        portal.bullhornAlerts = data.alerts || [];
-        updateCount(portal.bullhornAlerts.length);
-        portal.bullhornsI18n = data.i18n;
-        portal.bullhornMessage = data.message;
+        portal.bullhorns.alerts = data.alerts || [];
+        updateBullhornCounter(portal.bullhorns.alerts.length);
+        portal.bullhorns.i18n = data.i18n;
+        portal.bullhorns.message = data.message;
+        updateBullhornQtipContent(portal.bullhorns.alerts.length);
       });
 
-    portal.registerForMessages("notifications", message => {
-
-      portal.bullhornAlerts.push(message);
-      updateCount(portal.bullhornAlerts.length);
-    });
+    if (portal.sse && portal.sse.enabled) {
+      portal.registerForMessages("notifications", message => {
+        portal.bullhorns.alerts.push(message);
+        updateBullhornCounter(portal.bullhorns.alerts.length);
+      });
+    }
   }
 }) ($PBJQ);

--- a/library/src/webapp/js/sakai-message-broker.js
+++ b/library/src/webapp/js/sakai-message-broker.js
@@ -1,6 +1,6 @@
 portal = portal || {};
 
-if (portal?.user?.id) {
+if (portal?.sse?.enabled && portal?.user?.id) {
   portal.messagesEventSource = new EventSource("/api/users/me/events");
 
   portal.messagesEventSource.onopen = e => console.debug("events connection established");

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -59,6 +59,8 @@ import org.sakaiproject.event.cover.UsageSessionService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.SakaiException;
+import org.sakaiproject.messaging.api.BullhornAlert;
+import org.sakaiproject.messaging.api.MessagingService;
 import org.sakaiproject.pasystem.api.PASystem;
 import org.sakaiproject.portal.api.Editor;
 import org.sakaiproject.portal.api.PageFilter;
@@ -170,6 +172,8 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 	private BasicAuth basicAuth = null;
 
 	private boolean enableDirect = false;
+
+	private MessagingService messagingService;
 
 	private PortalService portalService;
 	
@@ -1796,10 +1800,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 
 			boolean useBullhornAlerts = ServerConfigurationService.getBoolean("portal.bullhorns.enabled", true);
 			rcontext.put("useBullhornAlerts", useBullhornAlerts);
-			if (useBullhornAlerts) {
-				int bullhornAlertInterval = ServerConfigurationService.getInt("portal.bullhorns.poll.interval", 240000);
-				rcontext.put("bullhornsPollInterval", bullhornAlertInterval);
-			}
+			rcontext.put("bullhornAlertCount", useBullhornAlerts ? messagingService.getAlerts(thisUser).size() : 0);
 
 			String faviconURL = ServerConfigurationService.getString("portal.favicon.url");
 			rcontext.put("faviconURL", faviconURL);
@@ -2030,6 +2031,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 
 		siteHelper = new PortalSiteHelperImpl(this, findPageAliases);
 
+		messagingService = ComponentManager.get(MessagingService.class);
 		portalService = org.sakaiproject.portal.api.cover.PortalService.getInstance();
 		securityService = (SecurityService) ComponentManager.get("org.sakaiproject.authz.api.SecurityService");
 		chatHelper = org.sakaiproject.portal.api.cover.PortalChatPermittedHelper.getInstance();

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
@@ -7,15 +7,11 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <script> ## Include this at the top so tool markup and headscripts.js can use it
-            ## SAK-16484 Allow Javascript to easily get at user details.
-            ## SAK-13987, SAK-16162, SAK-19132 - Portal Logout Timer
+        <script>
             var portal = {
                 "bullhorns": {
                     "enabled": $!{useBullhornAlerts},
-                    #if ($useBullhornAlerts)
-                    "pollInterval": $!{bullhornsPollInterval}
-                    #end
+                    "alertCount": $!{bullhornAlertCount}
                 },
                 "chat": {
                     "enabled": $!{neoChat},


### PR DESCRIPTION
SSE is awesome as it reduces the cost of polling, and we should move more tools to use it. We also need more experience with SSE and managing connections.

This commit:

a) Sets up the number of alerts in portal server page load
b) Avoids a fetch call to setup bullhorns
c) Bullhorns only called onclick
d) Disables setting up the SSE

To use SSE, I'd like to see one more tool use it (not just Bullhorns) and would like to see more research into how to resume an SSE conn.