### PR TITLE
SAK-48115: Trinity Portal: Add Quick Links Button

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -369,19 +369,27 @@
 # Icon entry can specify an icon to be used as an HTML class or an image to be added as a background-image 
 # attribute in the HTML. If using an icon put 'cl' before the name, if using an image put 'im' before the name.
 # Information message at the top of the quicklinks pop-up box:
-#portal.quicklink.info=Links open in a new window 
-#portal.quicklink.url.count=2
-#portal.quicklink.title.count=2
-#portal.quicklink.name.count=2
-#portal.quicklink.icon.count=2
-#portal.quicklink.url.1=https://www.sakailms.org/
-#portal.quicklink.title.1=Sakai Project Website
-#portal.quicklink.name.1=Sakai Project
-#portal.quicklink.icon.1=im /library/image/sakai/url.gif
-#portal.quicklink.url.2=https://www.apereo.org/
-#portal.quicklink.title.2=Apereo Website
-#portal.quicklink.name.2=Apereo
-#portal.quicklink.icon.2=cl fa fa-globe
+# portal.quicklink.info=Links open in a new window 
+# portal.quicklink.url.count=4
+# portal.quicklink.title.count=4
+# portal.quicklink.name.count=4
+# portal.quicklink.icon.count=4
+# portal.quicklink.url.1=https://www.sakailms.org/
+# portal.quicklink.title.1=Sakai Project Website
+# portal.quicklink.name.1=Sakai Project
+# portal.quicklink.icon.1=cl bi bi-globe
+# portal.quicklink.url.2=https://www.apereo.org/
+# portal.quicklink.title.2=Apereo Website
+# portal.quicklink.name.2=Apereo
+# portal.quicklink.icon.2=cl bi bi-globe
+# portal.quicklink.url.3=https://github.com/sakaiproject/sakai
+# portal.quicklink.title.3=Sakai Github
+# portal.quicklink.name.3=Sakai Github
+# portal.quicklink.icon.3=cl bi bi-github
+# portal.quicklink.url.4=https://www.sakailms.org/shop
+# portal.quicklink.title.4=Sakai Merch Store
+# portal.quicklink.name.4=Sakai Merch Store
+# portal.quicklink.icon.4=cl bi bi-cart
 
 # ########################################################################
 # DATABASE

--- a/library/src/skins/default/src/sass/base/_icons.scss
+++ b/library/src/skins/default/src/sass/base/_icons.scss
@@ -138,6 +138,7 @@ $fa-font-path: "./fonts";
     sakai-filled-right-arrow : bi-arrow-right-circle-fill,
     hidden: bi-eye-slash-fill,
     locked: bi-lock-fill,
+    link : bi-link-45deg,
   );
 
 

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAccountNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAccountNav.vm
@@ -61,7 +61,7 @@ For opening help sidebar
           aria-label="$rloader.sit_quick_links"
           aria-expanded="false"
           title="$rloader.sit_quick_links">
-        <i class="bi-link-45deg"></i>
+        <i class="si si-link"></i>
       </button>
     </li>
   #end

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAccountNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAccountNav.vm
@@ -59,6 +59,7 @@ For opening help sidebar
           data-bs-target="#sakai-quickLinksPanel"
           aria-controls="sakai-quickLinksPanel"
           aria-label="$rloader.sit_quick_links"
+          aria-expanded="false"
           title="$rloader.sit_quick_links">
         <i class="bi-link-45deg"></i>
       </button>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAccountNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAccountNav.vm
@@ -54,12 +54,14 @@ For opening help sidebar
 
   #if ($quickLinks)
     <li class="d-none d-md-inline">
-      <a class="sak-sysInd-quicklinks nav-link text-white position-relative" data-bs-toggle="offcanvas" href="#sakai-quickLinksPanel" role="button" aria-controls="sakai-quickLinksPanel">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-link-45deg" viewBox="0 0 16 16" role="img" data-bs-toggle="tooltip" data-bs-placement="bottom" title="${rloader.sit_quick_links}">
-          <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.002 1.002 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z"/>
-          <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243L6.586 4.672z"/>
-        </svg>
-      </a>
+      <button class="btn icon-button"
+          data-bs-toggle="offcanvas"
+          data-bs-target="#sakai-quickLinksPanel"
+          aria-controls="sakai-quickLinksPanel"
+          aria-label="$rloader.sit_quick_links"
+          title="$rloader.sit_quick_links">
+        <i class="bi-link-45deg"></i>
+      </button>
     </li>
   #end
 

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
@@ -64,7 +64,7 @@
           aria-label="$rloader.sit_quick_links"
           aria-expanded="false"
           title="$rloader.sit_quick_links">
-        <i class="bi-link-45deg"></i>
+        <i class="si si-link"></i>
       </button>
     </li>
   #end

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
@@ -54,6 +54,7 @@
       </button>
     </li>
     #end
+
   #if ($quickLinks)
     <li>
       <button class="btn icon-button"
@@ -66,6 +67,7 @@
       </button>
     </li>
   #end
+
     #if ($pageColumn0Tools && !$pageColumn0Tools.isEmpty())
         #set ($helpLink = $pageColumn0Tools.get(0).toolHelpActionUrl)
     #elseif ($pageColumn1Tools && !$pageColumn1Tools.isEmpty())

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
@@ -54,7 +54,18 @@
       </button>
     </li>
     #end
-
+  #if ($quickLinks)
+    <li>
+      <button class="btn icon-button"
+          data-bs-toggle="offcanvas"
+          data-bs-target="#sakai-quickLinksPanel"
+          aria-controls="sakai-quickLinksPanel"
+          aria-label="$rloader.sit_quick_links"
+          title="$rloader.sit_quick_links">
+        <i class="bi-link-45deg"></i>
+      </button>
+    </li>
+  #end
     #if ($pageColumn0Tools && !$pageColumn0Tools.isEmpty())
         #set ($helpLink = $pageColumn0Tools.get(0).toolHelpActionUrl)
     #elseif ($pageColumn1Tools && !$pageColumn1Tools.isEmpty())

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
@@ -62,6 +62,7 @@
           data-bs-target="#sakai-quickLinksPanel"
           aria-controls="sakai-quickLinksPanel"
           aria-label="$rloader.sit_quick_links"
+          aria-expanded="false"
           title="$rloader.sit_quick_links">
         <i class="bi-link-45deg"></i>
       </button>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48115

@ern I want the below Sakai properties to be added for testing purposes on nightly server 23: 
**update:**  I have created a pr on sakai-nighlty branch :)
`portal.quicklink.info=Links open in a new window 
portal.quicklink.url.count=4
portal.quicklink.title.count=4
portal.quicklink.name.count=4
portal.quicklink.icon.count=4
portal.quicklink.url.1=https://www.sakailms.org/
portal.quicklink.title.1=Sakai Project Website
portal.quicklink.name.1=Sakai Project
portal.quicklink.icon.1=cl bi bi-globe
portal.quicklink.url.2=https://www.apereo.org/
portal.quicklink.title.2=Apereo Website
portal.quicklink.name.2=Apereo
portal.quicklink.icon.2=cl bi bi-globe
portal.quicklink.url.3=https://github.com/sakaiproject/sakai
portal.quicklink.title.3=Sakai Github
portal.quicklink.name.3=Sakai Github
portal.quicklink.icon.3=cl bi bi-github
portal.quicklink.url.4=https://www.sakailms.org/shop
portal.quicklink.title.4=Sakai Merch Store
portal.quicklink.name.4=Sakai Merch Store
portal.quicklink.icon.4=cl bi bi-cart`



Thanks
![2022-11-25_16-14](https://user-images.githubusercontent.com/50500283/203966372-64620cd8-4088-49bd-a850-7b234d93a6bc.png)
![2022-11-25_16-02](https://user-images.githubusercontent.com/50500283/203966395-46b33dd8-7ffe-4627-9413-78a8cc6e81f2.png)

