### PR TITLE
SAK-48773 Calendar: Dark mode not obeyed + removed 'bg-light' class

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
+++ b/assignment/tool/src/webapp/vm/assignment/assignment_macros.vm
@@ -47,7 +47,7 @@
 ## Macro for the paginator
 #macro( paginator $topMsgPos $btmMsgPos $allMsgNumber $pagesize $goFPButton $goPPButton $goNPButton $goLPButton $sakai_csrf_token $pagesizes )
     <nav class="assignment-pager panel panel-default">
-        <div class="card text-center bg-light" id="pagingHeader">
+        <div class="card text-center" id="pagingHeader">
             $tlang.getString( "gen.viewing" ) $topMsgPos - $btmMsgPos $tlang.getString( "gen.of" ) $allMsgNumber $tlang.getString( "gen.items" )
         </div>
         <div class="card-body">

--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar-opaqueUrlExisting.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar-opaqueUrlExisting.vm
@@ -15,7 +15,7 @@
 			$tlang.getString('ical_opaqueurl_myworkspace')
 		</p>
 	#end
-	<div class="card text-dark bg-light mb-3 p-3">
+	<div class="card mb-3 p-3">
 		<p>$tlang.getString("ical_opaqueurl_webcal")<br/>
 			<a href="$!webcalUrl" target="_new_">$webcalUrl</a>
 		</p>

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_urls.vm
@@ -46,7 +46,7 @@
 				#set($i = $i + 1)
 				#set($next = $i + 1)
 				
-				<div id="contentDiv${DOT}$i" class="card text-dark bg-light mb-3 p-3">
+				<div id="contentDiv${DOT}$i" class="card mb-3 p-3">
 					<input type="hidden" name="exists${DOT}$i" id="exists${DOT}$i" value="true" />
 					<input type="hidden" name="extension${DOT}$i" id="extension${DOT}$i" value=".URL" />
 					<div class="form-group">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/GradeItemImportOmissionsPanel.html
@@ -5,7 +5,7 @@
             <div wicket:id="omissionsContainer">
                 <div wicket:id="missingUsersContainer">
                     <div class="card">
-                        <div class="card text-center bg-light" role="tab" id="missingUsersHeader">
+                        <div class="card text-center" role="tab" id="missingUsersHeader">
                             <h3 class="panel-title">
                                 <a role="button" data-bs-toggle="collapse" href="#missingUsers" aria-expanded="false" aria-controls="missingUsers">
                                     <wicket:message wicket:id="missingUsersHeader">{0} students were found in the Gradebook who are missing from the import file</wicket:message>
@@ -25,7 +25,7 @@
                 </div>
                 <div wicket:id="unknownUsersContainer">
                     <div class="card">
-                        <div class="card text-center bg-light" role="tab" id="unknownUsersHeader">
+                        <div class="card text-center" role="tab" id="unknownUsersHeader">
                             <h3 class="panel-title">
                                 <a role="button" data-bs-toggle="collapse" href="#unknownUsers" aria-expanded="false" aria-controls="unknownUsers">
                                     <wicket:message wicket:id="unknownUsersHeader">{0} students in the import file could not be found in the Gradebook</wicket:message>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/PreviewImportedGradesPanel.html
@@ -3,7 +3,7 @@
     <body>
         <wicket:panel>
             <div class="card">
-                <div class="card text-center bg-light" role="tab" id="previewGradesHeader">
+                <div class="card text-center" role="tab" id="previewGradesHeader">
                     <h3 class="panel-title">
                         <a role="button" data-bs-toggle="collapse" href="#previewGrades" aria-expanded="false" aria-controls="previewGrades">
                             <wicket:message wicket:id="previewGradesHeader">Preview Grades for '{0}'</wicket:message>

--- a/help/help-component/src/bundle/TutorialMessages.properties
+++ b/help/help-component/src/bundle/TutorialMessages.properties
@@ -75,7 +75,7 @@ introToSakai_toolMenu.title=Tools Menu
 introToSakai_toolMenu.body=Tools for the current site appear in the left menu. Each tool serves a different function, such as delivering content, providing assessments, or facilitating collaboration.<br/><br/>\
 Each site maintainer, such as the instructor, controls which tools appear in the site.\
 <br/><br/>\
-The tool menu can be opened or closed by clicking on the <span class="no-wrap">( <i class="bi bi-chevron-right" style="font-weight: bold; font-size: 18px;"></i>) chevron icon</span> next to the site title.
+The tool menu can be opened or closed by clicking on the expand/collapse <span class="no-wrap">( <i class="bi bi-chevron-right" style="font-weight: bold; font-size: 18px;"></i>) chevron icon</span> next to the site title.
 
 
 # Help Icon Panel (Desktop View Only)

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/histogramScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/histogramScores.jsp
@@ -247,7 +247,7 @@ $Id$
         </table>
         </h:panelGroup>
         <h:panelGroup layout="block" styleClass="panel panel-default">
-          <div class="card text-center bg-light" style="padding-top: 1px;padding-bottom: 1px;">
+          <div class="card text-center" style="padding-top: 1px;padding-bottom: 1px;">
             <strong>
               <h2>
                 <h:outputText value="#{evaluationMessages.fsd}" />

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step2.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step2.html
@@ -14,7 +14,7 @@
     </div>
     <div class="row">
       <div class="col-sm-8">
-        <div class="card text-dark bg-light mb-3 p-3">
+        <div class="card mb-3 p-3">
           <div th:text="#{autogroups.step2.role.info}">We see that you have selected to make groups of participants in the following role(s):</div>
             <ul>
               <li th:each="role : ${autoGroupsForm.selectedRoleList}"><span th:text="${role}"></span></li>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step3.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step3.html
@@ -9,7 +9,7 @@
     <div th:replace="fragments/wizard :: step (step3)"></div><br/>
     <div class="row">
       <div class="col-sm-8">
-        <div class="card text-dark bg-light mb-3 p-3">
+        <div class="card mb-3 p-3">
           <div th:text="#{autogroups.step3.role.info}">We see that you have selected to make groups of participants in the following role(s):</div>
             <ul>
               <li th:each="role : ${autoGroupsForm.selectedRoleList}"><span th:text="${role}"></span></li>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html
@@ -47,7 +47,7 @@
       </div>
       <div id="joinableOptionsDiv" class="row" th:if="${!joinableSetList.isEmpty()}">
         <div class="col-sm-8">
-          <div class="card text-dark bg-light mb-3 p-3">
+          <div class="card mb-3 p-3">
             <div class="form-check">
               <label for="groupAllowPreviewMembership" class="form-control-label block">
                 <input id="groupAllowPreviewMembership" class="form-check-input" type="checkbox" th:field="*{groupAllowPreviewMembership}" th:checked="${groupForm.groupAllowPreviewMembership}"/>

--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-summary.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-summary.js
@@ -66,7 +66,7 @@ export class SakaiRubricSummary extends rubricsApiMixin(RubricsElement) {
           ${this.criteria.map((c) => html`
             <div class="mb-2">
               <div class="card">
-                <div class="card text-center bg-light">
+                <div class="card text-center">
                   <h4>
                     <a class="collapse-toggle collapsed" data-bs-toggle="collapse" href="#collapse${c.id}">${c.title}</a>
                   </h4>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-48773

During the early stages of the Trinity project, the `bg-light` class from Bootstrap 5 was incorporated. However, it's time to eliminate it now. This is because it persistently overrides the appropriate background color when in dark mode.