### PR TITLE
SAK-48820 Scheduler SoftSiteDeletionJob deleting AuthzGroups for groups

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/SoftSiteDeletionJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/SoftSiteDeletionJob.java
@@ -115,7 +115,8 @@ public class SoftSiteDeletionJob implements Job {
 	
 					try {
 						enableSecurityAdvisor();
-	
+						//load in groups for removal of authzGroups
+						s.getGroups();
 						siteService.removeSite(s, hardDelete);
 						log.info("Removed site: " + s.getId());
 	


### PR DESCRIPTION
Delete AuthzGroups for groups when running he “Expunge softly deleted sites“ job for  softly deleted site.
