### PR TITLE
SAK-48907 Lessons restore subpage navigation

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -47,14 +47,6 @@
   <input type='hidden' rsf:id="lessonsSubnavItemId" id="lessonsSubnavItemId" />
   <input type='hidden' rsf:id="lessonsCurrentPageId" id="lessonsCurrentPageId" />
   <script>
-    if (sakai) {
-      if (sakai.lessons_subnav) {
-        // Notify the lessons_subnav that we're on a lessons page
-        sakai.lessons_subnav.set_current_lessons_page();
-      }
-    }
-  </script>
-  <script>
     includeLatestJQuery('ShowPage.html');
   </script>
   <script>
@@ -99,7 +91,7 @@
 
   <div rsf:id="portletBody" class="portletBody">
 
-<div class="row mt-4">
+<div class="row mt-1">
   <div class="column col-12 m-0 p-0 border-0">
     <span rsf:id="tool-bar:" class="navIntraTool" role="application" aria-labelledby="tool-bar::toolbar-label">
       <h3 id="toolbar-label" rsf:id="msg=simplepage.toolbar" class="lb-offscreen"></h3>

--- a/library/src/webapp/js/portal/portal.sidebar.sites.js
+++ b/library/src/webapp/js/portal/portal.sidebar.sites.js
@@ -4,6 +4,7 @@ class SitesSidebar {
 
     this._i18n = config?.i18n;
     this._element = element;
+    this._lessonsSubpageData = config?.lessonsSubpageData;
     this._pinnedSiteList = document.getElementById("pinned-site-list");
     this._recentSiteList = document.getElementById("recent-site-list");
     this._currentSite = config.currentSite;

--- a/portal/portal-impl/impl/pom.xml
+++ b/portal/portal-impl/impl/pom.xml
@@ -154,10 +154,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
-        <!--dependency>
+        <dependency>
             <groupId>org.sakaiproject.lessonbuilder</groupId>
             <artifactId>lessonbuilder-api</artifactId>
-        </dependency-->
+        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -513,7 +513,7 @@ public class SiteHandler extends WorksiteHandler
 			props.addProperty(PortalConstants.PROP_EXPANDED_SITE, siteId);
 			PreferencesService.commit(prefs);
 		} catch (Exception any) {
-			log.warn("Exception caught whilst setting {} property: {}", SELECTED_PAGE_PROP, any.toString());
+			log.warn("Exception caught whilst setting {} property: {}", PortalConstants.PROP_EXPANDED_SITE, any.toString());
 		}
 
 		if ( allowBuffer ) {

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeBodyScripts.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeBodyScripts.vm
@@ -61,6 +61,43 @@
     iconClasses: ["bi-info-circle", "bi-info-circle-fill"],
   });
 
+  // Setup lessons subpage navigaion
+
+  let lessonSubnavs = []; // exclude the current site
+  let currentLessonSubnav = null;
+
+  // Macros to add Lessons data to an js array
+  #macro (addLessonsSubnavData $site)
+    #if ($site && $site.lessonsSubPages)
+      #if ($site.isCurrent)
+        currentLessonSubnav = new LessonsSubPageNavigation(${site.lessonsSubPages});
+      #else
+        lessonSubnavs.push(${site.lessonsSubPages});
+      #end
+    #end
+  #end
+
+  #macro (addLessonsSubnavDataList $siteList)
+    #if ($siteList)
+      #foreach ($site in $siteList)
+        #addLessonsSubnavData ($site)
+      #end
+    #end
+  #end
+
+  #addLessonsSubnavDataList($sidebarSites.pinnedSites);
+  #addLessonsSubnavDataList($sidebarSites.recentSites);
+
+  // Remove duplicate pages e.g. page in pinned and recent, then create
+  // a LessonsSubPageNavigation instance for each site
+  
+  lessonSubnavs.filter((v, i) => lessonSubnavs.findIndex(val => val.siteId === v.siteId) === i)
+    .forEach(lessonSubnavData => new LessonsSubPageNavigation(lessonSubnavData));
+
+  if (currentLessonSubnav !== null && sakai && sakai.lessons_subnav) {
+    currentLessonSubnav.setCurrentLessonsPage();
+  }
+
   #if (!$loggedIn && $topLogin)
     //--start-logged-out-scripts
     // Setup header login password field

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/portalScripts-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/portalScripts-snippet.vm
@@ -5,6 +5,12 @@
     <script src="/library/js/lessons-subnav.js$!{portalCDNQuery}"></script>
     <script src="/library/js/portal/portal.init.js$!{portalCDNQuery}"></script>
     <script src="/library/js/portal/portal.all.sites.js$!{portalCDNQuery}"></script>
+    #if (${sitePages.additionalLessonsPages})
+    <script>
+      sakai = window.sakai || {};
+      sakai.lessons_subnav = true;
+    </script>
+    #end
 #else
     <script src="/library/js/portal/portal.login.password.js$!{portalCDNQuery}"></script>
     <script src="/library/js/portal/portal.login.mobile.js$!{portalCDNQuery}"></script>

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/LessonsSubnavEnabler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/LessonsSubnavEnabler.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2003-2017 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.site.tool;
+
+import org.sakaiproject.cheftool.Context;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.SessionState;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.util.ParameterParser;
+
+public class LessonsSubnavEnabler {
+
+    private static final String SITE_PROPERTY = "lessons_submenu";
+    private static final String STATE_KEY = "isLessonsSubNavEnabledForSite";
+    private static final String FORM_INPUT_ID = "isLessonsSubNavEnabledForSite";
+    private static final String CONTEXT_ENABLED_KEY = "isLessonsSubNavEnabledForSite";
+
+
+    /**
+     * Add MathJax settings to the context for the edit tools page
+     * @param context the context
+     * @param site the site
+     * @param state the state
+     * @return true if context was modified
+     */
+    public static boolean addToEditToolsContext(Context context, Site site, SessionState state)
+    {
+        if (context == null || site == null || state == null)
+        {
+            return false;
+        }
+
+        context.put(CONTEXT_ENABLED_KEY, isEnabledForSite(site));
+
+        return true;
+    }
+
+
+    /**
+     * Add Lesson subnav settings to the Site Info (view, edit, or confirm) context
+     * @param context the context
+     * @param site the site
+     * @param state the session state
+     * @return true if the context was modified
+     */
+    public static boolean addToSiteInfoContext(Context context, Site site, SessionState state)
+    {
+        if (context == null || site == null || state == null)
+        {
+            return false;
+        }
+
+        context.put(CONTEXT_ENABLED_KEY, isEnabledForSite(site));
+
+        return true;
+    }
+
+
+    /**
+     * Applies the Lessons sub-nav settings to the workflow state
+     * @param state the state
+     * @param params the params
+     * @return true if the state was modified
+     */
+    public static boolean applyToolSettingsToState(SessionState state, Site site, ParameterParser params)
+    {
+        // Allow checkbox to set the isLessonsSubNavEnabledForSite site property
+        // If checked, add this to the state
+        if ("on".equals(params.getString(FORM_INPUT_ID)))
+        {
+            state.setAttribute(STATE_KEY, true);
+        } else {
+            state.setAttribute(STATE_KEY, false);
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Add Lessons subnav settings to the context for the edit tools confirmation page
+     * @param context the context
+     * @param site the site
+     * @param state the state
+     * @return true if the context was modified
+     */
+    public static boolean addSettingsToEditToolsConfirmationContext(Context context, Site site, SessionState state)
+    {
+
+        if (site == null || context == null || state == null)
+        {
+            return false;
+        }
+
+        // Show a message on the confirmation screen if Lesson subnav is enabled for the site
+        final boolean isEnabled = (Boolean) state.getAttribute(STATE_KEY);
+        if (isEnabled)
+        {
+            context.put(CONTEXT_ENABLED_KEY, Boolean.TRUE);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * When user selects to enable the Lessons subnav, update the site property
+     * @param site The site
+     * @param state the session state
+     * @return true if the site properties were modified
+     */
+    public static boolean prepareSiteForSave(Site site, SessionState state)
+    {
+        if (site == null || state == null)
+        {
+            return false;
+        }
+
+        if (state.getAttribute(STATE_KEY) != null) {
+            final boolean isEnabled = (Boolean) state.getAttribute(STATE_KEY);
+            final ResourcePropertiesEdit props = site.getPropertiesEdit();
+            if (isEnabled) {
+                props.addProperty(SITE_PROPERTY, Boolean.TRUE.toString());
+            } else {
+                props.removeProperty(SITE_PROPERTY);
+            }
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Remove the Lessons subnav keys from the given state
+     * @param state the state
+     * @return true if the state was modifed
+     */
+    public static boolean removeFromState(SessionState state)
+    {
+        if (state != null)
+        {
+            state.removeAttribute(STATE_KEY);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Check the site's properties for the Lessons sub nav property
+     * @param site The site to check
+     * @return true if the lessons subnav is enabled for the site
+     */
+    private static boolean isEnabledForSite(Site site) 
+    {
+        return Boolean.parseBoolean(site.getProperties().getProperty(SITE_PROPERTY));
+    }
+}

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1277,6 +1277,7 @@ public class SiteAction extends PagedResourceActionII {
 		// SAK-24423 - remove joinable site settings from the state
 		JoinableSiteSettings.removeJoinableSiteSettingsFromState( state );
 
+		LessonsSubnavEnabler.removeFromState(state);
 		PortalNeochatEnabler.removeFromState(state);
 
 		state.removeAttribute(STATE_CREATE_FROM_ARCHIVE);
@@ -1826,6 +1827,7 @@ public class SiteAction extends PagedResourceActionII {
 				MenuBuilder.buildMenuForSiteInfo(portlet, data, state, context, site, rb, siteTypeProvider, SiteInfoActiveTab.MANAGE_TOOLS);
 
 				MathJaxEnabler.addMathJaxSettingsToEditToolsContext(context, site, state);  // SAK-22384
+				LessonsSubnavEnabler.addToEditToolsContext(context, site, state);
 				PortalNeochatEnabler.addToEditToolsContext(context, site, state);
 				context.put("SiteTitle", site.getTitle());
 				context.put("existSite", Boolean.TRUE);
@@ -2325,6 +2327,7 @@ public class SiteAction extends PagedResourceActionII {
 
 			// SAK-22384 mathjax support
 			MathJaxEnabler.addMathJaxSettingsToSiteInfoContext(context, site, state);
+			LessonsSubnavEnabler.addToSiteInfoContext(context, site, state);
 			PortalNeochatEnabler.addToSiteInfoContext(context, site, state);
 
 			return (String) getContext(data).get("template") + TEMPLATE[12];
@@ -2475,6 +2478,7 @@ public class SiteAction extends PagedResourceActionII {
 
 			// SAK-22384 mathjax support
 			MathJaxEnabler.addMathJaxSettingsToSiteInfoContext(context, site, state);
+			LessonsSubnavEnabler.addToSiteInfoContext(context, site, state);
 			PortalNeochatEnabler.addToSiteInfoContext(context, site, state);
 						
 			return (String) getContext(data).get("template") + TEMPLATE[13];
@@ -2546,6 +2550,7 @@ public class SiteAction extends PagedResourceActionII {
 
 			// SAK-22384 mathjax support
 			MathJaxEnabler.addMathJaxSettingsToSiteInfoContext(context, site, state);
+			LessonsSubnavEnabler.addToSiteInfoContext(context, site, state);
 			PortalNeochatEnabler.addToSiteInfoContext(context, site, state);
 
 			return (String) getContext(data).get("template") + TEMPLATE[14];
@@ -2569,6 +2574,7 @@ public class SiteAction extends PagedResourceActionII {
 			// put tool selection into context
 			toolSelectionIntoContext(context, state, site_type, site.getId(), overridePageOrderSiteTypes);
 			MathJaxEnabler.addMathJaxSettingsToEditToolsConfirmationContext(context, site, state, STATE_TOOL_REGISTRATION_TITLE_LIST);  // SAK-22384            
+			LessonsSubnavEnabler.addSettingsToEditToolsConfirmationContext(context, site, state);
 			PortalNeochatEnabler.addSettingsToEditToolsConfirmationContext(context, site, state);
 
 			return (String) getContext(data).get("template") + TEMPLATE[15];
@@ -7779,6 +7785,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		} else if (getStateSite(state) != null && ("13".equals(currentIndex) || "14".equals(currentIndex)))
 		{
 			MathJaxEnabler.removeMathJaxAllowedAttributeFromState(state);  // SAK-22384
+			LessonsSubnavEnabler.removeFromState(state);
 			PortalNeochatEnabler.removeFromState(state);
 			state.setAttribute(STATE_TEMPLATE_INDEX, SiteConstants.SITE_INFO_TEMPLATE_INDEX);
 		} else if ("15".equals(currentIndex)) {
@@ -8578,6 +8585,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 
 		// SAK-22384 mathjax support
 		MathJaxEnabler.prepareMathJaxAllowedSettingsForSave(Site, state);
+		LessonsSubnavEnabler.prepareSiteForSave(Site, state);
 		PortalNeochatEnabler.prepareSiteForSave(Site, state);
 				
 		if (state.getAttribute(STATE_MESSAGE) == null) {
@@ -11862,6 +11870,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 
 		boolean updateSite;
 		updateSite = MathJaxEnabler.prepareMathJaxToolSettingsForSave(site, state);
+		updateSite = LessonsSubnavEnabler.prepareSiteForSave(site, state) || updateSite;
 		updateSite = PortalNeochatEnabler.prepareSiteForSave(site, state) || updateSite;
 		if (updateSite) {
 			commitSite(site);
@@ -12766,6 +12775,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		state.removeAttribute(STATE_TOOL_REGISTRATION_LIST);
 		state.removeAttribute(STATE_TOOL_REGISTRATION_TITLE_LIST);
 		state.removeAttribute(STATE_TOOL_REGISTRATION_SELECTED_LIST);
+		LessonsSubnavEnabler.removeFromState(state);
 		PortalNeochatEnabler.removeFromState(state);
 	}
 
@@ -12973,6 +12983,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		} else if (option.equalsIgnoreCase("continue")) {
 			// continue
 			MathJaxEnabler.applySettingsToState(state, params);  // SAK-22384
+			LessonsSubnavEnabler.applyToolSettingsToState(state, site, params);
 			PortalNeochatEnabler.applyToolSettingsToState(state, site, params);
 
 			doContinue(data);

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-addRemoveFeatureConfirm.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-addRemoveFeatureConfirm.vm
@@ -225,6 +225,12 @@
     </p>
     #end
 
+    #if($!isLessonsSubNavEnabledForSite)
+    <p class="instruction">
+        $tlang.getString("sinfo.lessonbuildersubnav.confirmEnabled")
+    </p>
+    #end
+
     #if(!$!isPortalNeochatEnabledForSite && ($neoChat == 'true' || $neoChat == 'false'))
     <p class="instruction">
         $tlang.getString("sinfo.portalneochat.confirmDisabled")   

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -270,6 +270,17 @@
                 </td>
             </tr>
             #end			
+	    
+            #if ($isLessonsSubNavEnabledForSite)
+            <tr class="summary-lessons-subnav-enabled">
+                <th>
+                $tlang.getString("sinfo.lessonbuildersubnav.name")
+                </th>
+                <td>
+                $tlang.getString("sinfo.lessonbuildersubnav.enabled")
+                </td>
+            </tr>
+            #end
 
 		#if ($siteJoinable && $allowUnjoin)
 			<tr>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/toolGroupMultipleDisplay.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/toolGroupMultipleDisplay.vm
@@ -191,6 +191,14 @@
           <input type="checkbox" name="isMathJaxEnabledForSite" class="onoffswitch-checkbox" id="isMathJaxEnabledForSite" #if($isMathJaxEnabledForSite)checked="checked"#end>
       </div>
     </div>
+    <div class="lessonsSubNavToggleArea" style='display: none'>
+      <label class="onoffswitch-label" for="isLessonsSubNavEnabledForSite">
+          $tlang.getString("sinfo.lessonbuildersubnav.allowForSite")
+      </label>
+      <div class="onoffswitch">
+          <input type="checkbox" name="isLessonsSubNavEnabledForSite" class="onoffswitch-checkbox" id="isLessonsSubNavEnabledForSite" #if($isLessonsSubNavEnabledForSite)checked="checked"#end>
+      </div>
+    </div>
     #if ($neoChat == 'true' || $neoChat == 'false')
     <div class="portalNeochatToggleArea">
       <label class="onoffswitch-label" for="isPortalNeochatEnabledForSite">
@@ -205,6 +213,39 @@
       </div>
     </div>
     #end
+    <script>
+        $(function() {
+            var lessonsSubNavToggleArea = $('.lessonsSubNavToggleArea');
+            var toolSelectionList = $('#toolSelectionList');
+            var toolList = $('#toolHolderW');
+            var isLessonsSubNavEnabledForSiteCheckbox = $('#isLessonsSubNavEnabledForSite');
+
+            function checkForSelectedLessonsTools() {
+              if (toolSelectionList.find('li[id*=sakai_lessonbuildertool]:visible').length > 0) {
+                  lessonsSubNavToggleArea.show();
+              } else {
+                  lessonsSubNavToggleArea.hide();
+              }
+            };
+
+            toolList.find('input[type=checkbox]').on('click', function() {
+                setTimeout(checkForSelectedLessonsTools, 200); // fade out on selected item takes ~100ms
+                return true;
+            });
+
+            toolSelectionList.on('click', '.removeTool', function() {
+                setTimeout(checkForSelectedLessonsTools, 200); // fade out on selected item takes ~100ms
+                return true;
+            });
+
+            toolSelectionList.on('click mouseup keyup', '#alertBoxYes', function() {
+                setTimeout(checkForSelectedLessonsTools, 0);
+                return true;
+            });
+
+            checkForSelectedLessonsTools();
+        });
+    </script>
     </div>
   </div> <!-- row -->
 </div> <!-- toolHolderWW -->


### PR DESCRIPTION
Besides restoring the Lessons subpage nav code removed from SAK-48804, this proposed PR repairs UX issues that may not have yet been addressed when adapting the Lessons subpage nav to the new portal, Trinity. 

For a demo of the proposed fix, refer to the screencast, SAK-48907-ProposedFix.mp4, attached to the [corresponding jira](https://sakaiproject.atlassian.net/browse/SAK-48907).
