### PR TITLE
SAK-47536 Full screen message should appear at the bottom on vm

### DIFF
--- a/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
+++ b/library/src/morpheus-master/js/src/sakai.morpheus.toggletools.js
@@ -59,14 +59,14 @@ portal.toggleMinimizeNav = function () {
   }
 };
 
-const indicator = document.querySelector("#maximised-indicator a");
-indicator && indicator.addEventListener("click", portal.minimiseTool);
-
-$PBJQ("#toolsNav-toggle-li button").on("click", portal.toggleMinimizeNav);
-
 $PBJQ(document).ready(function () {
 //Shows or hides the subsites in a popout div. This isn't used unless
 // portal.showSubsitesAsFlyout is set to true in sakai.properties.
+
+    const indicator = document.querySelector("#maximised-indicator a");
+    indicator && indicator.addEventListener("click", portal.minimiseTool);
+
+    $PBJQ("#toolsNav-toggle-li button").on("click", portal.toggleMinimizeNav);
     $PBJQ("#toggleSubsitesLink").click(function (e) {
         var subsitesLink = $PBJQ(this);
         if ($PBJQ('#subSites').css('display') == 'block') {

--- a/library/src/morpheus-master/sass/base/_defaults.scss
+++ b/library/src/morpheus-master/sass/base/_defaults.scss
@@ -17,6 +17,7 @@ body{
 		overflow: hidden;
 		display: none;
 		left: 50%;
+		top: 0;
 		transform: translateX(-50%);
 		z-index: 100000;
 		div {
@@ -36,6 +37,19 @@ body{
 	&.tool-maximised {
 		#maximised-indicator {
 			display: block;
+		}
+	}
+}
+
+sakai-maximise-button {
+	@media #{$phone} {
+		display: none;
+	}
+
+	body.tool-maximised & {
+		.#{$namespace}toolTitleNav__link {
+			@extend .btn;
+			@extend .btn-primary;
 		}
 	}
 }

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
@@ -6,12 +6,6 @@
 
     <body #if( !${loggedIn} ) class="Mrphs-portalBody is-logged-out" #else class="Mrphs-portalBody ${logoSiteClass} #if ( ${toolsCollapsed} ) Mrphs-toolMenu-collapsed #end #if ( ${toolMaximised} ) tool-maximised #end" #end $pageSiteType>
 
-        <div id="maximised-indicator">
-            <div>
-                <a href="javascript:;">${rloader.sit_fullscreen_message}</a>
-            </div>
-        </div>
-
         <noscript>
             <span id="portal_js_warn" class="Mrphs-noJs js-warn-no-js">${rloader.sit_noscript_message}</span>
         </noscript>
@@ -270,6 +264,10 @@
         </div>
         #parse("/vm/morpheus/connection-manager.vm")
         #end
-
+        <div id="maximised-indicator">
+            <div>
+                <a href="javascript:;">${rloader.sit_fullscreen_message}</a>
+            </div>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47536

The reason for putting the message at the end of the HTML instead of at the beginning is because, when a browser for the visually impaired scrolls the page, it always shows that "exit full screen", when they don't even have a screen.

A couple of users complained to us about that. By putting it at the end of the document, as they were reading where they were interested and did not get to the end of the page, it was much more comfortable for them.

This change, as I said, was made because some people with sight problems told us about it.

Also, maximize button has been removed from mobile design.