### PR TITLE
SAK-47540 kernel: warn if user site doesn't exist yet

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/messaging/impl/UserMessagingServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/messaging/impl/UserMessagingServiceImpl.java
@@ -34,6 +34,7 @@ import org.sakaiproject.emailtemplateservice.api.RenderedTemplate;
 import org.sakaiproject.emailtemplateservice.api.EmailTemplateService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.messaging.api.Message;
 import org.sakaiproject.messaging.api.MessageMedium;
 import static org.sakaiproject.messaging.api.MessageMedium.*;
@@ -125,6 +126,8 @@ public class UserMessagingServiceImpl implements UserMessagingService {
                 } else {
                     log.debug("No preferences tool on user {}'s site", userId);
                 }
+            } catch (IdUnusedException iue) {
+                log.warn("User id {} doesn't have a home site yet. We can't add the preferences link until they've logged in a least once", userId);
             } catch (Exception e) {
                 log.error("Failed to add preferences link to email message body: {}", e.toString());
             }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47540

This fixes an issue with the user messaging service where an attempt to
add the preferences link to outgoing emails fails due the lack of a
user's home site.