### PR TITLE
SAK-48690 Rubrics: Show sakai-rubric-student-button when instructor, provide additional data in Assignments

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -301,8 +301,11 @@
 										#if ($rubricMap.containsKey($assignment.getId()))
 										<sakai-rubric-student-button
 											force-preview
+											dont-check-association
 											rubric-id="$rubricMap.get($assignment.getId())"
 											site-id="$assignment.getContext()"
+											tool-id="sakai.assignment.grades"
+											entity-id="$assignment.Id"
 											instructor="true">
 										</sakai-rubric-student-button>
 										#end

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student-button.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-student-button.js
@@ -100,11 +100,11 @@ class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
   setupHidden() {
 
     if (this.dontCheckAssociation) {
-      this.hidden = true;
+      this.hidden = !this.instructor;
     } else {
       this.apiGetAssociation()
         .then(association => {
-          this.hidden = association.parameters.hideStudentPreview;
+          this.hidden = association.parameters.hideStudentPreview && !this.instructor;
         })
         .catch(error => console.error(error));
     }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48690
When dont-check-association is one of the attributes on a sakai-rubric-student-button, it will automatically hide the button every time because the rest of the visibility logic hinges on retrieval of the association data. This PR makes the button visible if dont-check-association is present when the user is an instructor, since the association data is necessary for determining visibility only when the user is a student.