### PR TITLE
SAK-48682 Improve Portal UI and Responsiveness on Smaller Devices

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/navigation/_skipnav.scss
+++ b/library/src/skins/default/src/sass/modules/tool/navigation/_skipnav.scss
@@ -1,138 +1,58 @@
-.#{$namespace}skipNav__menu{
-	position: absolute;
-	top:  -30em;
-	left: -30em;
-	list-style: none;
-	padding: 0 0 0 0;
-	a{
-		&:focus{
-			@media #{$desktop}{
-				background-color: var(--sakai-selected-page-bg-color);
-				border: 1px solid var(--sakai-selected-page-bg-color);
-				color: var(--sakai-selected-page-color);
-				display: block !important;
-				font-size: 0.9em;
-				left: 5px;
-				line-height: 1;
-				padding: 7px 5px;
-				position: fixed;
-				text-decoration: none;
-				text-transform: capitalize;
-				top: 9px;
-				z-index: 100000;
-			}
-		}
-		.accesibility_key{
-			margin: 0 0 0 0.2em;
-		}
-	}
-	@media #{$phone}{
-		position: relative;
-		top: 0;
-		left: 0;
-		width: 100%;
-		margin:  0 0 0 0;
+.#{$namespace}skipNav__menu {
+    position: absolute;
+    top: -30em;
+    left: -30em;
+    list-style: none;
+    padding: 0 0 0 0;
 
-		box-shadow: inset 0 0 5px rgba(0,0,0,0.25);
-		@include transition( top 0.25s linear 0s );
-		&.moving{
-			top: -4.2em;
-		}
-		.accesibility_key{
-			display: none;
-		}
-		li{
-			display: block;
-			min-height: $banner-height - 4;
+    a {
+        &:focus {
+            @media #{$desktop} {
+                background-color: var(--sakai-selected-page-bg-color);
+                border: 1px solid var(--sakai-selected-page-bg-color);
+                color: var(--sakai-selected-page-color);
+                display: block !important;
+                font-size: 0.9em;
+                left: 5px;
+                line-height: 1;
+                padding: 7px 5px;
+                position: fixed;
+                text-decoration: none;
+                text-transform: capitalize;
+                top: 9px;
+                z-index: 100000;
+            }
+        }
+        .accesibility_key {
+            margin: 0 0 0 0.2em;
+        }
+    }
 
-			// Sites row
-			&.#{$namespace}skipNav__menuitem.#{$namespace}skipNav__menuitem--worksite {
-				background: var(--sites-nav-background);
-				position: relative;
-				border-bottom: 1px solid var(--sites-nav-menu-item-border-color);
+    @media #{$phone} {
+        position: absolute;
+        top: -30em;
+        left: -30em;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        list-style: none;
+        padding: 0 0 0 0;
 
-				a {
-					float: right;
-					color: var(--sites-nav-menu-item-color);
-					padding: 0 10px 0 14px;
-					position: relative;
-					background: var(--sites-nav-background);
-					border-bottom: 1px solid var(--sites-nav-menu-item-border-color);
-
-					&:before {
-						content: '';
-						position: absolute;
-						height: 80%;
-						left: 0;
-						top: 10%;
-						border-left: 1px solid var(--sites-nav-menu-item-border-color);
-					}
-				}
-			}
-
-			// Tool row
-			&.#{$namespace}skipNav__menuitem.#{$namespace}skipNav__menuitem--tools {
-				@include display-flex;
-				background: var(--portal-background-color);
-				box-shadow: var(--divider-shadow-fixed);
-				
-
-				a {
-					float: left;
-					color: var(--sites-nav-menu-item-color);
-					padding: 0 14px 0 10px;
-					position: relative;
-
-					&:after {
-						content: '';
-						position: absolute;
-						height: 80%;
-						right: 0;
-						top: 10%;
-						border-right: 1px solid var(--tool-menu-item-separator-color);
-					}
-				}
-				
-				a.#{$namespace}skipNav--toolName {
-					color: var(--link-color);
-				}
-				a.manage-overview-link-mobile {
-					display: inline-block;
-					margin-left: auto; 			// push this link to the far right
-					color: var(--link-color);
-
-					span {
-						padding-right: $standard-space;
-					}
-
-					&:after {
-						border-right: 0 none;
-					}
-				}
-			}
-
-			&.#{$namespace}skipNav__menuitem--content,
-			&.#{$namespace}skipNav__menuitem--accessibility
-			{
-				display: none;
-			}
-
-			a{
-				text-decoration: none;
-				white-space: nowrap;
-				max-width: 100%;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				height: $banner-height - 4;
-				line-height: $banner-height - 4;
-				
-				&:hover, &:active
-				{
-					text-decoration: none;
-					color:var(--sites-nav-menu-item-hover-color);
-					background: var(--sites-nav-menu-item-hover-background);
-				}
-			}
-		}
-	}
+        a:focus {
+            position: fixed;
+            top: 9px;
+            left: 5px;
+            z-index: 100000;
+            clip: auto;
+            clip-path: none;
+            display: block;
+            background-color: var(--sakai-selected-page-bg-color);
+            border: 1px solid var(--sakai-selected-page-bg-color);
+            color: var(--sakai-selected-page-color);
+            font-size: 0.9em;
+            line-height: 1;
+            padding: 7px 5px;
+            text-decoration: none;
+            text-transform: capitalize;
+        }
+    }
 }

--- a/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
+++ b/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
@@ -56,6 +56,22 @@
   grid-area: header;
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }
+
+// Responsive header for mobile
+@media (max-width: 767px) {
+  .portal-header {
+    background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity)) !important;
+    justify-content: space-between !important;
+  }
+}
+
+@media screen and (max-width: 560px) {
+  .portal-header-logo img {
+    width: 26vw;
+    height: auto;
+  }
+}
+
 .portal-nav-sidebar {
   grid-area: sidebar;
 }
@@ -230,16 +246,6 @@ a[href]:not(.btn):hover {
   .focus-#{$color} {
     @include focus-outline($value);
   }
-}
-
-.btn-input-group {
-  @include button-variant(
-    $input-bg,
-    $input-border-color,
-    $active-background: $input-group-addon-bg,
-  );
-  display: flex;
-  align-items: center;
 }
 
 .btn-sidebar-collapse {
@@ -425,5 +431,15 @@ a[href]:not(.btn):hover {
 
   .fa-tool-menu-icon {
     margin-top: 5px;
+  }
+}
+
+.sakai-sitesAndToolsNav * {
+  text-decoration: none;
+}
+
+#create-task {
+  @media (max-width: 460px) {
+    width: 100%;
   }
 }

--- a/library/src/skins/default/src/sass/modules/tool/theme-switcher/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/theme-switcher/_base.scss
@@ -2,19 +2,14 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin: 0 0 0 auto;     // push to far right
-    padding: $standard-space;
     background: var(--sakai-background-color-1);
-    font-size: $default-font-size-small;
-    line-height: 22px;
-    border: none;
-    font-weight: bold;
-    
-    &:focus {
-        outline:none;
-        box-shadow: $sakai-box-shadow-emulate-focus var(--focus-outline-color);
-    }
-    
+    font-size: 16px;
+    line-height: 30px;
+    border: 1px solid var(--sakai-border-color);
+    font-weight: normal;
+    padding: 0;
+    border-radius: inherit;
+
     span {
         padding: 0 $standard-spacing;
         pointer-events: none;

--- a/library/src/skins/default/src/sass/themes/_dark.scss
+++ b/library/src/skins/default/src/sass/themes/_dark.scss
@@ -175,7 +175,7 @@
     // actve state for radio button:
     --radio-button-background: var(--sakai-text-color-1);
     // actve state for checkbox:
-    --checkbox-background: var(--sakai-background-color-1);
+    --checkbox-background: var(--sakai-primary-color-1);
     // Information (info) banner
     --infoBanner-bordercolor: var(--sakai-color-blue--darker-4);
     --infoBanner-bgcolor: var(--sakai-color-blue--darker-6);

--- a/login/login-render-engine-impl/impl/src/webapp/vm/defaultskin/xlogin.vm
+++ b/login/login-render-engine-impl/impl/src/webapp/vm/defaultskin/xlogin.vm
@@ -38,13 +38,13 @@
                                 <input id="pw" name="pw" value="${password}" type="password" class="form-control $!{hasErrorsClass}" autocomplete="current-password"></input>
 
                                 <input type="checkbox" class="btn-check" id="showPw" autocomplete="off">
-                                <label class="btn btn-input-group" for="showPw">
+                                <label class="input-group-text" for="showPw">
                                     <i class="bi bi-eye-slash-fill" aria-hidden="true"></i>
                                     <span class="visually-hidden">${rloader.login_show_pw}</span>
                                 </label>
                             </div>
                             <div class="d-flex gap-2 mb-2">
-                                <input name="submit" type="submit" id="submit" class="order-2 btn btn-primary btn-lg flex-grow-1" value="${loginWording}"/>
+                                <input name="submit" type="submit" id="submit" class="btn btn-primary btn-lg flex-grow-1" value="${loginWording}"/>
                                 #if (${doCancel})
                                     <input name="cancel" type="submit" class="order-1 btn btn-secondary btn-lg" value="${cancelWording}"/>
                                 #end
@@ -53,7 +53,7 @@
 
                         #if (${passwordResetUrl})
                             <div class="text-end px-3 py-2">
-                                <a href="${passwordResetUrl}" class="text-end link-dark right">${passwordResetWording}</a>
+                                <a href="${passwordResetUrl}" class="text-end right">${passwordResetWording}</a>
                             </div>
                         #end
                     </div>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeFooter.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeFooter.vm
@@ -12,6 +12,7 @@
                       title="${rloader.footer_serverinfo_title}"
                       data-bs-container="footer"
                       data-bs-toggle="popover"
+                      data-bs-trigger="focus"
                       data-bs-placement="top"
                       data-bs-html="true" 
                       data-bs-content='#parse("/vm/morpheus/snippets/serverInfoPopover-snippet.vm")'

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeLoginNav.vm
@@ -10,14 +10,13 @@
         </div>
 
         <input type="checkbox" class="btn-check" id="showPwTop" autocomplete="off">
-        <label class="btn btn-input-group" for="showPwTop">
+        <label class="input-group-text" for="showPwTop">
             <i class="bi bi-eye-slash-fill" aria-hidden="true"></i>
             <span class="visually-hidden">${rloader.login_show_pw}</span>
         </label>
     </div>
     <button type="submit" class="btn btn-outline-light p-3 my-1 ">${rloader.login}</button>
 </form>
-<button id="mobileLoginBtn" class="d-sm-none btn btn-dark btn-outline-light mb-1 p-3 my-1 mx-2">
+<button id="mobileLoginBtn" class="d-sm-none btn btn-outline-light mb-1 my-1 mx-2">
     ${rloader.login}
-    <i class="bi bi-box-arrow-in-right" aria-hidden="true"></i>
 </button>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeMobileFooter.vm
@@ -55,6 +55,7 @@
     </li>
     #end
 
+#* Quick links doesn't look good in mobile view right now so we're hiding it
   #if ($quickLinks)
     <li>
       <button class="btn icon-button"
@@ -68,6 +69,7 @@
       </button>
     </li>
   #end
+*#  
 
     #if ($pageColumn0Tools && !$pageColumn0Tools.isEmpty())
         #set ($helpLink = $pageColumn0Tools.get(0).toolHelpActionUrl)

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -37,6 +37,7 @@
                 #if ($site.description)
                 <button class="d-inline-block p-1 btn bi bi-info-circle btn-site-opt site-description-button"
                     data-bs-toggle="popover"
+                    data-bs-trigger="focus"
                     data-bs-html="true"
                     data-bs-content="${site.description}"
                     aria-label="Click for the full site description"

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/header-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/header-snippet.vm
@@ -1,6 +1,13 @@
 ## Header that shows institution and/or banner logos
 
 <header class="portal-header bg-dark d-flex align-items-center justify-content-between" role="banner">
+
+  <button class="btn m-1 d-md-none" data-bs-toggle="offcanvas" data-bs-target="#portal-nav-sidebar" aria-controls="portal-nav-sidebar" aria-label="$rloader.sit_navigation" title="$rloader.sit_navigation">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="white" class="bi bi-list" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+    </svg>
+  </button>
+
   <div id="logoWrapper" class="portal-header-logo d-flex align-items-center justify-content-between bg-primary">
     <a class="px-3" href="/portal" title="Home page">
       <img src="/library/skin/$!{pageSkin}/images/sakaiLogo.png" alt="Sakai logo">

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/profile-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/profile-snippet.vm
@@ -77,8 +77,8 @@
       <fieldset class="btn-group" role="radiogroup" aria-label="Switch between light and dark themes">
             <button role="switch" aria-checked="false"
                 id="sakai-darkThemeSwitcher" class="sakaiThemeSwitch Mrphs-userNav__submenuitem--themeSwitcher switch">
-                <span class="bi bi-sun">${rloader.sit_themeSwitcherOff}</span>
-                <span class="bi bi-moon">${rloader.sit_themeSwitcherOn}</span>
+                <span class="bi bi-sun"> ${rloader.sit_themeSwitcherOff}</span> ## Note: The space before the variable is intentional to ensure proper spacing in the rendered output
+                <span class="bi bi-moon"> ${rloader.sit_themeSwitcherOn}</span>
             </button>
       </fieldset>
   </div>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48682

1. Refined Header Layout: We've optimized the header layout to ensure intuitive access to various tools, even on smaller devices, for an improved browsing experience.

2. Revamped Theme Switcher Button: We've redesigned the theme switcher button to provide a sleek and modern appearance, complementing the overall user interface.

3. Improved Login Button & Popup: We've fixed the login button and login popup for mobile view.

4. Convenient Site Description Popup: Users can now close the site description popup by simply clicking anywhere on the page, providing a more user-friendly experience.

5. Enhanced Mobile Responsiveness for Created Tasks: We've resolved responsive issues for created tasks on mobile view, ensuring that users can easily manage their tasks even on smaller screens.

6. Enhanced Input Check: Optimized for visibility in both dark and light modes, ensuring a seamless user experience across themes.

Below are the screenshots of all the changes made in this pr. Thanks. 





Before(22) | After
------ | -----
![Screenshot from 2023-03-27 13-27-44](https://user-images.githubusercontent.com/50500283/227877750-5ac2395c-e4c1-438d-ab4f-34037478011f.png) | ![Screenshot from 2023-03-27 13-29-00](https://user-images.githubusercontent.com/50500283/227878005-47a8432f-5ee3-4d45-8ded-a5e8dfc980ea.png)


Before | After
------ | -----
![Screenshot from 2023-03-27 13-32-41](https://user-images.githubusercontent.com/50500283/227878995-cd72173c-2049-4448-a63c-7a39d81d6eb5.png) | ![Screenshot from 2023-03-27 13-33-22](https://user-images.githubusercontent.com/50500283/227879150-7f1e78d1-3215-4bc3-8e41-130ce40d2911.png)

Before | After
------ | -----
![Screenshot from 2023-03-27 13-35-45](https://user-images.githubusercontent.com/50500283/227879712-6ce10563-28a1-4ef9-924b-4c746c28685a.png) | ![Screenshot from 2023-03-27 13-36-15](https://user-images.githubusercontent.com/50500283/227879868-370a0f6b-e078-4816-beb4-953657871da8.png)

Before | After
------ | -----
![Screenshot from 2023-03-27 13-38-33](https://user-images.githubusercontent.com/50500283/227880376-2874d880-18f9-45b3-80b3-e654cde60384.png) | ![Screenshot from 2023-03-27 13-39-32](https://user-images.githubusercontent.com/50500283/227880602-a84417d0-ace3-4163-a744-f192104192be.png)


