### PR TITLE
SAK-48622 Discussions Students unable to see rubric icon

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -617,9 +617,7 @@ public class DiscussionForumBean
 	}
 
 	public String getHasRubric(){
-
-        Optional<AssociationTransferBean> rubricAssociation = rubricsService.getAssociationForToolAndItem(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, forum.getDefaultAssignName(), forumManager.getContextForForumById(forum.getId()));
-        return rubricAssociation.isPresent() ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
+        return rubricsService.hasVisibleAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, forum.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
 	}
 
 	public void setOpenDateISO(String openDateISO) {

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -26,6 +26,7 @@ import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javax.faces.model.SelectItem;
@@ -36,6 +37,7 @@ import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.rubrics.api.RubricsConstants;
 import org.sakaiproject.rubrics.api.RubricsService;
+import org.sakaiproject.rubrics.api.beans.AssociationTransferBean;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.util.ResourceLoader;
 
@@ -615,7 +617,9 @@ public class DiscussionForumBean
 	}
 
 	public String getHasRubric(){
-		return rubricsService.hasAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, forum.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
+
+        Optional<AssociationTransferBean> rubricAssociation = rubricsService.getAssociationForToolAndItem(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, forum.getDefaultAssignName(), forumManager.getContextForForumById(forum.getId()));
+        return rubricAssociation.isPresent() ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
 	}
 
 	public void setOpenDateISO(String openDateISO) {

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -26,7 +26,6 @@ import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import javax.faces.model.SelectItem;
@@ -37,7 +36,6 @@ import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.rubrics.api.RubricsConstants;
 import org.sakaiproject.rubrics.api.RubricsService;
-import org.sakaiproject.rubrics.api.beans.AssociationTransferBean;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.util.ResourceLoader;
 

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
@@ -1278,8 +1278,6 @@ public class DiscussionTopicBean
 		topic.setRestrictPermissionsForGroups(Boolean.parseBoolean(restrictPermissionsForGroups));
 	}
 	public String getHasRubric(){
-
-      Optional<AssociationTransferBean> rubricAssociation = rubricsService.getAssociationForToolAndItem(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, topic.getDefaultAssignName(), forumManager.getContextForTopicById(topic.getId()));
-      return rubricAssociation.isPresent() ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
+      return rubricsService.hasVisibleAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, topic.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
 	}
 }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
@@ -40,6 +40,7 @@ import org.sakaiproject.api.app.messageforums.DiscussionForumService;
 import org.sakaiproject.api.app.messageforums.DiscussionTopic;
 import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
 import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.rubrics.api.beans.AssociationTransferBean;
 import org.sakaiproject.tasks.api.Task;
 import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.rubrics.api.RubricsConstants;
@@ -1277,6 +1278,8 @@ public class DiscussionTopicBean
 		topic.setRestrictPermissionsForGroups(Boolean.parseBoolean(restrictPermissionsForGroups));
 	}
 	public String getHasRubric(){
-		return rubricsService.hasAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, topic.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
+
+      Optional<AssociationTransferBean> rubricAssociation = rubricsService.getAssociationForToolAndItem(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, topic.getDefaultAssignName(), forumManager.getContextForTopicById(topic.getId()));
+      return rubricAssociation.isPresent() ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
 	}
 }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
@@ -40,7 +40,6 @@ import org.sakaiproject.api.app.messageforums.DiscussionForumService;
 import org.sakaiproject.api.app.messageforums.DiscussionTopic;
 import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
 import org.sakaiproject.component.cover.ComponentManager;
-import org.sakaiproject.rubrics.api.beans.AssociationTransferBean;
 import org.sakaiproject.tasks.api.Task;
 import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.rubrics.api.RubricsConstants;

--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/RubricsService.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/RubricsService.java
@@ -114,9 +114,27 @@ public interface RubricsService {
 
     EvaluationTransferBean cancelDraftEvaluation(Long draftEvaluationId);
 
+    /**
+     * Checks if there is an associated rubric for the given tool and ID, considering
+     * only users who have permissions to edit the rubric association.
+     *
+     * @param toolId                 The tool name or identifier.
+     * @param associatedToolItemId   The ID of the associated item.
+     * @return True if an associated rubric is found, false otherwise.
+     */
     boolean hasAssociatedRubric(String toolId, String associatedToolItemId);
 
     boolean hasAssociatedRubric(String toolId, String associatedToolItemId, String siteId);
+
+    /**
+     * Checks if there is a visible associated rubric for the given tool ID and associated item ID,
+     * considering users who have permissions to view the rubric association.
+     *
+     * @param toolId               The tool name or identifier.
+     * @param associatedToolItemId The ID of the associated item.
+     * @return True if a visible associated rubric is found, false otherwise.
+     */
+    boolean hasVisibleAssociatedRubric(String toolId, String associatedToolItemId);
 
     Optional<ToolItemRubricAssociation> getRubricAssociation(String toolId, String associatedToolItemId);
 

--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/RubricsService.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/RubricsService.java
@@ -118,7 +118,7 @@ public interface RubricsService {
      * Checks if there is an associated rubric for the given tool and ID, considering
      * only users who have permissions to edit the rubric association.
      *
-     * @param toolId                 The tool name or identifier.
+     * @param toolId                 The ID of the tool.
      * @param associatedToolItemId   The ID of the associated item.
      * @return True if an associated rubric is found, false otherwise.
      */
@@ -130,7 +130,7 @@ public interface RubricsService {
      * Checks if there is a visible associated rubric for the given tool ID and associated item ID,
      * considering users who have permissions to view the rubric association.
      *
-     * @param toolId               The tool name or identifier.
+     * @param toolId               The ID of the tool.
      * @param associatedToolItemId The ID of the associated item.
      * @return True if a visible associated rubric is found, false otherwise.
      */


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48622

The issue occurs because ```hasAssociatedRubric()``` only allows people who are rubric creator, editor or evaluator to view the rubric association.

Since this Jira ticket mentions that students are allowed to view rubric in the Discussions tool, I use ```getAssociationForToolAndItem``` to get the associated rubric.