### PR TITLE
SAK-47702 Add sakai namespace prefix to site archive XML files

### DIFF
--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteArchiver.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteArchiver.java
@@ -184,6 +184,7 @@ public class SiteArchiver {
 			root.setAttribute("server", m_serverConfigurationService.getServerId());
 			root.setAttribute("date", now.toString());
 			root.setAttribute("system", fromSystem);
+			root.setAttribute("xmlns:sakai", "https://www.sakailms.org/xmlns/archive/");
 			
 			stack.push(root);
 


### PR DESCRIPTION
The URI provided here isn't a real path on www.sakailms.org but that doesn't matter because it just needs to be unique.