### PR TITLE
SAK-47240: Site Info > Manage Groups > Create New Group > New "Assigned Members" field is not responsive

### DIFF
--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/javascript.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/javascript.html
@@ -240,7 +240,8 @@
     $('#groupMembers').select2({
       placeholder: searchPlaceHolderText,
       allowClear: true,
-      closeOnSelect: false
+      closeOnSelect: false,
+      width: '100%'
     });
 
     // Button spinners


### PR DESCRIPTION
### JIRA: https://sakaiproject.atlassian.net/browse/SAK-47240

### The problem is that *Select2* will automatically set the width if we do not manually set it.

In ```site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html```:

```
<div class="row">
      <div class="col-sm-8">
            <label for="groupMembers" class="form-control-label block" th:text="#{groups.assigned.members}">Assigned Members</label>
            <select name="groupMembers" th:field="*{groupMembers}" id="groupMembers" class="form-control" multiple="multiple">
              .......
            </select>
      </div>
</div>
```

And In ```site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/javascript.html```:

```
//Initialize the select2 component
var searchPlaceHolderText = /*[[#{groups.multiselect.search}]]*/;
$('#groupMembers').select2({
  placeholder: searchPlaceHolderText,
  allowClear: true,
  closeOnSelect: false
});
```

So, the issue occurred because the width of ```<select>``` or ```select2``` was not initialized.

### Explanations from [Select2 documentation](https://select2.org/appearance#container-width):

*Select2 will try to match the width of the original element as closely as possible. Sometimes this isn't perfect, in which case you may manually set the width.*

There are some [similar Issues](https://github.com/select2/select2/issues/3278) on Github.
