### PR TITLE
SAK-48928 GB: Incorrect icon for excused grades

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -303,7 +303,8 @@
   }
 
   .gb-flag-excused::before {
-    content: '\F4FC';
+    content: '\F1DF';
+    text-decoration-line: line-through;
   }
 
    .gb-flag-external:before {


### PR DESCRIPTION
![Screenshot from 2023-05-22 14-52-43](https://github.com/sakaiproject/sakai/assets/1661251/6a41d6c8-6269-40bb-bf8a-f27b2f922e2d)
