### PR TITLE
SAK-48373 - Roster: use a css class that actually exists

### DIFF
--- a/roster2/tool/src/webapp/js/roster.js
+++ b/roster2/tool/src/webapp/js/roster.js
@@ -848,7 +848,7 @@ roster.calculatePageSizes = function () {
 
   // height of container = height + top and bottom padding;
   // #roster-members-content has no height at load, so we approximate using the morpheus page container
-  var containerHeight = parseInt($('div.portal-main-container').height());
+  const containerHeight = parseInt($('div.portal-main-container').height());
 
   // number of rows per page = containerHeight / cardHeight, rounded down up nearest whole number
   var numBigRowsPerPage = Math.ceil(containerHeight / bigCardHeight);

--- a/roster2/tool/src/webapp/js/roster.js
+++ b/roster2/tool/src/webapp/js/roster.js
@@ -848,7 +848,7 @@ roster.calculatePageSizes = function () {
 
   // height of container = height + top and bottom padding;
   // #roster-members-content has no height at load, so we approximate using the morpheus page container
-  var containerHeight = parseInt($('div.Mrphs-pagebody').height());
+  var containerHeight = parseInt($('div.portal-main-container').height());
 
   // number of rows per page = containerHeight / cardHeight, rounded down up nearest whole number
   var numBigRowsPerPage = Math.ceil(containerHeight / bigCardHeight);


### PR DESCRIPTION
This fixes the NaN error, but there are still issues with the scroll-to-load content that I can't get figured out!