### PR TITLE
SAK-47662 Roster - Avoid endpoint crash due to concurrent modification and NPE recovering search indexes

### DIFF
--- a/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -50,9 +50,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Resource;
 
@@ -1286,7 +1288,8 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 
             if (MapUtils.isEmpty(index)) {
                 final List<RosterMember> membership = getMembership(userId, siteId, groupId, roleId, enrollmentSetId, enrollmentStatus);
-                index = membership.stream().collect(Collectors.toMap(RosterMember::getUserId, RosterMember::getDisplayName));
+                index = Optional.ofNullable(membership).map(Collection::stream).orElseGet(Stream::empty)
+                        .collect(Collectors.toMap(RosterMember::getUserId, RosterMember::getDisplayName));
                 cache.put(siteId+groupId, index);
             }
 		

--- a/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -859,7 +859,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 
         if (siteMembers != null) {
             log.debug("Cache hit on '{}'.", key);
-            return siteMembers;
+            return new ArrayList<>(siteMembers);
         } else {
             log.debug("Cache miss on '{}'.", key);
 
@@ -938,7 +938,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
                 // Cache the main site list
                 cache.put(siteId, siteMembers);
 
-                return (List<RosterMember>) cache.get(key);
+                return new ArrayList<>((List<RosterMember>) cache.get(key));
             }
         }
     }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47662
We already don't know what is the exact cause of the error in the Jira, but this should be checked to avoid the NPE.