### PR TITLE
SAK-48661 Trinity: Restore double column layout for Overview, etc.

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/iframe/_iframe.scss
+++ b/library/src/skins/default/src/sass/modules/tool/iframe/_iframe.scss
@@ -7,10 +7,6 @@
 	}
 }
 
-.#{$namespace}multipleTools .#{$namespace}sakai-iframe {
-	margin: -1em 0 0 0;
-}
-
 .#{$namespace}toolBody--sakai-iframe-myworkspace iframe {
 	padding: $standard-spacing;
 }

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
@@ -8,7 +8,7 @@
 
 #elseif ($pageColumnLayout == 'col1of2')
 
-    #set($columnClasses = "Mrphs-pageColumns Mrphs-pageColumns--first")
+    #set($columnClasses = "p-2 flex-fill w-50")
 
 #end
 
@@ -29,10 +29,13 @@
     #set( $numberTools = $pageColumn0Tools.size() )
 #end
 <div class="portal-main-container container-fluid mt-2">
-    <main id="$pageWrapperClass" class="portal-main-content d-flex flex-column #if( $numberTools > 1 || $homePage)Mrphs-multipleTools #end" role="main">
+    <main id="$pageWrapperClass" class="portal-main-content #if( $numberTools > 1 || $homePage)Mrphs-multipleTools #end" role="main">
         <h2 class="skip visually-hidden" tabindex="-1" id="tocontent">${rloader.sit_contentshead}</h2>
         #parse("/vm/morpheus/includeSiteHierarchy.vm")
         #parse("/vm/morpheus/snippets/siteStatus-snippet.vm")
+        #if ($pageTwoColumn)
+        <div class="d-flex">
+        #end
         <div id="$pageColumnLayout" class="${columnClasses}">
 
             #foreach ( $tool in $pageColumn0Tools )
@@ -194,7 +197,7 @@
 
         #if ($pageTwoColumn)
 
-            <div id="col2of2" class="Mrphs-pageColumns Mrphs-pageColumns--second">
+            <div id="col2of2" class="p-2 flex-fill w-50">
 
                 #foreach ( $tool in $pageColumn1Tools )
 
@@ -304,6 +307,7 @@
                 #end ## END of FOREACH ( $tool in $pageColumn1Tools )
 
             </div> <!-- end of #col2of2 -->
+        </div> <!-- end of d-flex container -->
 
         #end ## END of IF ($pageTwoColumn)
 


### PR DESCRIPTION
A screenshot of the expected two column layout which results from this proposed fix is attached to SAK-48661.

I removed the CSS styling for "#{$namespace}multipleTools .#{$namespace}sakai-iframe" to prevent one column from being higher than another when an iframe tool is presented as one of the columns (like we use at our institution's custom Gateway page).