### PR TITLE
SAK-47829 MathJax: Apply portalCDNQuery on mathjax-config.js imports

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1377,7 +1377,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				Element config = new Element("script");
 				Element srcPath = new Element("script");
 
-				config.attr("src", "/library/js/mathjax-config.js");
+				config.attr("src", "/library/js/mathjax-config.js"+PortalUtils.getCDNQuery());
 				srcPath.attr("type", "text/javascript").attr("src", MATHJAX_SRC_PATH);
 				headJs.append(config.toString()).append(srcPath.toString());
 			}

--- a/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
+++ b/portal/portal-tool/tool/src/java/org/sakaiproject/portal/tool/ToolPortal.java
@@ -40,6 +40,7 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.util.CSSUtils;
 import org.sakaiproject.portal.util.ErrorReporter;
+import org.sakaiproject.portal.util.PortalUtils;
 import org.sakaiproject.portal.util.ToolURLManagerImpl;
 import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.portal.util.URLUtils;
@@ -315,7 +316,7 @@ public class ToolPortal extends HttpServlet
 						Element config = new Element("script");
 						Element srcPath = new Element("script");
 
-						config.attr("src", "/library/js/mathjax-config.js");
+						config.attr("src", "/library/js/mathjax-config.js"+PortalUtils.getCDNQuery());
 						srcPath.attr("type", "text/javascript").attr("src", MATHJAX_SRC_PATH);
 						headJs.append(config.toString()).append(srcPath.toString());
 					}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2639,7 +2639,7 @@ public class DeliveryBean implements Serializable {
     }
     public String getMathJaxHeader(){
       Document headMJ = new Document("");
-      headMJ.appendElement("script").attr("src", "/library/js/mathjax-config.js");
+      headMJ.appendElement("script").attr("src", "/library/js/mathjax-config.js"+PortalUtils.getCDNQuery());
       headMJ.appendElement("script").attr("type", "text/javascript").attr("src", MATHJAX_SRC_PATH);
       return headMJ.toString();
     }


### PR DESCRIPTION
Jira: [SAK-47829](https://sakaiproject.atlassian.net/browse/SAK-47829)