### PR TITLE
SAK-48598 Rubrics: Sensitize criteria summary to weighted rubrics and fix width

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/rubrics/_rubrics.scss
+++ b/library/src/skins/default/src/sass/modules/tool/rubrics/_rubrics.scss
@@ -764,6 +764,10 @@ div.collapse-toggle-buttons > button {
     padding: 0.5rem;
 }
 
+sakai-rubric-summary div.panel-group {
+    margin-top: 1em;
+}
+
 // TODO: This is a hack to get the rubrics working in the new UI(Boosttrap-5)
 .arrow-1 {
     position: absolute;


### PR DESCRIPTION
This PR addresses the bugs with Criteria Summary on SAK-48598, where it incorrectly counts scores for weighted rubrics and makes no mention of the weights or adjusted point values.
https://sakaiproject.atlassian.net/browse/SAK-48598
I added parenthetical notations in each table's header cell when the rubric is weighted [to display the weighted point value essentially the same way a gradable rubric does], added a caption with the criterion's weight below each table, and took weight into account for the calculations of score counts for both normal and adjusted scores.
I also noticed that the first criterion's collapsible container gets cut off by the expand/collapse all buttons, so I added margins to the top of each container to fix that while I was in here!