### PR TITLE
SAK-48850 Sites Menu: Does not close if user clicks background

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -32,7 +32,6 @@
 
   <div id="select-site-sidebar"
       class="offcanvas offcanvas-end"
-      data-bs-backdrop="static"
       tabindex="-1"
       aria-labelledby="select-site-label">
     <div class="offcanvas-header">


### PR DESCRIPTION
Given that the Sites modal is now a “sidebar” (aligned to the right) and that scrolling is within the modal, the issue cited in SAK-48647 no longer applies, and the static backdrop can be reverted.