### PR TITLE
SAK-48407 Profile: Takes more steps to update a profile pic

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/sui-picture-changer/sui-picture-changer.js
+++ b/webcomponents/tool/src/main/frontend/js/sui-picture-changer/sui-picture-changer.js
@@ -253,9 +253,9 @@ export class SuiPictureChanger extends SakaiElement {
             </div>
         </div>
         <div class="modal-footer">
-          <button class="btn pull-left" @click=${this._save} ?disabled=${!this.needsSave}>${this.i18n.save}</button>
-          <button class="btn pull-right" @click="${this._remove}">${this.i18n.remove}</button>
-          <button class="btn pull-left" data-bs-dismiss="modal">${this.i18n.done}</button>
+          <button class="btn pull-left" data-bs-dismiss="modal" @click=${this._save} ?disabled=${!this.needsSave}>${this.i18n.save}</button>
+          <button class="btn float-start" @click="${this._remove}">${this.i18n.remove}</button>
+          <button class="btn float-start" data-bs-dismiss="modal">${this.i18n.cancel}</button>
         </div>
       </div>
     </div>

--- a/webcomponents/tool/src/main/frontend/js/sui-picture-changer/sui-picture-changer.js
+++ b/webcomponents/tool/src/main/frontend/js/sui-picture-changer/sui-picture-changer.js
@@ -253,7 +253,7 @@ export class SuiPictureChanger extends SakaiElement {
             </div>
         </div>
         <div class="modal-footer">
-          <button class="btn pull-left" data-bs-dismiss="modal" @click=${this._save} ?disabled=${!this.needsSave}>${this.i18n.save}</button>
+          <button class="btn float-start" data-bs-dismiss="modal" @click=${this._save} ?disabled=${!this.needsSave}>${this.i18n.save}</button>
           <button class="btn float-start" @click="${this._remove}">${this.i18n.remove}</button>
           <button class="btn float-start" data-bs-dismiss="modal">${this.i18n.cancel}</button>
         </div>

--- a/webcomponents/tool/src/main/frontend/js/sui-picture-changer/sui-picture-changer.js
+++ b/webcomponents/tool/src/main/frontend/js/sui-picture-changer/sui-picture-changer.js
@@ -254,7 +254,7 @@ export class SuiPictureChanger extends SakaiElement {
         </div>
         <div class="modal-footer">
           <button class="btn float-start" data-bs-dismiss="modal" @click=${this._save} ?disabled=${!this.needsSave}>${this.i18n.save}</button>
-          <button class="btn float-start" @click="${this._remove}">${this.i18n.remove}</button>
+          <button class="btn float-end" @click="${this._remove}">${this.i18n.remove}</button>
           <button class="btn float-start" data-bs-dismiss="modal">${this.i18n.cancel}</button>
         </div>
       </div>


### PR DESCRIPTION
The save button needed a data-bs-dismiss to dismiss the modal when saving the change. I also renamed the 'Done' button to 'Cancel'. I found the meaning of the former to be confusing, especially in relation to 'Save'. The button actually cancels without preserving changes made in the modal.