### PR TITLE
S2U-15 Make submission date format consistent and remove navigation to list when clicking update

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/SubmissionNavBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/SubmissionNavBean.java
@@ -1,11 +1,10 @@
 package org.sakaiproject.tool.assessment.ui.bean.evaluation;
 
 import java.io.Serializable;
-import java.text.DateFormat;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -16,7 +15,6 @@ import javax.faces.model.SelectItem;
 
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
-import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
@@ -52,7 +50,6 @@ public class SubmissionNavBean extends SpringBeanAutowiringSupport implements Se
 
 
     public void populate(List<AgentResults> agentResultsList, String currentGradingId, boolean displaySubmissionDate) {
-        Locale locale = ContextUtil.getLocale();
 
         this.displaySubmissionDate = displaySubmissionDate;
         this.currentGradingId = currentGradingId;
@@ -86,7 +83,8 @@ public class SubmissionNavBean extends SpringBeanAutowiringSupport implements Se
                     String displayName = agent.getLastName() + ", " + agent.getFirstName()
                         + " (" + agent.getAgentDisplayId()  + ")";
                     String optionLabel = displaySubmissionDate
-                            ? displayName + " - " + userTimeService.dateTimeFormat(agent.getSubmittedDate(), locale, DateFormat.MEDIUM)
+                            ? displayName + " - " + userTimeService.dateTimeFormat(agent.getSubmittedDate().toInstant(),
+                                    FormatStyle.MEDIUM, FormatStyle.SHORT)
                             : displayName;
                     return new SelectItem(agent.getAssessmentGradingId(), optionLabel);
                 })

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -362,15 +362,9 @@ function toPoint(id)
 </h:panelGroup>
 
 <p class="act">
-   <h:commandButton id="save" styleClass="active" value="#{evaluationMessages.save_cont}" action="totalScores" type="submit">
+   <h:commandButton id="save" styleClass="active" value="#{evaluationMessages.save_cont}" action="gradeStudentResult" type="submit">
       <f:actionListener
          type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreUpdateListener" />
-      <f:actionListener
-         type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreListener" />
-      <f:actionListener
-         type="org.sakaiproject.tool.assessment.ui.listener.evaluation.ResetTotalScoreListener" />
-      <f:actionListener
-         type="org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreListener" />
    </h:commandButton>
    <h:commandButton id="cancel" value="#{commonMessages.cancel_action}" action="totalScores" immediate="true">
       <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.ResetTotalScoreListener" />


### PR DESCRIPTION
This update to S2U-15 will:

1. Make the date-time display of the submission navigation be consistent with the time displayed in the assessment list
2. Remove the navigation to the assessment list when clicking the "Update" button while grading.

https://sakaiproject.atlassian.net/browse/S2U-15