### PR TITLE
SAK-48153 - Support Analytics GA4 since Universal is being deprecated

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -78,22 +78,19 @@
 # Cookie policy URL
 # portal.cookie.policy.warning.url = /library/content/cookie_policy.html
 
-# SAK-25634
-# Add support for Google Analytics to the Portal
-# Google analytics is NOT enabled by default, setting these will enable it
-#
-# portal.google.analytics_id=UA-XXXXXX-XX
-# portal.google.analytics_domain=yoursakaihost.edu
-# portal.google.analytics_detail=true
-
 # SAK-28052
 # Add support for Universal Google Analytics
-# Google analytics is NOT enabled by default, setting these will enable it
-#
+# Google will stop processing Universal Analytics hits on July 1, 2023
+# Google analytics is NOT enabled by default, setting these will enable it.
 # portal.google.universal_analytics_id=UA-XXXXXX-XX
 
+# SAK-48153
+# Add support for GA4 Google Analytics
+# Google analytics is NOT enabled by default, setting these will enable it. 
+# portal.google.ga4_id=G-XXXXXXXXXK
+
 # SAK-41039
-# Support to anonymize IP in Google Analytics, only supported by Universal Google Analytics.
+# Support to anonymize IP in Google Analytics
 # Default: false
 # portal.google.anonymize.ip = true
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1046,18 +1046,15 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		rcontext.put("includeExtraHead",includeExtraHead);
 
 		String universalAnalyticsId =  ServerConfigurationService.getString("portal.google.universal_analytics_id", null);
+		rcontext.put("googleAnonymizeIp", ServerConfigurationService.getBoolean("portal.google.anonymize.ip", false));
+
 		if ( universalAnalyticsId != null ) {
 			rcontext.put("googleUniversalAnalyticsId", universalAnalyticsId);
-			rcontext.put("googleAnonymizeIp", ServerConfigurationService.getBoolean("portal.google.anonymize.ip", false));
 		}
 
-		String analyticsId =  ServerConfigurationService.getString("portal.google.analytics_id", null);
-		if ( analyticsId != null ) {
-			rcontext.put("googleAnalyticsId", analyticsId);
-			rcontext.put("googleAnalyticsDomain", 
-				ServerConfigurationService.getString("portal.google.analytics_domain"));
-			rcontext.put("googleAnalyticsDetail", 
-				ServerConfigurationService.getBoolean("portal.google.analytics_detail", false));
+		String googleGA4Id =  ServerConfigurationService.getString("portal.google.ga4_id", null);
+		if ( googleGA4Id != null ) {
+			rcontext.put("googleGA4Id", googleGA4Id);
 		}
 
 		//SAK-29668

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAnalytics.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeAnalytics.vm
@@ -1,31 +1,3 @@
-#if (${googleAnalyticsId})
-
-    <script type="text/javascript">
-
-        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', '${googleAnalyticsId}']);
-        _gaq.push(['_setDomainName', '${googleAnalyticsDomain}']);
-
-        #if (${googleAnalyticsDetail})
-
-            if ( window.portal ) {
-            _gaq.push(['_setCustomVar', 1, 'eid', portal.user.eid, 1]);
-            _gaq.push(['_setCustomVar', 2, 'siteId', portal.siteId, 3]);
-            }
-
-        #end ## END of IF (${googleAnalyticsDetail})
-
-      _gaq.push(['_trackPageview']);
-
-        (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-        })();
-
-    </script>
-#end ## END of IF (${googleAnalyticsId})
-
 #if (${googleUniversalAnalyticsId})
 
     <script>
@@ -40,3 +12,17 @@
     </script>
 
 #end ## END of IF (${googleUniversalAnalyticsId})
+
+#if (${googleGA4Id})
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=${googleGA4Id}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '${googleGA4Id}', {
+      'anonymize_ip': ${googleAnonymizeIp},
+      'user_id': portal.user.id
+  });
+</script>
+#end ## END of IF ($(googleGA4Id))


### PR DESCRIPTION
This cleans up the 3 old properties that are long deprecated
* portal.google.analytics_id=UA-XXXXXX-XX
* portal.google.analytics_domain=yoursakaihost.edu
* portal.google.analytics_detail=true

And adds support for GA4.

I figured it be worth using a new property rather than re-using this old one since you can have both UA and GA4 sending events together. 