### PR TITLE
SAK-48944 - Update plugins from Maven 3.9.2 related to plugin validation

### DIFF
--- a/basiclti/portlet-util/pom.xml
+++ b/basiclti/portlet-util/pom.xml
@@ -48,7 +48,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.7</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/config/configuration/bundles/pom.xml
+++ b/config/configuration/bundles/pom.xml
@@ -58,7 +58,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>buildnumber-maven-plugin</artifactId>
-				<version>1.4</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>
@@ -74,7 +73,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.6</version>
 				<executions>
 					<execution>
 						<phase>process-resources</phase>

--- a/jsf/jsf-app/pom.xml
+++ b/jsf/jsf-app/pom.xml
@@ -107,7 +107,6 @@
 	      <plugin>
 	        <groupId>org.apache.maven.plugins</groupId>
 	        <artifactId>maven-jar-plugin</artifactId>
-	        <version>2.4</version>
 	        <executions>
 	          <execution>
 	          	<id>jsf</id>

--- a/jsf2/jsf2-app/pom.xml
+++ b/jsf2/jsf2-app/pom.xml
@@ -95,7 +95,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>2.4</version>
             <executions>
               <execution>
                   <id>jsf2</id>

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -31,7 +31,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -265,7 +265,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>1.7</version>
                         <executions>
                             <execution>
                                 <id>add-source</id>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -109,7 +109,7 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.webjars</groupId>
+			<groupId>com.github.jknack</groupId>
 			<artifactId>handlebars</artifactId>
 			<version>${handlebars4.version}</version>
 			<scope>runtime</scope>
@@ -364,7 +364,6 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>buildnumber-maven-plugin</artifactId>
-						<version>1.4</version>
 						<executions>
 							<execution>
 								<phase>validate</phase>
@@ -530,7 +529,6 @@
 					<plugin>
 						<groupId>com.github.eirslett</groupId>
 						<artifactId>frontend-maven-plugin</artifactId>
-						<version>1.12.0</version>
 						<configuration>
 							<installDirectory>target</installDirectory>
 							<workingDirectory>${basedir}/src/skins/${sakai.skin.source}</workingDirectory>
@@ -575,7 +573,6 @@
 					</plugin>
 					<plugin>
 						<artifactId>maven-clean-plugin</artifactId>
-						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>remove-skin</id>
@@ -600,7 +597,7 @@
 					<plugin>
 						<groupId>com.github.jknack</groupId>
 						<artifactId>handlebars-maven-plugin</artifactId>
-						<version>4.0.5</version>
+						<version>${handlebars4.version}</version>
 						<executions>
 							<execution>
 								<id>templates</id>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -90,8 +90,8 @@
     <reflectutils.version>0.9.20</reflectutils.version>
     <json.simple.version>1.1.1</json.simple.version>
     <handlebars1.version>1.3.2</handlebars1.version>
-    <handlebars2.version>2.1.0</handlebars2.version>
-    <handlebars4.version>4.0.6</handlebars4.version>
+    <handlebars2.version>2.3.2</handlebars2.version>
+    <handlebars4.version>4.3.1</handlebars4.version>
     <hamcrest.all.version>1.3</hamcrest.all.version>
     <junit.version>4.13.2</junit.version>
     <sakai.nimbus.jose.jwt.version>8.2</sakai.nimbus.jose.jwt.version>
@@ -2444,12 +2444,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2459,12 +2459,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <configuration>
             <archive>
               <manifest>
@@ -2499,7 +2499,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2509,7 +2509,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2519,17 +2519,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2620,7 +2620,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>net.sourceforge.maven-taglib</groupId>
@@ -2663,6 +2663,21 @@
                 </dependency>
             </dependencies>
         </plugin>
+        <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <version>1.12.1</version>
+        </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.4.0</version>
+        </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <version>3.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -2683,7 +2698,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -2746,7 +2761,7 @@
         <inherited>true</inherited>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <compilerVersion>${sakai.jdk.version}</compilerVersion>
           <source>${sakai.jdk.version}</source>

--- a/simple-rss-portlet/pom.xml
+++ b/simple-rss-portlet/pom.xml
@@ -228,7 +228,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-war-plugin</artifactId>
-						<version>2.2</version>
 						<configuration>
 							<webXml>${project.build.directory}/pluto-resources/web.xml</webXml>
 						</configuration>

--- a/webcomponents/tool/pom.xml
+++ b/webcomponents/tool/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.4</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -125,7 +124,6 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.0</version>
                 <configuration>
                     <installDirectory>target</installDirectory>
                     <workingDirectory>src/main/frontend</workingDirectory>


### PR DESCRIPTION
This may still get some more updates. There's 9 plugins that could be fixed on this.

* 2 of them are our plugins that we'll need to update `org.sakaiproject.maven.plugins:sakai:1.4.5`,`org.sakaiproject.maven.plugins:webjars-maven-plugin:1.0`
* 1 of them has a new version but the config changed: `org.apache.maven.plugins:maven-antrun-plugin:1.3`
* 1 of them is an old version of handlebars that probably could get upgraded: `com.github.jknack:handlebars-maven-plugin:1.3.2`
* 2 will likely eventually get upgraded but haven't yet: `com.github.jknack:handlebars-maven-plugin:4.3.1`, `org.apache.maven.plugins:maven-war-plugin:3.3.2`, 
* 3 will likely never see upgrades so will need local updates or alternatives: `com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0`, `org.apache.pluto:maven-pluto-plugin:1.1.7`, `com.github.eirslett:frontend-maven-plugin:1.12.1`