### PR TITLE
SAK-44549 - Fix references to non-existent tool.css

### DIFF
--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -1918,7 +1918,7 @@ public class SakaiBLTIUtil {
 	ext_ims_lti_tool_setting_url: http://localhost:8080/imsblis/service/
 	ext_lms: sakai-24-SNAPSHOT
 	ext_sakai_academic_session: OTHER
-	ext_sakai_launch_presentation_css_url_list: http://localhost:8080/library/skin/tool_base.css,http://localhost:8080/library/skin/morpheus-default/tool.css?version=49b21ca5
+	ext_sakai_launch_presentation_css_url_list: http://localhost:8080/library/skin/tool_base.css,http://localhost:8080/library/skin/default-skin/tool.css?version=49b21ca5
 	ext_sakai_role: maintain
 	ext_sakai_server: http://localhost:8080
 	ext_sakai_serverid: MacBook-Pro-92.local

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/lti13/util/SakaiExtension.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/lti13/util/SakaiExtension.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Generated("com.googlecode.jsonschema2pojo")
 
 // ext_sakai_academic_session: OTHER
-// ext_sakai_launch_presentation_css_url_list: http://localhost:8080/library/skin/tool_base.css,http://localhost:8080/library/skin/morpheus-default/tool.css?version=49b21ca5
+// ext_sakai_launch_presentation_css_url_list: http://localhost:8080/library/skin/tool_base.css,http://localhost:8080/library/skin/default-skin/tool.css?version=49b21ca5
 // ext_sakai_role: maintain
 // ext_sakai_server: http://localhost:8080
 // ext_sakai_serverid: MacBook-Pro-92.local

--- a/citations/citations-servlet/servlet/src/webapp/vm/compact.vm
+++ b/citations/citations-servlet/servlet/src/webapp/vm/compact.vm
@@ -19,7 +19,7 @@
 		<meta http-equiv="Content-Style-Type" content="text/css" />
 		<title>$tlang.getString( "window.gscholar" )</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 		<link href="/savecite/css/savecite.css" type="text/css" rel="stylesheet" media="all" />
 		<script type="text/javascript" src="/library/webjars/jquery/1.12.4/jquery.min.js"></script>
 	</head>

--- a/citations/citations-servlet/servlet/src/webapp/vm/servlet.vm
+++ b/citations/citations-servlet/servlet/src/webapp/vm/servlet.vm
@@ -19,7 +19,7 @@
 		<meta http-equiv="Content-Style-Type" content="text/css" />
 		<title>$tlang.getString( "window.gscholar" )</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 		<script type="text/javascript" src="/library/webjars/jquery/1.12.4/jquery.min.js"></script>
 		<script type="text/javascript" src="/savecite/js/savecite.js"></script>
 	</head>

--- a/cloud-storage/googledrive/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/cloud-storage/googledrive/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -4,7 +4,7 @@
 	<head>
 	    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
-	    <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
+	    <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
         <script src="/library/js/headscripts.js" type="text/javascript"></script>
 	    <meta http-equiv="Content-Style-Type" content="text/css" />
 	</head>

--- a/cloud-storage/onedrive/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/cloud-storage/onedrive/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -4,7 +4,7 @@
 	<head>
 	    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
-	    <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
+	    <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
         <script src="/library/js/headscripts.js" type="text/javascript"></script>
 	    <meta http-equiv="Content-Style-Type" content="text/css" />
 	</head>

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2302,7 +2302,7 @@
 #lti.role.mapping.Instructor=
 
 # Use to override the URL to the launch presentation CSS file
-# DEFAULT: none (null) - results in "[SERVER_URL]/library/skin/default/tool.css" being used
+# DEFAULT: none (null) - results in "[SERVER_URL]/library/skin/default-skin/tool.css" being used
 # lti.consumer.launch_presentation_css_url=
 
 # DEFAULT: none (null) - results in "[SERVER_URL]/imsblis/service/return-url" being used

--- a/help/help-tool/src/webapp/xsl/kb.xsl
+++ b/help/help-tool/src/webapp/xsl/kb.xsl
@@ -35,7 +35,7 @@
 					<xsl:call-template name="makeTableCellCSS" />
 				</style>
 				<link rel="stylesheet" media="all"
-					href="/library/skin/default/tool.css" type="text/css" />
+					href="/library/skin/default-skin/tool.css" type="text/css" />
 				<link rel="stylesheet" media="all"
 					href="/library/skin/default/help.css" type="text/css" />
 			</head>

--- a/help/util/kb-to-help.xsl
+++ b/help/util/kb-to-help.xsl
@@ -41,7 +41,7 @@
 	<link rel="stylesheet" media="all" href="/library/skin/tool_base.css" type="text/css" />
 <xsl:text>
 </xsl:text>
-	<link rel="stylesheet" media="all" href="/library/skin/default/tool.css" type="text/css" />
+	<link rel="stylesheet" media="all" href="/library/skin/default-skin/tool.css" type="text/css" />
 <xsl:text>
 </xsl:text>
 			</head>

--- a/lessonbuilder/tool/src/webapp/removePage.jsp
+++ b/lessonbuilder/tool/src/webapp/removePage.jsp
@@ -24,7 +24,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 </head>
 <body>
 

--- a/lessonbuilder/tool/src/webapp/templates/AssignmentPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/AssignmentPicker.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title rsf:id="msg=simplepage.assignment.chooser"></title>
 </head>
 <body rsf:id="scr=sakai-body">

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter"src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title rsf:id="msg=simplepage.blti.chooser"></title>
 <style>
 .ui-widget-overlay.ui-front {

--- a/lessonbuilder/tool/src/webapp/templates/Checklist.html
+++ b/lessonbuilder/tool/src/webapp/templates/Checklist.html
@@ -11,7 +11,7 @@
     <script src="../js/rsf.js"></script>
     <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />
     <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
     <link rel="stylesheet" rsf:id="customCSS" type="text/css" />
 
     <title rsf:id="msg=simplepage.checklist"></title>

--- a/lessonbuilder/tool/src/webapp/templates/ChecklistProgress.html
+++ b/lessonbuilder/tool/src/webapp/templates/ChecklistProgress.html
@@ -11,7 +11,7 @@
     <script src="../js/rsf.js"></script>
     <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />
     <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
     <link rel="stylesheet" rsf:id="customCSS" type="text/css" />
 
     <title rsf:id="msg=simplepage.checklist"></title>

--- a/lessonbuilder/tool/src/webapp/templates/CommentGradingPane.html
+++ b/lessonbuilder/tool/src/webapp/templates/CommentGradingPane.html
@@ -9,7 +9,7 @@
 <script src="/lessonbuilder-tool/js/SakaiRSFWidgets.js" rsf:id="fckScript"></script>
 <script src="../js/rsf.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />
 
 <title rsf:id="msg=simplepage.gradingpane"></title>

--- a/lessonbuilder/tool/src/webapp/templates/EditPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/EditPage.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script> 
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 
 <title rsf:id="msg=simplepage.edit-page"></title>
 </head>

--- a/lessonbuilder/tool/src/webapp/templates/FolderPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/FolderPicker.html
@@ -11,7 +11,7 @@
 		<script src="/library/editor/ckextraplugins/folder-listing/js/folder-listing.js"></script>
 		<script src="/library/editor/ckextraplugins/folder-listing/js/get-available-sites.js"></script>
 		<link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-		<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 		<link rel="stylesheet" href="/library/editor/ckextraplugins/folder-listing/css/file-tree.css" type="text/css"/>
 		<script src="$context/js/folder-picker.js"></script>
 	</head>

--- a/lessonbuilder/tool/src/webapp/templates/ForumPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/ForumPicker.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title rsf:id="msg=simplepage.forum.chooser"></title>
 </head>
 <body rsf:id="scr=sakai-body">

--- a/lessonbuilder/tool/src/webapp/templates/IFramePage.html
+++ b/lessonbuilder/tool/src/webapp/templates/IFramePage.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <link href="/portal/styles/portalstyles.css" type="text/css" rel="stylesheet" media="all" />
 <link href="/library/skin/default/portal.css" type="text/css" rel="stylesheet" media="all" />
 

--- a/lessonbuilder/tool/src/webapp/templates/LtiImportItem.html
+++ b/lessonbuilder/tool/src/webapp/templates/LtiImportItem.html
@@ -6,7 +6,7 @@
     <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
     <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
     <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
     <title rsf:id="msg=simplepage.blti.chooser"></title>
   </head>
   <body rsf:id="scr=sakai-body">

--- a/lessonbuilder/tool/src/webapp/templates/PagePicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/PagePicker.html
@@ -7,7 +7,7 @@
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <script>includeLatestJQuery('PagePicker.html');</script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />	
 <title rsf:id="msg=simplepage.page.chooser"></title>
 </head>

--- a/lessonbuilder/tool/src/webapp/templates/PeerEvalStats.html
+++ b/lessonbuilder/tool/src/webapp/templates/PeerEvalStats.html
@@ -6,7 +6,7 @@
     <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
     <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
     <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
     <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />
     <title rsf:id="msg=simplepage.peer-eval-stats"></title>
   </head>

--- a/lessonbuilder/tool/src/webapp/templates/PermissionsHelperProducer.html
+++ b/lessonbuilder/tool/src/webapp/templates/PermissionsHelperProducer.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title rsf:id="msg=simplepage.permissions"></title>
 </head>
 <body>

--- a/lessonbuilder/tool/src/webapp/templates/Preview.html
+++ b/lessonbuilder/tool/src/webapp/templates/Preview.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title rsf:id="title2"></title>
 </head>
 <body rsf:id="scr=sakai-body">

--- a/lessonbuilder/tool/src/webapp/templates/QuestionGradingPane.html
+++ b/lessonbuilder/tool/src/webapp/templates/QuestionGradingPane.html
@@ -9,7 +9,7 @@
 <script src="/lessonbuilder-tool/js/SakaiRSFWidgets.js" rsf:id="fckScript"></script>
 <script src="../js/rsf.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />
 
 <title rsf:id="msg=simplepage.gradingpane"></title>

--- a/lessonbuilder/tool/src/webapp/templates/QuizPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/QuizPicker.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title rsf:id="msg=simplepage.quiz.chooser"></title>
 </head>
 <body rsf:id="scr=sakai-body">

--- a/lessonbuilder/tool/src/webapp/templates/Reorder.html
+++ b/lessonbuilder/tool/src/webapp/templates/Reorder.html
@@ -6,7 +6,7 @@
         <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js">
         </script>
         <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-        <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+        <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
         <script>includeLatestJQuery('Reorder.html');</script>
         <script src="/library/js/spinner.js"></script>
         <script src="$context/js/reorder.js"></script>

--- a/lessonbuilder/tool/src/webapp/templates/ResourcePicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/ResourcePicker.html
@@ -6,7 +6,7 @@
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <title>Resource Picker</title>
 </head>
 <body rsf:id="scr=sakai-body">

--- a/lessonbuilder/tool/src/webapp/templates/ShowItem.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowItem.html
@@ -8,7 +8,7 @@
 </style>
 <script rsf:id="scr=portal-matter" src="/library/js/headscripts.js"></script>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />	
 <title rsf:id="msg=simplepage.showitem"></title>
 

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -11,7 +11,7 @@
   <script src="../js/rsf.js"></script>
   <link type="text/css" href="/library/webjars/jquery-ui-themes/1.12.1/smoothness/jquery-ui.min.css" rel="stylesheet" />
   <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-  <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+  <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
   <title rsf:id="msg=simplepage.showpage"></title>
 
   <!--style type="text/css">

--- a/lessonbuilder/tool/src/webapp/templates/SubpageBulkEdit.html
+++ b/lessonbuilder/tool/src/webapp/templates/SubpageBulkEdit.html
@@ -8,7 +8,7 @@
     </style>
     <script rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
     <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
     <link rel="stylesheet" rsf:id="scr=rewrite-url" href="../css/Simplepagetool.css" type="text/css"/>
     <link rel="stylesheet" rsf:id="customCSS" type="text/css" />
 

--- a/lessonbuilder/tool/src/webapp/templates/instructions/general.html
+++ b/lessonbuilder/tool/src/webapp/templates/instructions/general.html
@@ -3,7 +3,7 @@
 	<meta http-equiv="Content-Style-Type" content="text/css" />
 	<title>general.html</title>
 	<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-	<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
+	<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 	<script type="text/javascript" src="/library/js/headscripts.js"></script>
 	<style>body { padding: 5px !important; }</style>
 </head>

--- a/lessonbuilder/tool/src/webapp/templates/instructions/placeholder_tr.html
+++ b/lessonbuilder/tool/src/webapp/templates/instructions/placeholder_tr.html
@@ -1,7 +1,7 @@
 <meta http-equiv="Content-Style-Type" content="text/css" />
     <title>Derslere Başlarken</title>
     <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
     <script type="text/javascript" src="/library/js/headscripts.js"></script>
   </head>
   <body>

--- a/lessonbuilder/tool/src/webapp/templates/sakai-FCKEditor.html
+++ b/lessonbuilder/tool/src/webapp/templates/sakai-FCKEditor.html
@@ -4,7 +4,7 @@
 <head>
 <title>WYSIWYG Author</title>
 <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 <script src="../js/SakaiRSFWidgets.js" rsf:id="scr=contribute-script"></script>
 
 </head>

--- a/library/src/webapp/content/myworkspace_info_ja.html
+++ b/library/src/webapp/content/myworkspace_info_ja.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>マイワークスペース情報</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+		<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 

--- a/library/src/webapp/content/server_info_ja.html
+++ b/library/src/webapp/content/server_info_ja.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>Sakai へようこそ</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>

--- a/library/src/webapp/content/webcontent_instructions_ja.html
+++ b/library/src/webapp/content/webcontent_instructions_ja.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 		<title>ウェブコンテンツに関するインストラクション</title>
 		<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-		<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+		<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 		<script type="text/javascript" language="JavaScript" src="/library/js/sakai-iframe-copy-classes.js"></script>
 	</head>
 	<body>

--- a/podcasts/podcasts-app/src/webapp/podcasts/podListen.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podListen.jsp
@@ -9,7 +9,7 @@
 
 <f:view>
     <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
   <sakai:view toolCssHref="./css/podcaster.css">
     <script>includeWebjarLibrary('wavesurfer.js');</script>
   <h:form id="podListen" enctype="multipart/form-data">

--- a/podcasts/podcasts-app/src/webapp/podcasts/podOptions.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podOptions.jsp
@@ -11,7 +11,7 @@
 
 <f:view>
     <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 
     <script src="/library/js/headscripts.js"></script>
 

--- a/podcasts/podcasts-app/src/webapp/podcasts/podRevise.jsp
+++ b/podcasts/podcasts-app/src/webapp/podcasts/podRevise.jsp
@@ -9,7 +9,7 @@
 
 <f:view>
     <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-    <link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+    <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 
   <sakai:view toolCssHref="./css/podcaster.css">
       <script>includeLatestJQuery("podRevise");</script>

--- a/polls/tool/src/webapp/component-templates/Messages.html
+++ b/polls/tool/src/webapp/component-templates/Messages.html
@@ -3,7 +3,7 @@
  <head>
  <title>Evaluation Messages Template</title>
   <link href="../../library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-  <link href="../../library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+  <link href="../../library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
  	<link media="all" href="../content/css/evaluation_base.css" rel="stylesheet" type="text/css" />
  </head>
  <body>

--- a/polls/tool/src/webapp/templates/pollOptionDelete.html
+++ b/polls/tool/src/webapp/templates/pollOptionDelete.html
@@ -3,7 +3,7 @@
 <head>
 <title>Polls: Delete confirmation</title>
 <link rsf:id="scr=portal-matter" href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
 <script rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 </head>
 

--- a/polls/tool/src/webapp/templates/voteAdd.html
+++ b/polls/tool/src/webapp/templates/voteAdd.html
@@ -6,7 +6,7 @@
 <link rsf:id="scr=portal-matter"
 	href="https:https://vula.uct.ac.za/library/skin/tool_base.css"
 	type="text/css" rel="stylesheet" media="all" />
-<link href="https://vula.uct.ac.za/library/skin/default/tool.css"
+<link href="https://vula.uct.ac.za/library/skin/default-skin/tool.css"
 	type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
 <script rsf:id="scr=portal-matter" type="text/javascript"
 	language="JavaScript" src="/library/js/headscripts.js"></script>

--- a/polls/tool/src/webapp/templates/votePermissions.html
+++ b/polls/tool/src/webapp/templates/votePermissions.html
@@ -3,7 +3,7 @@
 <head>
 <title>Polls: Permissions</title>
 <link  rsf:id="scr=portal-matter"  href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+<link rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 <script  rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 </head>
 

--- a/polls/tool/src/webapp/templates/votePolls.html
+++ b/polls/tool/src/webapp/templates/votePolls.html
@@ -3,7 +3,7 @@
 <head >
 <title>Polls</title>
 <link rsf:id="scr=portal-matter" href="https://vula.uct.ac.za/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link href="https://vula.uct.ac.za/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
+<link href="https://vula.uct.ac.za/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
 <script  rsf:id="scr=portal-matter" type="text/javascript" src="/library/js/headscripts.js"></script>
 <script type="text/javascript">includeLatestJQuery('polls');</script>
 <script type="text/javascript">includeWebjarLibrary('jquery.tablesorter');</script>

--- a/polls/tool/src/webapp/templates/voteQuestion.html
+++ b/polls/tool/src/webapp/templates/voteQuestion.html
@@ -3,7 +3,7 @@
 <head>
 <title>Polls: Vote!</title>
 <link rsf:id="scr=portal-matter" href="https://vula.uct.ac.za/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link rsf:id="scr=portal-matter" href="https://vula.uct.ac.za/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+<link rsf:id="scr=portal-matter" href="https://vula.uct.ac.za/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 <script rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 </head>
 

--- a/polls/tool/src/webapp/templates/voteResults.html
+++ b/polls/tool/src/webapp/templates/voteResults.html
@@ -3,7 +3,7 @@
 <head>
 <title>Polls: Results</title>
 <link rsf:id="scr=portal-matter"  href="https://vula.uct.ac.za/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link rsf:id="scr=portal-matter" href="https://vula.uct.ac.za/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+<link rsf:id="scr=portal-matter" href="https://vula.uct.ac.za/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 <script rsf:id="scr=portal-matter" type="text/javascript" src="/library/js/headscripts.js"></script>
 <script type="text/javascript">includeLatestJQuery('polls');</script>
 <script type="text/javascript">includeWebjarLibrary('jquery.tablesorter');</script>

--- a/polls/tool/src/webapp/templates/voteThanks.html
+++ b/polls/tool/src/webapp/templates/voteThanks.html
@@ -3,7 +3,7 @@
 <head>
 <title>Polls: Thanks</title>
 <link rsf:id="scr=portal-matter"  href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link  rsf:id="scr=portal-matter" href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+<link  rsf:id="scr=portal-matter" href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
 <script rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 </head>
 

--- a/reset-pass/account-validator-tool/src/webapp/content/templates/error.html
+++ b/reset-pass/account-validator-tool/src/webapp/content/templates/error.html
@@ -3,7 +3,7 @@
 <head>
 <title>Account Validation</title>
 <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-<link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
 <link href="content/css/requestAccount.css" type="text/css" rel="stylesheet" media="all" />
 </head>
 <body>

--- a/reset-pass/account-validator-tool/src/webapp/content/templates/newUser.html
+++ b/reset-pass/account-validator-tool/src/webapp/content/templates/newUser.html
@@ -5,7 +5,7 @@
         <title th:text="${accountTitle}">Activate your account</title>
         <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="/library/skin/morpheus-default/portal.css" type="text/css" rel="stylesheet" media="all"/>
-        <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+        <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="/library/skin/morpheus-default/print.css" type="text/css" rel="stylesheet" media="print"/>
         <link href="/library/skin/morpheus-default/properties.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="content/css/newUser.css" type="text/css" rel="stylesheet" media="all"/>

--- a/reset-pass/account-validator-tool/src/webapp/content/templates/passwordReset.html
+++ b/reset-pass/account-validator-tool/src/webapp/content/templates/passwordReset.html
@@ -5,7 +5,7 @@
         <title th:text="#{passwordReset.title}">Reset Password</title>
         <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
-        <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
+        <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
         <link href="/library/skin/morpheus-default/print.css" type="text/css" rel="stylesheet" media="print"/>
         <link href="/library/skin/morpheus-default/properties.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
         <link href="content/css/passwordReset.css" type="text/css" rel="stylesheet" media="all" />

--- a/reset-pass/account-validator-tool/src/webapp/content/templates/requestAccount.html
+++ b/reset-pass/account-validator-tool/src/webapp/content/templates/requestAccount.html
@@ -5,7 +5,7 @@
         <title th:text="#{requestAccount.title}">Activate your account</title>
         <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="/library/skin/morpheus-default/portal.css" type="text/css" rel="stylesheet" media="all"/>
-        <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+        <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="/library/skin/morpheus-default/print.css" type="text/css" rel="stylesheet" media="print"/>
         <link href="/library/skin/morpheus-default/properties.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="content/css/requestAccount.css" type="text/css" rel="stylesheet" media="all" />

--- a/reset-pass/account-validator-tool/src/webapp/content/templates/transferMemberships.html
+++ b/reset-pass/account-validator-tool/src/webapp/content/templates/transferMemberships.html
@@ -5,7 +5,7 @@
         <title th:text="#{transferMemberships.title}">Accept invitation</title>
         <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
         <link href="/library/skin/morpheus-default/portal.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
-        <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
+        <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
         <link href="/library/skin/morpheus-default/print.css" type="text/css" rel="stylesheet" media="print"/>
         <link href="/library/skin/morpheus-default/properties.css" type="text/css" rel="stylesheet" media="screen, tty, tv, handheld, projection"/>
         <link href="content/css/transferMemberships.css" type="text/css" rel="stylesheet" media="all" />

--- a/reset-pass/account-validator-tool/src/webapp/content/templates/validate.html
+++ b/reset-pass/account-validator-tool/src/webapp/content/templates/validate.html
@@ -5,7 +5,7 @@
         <title th:text="#{validate.title}">Account Validation</title>
         <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
         <link href="/library/skin/morpheus-default/portal.css" type="text/css" rel="stylesheet" media="all"/>
-        <link href="/library/skin/morpheus-default/tool.css" type="text/css" rel="stylesheet" media="all"/>
+        <link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="/library/skin/morpheus-default/print.css" type="text/css" rel="stylesheet" media="print"/>
         <link href="/library/skin/morpheus-default/properties.css" type="text/css" rel="stylesheet" media="all"/>
         <link href="content/css/accountvalidator.css" type="text/css" rel="stylesheet" media="all" />

--- a/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-FCKEditor.html
+++ b/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-FCKEditor.html
@@ -4,7 +4,7 @@
 <head>
 <title>WYSIWYG Author</title>
 <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 <script type="text/javascript" language="JavaScript" src="../js/SakaiRSFWidgets.js" rsf:id="scr=contribute-script"></script>
 </head>
 <body>

--- a/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-old-date.html
+++ b/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-old-date.html
@@ -5,7 +5,7 @@
 <title>Sakai "Old-style" Date Choosing Widget</title>
 <link href="/library/skin/tool_base.css" type="text/css"
 	rel="stylesheet" media="all" />
-<link href="/library/skin/default/tool.css" type="text/css"
+<link href="/library/skin/default-skin/tool.css" type="text/css"
 	rel="stylesheet" media="all" />
 <script type="text/javascript" language="JavaScript"
 	src="/library/js/headscripts.js"></script>

--- a/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-plainTextEditor.html
+++ b/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-plainTextEditor.html
@@ -5,7 +5,7 @@
 <title>Plain text entry</title>
 <link href="/library/skin/tool_base.css" type="text/css"
 	rel="stylesheet" media="all" />
-<link href="/library/skin/default/tool.css" type="text/css"
+<link href="/library/skin/default-skin/tool.css" type="text/css"
 	rel="stylesheet" media="all" />
 <script type="text/javascript" language="JavaScript"
 	src="/library/js/headscripts.js"></script>

--- a/rsf/sakai-rsf-web/test/src/webapp/content/templates/sakai-test-components-index.html
+++ b/rsf/sakai-rsf-web/test/src/webapp/content/templates/sakai-test-components-index.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="../style.css" type="text/css" />
 <link href="/sakai22-jakarta-tomcat-5.5.9/webapps/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all"
 	rsf:id="scr=portal-matter" />
-<link href="/sakai22-jakarta-tomcat-5.5.9/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all"
+<link href="/sakai22-jakarta-tomcat-5.5.9/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all"
 	rsf:id="scr=portal-matter" />
 <script type="text/javascript" language="JavaScript" src="/sakai22-jakarta-tomcat-5.5.9/library/js/headscripts.js"
 	rsf:id="scr=portal-matter"></script>

--- a/rsf/sakai-rsf-web/test/src/webapp/content/templates/sakai-test-components-results.html
+++ b/rsf/sakai-rsf-web/test/src/webapp/content/templates/sakai-test-components-results.html
@@ -5,7 +5,7 @@
 <title>Sakai RSF Component Test Tool - Results</title>
 <link rel="stylesheet" href="../style.css" type="text/css" />
 <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
-<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
 <script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js" rsf:id="scr=portal-matter">
     
 </script>

--- a/rsf/sakai-rsf-web/test/src/webapp/content/templates/sakai-test-components-single.html
+++ b/rsf/sakai-rsf-web/test/src/webapp/content/templates/sakai-test-components-single.html
@@ -3,7 +3,7 @@
 <html xmlns:rsf="http://ponder.org.uk/rsf">
 <head>
 <link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
-<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
+<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" rsf:id="scr=portal-matter" />
 <script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js" rsf:id="scr=portal-matter">
     
 </script>

--- a/samigo/samigo-app/src/webapp/templates/BeginTakingAssessment.html
+++ b/samigo/samigo-app/src/webapp/templates/BeginTakingAssessment.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
 	<link href="/library/skin/tool_base.css" type="text/css" rel="stylesheet" media="all" />
-	<link href="/library/skin/default/tool.css" type="text/css" rel="stylesheet" media="all" />
+	<link href="/library/skin/default-skin/tool.css" type="text/css" rel="stylesheet" media="all" />
 	<link href="/samigo-app/css/tool_sam.css" type="text/css" rel="stylesheet" media="all" />
 	<title rsf:id="assessmentTitle">Assessment Title</title>
 </head>

--- a/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
+++ b/site-manage/pageorder/tool/src/webapp/content/templates/PageList.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Site Page Order</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
+	<link href="/library/skin/default-skin/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<link href="../css/PageList.css" rel="stylesheet" type="text/css" />
 	<script rsf:id="resize"/>
 	<script src="../js/orderUtil.js" rsf:id="scr=rewrite-url" defer="1"></script>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Site Add Participant</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
+	<link href="/library/skin/default-skin/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<script type="text/javascript" rsf:id="resize"/>
 	<link type="text/css" href="/library/webjars/jquery-ui/1.12.1/jquery-ui.min.css" rel="stylesheet" media="screen" />
 	<script type="text/javascript" src="/library/js/headscripts.js"></script>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Confirm.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Confirm.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Confirm participant</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
+	<link href="/library/skin/default-skin/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<script type="text/javascript" rsf:id="resize"/>
 	<script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 	<script type="text/javascript" src="/library/js/spinner.js"></script>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/DifferentRole.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/DifferentRole.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Site Add Participant</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
+	<link href="/library/skin/default-skin/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<script type="text/javascript" rsf:id="resize"/>
 	<link type="text/css" href="/library/webjars/jquery-ui/1.12.1/jquery-ui.min.css" rel="stylesheet" media="screen" />
 	<script type="text/javascript" src="/library/js/headscripts.js"></script>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/EmailNoti.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/EmailNoti.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Same Role for participant</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
+	<link href="/library/skin/default-skin/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<script type="text/javascript" rsf:id="resize"/>
 	<script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 	<script type="text/javascript" src="/library/js/spinner.js"></script>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/SameRole.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/SameRole.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Same Role for participant</title>
 	<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
-	<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
+	<link href="/library/skin/default-skin/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 	<script type="text/javascript" rsf:id="resize"/>
 	<script type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
 	<script type="text/javascript" src="/library/js/spinner.js"></script>

--- a/site/admin-perms-tool/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/site/admin-perms-tool/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -26,7 +26,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
-<link media="all" href="/library/skin/default/tool.css" rel="stylesheet" type="text/css" />
+<link media="all" href="/library/skin/default-skin/tool.css" rel="stylesheet" type="text/css" />
 <link media="all" href="<c:url value='/css/AdminSitePerms.css'/>" rel="stylesheet" type="text/css" />
 
 <script src="/library/js/headscripts.js" language="JavaScript" type="text/javascript"></script>


### PR DESCRIPTION
I updated this after trinity - there are two legacy URLs all over the place.   I fixed all of them except in the screen_steps content as I don't know how that is created and update right before a release.   This should be 23 only.