### PR TITLE
SAK-48876 Lessons-Assignment: mainContentbug in spinner.js 

### DIFF
--- a/library/src/webapp/js/spinner.js
+++ b/library/src/webapp/js/spinner.js
@@ -24,7 +24,11 @@
 var SPNR = SPNR || {};
 
 // Get the main content div
-const mainContent = () => document.getElementById("content");
+const mainContent = () => {
+  const mc = document.getElementById("content");
+  const result = (mc) ? mc : document.getElementsByClassName('portletBody')[0];
+  return result;
+}
 
 /********** MAIN FUNCTIONS TO BE CALLED FROM OUTSIDE LIBRARY ******************/
 


### PR DESCRIPTION
The DOM within the iframe does not contain a "main" element (with id="content"). In such cases, the proposed fix returns the first element with class="portletBody".