### PR TITLE
SAK-48613 Assignments: Existing GB item not receiving scores

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentToolUtils.java
@@ -581,7 +581,9 @@ public class AssignmentToolUtils {
                                             if (grade != null && gradingService.isUserAbleToGradeItemForStudent(gradebookUid, associateGradebookAssignmentId, submitterId)) {
                                                 gradingService.setAssignmentScoreString(gradebookUid, associateGradebookAssignmentId, submitterId, grade, "");
                                                 String comment = StringUtils.isNotEmpty(cm.get(submitterId)) ? cm.get(submitterId) : "";
-                                                gradingService.setAssignmentScoreComment(gradebookUid, associateGradebookAssignmentId, submitterId, comment);
+                                                if (StringUtils.isNotBlank(comment)) {
+					            gradingService.setAssignmentScoreComment(gradebookUid, associateGradebookAssignmentId, submitterId, comment);
+                                                }
                                             }
                                         }
                                     }

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -5112,6 +5112,11 @@ public class GradingServiceImpl implements GradingService {
 
     @Deprecated
     private GradebookAssignment getAssignmentWithoutStats(String gradebookUid, String assignmentName) {
+        // Check if assignmentName is really an assignmentId. If not get assignment by assignmentName (i.e., title).
+        if (NumberUtils.isCreatable(assignmentName)) {
+            final Long assignmentId = new Long(NumberUtils.toLong(assignmentName));
+            return getAssignmentWithoutStats(gradebookUid, new Long(assignmentId));
+        }
         return gradingPersistenceManager.getAssignmentByNameAndGradebook(assignmentName, gradebookUid).orElse(null);
     }
 


### PR DESCRIPTION
The proposed solution resolves two distinct bugs:

The first fix in AssignmentToolUtils prevents calls to gradingService.setAssignmentScoreComment which throw IllegalArgumentExceptions for blank comments.

The second fix conditionally reroutes assignmentName values which-- instead of being the titles of gradebook items-- are now the IDs, at least for Sakai 23 & 24. Note however that prior to Sakai 23 & 24, the associations between assignments and gradebook items that originate from Gradebook are still based on gradebook item titles. This second fix assumes that continuity with those associations will still be upheld (without necessarily provisioning a one-time Quartz job to homogenize all such associations to be based on gradebook item ID).
