### PR TITLE
SAK-48084 Samigo: Add spanish translations

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages_es.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages_es.properties
@@ -179,6 +179,9 @@ feedback_available_on_threshold=Solo los estudiantes con nota inferior a <b>{0}%
 feedback_available_ranges=Los estudiantes recibir\u00e1n <b>comentarios</b> entre <b>{0}</b> y <b>{1}</b>.
 feedback_available_ranges_threshold=Solo los estudiantes con nota inferior a <b>{0}%</b> recibir\u00e1n <b>comentarios</b> entre <b>{1}</b> y <b>{2}</b>.
 
+autosubmit_info=El trabajo del estudiante guardado se enviar\u00e1 autom\u00e1ticamente despu\u00e9s de la/las {0} (<b>{1}</b>)
+autosubmit_info_extended_time=<b>Nota:</b> si a un usuario o grupo se le otorga una extensi\u00f3n de tiempo para esta evaluaci\u00f3n, la/las {0} se convierte efectivamente en la fecha de vencimiento para el usuario o grupo en particular en cuesti\u00f3n.
+
 feedback_components=Defina opciones avanzadas sobre comentarios
 question_text=Texto de la pregunta
 student_assessment_score=Su puntuaci\u00f3n en el examen
@@ -326,6 +329,7 @@ due_same_as_available=La fecha de entrega no puede ser anterior a la fecha de ap
 retract_earlier_than_avaliable=La fecha l\u00edmite de env\u00edo no puede ser anterior a la fecha de apertura ni a la fecha de entrega.
 retract_earlier_than_due=La fecha l\u00edmite no puede ser anterior ni a la fecha de comienzo ni a la fecha de entrega.
 retract_required_with_auto_submit=Se debe establecer una fecha de entrega si se activa el autoenv\u00edo. Por favor, introduzca una fecha de entrega para el examen.
+due_required_with_auto_submit=La fecha de entrega debe establecerse para forzar la presentaci\u00f3n del trabajo del estudiante guardado despu\u00e9s de la fecha de vencimiento.
 due_null_with_retract_date=Por favor, introduzca una fecha de entrega si el examen tiene una fecha l\u00edmite.
 open_window_less_than_time_limit=El tiempo l\u00edmite de la excepci\u00f3n es superior a la fecha de entrega. Por favor, reduce el tiempo l\u00edmite o cambie las fechas correspondientes.
 


### PR DESCRIPTION
The autosubmit strings are a bit tricky, because either `header_extendedTime_due_date=Fechas de entrega` or
`header_extendedTime_retract_date=Fecha l\u00edmite de entrega` will be inserted for `{0}`. and I could not find out if `Fechas de entrega` has to be plural.

https://sakaiproject.atlassian.net/browse/SAK-48084