### PR TITLE
SAK-48818 set due on defaultTask to be current epoch millis

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/sakai-date-picker.js
+++ b/webcomponents/tool/src/main/frontend/js/sakai-date-picker.js
@@ -2,7 +2,6 @@ import { SakaiElement } from "./sakai-element.js";
 import { html } from "./assets/lit-element/lit-element.js";
 import { getOffsetFromServerMillis, getTimezone } from "./sakai-portal-utils.js";
 import { toTemporalInstant } from "./assets/@js-temporal/polyfill/dist/index.esm.js";
-//import { Temporal, Intl, toTemporalInstant } from "./assets/@js-temporal/polyfill/dist/index.esm.js";
 
 Date.prototype.toTemporalInstant = toTemporalInstant;
 

--- a/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
+++ b/webcomponents/tool/src/main/frontend/js/tasks/sakai-tasks-create-task.js
@@ -38,7 +38,7 @@ export class SakaiTasksCreateTask extends SakaiDialogContent {
     super();
 
     this.deliverTasks = false;
-    this.defaultTask = { taskId: "", description: "", priority: "3", notes: "", due: "", assignationType: "", selectedGroups: [], siteId: "", owner: "", taskAssignedTo: "", complete: null };
+    this.defaultTask = { taskId: "", description: "", priority: "3", notes: "", due: Date.now(), assignationType: "", selectedGroups: [], siteId: "", owner: "", taskAssignedTo: "", complete: null };
     this.task = { ...this.defaultTask};
     this.assignationType = "user";
     this.mode = "create";


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48818

The basic problem with this issue is that on FF change is only fired when the time fields are populated, so due on the task is never set. Setting the default due to the current epoch millis will populate the datetime-local time fields and hopefully inform the user how to set those fields.

Mozilla has an open ticket about actually showing the time picker alongside the date picker, as Chrome does. *Hopefully*, this will be coming down the pipeline soon.

https://bugzilla.mozilla.org/show_bug.cgi?id=1726108