### PR TITLE
SAK-48710 T&Q: Distorted settings view 

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -787,11 +787,10 @@
             <h:commandButton value="#{assessmentSettingsMessages.validateURL}" type="button" onclick="javascript:validateUrl();"/>
         </div>
     </h:panelGroup>
-</div>
 </h:panelGroup>
 
-</div><!-- This is the end of the sub-accordion -->
 </samigo:hideDivision><!-- END Layout and Appearance Category -->
+</div> <!-- END of #jqueryui-accordion -->
 
  <p class="act">
 
@@ -824,7 +823,6 @@
 </p>
 </h:form>
 <!-- end content -->
-</div>
 </div>
       </body>
     </html>

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -803,11 +803,10 @@
             <h:commandButton value="#{assessmentSettingsMessages.validateURL}" type="button" onclick="javascript:validateUrl();"/>
         </div>
     </h:panelGroup>
-</div>
 </h:panelGroup>
 
-</div><!-- This is the end of the sub-accordion -->
 </samigo:hideDivision><!-- END Layout and Appearance Category -->
+</div> <!-- END of #jqueryui-accordion -->
 
  <p class="act">
 
@@ -829,7 +828,6 @@
 </p>
 </h:form>
 <!-- end content -->
-</div>
 </div>
       </body>
     </html>


### PR DESCRIPTION
The cause of the Settings view distortions is extraneous and/or misplaced closing div tags.

I've attached a screencast to demo the results of this proposed fix to the [corresponding jira](https://sakaiproject.atlassian.net/browse/SAK-48710).