### PR TITLE
SAK-48123 - Fix double Home entry on breadcrumb

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteHierarchy.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteHierarchy.vm
@@ -54,7 +54,7 @@
     
     #set($index = 0)
     #foreach( $page in $sitePages.pageNavTools )
-        #if ( $index == 0 )
+        #if ( ( $index == 0 ) && ! ${isUserSite} )
             <li class="Mrphs-hierarchy--siteName breadcrumb-item" title="${siteTitle}">
                 <a class="text-decoration-none" href="${page.pageResetUrl}">
                     <small>${siteTitleTruncated}</small>


### PR DESCRIPTION
Redundant breadcrumbs induce a confusing or disorienting UX, so the approach I propose is to omit the breadcrumb that indicates the current site if the current site isUserSite (i.e., a user's "Home"). 