### PR TITLE
SAK-48217 - Trinity: Remove excess margin for modal-title headings

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/_base.scss
@@ -246,3 +246,8 @@
 .alertMessage{
 	@extend .bs-callout-danger;
 }
+
+//Remove excessive heading margin for bootstrap modals
+.modal-title {
+  margin-top: 0;
+}


### PR DESCRIPTION
I placed the .modal-title in tool/_base.scss instead of _defaults.scss where the h1 through h6 rules are since not many class or id specific selectors seem to be defined in the latter.