### PR TITLE
SAK-47743 Make GradingService.updateExternalAssessment accept a category parameter

### DIFF
--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
@@ -957,6 +957,9 @@ public interface GradingService extends EntityProducer {
                                          String title, Double points, Date dueDate, Boolean ungraded)
             throws AssessmentNotFoundException, ConflictingAssignmentNameException, AssignmentHasIllegalPointsException;
 
+    public void updateExternalAssessment(String gradebookUid, String externalId, String externalUrl, String externalData, String title, Long categoryId, Double points, Date dueDate, Boolean ungraded)
+            throws AssessmentNotFoundException, ConflictingAssignmentNameException, AssignmentHasIllegalPointsException;
+
     /**
      * Remove the assessment reference from the gradebook. Although Samigo
      * doesn't currently delete assessments, an instructor can retract an

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -4334,7 +4334,7 @@ public class GradingServiceImpl implements GradingService {
         } else {
             asn.setUngraded(false);
         }
-        if(categoryId != null){
+        if (categoryId != null) {
             asn.setCategory(getCategory(categoryId));
         }
         gradingPersistenceManager.saveGradebookAssignment(asn);

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -4289,7 +4289,13 @@ public class GradingServiceImpl implements GradingService {
     }
 
     @Override
-    public void updateExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl, String externalData, final String title,
+    public void updateExternalAssessment(String gradebookUid, String externalId, String externalUrl, String externalData, String title, Double points, Date dueDate, Boolean ungraded)
+            throws AssessmentNotFoundException, ConflictingAssignmentNameException, AssignmentHasIllegalPointsException {
+        updateExternalAssessment(gradebookUid, externalId, externalUrl, externalData, title, null, points, dueDate, ungraded);
+    }
+
+    @Override
+    public void updateExternalAssessment(final String gradebookUid, final String externalId, final String externalUrl, String externalData, final String title, Long categoryId,
                                          final Double points, final Date dueDate, final Boolean ungraded)
             throws AssessmentNotFoundException, ConflictingAssignmentNameException, AssignmentHasIllegalPointsException {
         final Optional<GradebookAssignment> optAsn = getDbExternalAssignment(gradebookUid, externalId);
@@ -4327,6 +4333,9 @@ public class GradingServiceImpl implements GradingService {
             asn.setUngraded(ungraded.booleanValue());
         } else {
             asn.setUngraded(false);
+        }
+        if(categoryId != null){
+            asn.setCategory(getCategory(categoryId));
         }
         gradingPersistenceManager.saveGradebookAssignment(asn);
 


### PR DESCRIPTION
This PR allows externally-maintained Gradebook items to be updated with a Category ID as a parameter. It could be used with any tool that can send grades to Gradebook, but it's currently relevant as a part of an Attendance function we've recently made at University Of Dayton. The separate Attendance ticket and PR are on GitHub.
   Ticket: https://github.com/sakaicontrib/attendance/issues/110
   PR: https://github.com/sakaicontrib/attendance/pull/111