### PR TITLE
SAK-48616 Add IDs to rubric summary tabs and restyle on click

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/rubrics/_rubrics.scss
+++ b/library/src/skins/default/src/sass/modules/tool/rubrics/_rubrics.scss
@@ -716,7 +716,7 @@ sakai-rubric-student-comment {
     display: inline-block;
     text-align: center;
     border-radius: 4px 4px 0 0;
-    background: var(--sakai-background-color);
+    background: var(--sakai-background-color-2);
 
     &:hover {
         cursor: pointer;
@@ -729,7 +729,7 @@ sakai-rubric-student-comment {
 
 a.rubrics-tab-selected {
     border-bottom: none;
-    background: var(--sakai-background-color-2);
+    background: var(--sakai-background-color);
     pointer-events: none;
     text-decoration: none;
 

--- a/webcomponents/tool/src/main/frontend/js/rubrics/rubrics-element.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/rubrics-element.js
@@ -70,7 +70,7 @@ export class RubricsElement extends SakaiElement {
     const tabNow = document.getElementById(tabId);
     tabNow && tabNow.setAttribute("class", "rubric-tab-content rubrics-visible"); // style the clicked tab to be visible
     this.querySelectorAll(".rubrics-tab-button").forEach(tb => tb.setAttribute("class", "rubrics-tab-button"));
-    const tabButtonNow = this.querySelector(`#${tabId}-button`);
+    const tabButtonNow = this.querySelector(`#${tabId}-tab`); //name of the tab will be the same as 'tabId' [the tab's content] plus the word '-tab'
     tabButtonNow && tabButtonNow.setAttribute("class", "rubrics-tab-button rubrics-tab-selected"); //select styling on current tab button
   }
 

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading.js
@@ -91,18 +91,21 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
         <div class="rubrics-tab-row">
           <a href="javascript:void(0);"
               class="rubrics-tab-button rubrics-tab-selected"
+              id="rubric-grading-or-preview-${this.instanceSalt}-tab"
               @keypress=${this.openGradePreviewTab}
               @click=${this.openGradePreviewTab}>
             <sr-lang key="grading_rubric">gradingrubric</sr-lang>
           </a>
           <a href="javascript:void(0);"
               class="rubrics-tab-button"
+              id="rubric-student-summary-${this.instanceSalt}-tab"
               @keypress=${this.makeStudentSummary}
               @click=${this.makeStudentSummary}>
             <sr-lang key="student_summary">studentsummary</sr-lang>
           </a>
           <a href="javascript:void(0);"
               class="rubrics-tab-button"
+              id="rubric-criteria-summary-${this.instanceSalt}-tab"
               @keypress=${this.makeCriteriaSummary}
               @click=${this.makeCriteriaSummary}>
             <sr-lang key="criteria_summary">criteriasummary</sr-lang>


### PR DESCRIPTION
On 23.x and Master, the Rubrics summary tabs to not behave properly on click; they all stay the same so that it can't be visually discerned which one is active/current. The current tab is also never disabled, which causes multiple copies of its content to appear if you click it again.
Using the same "instanceSalt" values that Adrian added to each tab's content div, this PR adds IDs to the tabs so that each may be individually selected for different styling and behavior when clicked.
I opened a Jira for this: https://sakaiproject.atlassian.net/browse/SAK-48616