### PR TITLE
SAK-47516: Dashboard: Tasks widget - creating a group task fails, then blocks future task creation

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
+++ b/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
@@ -65,7 +65,7 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
   addSelectedGroups() {
 
     if (this.selectedGroups != null) {
-      this.task.selectedGroups = this.selectedGroups.map(sg => sg.value);
+      this.task.selectedGroups = [...this.selectedGroups].map(sg => sg.value);
     }
   }
 


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-47516

```this.selectedGroups``` is an HTMLCollection and does not have a ```map()``` function. The ```...``` spread operator is used to convert the HTMLCollection to an array.