### PR TITLE
SAK-48748 HTML Editor: Embedded Videos should have controls enabled by default

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -90,8 +90,8 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.webjars.bower</groupId>
-			<artifactId>github-com-bahriddin-ckeditor-html5-video</artifactId>
+			<groupId>org.webjars</groupId>
+			<artifactId>ckeditor-html5-video</artifactId>
 			<version>${ckeditor.html5video.version}</version>
 			<scope>runtime</scope>
 		</dependency>

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -461,7 +461,7 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
 
         //These could be applicable to the basic toolbar
         CKEDITOR.plugins.addExternal('lineutils',basePath+'lineutils/', 'plugin.js');
-        CKEDITOR.plugins.addExternal('html5video',webJars+'github-com-bahriddin-ckeditor-html5-video/${ckeditor.html5video.version}/html5video/', 'plugin.js');
+        CKEDITOR.plugins.addExternal('html5video',webJars+'ckeditor-html5-video/${ckeditor.html5video.version}/', 'plugin.js');
         CKEDITOR.plugins.addExternal('audiorecorder',basePath+'audiorecorder/', 'plugin.js');
         CKEDITOR.plugins.addExternal('contentitem',basePath+'contentitem/', 'plugin.js');
         CKEDITOR.plugins.addExternal('sakaipreview',basePath+'sakaipreview/', 'plugin.js');

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -114,7 +114,7 @@
     <ckeditor.a11ychecker.version>1.1.1</ckeditor.a11ychecker.version>
     <ckeditor.balloonpanel.version>4.9.2</ckeditor.balloonpanel.version>
     <ckeditor.image2.version>4.16.1</ckeditor.image2.version>
-    <ckeditor.html5video.version>1.2.1</ckeditor.html5video.version>
+    <ckeditor.html5video.version>1.1</ckeditor.html5video.version>
 
   </properties>
   <distributionManagement>


### PR DESCRIPTION
Updated webjar abandoned repository by a new one with all changes required.

Related PRs with the actual changes:
 - https://github.com/SedueRey/ckeditor-html5-video/pull/1
 - https://github.com/SedueRey/ckeditor-html5-video/pull/2

Release: https://github.com/SedueRey/ckeditor-html5-video/releases/tag/1.1

Also, related Jira: https://sakaiproject.atlassian.net/browse/SAK-45131