### PR TITLE
SAK-47748 Commons creating/editing posts inserts default values when the content is removed

### DIFF
--- a/commons/tool/src/webapp/WEB-INF/templates/post.hbs
+++ b/commons/tool/src/webapp/WEB-INF/templates/post.hbs
@@ -8,7 +8,7 @@
                 <div class="commons-post-content">
                     <span id="commons-high-priority-{{id}}" class="fa fa-flag commons-high-priority" title={{tr 'priority_icon'}} style="display:none;"></span>
                     <a id="commons-author-name-{{id}}" class="commons-post-author-name" data-user-id="{{creatorId}}" href="javascript:;">{{creatorDisplayName}}</a>
-                    <span class="commons-post-content" id="commons-post-content-{{id}}">{{{content}}}<span>
+                    <span class="commons-post-content" id="commons-post-content-{{id}}">{{{content}}}</span>
                 </div>
                 <div id="commons-post-options-{{id}}" class="commons-post-options">
                     <span id="commons-like-section" >

--- a/commons/tool/src/webapp/WEB-INF/templates/posts.hbs
+++ b/commons/tool/src/webapp/WEB-INF/templates/posts.hbs
@@ -2,7 +2,7 @@
         <div class="commons-photo-text-wrapper">
             <sakai-user-photo user-id="{{currentUserId}}"></sakai-user-photo>
             <div class="commons-editor-text-wrapper">
-                <div class="commons-editor-text"><div id="commons-post-creator-editor" contenteditable="true">{{tr 'post_editor_initial_text'}}</div></div>
+                <div class="commons-editor-text"><span id="commons-post-creator-editor" contenteditable="true">{{tr 'post_editor_initial_text'}}</span></div>
             </div>
         </div>
         <div id="commons-editor-toolbar" class="act">

--- a/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
+++ b/library/src/morpheus-master/sass/modules/tool/commons/_commons.scss
@@ -258,3 +258,7 @@ span.commons-high-priority {
     border: 1px solid black;
     overflow: hidden;
 }
+
+.commons-post-content[contenteditable="true"]:empty:before {
+    content: "\feff"; /* ZERO WIDTH NO-BREAK SPACE */
+}


### PR DESCRIPTION
…" values when the content is removed.

The change in post.hbs didn't seem like it was part of the problem, it just looked wrong, so I fixed it!
In posts.hbs, changing from a div to a span was enough to make it stop putting a `<br>` when the content was cleared out.
The scss change fixes the same issue when editing a post.  It was putting in `<span></span>` when the content was cleared.  So, the css rule puts content in there when empty.