### PR TITLE
SAK-49015 Assignments Grader not loading

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -934,7 +934,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
         Set<String> activeSubmitters = allowAddSubmissionUsers.stream().map(Entity::getId).collect(Collectors.toSet());
 
         // Get users who are visible to the current user from all groups
-        List<User> visibleUsers = assignmentService.getSelectedGroupUsers(ALL, site.getTitle(), assignment, allowAddSubmissionUsers);
+        List<User> visibleUsers = assignmentService.getSelectedGroupUsers(ALL, site.getId(), assignment, allowAddSubmissionUsers);
         Set<String> visibleUserIds = visibleUsers.stream().map(Entity::getId).collect(Collectors.toSet());
 
         // Get sorted submissions visible for the current user


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-49015

The issue arises because we are retrieving the title of the site instead of its Id. 

In course sites created by the Job Scheduler, there is no error since `site.getTitle()` is the same as `site.getId()`. However, in manually created course sites, `site.getTitle()` differs from `site.getId()`.