### PR TITLE
SAK-48927 - Gradebook: Don't escape the strings when setting the panel titles

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverrideLogPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverrideLogPanel.java
@@ -61,7 +61,8 @@ public class CourseGradeOverrideLogPanel extends BasePanel {
 		final GbUser user = this.businessService.getUser(studentUuid);
 		CourseGradeOverrideLogPanel.this.window.setTitle(
 				(new StringResourceModel("heading.coursegradelog", null,
-						new Object[] { user.getDisplayName(), user.getDisplayId() })).getString());
+						new Object[] { user.getDisplayName(), user.getDisplayId() })).getString())
+				.setEscapeModelStrings(false);
 
 		// get the course grade
 		final CourseGradeTransferBean courseGrade = this.businessService.getCourseGrade(studentUuid);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/CourseGradeOverridePanel.java
@@ -88,7 +88,8 @@ public class CourseGradeOverridePanel extends BasePanel {
 		// heading
 		CourseGradeOverridePanel.this.window.setTitle(
 				(new StringResourceModel("heading.coursegrade", null,
-						new Object[] { studentUser.getDisplayName(), studentUser.getDisplayId() })).getString());
+						new Object[] { studentUser.getDisplayName(), studentUser.getDisplayId() })).getString())
+				.setEscapeModelStrings(false);
 
 		// form model
 		// we are only dealing with the 'entered grade' so we use this directly
@@ -97,7 +98,7 @@ public class CourseGradeOverridePanel extends BasePanel {
 		// form
 		final Form<String> form = new Form<String>("form", formModel);
 
-		form.add(new Label("studentName", studentUser.getDisplayName()));
+		form.add(new Label("studentName", studentUser.getDisplayName()).setEscapeModelStrings(false));
 		form.add(new Label("studentEid", studentUser.getDisplayId()));
 		form.add(new Label("points", formatPoints(courseGrade, gradebook)));
 		form.add(new Label("calculated", courseGradeFormatter.format(courseGrade)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditCourseGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditCourseGradeCommentPanel.java
@@ -81,7 +81,8 @@ public class EditCourseGradeCommentPanel extends BasePanel {
         form.add(cancel);
         // heading
         final GbUser user = this.businessService.getUser(studentUuid);
-        EditCourseGradeCommentPanel.this.window.setTitle((new StringResourceModel("heading.editcomment", null, new Object[] { user.getDisplayName(), user.getDisplayId(), "Course Grade" })).getString());
+        EditCourseGradeCommentPanel.this.window.setTitle((new StringResourceModel("heading.editcomment", null, new Object[] { user.getDisplayName(), user.getDisplayId(), "Course Grade" })).getString())
+                .setEscapeModelStrings(false);
         // textarea
         form.add(new TextArea<>("comment", new PropertyModel<>(formModel, "gradeComment")).add(StringValidator.maximumLength(CommentValidator.getMaxCommentLength(serverConfigService))));
         add(form);

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/EditGradeCommentPanel.java
@@ -130,7 +130,8 @@ public class EditGradeCommentPanel extends BasePanel {
 		final Assignment assignment = this.businessService.getAssignment(assignmentId);
 		EditGradeCommentPanel.this.window.setTitle(
 				(new StringResourceModel("heading.editcomment", null,
-						new Object[] { user.getDisplayName(), user.getDisplayId(), assignment.getName() })).getString());
+						new Object[] { user.getDisplayName(), user.getDisplayId(), assignment.getName() })).getString())
+				.setEscapeModelStrings(false);
 
 		// textarea
 		form.add(new TextArea<>("comment", new PropertyModel<>(formModel, "gradeComment"))

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeLogPanel.java
@@ -115,7 +115,8 @@ public class GradeLogPanel extends BasePanel {
 		final GbUser user = this.businessService.getUser(studentUuid);
 		GradeLogPanel.this.window.setTitle(
 				(new StringResourceModel("heading.gradelog", null,
-						new Object[] { user.getDisplayName(), user.getDisplayId() })).getString());
+						new Object[] { user.getDisplayName(), user.getDisplayId() })).getString())
+				.setEscapeModelStrings(false);
 
 	}
 


### PR DESCRIPTION
I obviously don't have lots of test data locally, so if there are use cases where you would still need to escape these pieces, I'd be interested to hear about them!