### PR TITLE
SAK-48584 Rubrics: Adapt comment popovers to B-5

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/rubrics/_rubrics.scss
+++ b/library/src/skins/default/src/sass/modules/tool/rubrics/_rubrics.scss
@@ -777,10 +777,8 @@ div.collapse-toggle-buttons > button {
     -webkit-filter: drop-shadow(0 -2px 2px #AAA);
 }
 
-.arrow-0 {
+.arrow-0, .arrow-comment {
     position: absolute;
-    bottom: 42px;
-    right: -18px;
     border-bottom: 10px solid transparent;
     border-top: 10px solid transparent;
     border-left: 19px solid #f8f9fa;
@@ -789,14 +787,27 @@ div.collapse-toggle-buttons > button {
     -webkit-filter: drop-shadow(2px 0px 0px #AAA);
 }
 
+.arrow-0 {
+    bottom: 42px;
+    right: -18px;
+}
+
+.arrow-comment {
+    bottom: 50px;
+    right: -18px;
+}
+
 .label-rubrics {
     font-weight: bold;
+}
+
+.rubrics-popover, .rubrics-comment-popover {
+    display: none; 
+    position: absolute; 
+    padding: 10px;
 }
 
 .rubrics-popover {
     top: 389px; 
     left: -10px; 
-    display: none; 
-    position: absolute; 
-    padding: 10px;
 }

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading-comment.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading-comment.js
@@ -39,15 +39,15 @@ export class SakaiRubricGradingComment extends RubricsElement {
       <div tabindex="0" style="cursor: pointer;" class="comment-icon fa fa-2x fa-comments ${this.criterion.comments ? "active" : ""}" @click=${this.toggleEditor} @keypress=${this.toggleEditor} title="${tr("criterion_comment")}"></div>
 
       <!-- popover -->
-      <div id="criterion-editor-${this.criterion.id}-${this.randombit}" class="popover criterion-edit-popover left">
-        <div class="arrow"></div>
+      <div id="criterion-editor-${this.criterion.id}-${this.randombit}" class="popover criterion-edit-popover left rubrics-comment-popover">
+        <div class="arrow-comment"></div>
         <div class="popover-title" style="display: flex;">
           <div style="flex: auto;">
             <span class="criterion-title">
               <sr-lang key="comment_for_criterion" values="${JSON.stringify([this.criterion.title])}" />
             </span>
           </div>
-          <div class="buttons act" style="flex: 0">
+          <div class="buttons act mt-0" style="flex: 0">
             <button class="active btn-xs done" @click="${this.hideTooltip}"><sr-lang key="done" /></button>
           </div>
         </div>
@@ -83,8 +83,8 @@ export class SakaiRubricGradingComment extends RubricsElement {
 
       const popover = $(`#criterion-editor-${this.criterion.id}-${this.randombit}`);
 
-      popover[0].style.left = `${e.target.offsetLeft - 270  }px`;
-      popover[0].style.top = `${e.target.offsetTop + e.target.offsetHeight / 2 + 20 - popover.height() / 2  }px`;
+      popover[0].style.left = `${e.target.offsetLeft - 280  }px`;
+      popover[0].style.top = `${e.target.offsetTop + e.target.offsetHeight / 2 + 20 - popover.height() / 2 - 46  }px`;
 
       Object.keys(CKEDITOR.instances)
         .filter(n => n.includes("criterion-")).forEach(n => CKEDITOR.instances[n].destroy(true));


### PR DESCRIPTION
I added new classes for CSS styling predicated on the arrow-0, etc. classes recently introduced, but I break from that nomenclature to signal the class's purpose. 

I needed to add an !important to .rubrics-comment-popover to override a 'top' value that is (somehow) dynamically set within a style attribute of the target div.