### PR TITLE
SAK-48247 -TRINITY: Navbar sites don't line up

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -18,7 +18,7 @@
 
     <li class="site-list-item py-1 $!{currentSiteClass}">
         <div class="site-list-item-head d-flex align-items-center pe-2">
-            <button class="btn btn-nav btn-site rounded-end text-start border-0 me-1 #if (!$isCurrentSite)collapsed#end"
+            <button class="d-flex btn btn-nav btn-site rounded-end text-start border-0 me-1 #if (!$isCurrentSite)collapsed#end"
                     data-bs-toggle="collapse"
                     data-bs-target="#site-${index}-pages"
                     aria-expanded="${isExpanded}"


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48247



Before:
![2022-12-27_15-18](https://user-images.githubusercontent.com/50500283/209650885-fd9a904f-1bf7-46a2-9648-5b7613f9de7c.png)

After:
![After](https://user-images.githubusercontent.com/50500283/209650914-db94dc0e-3755-4bb4-a82a-f93f46630826.png)
