### PR TITLE
SAK-48686 Messages a draft message with no scheduled date can cause an NPE

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -1175,7 +1175,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
 		  setBooleanEmailOut(draft.getExternalEmail());
 	  }
 
-	  if(draft.getScheduler() != null && draft.getScheduler()) {
+	  if(draft.getScheduler() != null && draft.getScheduler() && draft.getScheduledDate() != null) {
 		  setSchedulerSendDateString(draft.getScheduledDate().toString());
 		  setBooleanSchedulerSend(draft.getScheduler());
 	  }


### PR DESCRIPTION
Null Pointer on org.sakaiproject.tool.messageforums.PrivateMessagesTool.processPvtMsgDraft

https://sakaiproject.atlassian.net/browse/SAK-48686