### PR TITLE
SAK-48546 - Gradebook: Comment icon overlapped by cell menu button

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -231,6 +231,7 @@
     position: absolute;
     right: 0;
     bottom: 2px;
+    height: 12px;
   }
   #gradeTableWrapper .gb-comment-notification, #gradeTableWrapper .gb-course-comment-notification {
     position: absolute;
@@ -1512,6 +1513,11 @@
       display: block;
       width: 485px;
       height: 100px;
+  }
+
+  .dropdown-toggle::after {
+      position: relative;
+      top: -7px;
   }
 }
 


### PR DESCRIPTION
I've reduced the height of the cell menu button to match Sakai 22 and before. I also moved the down arrow icon to be in the center of the button's active area.