### PR TITLE
SAK-49046 Lessons: Add Comment button should disappear after clicked

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -2858,7 +2858,7 @@
 
                     <div class="add-comment-button">
                       <img rsf:id="comment-required-image" src="/lessonbuilder-tool/images/available.png" class="status-image icon-image" style="margin-right:3px" />
-                      <button type="button" rsf:id="add-comment-link" class="btn btn-link" onclick="switchEditors($(this))"><span rsf:id="add-comment-text"></span></button>
+                      <button type="button" rsf:id="add-comment-link" class="btn btn-link switchLink" onclick="switchEditors($(this))"><span rsf:id="add-comment-text"></span></button>
                     </div>
                     <form class="commentArea" rsf:id="comment-form">
                       <input type="hidden" rsf:id="csrf2" />


### PR DESCRIPTION
Probably during the transition to Trinity, the switchLink class for the Add Comment button was omitted. The switchEditors function defined in comments.js relies on the switchLink class for showing/hiding the button.