### PR TITLE
Add Sakai theme information to LTI launch data

### DIFF
--- a/basiclti/basiclti-common/src/java/org/sakaiproject/lti13/util/SakaiExtension.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/lti13/util/SakaiExtension.java
@@ -21,6 +21,7 @@ import javax.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.tsugi.lti13.LTICustomVars;
 
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -54,6 +55,12 @@ public class SakaiExtension extends org.tsugi.jackson.objects.JacksonBase {
 	@JsonProperty("sakai_eid")
 	public String sakai_eid;
 
+	@JsonProperty("theme_base")
+	public String theme_base;
+
+	@JsonProperty("theme_dark_mode")
+	public String theme_dark_mode;
+
 	public void copyFromPost(Properties ltiProps) {
 		this.sakai_launch_presentation_css_url_list = ltiProps.getProperty("ext_sakai_launch_presentation_css_url_list");
 		this.sakai_academic_session = ltiProps.getProperty("ext_sakai_academic_session");
@@ -61,6 +68,8 @@ public class SakaiExtension extends org.tsugi.jackson.objects.JacksonBase {
 		this.sakai_server = ltiProps.getProperty("ext_sakai_server");
 		this.sakai_serverid = ltiProps.getProperty("ext_sakai_serverid");
 		this.sakai_eid = ltiProps.getProperty("ext_sakai_eid");
+		this.theme_base = ltiProps.getProperty(LTICustomVars.THEME_BASE);
+		this.theme_dark_mode = ltiProps.getProperty(LTICustomVars.THEME_DARK_MODE);
 	}
 
 }

--- a/basiclti/tsugi-util/src/java/org/tsugi/basiclti/BasicLTIConstants.java
+++ b/basiclti/tsugi-util/src/java/org/tsugi/basiclti/BasicLTIConstants.java
@@ -586,4 +586,9 @@ public class BasicLTIConstants {
      */
     public static final String TOOLCONSUMERINFO_VERSION = "ToolConsumerInfo.version";
 
+	/**
+	 * Constants for theming and dark mode
+	 */
+	public static final String THEME_BASE_LIGHT_SAK_PROP = "basiclti.theme.base.light";
+	public static final String THEME_BASE_DARK_SAK_PROP = "basiclti.theme.base.dark";
 }

--- a/basiclti/tsugi-util/src/java/org/tsugi/lti13/LTICustomVars.java
+++ b/basiclti/tsugi-util/src/java/org/tsugi/lti13/LTICustomVars.java
@@ -307,6 +307,12 @@ public class LTICustomVars {
 	public static final String PERSON_WEBADDRESS = "Person.webaddress";
 
 	/**
+	 * Theme properties. Base color and dark mode enabled
+	 */
+	public static final String THEME_BASE = "theme_base";
+	public static final String THEME_DARK_MODE = "theme_dark_mode";
+
+	/**
 	 * CONTEXT_ID
 	 *
 	 *  context.id property
@@ -1101,6 +1107,8 @@ public class LTICustomVars {
 		PERSON_SMS,
 		PERSON_SOURCEDID,
 		PERSON_WEBADDRESS,
+		THEME_BASE,
+		THEME_DARK_MODE,
 		CONTEXT_ID, CONTEXT_ORG, CONTEXT_TYPE, CONTEXT_TYPE_DEFAULT,
 		CONTEXT_LABEL, CONTEXT_TITLE, CONTEXT_SOURCEDID,
 		CONTEXT_ID_HISTORY, CONTEXT_TIMEZONE,

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5602,6 +5602,15 @@ rubrics.integration.token-secret=12345678900909091234
 # lti.advantage.lti13servlet.private=MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYw...
 
 # ###############################
+# LAUNCH INFO FOR THEME
+# ###############################
+
+# Sets the base theme color for LTI tools
+# default: null
+# basiclti.theme.base.light=#171b48
+# basiclti.theme.base.dark=#0E4466
+
+# ###############################
 # LTI Custom Substitution Values
 # ###############################
 


### PR DESCRIPTION
Add the theme base color set in sakai properties for light and dark mode as well as the user's dark mode preference to the LTI launch data. This is primarily used in Tsugi to match the Tsugi theme and Tsugi tool theme to whatever the theme is from the Sakai instance that launched the tool.