### PR TITLE
SAK-48324 Calendar: TypeError: this.i18n is undefined

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/calendar/sakai-calendar.js
+++ b/webcomponents/tool/src/main/frontend/js/calendar/sakai-calendar.js
@@ -173,7 +173,7 @@ export class SakaiCalendar extends LionCalendar {
 
     return html`
 
-      <div class="calendar-msg">${this.i18n.days_message.replace("{}", this.days)}</div>
+    <div class="calendar-msg">${this.i18n.days_message.replace("{}", this.days)}</div>
 
       <div id="container">
         ${super.render()}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48324

Note: This fix should work in all browsers, the reason it shows an error in Firefox but not in Chrome because Firefox doesn't support template literals inside of ${...} expressions within template strings in some versions.