### PR TITLE
SAK-49025 Samigo: Table page length select is small and not aligned with label (22.x)

### DIFF
--- a/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/morpheus-master/sass/modules/tool/samigo/_samigo.scss
@@ -486,3 +486,7 @@
 		}
 	}
 }
+
+select.form-control.input-sm {
+	line-height: inherit;
+}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49025

![Screenshot from 2023-06-15 22-00-02](https://github.com/sakaiproject/sakai/assets/50500283/dbe107ba-3370-44e0-ab19-40a6560fc541)
