### PR TITLE
SAK-47654 rubrics: remove siteId from rubric association

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/beans/AssociationTransferBean.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/beans/AssociationTransferBean.java
@@ -37,7 +37,7 @@ public class AssociationTransferBean {
         bean.id = assoc.getId();
         bean.toolId = assoc.getToolId();
         bean.itemId = assoc.getItemId();
-        bean.siteId = assoc.getSiteId();
+        bean.siteId = assoc.getRubric().getOwnerId();
         bean.rubricId = assoc.getRubricId();
         bean.parameters = assoc.getParameters();
         return bean;
@@ -49,7 +49,6 @@ public class AssociationTransferBean {
         assoc.setId(id);
         assoc.setToolId(toolId);
         assoc.setItemId(itemId);
-        assoc.setSiteId(siteId);
         assoc.setRubricId(rubricId);
         assoc.setParameters(parameters);
         return assoc;

--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/ToolItemRubricAssociation.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/ToolItemRubricAssociation.java
@@ -66,7 +66,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Table(name = "rbc_tool_item_rbc_assoc",
-    indexes = { @Index(name = "rbc_tool_item_owner", columnList = "toolId, itemId, siteId"),
+    indexes = { @Index(name = "rbc_tool_item", columnList = "toolId, itemId"),
                 @Index(name = "rbc_item_rubric", columnList = "itemId, rubric_id", unique = true) }
 )
 @ToString(exclude = {"rubric", "parameters"})
@@ -98,9 +98,6 @@ public class ToolItemRubricAssociation implements PersistableEntity<Long>, Seria
 
     @Column(length = 99)
     private String creatorId;
-
-    @Column(length = 99)
-    private String siteId;
 
     @Column(name = "active", nullable = false)
     private Boolean active = Boolean.TRUE;

--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
@@ -665,7 +665,6 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
 
         String associationId = null;
         String created = "";
-        String owner = "";
         String ownerType = "";
         String creatorId = "";
         String oldRubricId = null;
@@ -677,7 +676,6 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
             if (optAssociation.isPresent()) {
                 association = optAssociation.get();
                 created = association.getCreated().toString();
-                owner = association.getSiteId();
                 creatorId = association.getCreatorId();
                 oldParams = association.getParameters();
                 oldRubricId = association.getRubricId().toString();
@@ -699,7 +697,7 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
                     }
 
                     // See if there's already an association for the requested rubric and reuse that.
-                    Optional<ToolItemRubricAssociation> optionalExisting = findAssociationByItemIdAndRubricId(toolItemId, Long.parseLong(rubricId), toolId, null);
+                    Optional<ToolItemRubricAssociation> optionalExisting = findAssociationByItemIdAndRubricId(toolItemId, Long.parseLong(rubricId), toolId);
                     if (optionalExisting.isPresent()) {
                         return Optional.of(setAssociationActive(optionalExisting.get(), true, toolId));
                     } else {
@@ -711,7 +709,6 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
                         LocalDateTime now = LocalDateTime.now();
                         newAssociation.setCreated(now);
                         newAssociation.setModified(now);
-                        newAssociation.setSiteId(siteId);
                         newAssociation.setCreatorId(userDirectoryService.getCurrentUser().getId());
                         newAssociation.setParameters(setConfigurationParameters(params, oldParams));
 
@@ -736,9 +733,11 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
         }
     }
 
-    private Optional<ToolItemRubricAssociation> findAssociationByItemIdAndRubricId(String toolItemId, Long rubricId, String toolId, String siteId) {
+    private Optional<ToolItemRubricAssociation> findAssociationByItemIdAndRubricId(String toolItemId, Long rubricId, String toolId) {
 
         return associationRepository.findByItemIdAndRubricId(toolItemId, rubricId).map(assoc -> {
+
+            String siteId = assoc.getRubric().getOwnerId();
 
             String currentUserId = userDirectoryService.getCurrentUser().getId();
 
@@ -795,7 +794,7 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
 
             String currentUserId = userDirectoryService.getCurrentUser().getId();
 
-            if (isEditor(assoc.getSiteId()) || assoc.getCreatorId().equalsIgnoreCase(currentUserId)) {
+            if (isEditor(assoc.getRubric().getOwnerId()) || assoc.getCreatorId().equalsIgnoreCase(currentUserId)) {
                 return assoc;
             } else {
                 return null;
@@ -826,7 +825,7 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
 
         associationRepository.findByItemIdPrefix(toolId, itemId).forEach(assoc -> {
 
-            if (securityService.unlock(RubricsConstants.RBCS_PERMISSIONS_EDITOR, siteService.siteReference(assoc.getSiteId()))) {
+            if (securityService.unlock(RubricsConstants.RBCS_PERMISSIONS_EDITOR, siteService.siteReference(assoc.getRubric().getOwnerId()))) {
                 try {
                     evaluationRepository.deleteByToolItemRubricAssociation_Id(assoc.getId());
                 } catch (Exception e) {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47654

We can get the ownerId from the rubric instead.