### PR TITLE
SAK-48747 Trinity: 'Expand toolbar' in HTML editor is back on black in dark mode

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
@@ -16,6 +16,7 @@
 		padding: 1px;
 		color: $text-color;
 		border-color: var(--sakai-border-color);
+		background-color: #fff;
 
 		&:hover,
 		&:focus {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48747