### PR TITLE
SAK-48815 Gradebook - Duplicate item column names when synchronizing grades from Wooclap

### DIFF
--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -2946,8 +2946,12 @@ public class SakaiBLTIUtil {
 				org.sakaiproject.grading.api.Assignment aColumn = (org.sakaiproject.grading.api.Assignment) i.next();
 
 				if (title.trim().equalsIgnoreCase(aColumn.getName().trim())) {
-					returnColumn = aColumn;
-					break;
+					if (returnColumn == null) {
+						returnColumn = aColumn;
+					} else {
+						// removing other items with same name
+						g.removeAssignment(aColumn.getId());
+					}
 				}
 			}
 		} finally {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48815

Maybe for cache or ignite reason this line:
`List gradeboolColumns = g.getAssignments(siteId);`

could return some gradebook item with the same name.