### PR TITLE
SAK-48373 - Roster: use a css class that actually exists

### DIFF
--- a/roster2/tool/src/webapp/js/roster.js
+++ b/roster2/tool/src/webapp/js/roster.js
@@ -805,7 +805,7 @@ roster.calculatePageSizes = function () {
 
   // height of container = height + top and bottom padding;
   // #roster-members-content has no height at load, so we approximate using the morpheus page container
-  var containerHeight = parseInt($('div.Mrphs-pagebody').height());
+  const containerHeight = parseInt($('div.portal-main-container').height());
 
   // number of rows per page = containerHeight / cardHeight, rounded down up nearest whole number
   var numBigRowsPerPage = Math.ceil(containerHeight / bigCardHeight);


### PR DESCRIPTION
(For the 2nd time since the original merge got undone by someone else's subsequent commit)

This is the same as #11492, but it got undone by #11530 