### PR TITLE
SAK-48738 Trinity: Tool titles need more right margin

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -87,7 +87,7 @@
             <div class="d-flex text-start align-items-center">
                 <div class="d-flex me-auto rounded-end">
                     <i class="me-1 $!{icon}" aria-hidden="true"></i>
-                    <span>${title}</span>
+                    <span class="me-2">${title}</span>
                 </div>
                 <div class="me-1">
                 #if ($hidden)


### PR DESCRIPTION
The proposed PR adds right margin so that the lock and invisibility icons to not abut directly against the tool title. Screenshots that apply this PR are depicted below.
![ExpectedToolMargin_Mobile](https://user-images.githubusercontent.com/1661251/230511172-27e0ebec-796c-47ca-8a4f-a0abc00f5bc3.png)
![ExpectedToolMargin](https://user-images.githubusercontent.com/1661251/230511177-3478d5e5-c784-4621-a7b7-4bf8d730de9a.png)
