### PR TITLE
SAK-48871 Dashboard > Tasks: "Completed" checkbox remains checked after cancelling editing

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
+++ b/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
@@ -71,6 +71,7 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
   }
 
   save() {
+
     this.task.description = this.shadowRoot.getElementById("description").value;
     this.task.notes = this.getEditor().getContent();
     this.task.assignationType = this.assignationType;

--- a/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
+++ b/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
@@ -30,7 +30,7 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
       optionsGroup: { attribute: false, type: Array },
       mode: { attribute: false, type: String },
       siteIdBackup: { attribute: false, type: String },
-      completed: {attribute: false, type: Boolean },
+      completed: { attribute: false, type: Boolean },
     };
   }
 

--- a/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
+++ b/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
@@ -30,7 +30,6 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
       optionsGroup: { attribute: false, type: Array },
       mode: { attribute: false, type: String },
       siteIdBackup: { attribute: false, type: String },
-      completed: { attribute: false, type: Boolean },
     };
   }
 
@@ -78,12 +77,14 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
     this.task.siteId = this.siteId;
     this.task.userId = this.userId;
     this.task.owner = this.task.owner || this.userId;
-    this.task.complete = this.completed;
-    if (this.completed) {
-      this.task.softDeleted = false;
+    const completeEl = this.shadowRoot.getElementById("complete");
+    // "Add a new task" page includes a 'completed' checkbox, whereas the "Edit task" page does not have this checkbox
+    if (completeEl) {
+      this.task.complete = completeEl.checked;
     }
     this.addSelectedGroups();
 
+    // Update the task on the server
     const url = `/api/tasks${this.task.taskId ? `/${this.task.taskId}` : ""}`;
     fetch(url, {
       credentials: "include",
@@ -232,9 +233,6 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
     this.siteId = this.siteIdBackup;
   }
 
-  complete(e) {
-    this.completed = e.target.checked;
-  }
 
   groupComboList() {
 
@@ -311,7 +309,6 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
               type="checkbox"
               id="complete"
               title="${this.i18n.complete_tooltip}"
-              @click=${this.complete}
               ?checked=${this.task.complete}>
           </div>
         </div>

--- a/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
+++ b/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
@@ -30,6 +30,7 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
       optionsGroup: { attribute: false, type: Array },
       mode: { attribute: false, type: String },
       siteIdBackup: { attribute: false, type: String },
+      completed: {attribute: false, type: Boolean },
     };
   }
 
@@ -70,14 +71,18 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
   }
 
   save() {
-
     this.task.description = this.shadowRoot.getElementById("description").value;
     this.task.notes = this.getEditor().getContent();
     this.task.assignationType = this.assignationType;
     this.task.siteId = this.siteId;
     this.task.userId = this.userId;
     this.task.owner = this.task.owner || this.userId;
+    this.task.complete = this.completed;
+    if (this.completed) {
+      this.task.softDeleted = false;
+    }
     this.addSelectedGroups();
+
     const url = `/api/tasks${this.task.taskId ? `/${this.task.taskId}` : ""}`;
     fetch(url, {
       credentials: "include",
@@ -227,11 +232,7 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
   }
 
   complete(e) {
-
-    this.task.complete = e.target.checked;
-    if (e.target.checked) {
-      this.task.softDeleted = false;
-    }
+    this.completed = e.target.checked;
   }
 
   groupComboList() {


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48871

```this.task.complete``` should be updated only when users click on "save" button, which triggers the ```save()``` function. It should not be updated immediately after the "completed" checkbox is clicked.

<img width="1155" alt="Screenshot 2023-05-09 at 7 44 47 PM" src="https://github.com/sakaiproject/sakai/assets/102482288/c8095674-5ee6-4523-855f-e97192c74193">
