### PR TITLE
S2U-21 SEB: Only run pre-delivery phase for uploaded configs

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
@@ -324,14 +324,15 @@ public class PublishAssessmentListener
             PhaseStatus executionResult = secureDeliveryService.executePreDeliveryPhase(moduleId, PreDeliveryPhase.ASSESSMENT_PUBLISH,
                     assessment, publishedAssessment, request);
 
-            log.debug("Pre-delivery phase {} executed with result [{}]", PreDeliveryPhase.ASSESSMENT_PUBLISH, executionResult);
+            log.debug("Pre-delivery phase {} executed for module [{}] with result [{}]", PreDeliveryPhase.ASSESSMENT_PUBLISH, moduleId, executionResult);
 
             if (!PhaseStatus.SUCCESS.equals(executionResult)) {
                 String errorMessage = MessageFormat.format(
                         ContextUtil.getLocalizedString(SamigoConstants.AUTHOR_BUNDLE, "secure_delivery_exception_publish"),
                         new Object[]{ secureDeliveryService.getModuleName(moduleId, ContextUtil.getLocale()) });
                 FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(errorMessage));
-                throw new AbortProcessingException("Pre-delivery phase failed when trying to publish assessment");
+                throw new AbortProcessingException("Pre-delivery phase " + PreDeliveryPhase.ASSESSMENT_PUBLISH
+                        + " failed for module [" + moduleId + "] when trying to publish assessment");
             }
         }
     }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/SecureDeliverySeb.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/SecureDeliverySeb.java
@@ -250,14 +250,23 @@ public class SecureDeliverySeb implements SecureDeliveryModuleIfc {
             HttpServletRequest request, PreDeliveryPhase phase) {
         log.debug("Executing pre delivery phase [{}]", phase);
 
-        switch(phase) {
-            case ASSESSMENT_PUBLISH:
-                return publishConfigUpload(publishedAssessment, request) ? PhaseStatus.SUCCESS : PhaseStatus.FAILURE;
-            default:
-                break;
+        if (publishedAssessment == null) {
+            log.error("Published assessment is null, returning {}", PhaseStatus.FAILURE);
+            return PhaseStatus.FAILURE;
         }
 
-        return PhaseStatus.SUCCESS;
+        String configModeString = publishedAssessment.getAssessmentMetaDataByLabel(SebConfig.CONFIG_MODE);
+
+        switch (phase) {
+            case ASSESSMENT_PUBLISH:
+                if (ConfigMode.UPLOAD.toString().equals(configModeString)) {
+                    return publishConfigUpload(publishedAssessment, request) ? PhaseStatus.SUCCESS : PhaseStatus.FAILURE;
+                } else {
+                    return PhaseStatus.SUCCESS;
+                }
+            default:
+                return PhaseStatus.SUCCESS;
+        }
     }
 
     public boolean validateContext(Object context) {


### PR DESCRIPTION
If the SEB config mode is not UPLOAD, it the pre-delivery phase should just return success, because no action is needed.
Missing this check cause problems publishing assessments using SEB without uploaded config.