### PR TITLE
SAK-48914 Search group icon missing for bootstrap-multiselect

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
@@ -75,7 +75,11 @@ function resizeFrame(){
                             class="btn btn-primary multiselect dropdown-toggle"
                             data-bs-toggle="dropdown">
                         <span class="multiselect-selected-text"></span>
+                        <i class="si si-caret-down-fill ps-2"></i>
                     </button>
+                `,
+                filter: `
+                    <div class="multiselect-filter d-flex align-items-center"><i class="fa fa-sm fa-search text-muted"></i><input type="search" class="multiselect-search form-control" /></div>
                 `,
             },
         });

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -20,7 +20,11 @@
                             class="btn btn-primary multiselect dropdown-toggle"
                             data-bs-toggle="dropdown">
                         <span class="multiselect-selected-text"></span>
+                        <i class="si si-caret-down-fill ps-2"></i>
                     </button>
+                `,
+                filter: `
+                    <div class="multiselect-filter d-flex align-items-center"><i class="fa fa-sm fa-search text-muted"></i><input type="search" class="multiselect-search form-control" /></div>
                 `,
             },
         });

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
@@ -18,6 +18,7 @@
             filterPlaceholder: '$tlang.getString("access.edit.searchgroup")',
             templates: {
                 button: '<button type="button" class="multiselect dropdown-toggle btn-primary" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span><i class="si si-caret-down-fill ps-2"></i></button>',
+                filter: '<div class="multiselect-filter d-flex align-items-center"><i class="fa fa-sm fa-search text-muted"></i><input type="search" class="multiselect-search form-control" /></div>',
             },
             enableFiltering: true,
             enableCaseInsensitiveFiltering: true
@@ -32,6 +33,7 @@
                 nSelectedText: ' $tlang.getString("access.edit.groupsselected")',
                 templates: {
                     button: '<button type="button" class="multiselect dropdown-toggle btn-primary" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span><i class="si si-caret-down-fill ps-2"></i></button>',
+                    filter: '<div class="multiselect-filter d-flex align-items-center"><i class="fa fa-sm fa-search text-muted"></i><input type="search" class="multiselect-search form-control" /></div>',
                 },
                 filterPlaceholder: '$tlang.getString("access.edit.searchgroup")',
                 enableFiltering: true,

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -189,7 +189,8 @@
               allSelectedText: allSelectedText,
               nSelectedText: nSelectedText,
               templates: {
-                button: '<button type="button" class="multiselect dropdown-toggle btn-primary" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span><i class="si si-caret-down-fill ps-2"></i></button>'
+                button: '<button type="button" class="multiselect dropdown-toggle btn-primary" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span><i class="si si-caret-down-fill ps-2"></i></button>',
+                filter: '<div class="multiselect-filter d-flex align-items-center"><i class="fa fa-sm fa-search text-muted"></i><input type="search" class="multiselect-search form-control" /></div>',
               },
           });
       });

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -200,7 +200,8 @@
               allSelectedText: allSelectedText,
               nSelectedText: nSelectedText,
               templates: {
-                button: '<button type="button" class="multiselect dropdown-toggle btn-primary" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span><i class="si si-caret-down-fill ps-2"></i></button>'
+                button: '<button type="button" class="multiselect dropdown-toggle btn-primary" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span><i class="si si-caret-down-fill ps-2"></i></button>',
+                filter: '<div class="multiselect-filter d-flex align-items-center"><i class="fa fa-sm fa-search text-muted"></i><input type="search" class="multiselect-search form-control" /></div>',
               },
           });
       });


### PR DESCRIPTION
I’ve attached screenshots of Assignments, Announcements, Resources, and Tests & Quizzes where my proposed fix restores a magnifying glass icon for the filter part of bootstrap-multiselect. 

With this proposed fix, I am overriding the default ‘filter’ parameter not only out of expedience. It seems like the class ‘fas’ found in the default for bootstrap-multiselect (since 0.9.16) is intentional; that ‘fas’ class is also used elsewhere in bootstrap-multiselect.js. We instead need an “fa” class for the magnifying icon to display.

![Screenshot from 2023-05-22 14-16-55](https://github.com/sakaiproject/sakai/assets/1661251/5f5795e9-be99-41b3-bb5e-9d9cc0722fa7)
![Screenshot from 2023-05-22 14-16-34](https://github.com/sakaiproject/sakai/assets/1661251/32e76325-327f-40b9-8eac-78850c83ca9b)
![Screenshot from 2023-05-22 14-16-16](https://github.com/sakaiproject/sakai/assets/1661251/ee36011d-c65c-48a0-aae6-daf1085c2865)
![Screenshot from 2023-05-22 14-15-54](https://github.com/sakaiproject/sakai/assets/1661251/ac41fcc5-3595-448f-a8f8-3217ff94b18d)
