### PR TITLE
SAK-48703 Trinity: Two-column layouts should have one-column on phones

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
@@ -8,7 +8,7 @@
 
 #elseif ($pageColumnLayout == 'col1of2')
 
-    #set($columnClasses = "p-2 flex-fill w-50")
+    #set($columnClasses = "p-2 col-lg-6 col-md-12")
 
 #end
 
@@ -34,7 +34,7 @@
         #parse("/vm/morpheus/includeSiteHierarchy.vm")
         #parse("/vm/morpheus/snippets/siteStatus-snippet.vm")
         #if ($pageTwoColumn)
-        <div class="d-flex">
+        <div class="row">
         #end
         <div id="$pageColumnLayout" class="${columnClasses}">
 
@@ -197,7 +197,7 @@
 
         #if ($pageTwoColumn)
 
-            <div id="col2of2" class="p-2 flex-fill w-50">
+            <div id="col2of2" class="p-2 col-lg-6 col-md-12">
 
                 #foreach ( $tool in $pageColumn1Tools )
 
@@ -307,7 +307,7 @@
                 #end ## END of FOREACH ( $tool in $pageColumn1Tools )
 
             </div> <!-- end of #col2of2 -->
-        </div> <!-- end of d-flex container -->
+        </div> <!-- end of row -->
 
         #end ## END of IF ($pageTwoColumn)
 


### PR DESCRIPTION
I placed the responsive breakpoint between lg and md. Doing so between md and sm made the two columns look too confining for smaller screens. Below are screenshots for a desktop, tablet, and phone rendering of a two-column layout.

![DesktopTwoColumns](https://user-images.githubusercontent.com/1661251/228667156-145960d8-dc98-4ffd-a4a4-70f7805347b6.png)

![TabletOneColumn](https://user-images.githubusercontent.com/1661251/228667174-1d62cb51-ecd8-479c-ad60-3f4173feed60.png)

![PhoneOneColumn](https://user-images.githubusercontent.com/1661251/228667181-b306a68b-e2fe-4412-b3c4-97b5b0569e8a.png)
