### PR TITLE
SAK-48678 Rubrics: Enable PDFs of publicly shared rubrics for all users who can view them

### DIFF
--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
@@ -1080,12 +1080,12 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
     public byte[] createPdf(String siteId, Long rubricId, String toolId, String itemId, String evaluatedItemId)
             throws IOException {
 
-        if (!isEvaluator(siteId) && !isEvaluee(siteId)) {
+        Rubric rubric = rubricRepository.findById(rubricId)
+                .orElseThrow(() -> new IllegalArgumentException("No rubric for id " + rubricId));
+
+        if (!isEvaluator(siteId) && !isEvaluee(siteId) && !rubric.getShared()) {
             throw new SecurityException("You must be either an evaluator or evaluee to create PDFs");
         }
-
-        Rubric rubric = rubricRepository.findById(rubricId)
-            .orElseThrow(() -> new IllegalArgumentException("No rubric for id " + rubricId));
 
         Optional<Evaluation> optEvaluation = Optional.empty();
         if (toolId != null && itemId != null && evaluatedItemId != null) {

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-readonly.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-readonly.js
@@ -49,9 +49,9 @@ export class SakaiRubricReadonly extends SakaiRubric {
           ${this.enablePdfExport ? html`
             <div class="action-container">
               <sakai-rubric-pdf
-                  site-id="${this.siteId}"
+                  site-id="${this.rubric.ownerId}"
                   rubric-title="${this.rubric.title}"
-                  rubricId="${this.rubric.id}"
+                  rubric-id="${this.rubric.id}"
               />
             </div>
           ` : ""}

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubrics-shared-list.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubrics-shared-list.js
@@ -35,7 +35,7 @@ export class SakaiRubricsSharedList extends SakaiRubricsList {
     return html`
       <div role="tablist">
       ${this.rubrics.map(r => html`
-        <sakai-rubric-readonly rubric="${JSON.stringify(r)}" @copy-to-site="${this.copyToSite}" ?enablePdfExport="${this.enablePdfExport}"></sakai-rubric-readonly>
+        <sakai-rubric-readonly rubric="${JSON.stringify(r)}" @copy-to-site="${this.copyToSite}" ?enable-pdf-export="${this.enablePdfExport}"></sakai-rubric-readonly>
       `)}
       </div>
     `;


### PR DESCRIPTION
This PR re-adds the backing for PDF downloads of Publicly Shared rubrics by correcting typos in the sakai-shared-list and sakai-rubric-readonly webcomponents, injecting a native site ID for the rubric in sakai-rubric-readonly, and granting public PDF access to any rubric that is public in RubricsServiceImpl.
https://sakaiproject.atlassian.net/browse/SAK-48678