### PR TITLE
SAK-47649 SITESTATS Avoid NULL when recompiling sitestats

### DIFF
--- a/sitestats/sitestats-impl-hib/src/java/org/sakaiproject/sitestats/impl/SitePresenceTotalImpl.java
+++ b/sitestats/sitestats-impl-hib/src/java/org/sakaiproject/sitestats/impl/SitePresenceTotalImpl.java
@@ -50,7 +50,7 @@ public class SitePresenceTotalImpl implements SitePresenceTotal, Serializable {
         siteId = sp.getSiteId();
         userId = sp.getUserId();
         totalVisits = 1;
-        lastVisitTime = sp.getLastVisitStartTime();
+        lastVisitTime = sp.getLastVisitStartTime() != null ? sp.getLastVisitStartTime() : sp.getDate();
     }
 
     public void incrementTotalVisits() {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47649

SST_PRESENCE_TOTALS has not null constraint in column LAST_VISIT_TIME and new rows are populated with data from SST_PRESENCES and column LAST_VISIT_START_TIME that has “default null”, so you have to avoid this using P_DATE column instead, that is also NOT NULL. Just restoring the original line from [SAK-31760: ORA-01407 Error with LAST_VISIT_TIME when site presence enabledRESOLVED](https://sakaiproject.atlassian.net/browse/SAK-31760) here lost in [SAK-39989: Sitestats: test failureCLOSED](https://sakaiproject.atlassian.net/browse/SAK-39989).