### PR TITLE
SAK-48751 Archive add DAV namespace to Sakai archive xml

### DIFF
--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteArchiver.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteArchiver.java
@@ -161,6 +161,7 @@ public class SiteArchiver {
 			root.setAttribute("system", fromSystem);
 			root.setAttribute("xmlns:sakai", ArchiveService.SAKAI_ARCHIVE_NS);
 			root.setAttribute("xmlns:CHEF", ArchiveService.SAKAI_ARCHIVE_NS.concat("CHEF"));
+			root.setAttribute("xmlns:DAV", ArchiveService.SAKAI_ARCHIVE_NS.concat("DAV"));
 			
 			stack.push(root);
 
@@ -207,6 +208,7 @@ public class SiteArchiver {
 			root.setAttribute("system", fromSystem);
 			root.setAttribute("xmlns:sakai", ArchiveService.SAKAI_ARCHIVE_NS);
 			root.setAttribute("xmlns:CHEF", ArchiveService.SAKAI_ARCHIVE_NS.concat("CHEF"));
+			root.setAttribute("xmlns:DAV", ArchiveService.SAKAI_ARCHIVE_NS.concat("DAV"));
 			
 			stack.push(root);
 


### PR DESCRIPTION
Some content attributes can show up with DAV namespace, so add this to the declaration.
