### PR TITLE
SAK-47415. Resources: drop-down menu content exceeds parent's size

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -97,7 +97,7 @@
 	}
 
 	#navigatePanelInner {
-		height:98%;
+		height:92%;
 		overflow:auto
 	}
 	#navigatePanel p.close{


### PR DESCRIPTION
In a site with many files or folders in Resources, when displaying the menu with title "All site files", the last item is displayed outside the space reserved by the container.  As can be seen in [SAK-47415](https://sakaiproject.atlassian.net/browse/SAK-47415).