### PR TITLE
S2U-14 Tests & Quizzes: Canceled questions and score re-calculation

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -50,6 +50,24 @@
 			}
 	}
 
+	.samigo-question-cancelled {
+		opacity: 0.7;
+
+		.sak-banner-info {
+			margin-bottom: 0;
+		}
+	}
+
+	.question-cancel-modal {
+		input[type="checkbox"] {
+			margin-right: $standard-space;
+		}
+
+		.act {
+			margin: unset;
+		}
+	}
+
 	.listNav {
 		.inlineForm {
 			@extend .panel;

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -147,10 +147,20 @@ public final class SamigoConstants {
     public static final     String      AUTHOR_BUNDLE                                       = "org.sakaiproject.tool.assessment.bundle.AuthorMessages";
 
     /*
+     * Author Outcomes
+     */
+    public static final     String      OUTCOME_AUTHOR_EDIT_ASSESSMENT                      = "editAssessment";
+
+    /*
      * Delivery Outcomes
      */
     public static final     String      OUTCOME_DELIVERY_TAKE_ASSESSMENT                    = "takeAssessment";
     public static final     String      OUTCOME_DELIVERY_SECURE_DELIVERY_ERROR              = "secureDeliveryError";
+
+    /*
+     * Evaluation Outcomes
+     */
+    public static final     String      OUTCOME_EVALUATION_QUESTION_SCORES                  = "questionScores";
 
     private SamigoConstants() {
     	throw new AssertionError();

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/ItemDataIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/ItemDataIfc.java
@@ -36,6 +36,12 @@ public interface ItemDataIfc extends Comparable<ItemDataIfc>, java.io.Serializab
   public static final Integer ACTIVE_STATUS = 1;
   public static final Integer INACTIVE_STATUS = 0;
 
+  public static final int ITEM_NOT_CANCELED = 0;
+  public static final int ITEM_TOTAL_SCORE_TO_CANCEL = 10;
+  public static final int ITEM_TOTAL_SCORE_CANCELLED = 11;
+  public static final int ITEM_DISTRIBUTED_TO_CANCEL = 20;
+  public static final int ITEM_DISTRIBUTED_CANCELLED = 21;
+
   Long getItemId();
 
   void setItemId(Long itemId);
@@ -103,6 +109,10 @@ public interface ItemDataIfc extends Comparable<ItemDataIfc>, java.io.Serializab
   Integer getStatus();
 
   void setStatus(Integer status);
+
+  Integer getCancellation();
+
+  void setCancellation(Integer cancellation);
 
   String getCreatedBy();
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages.properties
@@ -36,3 +36,21 @@ action_save_pair=Save Pairing
 delete=Delete
 delete_attempt=Delete attempt
 confirm_delete_attempt=Are you sure you want to delete this attempt?
+
+# S2U-14
+cancel_question=Cancel question
+cancel_question_reduce_total=Reduce total points
+cancel_question_distribute_points=Equally distribute points
+cancel_question_cancel=Do not cancel question
+cancel_question_info_cancelled_question=This question has been cancelled and will not affect the total score.
+cancel_question_info_cancellation=Cancelling this question will cause it to not be counted in the evaluation. \
+The cancellation of this questions points can be handled in two ways:
+cancel_question_info_distribute_points=Possible score of cancelled question will be equally distributed across \
+the other questions. Total points remain unaffected.
+cancel_question_info_reduce_total=Possible score of cancelled question will be deducted from the total points. \
+Other questions remain unaffected.
+cancel_question_info_regrade=By cancelling the question, existing submmissions will be regraded.
+cancel_question_info_no_undo=This action can not be undone!
+cancel_question_info_skip_question=You can skip this question.
+cancel_question_error_cancelling=An error occurred, when trying to cancel the question. No changes have been made.
+cancel_question_info_emi=Extended Matching Items will not receive adjusted Scores.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages_ca.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages_ca.properties
@@ -36,3 +36,21 @@ action_save_pair=Desa la parella
 delete=Elimina
 delete_attempt=Elimina l\u2019intent
 confirm_delete_attempt=Esteu segur de voler eliminar aquest intent?
+
+# S2U-14
+cancel_question=Cancel\u00b7la la pregunta
+cancel_question_reduce_total=Redueix els punts totals
+cancel_question_distribute_points=Distribueix els punts de manera igual
+cancel_question_cancel=No cancel\u00b7lar la pregunta
+cancel_question_info_cancelled_question=Aquesta pregunta s\u0027ha cancel\u00b7lat i no afectar\u00e0 a la puntuaci\u00f3 total.
+cancel_question_info_cancellation=La cancel\u00b7laci\u00f3 d\u0027aquesta pregunta far\u00e0 que no es compti en l\u0027avaluaci\u00f3. \
+La cancel\u00b7laci\u00f3 d\u0027aquests punts de les preguntes es pot gestionar de dues maneres:
+cancel_question_info_distribute_points=La possible puntuaci\u00f3 de la pregunta cancel\u00b7lada es distribuir\u00e0 igualment a trav\u00e9s de \
+les altres preguntes. Els punts totals no es veuen afectats.
+cancel_question_info_reduce_total=La possible puntuaci\u00f3 de la pregunta cancel\u00b7lada es deduir\u00e0 dels punts totals. \
+Altres preguntes no es veuen afectades.
+cancel_question_info_regrade=Per cancel\u00b7lar la pregunta, els enviaments existents es tornaran a qualificar.
+cancel_question_info_no_undo=Aquesta acci\u00f3 no es pot desfer!
+cancel_question_info_skip_question=Podeu ometre aquesta pregunta.
+cancel_question_error_cancelling=S\u0027ha produït un error intentant cancel\u00b7lar la pregunta. No s\u0027han fet canvis.
+cancel_question_info_emi=Les preguntes d\u0027elements de correspond\u00e8ncia no rebr\u00e0 puntuacions ajustades.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages_es.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages_es.properties
@@ -36,3 +36,21 @@ action_save_pair=Guardar par
 delete=Borrar
 delete_attempt=Eliminar intento
 confirm_delete_attempt=\u00bfEst\u00e1 seguro que desea eliminar este env\u00edo de examen?
+
+# S2U-14
+cancel_question=Cancelar pregunta
+cancel_question_reduce_total=Reducir la puntuaci\u00f3n total
+cancel_question_distribute_points=Distribuir la puntuaci\u00f3n equitativamente
+cancel_question_cancel=No cancelar la pregunta
+cancel_question_info_cancelled_question=Esta pregunta se ha cancelado y no afectar\u00e1 a la puntuaci\u00f3n total.
+cancel_question_info_cancellation=Al cancelar esta pregunta su puntuaci\u00f3n no contar\u00e1 en la evaluaci\u00f3n. \
+La cancelaci\u00f3n de los puntos de esta pregunta puede manejarse de dos maneras:
+cancel_question_info_distribute_points=La posible puntuaci\u00f3n de la pregunta cancelada se distribuir\u00e1 equitativamente \
+las otras preguntas. La puntuaci\u00f3n total permanecer\u00e1 inalterada.
+cancel_question_info_reduce_total=La posible puntuaci\u00f3n de la pregunta cancelada se restar\u00e1 de la puntuaci\u00f3n total. \
+El resto de preguntas permanecer\u00e1n inalteradas.
+cancel_question_info_regrade=Al cancelar esta pregunta, las entregas existentes se recalificar\u00e1n.
+cancel_question_info_no_undo=Esta acci\u00f3n no puede deshacerse!
+cancel_question_info_skip_question=Puedes omitir esta pregunta.
+cancel_question_error_cancelling=Ha ocurrido un error al intentar cancelar la pregunta. No se han realizado cambios.
+cancel_question_info_emi=En las preguntas de tipo Relacionar M\u00faltiples Opciones no se ajustar\u00e1 la puntuaci\u00f3n.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages_eu.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/CommonMessages_eu.properties
@@ -36,3 +36,21 @@ action_save_pair=Gorde parea
 delete=Ezabatu
 delete_attempt=Ezabatu saialdia
 confirm_delete_attempt=Ziur zaude saialdi hau ezabatu nahi duzula?
+
+# S2U-14
+cancel_question=Cancel question
+cancel_question_reduce_total=Reduce total points
+cancel_question_distribute_points=Equally distribute points
+cancel_question_cancel=Do not cancel question
+cancel_question_info_cancelled_question=This question has been cancelled and will not affect the total score.
+cancel_question_info_cancellation=Cancelling this question will cause it to not be counted in the evaluation. \
+The cancellation of this questions points can be handled in two ways:
+cancel_question_info_distribute_points=Possible score of cancelled question will be equally distributed across \
+the other questions. Total points remain unaffected.
+cancel_question_info_reduce_total=Possible score of cancelled question will be deducted from the total points. \
+Other questions remain unaffected.
+cancel_question_info_regrade=By cancelling the question, existing submmissions will be regraded.
+cancel_question_info_no_undo=This action can not be undone!
+cancel_question_info_skip_question=You can skip this question.
+cancel_question_error_cancelling=An error occurred, when trying to cancel the question. No changes have been made.
+cancel_question_info_emi=Extended Matching Items will not receive adjusted Scores.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
@@ -43,6 +43,7 @@ import org.apache.commons.math3.util.Precision;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.samigo.util.SamigoConstants;
+import org.sakaiproject.tool.assessment.data.dao.assessment.ItemData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingAttachment;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.MediaData;
@@ -1716,6 +1717,14 @@ public class ItemContentsBean implements Serializable {
 		} else {
 			return itemData.getItemId();
 		}
+	}
+
+	public boolean isCancelled() {
+		return this.itemData.getCancellation().intValue() != ItemDataIfc.ITEM_NOT_CANCELED;
+	}
+
+	public boolean isCancellable() {
+		return !this.isCancelled();
 	}
 }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/SectionContentsBean.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import javax.faces.model.SelectItem;
@@ -46,6 +47,7 @@ import org.apache.commons.math3.util.Precision;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
+import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.QuestionPoolFacade;
 import org.sakaiproject.tool.assessment.services.QuestionPoolService;
@@ -698,6 +700,29 @@ public class SectionContentsBean extends SpringBeanAutowiringSupport implements 
 
   public void setRandomQuestionsDrawTime(String randomQuestionsDrawTime) {
 	  this.randomQuestionsDrawTime = randomQuestionsDrawTime;
+  }
+
+  public boolean isEmiItemPresent() {
+    return this.itemContents != null
+        ? this.itemContents.stream()
+            .filter(item -> TypeIfc.EXTENDED_MATCHING_ITEMS.equals(item.getItemData().getTypeId()))
+            .collect(Collectors.counting())
+            .intValue() > 0
+        : false;
+  }
+
+  public int getCancelledItemsCount() {
+    return this.itemContents != null
+        ? this.itemContents.stream()
+            .filter(item -> !TypeIfc.EXTENDED_MATCHING_ITEMS.equals(item.getItemData().getTypeId()))
+            .filter(item -> !item.isCancelled())
+            .collect(Collectors.counting())
+            .intValue()
+        : 0;
+  }
+
+  public boolean isCancellationAllowed() {
+    return getCancelledItemsCount() > 1;
   }
 }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -50,6 +50,7 @@ import org.sakaiproject.rubrics.api.RubricsConstants;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.tool.assessment.business.entity.RecordingData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentAccessControl;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
 import org.sakaiproject.tool.assessment.ui.bean.util.Validator;
 import org.sakaiproject.tool.assessment.ui.listener.evaluation.QuestionScoreListener;
@@ -173,6 +174,15 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
 
   @Setter @Getter
   private boolean hasAssociatedRubric;
+
+  @Setter @Getter
+  private boolean cancellationAllowed;
+
+  @Setter @Getter
+  private boolean emiItemPresent;
+
+  @Getter @Setter
+  private boolean regradedAssessmentReSubmittable;
 
   private static final ToolManager toolManager = (ToolManager) ComponentManager.get(ToolManager.class);
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemCancellationListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemCancellationListener.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2023 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.tool.assessment.ui.listener.author;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.ActionEvent;
+import javax.faces.event.ActionListener;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.sakaiproject.samigo.util.SamigoConstants;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
+import org.sakaiproject.tool.assessment.facade.ItemFacade;
+import org.sakaiproject.tool.assessment.services.PublishedItemService;
+import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
+import org.sakaiproject.tool.assessment.ui.bean.author.AssessmentBean;
+import org.sakaiproject.tool.assessment.ui.bean.evaluation.QuestionScoresBean;
+import org.sakaiproject.tool.assessment.ui.listener.evaluation.QuestionScoreListener;
+import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+
+
+@Slf4j
+public class ItemCancellationListener implements ActionListener {
+
+
+    public void processAction(ActionEvent ae) throws AbortProcessingException {
+        PublishedItemService publishedItemService = new PublishedItemService();
+        PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
+
+        String cancellation = ContextUtil.lookupParam("cancellation");
+        String itemId = ContextUtil.lookupParam("itemId");
+        String outcome = ContextUtil.lookupParam("outcome");
+        boolean regrade = Boolean.parseBoolean(ContextUtil.lookupParam("regrade"));
+
+        AssessmentBean assessmentBean = (AssessmentBean) ContextUtil.lookupBean("assessmentBean");
+        QuestionScoresBean questionScoresBean = (QuestionScoresBean) ContextUtil.lookupBean("questionScores");
+
+        log.debug("cancellation {}", cancellation);
+        log.debug("itemId: {}", itemId);
+        log.debug("outcome {}", outcome);
+        log.debug("regrade: {}", regrade);
+
+        String publishedAssessmentId = assessmentBean.getAssessmentId() != null
+                ? assessmentBean.getAssessmentId()
+                : questionScoresBean.getPublishedId();
+
+        // Abort if publishedAssessmentId or passed params are invalid
+        if (!NumberUtils.isParsable(publishedAssessmentId)
+                || !NumberUtils.isParsable(itemId)
+                || !NumberUtils.isParsable(cancellation)) {
+            //Add error message to context
+            String errorMessage = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.CommonMessages",
+                    "cancel_question_error_cancelling");
+            FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(errorMessage));
+
+            throw new AbortProcessingException(String.format("AssessmentId [%s], ItemId [%s] or cancellation [%s] is not parsable",
+                    publishedAssessmentId, itemId, cancellation));
+        }
+
+        ItemFacade publishedItemFacade = publishedItemService.getItem(itemId);
+
+        // Set cancellation and save item
+        publishedItemFacade.getData().setCancellation(Integer.parseInt(cancellation));
+        publishedItemService.saveItem(publishedItemFacade);
+
+        // Process cancellation
+        PublishedAssessmentIfc updatedPublishedAssessment = publishedAssessmentService.preparePublishedItemCancellation(
+                publishedAssessmentService.getPublishedAssessment(publishedAssessmentId));
+
+        // Update bean with updated Assessment
+        if (SamigoConstants.OUTCOME_AUTHOR_EDIT_ASSESSMENT.equals(outcome)) {
+            assessmentBean.setAssessment(updatedPublishedAssessment);
+        }
+
+        // If we are republishing from questions tab we need to pass the value of the allow-resumission checkbox
+        if (SamigoConstants.OUTCOME_EVALUATION_QUESTION_SCORES.equals(outcome)) {
+            boolean reSubmittable = questionScoresBean.isRegradedAssessmentReSubmittable();
+            log.debug("reSubmittable {}", reSubmittable);
+
+            if (regrade) {
+                publishedAssessmentService.regradePublishedAssessment(
+                    publishedAssessmentService.getPublishedAssessment(publishedAssessmentId), reSubmittable);
+            }
+
+            // Update questionsScores bean
+            questionScoresBean.setPublishedAssessment(updatedPublishedAssessment);
+            QuestionScoreListener questionScoreListener = new QuestionScoreListener();
+            questionScoreListener.questionScores(publishedAssessmentId, questionScoresBean, false);
+        }
+    }
+}

--- a/samigo/samigo-app/src/webapp/js/authoringQuestionCancellation.js
+++ b/samigo/samigo-app/src/webapp/js/authoringQuestionCancellation.js
@@ -1,0 +1,46 @@
+// S2U-14
+// When the Cancel Question button is clicked we want to open
+// the Modal to choose which method for cancellation should be selected
+// To apply it to the correct item we need modify the onclick handler
+
+(() => {
+
+    // For B3 we still need JQuery, isolating it here
+    function openModal(modalElement) {
+        // B3 version
+        $(modalElement).modal();
+
+        // B5 version
+        // new bootstrap.Modal(modalElement).show();
+    }
+
+    // Replaces the itemId that is present within the onclick handler of the button
+    function replaceParam(param, button, itemId) {
+        const onClickFnString = button?.getAttribute("onclick");
+
+        if (onClickFnString) {
+            const newOnClickFnString = onClickFnString.replace(new RegExp("(?<='" + param + "':').*(?=',)", "gm"), itemId);
+            button.onclick = new Function(newOnClickFnString);
+        }
+    }
+
+    function openQuestionCancelModal(event) {
+        event.preventDefault();
+        const itemId = event.target.getAttribute("data-itemId");
+        const modal = document.getElementById("cancelQuestionModal");
+        const distributeCancelButton = document.getElementById("assessmentForm:cancelItemDistribute")
+                ?? document.getElementById("assessmentForm:parts:0:cancelItemDistribute");
+        const totalPointsCancelButton = document.getElementById("assessmentForm:cancelItemTotal")
+                ?? document.getElementById("assessmentForm:parts:0:cancelItemTotal");
+
+        replaceParam("itemId", distributeCancelButton, itemId);
+        replaceParam("itemId", totalPointsCancelButton, itemId);
+        openModal(modal);
+    }
+
+    window.addEventListener("load", () => {
+        document.querySelectorAll("[data-item-cancellable][data-itemId]")
+                .forEach(cancelButton => cancelButton.addEventListener("click", openQuestionCancelModal));
+    });
+
+})();

--- a/samigo/samigo-app/src/webapp/js/deliveryQuestionCancellation.js
+++ b/samigo/samigo-app/src/webapp/js/deliveryQuestionCancellation.js
@@ -1,0 +1,24 @@
+// S2U-14
+// This will student input disable for cancelled questions while delivery.
+// This does not have to be secure, the question has a score of 0 anyway.
+
+(() => {
+
+    function disableInputs(question) {
+        const inputs = question?.querySelectorAll("input");
+        inputs?.forEach((input) => input.disabled = true);
+    }
+
+    function disableAudioRecording(question) {
+        // Remove link that opens audio recording
+        question?.querySelector("[id*='openRecord']")?.remove();
+    }
+
+    window.addEventListener("load", () => {
+        const question = document.querySelector(".samigo-question-cancelled");
+
+        disableInputs(question);
+        disableAudioRecording(question);
+    });
+
+})();

--- a/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/editAssessment.jsp
@@ -34,6 +34,7 @@
       <head><%= request.getAttribute("html.head") %>
       <title><h:outputText value="#{authorMessages.create_modify_a}" /></title>
       <script type="text/javascript" src="/samigo-app/js/authoring.js"></script>
+      <script type="text/javascript" src="/samigo-app/js/authoringQuestionCancellation.js"></script>
 
 <script type="text/JavaScript">
 <%@ include file="/js/samigotree.js" %>
@@ -361,7 +362,8 @@ $(window).load( function() {
      <h:outputText rendered="#{question.itemData.typeId== 16}" value=" #{authorMessages.image_map_question}"/><!-- IMAGEMAP_QUESTION -->
 
      <h:outputText value=" #{authorMessages.dash} " />
-     <h:inputText id="answerptr" value="#{question.updatedScore}" required="true" disabled="#{author.isEditPoolFlow || (question.itemData.typeId== 14)}" label="#{authorMessages.pt}" size="6" onkeydown="inIt()" styleClass="ConvertPoint" rendered="#{question.itemData.typeId!= 3}">
+     <h:inputText id="answerptr" styleClass="ConvertPoint" value="#{question.updatedScore}" required="true" label="#{authorMessages.pt}" size="6" onkeydown="inIt()"
+         disabled="#{author.isEditPoolFlow || question.itemData.typeId == 14 || question.cancelled}" rendered="#{question.itemData.typeId!= 3}">
        <f:validateDoubleRange minimum="0.00"/>
      </h:inputText>
      <h:outputText value="&#160;" escape="false" />
@@ -379,6 +381,12 @@ $(window).load( function() {
 
         </h:panelGroup>
           <h:panelGroup>
+            <h:panelGroup rendered="#{!author.isEditPendingAssessmentFlow && question.cancellable && partBean.cancellationAllowed}">
+              <a href="#" data-item-cancellable="true" data-itemId='<h:outputText value="#{question.itemData.itemIdString}" />'>
+                <h:outputText value="#{commonMessages.cancel_question}" />
+              </a>
+              <h:outputText value=" #{authorMessages.separator} " />
+            </h:panelGroup>
             <h:commandLink title="#{authorMessages.t_removeQ}" immediate="true" id="deleteitem" action="#{itemauthor.confirmDeleteItem}" rendered="#{author.isEditPendingAssessmentFlow}">
               <h:outputText value="#{commonMessages.remove_action}" />
               <f:param name="itemid" value="#{question.itemData.itemIdString}"/>
@@ -394,9 +402,9 @@ $(window).load( function() {
           </h:panelGroup>
         </h:panelGrid>
 
-       <div class="samigo-question-callout">
-		  <h:panelGroup rendered="#{question.itemData.typeId == 11}">
-	  			<%@ include file="/jsf/author/preview_item/FillInNumeric.jsp" %>
+        <h:panelGroup styleClass="samigo-question-callout#{question.cancelled ? ' samigo-question-cancelled' : ''}" layout="block">
+          <h:panelGroup rendered="#{question.itemData.typeId == 11}">
+            <%@ include file="/jsf/author/preview_item/FillInNumeric.jsp" %>
           </h:panelGroup>
           <h:panelGroup rendered="#{question.itemData.typeId == 9}">
             <%@ include file="/jsf/author/preview_item/Matching.jsp" %>
@@ -453,7 +461,11 @@ $(window).load( function() {
           <h:panelGroup rendered="#{question.itemData.typeId == 16}"><!-- IMAGEMAP_QUESTION -->
                 <%@ include file="/jsf/author/preview_item/ImageMapQuestion.jsp" %>
           </h:panelGroup>   
-      </div>
+
+          <h:panelGroup styleClass="sak-banner-info" rendered="#{question.cancelled}" layout="block">
+            <h:outputText value="#{commonMessages.cancel_question_info_cancelled_question}"/>
+          </h:panelGroup>
+        </h:panelGroup>
 
       <!-- Only want this displayed at the bottom of the last part (others hidden via docReady JS) -->
       <h:panelGroup styleClass="part-insert-question" layout="block" rendered="#{author.isEditPendingAssessmentFlow}">
@@ -473,6 +485,64 @@ $(window).load( function() {
 
     </h:column>
   </t:dataTable>
+</div>
+<%--Question Cancellation Modal--%>
+<div id="cancelQuestionModal" class="modal fade question-cancel-modal" tabindex="-1">
+  <h:panelGroup styleClass="modal-dialog" layout="block">
+    <h:panelGroup styleClass="modal-content" layout="block">
+      <h:panelGroup styleClass="modal-header" layout="block">
+        <button type="button" class="close" data-dismiss="modal"
+            aria-label='<h:outputText value="#{authorMessages.button_close}" />'>
+          <span class="fa fa-times" aria-hidden="true"></span>
+        </button>
+        <h2 class="modal-title">
+          <h:outputText value="#{commonMessages.cancel_question}" />
+        </h2>
+      </h:panelGroup>
+      <h:panelGroup styleClass="modal-body" layout="block">
+        <h:panelGroup styleClass="sak-banner-info" layout="block">
+          <h:outputText value="#{commonMessages.cancel_question_info_cancellation}" />
+          <br /><br />
+          <strong>
+            <h:outputText value="#{commonMessages.cancel_question_distribute_points}:" />
+          </strong>
+          <h:outputText value="#{commonMessages.cancel_question_info_distribute_points}" />
+          <br /><br />
+          <strong>
+            <h:outputText value="#{commonMessages.cancel_question_reduce_total}:" />
+          </strong>
+          <h:outputText value="#{commonMessages.cancel_question_info_reduce_total}" />
+        </h:panelGroup>
+        <h:panelGroup styleClass="sak-banner-warn" layout="block">
+          <h:panelGroup rendered="#{partBean.emiItemPresent}">
+            <h:outputText value="#{commonMessages.cancel_question_info_emi} " />
+            </br>
+            </br>
+          </h:panelGroup>
+          <h:outputText value="#{commonMessages.cancel_question_info_no_undo}" />
+        </h:panelGroup>
+      </h:panelGroup>
+      <h:panelGroup styleClass="modal-footer act" layout="block">
+        <h:commandButton styleClass="active" immediate="true" id="cancelItemTotal" action="editAssessment"
+            value="#{commonMessages.cancel_question_reduce_total}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ItemCancellationListener" />
+          <f:param name="outcome" value="editAssessment" />
+          <f:param name="itemId" value="ITEM_ID" />
+          <f:param name="cancellation" value="10" />
+        </h:commandButton>
+        <h:commandButton styleClass="button" immediate="true" id="cancelItemDistribute" action="editAssessment"
+            value="#{commonMessages.cancel_question_distribute_points}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ItemCancellationListener" />
+          <f:param name="outcome" value="editAssessment" />
+          <f:param name="itemId" value="ITEM_ID" />
+          <f:param name="cancellation" value="20" />
+        </h:commandButton>
+        <button type="button" class="button" data-dismiss="modal">
+          <h:outputText value="#{commonMessages.cancel_question_cancel}" />
+        </button>
+      </h:panelGroup>
+    </h:panelGroup>
+  </h:panelGroup>
 </div>
   </h:column>
 </h:dataTable>
@@ -529,7 +599,8 @@ $(window).load( function() {
 	  <h:outputText value="#{authorMessages.edit_published_assessment_warn_22}" rendered="#{!assessmentBean.hasGradingData}"/>
     </h:panelGrid>
   </h:panelGroup>
-  
+
+
   <h:inputHidden id="randomQuestionsSectionId" value=""/>
 </h:form>
 <!-- end content -->

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -39,6 +39,7 @@
       <script src="/sakai-editor/editor.js"></script>
       <script src="/sakai-editor/editor-launch.js"></script>
       <script src="/samigo-app/js/saveForm.js"></script>
+      <script src="/samigo-app/js/deliveryQuestionCancellation.js"></script>
       <script src="/webcomponents/rubrics/sakai-rubrics-utils.js<h:outputText value="#{studentScores.CDNQuery}" />"></script>
       <script type="module" src="/webcomponents/rubrics/rubric-association-requirements.js<h:outputText value="#{questionScores.CDNQuery}" />"></script>
 
@@ -351,7 +352,7 @@ document.links[newindex].onclick();
                 entity-id="<h:outputText value="#{delivery.rubricAssociation}.#{question.effectiveItemId}" />"></sakai-rubric-student-preview-button>
        </h:panelGroup>
 
-       <div class="samigo-question-callout">
+       <h:panelGroup styleClass="samigo-question-callout#{question.cancelled ? ' samigo-question-cancelled' : ''}" layout="block">
           <h:panelGroup rendered="#{question.itemData.typeId == 7}">
            <f:subview id="deliverAudioRecording">
            <%@ include file="/jsf/delivery/item/deliverAudioRecording.jsp" %>
@@ -454,7 +455,12 @@ document.links[newindex].onclick();
                <li><h:outputText value="#{deliveryMessages.multipleTabsWarningFix_4}" escape="false" /></li>
              </ol>
            </div>
-         </div>
+           <h:panelGroup styleClass="sak-banner-info" rendered="#{question.cancelled}" layout="block">
+             <h:outputText value="#{commonMessages.cancel_question_info_cancelled_question}" />
+             <h:outputText value=" " />
+             <h:outputText value="#{commonMessages.cancel_question_info_skip_question}" />
+           </h:panelGroup>
+         </h:panelGroup>
         </h:column>
       </h:dataTable>
      </div>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -234,7 +234,7 @@ function toPoint(id)
         <div class="tab-content">
           <div id="<h:outputText value="submition#{question.itemData.itemId}" />" class="tab-pane active">
       </h:panelGroup>
-          <div class="samigo-question-callout">
+          <h:panelGroup styleClass="samigo-question-callout#{question.cancelled ? ' samigo-question-cancelled' : ''}" layout="block">
             <h:panelGroup rendered="#{question.itemData.typeId == 7}">
               <f:subview id="deliverAudioRecording">
                <%@ include file="/jsf/evaluation/item/displayAudioRecording.jsp" %>
@@ -314,7 +314,10 @@ function toPoint(id)
                 <%@ include file="/jsf/delivery/item/deliverMatrixChoicesSurvey.jsp" %>
               </f:subview>
             </h:panelGroup>
-          </div>
+            <h:panelGroup styleClass="sak-banner-info" rendered="#{question.cancelled}" layout="block">
+              <h:outputText value="#{commonMessages.cancel_question_info_cancelled_question}"/>
+            </h:panelGroup>
+          </h:panelGroup>
 
         <h:panelGroup rendered="#{question.hasAssociatedRubric}">
           </div>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/questionScore.jsp
@@ -36,6 +36,7 @@ $Id$
       <title><h:outputText value="#{evaluationMessages.title_question}" /></title>
       <script src="/webcomponents/rubrics/sakai-rubrics-utils.js<h:outputText value="#{questionScores.CDNQuery}" />"></script>
       <script type="module" src="/webcomponents/rubrics/rubric-association-requirements.js<h:outputText value="#{questionScores.CDNQuery}" />"></script>
+      <script type="text/javascript" src="/samigo-app/js/authoringQuestionCancellation.js"></script>
       </head>
       <body onload="<%= request.getAttribute("html.body.onload") %>">
 
@@ -228,12 +229,11 @@ $Id$
     </div>
   </t:dataList>
 
-  <div class="samigo-question-callout">
   <t:dataList value="#{questionScores.deliveryItem}" var="question">
+  <h:panelGroup styleClass="samigo-question-callout#{question.cancellation != 0 ? ' samigo-question-cancelled' : ''}" layout="block">
   <div id="questionScoreItemAttachments">
       <%@ include file="/jsf/evaluation/questionScoreItemAttachment.jsp" %>
   </div>
-
   <h:panelGroup rendered="#{questionScores.typeId == '7'}">
     <f:subview id="displayAudioRecording">
       <%@ include file="/jsf/evaluation/item/displayAudioRecordingQuestion.jsp" %>
@@ -301,8 +301,16 @@ $Id$
     <%@ include file="/jsf/evaluation/item/displayImageMapQuestion.jsp" %>
     </f:subview>
   </h:panelGroup>
+  <h:panelGroup styleClass="sak-banner-info" rendered="#{question.cancellation != 0}" layout="block">
+    <h:outputText value="#{commonMessages.cancel_question_info_cancelled_question}" />
+  </h:panelGroup>
+  </h:panelGroup>
+  <h:panelGroup rendered="#{question.cancellation == 0 && questionScores.cancellationAllowed}">
+    <button class="button" data-item-cancellable="true" data-itemId='<h:outputText value="#{question.itemIdString}" />'>
+      <h:outputText value="#{commonMessages.cancel_question}" />
+    </button>
+  </h:panelGroup>
   </t:dataList>
-  </div>
 
   <h2>
     <p class="navView navModeAction">
@@ -1253,6 +1261,74 @@ $Id$
    </h:commandButton>
    <h:commandButton id="cancel" value="#{commonMessages.cancel_action}" action="totalScores" immediate="true"/>
 </p>
+
+<%--Question Cancellation Modal--%>
+<div id="cancelQuestionModal" class="modal fade question-cancel-modal" tabindex="-1">
+  <h:panelGroup styleClass="modal-dialog" layout="block">
+    <h:panelGroup styleClass="modal-content" layout="block">
+      <h:panelGroup styleClass="modal-header" layout="block">
+        <button type="button" class="close" data-dismiss="modal"
+            aria-label='<h:outputText value="#{authorMessages.button_close}" />'>
+          <span class="fa fa-times" aria-hidden="true"></span>
+        </button>
+        <h2 class="modal-title">
+          <h:outputText value="#{commonMessages.cancel_question}" />
+        </h2>
+      </h:panelGroup>
+      <h:panelGroup styleClass="modal-body" layout="block">
+        <h:panelGroup styleClass="sak-banner-info" layout="block">
+          <h:outputText value="#{commonMessages.cancel_question_info_cancellation}" />
+          <br /><br />
+          <strong>
+            <h:outputText value="#{commonMessages.cancel_question_distribute_points}:" />
+          </strong>
+          <h:outputText value="#{commonMessages.cancel_question_info_distribute_points}" />
+          <br /><br />
+          <strong>
+            <h:outputText value="#{commonMessages.cancel_question_reduce_total}:" />
+          </strong>
+          <h:outputText value="#{commonMessages.cancel_question_info_reduce_total}" />
+        </h:panelGroup>
+        <h:panelGroup styleClass="sak-banner-warn" layout="block">
+          <h:panelGroup rendered="#{questionScores.emiItemPresent}">
+            <h:outputText value="#{commonMessages.cancel_question_info_emi} " />
+            <br /><br />
+          </h:panelGroup>
+          <h:outputText value="#{commonMessages.cancel_question_info_regrade} #{commonMessages.cancel_question_info_no_undo}" />
+        </h:panelGroup>
+        <h:panelGroup styleClass="form-row" layout="block">
+          <h:selectBooleanCheckbox id="regradedAssessmentReSubmittable" value="#{questionScores.regradedAssessmentReSubmittable}" />
+          <h:outputLabel for="regradedAssessmentReSubmittable" value="#{assessmentSettingsMessages.update_most_current_submission_checkbox}" />
+          <label class="help-block info-text small">
+            <h:outputText value="#{assessmentSettingsMessages.update_most_current_submission_checkbox_warn}" />
+          </label>
+        </h:panelGroup>
+      </h:panelGroup>
+      <h:panelGroup styleClass="modal-footer act" layout="block">
+        <h:commandButton styleClass="active" type="submit" id="cancelItemTotal" action="questionScores"
+            value="#{commonMessages.cancel_question_reduce_total}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ItemCancellationListener" />
+          <f:param name="outcome" value="questionScores"/>
+          <f:param name="itemId" value="ITEM_ID"/>
+          <f:param name="cancellation" value="10"/>
+          <f:param name="regrade" value="true"/>
+        </h:commandButton>
+        <h:commandButton styleClass="button" type="submit" id="cancelItemDistribute" action="questionScores"
+            value="#{commonMessages.cancel_question_distribute_points}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.author.ItemCancellationListener" />
+          <f:param name="outcome" value="questionScores"/>
+          <f:param name="itemId" value="ITEM_ID"/>
+          <f:param name="cancellation" value="20"/>
+          <f:param name="regrade" value="true"/>
+        </h:commandButton>
+        <button type="button" class="button" data-dismiss="modal">
+          <h:outputText value="#{commonMessages.cancel_question_cancel}" />
+        </button>
+      </h:panelGroup>
+    </h:panelGroup>
+  </h:panelGroup>
+</div>
+
 </h:form>
 </div>
   <!-- end content -->

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/ItemData.java
@@ -95,6 +95,8 @@ public class ItemData
   private Integer answerOptionsRichCount;
   private Integer answerOptionsSimpleOrRich = ItemDataIfc.ANSWER_OPTIONS_SIMPLE;
 
+  @Getter @Setter private Integer cancellation = ItemDataIfc.ITEM_NOT_CANCELED;
+
   private String tagListToJsonString;
   
 public ItemData() {}

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.hbm.xml
@@ -37,6 +37,7 @@
     <property name="hash" type="string" column="HASH" not-null="false" />
     <property name="itemHash" type="string" column="ITEMHASH" not-null="false" />
     <property name="isExtraCredit" type="boolean" column="ISEXTRACREDIT" not-null="false" />
+    <property name="cancellation" type="integer" column="CANCELLATION" not-null="true" />
     <set name="itemTextSet" table="SAM_PUBLISHEDITEMTEXT_T" cascade="all-delete-orphan" order-by="sequence asc" inverse="true" lazy="false" batch-size="50">
        <key column="ITEMID"/>
        <one-to-many class="org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemText"/>

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -101,7 +102,9 @@ public class PublishedItemData
   private Integer answerOptionsSimpleOrRich;
 
   private String tagListToJsonString;
-  
+
+  @Getter @Setter private Integer cancellation = ItemDataIfc.ITEM_NOT_CANCELED;
+
   public PublishedItemData() {}
 
   // this constructor should be deprecated, it is missing triesAllowed

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/ItemFacade.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/ItemFacade.java
@@ -110,6 +110,8 @@ public class ItemFacade implements Serializable, ItemDataIfc, Comparable<ItemDat
   
   @Getter @Setter private Long originalItemId;
 
+  @Getter @Setter private Integer cancellation = ItemDataIfc.ITEM_NOT_CANCELED;
+
   
   /** ItemFacade is the class that is exposed to developer
    *  It contains some of the useful methods specified in

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/ItemCancellationTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/ItemCancellationTest.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2023 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.tool.assessment.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.data.dao.assessment.Answer;
+import org.sakaiproject.tool.assessment.data.dao.assessment.ItemData;
+import org.sakaiproject.tool.assessment.data.dao.assessment.ItemText;
+import org.sakaiproject.tool.assessment.data.dao.assessment.SectionData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
+import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
+import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
+import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
+
+
+public class ItemCancellationTest {
+
+
+    private static final double SCORE_MAX_DELTA = 0.0;
+
+
+    private static AtomicLong atomicId;
+    private static PublishedAssessmentService publishedAssessmentService;
+
+
+    @Before
+    public void setUp() {
+        publishedAssessmentService = mock(PublishedAssessmentService.class);
+        doCallRealMethod().when(publishedAssessmentService).preparePublishedItemCancellation(any());
+        doCallRealMethod().when(publishedAssessmentService).preparePublishedItemHash(any());
+
+        atomicId = new AtomicLong();
+    }
+
+    @Test
+    public void testTotalCancellation() {
+        // Array index of the item that is going to be cancelled
+        int cancelItemIndex = 0;
+
+        // Items that we use as input for the cancellation
+        ItemDataIfc[] testItems = {
+            createItem(0L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_TOTAL_SCORE_TO_CANCEL),
+            createItem(1L, 0, 2.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(2L, 0, 3.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 8.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        // Reference cancelled items - what we are going to compare to
+        ItemDataIfc[] cancelledTestItems = {
+            createItem(0L, 0, 0.0, 1, 1, ItemDataIfc.ITEM_TOTAL_SCORE_CANCELLED),
+            createItem(1L, 0, 2.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(2L, 0, 3.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 8.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        assertItemCancellation(testItems, cancelledTestItems, cancelItemIndex);
+    }
+
+    @Test
+    public void testDistributedCancellation() {
+        // Array index of the item that is going to be cancelled
+        int cancelItemIndex = 0;
+
+        // Items that we use as input for the cancellation
+        ItemDataIfc[] testItems = {
+            createItem(0L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_DISTRIBUTED_TO_CANCEL),
+            createItem(1L, 0, 2.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(2L, 0, 3.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 8.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        // Reference cancelled items - what we are going to compare to
+        ItemDataIfc[] cancelledTestItems = {
+            createItem(0L, 0, 0.0, 1, 1, ItemDataIfc.ITEM_DISTRIBUTED_CANCELLED),
+            createItem(1L, 0, 3.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(2L, 0, 4.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 7.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 9.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        assertItemCancellation(testItems, cancelledTestItems, cancelItemIndex);
+    }
+
+    @Test
+    public void testMixedCancellation() {
+        // Multiple cancellations at the same time don't occur at the moment, but it should work
+
+        // Items that we use as input for the cancellation
+        ItemDataIfc[] testItems = {
+            createItem(0L, 0, 4.0, 1, 1, ItemDataIfc.ITEM_DISTRIBUTED_TO_CANCEL),
+            createItem(1L, 0, 2.0, 1, 1, ItemDataIfc.ITEM_TOTAL_SCORE_TO_CANCEL),
+            createItem(2L, 0, 3.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 8.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        // Reference cancelled items - what we are going to compare to
+        ItemDataIfc[] cancelledTestItems = {
+            createItem(0L, 0, 0.0, 1, 1, ItemDataIfc.ITEM_DISTRIBUTED_CANCELLED),
+            createItem(1L, 0, 0.0, 1, 1, ItemDataIfc.ITEM_TOTAL_SCORE_CANCELLED),
+            createItem(2L, 0, 4.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 7.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 9.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        assertItemCancellation(testItems, cancelledTestItems, 0);
+        assertItemCancellation(testItems, cancelledTestItems, 1);
+    }
+
+    @Test
+    public void testNoCancellation() {
+        // Not cancelling items is does not happen, but we can test it anyway, to further validate the integrity
+
+        // Items that we use as input for the cancellation
+        ItemDataIfc[] testItems = {
+            createItem(0L, 0, 4.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(1L, 0, 2.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(2L, 0, 3.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(3L, 0, 6.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(4L, 0, 5.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+            createItem(5L, 0, 8.0, 1, 1, ItemDataIfc.ITEM_NOT_CANCELED),
+        };
+
+        ItemDataIfc[] cancelledTestItems = SerializationUtils.clone(testItems);
+
+        assertItemCancellation(testItems, cancelledTestItems, 0);
+    }
+
+    private void assertItemCancellation(ItemDataIfc[] testItems, ItemDataIfc[] cancelledTestItems, int cancelItemIndex) {
+        // The method getAssessment is called when cancellation is done, we can ignore it
+        when(publishedAssessmentService.getAssessment(anyString())).thenReturn(new AssessmentFacade());
+
+        // Create a mock of publishedAssessment and add one section with out testItems
+        PublishedAssessmentFacade publishedAssessment = mock(PublishedAssessmentFacade.class);
+        List<SectionDataIfc> sectionList = new ArrayList<>();
+        sectionList.add(createSection(SerializationUtils.clone(testItems)));
+        when(publishedAssessment.getSectionArray()).thenReturn((ArrayList<SectionDataIfc>) sectionList);
+
+        // Get testItems from stubbed saveItem method
+        List<ItemDataIfc> savedItemList = new ArrayList<>();
+        doAnswer(invocation -> {
+            ItemDataIfc item = invocation.getArgument(0);
+            savedItemList.add(item);
+            return null;
+        }).when(publishedAssessmentService).saveItem(any());
+
+        // Call cancellation process
+        publishedAssessmentService.preparePublishedItemCancellation(publishedAssessment);
+
+        // Convert "saved" items to array
+        ItemDataIfc[] savedItems = savedItemList.toArray(new ItemDataIfc[savedItemList.size()]);
+
+        // Test if we have same number of items
+        Assert.assertEquals(cancelledTestItems.length, savedItems.length);
+
+        // Test if item-cancellation has been set
+        Assert.assertEquals(cancelledTestItems[cancelItemIndex].getCancellation(), savedItems[cancelItemIndex].getCancellation());
+
+        // Test if items have the same scores
+        for (int i = 0; i < testItems.length; i++) {
+            assertItemScoreEquals(cancelledTestItems[i], savedItems[i]);
+        }
+
+        // Test if items have the same scores set for the answers
+        for (int i = 0; i < testItems.length; i++) {
+            assertItemAnswerScoresEqual(cancelledTestItems[i], savedItems[i]);
+        }
+
+    }
+
+    private void assertItemScoreEquals(ItemDataIfc item1, ItemDataIfc item2) {
+        Assert.assertEquals(item1.getScore(), item2.getScore(), SCORE_MAX_DELTA);
+    }
+
+    private void assertItemAnswerScoresEqual(ItemDataIfc item1, ItemDataIfc item2) {
+        double[] item1Scores = item1.getItemTextArray().stream()
+                .flatMap(itemText -> itemText.getAnswerArray().stream())
+                .mapToDouble(answer -> answer.getScore())
+                .toArray();
+        double[] item2Scores = item2.getItemTextArray().stream()
+                .flatMap(itemText -> itemText.getAnswerArray().stream())
+                .mapToDouble(answer -> answer.getScore())
+                .toArray();
+
+        Assert.assertArrayEquals(item1Scores, item2Scores, SCORE_MAX_DELTA);
+    }
+
+    private SectionDataIfc createSection(ItemDataIfc[] items) {
+        SectionDataIfc section = mock(SectionData.class);
+
+        ArrayList<ItemDataIfc> itemList = new ArrayList<>(Arrays.asList(items));
+
+        when(section.getItemArray()).thenReturn(itemList);
+
+        return section;
+    }
+
+    private ItemDataIfc createItem(long id, int sequence, Double score, int itemTextCount, int answerCount, int cancellation) {
+        ItemDataIfc item = new ItemData();
+        item.setItemId(id);
+        item.setScore(score);
+        item.setCancellation(cancellation);
+        item.setSequence(sequence);
+
+        ArrayList<ItemTextIfc> itemTextList = new ArrayList<>();
+        for (int i = 0; i < itemTextCount; i++) {
+            itemTextList.add(createItemText((long) i, score, answerCount));
+        }
+        item.setItemTextSet(itemTextList.stream().collect(Collectors.toSet()));
+
+        return item;
+    }
+
+    private ItemTextIfc createItemText(Long sequence, Double score, int answerCount) {
+        ItemTextIfc itemText = new ItemText();
+        itemText.setId(atomicId.getAndIncrement());
+        itemText.setSequence(sequence);
+
+        List<AnswerIfc> answerList = new ArrayList<>();
+        for (int i = 0; i < answerCount; i++) {
+            answerList.add(createAnswer((long) i, score));
+        }
+        itemText.setAnswerSet(answerList.stream().collect(Collectors.toSet()));
+
+        return itemText;
+    }
+
+    private AnswerIfc createAnswer(Long sequence, Double score) {
+        AnswerIfc answer = new Answer();
+        answer.setItem(mock(ItemData.class));
+        answer.setId(atomicId.getAndIncrement());
+        answer.setSequence(sequence);
+        answer.setScore(score);
+
+        return answer;
+    }
+}


### PR DESCRIPTION
This lets instructors cancel questions, which will give them a score of 0 and scores are recalculated.

Changes to `PublishedAssessmentService`:

1. Added method `preparePublishedItemCancellation` which will process cancellation of the items
2. Moved `regradePublishedAssessment` from `RepublishAssessmentListener`

`preparePublishedItemCancellation` is used by `ItemCancellationListener`
`regradePublishedAssessment` is used by `RepublishAssessmentListener` and `ItemCancellationListener`

`ItemCancellationListener` is called from Edit assessment page - `editAssessment.jsp`, when editing a published assessment (republishing). And also from the Questions ab Published Assessment -> Scores -> Questions `questionScores.jsp`

Item cancellation works like so:
1. Is called and sets pending cancellation on item (like `ITEM_TOTAL_SCORE_TO_CANCEL`)
2. preparePublishedItemCancellation will set the score to 0 and depending on the cancellation method adjust scores of other items. The sore is set to a cancelled cancellation (like `ITEM_TOTAL_SCORE_CANCELLED`)
3. Regrading will happen when the regrade and republish button is is clicked of for the Questions tab view, right away. The regrading is just based on the new scores and not affected by the cancellation of the item.

Details on how the two cancellation methods work are detailed int the Jira:
https://sakaiproject.atlassian.net/browse/S2U-14

Conversion Scripts: https://github.com/sakaiproject/sakai-reference/pull/191

**Missing:** ES, CA and EU translations