### PR TITLE
SAK-48762 Lessons: Embedded YouTube videos don’t display via URL

### DIFF
--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -425,7 +425,7 @@ $(document).ready(function () {
 
       // mm-display-type is 1 -- embed code, 2 -- av type, 3 -- oembed, 4 -- iframe
 
-      const url = $('#mm-url').val();
+      let url = $('#mm-url').val();
       if (url !== '' && $('#mm-is-mm').val() === 'true') {
         if (mm_testing === 0) {
           // initial submit for URL. see what we've got


### PR DESCRIPTION
The 'url' is modified further below, causing an error which prevents the proper assignment of mm-display-type for YouTube URLs. This proposed fix defines the url back to a 'var' which fixes the bug.

Jira: https://sakaiproject.atlassian.net/browse/SAK-48762