### PR TITLE
SAK-47698 - No need to show an empty table.  The datatable javascript…

### DIFF
--- a/sections/sections-app/src/webapp/overview.jsp
+++ b/sections/sections-app/src/webapp/overview.jsp
@@ -34,6 +34,7 @@
         styleClass="listHier sectionTable"
         columnClasses=",,leftIndent,left,left,left,left,right,right,center"
         rowClasses="groupRow"
+        renderedIfEmpty="false"
         >
         <h:column>
             <f:facet name="header">


### PR DESCRIPTION
… gets mad when the row columns don't match up with the header columns.