### PR TITLE
SAK-48741 Gradebook Icons not appearing

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -195,7 +195,7 @@ public class GradebookNgBusinessService {
 
 	public static final String GB_PREF_KEY = "GBNG-";
 	public static final String ASSIGNMENT_ORDER_PROP = "gbng_assignment_order";
-	public static final String ICON_SAKAI = "icon-sakai--";
+	public static final String ICON_SAKAI = "si si-";
 	public static final String ALL = "all";
 
 	private static final String SAK_PROP_ALLOW_STUDENTS_TO_COMPARE_GRADES = "gradebookng.allowStudentsToCompareGradesWithClassmates";


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-48741

Now icons show up:

<img width="1678" alt="SAK-48741-local" src="https://github.com/sakaiproject/sakai/assets/102482288/934fde5c-c740-4a2b-81a3-5a3bb8ac1fc0">
