### PR TITLE
SAK-47992 Fix startup error with demo mode disabled

### DIFF
--- a/roster2/bundle/src/bundle/roster.properties
+++ b/roster2/bundle/src/bundle/roster.properties
@@ -64,7 +64,7 @@ profile_picture_alt = Photo of
 
 # Additional info
 additionalInfo_button_text=View additional information
-additionalInfo_modal_title=Special needs of user {0}
+additionalInfo_modal_title=Additional information of user {0}
 
 # Modal
 roster_modal_close=Close
@@ -108,7 +108,6 @@ perm-roster.viewofficialphoto = View participant's official photo
 perm-roster.viewsitevisits = View participant's site visits
 perm-roster.viewuserproperties= View participant's properties
 perm-roster.viewcandidatedetails= View participant's additional information
-perm-roster.viewstudentnumber= View participant's student number
 
 groups = Group
 roles_label = Role

--- a/roster2/bundle/src/bundle/roster_ca.properties
+++ b/roster2/bundle/src/bundle/roster_ca.properties
@@ -62,6 +62,13 @@ roster_spreadsheet_view=Llista
 profile_email=Correu electr\u00f2nic
 profile_picture_alt=Fotografia de
 
+# Additional info
+additionalInfo_button_text=Veure informaci\u00f3 addicional
+additionalInfo_modal_title=Informaci\u00f3 addicional de l\u2019usuari {0}
+
+# Modal
+roster_modal_close=Tancar
+
 # Facets
 facet_picture=Fotografia
 facet_name=Nom
@@ -69,6 +76,10 @@ facet_userId=Identificaci\u00f3 de l\u2019usuari
 facet_pronouns=Pronoms
 facet_user_name_pronunciation=Com es pronuncia
 facet_userProperties=Propietats de l\u2019usuari
+facet_specialNeeds=Mesures de suport a l\u2019avaluaci\u00f3
+facet_additionalNotes=Anotacions addicionals
+facet_studentNumber=N\u00famero d\u2019expedient
+facet_additionalInfo=Informaci\u00f3 addicional
 facet_email=Correu electr\u00f2nic
 facet_role=Rol
 facet_status=Estat
@@ -96,6 +107,7 @@ perm-roster.viewemail=Pot veure el correu electr\u00f2nic dels participants
 perm-roster.viewofficialphoto=Pot veure la fotografia oficial dels participants
 perm-roster.viewsitevisits=Pot veure el nombre de visites a l\u2019espai dels participants
 perm-roster.viewuserproperties=Pot veure les propietats dels participants
+perm-roster.viewcandidatedetails=Pot veure informaci\u00f3 addicional dels participants
 
 groups=Grup
 roles_label=Rol

--- a/roster2/bundle/src/bundle/roster_es.properties
+++ b/roster2/bundle/src/bundle/roster_es.properties
@@ -62,6 +62,13 @@ roster_spreadsheet_view=Lista
 profile_email=Correo
 profile_picture_alt=Foto de
 
+# Additional info
+additionalInfo_button_text=Ver informaci\u00f3n adicional
+additionalInfo_modal_title=Informaci\u00f3n adicional del usuario {0}
+
+# Modal
+roster_modal_close=Cerrar
+
 # Facets
 facet_picture=Foto
 facet_name=Nombre
@@ -69,6 +76,10 @@ facet_userId=ID
 facet_pronouns=Pronombres
 facet_user_name_pronunciation=Pronunciaci\u00f3n
 facet_userProperties=Propiedades de usuario
+facet_specialNeeds=Necesidades especiales del estudiante
+facet_additionalNotes=Anotaciones adicionales
+facet_studentNumber=N\u00famero de estudiante
+facet_additionalInfo=Informaci\u00f3n Adicional
 facet_email=Correo
 facet_role=Rol
 facet_status=Estado
@@ -96,6 +107,7 @@ perm-roster.viewemail=Ver direcciones de correos
 perm-roster.viewofficialphoto=Ver fotos oficiales
 perm-roster.viewsitevisits=Ver visitas al sitio
 perm-roster.viewuserproperties=Ver propiedades de participantes
+perm-roster.viewcandidatedetails=Ver informaci\u00f3n adicional del participante
 
 groups=Grupo
 roles_label=Rol

--- a/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -116,6 +116,9 @@ import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -139,8 +142,9 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 
 	@Resource(name = "org.sakaiproject.authz.api.GroupProvider")
 	private GroupProvider groupProvider;
-
-	@Resource(name = "org.sakaiproject.user.api.CandidateDetailProvider")
+	
+	@Qualifier("org.sakaiproject.user.api.CandidateDetailProvider")
+	@Autowired(required = false)
 	private CandidateDetailProvider candidateDetailProvider;
 
 	@Resource private PrivacyManager privacyManager;


### PR DESCRIPTION
Fix startup error with `sakai.demo=false` by setting candidateDetailProvider as an non required property.

Also add Spanish and Catalan translations for the special needs feature.