### PR TITLE
SAK-48729 Viewing a forum in Discussions hides the tools in sitenav

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/js/forum.js
+++ b/msgcntr/messageforums-app/src/webapp/js/forum.js
@@ -504,44 +504,6 @@ function InsertHTML(header) {
   return false;
 }
 
-var setupLongDesc = function(){
-    var showMoreText = $('.showMoreText').text();
-    $('.show').hide();
-    $('.textPanel').each(function(i){
-        if ($(this).text().length > 200) {
-            var trimmed = $(this).text().substring(0, 200) + '... <a class=\"moreDescription\")" href=\"#\">' + showMoreText + '</a>';
-        }
-        else{
-            var trimmed = $(this).html();
-        }
-        var insertPoint = $(this).parent('.toggle');
-        $('<p class=\"trimmedPanelTop\">' + trimmed + '</p>').insertBefore(insertPoint);
-    });
-    
-    $('.forumHeader, .topicBloc').each(function(i){
-        var attachList = $(this).find('.attachListTable');
-        var insertPoint='';
-        if ($(this).find('.toggle').length){
-            var insertPoint = $(this).find('.toggle');
-        }
-        else{
-            var insertPoint = $(this).find('.hide');            
-        }
-        $(attachList).insertAfter(insertPoint);
-    });
-     
-    $('.moreDescription').live('click', function(e){
-        e.preventDefault();
-        var trimmedText = $(this).parent();
-        var textPanel = $(this).parent('p').next('div.toggle');
-        $(trimmedText).fadeOut('slow', function(){
-            $(textPanel).fadeIn('slow');
-        });
-        resizeFrame('grow')
-        
-    });
-    
-}
 var setupdfAIncMenus = function(){
     
     $('body').click(function(e){

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/forum/dfForumDetail.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/forum/dfForumDetail.jsp
@@ -19,9 +19,6 @@
 				var menuLinkSpan = menuLink.closest('span');
 				menuLinkSpan.addClass('current');
 				menuLinkSpan.html(menuLink.text());
-
-				setupLongDesc();
-
 			});
 		</script>
 <!--jsp/discussionForum/forum/dfForumDetail.jsp-->

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/includes/dfAreaInclude.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/includes/dfAreaInclude.jsp
@@ -44,7 +44,6 @@ $(document).ready(function() {
     setupdfAIncMenus();
 });
 </script>
-<h:outputText escape="false" value="<script>$(document).ready(function() {setupLongDesc()});</script>"  rendered="#{!ForumTool.showShortDescription}"/>
 
             <h:outputText styleClass="showMoreText"  style="display:none" value="#{msgs.cdfm_show_more_full_description}"  />
 

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfAllMessages.jsp
@@ -474,7 +474,6 @@
   				mySetMainFrameHeight('<%= org.sakaiproject.util.Web.escapeJavascript(thisId)%>');
   			}
 			</script> 
-<h:outputText escape="false" value="<script>$(document).ready(function() {setupLongDesc()});</script>"  rendered="#{!ForumTool.showShortDescription}"/>
 	</h:form>
 
 	<h:outputText value="#{msgs.cdfm_insufficient_privileges_view_topic}" rendered="#{ForumTool.selectedTopic.topic.draft && ForumTool.selectedTopic.topic.createdBy != ForumTool.userId}" />


### PR DESCRIPTION
I'm removing the client-side setupLongDesc function which seems vestigial and is causing the tool menu in the site nav to disappear. With setupLongDesc, I'm not observing the "moreDescription" logic actually working-- which seems redundant anyway given the methods attached to .toggle elements. Also the attachments, if present, should be hidden when the .toggle element is collapsed; the "View/Hide Full Description and Attachment(s)" labels would then make more sense. Removing setupLongDesc seems to fix that issue.