### PR TITLE
SAK-48072 - Lessons: BltiPicker not working in Trinity

### DIFF
--- a/basiclti/basiclti-tool/src/webapp/vm/lti_tool_system.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_tool_system.vm
@@ -111,7 +111,7 @@ ${includeLatestJQuery}
         #if ($configMessage)<div class="sak-banner-error">$tlang.getString("gen.alert") $formattedText.escapeHtml($configMessage)</div>#end
 	#if ($isAdmin || $allowMaintainerAddSystemTool)<div align="right" style="padding:10px"><a href="" title="$tlang.getString("add.to.system")" onclick="location = '$sakai_ActionURL.setPanel("ToolInsert")';return false;"> $tlang.getString("add.to.system")</a>#if ($isAdmin )<br/><a href="" title="$tlang.getString("add.auto")" onclick="location = '$sakai_ActionURL.setPanel("AutoInsert")';return false;"> $tlang.getString("add.auto")</a>#end</div>#end
 	<br/>
-        <div style="padding: 10px">
+        <div class="p-2">
 	#if ($!ltiTools && $ltiTools.size() > 0 )
 		$tlang.getString("tool.description.system")
 		<br/>

--- a/basiclti/basiclti-tool/src/webapp/vm/lti_tool_system.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_tool_system.vm
@@ -109,8 +109,9 @@ ${includeLatestJQuery}
 	#if ($messageSuccess)<div class="sak-banner-success">$tlang.getString("gen.success") $formattedText.escapeHtml($messageSuccess)</div>#end
 	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("gen.alert") $formattedText.escapeHtml($alertMessage)</div>#end
         #if ($configMessage)<div class="sak-banner-error">$tlang.getString("gen.alert") $formattedText.escapeHtml($configMessage)</div>#end
-	#if ($isAdmin || $allowMaintainerAddSystemTool)<div align="right"><a href="" title="$tlang.getString("add.to.system")" onclick="location = '$sakai_ActionURL.setPanel("ToolInsert")';return false;"> $tlang.getString("add.to.system")</a>#if ($isAdmin )<br/><a href="" title="$tlang.getString("add.auto")" onclick="location = '$sakai_ActionURL.setPanel("AutoInsert")';return false;"> $tlang.getString("add.auto")</a>#end</div>#end
+	#if ($isAdmin || $allowMaintainerAddSystemTool)<div align="right" style="padding:10px"><a href="" title="$tlang.getString("add.to.system")" onclick="location = '$sakai_ActionURL.setPanel("ToolInsert")';return false;"> $tlang.getString("add.to.system")</a>#if ($isAdmin )<br/><a href="" title="$tlang.getString("add.auto")" onclick="location = '$sakai_ActionURL.setPanel("AutoInsert")';return false;"> $tlang.getString("add.auto")</a>#end</div>#end
 	<br/>
+        <div style="padding: 10px">
 	#if ($!ltiTools && $ltiTools.size() > 0 )
 		$tlang.getString("tool.description.system")
 		<br/>
@@ -183,6 +184,7 @@ ${includeLatestJQuery}
 		<p>$tlang.getString("tool.none")</p>
 	#end
 	$tlang.getString("tool.note")
+        </div>
 #if ( ! $isAdmin )
 <script>
 $(document).ready( function() {

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -108,8 +108,8 @@
 			<input type="submit" rsf:id="cancel" class='cancelButton'/>
 		</form>
 
-    <div id="modal-iframe-div" class="modal fade" tabindex="-1" aria-labelledby="bltiModalLabel" aria-hidden="true">
-      <div class="modal-dialog">
+    <div id="modal-iframe-div" class="modal fade" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="bltiModalLabel" aria-hidden="true">
+      <div id="blti-dialog" class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="bltiModalLabel">Modal title</h5>
@@ -131,22 +131,21 @@
   <script>
     //<![CDATA[
     function showIframe(title, doreload) {
+      const el = document.getElementById("modal-iframe-div");
+      const modal = bootstrap.Modal.getOrCreateInstance(el);
 
-      const el = document.getElementById("modal-iframe-div")
-      const modal = bootstrap.Modal.getOrCreateInstance(el)
-      modal.addEventListener("shown.bs.modal", e => {
-
+      el.addEventListener("shown.bs.modal", e => {
         $('#sakai-basiclti-admin-iframe').attr('width', $("#modal-iframe-div").width());
         $('#sakai-basiclti-admin-iframe').attr('height', $("#modal-iframe-div").height());
       });
-      modal.addEventListener("hidden.bs.modal", e => {
 
+      el.addEventListener("hidden.bs.modal", e => {
         if ( doreload ) {
           location.reload();
         } else {
           $('#sakai-basiclti-admin-iframe').attr('src','/library/image/sakai/spinner.gif');
         }
-      });
+      });   
       modal.show();
 
       $(window).resize(function() {

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -145,7 +145,7 @@
         } else {
           $('#sakai-basiclti-admin-iframe').attr('src','/library/image/sakai/spinner.gif');
         }
-      });   
+      });
       modal.show();
 
       $(window).resize(function() {

--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -2924,6 +2924,11 @@
     width: 60%;
   }
 
+  #blti-dialog {
+    @media #{$desktop} {
+      min-width: 900px;
+    }	
+  }
 }
 
 .#{$namespace}multipleTools {


### PR DESCRIPTION
In BltiPicker.html the JS object “modal” is not part of the DOM which is why addEventListener cannot be invoked from that object. Use of the ‘el’ object instead works.

Besides some CSS styling for the LTI iframe presented in the modal, I added some "data-" attributes to force the backdrop of the modal to be static-- without which it’s frustratingly easy to inadvertently close the modal while attempting to fill out multiple data entry fields.