### PR TITLE
SAK-48654:  SakaiPlus: Screen reader should prompt the user to enter a value on initial tab to field instead of announcing invalid entry

### DIFF
--- a/plus/tool/src/main/webapp/WEB-INF/templates/form.html
+++ b/plus/tool/src/main/webapp/WEB-INF/templates/form.html
@@ -28,7 +28,7 @@
         <div id="issuer-group" class="form-group form-control-required">
           <label for="issuer" class="form-control-label" th:text="#{plus.tool.issuer}">Value</label>
           <div>
-            <input type="text" class="form-control" id="issuer" th:value="${tenant.issuer}" th:field="*{issuer}" pattern="https?://[^\s/]+(?:/[^/\s]+)*$" th:attr="title=#{plus.tenant.issuer.error.slash}" required aria-describedby="issuer-error" />
+            <input type="text" class="form-control" id="issuer" th:value="${tenant.issuer}" th:field="*{issuer}" pattern="https?://[^\s/]+(?:/[^/\s]+)*$" th:attr="title=#{plus.tenant.issuer.error.slash}" required aria-describedby="issuer-input-error" />
             <span id="issuer-input-error" class="sr-only"></span>
           </div>
           <div th:text="#{plus.tool.issuer.detail}">

--- a/plus/tool/src/main/webapp/WEB-INF/templates/form.html
+++ b/plus/tool/src/main/webapp/WEB-INF/templates/form.html
@@ -28,7 +28,8 @@
         <div id="issuer-group" class="form-group form-control-required">
           <label for="issuer" class="form-control-label" th:text="#{plus.tool.issuer}">Value</label>
           <div>
-            <input type="text" class="form-control" id="issuer" th:value="${tenant.issuer}" th:field="*{issuer}" pattern="https?://[^\s/]+(?:/[^/\s]+)*$" th:attr="title=#{plus.tenant.issuer.error.slash}" required/>
+            <input type="text" class="form-control" id="issuer" th:value="${tenant.issuer}" th:field="*{issuer}" pattern="https?://[^\s/]+(?:/[^/\s]+)*$" th:attr="title=#{plus.tenant.issuer.error.slash}" required aria-describedby="issuer-error" />
+            <span id="issuer-input-error" class="sr-only"></span>
           </div>
           <div th:text="#{plus.tool.issuer.detail}">
               This is different for each LMS, but it is usually a URL like "https://plus.sakalms.org" - with no trailing slash.


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48654

Screen readers will read the error message from the ```title``` in the ```<input>``` tag only after incorrect input has been submitted.
