### PR TITLE
SAK-48095 Samigo: Spanish Assessment Settings reword "Who can access this assessment?"

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages_es.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages_es.properties
@@ -98,8 +98,8 @@ timed_minutes=minutos
 auto_submit_description=El examen se enviar\u00e1 autom\u00e1ticamente cuando se termine el tiempo
 
 released_to=Examen publicado para
-anonymous_users=cualquier usuario con el enlace (encuesta an\u00f3nima)
-entire_site=todos en el sitio
+anonymous_users=Cualquiera que tenga el enlace (Encuesta an\u00f3nima)
+entire_site=Todos los miembros del sitio
 assessment_type_info=Si se establece la opci\u00f3n "Cualquiera con el link", no se almacenar\u00e1 ninguna asociaci\u00f3n de estudiante-respuestas. Este link no aparecer\u00e1 dentro de Ex\u00e1menes. Cualquier persona que tenga el link podr\u00e1 realizar el examen/encuesta tantas veces como desee.
 selected_groups=Grupos seleccionados
 select_all_groups=Seleccionar todos los grupos

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages_es.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages_es.properties
@@ -98,8 +98,8 @@ timed_minutes=minutos
 auto_submit_description=El examen se enviar\u00e1 autom\u00e1ticamente cuando se termine el tiempo
 
 released_to=Examen publicado para
-anonymous_users=Usuarios An\u00f3nimos
-entire_site=Todas las secciones/grupos
+anonymous_users=cualquier usuario con el enlace (encuesta an\u00f3nima)
+entire_site=todos en el sitio
 assessment_type_info=Si se establece la opci\u00f3n "Cualquiera con el link", no se almacenar\u00e1 ninguna asociaci\u00f3n de estudiante-respuestas. Este link no aparecer\u00e1 dentro de Ex\u00e1menes. Cualquier persona que tenga el link podr\u00e1 realizar el examen/encuesta tantas veces como desee.
 selected_groups=Grupos seleccionados
 select_all_groups=Seleccionar todos los grupos


### PR DESCRIPTION
I Tried to base the translations on the rewording that has been made in English.
Does that look fine? else I can still change `Todas las secciones/grupos` to `Todas las usuarios/grupos`

![image](https://user-images.githubusercontent.com/53173679/203314208-7a50e092-405d-45af-9564-b368b8387743.png)
![image](https://user-images.githubusercontent.com/53173679/203314880-d4666030-cd32-4458-aa05-4fda56b8c7da.png)
