### PR TITLE
SAK-47777 Implement toXml for groups and include site groups in site XML

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseGroup.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseGroup.java
@@ -40,6 +40,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.util.BaseResourceProperties;
 import org.sakaiproject.util.BaseResourcePropertiesEdit;
+import org.sakaiproject.util.Xml;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -238,7 +239,45 @@ public class BaseGroup implements Group, Identifiable
 	 */
 	public Element toXml(Document doc, Stack stack)
 	{
-		return null;
+
+		Element group = doc.createElement("group");
+		if (stack.isEmpty())
+		{
+			doc.appendChild(group);
+		}
+		else
+		{
+			((Element) stack.peek()).appendChild(group);
+		}
+
+		group.setAttribute("id", getId());
+
+		if (m_title != null) group.setAttribute("title", m_title);
+
+		// encode the description
+		if (m_description != null) {
+			Xml.encodeAttribute(group, "description-enc", m_description);
+		}
+
+		if (getCreatedBy() != null) {
+			group.setAttribute("created-id", getCreatedBy().getId());
+		}
+		if (getModifiedBy() != null) {
+			group.setAttribute("modified-id", getModifiedBy().getId());
+		}
+		if (getCreatedDate() != null) {
+			group.setAttribute("created-time", getCreatedDate().toString());
+		}
+		if (getModifiedDate() != null) {
+			group.setAttribute("modified-time", getModifiedDate().toString());
+		}
+
+		// properties
+		stack.push(group);
+		getProperties().toXml(doc, stack);
+		stack.pop();
+
+		return group;
 	}
 
 	/**

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSite.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSite.java
@@ -1003,7 +1003,7 @@ public class BaseSite implements Site
 	/**
 	 * {@inheritDoc}
 	 */
-	public Collection getGroups()
+	public Collection<Group> getGroups()
 	{
 		// Default to loading the groups if lazy
 		return getGroups(true);
@@ -1022,7 +1022,7 @@ public class BaseSite implements Site
 	 * @return The Site's list of Groups.
 	 *
 	 */
-	public Collection getGroups(boolean allowFetch)
+	public Collection<Group> getGroups(boolean allowFetch)
 	{
 		// Avoid fetching if requested (as for copy constructor)
 		if (allowFetch && m_groupsLazy)
@@ -1490,7 +1490,14 @@ public class BaseSite implements Site
 		}
 		stack.pop();
 
-		// TODO: site groups
+		// site groups
+		Element groupNode = doc.createElement("groups");
+		site.appendChild(groupNode);
+		stack.push(groupNode);
+		for (Group group : getGroups()) {
+			group.toXml(doc, stack);
+		}
+		stack.pop();
 
 		return site;
 	}


### PR DESCRIPTION
Adds support for site groups in the site.xml exported by Site Archive.

Both groups and sections are supported, as sections are decorated groups with additional properties defined. group properties are included in the export.