### PR TITLE
SAK-48553 - Assignments: Occasional NPEs and severed GB associations

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -384,6 +384,17 @@ public interface AssignmentService extends EntityProducer {
     public Assignment getAssignment(String assignmentId) throws IdUnusedException, PermissionException;
 
     /**
+     * Access the Assignment with the specified id. Ensure it is refreshed from the database.
+     *
+     * @param assignmentId -
+     *                     The id of the Assignment.
+     * @return The Assignment corresponding to the id, or null if it does not exist.
+     * @throws IdUnusedException   if there is no object with this id.
+     * @throws PermissionException if the current user is not allowed to read this.
+     */
+    public Assignment getAssignmentFromDatabase(String assignmentId) throws IdUnusedException, PermissionException;
+
+    /**
      * Retrieves the current status of the specified assignment.
      *
      * @return

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/persistence/AssignmentRepository.java
@@ -34,6 +34,8 @@ public interface AssignmentRepository extends SerializableRepository<Assignment,
 
     Assignment findAssignment(String id);
 
+    Assignment getAssignmentFromDatabase(String id);
+
     List<Assignment> findAssignmentsBySite(String siteId);
 
     List<Assignment> findDeletedAssignmentsBySite(String siteId);
@@ -41,6 +43,8 @@ public interface AssignmentRepository extends SerializableRepository<Assignment,
     List<String> findAllAssignmentIds();
 
     void newAssignment(Assignment assignment);
+
+    Assignment updateAssignment(Assignment assignment);
 
     boolean existsAssignment(String assignmentId);
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentPeerAssessmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentPeerAssessmentServiceImpl.java
@@ -67,7 +67,7 @@ public class AssignmentPeerAssessmentServiceImpl extends HibernateDaoSupport imp
         //now schedule a time for the review to be setup
         Assignment assignment;
         try {
-            assignment = assignmentService.getAssignment(assignmentId);
+            assignment = assignmentService.getAssignmentFromDatabase(assignmentId);
             if (!assignment.getDraft() && assignment.getAllowPeerAssessment()) {
                 Instant assignmentCloseTime = assignment.getCloseDate();
                 Instant openTime = null;

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1462,7 +1462,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
         assignment.setDateModified(Instant.now());
         assignment.setModifier(sessionManager.getCurrentSessionUserId());
-        Assignment updatedAssingment = assignmentRepository.merge(assignment);
+        Assignment updatedAssingment = assignmentRepository.updateAssignment(assignment);
 
         Task task = new Task();
         task.setSiteId(updatedAssingment.getContext());
@@ -1608,6 +1608,19 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         // check security on the assignment
 
         return checkAssignmentAccessibleForUser(assignment, currentUserId);
+    }
+
+    @Override
+    public Assignment getAssignmentFromDatabase(String assignmentId) throws IdUnusedException, PermissionException {
+	    log.debug("GET ASSIGNMENT : ID : {}", assignmentId);
+
+	    Assignment assignment = assignmentRepository.getAssignmentFromDatabase(assignmentId);
+	    if (assignment == null) throw new IdUnusedException(assignmentId);
+
+	    String currentUserId = sessionManager.getCurrentSessionUserId();
+	    // check security on the assignment
+
+	    return checkAssignmentAccessibleForUser(assignment, currentUserId);
     }
 
     @Override

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/persistence/AssignmentRepositoryImpl.java
@@ -66,6 +66,16 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
     }
 
     @Override
+    @Transactional
+    public Assignment getAssignmentFromDatabase(String id) {
+	    Assignment asn = findOne(id);
+	    Session session = geCurrentSession();
+	    session.refresh(asn);
+	    return asn;
+    }
+    
+
+    @Override
     @SuppressWarnings("unchecked")
     public List<Assignment> findAssignmentsBySite(String siteId) {
         return startCriteriaQuery()
@@ -97,6 +107,18 @@ public class AssignmentRepositoryImpl extends BasicSerializableRepository<Assign
             assignment.setDateCreated(Instant.now());
             geCurrentSession().persist(assignment);
         }
+    }
+
+    @Override
+    @Transactional
+    public Assignment updateAssignment(Assignment assignment) {
+	if (existsAssignment(assignment.getId())) {
+		assignment.setDateModified(Instant.now());
+		Session session = geCurrentSession();
+		assignment = (Assignment) session.merge(assignment);
+		session.flush();
+	}
+	return assignment;
     }
 
     @Override

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/reminder/AssignmentDueReminderServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/reminder/AssignmentDueReminderServiceImpl.java
@@ -114,7 +114,7 @@ public class AssignmentDueReminderServiceImpl implements AssignmentDueReminderSe
         long reminderSeconds = 60 * 60 * serverConfigurationService.getInt("assignment.reminder.hours", 24); // Convert hours to seconds
 
         try {
-            Assignment assignment = assignmentService.getAssignment(assignmentId);
+            Assignment assignment = assignmentService.getAssignmentFromDatabase(assignmentId);
             // Only schedule due date reminders for posted assignments with due dates far enough in the future for a reminder
             if (!assignment.getDraft() && Instant.now().plusSeconds(reminderSeconds).isBefore(assignment.getDueDate())) {
                 Instant reminderDate = assignment.getDueDate().minusSeconds(reminderSeconds);


### PR DESCRIPTION
Our institution initially attempted to fix this problem with just the Hibernate session flush. However, the flush by itself was not sufficient. for preventing the bug. We needed to also include a Hibernate refresh of the assignment object. Both seemingly work in tandem to guarantee that the assignment object's data integrity is upheld throughout the logic triggered by "Post".