### PR TITLE
SAK-48135 - Trinity portal: Selected custom icon for LTI ignored

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
+++ b/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
@@ -412,4 +412,8 @@ text-decoration-line-throughh
       background-color: var(--sakai-background-color-2);
     }
   }
+
+  .fa-tool-menu-icon {
+    margin-top: 5px;
+  }
 }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -444,7 +444,17 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				pageMap.put("resetUrl", page.getUrl().replaceFirst("page", "page-reset"));
 			}
 			pageMap.put("id", page.getId());
-			pageMap.put("icon", "si-" + toolList.get(0).getToolId().replace('.', '-'));
+
+			ToolConfiguration firstTool = toolList.get(0);
+			String icon = "si si-" + firstTool.getToolId().replace('.', '-');
+			Properties tmp = firstTool.getConfig();
+			if ( tmp != null ) {
+				String fa = tmp.getProperty("imsti.fa_icon");
+				if (StringUtils.isNotBlank(fa)) {
+					icon = "fa fa-tool-menu-icon " + collapseToVariable(fa);
+				}
+			}
+			pageMap.put("icon", icon);
 		} else {
 			pageMap.put("icon", "si-default-tool");
 		}

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -45,7 +45,7 @@
                 #else
                     #set ($pageUrl = $page.url)
                 #end
-                #pageListItem ($page.id, $page.title, $pageUrl, "si ${page.icon}", 4, $page.hidden, $page.locked)
+                #pageListItem ($page.id, $page.title, $pageUrl, "${page.icon}", 4, $page.hidden, $page.locked)
             #end
             #if ($site.subSites)
                 <li class="nav-item">


### PR DESCRIPTION
With respect to CSS selectors and styling, the font-awesome classes used by LTI tools (e.g., lti_tools.fa_icon and lti_controls.fa_icon) seem to conflict with the new "si" class, so I've retrofitted the (legacy?) font-awesome stuff to at least have fa icons display in Trinity. In that vein, the fa-tool-menu-icon class I added is intended to correct otherwise noticeable vertical misalignment between the icon and the tool title.