### PR TITLE
SAK-47526 Add Topic ID to Discussions archive (msgcntr)

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -275,6 +275,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 			for (DiscussionTopic discussionTopic : discussionTopics) {
 				final Element discussionTopicElement = doc.createElement(DISCUSSION_TOPIC);
 				discussionTopicElement.setAttribute(TOPIC_TITLE, discussionTopic.getTitle());
+				discussionTopicElement.setAttribute(ID, discussionTopic.getId().toString());
 				discussionTopicElement.setAttribute(DRAFT, discussionTopic.getDraft().toString());
 				discussionTopicElement.setAttribute(LOCKED, discussionTopic.getLocked().toString());
 				discussionTopicElement.setAttribute(MODERATED, discussionTopic.getModerated().toString());


### PR DESCRIPTION
Supports cross-referencing Lessons links with Discussions in site archive.