### PR TITLE
SAK-47604 GB Adding or removing a TA's permissions causes duplicate values

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
+++ b/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
@@ -17,6 +17,7 @@ package org.sakaiproject.springframework.data;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Transactional(readOnly = true)
 public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, ID extends Serializable> implements SpringCrudRepository<T, ID> {
 
@@ -139,7 +141,7 @@ public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, 
         try {
             findById(entity.getId()).ifPresent(session::delete);
         } catch (Exception he) {
-            he.printStackTrace();
+            log.error("Failed to delete the entity: " + he.getMessage());
         }
     }
 

--- a/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
+++ b/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
@@ -140,7 +140,7 @@ public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, 
 
         try {
             findById(entity.getId()).ifPresent(session::delete);
-        } catch (Exception he) {
+        } catch (Exception e) {
             log.error("Failed to delete the entity: " + he.getMessage());
         }
     }

--- a/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
+++ b/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
@@ -125,7 +125,7 @@ public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, 
 
         List<T> list = new ArrayList<>();
         if (ids != null) {
-            ids.forEach(id -> findById(id).ifPresent(found -> list.add(found)));
+            ids.forEach(id -> findById(id).ifPresent(list::add));
         }
         return list;
     }
@@ -137,9 +137,9 @@ public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, 
         Session session = sessionFactory.getCurrentSession();
 
         try {
-            session.delete(entity);
+            findById(entity.getId()).ifPresent(session::delete);
         } catch (Exception he) {
-            session.delete(session.merge(entity));
+            he.printStackTrace();
         }
     }
 
@@ -161,7 +161,7 @@ public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, 
     @Override
     @Transactional
     public void deleteById(ID id) {
-        findById(id).ifPresent(found -> delete(found));
+        findById(id).ifPresent(this::delete);
     }
 
     /**

--- a/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
+++ b/kernel/api/src/main/java/org/sakaiproject/springframework/data/SpringCrudRepositoryImpl.java
@@ -141,7 +141,7 @@ public abstract class SpringCrudRepositoryImpl<T extends PersistableEntity<ID>, 
         try {
             findById(entity.getId()).ifPresent(session::delete);
         } catch (Exception e) {
-            log.error("Failed to delete the entity: " + he.getMessage());
+            log.warn("Could not delete entity [{}:{}], {}", entity.getClass().getName(), entity.getId(), e.toString());
         }
     }
 


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-47604

The reason is that it raises an error when removing a detached instance in ```delete()``` method.
```
Removing a detached instance org.sakaiproject.grading.api.model.Permission#37
...
```

@ern Thank you for guiding me through the issue :)