### PR TITLE
S2U-27 Handle deleted forums/topic and other fixes

### DIFF
--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -956,6 +956,7 @@ topics_revise_title_validation=Please enter a valid topic title.
 
 #S2U-27
 pvt_publish_to_faq=Publish to FAQ
+pvt_publish_to_faq_success=The message was successfully published to FAQ
 pvt_title=Title
 pvt_question=Question
 pvt_question_title_prefix=Q:

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_ca.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_ca.properties
@@ -939,6 +939,7 @@ topics_revise_title_validation=Cal que introdu\u00efu un nom de tema v\u00e0lid.
 
 #S2U-27
 pvt_publish_to_faq=Publicar en Preguntes Freq\u00fcents
+pvt_publish_to_faq_success=El missatge s\u0027ha publicat correctament en Preguntes Mes Frequents
 pvt_title=T\u00edtol
 pvt_question=Pregunta
 pvt_question_title_prefix=P:

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_ca.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_ca.properties
@@ -939,7 +939,7 @@ topics_revise_title_validation=Cal que introdu\u00efu un nom de tema v\u00e0lid.
 
 #S2U-27
 pvt_publish_to_faq=Publicar en Preguntes Freq\u00fcents
-pvt_publish_to_faq_success=El missatge s\u0027ha publicat correctament en Preguntes Mes Frequents
+pvt_publish_to_faq_success=El missatge s\u2019ha publicat correctament en Preguntes Mes Frequents
 pvt_title=T\u00edtol
 pvt_question=Pregunta
 pvt_question_title_prefix=P:

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es.properties
@@ -950,6 +950,7 @@ topics_revise_title_validation=Introduzca un t\u00edtulo v\u00e1lido para el tem
 
 #S2U-27
 pvt_publish_to_faq=Publicar en preguntas frecuentes
+pvt_publish_to_faq_success=El mensaje se ha publicado correctamente en preguntas m\u00e1s frecuentes
 pvt_title=T\u00edtulo
 pvt_question=Pregunta
 pvt_question_title_prefix=P:

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_eu.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_eu.properties
@@ -894,6 +894,7 @@ perm-msg.permissions.allowToField.myGroupRoles=Norberaren taldeen rolei bidali
 
 #S2U-27
 pvt_publish_to_faq=Publikatu FAQ gisa
+pvt_publish_to_faq_success=The message was successfully published to FAQ
 pvt_title=Titulua
 pvt_question=Galdera
 pvt_question_title_prefix=Q:

--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsForumManager.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsForumManager.java
@@ -77,8 +77,41 @@ public interface MessageForumsForumManager {
 
     /**
      * Retrieve FAQ Forum from a given area
+     * @return existing faq forum or null
      */
     public DiscussionForum getFaqForumForArea(Area area);
+
+    /**
+     * Retrieve FAQ Topic from a given forum
+     * @return existing faq forum or null
+     */
+    public DiscussionTopic getFaqTopicForForum(DiscussionForum discussionForum);
+
+    /**
+     * Create and save FAQ Forum for a given area
+     * @return newly created faq forum
+     */
+    public DiscussionForum createFaqForum(Area discussionArea);
+
+    /**
+     * Create and save FAQ Topic for a given forum
+     * @return newly created faq topic
+     */
+    public DiscussionTopic createFaqTopic(DiscussionForum discussionForum);
+
+    /**
+     * Retrieve or create and save FAQ Forum from a given area
+     * Create and save FAQ Forum for a given area
+     * @return existing or newly created faq forum
+     */
+    public DiscussionForum getOrCreateFaqForumForArea(Area area);
+
+    /**
+     * Retrieve or create and save FAQ Topic from a given forum
+     * Create and save FAQ Forum for a given area
+     * @return existing or newly created faq topic
+     */
+    public DiscussionTopic getOrCreateFaqTopicForForum(DiscussionForum discussionForum);
 
     /**
      * Create and save an empty discussion forum

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -166,6 +166,7 @@ public class PrivateMessagesTool {
   private static final String NO_MARKED_MOVE_MESSAGE = "pvt_no_message_mark_move";
   private static final String MULTIDELETE_SUCCESS_MSG = "pvt_deleted_success";
   private static final String PERM_DELETE_SUCCESS_MSG = "pvt_perm_deleted_success";
+  private static final String SUCCESS_PUBLISH_TO_FAQ = "pvt_publish_to_faq_success";
   
   public static final String RECIPIENTS_UNDISCLOSED = "pvt_bccUndisclosed";
   
@@ -1060,6 +1061,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   public String processDisplayForum()
   {
     log.debug("processDisplayForum()");
+    multiDeleteSuccess = false;
     if (searchPvtMsgs != null)
     	searchPvtMsgs.clear();
     return DISPLAY_MESSAGES_PG;
@@ -1289,6 +1291,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   public String processPvtMsgReply() {
     log.debug("processPvtMsgReply()");
     
+    multiDeleteSuccess = false;
     setDetailMsgCount = 0;
 
     if (getDetailMsg() == null)
@@ -1363,6 +1366,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   public String processPvtMsgForward() {
 	    log.debug("processPvtMsgForward()");
 	    
+      multiDeleteSuccess = false;
 	    setDetailMsgCount = 0;
 	    
 	    if (getDetailMsg() == null)
@@ -1445,6 +1449,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   public String processPvtMsgReplyAll() {
 	    log.debug("processPvtMsgReplyAll()");
 	    
+      multiDeleteSuccess = false;
 	    setDetailMsgCount = 0;
 	    
 	    if (getDetailMsg() == null)
@@ -1603,6 +1608,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   public String processPvtMsgDeleteConfirm() {
     log.debug("processPvtMsgDeleteConfirm()");
     
+    this.setMultiDeleteSuccess(false);
     this.setDeleteConfirm(true);
     setErrorMessage(getResourceBundleString(CONFIRM_MSG_DELETE));
     /*
@@ -2020,6 +2026,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
    */
   public String processDisplayPreviousMsg()
   {
+	multiDeleteSuccess = false;
 
 	List tempMsgs = getDecoratedPvtMsgs(); // all messages
     int currentMsgPosition = -1;
@@ -2084,6 +2091,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
    */    
   public String processDisplayNextMsg()
   {
+	multiDeleteSuccess = false;
 
 	List tempMsgs = getDecoratedPvtMsgs();
     int currentMsgPosition = -1;
@@ -3711,6 +3719,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
   
   public String getMoveToTopic()
   {
+    multiDeleteSuccess = false;
     if(StringUtils.isNotEmpty(moveToNewTopic))
     {
       moveToTopic=moveToNewTopic;
@@ -3735,7 +3744,6 @@ public void processChangeSelectView(ValueChangeEvent eve)
     log.debug("processPvtMsgPublishToFaq()");
     MessageForumPublishToFaqBean publishToFaqBean =
         (MessageForumPublishToFaqBean) lookupBean(MessageForumPublishToFaqBean.NAME);
-    publishToFaqBean.publishToFaq();
 
     if (StringUtils.isBlank(publishToFaqBean.getTitle())) {
       setErrorMessage(getResourceBundleString(MISSING_TITLE));
@@ -3744,6 +3752,9 @@ public void processChangeSelectView(ValueChangeEvent eve)
       setErrorMessage(getResourceBundleString(MISSING_QUESTION));
       return null;
     } else {
+      publishToFaqBean.publishToFaq();
+      multiDeleteSuccessMsg = getResourceBundleString(SUCCESS_PUBLISH_TO_FAQ);
+      multiDeleteSuccess = true;
       return SELECTED_MESSAGE_PG;
     }
     
@@ -3751,6 +3762,7 @@ public void processChangeSelectView(ValueChangeEvent eve)
 
   public String processPvtMsgPublishToFaqEdit() {
     log.debug("processPvtMsgPublishToFaqEdit()");
+    multiDeleteSuccess = false;
 
     MessageForumPublishToFaqBean publishToFaqBean =
         (MessageForumPublishToFaqBean) lookupBean(MessageForumPublishToFaqBean.NAME);
@@ -4203,6 +4215,13 @@ public void processChangeSelectView(ValueChangeEvent eve)
     FacesContext.getCurrentInstance().addMessage(null,
         new FacesMessage(FacesMessage.SEVERITY_ERROR,
             getResourceBundleString(ALERT) + " " + errorMsg, null));
+  }
+
+  private void setSuccessMessage(String successMsg)
+  {
+    log.debug("setSuccessMessage(String " + successMsg + ")");
+    FacesContext.getCurrentInstance().addMessage(null,
+        new FacesMessage(FacesMessage.SEVERITY_INFO, successMsg, null));
   }
 
   private void setInformationMessage(String infoMsg)

--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsgDetail.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsgDetail.jsp
@@ -49,6 +49,7 @@
 <!--jsp/privateMsg/pvtMsgDetail.jsp-->
 <%--			<sakai:tool_bar_message value="#{msgs.pvt_detmsgreply}" /> --%> 
 			<h:messages styleClass="alertMessage" id="errorMessages" rendered="#{! empty facesContext.maximumSeverity}"/> 
+            <h:outputText value="#{PrivateMessagesTool.multiDeleteSuccessMsg}" styleClass="sak-banner-success" rendered="#{PrivateMessagesTool.multiDeleteSuccess}" />
 
 <h:panelGrid columns="2" width="100%" styleClass="navPanel specialLink">
 	<h:panelGroup>

--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsgPublishToFaqEdit.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsgPublishToFaqEdit.jsp
@@ -66,12 +66,12 @@
                 <h:outputText value=" #{msgs.pvt_star}" styleClass="highlight" />
             </h:outputLabel>
             <sakai:inputRichText id="question" value="#{mfPublishToFaqBean.question}" textareaOnly="#{PrivateMessagesTool.mobileSession}"
-                    rows="#{ForumTool.editorRows}" cols="132" />
+                    rows="#{ForumTool.editorRows}" />
         </h:panelGroup>
-        <h:panelGroup styleClass="form-group" layout="block" rendered="mfPublishToFaqBean.canReply">
+        <h:panelGroup styleClass="form-group" layout="block" rendered="#{mfPublishToFaqBean.canReply}">
             <h:outputLabel for="answer" value="#{msgs.pvt_answer}" styleClass="control-label" />
             <sakai:inputRichText id="answer" value="#{mfPublishToFaqBean.answer}" textareaOnly="#{PrivateMessagesTool.mobileSession}"
-                    rows="#{ForumTool.editorRows}" cols="132" />
+                    rows="#{ForumTool.editorRows}" />
             <h:panelGroup styleClass="b5 form-text" layout="block">
                 <h:outputText value="#{msgs.pvt_answer_info}" />
             </h:panelGroup>


### PR DESCRIPTION
- When the automatically created faq forum or topic is deleted, the private message page was broken. Now a new forum or topic is created. 
- A success message is displayed, after the message is published to faq
- The answer field was not displayed in the edit form, that's fixed as well

https://sakaiproject.atlassian.net/browse/S2U-27