### PR TITLE
SAK-48795: Gradebook / print icon alignment issue

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -1753,7 +1753,7 @@ div.wicket-mask-transparent, div.wicket-mask-dark {
 }
 .gb-summary-print {
   position: absolute;
-  top: 15px;
+  top: 11px;
   right: 10px;
 }
 .gb-summary-print:before {


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48795

Attached a screenshot for Firefox and Chrome

<img width="1920" alt="SAK-48795-local" src="https://user-images.githubusercontent.com/102482288/233666331-3c1168ab-bc80-44c8-aacd-d3adceb6e019.png">
