### PR TITLE
SAK-48627 roster: remove the need for site.upd.site.mbrshp

### DIFF
--- a/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -1262,9 +1262,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 	 */
 	public boolean isSiteMaintainer(String siteId) {
 
-		String userId = getCurrentUserId();
-		return hasUserSitePermission(userId, SiteService.SECURE_UPDATE_SITE, siteId)
-		        && hasUserSitePermission(userId, SiteService.SECURE_UPDATE_SITE_MEMBERSHIP, siteId);
+		return hasUserSitePermission(getCurrentUserId(), SiteService.SECURE_UPDATE_SITE, siteId);
 	}
 
 	/**


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48627

Originally, the dependency on site.upd.site.mbrshp was introduced in RSTR-77 as permissions changes back then must have required this permission. They don't any longer.