### PR TITLE
S2U-21 SEB: Remove demo configuration properties

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
@@ -255,9 +255,10 @@ public class SebConfig {
         map.put(SEB_WEBVIEW_VERSION_KEY, 3);
         map.put(QUIT_LINK_KEY, QUIT_LINK);
 
-        // TODO remove
-        map.put("killExplorerShell", false);
-        map.put("createNewDesktop", false);
+        // Useful properties for demos, makes it possible to record or share the screen
+        // Commented, since it is disabling security features of SEB
+        //map.put("killExplorerShell", false);
+        //map.put("createNewDesktop", false);
 
         return map;
     }


### PR DESCRIPTION
Remove properties for SEB configuration that are useful for a demo (screen record/share), but should not be set in production.