### PR TITLE
SAK-48551 - Assignments: Not all released grades recorded in GB

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
@@ -52,7 +52,7 @@ public interface AssignmentRepository extends SerializableRepository<Assignment,
 
     AssignmentSubmission findSubmission(String submissionId);
 
-    void updateSubmission(AssignmentSubmission submission);
+    AssignmentSubmission updateSubmission(AssignmentSubmission submission);
 
     boolean existsSubmission(String submissionId);
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1510,7 +1510,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         }
         eventTrackingService.post(eventTrackingService.newEvent(AssignmentConstants.EVENT_UPDATE_ASSIGNMENT_SUBMISSION, reference, true));
 
-        assignmentRepository.updateSubmission(submission);
+        submission = assignmentRepository.updateSubmission(submission);
 
         // Assignment Submission Notifications
         Instant dateReturned = submission.getDateReturned();

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
@@ -145,11 +145,12 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
 
     @Override
     @Transactional
-    public void updateSubmission(AssignmentSubmission submission) {
+    public AssignmentSubmission updateSubmission(AssignmentSubmission submission) {
         if (existsSubmission(submission.getId())) {
             submission.setDateModified(Instant.now());
-            geCurrentSession().merge(submission);
+            submission = (AssignmentSubmission) geCurrentSession().merge(submission);
         }
+	return submission;
     }
 
     @Override

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
@@ -405,6 +405,7 @@ public class AssignmentToolUtils {
             properties.put(PROP_LAST_GRADED_DATE, DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG).withZone(ZoneId.systemDefault()).format(Instant.now()));
 
             try {
+                log.debug("AssignmentSubmission hashCode instance = {}; grade = {}", Integer.toHexString(submission.hashCode()), submission.getGrade());
                 assignmentService.updateSubmission(submission);
             } catch (PermissionException e) {
                 log.warn("Could not update submission: {}, {}", submission.getId(), e.getMessage());
@@ -594,6 +595,7 @@ public class AssignmentToolUtils {
                             // only update one submission
                             AssignmentSubmission aSubmission = assignmentService.getSubmission(submissionId);
                             if (aSubmission != null) {
+                                log.debug("AssignmentSubmission hashCode instance = {}; grade = {}", Integer.toHexString(aSubmission.hashCode()), aSubmission.getGrade());
                                 int factor = aSubmission.getAssignment().getScaleFactor();
                                 Set<AssignmentSubmissionSubmitter> submitters = aSubmission.getSubmitters();
                                 String gradeString = displayGrade(StringUtils.trimToNull(aSubmission.getGrade()), factor);


### PR DESCRIPTION
Our institution initially attempted to fix this problem with just the Hibernate session flush. However, the flush by itself was not sufficient. for preventing the bug. We needed to also include a Hibernate refresh of the submission object. Both seemingly work in tandem to guarantee that the submission object's data integrity is upheld throughout the logic triggered by "Save & Release".