### PR TITLE
SAK-48337 Trinity: Collapse Home after login to improve pinned site visibility 

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/tool/api/Session.java
+++ b/kernel/api/src/main/java/org/sakaiproject/tool/api/Session.java
@@ -31,6 +31,9 @@ import java.util.Enumeration;
  */
 public interface Session
 {
+        /** A session attribute that is set when just logged in, and thenceforth removed by the portal. */
+        final static String JUST_LOGGED_IN = "justLoggedIn";
+
 	/**
 	 * Returns the object bound with the specified name in this session, or <code>null</code> if no object is bound under the name.
 	 * 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/UsageSessionServiceAdaptor.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/event/impl/UsageSessionServiceAdaptor.java
@@ -539,7 +539,7 @@ public abstract class UsageSessionServiceAdaptor implements UsageSessionService
 
 		// post the login event
 		eventTrackingService().post(eventTrackingService().newEvent(event != null ? event : EVENT_LOGIN, null, true));
-
+		sakaiSession.setAttribute(Session.JUST_LOGGED_IN, Boolean.TRUE);
 		return true;
 	}
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1084,6 +1084,13 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		rcontext.put("userSiteRole", role != null ? role.getId() : "");
 		rcontext.put("editorType", editorType);
 
+                Session session = SessionManager.getCurrentSession();
+                boolean justLoggedIn = session.getAttribute(Session.JUST_LOGGED_IN) != null;
+                if (justLoggedIn) {
+			session.removeAttribute(Session.JUST_LOGGED_IN);
+		}
+		rcontext.put("justLoggedIn", justLoggedIn);
+
 		rcontext.put("loggedOutUrl",ServerConfigurationService.getLoggedOutUrl());
 		rcontext.put("portalPath",ServerConfigurationService.getPortalUrl());
 		rcontext.put("timeoutDialogEnabled",Boolean.valueOf(ServerConfigurationService.getBoolean("timeoutDialogEnabled", true)));

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -48,7 +48,7 @@
                 #end
             #end
         </div>
-        <div id="site-${index}-pages" class="site-list-item-collapse collapse #if ($isCurrentSite)show#end">
+        <div id="site-${index}-pages" class="site-list-item-collapse collapse #if ($isCurrentSite && !($isUserSite && $justLoggedIn))show#end">
             <ul class="site-page-list nav flex-column py-1 mb-2">
             #foreach ( $page in $site.pages )
                 #if ($isCurrentSite)


### PR DESCRIPTION
The Home site is only collapsed immediately after login, via a new proposed Session attribute "JUST_LOGGED_IN". After applied to the portal this Session attribute is immediately removed. 

The screenshot below depicts the Home site collapsed immediately after login. After which, the Home site will be expanded when it is the current site.

![HomeSiteCollapsedAfterLogin](https://user-images.githubusercontent.com/1661251/232061016-0bf2af75-9af2-4c60-bd79-3cd2595ee7c9.png)
