### PR TITLE
SAK-48603 Gradebook: Multiple modals not scrollable

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/GradebookPage.java
@@ -176,7 +176,7 @@ public class GradebookPage extends BasePage {
 		 */
 		this.addOrEditGradeItemWindow = new GbModalWindow("addOrEditGradeItemWindow");
 		this.addOrEditGradeItemWindow.showUnloadConfirmation(false);
-		this.addOrEditGradeItemWindow.setCssClassName("modal-add-or-edit-gbitem");
+		this.addOrEditGradeItemWindow.setCssClassName("w_blue modal-add-or-edit-gbitem");
 		this.form.add(this.addOrEditGradeItemWindow);
 
 		this.studentGradeSummaryWindow = new GbModalWindow("studentGradeSummaryWindow");

--- a/library/src/skins/default/src/sass/base/_extendables.scss
+++ b/library/src/skins/default/src/sass/base/_extendables.scss
@@ -598,7 +598,7 @@ div.wicket-modal div.w_blue a.w_close {
 	padding: $standard-space-4x;
 	font-size: 1.5em;
 	overflow: visible;
-	color: var(--sakai-active-color-1);
+	color: var(--sakai-modal-header-color-1);
 
 	&::before {
 		@extend .fa;

--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -1796,6 +1796,6 @@ overflow-x: hidden;
 max-height:100px;
 }
 
-.modal-add-or-edit-gbitem .w_content_container {
-  max-height: 500px;
+.w_blue .w_content_container {
+  max-height: 450px;
 }


### PR DESCRIPTION
The w_blue class needs to be maintained throughout all modals launched from the Grades tab in order to retain the 'X' close button at the top right corner of the modal. Re-adding this class for the "Add Gradebook Item" modal restores that close button.

I then simplified the selector in the CSS file for restricting the max-height across all modals in Gradebook.