### PR TITLE
SAK-48759 Lessons: Edit Multimedia modal needs ‘card’ div

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -933,13 +933,13 @@
                     </p>
 
                     <p class="shorttext required" id="width-p">
-                      <label rsf:id="width-label" for="width" class="col-sm-1">Page Title</label>
+                      <label rsf:id="width-label" for="width" class="col-sm-2">Page Title</label>
                       <input type="text" name="width" rsf:id="width" id="width" length="30" class="edit-multimedia-input" />
                       <br />
                     </p>
 
                     <p class="shorttext required" id="height-p">
-                      <label rsf:id="height-label" for="height" class="col-sm-1">Page Title</label>
+                      <label rsf:id="height-label" for="height" class="col-sm-2">Page Title</label>
                       <input type="text" name="height" rsf:id="height" id="height" length="30" class="edit-multimedia-input" />
                       <br />
                     </p>
@@ -963,7 +963,7 @@
                   </div>
                 </div>
 
-                <div class="panel panel-default mt-2">
+                <div class="card mt-2">
                   <div class="card-header edit-header">
                     <button type="button" class="accordionBtn collapsed" rsf:id="msg=simplepage.prereqs" data-bs-toggle="collapse" data-bs-target="#mm-prereqbody"></button>
                   </div>
@@ -979,7 +979,7 @@
                 </div>
                 <div class="card mt-2">
                   <div class="card-header edit-header">
-                    <button type="button" class="accordionBtn" rsf:id="msg=simplepage.visibility" data-bs-toggle="collapse" data-bs-target="#mm-visibility"></button>
+                    <button type="button" class="accordionBtn collapsed" rsf:id="msg=simplepage.visibility" data-bs-toggle="collapse" data-bs-target="#mm-visibility"></button>
                   </div>
                   <div class="collapse in" id="mm-visibility">
                     <div class="card-body">


### PR DESCRIPTION
Besides fixing the ‘Prerequisites & Requirements’ div, I also fixed:

1. the default collapsed state for the ‘Visibility & Access’ div so that the collapse/expand arrow doesn’t point down (while the section is collapsed) by default 
2. the allocated column spacing for the Width and Height labels so that the latter does not wrap.

A screenshot of the proposed fix is depicted below: 

![SAK-48759-proposed-fix](https://user-images.githubusercontent.com/1661251/231279706-1aa10e90-66f6-4805-990d-384b401a5850.png)
