### PR TITLE
SAK-47519 Rubrics: Criterion groups can not be renamed by an instructor

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-criteria.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-criteria.js
@@ -71,7 +71,13 @@ export class SakaiRubricCriteria extends RubricsElement {
               <h4 class="criterion-title">
                 <span @focus="${this.onFocus}" @focusout="${this.focusOut}" tabindex="0" role="button" title="${tr("drag_order")}" class="reorder-icon fa fa-bars"></span>
                 ${c.title}
-                <sakai-rubric-criterion-edit @criterion-edited="${this.criterionEdited}" criterion="${JSON.stringify(c)}" token="${this.token}" ?is-criterion-group="${true}"></sakai-rubric-criterion-edit>
+                <sakai-rubric-criterion-edit
+                    @criterion-edited="${this.criterionEdited}"
+                    site-id="${this.siteId}"
+                    rubric-id="${this.rubricId}"
+                    criterion="${JSON.stringify(c)}"
+                    ?is-criterion-group="${true}">
+                </sakai-rubric-criterion-edit>
               </h4>
               <p>${unsafeHTML(c.description)}</p>
             </div>
@@ -86,7 +92,8 @@ export class SakaiRubricCriteria extends RubricsElement {
               <h4 class="criterion-title">
                 <span @focus="${this.onFocus}" @focusout="${this.focusOut}" tabindex="0" role="button" title="${tr("drag_order")}" class="reorder-icon fa fa-bars"></span>
                 ${c.title}
-                <sakai-rubric-criterion-edit @criterion-edited="${this.criterionEdited}"
+                <sakai-rubric-criterion-edit
+                    @criterion-edited="${this.criterionEdited}"
                     site-id="${this.siteId}"
                     rubric-id="${this.rubricId}"
                     criterion="${JSON.stringify(c)}">


### PR DESCRIPTION
When trying to rename an criterion group as an instructor, it fails and an error will be promoted in the browser console. This happens, because `site-id` and `rubric-id` is not passed to the criterion group, so the request is being made to `undefined` site and rubric which will cause an permission exemption.
Also removed the token attribute, which seems to be a thing of the past.