### PR TITLE
SAK-47597 - Web content is not on dark mode

### DIFF
--- a/library/src/webapp/content/myworkspace_info.html
+++ b/library/src/webapp/content/myworkspace_info.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body style="background-color:transparent">

--- a/library/src/webapp/content/myworkspace_info_ca.html
+++ b/library/src/webapp/content/myworkspace_info_ca.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body>

--- a/library/src/webapp/content/myworkspace_info_es.html
+++ b/library/src/webapp/content/myworkspace_info_es.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body>

--- a/library/src/webapp/content/myworkspace_info_ja.html
+++ b/library/src/webapp/content/myworkspace_info_ja.html
@@ -5,6 +5,7 @@
 		<title>マイワークスペース情報</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
 		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body>

--- a/library/src/webapp/content/myworkspace_info_mn.html
+++ b/library/src/webapp/content/myworkspace_info_mn.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body>

--- a/library/src/webapp/content/myworkspace_info_tr_TR.html
+++ b/library/src/webapp/content/myworkspace_info_tr_TR.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body>

--- a/library/src/webapp/content/myworkspace_info_zh_CN.html
+++ b/library/src/webapp/content/myworkspace_info_zh_CN.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 
 	<body>

--- a/library/src/webapp/content/server_info.html
+++ b/library/src/webapp/content/server_info.html
@@ -10,7 +10,7 @@
     includeLatestJQuery('server_info.html');
     includeWebjarLibrary('bootstrap');
 </script>
-
+<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 <style type="text/css">
 
 .jtop{

--- a/library/src/webapp/content/server_info_ca.html
+++ b/library/src/webapp/content/server_info_ca.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/server_info_es.html
+++ b/library/src/webapp/content/server_info_es.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/server_info_ja.html
+++ b/library/src/webapp/content/server_info_ja.html
@@ -5,6 +5,7 @@
 		<title>Sakai へようこそ</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
 		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/server_info_mn.html
+++ b/library/src/webapp/content/server_info_mn.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/server_info_tr_TR.html
+++ b/library/src/webapp/content/server_info_tr_TR.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/server_info_zh_CN.html
+++ b/library/src/webapp/content/server_info_zh_CN.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions.html
+++ b/library/src/webapp/content/webcontent_instructions.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions_ca.html
+++ b/library/src/webapp/content/webcontent_instructions_ca.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions_es.html
+++ b/library/src/webapp/content/webcontent_instructions_es.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions_ja.html
+++ b/library/src/webapp/content/webcontent_instructions_ja.html
@@ -5,6 +5,7 @@
 		<title>ウェブコンテンツに関するインストラクション</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
 		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions_mn.html
+++ b/library/src/webapp/content/webcontent_instructions_mn.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions_tr_TR.html
+++ b/library/src/webapp/content/webcontent_instructions_tr_TR.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webcontent_instructions_zh_CN.html
+++ b/library/src/webapp/content/webcontent_instructions_zh_CN.html
@@ -32,6 +32,7 @@
 			}
 		// -->
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>
 		<div class="portletBody">

--- a/library/src/webapp/content/webdav_instructions.html
+++ b/library/src/webapp/content/webdav_instructions.html
@@ -133,7 +133,7 @@
 	
 		// -->
 		</script>
-		
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 <body onload="(window.frameElement) ? setMainFrameHeight(trim(window.frameElement.id)):'';localizeData()">
           <div id="tabs" style="font-size:95%">

--- a/library/src/webapp/content/webdav_instructions_ca.html
+++ b/library/src/webapp/content/webdav_instructions_ca.html
@@ -122,7 +122,7 @@
 
 		// -->
 		</script>
-		
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 <body onload="(window.frameElement) ? setMainFrameHeight(trim(window.frameElement.id)):'';localizeData()">
 		<div id="tabs" style="font-size: 95%">

--- a/library/src/webapp/content/webdav_instructions_es.html
+++ b/library/src/webapp/content/webdav_instructions_es.html
@@ -131,6 +131,7 @@
 			return 'dav'+$(parent.document.getElementById("webDavUrl")).val().substring(4);
 		}
 	</script>
+	<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 </head>
 
 <body onload="(window.frameElement) ? setMainFrameHeight(trim(window.frameElement.id)):'';localizeData()">

--- a/library/src/webapp/content/webdav_instructions_ja.html
+++ b/library/src/webapp/content/webdav_instructions_ja.html
@@ -31,6 +31,7 @@
 				}
 			}
 		</script>
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body style="width:97%;padding:1em">
 		<div>

--- a/library/src/webapp/content/webdav_instructions_mn.html
+++ b/library/src/webapp/content/webdav_instructions_mn.html
@@ -94,7 +94,7 @@
 	
 		// -->
 		</script>
-		
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 <body onload="(window.frameElement) ? setMainFrameHeight(trim(window.frameElement.id)):'';localizeData()">
 		<div>

--- a/library/src/webapp/content/webdav_instructions_sv.html
+++ b/library/src/webapp/content/webdav_instructions_sv.html
@@ -93,7 +93,7 @@
 	
 		// -->
 		</script>
-		
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 <body onload="(window.frameElement) ? setMainFrameHeight(trim(window.frameElement.id)):'';localizeData()">
 		<div>

--- a/library/src/webapp/content/webdav_instructions_zh_CN.html
+++ b/library/src/webapp/content/webdav_instructions_zh_CN.html
@@ -94,7 +94,7 @@
 	
 		// -->
 		</script>
-		
+		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 <body onload="(window.frameElement) ? setMainFrameHeight(trim(window.frameElement.id)):'';localizeData()">
 		<div>

--- a/library/src/webapp/js/sakai-iframe-copy-classes.js
+++ b/library/src/webapp/js/sakai-iframe-copy-classes.js
@@ -1,0 +1,4 @@
+if (window.self !== window.top) {
+  document.body.classList = [...window.top.document.body.classList].join(' ')
+  document.getElementsByTagName("html")[0].classList = window.top.document.getElementsByTagName("html")[0].classList
+}


### PR DESCRIPTION
When the web content tool is added to a site, a language-dependent static HTML appears that does not display correctly according to the user's theme preferences.

This also occurs in other static HTML displayed as an iframe.

A new JS is added that copies, if in an iframe, the HTML and BODY tag classes to the web document inside the iframe.