### PR TITLE
S2U-24 Tests & Quizzes: Event Log - Several fixes

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -139,6 +139,12 @@ public final class SamigoConstants {
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_ENABLED     = "samigo.email.autoSubmit.errorNotification.enabled";
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_TO_ADDRESS  = "samigo.email.autoSubmit.errorNotification.toAddress";
     public static final     String      SAK_PROP_SUPPORT_EMAIL_ADDRESS                      = "mail.support";
+    public static final     String      SAK_PROP_EVENTLOG_IPADDRESS_ENABLED                 = "samigo.eventlog.ipaddress.enabled";
+
+    /*
+     * Sakai.properties defaults
+     */
+    public static final     boolean     SAK_PROP_DEFAULT_EVENTLOG_IPADDRESS_ENABLED                 = false;
 
     /*
      * Message Bundles

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EventLogMessages_ca.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EventLogMessages_ca.properties
@@ -62,6 +62,6 @@ alt_sortIPAscending=Ordena per adre\u00e7a IP en sentit ascendent
 alt_sortIPDescending=Ordena per adre\u00e7a IP en sentit descendent
 
 # S2U-24
-export_csv=Export as CSV
+export_csv=Exportar com a CSV
 
-datatables_entities=records
+datatables_entities=esdeveniments

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EventLogMessages_es.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EventLogMessages_es.properties
@@ -62,6 +62,6 @@ alt_sortIPAscending=Ordenar por direcci\u00f3n IP en orden ascendente
 alt_sortIPDescending=Ordenar por direcci\u00f3n IP en orden descendente
 
 # S2U-24
-export_csv=Exportar com a CSV
+export_csv=Exportar como CSV
 
-datatables_entities=esdeveniments
+datatables_entities=eventos

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/EventLogBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/EventLogBean.java
@@ -63,14 +63,14 @@ public class EventLogBean implements Serializable {
 	
 	private Map<Long,Integer> statusMap;
 		
-	private static final String SAMIGO_EVENTLOG_IPADDRESS_ENABLE = "samigo.eventlog.ipaddress.enabled";
 	private boolean enabledIpAddress = false;
 	private ServerConfigurationService serverConfigurationService;
 		
 	public EventLogBean()
 	{		
 		serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
-		enabledIpAddress = serverConfigurationService.getBoolean(SAMIGO_EVENTLOG_IPADDRESS_ENABLE, false);			
+		enabledIpAddress = serverConfigurationService.getBoolean(SamigoConstants.SAK_PROP_EVENTLOG_IPADDRESS_ENABLED,
+				SamigoConstants.SAK_PROP_DEFAULT_EVENTLOG_IPADDRESS_ENABLED);			
 	}
 		
 	/**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/EventLogListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/EventLogListener.java
@@ -31,6 +31,8 @@ import javax.faces.model.SelectItem;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.site.cover.SiteService;
@@ -51,6 +53,7 @@ public class EventLogListener
 implements ActionListener, ValueChangeListener
 {
 	private BeanSort bs;
+	private ServerConfigurationService serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
 
 	public EventLogListener() {}
 
@@ -219,6 +222,9 @@ implements ActionListener, ValueChangeListener
 	}
 
 	private DataTableConfig eventLogDataTableConfig(boolean titleColumnSortable) {
+		boolean displayIpAddressColumn = serverConfigurationService.getBoolean(SamigoConstants.SAK_PROP_EVENTLOG_IPADDRESS_ENABLED,
+				SamigoConstants.SAK_PROP_DEFAULT_EVENTLOG_IPADDRESS_ENABLED);
+
 		return DataTableConfig.builderWithDefaults()
 				.entitiesMessage(ContextUtil.getLocalizedString(SamigoConstants.EVENT_LOG_BUNDLE, "datatables_entities"))
 				.columns(new LinkedList<DataTableColumn>() {{
@@ -262,6 +268,13 @@ implements ActionListener, ValueChangeListener
 								.orderable(true)
 								.searchable(false)
 								.build());
+						// IP ADDRESS
+						if (displayIpAddressColumn) {
+							add(DataTableColumn.builder()
+									.orderable(true)
+									.searchable(true)
+									.build());
+						}
 				}}).build();
 	}
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/model/DataTableColumn.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/model/DataTableColumn.java
@@ -12,6 +12,7 @@ public class DataTableColumn {
     public static final String TYPE_HTML_NUM = "html-num";
     public static final String TYPE_NUM = "numeric";
     public static final String TYPE_ANY_NUM = "any-number";
+    public static final String TYPE_IP_ADDRESS = "ip-address";
 
 
     private boolean orderable;

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
@@ -106,7 +106,9 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
                 add(RESOURCE_BUNDLE.getString("date_submitted"));
                 add(RESOURCE_BUNDLE.getString("duration"));
                 add(RESOURCE_BUNDLE.getString("errors"));
-                add(RESOURCE_BUNDLE.getString("ipAddress"));
+                if (displayIpAddressColumn) {
+                    add(RESOURCE_BUNDLE.getString("ipAddress"));
+                }
         }};
         lines.add(headerList.toArray(new String[headerList.size()]));
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
@@ -39,9 +39,9 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
     private static final DateTimeFormatter EXPORT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final ResourceLoader RESOURCE_BUNDLE = new ResourceLoader(SamigoConstants.EVENT_LOG_BUNDLE);
 
-    private UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
 	private ServerConfigurationService serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
     private FormattedText formattedText = ComponentManager.get(FormattedText.class);
+    private UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
 
     public static final String PARAM_SITE_ID = "siteId";
     public static final String PARAM_ASSESSMENT_ID = "assessmentId";

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
@@ -29,7 +29,6 @@ import org.sakaiproject.util.ResourceLoader;
 
 import com.opencsv.CSVWriter;
 import com.opencsv.CSVWriterBuilder;
-import com.opencsv.ICSVWriter;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
@@ -5,11 +5,11 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.ResourceBundle;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.time.api.UserTimeService;
@@ -24,8 +25,11 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.EventLogData;
 import org.sakaiproject.tool.assessment.services.assessment.EventLogService;
 import org.sakaiproject.tool.assessment.ui.servlet.SamigoBaseServlet;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.ResourceLoader;
 
 import com.opencsv.CSVWriter;
+import com.opencsv.CSVWriterBuilder;
+import com.opencsv.ICSVWriter;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,9 +38,10 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
 
 
     private static final DateTimeFormatter EXPORT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-    private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(SamigoConstants.EVENT_LOG_BUNDLE);
+    private static final ResourceLoader RESOURCE_BUNDLE = new ResourceLoader(SamigoConstants.EVENT_LOG_BUNDLE);
 
     private UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
+	private ServerConfigurationService serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
     private FormattedText formattedText = ComponentManager.get(FormattedText.class);
 
     public static final String PARAM_SITE_ID = "siteId";
@@ -74,9 +79,12 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
             return;
         }
 
+        boolean displayIpAddressColumn = serverConfigurationService.getBoolean(SamigoConstants.SAK_PROP_EVENTLOG_IPADDRESS_ENABLED,
+                SamigoConstants.SAK_PROP_DEFAULT_EVENTLOG_IPADDRESS_ENABLED);
+
         // Set headers
         String filename = StringUtils.replace(RESOURCE_BUNDLE.getString("log"), " ", "_");
-        res.setContentType("text/csv");
+        res.setContentType("text/csv; charset=utf-8");
         res.setHeader("Content-Disposition", "\"attachment;filename=\"" + filename + ".csv\";");
 
         // Get data
@@ -89,30 +97,37 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
         }
 
         // Prepare data for csv
-        List<String[]> lines = new LinkedList<>() {{
-            // Add headers
-            add(new String[] {
-                RESOURCE_BUNDLE.getString("title"),
-                RESOURCE_BUNDLE.getString("id"),
-                RESOURCE_BUNDLE.getString("user_id"),
-                RESOURCE_BUNDLE.getString("date_startd"),
-                RESOURCE_BUNDLE.getString("date_submitted"),
-                RESOURCE_BUNDLE.getString("duration")
-            });
+        List<String[]> lines = new LinkedList<>();
+
+        List<String> headerList = new ArrayList<>(){{
+                add(RESOURCE_BUNDLE.getString("title"));
+                add(RESOURCE_BUNDLE.getString("id"));
+                add(RESOURCE_BUNDLE.getString("user_id"));
+                add(RESOURCE_BUNDLE.getString("date_startd"));
+                add(RESOURCE_BUNDLE.getString("date_submitted"));
+                add(RESOURCE_BUNDLE.getString("duration"));
+                add(RESOURCE_BUNDLE.getString("errors"));
+                add(RESOURCE_BUNDLE.getString("ipAddress"));
         }};
+        lines.add(headerList.toArray(new String[headerList.size()]));
 
         for (EventLogData eventLogData : eventLogDataList) {
             Integer minutes = eventLogData.getEclipseTime();
 
-            lines.add(new String[] {
-                eventLogData.getTitle(),
-                eventLogData.getAssessmentIdStr(),
-                eventLogData.getUserDisplay(),
-                csvDateFormat(eventLogData.getStartDate()),
-                csvDateFormat(eventLogData.getEndDate()),
-                minutes != null ? minutes.toString() : null,
-                StringUtils.trimToEmpty(eventLogData.getErrorMsg())
-            });
+            List<String> cellList = new ArrayList<>(){{
+                    add(eventLogData.getTitle());
+                    add(eventLogData.getAssessmentIdStr());
+                    add(eventLogData.getUserDisplay());
+                    add(csvDateFormat(eventLogData.getStartDate()));
+                    add(csvDateFormat(eventLogData.getEndDate()));
+                    add(minutes != null ? minutes.toString() : null);
+                    add(StringUtils.trimToEmpty(eventLogData.getErrorMsg()));
+                    if (displayIpAddressColumn) {
+                        add(StringUtils.trimToEmpty(eventLogData.getIpAddress()));
+                    }
+            }};
+
+            lines.add(cellList.toArray(new String[cellList.size()]));
         }
 
         // Write csv to response
@@ -125,10 +140,8 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
     private void writeCsv(List<String[]> lines, Writer writer) {
         char csvSeperator = StringUtils.equals(formattedText.getDecimalSeparator(), ",") ? ';' : ',';
 
-        try (CSVWriter csvWriter = new CSVWriter(writer, csvSeperator, '"', '\\', "\n")) {
-            for (String[] line : lines) {
-                csvWriter.writeNext(line);
-            }
+        try (CSVWriter csvWriter = (CSVWriter) new CSVWriterBuilder(writer).withSeparator(csvSeperator).build()) {
+            csvWriter.writeAll(lines);
         } catch (Exception e) {
             log.debug("Could not write csv: {}", e.toString());
         }


### PR DESCRIPTION
Fixes:
- Only English bundle being used for export
- Spanish bundle is Catalan, Catalan bundle is English
- UTF-8 encoding not specified in HTTP header for export
- Errors header not present in export
- IP Address column not present in export
- Datatables column configuration for IP Address column not defined 

https://sakaiproject.atlassian.net/browse/S2U-24
