### PR TITLE
SAK-48780: Gradebook: Item Order has a phantom f0c9 icon in Firefox

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
@@ -15,10 +15,6 @@
   margin-right: 40px;
 }
 
-#gradebookSorter .gb-sorter-sortable:before {
-  font-family: "bootstrap-icons";
-  content: '\f0c9';
-}
 
 #gradebookSorter .gb-sorter-sortable .si-grip-horizontal:before {
   margin-right: 5px;


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48780

Instead of using the previous method of adding icons before text with the ```#gradebookSorter .gb-sorter-sortable:before``` selector, we now utilize the ```si-grip-horizontal``` class to achieve the same result. This change was implemented in [SAK-48172](https://sakaiproject.atlassian.net/browse/SAK-48172) ```<span wicket:id="name" class="si si-grip-horizontal"></span>```.

<img width="1315" alt="SAK-48780-local" src="https://user-images.githubusercontent.com/102482288/233794269-6d2b2d88-c2db-42fc-9d9e-7a4a555b22fc.png">


[SAK-48172]: https://sakaiproject.atlassian.net/browse/SAK-48172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ