### PR TITLE
SAK-48105 rWiki search using incorrect namespace

### DIFF
--- a/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/VelocityInlineDispatcher.java
+++ b/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/VelocityInlineDispatcher.java
@@ -146,6 +146,11 @@ public class VelocityInlineDispatcher implements Dispatcher
 			return ComponentManager.get(FormattedText.class).escapeHtml(val, false);
 		}
 
+		public String escapeHtmlFormattedText(String val)
+		{
+			return ComponentManager.get(FormattedText.class).escapeHtmlFormattedText(val);
+		}
+
 		public String formatDisplayName(String name)
 		{
 			if (name == null)

--- a/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/bean/FullSearchBean.java
+++ b/rwiki/rwiki-tool/tool/src/java/uk/ac/cam/caret/sakai/rwiki/tool/bean/FullSearchBean.java
@@ -23,6 +23,7 @@ package uk.ac.cam.caret.sakai.rwiki.tool.bean;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +45,7 @@ public class FullSearchBean
 {
 
 	/** Tool restriction: see RWikiEntityContentProducer.getTool() **/
-	private static final String SEARCH_SUFFIX = " +tool:wiki";
+	private static final String SEARCH_TOOL = "wiki";
 		
 	/**
 	 * The search criteria
@@ -197,7 +198,7 @@ public class FullSearchBean
 			int searchStart = requestPage * pagesize;
 			int searchEnd = searchStart + pagesize;
 			try {
-				searchResults = searchService.search(search.concat(SEARCH_SUFFIX), l, null, searchStart,
+				searchResults = searchService.search(search, l, Collections.singletonList(SEARCH_TOOL), searchStart,
 						searchEnd);
 				long end = System.currentTimeMillis();
 				timeTaken = end - start;

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/full_search.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/full_search.vm
@@ -77,7 +77,7 @@
 				<!--is-->
 				<li>
 					<h5> <a href="${result.url}" class="searchTopLink" >${util.escapeHtml($searchBean.pageNameFromSearchTitle(${result.title}))}</a></h5> 
-					<div class="searchItemBody" >${util.escapeHtml($result.searchResult)}</div>
+					<div class="searchItemBody" >${result.searchResult}</div>
 					<div class="searchItemFooter" ><a href="${result.url}" target="searchresult" class="searchBottonLink" >${result.url}</a></div>
 				</li>	
 				<!--ie-->

--- a/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/full_search.vm
+++ b/rwiki/rwiki-tool/tool/src/webapp/WEB-INF/vm/full_search.vm
@@ -77,7 +77,7 @@
 				<!--is-->
 				<li>
 					<h5> <a href="${result.url}" class="searchTopLink" >${util.escapeHtml($searchBean.pageNameFromSearchTitle(${result.title}))}</a></h5> 
-					<div class="searchItemBody" >${result.searchResult}</div>
+					<div class="searchItemBody" >${util.escapeHtmlFormattedText($result.searchResult)}</div>
 					<div class="searchItemFooter" ><a href="${result.url}" target="searchresult" class="searchBottonLink" >${result.url}</a></div>
 				</li>	
 				<!--ie-->


### PR DESCRIPTION
I'm speculating a bit, but I think rwiki was still using the old lucene style of searching?  I switched it so that the tool gets passed into the appropriate field instead of appended to the search terms.

Also, removed the html escaping from the results since we need to render the returned markup (matching search terms are bolded).  This should be consistent with the way the main search tool is working.