### PR TITLE
S2U-21 Fix whitespaces being removed from assessment title

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -375,13 +375,9 @@ public class SaveAssessmentSettings
     
     // kkk. remove the existing title decoration (if any) and then add the new one (if any)    
     String titleDecoration = assessment.getAssessmentMetaDataByLabel( SecureDeliveryServiceAPI.TITLE_DECORATION );
-    String newTitle;
-    if ( titleDecoration != null )
-    	newTitle = StringUtils.replace(assessment.getTitle(), " " + titleDecoration, "");
-    else
-    	newTitle = assessment.getTitle();
-    
-    // getTitleDecoration() returns "" if null or NONE module is passed
+    String newTitle = StringUtils.isEmpty(titleDecoration) && !"NONE".equals(titleDecoration)
+            ? StringUtils.replace(assessment.getTitle(), " " + titleDecoration, "")
+            : assessment.getTitle();
     titleDecoration = secureDeliveryService.getTitleDecoration( assessmentSettings.getSecureDeliveryModule(), new ResourceLoader().getLocale() );
     if (titleDecoration != null && !titleDecoration.trim().equals("")) {
     	newTitle = newTitle + " " + titleDecoration;

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -191,12 +191,9 @@ implements ActionListener
 
 	    // kk. remove the existing title decoration (if any) and then add the new one (if any)	    
 	    String titleDecoration = assessment.getAssessmentMetaDataByLabel( SecureDeliveryServiceAPI.TITLE_DECORATION );
-	    String newTitle;
-	    if ( titleDecoration != null )
-    		newTitle = StringUtils.replace(assessment.getTitle(), " " + titleDecoration, "");
-	    else
-	    	newTitle = assessment.getTitle();
-	    // getTitleDecoration() returns "" if null or NONE module is passed
+	    String newTitle = StringUtils.isEmpty(titleDecoration) && !"NONE".equals(titleDecoration)
+	            ? StringUtils.replace(assessment.getTitle(), " " + titleDecoration, "")
+	            : assessment.getTitle();
 	    titleDecoration = secureDeliveryService.getTitleDecoration( assessmentSettings.getSecureDeliveryModule(), new ResourceLoader().getLocale() );
 	    if (titleDecoration != null && !titleDecoration.trim().equals("")) {
 	    	newTitle = newTitle + " " + titleDecoration;


### PR DESCRIPTION
When `titleDecoration` was an empty string, all white-spaces were removed from the title.