### PR TITLE
SAK-48482: Home-Tasks Widget: If student changes priority on an assignment task, link to assignment is gone

### DIFF
--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/TasksController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/TasksController.java
@@ -286,6 +286,7 @@ public class TasksController extends AbstractSakaiApiController {
      * @throws IdUnusedException if the specified site ID is invalid
      */
     private void updateUserTaskAdapterBean(UserTaskAdapterBean bean) throws IdUnusedException {
+
         Site site = siteService.getSite(bean.getSiteId());
 
         bean.setSiteTitle(site.getTitle());


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48482

After investigating the codebase, I found that the missing URL issue was caused by a backend issue. Specifically, when the user edits the information of the task, use the PUT request to update the data through ```updateTask()```. However, unlike ```getTasks()``` which correctly sets the URL, ```updateTask()``` does not, leading to the missing URL problem.

I extracted some of codes in ```getTasks()``` and created a new function that handles the same logic used in ```getTasks()``` and ```updateTasks()```. This function is designed to ensure that all necessary information, including the URL, is properly updated when a user edits a task's details. By doing so, we were able to resolve the issue of missing URLs that occurred when using the ```updateTasks()``` function.