### PR TITLE
SAK-47816 Rubrics: Add weight value to Rubric Criterion cloning

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/Criterion.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/Criterion.java
@@ -89,6 +89,7 @@ public class Criterion implements PersistableEntity<Long>, Serializable {
         Criterion clonedCriterion = new Criterion();
         clonedCriterion.setTitle(this.title);
         clonedCriterion.setDescription(this.description);
+        clonedCriterion.setWeight(this.weight);
         clonedCriterion.getRatings()
                 .addAll(this.getRatings().stream()
                         .map(r -> {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47816
This PR addresses the loss of a criterion's weight value when cloning rubrics. For weighted or unweighted rubrics, it will take the weight of the existing criterion and set the same value on the clone.