### PR TITLE
 SAK-47700 Assignments: Get back to "type text" for bulk grading input

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -90,7 +90,7 @@ function printView(url) {
 								</select>
 							#else
 							## instructor needs to type in default points in point-based-grading
-							<input type="number" id="defaultGrade_2" name="defaultGrade" value="$!defaultGrade" min="0" step="0.01" placeholder="$tlang.getString('gen.gra')" />
+							<input type="text" id="defaultGrade_2" name="defaultGrade" value="$!defaultGrade" placeholder="$tlang.getString('gen.gra')" size="6" />
 							#end
 							<input type="button" accesskey="a" class="active" name="apply" value="$tlang.getString('gen.applygrade')" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'defaultGradeForm', null, null, null );" title="$tlang.getString("gen.applygrade")" />
 							<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />

--- a/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
+++ b/library/src/morpheus-master/sass/modules/tool/assignments/_assignments.scss
@@ -148,10 +148,9 @@
 		font-weight: bold;
 	}
 
-	input[type=number] {
+	input[type=text] {
 		margin-right: 4px;
 		padding: 0px 6px;
-		width: 100px;
 	}
 
 	::placeholder {


### PR DESCRIPTION
Related to [Commit #10378](https://github.com/sakaiproject/sakai/pull/10378)
Jira: [SAK-47700](https://sakaiproject.atlassian.net/browse/SAK-47700)

Reason: incompatibility with decimal comma based languages.

It makes sense to use type “number” as the input will always receive a score, and results in less checks on the backend.

So the best option would be to modify the backend, but by the way it’s coded, a lot of extra inputs/logic should be modified, taking longer than expected. Then, this should be a temporal patch.