### PR TITLE
SAK-48103 Gradebook: Change grades not released icon and position

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -12,7 +12,7 @@
                 <a class="gb-title">
                     <wicket:message key="column.header.coursegrade"/>
                 </a>
-                <div class="gb-grade-item-flags">
+                <div class="gb-title gb-grade-item-flags">
                     {if settings.isCourseGradeReleased}
                     <span class="gb-flag-released" wicket:message="title:label.coursegrade.released">
                         {if settings.isUserAbleToEditAssessments}
@@ -120,7 +120,7 @@
                     <wicket:message key="label.due"/> 
                     <span>${dueDate}</span>
                 </div>
-                <div class="gb-grade-item-flags">
+                <div class="gb-title gb-grade-item-flags">
                     {if includedInCourseGrade}
                         <span class="gb-flag-counted" wicket:message="title:label.gradeitem.counted"></span>
                     {else}

--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -139,7 +139,6 @@
     line-height: 1.2em;
     display: inline-block;
     cursor: pointer;
-    width: calc(100% - 16px);
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -177,10 +176,7 @@
     line-height: 1.3em;
   }
   #gradeTableWrapper .gb-grade-item-flags {
-    position: absolute;
-    bottom: 5px;
-    left: 5px;
-    font-size: 16px;
+    display: inline;
   }
   #gradeTableWrapper th .dropdown,
   #gradeTableWrapper td .dropdown {
@@ -272,8 +268,7 @@
     text-decoration-line: line-through;
   }
   .gb-flag-not-released:before {
-    content: '\F33E';
-    text-decoration-line: line-through;
+    content: '\F33F';
   }
   .gb-flag-counted,
   .gb-flag-released {


### PR DESCRIPTION
Changed bi-eye-fill icon to bi-eye-slash icon
Removed CSS strikethrough line (that was underlining the icon)
Aligned icon with header title, previously aligned with dropdown button.

https://sakaiproject.atlassian.net/browse/SAK-48103