### PR TITLE
SAK-48931 Rubrics criterion description can load lots of instances of…

### DIFF
--- a/rubrics/api/src/main/bundle/rubrics.properties
+++ b/rubrics/api/src/main/bundle/rubrics.properties
@@ -140,3 +140,5 @@ collapse_all=Collapse All
 rubric_points_warning=A rubric's point value should match the maximum point value of the activity or question to grade.
 rubric_view_selection_title=Select the type of rubric view: grading, student summary, or criteria summary
 remove=Remove
+
+toggle_editor=Toggle editor

--- a/rubrics/api/src/main/bundle/rubrics_ca.properties
+++ b/rubrics/api/src/main/bundle/rubrics_ca.properties
@@ -128,3 +128,5 @@ expand_all=Desplega-ho tot
 collapse_all=Replega\u2019ls tots
 rubric_points_warning=El valor en punts d\u2019una r\u00fabrica ha de coincidir amb valor m\u00e0xim de l\u2019activitat o la pregunta a qualificar.
 rubric_view_selection_title=Seleccioneu el tipus de vista de la r\u00fabrica\: qualificaci\u00f3, resum per a l\u2019estudiant o resum dels criteris
+
+toggle_editor=Canviar editor

--- a/rubrics/api/src/main/bundle/rubrics_es.properties
+++ b/rubrics/api/src/main/bundle/rubrics_es.properties
@@ -109,3 +109,5 @@ default_c2_r5_title=Excepcional
 default_criterion_title=Nuevo Criterio
 default_empty_criterion_title=Nuevo grupo de criterios
 default_rating_title=Nuevo valor
+
+toggle_editor=Cambiar editor

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-criterion-edit.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-criterion-edit.js
@@ -21,6 +21,7 @@ export class SakaiRubricCriterionEdit extends RubricsElement {
       rubricId: { attribute: "rubric-id", type: String },
       criterion: { type: Object, notify: true },
       isCriterionGroup: {attribute: "is-criterion-group", type: Boolean},
+      enableCkEditor: { type: Boolean },
     };
   }
 
@@ -91,12 +92,18 @@ export class SakaiRubricCriterionEdit extends RubricsElement {
                 <sr-lang key="criterion_description">Criterion Description</sr-lang>
               `}
             </label>
-            <sakai-editor
-              toolbar="BasicText"
-              content="${this.criterionClone.description ? `${this.criterionClone.description}` : ``}"
-              @changed="${this.updateCriterionDescription}"
-              id="criterion-description-field-${this.criterion.id}">
-            </sakai-editor>
+            <br/><a tabindex="0" role="button" href="#" title="${tr("toggle_editor")}" aria-label="${tr("toggle_editor")}" @click="${this.toggleCkEditor}"><sr-lang key="toggle_editor">Toggle CK Editor</sr-lang></a>
+            ${!this.enableCkEditor ?
+              html`<textarea id="criterion-description-field-${this.criterion.id}" class="form-control">${this.criterionClone.description}</textarea>` :
+                html`
+                  <sakai-editor
+                    toolbar="BasicText"
+                    content="${this.criterionClone.description ? `${this.criterionClone.description}` : ``}"
+                    @changed="${this.updateCriterionDescription}"
+                    id="criterion-description-field-${this.criterion.id}">
+                  </sakai-editor>
+                `
+            }
           </div>
 
           <div class="mt-2">
@@ -127,7 +134,10 @@ export class SakaiRubricCriterionEdit extends RubricsElement {
     e.stopPropagation();
 
     const title = e.target.closest(".popover-body").querySelector("input").value;
-    const description = e.target.closest("div.form").querySelector("sakai-editor").getContent();
+    // Get the description from the CkEditor or the textarea.
+    const description = !this.enableCkEditor ?
+      document.getElementById(`criterion-description-field-${this.criterion.id}`).value
+      : this.criterionClone.description;
 
     const body = JSON.stringify([
       { "op": "replace", "path": "/title", "value": title },
@@ -166,6 +176,12 @@ export class SakaiRubricCriterionEdit extends RubricsElement {
   updateCriterionDescription(e) {
     this.criterionClone.description = e.detail.content;
   }
+
+  toggleCkEditor(e) {
+    e.preventDefault();
+    this.enableCkEditor = this.enableCkEditor === undefined ? true : !this.enableCkEditor;
+  }
+
 }
 
 const tagName = "sakai-rubric-criterion-edit";


### PR DESCRIPTION
… CKEditor on page load

This has been tested successfully in 22.x, however, it caused a conflict and needed a little bit adjustment for 24.x. the part about getting the description before saving is not optimal but differs from 22.x, better safe than wrong without proper testing.

![SAK-48931](https://github.com/sakaiproject/sakai/assets/8653754/9cfcaacd-4cd7-4e1c-8e65-89192f1a9d6a)

[SAK-48931]: https://sakaiproject.atlassian.net/browse/SAK-48931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ