### PR TITLE
SAK-48763 Gradebook: Scores are not visible for all students in group assignment

### DIFF
--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
@@ -281,7 +281,7 @@ public interface GradingService extends EntityProducer {
      * @param gradebookUid
      * @param assignmentId
      * @param studentUid
-     * @param comment a plain text comment, or null to remove any currrent comment
+     * @param comment a plain text comment, or null to remove any current comment
      * @throws AssessmentNotFoundException
      */
     public void setAssignmentScoreComment(String gradebookUid, Long assignmentId, String studentUid, String comment)

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -117,6 +117,7 @@ import org.sakaiproject.plus.api.PlusService;
 import org.sakaiproject.grading.api.GradingAuthz;
 import org.sakaiproject.util.ResourceLoader;
 
+import org.springframework.lang.Nullable;
 import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -5035,10 +5036,10 @@ public class GradingServiceImpl implements GradingService {
         return commentDefinition;
     }
 
-    public void setAssignmentScoreComment(String gradebookUid, Long assignmentId, String studentUid, String commentText) throws AssessmentNotFoundException {
+    public void setAssignmentScoreComment(String gradebookUid, Long assignmentId, String studentUid, @Nullable String commentText) throws AssessmentNotFoundException {
 
-        if (StringUtils.isBlank(gradebookUid) || assignmentId == null || StringUtils.isBlank(studentUid) || StringUtils.isBlank(commentText)) {
-            throw new IllegalArgumentException("gradebookUid, assignmentId, studentUid and commentText must be valid.");
+        if (StringUtils.isBlank(gradebookUid) || assignmentId == null || StringUtils.isBlank(studentUid)) {
+            throw new IllegalArgumentException("gradebookUid, assignmentId and studentUid must be valid.");
         }
 
         GradebookAssignment gradebookColumn = getAssignmentWithoutStats(gradebookUid, assignmentId);


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48763

The reason for the issue is that an error is raised at the beginning of the ```setAssignmentScoreComment()``` function, preventing the grade from being populated in the Gradebook. 

To address this, the solution is to resolve the parameter checking. In my opinion, ```commentText``` can be an empty string, so the empty string checking for it can be removed. @adrianfish Is it correct?