### PR TITLE
SAK-48248 Rubrics: Allow removal of item associations by parsing blank rubric IDs as 0

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/RubricsService.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/RubricsService.java
@@ -119,6 +119,8 @@ public interface RubricsService {
 
     /**
      * Save the association between a tool item (an assignment, for example), and a rubric
+     * If you are deactivating/removing an existing association, it will soft-delete its data by doing setActive(false) on it.
+     * If you are reactivating an association that has already existed, it will take the old data for it and simply do setActive(true) on it.
      *
      * @param toolId the tool id, something like "sakai.assignment"
      * @param toolItemId the id of the tool's item that is being associated with the rubric

--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
@@ -877,7 +877,8 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
                     return Optional.empty();
                 }
             } else {
-                //if existingAssociation is not present, it could just mean that it was deactivated previously; the specific getRubricAssociation impl that we used earlier to load it will ignore deactivated ones.
+                // if existingAssociation is not present, it could just mean that it was deactivated previously
+                // the specific getRubricAssociation impl that we used earlier to load it will ignore deactivated ones.
                 Optional<ToolItemRubricAssociation> optionalExistingAssociation = findAssociationByItemIdAndRubricId(toolItemId, requestedRubricId);    // this will include inactive [soft-deleted] ones
                 if (optionalExistingAssociation.isPresent()) {  // if there's already an old association for the requested rubric that was deactivated previously, reuse it
                     optionalExistingAssociation.get().setActive(true);

--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
@@ -840,13 +840,7 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
             final String optionRubricAssociate = Optional.ofNullable(params.get(RubricsConstants.RBCS_ASSOCIATE)).orElse(StringUtils.EMPTY);
             final Optional<ToolItemRubricAssociation> existingAssociation = getRubricAssociation(toolId, toolItemId);
 
-            Long requestedRubricId;
-            try {
-                requestedRubricId = NumberUtils.createLong(optionRubricId);
-            } catch (NumberFormatException nfe) {
-                log.warn("requested rubric id [{}] could not be converted to a long", optionRubricId, nfe);
-                return Optional.empty();
-            }
+            Long requestedRubricId = NumberUtils.toLong(optionRubricId);
 
             if (existingAssociation.isPresent()) {
                 final ToolItemRubricAssociation association = existingAssociation.get();
@@ -876,9 +870,19 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
                             }
                         }
                     }
+                } else if (requestedRubricId.equals(0L)){
+                    //deactivating an association without making a new one
+                    association.setActive(false);
+                    associationRepository.save(association);
+                    return Optional.empty();
                 }
             } else {
-                // first association for this rubric
+                //if existingAssociation is not present, it could just mean that it was deactivated previously; the specific getRubricAssociation impl that we used earlier to load it will ignore deactivated ones.
+                Optional<ToolItemRubricAssociation> optionalExistingAssociation = findAssociationByItemIdAndRubricId(toolItemId, requestedRubricId);    // this will include inactive [soft-deleted] ones
+                if (optionalExistingAssociation.isPresent()) {  // if there's already an old association for the requested rubric that was deactivated previously, reuse it
+                    optionalExistingAssociation.get().setActive(true);
+                    return Optional.of(associationRepository.save(optionalExistingAssociation.get()));
+                }
                 Optional<ToolItemRubricAssociation> newAssociation = createToolItemRubricAssociation(toolId, toolItemId, params, requestedRubricId);
                 if (newAssociation.isPresent()) {
                     return Optional.of(associationRepository.save(newAssociation.get()));

--- a/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
+++ b/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
@@ -503,6 +503,20 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
         Optional<ToolItemRubricAssociation> association2 = rubricsService.saveRubricAssociation(toolId, toolItemId, rbcsParams2);
         assertTrue(association2.isPresent());
         assertEquals(rubricBean2.getId(), association2.get().getRubric().getId());
+
+        // remove association
+        Map<String, String> rbcsParams3 = new HashMap<>();
+        rbcsParams3.put(RubricsConstants.RBCS_ASSOCIATE, "");
+        rbcsParams3.put(RubricsConstants.RBCS_LIST, "0");
+        Optional<ToolItemRubricAssociation> association3 = rubricsService.saveRubricAssociation(toolId, toolItemId, rbcsParams3);
+        assertFalse(association3.isPresent());
+
+        // random text string
+        Map<String, String> rbcsParams4 = new HashMap<>();
+        rbcsParams4.put(RubricsConstants.RBCS_ASSOCIATE, "1");
+        rbcsParams4.put(RubricsConstants.RBCS_LIST, "one");
+        Optional<ToolItemRubricAssociation> association4 = rubricsService.saveRubricAssociation(toolId, toolItemId, rbcsParams3);
+        assertFalse(association4.isPresent());
     }
 
     @Test


### PR DESCRIPTION
This PR addresses SAK-48248:
https://sakaiproject.atlassian.net/browse/SAK-48248
RubricsServiceImpl.saveRubricAssociation required a rubric ID in order to save associations, but that value is blank when a user attempts to remove an association. Earle showed me that using NumberUtils.toLong on the blank value would return 0 in this case, which we can then process much more naturally than the try/catch statement that createLong required, as it would throw an error trying to parse the same blank. This code interprets a rubric ID of 0 as an indication that the existing association for the tool and item should be removed ["deactivated"].
I added a couple tests based on Earle's advice, and added another workflow to handle the case of an association that has been removed and needs to be reactivated.