### PR TITLE
SAK-48849 Lessons: Edit embedded multimedia was opening the wrong dialog

### DIFF
--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -2100,6 +2100,12 @@ $(document).ready(function () {
     });
 
     $('#change-resource-mm').click(function () {
+      const deleteEl = document.querySelector("#edit-multimedia-dialog");
+      const modal = bootstrap.Modal.getInstance(deleteEl);
+      modal && modal.hide();
+      const mmEl = document.querySelector("#add-multimedia-dialog");
+      const mmModal = bootstrap.Modal.getOrCreateInstance(mmEl);
+      mmModal && mmModal.show();
 
       mm_test_reset();
       $("#mm-name-section").hide();

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -2716,7 +2716,7 @@
                     <img rsf:id="image" class="multimedia playerwidth" />
                     <div rsf:id="editimage-td" role="toolbar" class="edit-col">
                       <div>
-                        <a  rsf:id="image-edit" role="button" class="usebutton multimedia-edit" data-bs-toggle="modal" data-bs-target="#movie-dialog" aria-controls="movie-dialog" aria-expanded="false" href="#" onclick="return false">
+                        <a  rsf:id="image-edit" role="button" class="usebutton multimedia-edit" data-bs-toggle="modal" data-bs-target="#edit-multimedia-dialog" aria-controls="edit-multimedia-dialog" aria-expanded="false" href="#" onclick="return false">
                           <span aria-hidden="true" class="fa-edit fa-edit-icon"></span>
                         </a>
                         <a role="button" href="#" class="usebutton del-item-link" onclick="return false">


### PR DESCRIPTION
The switch to BS 5 changed the edit link next to an embedded image from opening the multimedia dialog to opening the movie dialog, which broke everything. The link was labeled wrong previously, which was probably why it was accidentally switched.