### PR TITLE
SAK-48595 Gradebook: Restyle sort order buttons to not overlap

### DIFF
--- a/gradebookng/bundle/src/main/bundle/gradebookng.properties
+++ b/gradebookng/bundle/src/main/bundle/gradebookng.properties
@@ -688,6 +688,9 @@ sortgradeitems.success.byitem=Sort Order Updated
 sortgradeitems.success.bycategory=Categorized Sort Order Updated
 sortgradeitems.error=Unable to update sort order. Please contact your System Administrator.
 
+sortgradeitems.move.item.up=Move item {0} up
+sortgradeitems.move.item.down=Move item {0} down
+
 metadata.header=Current Cell Metadata
 metadata.student=Student:
 metadata.assignment=Assignment:

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.html
@@ -15,8 +15,8 @@
 						<input wicket:id="current_order" type="hidden"/>
 						<span wicket:id="name" class="si si-grip-horizontal"></span>
 
-						<button class="gb-sort-up btn-link"><i class="si si-caret-up position-absolute"></i></button>
-						<button class="gb-sort-down btn-link"><i class="si si-caret-down position-absolute"></i></button>
+						<button wicket:id="sort-up" class="gb-sort-up btn-link py-1" title="sortgradeitems.move.item.up"><i class="si si-caret-up-fill position-absolute"></i></button>
+						<button wicket:id="sort-down" class="gb-sort-down btn-link py-1" title="sortgradeitems.move.item.down"><i class="si si-caret-down-fill position-absolute"></i></button>
 					</li>
 				</ul>
 			</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByCategoryPanel.java
@@ -17,6 +17,7 @@ package org.sakaiproject.gradebookng.tool.panels;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.HiddenField;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
@@ -29,6 +30,7 @@ import org.sakaiproject.gradebookng.tool.model.GradebookUiSettings;
 import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.grading.api.CategoryDefinition;
 
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -86,6 +88,12 @@ public class SortGradeItemsByCategoryPanel extends Panel {
 								Model.of(assignment.getCategorizedSortOrder())).add(
 										new AttributeModifier("name",
 												String.format("item_%s[current_order]", assignment.getId()))));
+						Button sortUpBtn = new Button("sort-up");
+						sortUpBtn.add(new AttributeModifier("title", MessageFormat.format(getString("sortgradeitems.move.item.up"), assignment.getName())));
+						assignmentItem.add(sortUpBtn);
+						Button sortDownBtn = new Button("sort-down");
+						sortDownBtn.add(new AttributeModifier("title", MessageFormat.format(getString("sortgradeitems.move.item.down"), assignment.getName())));
+						assignmentItem.add(sortDownBtn);
 					}
 				});
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByGradeItemPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByGradeItemPanel.html
@@ -13,8 +13,8 @@
 					<input wicket:id="current_order" type="hidden"/>
 					<span wicket:id="name" class="si si-grip-horizontal"></span>
 
-					<button class="gb-sort-up btn-link"><i class="si si-caret-up position-absolute"></i></button>
-					<button class="gb-sort-down btn-link"><i class="si si-caret-down position-absolute"></i></button>
+					<button wicket:id="sort-up" class="gb-sort-up btn-link py-1" title="sortgradeitems.move.item.up"><i class="si si-caret-up-fill position-absolute"></i></button>
+					<button wicket:id="sort-down" class="gb-sort-down btn-link py-1" title="sortgradeitems.move.item.down"><i class="si si-caret-down-fill position-absolute"></i></button>
 				</li>
 			</ul>
 		</div>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByGradeItemPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SortGradeItemsByGradeItemPanel.java
@@ -17,6 +17,7 @@ package org.sakaiproject.gradebookng.tool.panels;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.HiddenField;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
@@ -27,6 +28,7 @@ import org.sakaiproject.gradebookng.business.GradebookNgBusinessService;
 import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.grading.api.SortType;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 public class SortGradeItemsByGradeItemPanel extends Panel {
@@ -63,6 +65,13 @@ public class SortGradeItemsByGradeItemPanel extends Panel {
 						Model.of(assignment.getSortOrder())).add(
 								new AttributeModifier("name",
 										String.format("item_%s[current_order]", assignment.getId()))));
+
+				Button sortUpBtn = new Button("sort-up");
+				sortUpBtn.add(new AttributeModifier("title", MessageFormat.format(getString("sortgradeitems.move.item.up"), assignment.getName())));
+				assignmentItem.add(sortUpBtn);
+				Button sortDownBtn = new Button("sort-down");
+				sortDownBtn.add(new AttributeModifier("title", MessageFormat.format(getString("sortgradeitems.move.item.down"), assignment.getName())));
+				assignmentItem.add(sortDownBtn);
 			}
 		});
 	}

--- a/library/src/skins/default/src/sass/base/_icons.scss
+++ b/library/src/skins/default/src/sass/base/_icons.scss
@@ -163,6 +163,7 @@ $fa-font-path: "./fonts";
     plus-lg: bi-plus-lg,
     grid-3x3-fill: bi-grid-3x3-gap-fill,
     share : bi-share-fill,
+    caret-up-fill: bi-caret-up-fill,
     caret-down-fill: bi-caret-down-fill,
     remove: bi-x-square-fill,
   );

--- a/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
@@ -20,6 +20,10 @@
   content: '\f0c9';
 }
 
+#gradebookSorter .gb-sorter-sortable .si-grip-horizontal:before {
+  margin-right: 5px;
+}
+
 #gradebookSorter .gb-sorter-placeholder {
   border: 1px dashed var(--sakai-border-color);
   padding: 4px 10px;
@@ -34,8 +38,8 @@
 #gradebookSorter .gb-sort-up {
   position: absolute;
   right: -42px;
-  bottom: 4px;
-  height: 21px;
+  bottom: 17px;
+  height: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -44,11 +48,16 @@
 #gradebookSorter .gb-sort-down {
   position: absolute;
   right: -42px;
-  bottom: 4px;
-  height: 21px;
+  bottom: -2px;
+  height: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+#gradebookSorter .gb-sort-down i,
+#gradebookSorter .gb-sort-up i {
+  font-size: 10px;
 }
 
 #gradebookSorter .gb-sorter-sortable:first-child .gb-sort-up {


### PR DESCRIPTION
I have posted to the SAK-48595 jira two "expected" screenshots for what my proposed restyling looks like.

I attempted to use a bootstrap class like "fs-6" to shrink down these icons, but I needed to go smaller with explicit CSS statements. Also, the fill versions of caret-up and caret-down improved the contrast needed for the background color of the buttons when the icons are at a font-size of 10px.