### PR TITLE
SAK-47992 Add setters needed for injection to CDP

### DIFF
--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import lombok.Setter;
+
 import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.authz.api.SecurityService;
@@ -54,13 +56,13 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	private final static String PROP_ENCRYPT_NUMERIC_ID = "encryptInstitutionalNumericID";
 	private final static String PROP_ENCRYPT_CANDIDATE_DETAILS = "encryptCandidateDetails";
 
-	private PreferencesService preferencesService;
-	private ServerConfigurationService serverConfigurationService;
-	private SessionManager sessionManager;
-	private SiteService siteService;
-	private SecurityService secServ;
-	private ToolManager toolManager;
-	private ValueEncryptionUtilities encryptionUtilities;
+	@Setter private PreferencesService preferencesService;
+	@Setter private ServerConfigurationService serverConfigurationService;
+	@Setter private SessionManager sessionManager;
+	@Setter private SiteService siteService;
+	@Setter private SecurityService securityService;
+	@Setter private ToolManager toolManager;
+	@Setter private ValueEncryptionUtilities encryptionUtilities;
 	
 	public void init() {
 		Objects.requireNonNull(preferencesService, "ServerConfigurationService must be set");
@@ -69,7 +71,7 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 		Objects.requireNonNull(serverConfigurationService, "ServerConfigurationService must be set");
 		Objects.requireNonNull(sessionManager, "SessionManager must be set");
 		Objects.requireNonNull(encryptionUtilities, "ValueEncryptionUtilities must be set");
-		Objects.requireNonNull(secServ, "SecurityService must be set");
+		Objects.requireNonNull(securityService, "SecurityService must be set");
 	}
 	
 	public Optional<String> getCandidateID(User user, Site site) {
@@ -229,7 +231,7 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	private Optional<String> getNumericId(User user, Site site, boolean checkVisibilityPermission)
 	{
 		if (user == null || site == null || !isInstitutionalNumericIdEnabled(site)
-				|| (checkVisibilityPermission && !secServ.unlock(user, USER_PERM_STUDENT_NUMBER_VISIBLE, site.getReference())))
+				|| (checkVisibilityPermission && !securityService.unlock(user, USER_PERM_STUDENT_NUMBER_VISIBLE, site.getReference())))
 		{
 			return Optional.empty();
 		}
@@ -264,7 +266,7 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	
 	public void setSecurityService(SecurityService value)
 	{
-		secServ = value;
+		securityService = value;
 	}
 
 	public void setToolManager(ToolManager toolManager) {

--- a/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
+++ b/providers/userdetail/src/java/org/sakaiproject/user/detail/CandidateDetailProviderImpl.java
@@ -41,6 +41,7 @@ import org.sakaiproject.user.api.User;
  * user object.
  */
 @Slf4j
+@Setter 
 public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	
 	private static final String USER_PROP_CANDIDATE_ID = "candidateID";
@@ -56,13 +57,13 @@ public class CandidateDetailProviderImpl implements CandidateDetailProvider {
 	private final static String PROP_ENCRYPT_NUMERIC_ID = "encryptInstitutionalNumericID";
 	private final static String PROP_ENCRYPT_CANDIDATE_DETAILS = "encryptCandidateDetails";
 
-	@Setter private PreferencesService preferencesService;
-	@Setter private ServerConfigurationService serverConfigurationService;
-	@Setter private SessionManager sessionManager;
-	@Setter private SiteService siteService;
-	@Setter private SecurityService securityService;
-	@Setter private ToolManager toolManager;
-	@Setter private ValueEncryptionUtilities encryptionUtilities;
+	private PreferencesService preferencesService;
+	private ServerConfigurationService serverConfigurationService;
+	private SessionManager sessionManager;
+	private SiteService siteService;
+	private SecurityService securityService;
+	private ToolManager toolManager;
+	private ValueEncryptionUtilities encryptionUtilities;
 	
 	public void init() {
 		Objects.requireNonNull(preferencesService, "ServerConfigurationService must be set");


### PR DESCRIPTION
When the CandidateDetailProvider is enabled it will need setter methods for its dependencies, so they can be injected.