### PR TITLE
SAK-47725 Gradebook: Add a Quick Entry form for rapid grading

### DIFF
--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -16,6 +16,32 @@ link.importexport.tooltip = Import /  Export
 link.permissions = Permissions
 link.permissions.tooltip = Permissions
 
+link.quickentry = Quick Entry
+link.quickentry.tooltip = Quick Entry
+quickentry.title = Quick Entry
+itempicker.null = Select Gradebook item
+quickentry.success = Scores for item {0} have been updated in Quick Entry.
+quickentry.error = There were errors saving grades for the following user: {0}
+groupicker.nullValid = All groups
+quickentry.comment = Comment
+quickentry.grade = Grade
+quickentry.student = Student
+quickentry.points = points
+quickentry.setscore = Set Score
+quickentry.caption = Quickly set grades and comments for a single Gradebook item using the form below.<br />You can navigate between the fields on the page using Tab, Enter, or your keyboard's arrow keys.
+quickentry.comment.caption = Fill Empty Comments
+quickentry.comment.link = Set
+quickentry.reset = Reset
+quickentry.externally = Grade externally maintained in {0}
+quickentry.itemlabel = Gradebook item: 
+quickentry.replacegradelabel = Set Score For Empty Grades
+quickentry.replacecomment = Set empty comments to: 
+quickentry.replacescore = Set empty scores to: 
+quickentry.excuse = Excused
+quickentry.count = Showing {0} of {1} students 
+quickentry.scorecaption = Use this form to bulk-enter a value for all empty grades in the table.
+quickentry.commentcaption = Use this form to set the text for all students with no comment.
+
 link.screenreader.tabnotselected = tab
 link.screenreader.tabselected = tab selected
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/QuickEntryAction.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/QuickEntryAction.java
@@ -1,0 +1,26 @@
+package org.sakaiproject.gradebookng.tool.actions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.sakaiproject.gradebookng.tool.pages.GradebookPage;
+import org.sakaiproject.gradebookng.tool.pages.QuickEntryPage;
+
+import java.io.Serializable;
+
+public class QuickEntryAction extends InjectableAction implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public QuickEntryAction() {
+    }
+
+    @Override
+    public ActionResponse handleEvent(final JsonNode params, final AjaxRequestTarget target) {
+        final String assignmentId = params.get("assignmentId").asText();
+        PageParameters paramsNow = new PageParameters();
+        paramsNow.add("selected",assignmentId);
+        final GradebookPage gradebookPage = (GradebookPage) target.getPage();
+        gradebookPage.setResponsePage(QuickEntryPage.class, paramsNow);
+        return new EmptyOkResponse();
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -138,6 +138,7 @@
                     <ul class="dropdown-menu dropdown-menu-right" role="menu">
                         {if settings.isUserAbleToEditAssessments}
                             <li><a href="javascript:void(0);" class="edit-assignment-details" role="menuitem"><wicket:message key="assignment.option.edit" /></a></li>
+                            <li><a href="javascript:void(0);" class="gb-quick-entry" role="menuitem"><wicket:message key="link.quickentry" /></a></li>
                         {/if}
                         <li><a href="javascript:void(0);" class="gb-view-statistics" role="menuitem"><wicket:message key="assignment.option.viewgradestatistics" /></a></li>
                         {if settings.isUserAbleToEditAssessments}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.html
@@ -14,7 +14,15 @@
 						<span wicket:id="screenreaderlabel" class="sr-only"></span>
 					</a>
 				</span>
-			</li>    
+			</li>
+			<li>
+				<span>
+					<a wicket:id="quickEntryPageLink" wicket:message="title:link.quickentry.tooltip">
+						<wicket:message key="link.quickentry" />
+						<span wicket:id="screenreaderlabel" class="sr-only"></span>
+					</a>
+				</span>
+			</li>
 			<li>
 				<span>
 					<a wicket:id="importExportPageLink" wicket:message="title:link.importexport.tooltip">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/BasePage.java
@@ -70,6 +70,7 @@ public class BasePage extends WebPage {
 	Link<Void> settingsPageLink;
 	Link<Void> importExportPageLink;
 	Link<Void> permissionsPageLink;
+	Link<Void> quickEntryPageLink;
 
 	public final GbFeedbackPanel feedbackPanel;
 
@@ -162,6 +163,18 @@ public class BasePage extends WebPage {
 		};
 		this.settingsPageLink.add(new Label("screenreaderlabel", getString("link.screenreader.tabnotselected")));
 		nav.add(this.settingsPageLink);
+
+		// quick entry page
+		this.quickEntryPageLink = new BookmarkablePageLink<Void>("quickEntryPageLink", QuickEntryPage.class) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean isVisible() {
+				return (businessService.isUserAbleToEditAssessments());
+			}
+		};
+		this.quickEntryPageLink.add(new Label("screenreaderlabel", getString("link.screenreader.tabnotselected")));
+		nav.add(this.quickEntryPageLink);
 
 		add(nav);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -55,6 +55,7 @@ import org.sakaiproject.gradebookng.tool.actions.GradeUpdateAction;
 import org.sakaiproject.gradebookng.tool.actions.MoveAssignmentLeftAction;
 import org.sakaiproject.gradebookng.tool.actions.MoveAssignmentRightAction;
 import org.sakaiproject.gradebookng.tool.actions.OverrideCourseGradeAction;
+import org.sakaiproject.gradebookng.tool.actions.QuickEntryAction;
 import org.sakaiproject.gradebookng.tool.actions.SetScoreForUngradedAction;
 import org.sakaiproject.gradebookng.tool.actions.SetStudentNameOrderAction;
 import org.sakaiproject.gradebookng.tool.actions.SetZeroScoreAction;
@@ -304,6 +305,7 @@ public class GradebookPage extends BasePage {
 		this.gradeTable.addEventListener("viewGradeSummary", new ViewGradeSummaryAction());
 		this.gradeTable.addEventListener("setZeroScore", new SetZeroScoreAction());
 		this.gradeTable.addEventListener("viewCourseGradeLog", new ViewCourseGradeLogAction());
+		this.gradeTable.addEventListener("quickEntry", new QuickEntryAction());
 		this.gradeTable.addEventListener("deleteAssignment", new DeleteAssignmentAction());
 		this.gradeTable.addEventListener("setUngraded", new SetScoreForUngradedAction());
 		this.gradeTable.addEventListener("setStudentNameOrder", new SetStudentNameOrderAction());

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/QuickEntryPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/QuickEntryPage.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:extend>
+    <h2>
+        <wicket:message key="quickentry.title" />
+    </h2>
+    <wicket:message key="quickentry.caption" />
+    <form wicket:id="form" >
+        <h3><wicket:message key="quickentry.itemlabel" /></h3>
+        <select wicket:id="itempicker" />
+        <hr />
+        <h3 wicket:id="itemtitle" />
+        <span class="detailsFont" wicket:id="itemdetails" />
+        <div class="quickentrySpacing">
+            <span>
+                <strong><span wicket:id="summarycount" /></strong>
+                <select wicket:id="groupicker" />
+            </span>
+            <span class="buttons">
+                <button class="endButton" wicket:id="showBulkGrade" >
+                    <wicket:message key="quickentry.replacegradelabel" />
+                </button>
+                <button class="endButton" wicket:id="showBulkComment" >
+                    <wicket:message key="quickentry.comment.caption" />
+                </button>
+            </span>
+        </div>
+        <table wicket:id="tableVisibility" class="table table-striped table-bordered" >
+            <thead>
+            <tr>
+                <th class="col-sm-3"><wicket:message key="quickentry.student" /></th>
+                <th><wicket:message key="quickentry.grade" /></th>
+                <th><wicket:message key="quickentry.comment" /></th>
+                <th><wicket:message key="quickentry.excuse" /></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr wicket:id="studentRow">
+                <td>
+                    <span wicket:id="studentName"></span>
+                </td>
+                <td>
+                    <input wicket:id="studentGrade" type="text" />
+                    <i wicket:id="lockicon" />
+                </td>
+                <td>
+                    <textarea wicket:id="studentComment" />
+                </td>
+                <td>
+                    <input type="checkbox" wicket:id="studentExcuse" />
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <div class="act" >
+            <button wicket:id="submit" class="btn btn-primary active"><wicket:message key="button.update" /></button>
+            <button wicket:id="reset" class="btn" ><wicket:message key="quickentry.reset" /></button>
+            <button wicket:id="cancel" class="btn" ><wicket:message key="button.cancel" /></button>
+        </div>
+        <div wicket:id="bulkGradeModal" />
+        <div wicket:id="bulkCommentModal" />
+    </form>
+</wicket:extend>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/QuickEntryPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/QuickEntryPage.java
@@ -1,0 +1,386 @@
+package org.sakaiproject.gradebookng.tool.pages;
+
+import java.io.Serializable;
+import java.text.MessageFormat;
+import java.util.*;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
+import org.apache.wicket.markup.head.CssHeaderItem;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.*;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.sakaiproject.gradebookng.business.GradeSaveResponse;
+import org.sakaiproject.gradebookng.business.model.GbGroup;
+import org.sakaiproject.gradebookng.business.model.GbUser;
+import org.sakaiproject.gradebookng.tool.panels.BulkGradePanel;
+import org.sakaiproject.portal.util.PortalUtils;
+import org.sakaiproject.grading.api.Assignment;
+import org.sakaiproject.grading.api.SortType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class QuickEntryPage extends BasePage {
+    private static final long serialVersionUID = 1L;
+
+    private Assignment assignmentNow;
+    private GbGroup groupNow;
+    private String assignmentIdNow;
+    @Getter
+    private ModalWindow bulkGrade;
+    @Getter
+    private ModalWindow bulkComment;
+    private boolean noErrors = true;
+
+    public QuickEntryPage() {
+        disableLink(this.quickEntryPageLink);
+    }
+
+    @Override
+    public void onInitialize() {
+        super.onInitialize();
+        SortType sortBy = SortType.SORT_BY_NAME;
+        final List<Assignment> assignments = this.businessService.getGradebookAssignments(sortBy);
+        final DropDownChoice<Assignment> itempicker = new DropDownChoice<Assignment>("itempicker", new Model<Assignment>(),assignments, new ChoiceRenderer<Assignment>(){
+            private static final long serialVersionUID = 1L;
+            @Override
+            public Object getDisplayValue(final Assignment a) {
+                return a.getName();
+            }
+            @Override
+            public String getIdValue(final Assignment a,final int index) {
+                return String.valueOf(a.getId());
+            }
+        });
+        itempicker.add(new AjaxFormComponentUpdatingBehavior("onchange") {  // add the onchange to the chooser
+            private static final long serialVersionUID = 1L;
+            @Override
+            protected void onUpdate(final AjaxRequestTarget target) {
+                final Assignment selection = (Assignment) itempicker.getDefaultModelObject();   //get selected assignment
+                final PageParameters pageParameters = new PageParameters();
+                if(groupNow != null){
+                    pageParameters.add("groupNow", groupNow.getId());
+                }
+                pageParameters.add("selected", selection.getId());
+                setResponsePage(QuickEntryPage.class, pageParameters);  // refresh this page with the selected item
+            }
+        });
+        final List<GbGroup> groups = this.businessService.getSiteSectionsAndGroups();
+        final DropDownChoice<GbGroup> groupFilter = new DropDownChoice<GbGroup>("groupicker", new Model<GbGroup>(), groups, new ChoiceRenderer<GbGroup>() {
+            private static final long serialVersionUID = 1L;
+            @Override
+            public Object getDisplayValue(final GbGroup g) {
+                return g.getTitle();
+            }
+            @Override
+            public String getIdValue(final GbGroup g, final int index) {
+                return g.getId();
+            }
+        });
+        groupFilter.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+            @Override
+            protected void onUpdate(final AjaxRequestTarget target) {
+                final GbGroup selectedgroup = (GbGroup) groupFilter.getDefaultModelObject();
+                final PageParameters pageParameters = new PageParameters();
+                if(selectedgroup != null){
+                    pageParameters.add("groupNow", selectedgroup.getId());
+                }
+                pageParameters.add("selected",assignmentNow.getId());
+                setResponsePage(QuickEntryPage.class,pageParameters);
+            }
+        });
+        final PageParameters params = getPageParameters();
+        final String selecteditem = params.get("selected").toOptionalString();
+        groupFilter.setVisible(groups.size() > 0 && !params.get("selected").isNull());  // if only one item or no assignment, hide the dropdown
+        groupFilter.setNullValid(true);
+        final QuickEntryPageModel pageModel = new QuickEntryPageModel();
+        pageModel.setItemgrades(new ArrayList<>());
+        final Form form = new Form("form", Model.of(pageModel)) {
+            private static final long serialVersionUID = 1L;
+            @Override
+            public void onSubmit(){
+                noErrors = true;    //reset on every submission; we should be assessing this from scratch every time
+                QuickEntryPageModel dataNow = (QuickEntryPageModel) this.getModelObject();
+                ArrayList<QuickEntryRowModel> allgrades = dataNow.getItemgrades();
+                Long itemId = dataNow.getItemIdNow();
+                for(QuickEntryRowModel row: allgrades){ //first loop vor validation only
+                    try {
+                        Double gradeValidator = Double.valueOf(row.getGrade());
+                        if(gradeValidator<0){
+                            getSession().error(MessageFormat.format(getString("quickentry.error"),row.getName()));
+                            row.setHasError(true);
+                            noErrors = false;
+                            continue;
+                        } else {
+                            row.setHasError(false);
+                        }
+                    } catch (NumberFormatException e){
+                        getSession().error(MessageFormat.format(getString("quickentry.error"),row.getName()));
+                        row.setHasError(true);
+                        noErrors = false;
+                        continue;
+                    } catch (NullPointerException n){
+                        row.setGrade("");   //NPE is actually ok, we just need to turn it into a blank string.
+                    }
+                }
+                if(noErrors){   //if still no errors, second loop to start saving things
+                    for(QuickEntryRowModel row: allgrades){
+                        String oldGrade = businessService.getGradeForStudentForItem(row.getStudentid(),itemId).getGrade();
+                        GradeSaveResponse succeeded = businessService.saveGrade(itemId,row.getStudentid(),oldGrade,row.getGrade(),row.getComment());
+                        if(succeeded == GradeSaveResponse.ERROR || succeeded == GradeSaveResponse.CONCURRENT_EDIT){
+                            getSession().error(MessageFormat.format(getString("quickentry.error"),row.getName()));
+                            row.setHasError(true);
+                            noErrors = false;
+                            break;
+                        } else {
+                            row.setHasError(false);
+                        }
+                        if(row.getComment() != null){   //in case a changed comment is with an unchanged/blank grade
+                            boolean commentSucceeded = businessService.updateAssignmentGradeComment(itemId,row.getStudentid(),row.getComment());
+                            if(!commentSucceeded){
+                                getSession().error(MessageFormat.format(getString("quickentry.error"),row.getName()));
+                                row.setHasError(true);
+                                noErrors = false;
+                                break;
+                            } else {
+                                row.setHasError(false);
+                            }
+                        }
+                        GradeSaveResponse succeededExcuse = businessService.saveExcuse(itemId,row.getStudentid(),row.isExcused());
+                        if(succeededExcuse == GradeSaveResponse.ERROR){
+                            getSession().error(MessageFormat.format(getString("quickentry.error"),row.getName()));
+                            row.setHasError(true);
+                            noErrors = false;
+                            break;
+                        } else {
+                            row.setHasError(false);
+                        }
+                    }
+                }
+                if(noErrors){
+                    getSession().success(MessageFormat.format(getString("quickentry.success"), assignmentNow.getName()));
+                    final Assignment selection = (Assignment) itempicker.getDefaultModelObject();   //get selected assignment
+                    final PageParameters pageParameters = new PageParameters();
+                    final GbGroup selectedgroup = (GbGroup) groupFilter.getDefaultModelObject();
+                    if(selectedgroup != null){
+                        pageParameters.add("groupNow", selectedgroup.getId());
+                    }
+                    pageParameters.add("selected", selection.getId());
+                    setResponsePage(QuickEntryPage.class, pageParameters);
+                }
+            }
+        };
+        form.add(new AttributeModifier("class","quickEntryForm"));
+        WebMarkupContainer tableVisibility = new WebMarkupContainer("tableVisibility");
+        if(StringUtils.isNotBlank(selecteditem)){
+            for (final Assignment a : assignments) {
+                if (selecteditem.equals(a.getId().toString())) {
+                    this.assignmentNow = a;
+                    pageModel.setItemIdNow(a.getId());
+                    itempicker.setModel(Model.of(this.assignmentNow));  //make sure dropdown shows current assignment
+                    break;
+                }
+            }
+            for(final GbGroup g:groups){
+                if(!params.get("groupNow").isNull() && params.get("groupNow").toString().equals(g.getId())){
+                    this.groupNow = g;
+                    groupFilter.setModel(Model.of(this.groupNow));
+                    break;
+                }
+            }
+            form.add(new Label("itemtitle", assignmentNow.getName()));
+            String itemdetails = " - " + assignmentNow.getPoints().toString() + ' ' + getString("quickentry.points");
+            if(assignmentNow.getExternallyMaintained()){
+                itemdetails = itemdetails + " - " + MessageFormat.format(getString("quickentry.externally"),assignmentNow.getExternalAppName());
+            }
+            form.add(new Label("itemdetails", itemdetails));
+            final List<String> gradableUsers = this.businessService.getGradeableUsers();
+            List<QuickEntryRowModel> rows = new ArrayList<>();
+            Map<String, List<String>> groupContainer = this.businessService.getGroupMemberships();
+            int totalstudents = 0;
+            int studentsnow = 0;
+            for(String uid: gradableUsers){
+                QuickEntryRowModel rowNow = new QuickEntryRowModel();
+                totalstudents++;
+                if(!params.get("groupNow").isNull() && !groupContainer.get("/site/" + this.businessService.getCurrentSiteId() + "/group/"+params.get("groupNow").toString()).contains(uid)){
+                    continue;
+                }
+                studentsnow++;
+                GbUser userNow = this.businessService.getUser(uid);
+                rowNow.setName(userNow.getLastName() + ", " + userNow.getFirstName() + " (" + userNow.getDisplayId() + ')');
+                String commentNow = this.businessService.getAssignmentGradeComment(this.assignmentNow.getId(),uid);
+                if(commentNow != null){
+                    rowNow.setComment(commentNow);
+                } else {
+                    rowNow.setComment("");
+                }
+                String gradeNow = this.businessService.getGradeForStudentForItem(uid,this.assignmentNow.getId()).getGrade();
+                if(StringUtils.isNotBlank(gradeNow)){
+                    rowNow.setGrade(gradeNow);
+                } else {
+                    rowNow.setGrade(null);
+                }
+                rowNow.setExcused(this.businessService.getAssignmentExcuse(this.assignmentNow.getId(),uid) != "0");
+                rowNow.setLocked(this.assignmentNow.getExternallyMaintained());
+                rowNow.setMaxGrade(this.assignmentNow.getPoints());
+                rowNow.setStudentid(uid);
+                rows.add(rowNow);
+                ((QuickEntryPageModel)form.getModelObject()).getItemgrades().add(rowNow);
+            }
+            rows.sort(new Comparator<QuickEntryRowModel>() {
+                @Override
+                public int compare(QuickEntryRowModel quickEntryRowModel, QuickEntryRowModel t1) {
+                    return quickEntryRowModel.getName().compareTo(t1.getName());
+                }
+            });
+            form.add(new Label("summarycount",MessageFormat.format(getString("quickentry.count"),studentsnow,totalstudents)).add(new AttributeModifier("class","summarycount")));
+            ListView<QuickEntryRowModel> userFields = new ListView<QuickEntryRowModel>("studentRow",rows){
+                @Override
+                protected void populateItem(final ListItem<QuickEntryRowModel> item) {
+                    item.add(new Label("studentName",item.getModelObject().getName()));
+                    TextField gradeNow = new TextField<String>("studentGrade", new PropertyModel<String>(item.getModelObject(),"grade"));
+                    gradeNow.add(new AttributeModifier("onchange","enableUpdate()"));
+                    String gradeClass = "enabledGrade";
+                    if(item.getModelObject().isLocked()){
+                        gradeNow.setEnabled(false);
+                        gradeClass = "disabledGrade";
+                        item.add(new WebMarkupContainer("lockicon").add(new AttributeModifier("class","fa fa-lock")));
+                    } else {
+                        item.add(new WebMarkupContainer("lockicon"));
+                    }
+                    if(item.getModelObject().isHasError()){
+                        gradeClass = gradeClass + " errorCell";
+                    }
+                    gradeNow.add(new AttributeModifier("class",gradeClass));
+                    item.add(gradeNow);
+                    item.add(new TextArea<String>("studentComment",new PropertyModel<String>(item.getModelObject(),"comment")).add(new AttributeModifier("class","quickEntryComment")).add(new AttributeModifier("onchange","enableUpdate()")));
+                    AjaxCheckBox excused = new AjaxCheckBox("studentExcuse",new PropertyModel<Boolean>(item.getModelObject(), "excused")){
+                        @Override
+                        public void onUpdate(AjaxRequestTarget target){}    //necessary for compliance but not actual functionality.
+                    };
+                    excused.add(new AttributeModifier("onchange","enableUpdate()"));
+                    item.add(excused);
+                }
+            };
+            tableVisibility.add(userFields);
+            final SubmitLink submit = new SubmitLink("submit");
+            submit.add(new AttributeModifier("id","quickentrySubmit")).add(new AttributeModifier("disabled",""));
+            form.add(submit);
+            Button reset = new Button("reset"){
+                private static final long serialVersionUID = 1L;
+                @Override
+                public void onSubmit(){
+                    final Assignment selection = (Assignment) itempicker.getDefaultModelObject();   //get selected assignment
+                    final PageParameters pageParameters = new PageParameters();
+                    final GbGroup selectedgroup = (GbGroup) groupFilter.getDefaultModelObject();
+                    if(selectedgroup != null){
+                        pageParameters.add("groupNow", selectedgroup.getId());
+                    }
+                    pageParameters.add("selected", selection.getId());
+                    setResponsePage(QuickEntryPage.class, pageParameters);
+                }
+            };
+            reset = reset.setDefaultFormProcessing(false);
+            reset.add(new AttributeModifier("id","quickentryReset"));
+            form.add(reset);
+        } else {
+            WebMarkupContainer itemtitle = new WebMarkupContainer("itemtitle",null);
+            WebMarkupContainer emptyrow = new WebMarkupContainer("studentRow",null);
+            emptyrow.add(new WebMarkupContainer("studentName",null));
+            emptyrow.add(new WebMarkupContainer("studentGrade",null));
+            emptyrow.add(new WebMarkupContainer("studentComment",null));
+            emptyrow.setVisible(false);
+            form.add(emptyrow);
+            form.add(itemtitle);
+            form.add(new WebMarkupContainer("itemdetails",null));
+            form.add(new Label("summarycount",""));
+            form.add(new WebMarkupContainer("submit",null).setVisible(false));
+            form.add(new WebMarkupContainer("reset",null).setVisible(false));
+            tableVisibility.setVisible(false);
+        }
+        form.add(tableVisibility);
+        form.add(new Button("cancel"){
+            private static final long serialVersionUID = 1L;
+            @Override
+            public void onSubmit(){
+                setResponsePage(GradebookPage.class, null);
+            }
+        }.setDefaultFormProcessing(false).setVisible(this.assignmentNow != null));
+        form.add(this.bulkGrade = new ModalWindow("bulkGradeModal"));
+        bulkGrade.setTitle(getString("quickentry.replacegradelabel"));
+        bulkGrade.setInitialHeight(240);
+        form.add(new AjaxLink<Void>("showBulkGrade") {
+            @Override
+            public void onClick(AjaxRequestTarget target)
+            {
+                bulkGrade.show(target);
+            }
+            @Override
+            public boolean isVisible(){
+                return assignmentNow != null && !assignmentNow.getExternallyMaintained();
+            }
+        });
+        form.add(this.bulkComment = new ModalWindow("bulkCommentModal"));
+        bulkComment.setTitle(getString("quickentry.comment.caption"));
+        bulkComment.setInitialHeight(300);
+        form.add(new AjaxLink<Void>("showBulkComment") {
+            @Override
+            public void onClick(AjaxRequestTarget target)
+            {
+                bulkComment.show(target);
+            }
+            @Override
+            public boolean isVisible(){
+                return assignmentNow != null;
+            }
+        });
+        if(assignmentNow != null){
+            bulkGrade.setContent(new BulkGradePanel(bulkGrade.getContentId(),false,assignmentNow.getPoints()).add(new AttributeModifier("class","quickEntryBulk")));
+            bulkComment.setContent(new BulkGradePanel(bulkComment.getContentId(),true,assignmentNow.getPoints()).add(new AttributeModifier("class","quickEntryBulk")));
+        }
+        form.add(bulkGrade);
+        form.add(bulkComment);
+        form.add(itempicker);
+        form.add(groupFilter);
+        this.add(form);
+    }
+
+    @Override
+    public void renderHead(final IHeaderResponse response) {
+        super.renderHead(response);
+        response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/styles/gradebook-shared.css%s", PortalUtils.getCDNQuery())));
+        response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/styles/gradebook-grades.css%s", PortalUtils.getCDNQuery())));
+        response.render(JavaScriptHeaderItem.forUrl("/gradebookng-tool/scripts/gradebook-quick-entry.js"));
+    }
+
+    private class QuickEntryPageModel implements Serializable {
+        private static final long serialVersionUID = 1L;
+        @Getter @Setter private Long itemIdNow;
+        @Getter @Setter private ArrayList<QuickEntryRowModel> itemgrades;
+    }
+
+    private class QuickEntryRowModel implements Serializable {
+        private static final long serialVersionUID = 1L;
+        @Getter @Setter private String studentid;
+        @Getter @Setter private String name;
+        @Getter @Setter private String grade;
+        @Getter @Setter private String comment;
+        @Getter @Setter private boolean excused = false;
+        @Getter @Setter private boolean locked;
+        @Getter @Setter private double maxGrade;
+        @Getter @Setter private boolean hasError;
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkGradePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkGradePanel.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:panel >
+    <div wicket:id="bulkcaption" />
+    <div class="bulkInputArea">
+        <strong><span wicket:id="replacelabel" /></strong>
+        <input wicket:id="replacementScore" />
+        <span wicket:id="pointsLabel" />
+        <textarea wicket:id="replacementComment" />
+    </div>
+    <div id="buttonDiv">
+        <button wicket:id="replace" onclick="" >
+            <wicket:message key="quickentry.comment.link" />
+        </button>
+        <button wicket:id="cancel" >
+            <wicket:message key="button.cancel" />
+        </button>
+    </div>
+
+</wicket:panel>
+</body>
+</html>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkGradePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkGradePanel.java
@@ -1,0 +1,62 @@
+package org.sakaiproject.gradebookng.tool.panels;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.head.CssHeaderItem;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+
+import org.sakaiproject.gradebookng.tool.pages.QuickEntryPage;
+import org.sakaiproject.portal.util.PortalUtils;
+
+public class BulkGradePanel extends Panel {
+    private static final long serialVersionUID = 1L;
+
+    public BulkGradePanel(final String id, boolean comment, double points) {
+        super(id);
+        AjaxLink<Void> replace = new AjaxLink<Void>("replace"){
+            @Override
+            public void onClick(AjaxRequestTarget target){
+                ((QuickEntryPage) target.getPage()).getBulkGrade().close(target);
+            }
+        };
+        WebMarkupContainer score = new WebMarkupContainer("replacementScore");
+        score.add(new AttributeAppender("id","replacementScore"));
+        WebMarkupContainer commentBox = new WebMarkupContainer("replacementComment");
+        commentBox.add(new AttributeAppender("id","replacementComment"));
+        Label pointsLabel = new Label("pointsLabel", " / " + points);
+        if(comment){
+            replace.add(new AttributeModifier("onclick","fillComments();"));
+            add(new Label("replacelabel",getString("quickentry.replacecomment")));
+            add(new Label("bulkcaption",getString("quickentry.commentcaption")));
+            score.setVisible(false);
+            pointsLabel.setVisible(false);
+        } else {
+            replace.add(new AttributeModifier("onclick","replaceEmptyScores();"));
+            add(new Label("replacelabel",getString("quickentry.replacescore")));
+            add(new Label("bulkcaption",getString("quickentry.scorecaption")));
+            commentBox.setVisible(false);
+        }
+        add(pointsLabel);
+        add(score);
+        add(commentBox);
+        add(replace);
+        AjaxLink<Void> cancel = new AjaxLink<Void>("cancel"){
+            @Override
+            public void onClick(AjaxRequestTarget target){
+                ((QuickEntryPage) target.getPage()).getBulkGrade().close(target);
+            }
+        };
+        add(cancel);
+    }
+
+    @Override
+    public void renderHead(final IHeaderResponse response) {
+        super.renderHead(response);
+        response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/styles/gradebook-shared.css%s", PortalUtils.getCDNQuery())));
+    }
+}

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -1193,6 +1193,14 @@ GbGradeTable.renderTable = function (elementId, tableData) {
       studentId: $.data($cell[0], "studentid")
     });
   }).
+  on("click", ".gb-dropdown-menu .gb-quick-entry", function() { // go to this item's Quick Entry
+    var $dropdown = $(this).closest(".gb-dropdown-menu");
+    var $cell = $dropdown.data("cell");
+    GbGradeTable.ajax({
+      action: 'quickEntry',
+      assignmentId: $.data($cell[0], "assignmentid")
+    });
+  }).
   // Delete Grade Item
   on("click", ".gb-dropdown-menu .gb-delete-item", function() {
     var $dropdown = $(this).closest(".gb-dropdown-menu");

--- a/gradebookng/tool/src/webapp/scripts/gradebook-quick-entry.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-quick-entry.js
@@ -1,0 +1,55 @@
+document.addEventListener( 'keydown', ( event ) => {
+    const currentInput = document.activeElement;
+    const currentTd = currentInput.parentNode;
+    const currentTr = currentTd.parentNode;
+    const index = Array.from(currentTr.children).indexOf(currentTd);
+    switch (event.key) {
+        case "ArrowLeft":
+            // Left pressed
+            currentTd.previousElementSibling.querySelectorAll('input,textarea')[0].focus();
+            break;
+        case "ArrowRight":
+            // Right pressed
+            currentTd.nextElementSibling.querySelectorAll('input,textarea')[0].focus();
+            break;
+        case "ArrowUp":
+            // Up pressed
+            Array.from( currentTr.previousElementSibling.children )[index].querySelectorAll('input,textarea')[0].focus();
+            break;
+        case "ArrowDown":
+            // Down pressed
+            Array.from( currentTr.nextElementSibling.children )[index].querySelectorAll('input,textarea')[0].focus();
+            break;
+        case "Enter":
+            // Down pressed
+            event.preventDefault();
+            Array.from( currentTr.nextElementSibling.children )[index].querySelectorAll('input,textarea')[0].focus();
+            break;
+    }
+});
+
+function replaceEmptyScores(){
+    let scores = document.getElementsByClassName('enabledGrade');
+    let replacement = document.getElementById('replacementScore').value;
+    for(let count=0;count<scores.length;count++){
+        if(scores[count].value ===''){
+            scores[count].value = replacement;
+            enableUpdate();
+        }
+    }
+}
+
+function fillComments(){
+    let comments = document.getElementsByClassName('quickEntryComment');
+    let replacement = document.getElementById('replacementComment').value;
+    for(let count=0;count<comments.length;count++){
+        if(comments[count].value===''){
+            comments[count].value = replacement;
+            enableUpdate();
+        }
+    }
+}
+
+function enableUpdate(){
+    document.getElementById('quickentrySubmit').removeAttribute('disabled');
+}

--- a/gradebookng/tool/src/webapp/styles/gradebook-shared.css
+++ b/gradebookng/tool/src/webapp/styles/gradebook-shared.css
@@ -43,3 +43,95 @@ ul.feedbackPanel li span {
 .btn-table {
   height: 34px;
 }
+
+tr.categoryRow {
+    font-weight: bold;
+}
+div.gb-title {
+    word-wrap: break-word;
+    width: 350px;
+}
+span.itemTitle {
+    word-wrap: break-word;
+    display: block;
+    width: 280px;
+}
+
+div.gb-summary-legend, div.gb-table-legend {
+    display: table;
+}
+div.gb-table-legend {
+    margin: 1em 0;
+}
+div.gb-summary-legend-row, div.gb-table-legend-row {
+    display: table-row;
+}
+div.gb-summary-legend-col, div.gb-summary-legend-col-first, div.gb-table-legend-col, div.gb-table-legend-col-first {
+    display: table-cell;
+    padding-right: 4px;
+}
+div.gb-summary-legend-col-first, div.gb-table-legend-col-first {
+    text-align: right;
+}
+tr.categoryRow{
+    color: var(--sakai-primary-color-1);
+}
+form.quickEntryForm {
+    margin-top: 1em;
+    margin-bottom: 1em;
+    width: 100%;
+}
+form.quickEntryForm th{
+    background-color: var(--sakai-background-color-3);
+}
+form.quickEntryForm table.table-striped tbody tr td{
+    vertical-align: top !important;
+}
+form.quickEntryForm h3{
+    display: inline-block;
+}
+form.quickEntryForm input.quickEntryComment, form.quickEntryForm textarea {
+    width: 100%;
+}
+form.quickEntryForm input.disabledGrade {
+    cursor: not-allowed;
+    background-color: var(--sakai-background-color-3);
+}
+form.quickEntryForm input.disabledGrade, form.quickEntryForm input.enabledGrade {
+    width: 7ch;
+}
+form.quickEntryForm input.errorCell {
+    border: 3px solid red;
+}
+form.quickEntryForm span.summarycount {
+    margin-right: 3em;
+}
+form.quickEntryForm div.quickentrySpacing {
+    display: flex;
+    align-items: end;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+form.quickEntryForm div.quickentrySpacing span.buttons {
+    align-self: end;
+}
+form.quickEntryForm div.quickentrySpacing>* {
+    margin-bottom: 1rem;
+}
+form.quickEntryForm span.detailsFont {
+    font-size: 16px;
+}
+div.quickEntryBulk div#buttonDiv {
+    margin-top: 1em;
+}
+div.quickEntryBulk div.bulkInputArea {
+    padding: 2em;
+    margin-top: 1em;
+    background-color: var(--sakai-background-color-2);
+    border: 1px solid var(--sakai-border-color-1);
+}
+div.quickEntryBulk textarea {
+    display: block;
+    width: 485px;
+    height: 100px;
+}


### PR DESCRIPTION
This PR adds University Of Dayton's Quick Entry feature to Gradebook. It's a page that allows the user to rapidly enter grades for an assignment for many students on one form, eliminating the lag we've experienced waiting for the one-by-one saving that the main Gradebook table does. It has group filtering, and also offers bulk replacement of blanks for grades and comments.
https://sakaiproject.atlassian.net/browse/SAK-47725