### PR TITLE
SAK-48998 Footer build info is missing

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -52,7 +52,6 @@
 	                                <pluginExecutionFilter>
 	                                    <groupId>org.apache.maven.plugins</groupId>
 	                                    <artifactId>maven-antrun-plugin</artifactId>
-	                                    <versionRange>[1.6,)</versionRange>
 	                                    <goals>
 	                                        <goal>run</goal>
 	                                    </goals>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -2679,6 +2679,11 @@
             <artifactId>buildnumber-maven-plugin</artifactId>
             <version>3.1.0</version>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/pack/pom.xml
+++ b/pack/pom.xml
@@ -125,7 +125,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.6</version>
                 </plugin>
                 <plugin>
                     <inherited>true</inherited>

--- a/webjars/ckeditor-a11ychecker/pom.xml
+++ b/webjars/ckeditor-a11ychecker/pom.xml
@@ -36,7 +36,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>

--- a/webjars/ckeditor-balloonpanel/pom.xml
+++ b/webjars/ckeditor-balloonpanel/pom.xml
@@ -36,7 +36,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>


### PR DESCRIPTION
This fixes [SAK-48998]. It looks like a previous commit pushed the antrun plugin back to 1.3.

I tested some more and didn't see any issue upgrading everything up to 3.1.0. Everything is building and this fixes the issue.

[SAK-48998]: https://sakaiproject.atlassian.net/browse/SAK-48998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ