### PR TITLE
SAK-48060 Gradebook: NPE for convertGradeRecordToGradeDefinition

### DIFF
--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -1804,7 +1804,8 @@ public class GradingServiceImpl implements GradingService {
             gradeDef.setGradeComment(commentText);
         }
 
-        gradeDef.setExcused(gradeRecord.getExcludedFromGrade());
+	Boolean excludedFromGrade = (gradeRecord.getExcludedFromGrade() != null) ? gradeRecord.getExcludedFromGrade() : Boolean.FALSE;
+        gradeDef.setExcused(excludedFromGrade);
 
         return gradeDef;
     }


### PR DESCRIPTION
The excludedFromGrade field of AssignmentGradeRecord is a Boolean allowed to be null. This allowance to be null also holds when examining the GB_GRADE_RECORD_T.IS_EXCLUDED_FROM_GRADE column in MySQL.

However, the excused field in GradeDefinition is a primitive Boolean. NPEs are thrown when attempting to set a null value for excused. 

I added a line that translates null values to the default of Boolean.FALSE, making the assumption that excused is a primitive boolean for a good reason. 