### PR TITLE
SAK-47776 Erreur de lecture de [dateAsString] sur le type [org.sakaiproject.tool.summarycalendar.ui.Day]

### DIFF
--- a/calendar/calendar-bundles/resources/calendar_fr_FR.properties
+++ b/calendar/calendar-bundles/resources/calendar_fr_FR.properties
@@ -477,7 +477,7 @@ prefs_low_priority=Priorit\u00e9 basse
 prefs_move_up=D\u00e9placer vers le haut
 prefs_move_down=D\u00e9placer vers le bas
 date_format=dd MMMMM yyyy
-date_link_format=aaaa-MM-jj
+date_link_format=yyyy-MM-dd
 
 java.opaque_subscribe=S'abonner (fils nomm\u00e9s al\u00e9atoirement)
 java.opaque_subscribe.title=G\u00e9n\u00e9rer le lien pour un usage personnel dans d'autres applications de calendrier

--- a/kernel/kernel-util/src/main/java/org/sakaiproject/util/ResourceLoader.java
+++ b/kernel/kernel-util/src/main/java/org/sakaiproject/util/ResourceLoader.java
@@ -214,7 +214,7 @@ public class ResourceLoader extends DummyMap implements InternationalizedMessage
 			this.baseName + ", locale=" + getLocale().toString() +
 			", key=" + key + ", pattern=" + pattern);
 		}
-			
+		pattern = pattern.replaceAll("'", "''");
 		return (new MessageFormat(pattern, getLocale())).format(args, new StringBuffer(), null).toString();
 	}
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47776

We need the replaceAll

Seen here: https://www.tabnine.com/code/java/methods/java.text.MessageFormat/applyPattern

```
/**
 * Translate a text string based on our i18n files.
 * @since 3.1
 */
public static String i18n(ResourceBundle messages, String key, Object... messageArguments) {
 MessageFormat formatter = new MessageFormat("");
 formatter.applyPattern(messages.getString(key).replaceAll("'", "''"));
 return formatter.format(messageArguments);
```



