### PR TITLE
SAK-46294 T&Q: Test Settings - Improve Text Wrapping around Radio Buttons for Exceptions

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -454,6 +454,18 @@
 		background-color: transparent;
 		color: var(--sakai-text-color-disabled);
 	}
+
+	.display-flex {
+		display: flex;
+		margin-bottom: 5px;
+		label {
+			padding-top: 3px;
+		}
+	}
+
+	input[type="text"].hasDatepicker {
+		margin: 0 4px 4px 0;
+	}
 }
 
 .#{$namespace}sakai-samigo, .#{$namespace}toolBody--sakai-samigo {

--- a/samigo/samigo-app/src/webapp/jsf/author/inc/extendedTime.jspf
+++ b/samigo/samigo-app/src/webapp/jsf/author/inc/extendedTime.jspf
@@ -3,28 +3,28 @@
     <h:outputLabel value="#{assessmentSettingsMessages.extendedTimeNew}" />
 </h:panelGroup>
 <h:panelGroup styleClass="row" layout="block">
-    <h:panelGroup styleClass="col-md-10" layout="block">
+    <h:panelGroup styleClass="col-md-12" layout="block">
         <h:panelGroup styleClass="form-group row" layout="block">
-                <h:panelGroup styleClass="col-md-2" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-2 display-flex" layout="block">
                     <h:selectOneRadio id="extendedEnableUser" group="userOrGroup">
                         <f:selectItem itemLabel="#{assessmentSettingsMessages.extendedTimeUser}" />
                     </h:selectOneRadio>
                 </h:panelGroup>
                 <h:outputLabel styleClass="sr-only" for="newEntry-user" value="#{assessmentSettingsMessages.extendedTimeUser}"/>
-                <h:panelGroup styleClass="col-md-4" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-4" layout="block">
                     <h:selectOneMenu id="newEntry-user" value="#{assessmentSettings.extendedTime.user}">
                         <f:selectItems value="#{assessmentSettings.usersInSite}" />
                     </h:selectOneMenu>
                 </h:panelGroup>
         </h:panelGroup>
         <h:panelGroup styleClass="form-group row" layout="block">
-                <h:panelGroup styleClass="col-md-2" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-2 display-flex" layout="block">
                     <h:selectOneRadio id="extendedEnableGroup" group="userOrGroup">
                         <f:selectItem itemLabel="#{assessmentSettingsMessages.extendedTimeGroup}" />
                     </h:selectOneRadio>
                 </h:panelGroup>
                 <h:outputLabel styleClass="sr-only" for="newEntry-group" value="#{assessmentSettingsMessages.extendedTimeGroup}"/>
-                <h:panelGroup styleClass="col-md-4" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-4" layout="block">
                     <h:selectOneMenu id="newEntry-group" value="#{assessmentSettings.extendedTime.group}">
                         <f:selectItems value="#{assessmentSettings.groupsForSiteWithNoGroup}" />
                     </h:selectOneMenu>

--- a/samigo/samigo-app/src/webapp/jsf/author/inc/publishedExtendedTime.jspf
+++ b/samigo/samigo-app/src/webapp/jsf/author/inc/publishedExtendedTime.jspf
@@ -3,28 +3,28 @@
     <h:outputLabel value="#{assessmentSettingsMessages.extendedTimeNew}" />
 </h:panelGroup>
 <h:panelGroup styleClass="row" layout="block">
-    <h:panelGroup styleClass="col-md-10" layout="block">
+    <h:panelGroup styleClass="col-md-12" layout="block">
         <h:panelGroup styleClass="form-group row" layout="block">
-                <h:panelGroup styleClass="col-md-2" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-2 display-flex" layout="block">
                     <h:selectOneRadio id="extendedEnableUser" group="userOrGroup">
                         <f:selectItem itemLabel="#{assessmentSettingsMessages.extendedTimeUser}" />
                     </h:selectOneRadio>
                 </h:panelGroup>
                 <h:outputLabel styleClass="sr-only" for="newEntry-user" value="#{assessmentSettingsMessages.extendedTimeUser}"/>
-                <h:panelGroup styleClass="col-md-4" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-4" layout="block">
                     <h:selectOneMenu id="newEntry-user" value="#{publishedSettings.extendedTime.user}">
                         <f:selectItems value="#{publishedSettings.usersInSite}" />
                     </h:selectOneMenu>
                 </h:panelGroup>
         </h:panelGroup>
         <h:panelGroup styleClass="form-group row" layout="block">
-                <h:panelGroup styleClass="col-md-2" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-2 display-flex" layout="block">
                     <h:selectOneRadio id="extendedEnableGroup" group="userOrGroup">
                         <f:selectItem itemLabel="#{assessmentSettingsMessages.extendedTimeGroup}" />
                     </h:selectOneRadio>
                 </h:panelGroup>
                 <h:outputLabel styleClass="sr-only" for="newEntry-group" value="#{assessmentSettingsMessages.extendedTimeGroup}"/>
-                <h:panelGroup styleClass="col-md-4" layout="block">
+                <h:panelGroup styleClass="col-xs-12 col-lg-4" layout="block">
                     <h:selectOneMenu id="newEntry-group" value="#{publishedSettings.extendedTime.group}">
                         <f:selectItems value="#{publishedSettings.groupsForSiteWithNoGroup}" />
                     </h:selectOneMenu>


### PR DESCRIPTION
Jira: [SAK-46294](https://sakaiproject.atlassian.net/browse/SAK-46294) (screenshot)

- The label will always start next to the Radio button (not from next line).
- Now the section content will expand further to the right & added space between date input and its button.