### PR TITLE
SAK-48423 SAK-48455 Re-add rubric ratings' "order_index" OrderColumn on Criterion

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/Criterion.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/Criterion.java
@@ -75,6 +75,7 @@ public class Criterion implements PersistableEntity<Long>, Serializable {
     private Float weight = 0F;
 
     @EqualsAndHashCode.Exclude
+    @OrderColumn(name = "order_index")
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "criterion")
     private List<Rating> ratings = new ArrayList<>();
 


### PR DESCRIPTION
This PR covers misbehavior in Rubrics ratings' reordering as documented on SAK-48423 and SAK-48455:
https://sakaiproject.atlassian.net/browse/SAK-48423
https://sakaiproject.atlassian.net/browse/SAK-48455
In both cases, the order of the Ratings within a Criterion was not persisting at all, which I discovered to be the case in the database records as well. Earle theorized on SAK-48423 that it was caused by the removal of an OrderColumn notation on the Ratings attribute in the Criterion class. I added it back and that has fixed the bugs from both of these Jiras, although _not_ SAK-47798 that has been attached to both as a related ticket.