### PR TITLE
S2U-21 5.1.1.17 Tests & Quizzes: Support for Safe Exam Browser

### DIFF
--- a/samigo/samigo-app/src/webapp/js/deliverySafeExamBrowser.js
+++ b/samigo/samigo-app/src/webapp/js/deliverySafeExamBrowser.js
@@ -2,7 +2,8 @@
 
 const siteId = "IS_NOT_NEEDED";
 const formId = "takeAssessmentForm";
-const sebProtocol = "seb:";
+// Replacing http: to seb: and https: to sebs:
+const sebProtocol = window.location.protocol.replace('http','seb');
 const startButtonId = formId + ":restViewHidden";
 const launchSebLinkId = "sebLaunchSeb";
 const downloadSebLink = seb.downloadLink;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/SecureDeliverySeb.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/SecureDeliverySeb.java
@@ -448,7 +448,7 @@ public class SecureDeliverySeb implements SecureDeliveryModuleIfc {
         String assessmentAccessId = StringUtils.trimToNull(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.ALIAS));
         if (assessmentAccessId != null) {
             return UriComponentsBuilder.newInstance()
-                    .scheme("http")
+                    .scheme(requestUrl.getProtocol())
                     .host(requestUrl.getHost())
                     .port(requestUrl.getPort())
                     .path(LOGIN_SERVLET_PATH)

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/SecureDeliveryController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/SecureDeliveryController.java
@@ -148,7 +148,7 @@ public class SecureDeliveryController extends AbstractSakaiApiController {
             URL requestUrl = new URL(request.getRequestURL().toString());
 
             String startLink = UriComponentsBuilder.newInstance()
-                    .scheme("http")
+                    .scheme(requestUrl.getProtocol())
                     .host(requestUrl.getHost())
                     .port(requestUrl.getPort())
                     .path(LOGIN_SERVLET_PATH)


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/S2U-21

We have to detect here if the protocol is https

https://github.com/sakaiproject/sakai/pull/11562/files#diff-7ad9f49d779fc77743ae382aa60b150b35d5138a4ec91ee16a4da221a8069d13R26

Questions:

1. When a student starts the asessment 2 rows are created. 
2. Column URL is always: https://....... /samigo-app/jsf/delivery/begin/beginTakingAssessment.faces

![image](https://github.com/sakaiproject/sakai/assets/15141743/5e2d71b7-77f4-492b-af10-de84dd432045)


