### PR TITLE
SAK-48490: Gradebook: Print button is incorrect color and inconsistent between instructor and student views

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/StudentPage.html
@@ -7,7 +7,7 @@
 	<div class="row">
 		<div class="col-sm-12">
 			<h2 wicket:id="heading">Grade Report for Tony Stark</h2>
-			<button type="button" class="btn btn-info btn-xs gb-summary-print pull-right"><wicket:message key="button.print" /></button>
+			<button type="button" class="btn btn-link btn-xs gb-summary-print pull-right"><wicket:message key="button.print" /></button>
 		</div>
 	</div>
 


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48490

t appears that the issue with the blue button on the instructor's view has already been resolved somewhere. I only fixed the issue with the blue button in the student’s view.

<img width="958" alt="SAK-48490-local" src="https://user-images.githubusercontent.com/102482288/230724293-10efbe27-aba3-49ea-855d-ba5443a7e61d.png">
