### PR TITLE
SAK-48969 Assignments TAs unable to grade group submissions for their own section

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -642,6 +642,7 @@ public interface AssignmentService extends EntityProducer {
      * @return The list of selected group users based on the specified criteria.
      */
     List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment assignment, List<User> allowAddSubmissionUsers);
+    
     /**
      * @param accentedString
      * @return

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -632,6 +632,7 @@ public interface AssignmentService extends EntityProducer {
      */
     String getSubmitterIdForAssignment(Assignment assignment, User user);
 
+    List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment a, List<User> allowAddSubmissionUsers);
     /**
      * @param accentedString
      * @return

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -632,7 +632,16 @@ public interface AssignmentService extends EntityProducer {
      */
     String getSubmitterIdForAssignment(Assignment assignment, User user);
 
-    List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment a, List<User> allowAddSubmissionUsers);
+    /**
+     * Retrieves the selected group users based on the given parameters.
+     *
+     * @param allOrOneGroup           Determines if all groups or a specific group should be considered.
+     * @param contextString           The context string indicating the site title.
+     * @param assignment              The assignment object for which the users are selected.
+     * @param allowAddSubmissionUsers The list of users allowed to submit the assignment.
+     * @return The list of selected group users based on the specified criteria.
+     */
+    List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment assignment, List<User> allowAddSubmissionUsers);
     /**
      * @param accentedString
      * @return

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2699,7 +2699,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         return submitter;
     }
 
-    public List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment a, List<User> allowAddSubmissionUsers) {
+    public List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment assignment, List<User> allowAddSubmissionUsers) {
         Collection<String> authzRefs = new ArrayList<>();
 
         List<User> selectedGroupUsers = new ArrayList<>();
@@ -2716,7 +2716,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     }
                 } else {
                     // get all those groups that user is allowed to grade
-                    Collection<Group> groups = getGroupsAllowGradeAssignment(AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference());
+                    Collection<Group> groups = getGroupsAllowGradeAssignment(AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference());
                     groups.forEach(g -> authzRefs.add(g.getReference()));
                 }
             } else {

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2426,20 +2426,15 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         allOrOneGroup = StringUtils.trimToNull(allOrOneGroup);
         try {
             Assignment a = getAssignment(assignmentId);
+            String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference();
+
             if (a != null) {
                 Site st = siteService.getSite(contextString);
                 if (StringUtils.equals(allOrOneGroup, AssignmentConstants.ALL) || StringUtils.isEmpty(allOrOneGroup)) {
                     if (a.getTypeOfAccess().equals(SITE)) {
-                        for (Group group : st.getGroups()) {
-                            rv.add(group);
-                        }
+                        rv.addAll(st.getGroups());
                     } else {
-                        for (String groupRef : a.getGroups()) {
-                            Group group = st.getGroup(groupRef);        // NO SECTIONS (this might not be valid test for manually created sections)
-                            if (group != null) {
-                                rv.add(group);
-                            }
-                        }
+                        rv.addAll(getGroupsAllowGradeAssignment(assignmentReference));
                     }
                 } else {
                     Group group = st.getGroup(allOrOneGroup);
@@ -2451,7 +2446,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 for (Group g : rv) {
                     AssignmentSubmission uSubmission = getSubmission(assignmentId, g.getId());
                     if (uSubmission == null) {
-                        if (allowGradeSubmission(AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference())) {
+                        if (allowGradeSubmission(assignmentReference)) {
                             if (a.getIsGroup()) {
                                 // temporarily allow the user to read and write from assignments (asn.revise permission)
                                 SecurityAdvisor securityAdvisor = new MySecurityAdvisor(

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2699,7 +2699,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         return submitter;
     }
 
-    private List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment a, List allowAddSubmissionUsers) {
+    public List<User> getSelectedGroupUsers(String allOrOneGroup, String contextString, Assignment a, List<User> allowAddSubmissionUsers) {
         Collection<String> authzRefs = new ArrayList<>();
 
         List<User> selectedGroupUsers = new ArrayList<>();

--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -926,7 +926,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
 
         List<SimpleGroup> groups = assignmentService.getGroupsAllowGradeAssignment(assignmentReference)
                 .stream().map(SimpleGroup::new).sorted((group, otherGroup) -> StringUtils.compare(group.getTitle(), otherGroup.getTitle())).collect(Collectors.toList());
-        
+
         // Get all users who are allowed to submit.
         List<User> allowAddSubmissionUsers = assignmentService.allowAddSubmissionUsers(assignmentReference);
         Set<String> activeSubmitters = allowAddSubmissionUsers.stream().map(Entity::getId).collect(Collectors.toSet());


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48969

This issue occurs because the ```getGradableForSite()``` endpoint returns all submissions without filtering those that the current user does not have access to. To address this, we need to update the endpoint implementation to filter the submissions based on the access rights of the current user.

1. The ```getSelectedGroupUsers()``` function has been modified to make it ```public``` and the last parameter type has been changed from ```List``` to ```List<User>```. This change ensures consistency across all usages of the function, as all the places where it is used already pass a ```List<User>``` as the last parameter. 

2. I use ```assignmentService.allowAddSubmissionUser()``` function to fetch the users who are allowed to submit. These users are the same as those displayed in the "Submissions" page of the Assignment, which is accessed by clicking the "grade" button. (Refer to the screenshot)

3. Add a filter in ```getGradableForSite()``` to ensure that for the current assignment, the current user can only view submitters who are visible to them.

4. Add a filter in ```getSubmitterGroupList()``` to ensure that for the group assignment, the current user can only view groups where they have the grading permission.


Individual assignment:
<img width="1908" alt="SAK-48969-local" src="https://github.com/sakaiproject/sakai/assets/102482288/0d885151-e507-4567-af37-287bbdfeb412">

Group assignment:
<img width="1910" alt="SAK-48969-local-group" src="https://github.com/sakaiproject/sakai/assets/102482288/3e64e3de-184d-43b1-b578-c3a2c433850e">


