### PR TITLE
SAK-48511 - Apache Maven >= 3.9, some plugins are causing an error

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -484,7 +484,7 @@
 							<dependency>
 								<groupId>org.codehaus.plexus</groupId>
 								<artifactId>plexus-utils</artifactId>
-								<version>3.0.24</version>
+								<version>3.5.1</version>
 							</dependency>
 						</dependencies>
 						<executions>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -479,6 +479,14 @@
 						<groupId>com.samaxes.maven</groupId>
 						<artifactId>minify-maven-plugin</artifactId>
 						<version>1.7.6</version>
+						<dependencies>
+							<!-- Must override this dependency, even though not declared (see MNG-6965) -->
+							<dependency>
+								<groupId>org.codehaus.plexus</groupId>
+								<artifactId>plexus-utils</artifactId>
+								<version>3.0.24</version>
+							</dependency>
+						</dependencies>
 						<executions>
                             <execution>
                                 <id>default-minify</id>

--- a/roster2/tool/pom.xml
+++ b/roster2/tool/pom.xml
@@ -14,7 +14,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <yuicompressor.plugin.version>1.2</yuicompressor.plugin.version>
+        <yuicompressor.plugin.version>1.5.1</yuicompressor.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -173,27 +173,6 @@
 
     <build>
         <plugins>
-            <!-- compress CSS and JS -->
-            <!--plugin>
-                <groupId>com.samaxes.maven</groupId>
-                <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.6</version>
-                <executions>
-                    <execution>
-                        <id>default-minify</id>
-                        <configuration>
-                            <charset>UTF-8</charset>
-                            <webappSourceDir>${basedir}/src/webapp</webappSourceDir>
-                            <jsSourceDir>js/</jsSourceDir>
-                            <jsIncludes>*.js</jsIncludes>
-                            <jsTargetDir>js</jsTargetDir>
-                            <jsFinalFile>roster.js</jsFinalFile>
-                            <jsEngine>CLOSURE</jsEngine>
-                        </configuration>
-                        <goals><goal>minify</goal></goals>
-                    </execution>
-                </executions>
-            </plugin-->
             <plugin>
                 <groupId>com.github.jknack</groupId>
                 <artifactId>handlebars-maven-plugin</artifactId>

--- a/sitestats/sitestats-tool/pom.xml
+++ b/sitestats/sitestats-tool/pom.xml
@@ -148,7 +148,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>yuicompressor-maven-plugin</artifactId>
-        <version>1.2</version>
+        <version>1.5.1</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
I tested this both with and without running tests.

Just had to upgrade yuicompressor but there's no upgrade for minify-maven-plugin so that needs this explicit dependency and I removed the other that was commented out. 