### PR TITLE
SAK-49006 Site Manage: The course and user locale is ignored for mail templates

### DIFF
--- a/site-manage/site-manage-impl/impl/src/bundle/notifyAddedParticipants.xml
+++ b/site-manage/site-manage-impl/impl/src/bundle/notifyAddedParticipants.xml
@@ -1,42 +1,6 @@
 <?xml version="1.0"?>
 <emailTemplates>
 	<emailTemplate>
-		<subject>${localSakaiName} Site Notification</subject>
-		<message>
-			Dear ${userName},
-
-				${currentUserName} added you to the following ${localSakaiName} site:
-					${siteName}
-
-			&lt;#if newNonOfficialAccount == "true" &gt;
-			&lt;#if hasNonOfficialAccountUrl == "true" &gt;
-				To get a guest account, follow the steps on ${nonOfficialAccountUrl}
-
-			&lt;/#if&gt;
-				Once you have your guest account, you can log into ${localSakaiName}:
-
-					1. Visit ${localSakaiName}: ${localSakaiURL}
-					2. In the top right corner of the page, type your guest account user id and password into the login fields, and click the "Log In" button.
-					3. Once you're logged in, find this site using these steps:
-						a. click the "Sites" link in the top right corner, then
-						b. type the site name in the provided search field
-					4. Click on the name of the site that appears to visit it
-
-			&lt;#else&gt;
-				To log in:
-
-					1. Open ${localSakaiName}: ${localSakaiURL}
-					2. In the top right corner of the page, type your user id and password into the login fields, and click the "Log In" button.
-					3. Once you're logged in, find this site using these steps:
-						a. click the "Sites" link in the top right corner, then
-						b. type the site name in the provided search field
-					4. Click on the name of the site that appears to visit it
-			&lt;/#if&gt;
-		</message>
-		<locale></locale>
-	</emailTemplate>
-	
-	<emailTemplate>
 		<subject>${localSakaiName} Notificació de lloc
 		</subject>
 		<message>${userName}: Se us ha
@@ -109,4 +73,62 @@ Zodra u uw gastaccount heeft, kunt u inloggen voor ${localSakaiName} :
 &lt;/#if&gt;4. Ga naar de site en klik op de site tab. (U ziet twee of meer tabs naast elkaar over het bovenste deel van het scherm.)</message>
  <locale>nl</locale>
 </emailTemplate>
+<emailTemplate>
+ <subject>${localSakaiName} Notificación del Sitio</subject>
+ <message>Estimado ${userName}:
+
+Ha sido añadido al sitio ${siteName} en ${localSakaiName}: por ${currentUserDisplayName}. 
+
+&lt;#if newNonOfficialAccount == "true" &gt;Insert your institutions specific instructions for new guest users here 
+
+Después de tener su cuenta de invitado, ya puede entrar. ${localSakaiName} : 
+1. Abrir ${localSakaiName} : ${localSakaiURL}
+2. Pulse el botón de Identificación.
+3. Teclee el login de su cuenta de invitado y el password, luego pulse Login.
+&lt;#else &gt;
+
+Para iniciar la sesión:
+1. Abra ${localSakaiName} : ${localSakaiURL}
+2. Pulse el botón de Identificación.
+3. Teclee el usuario y password, luego pulse Login.
+&lt;/#if&gt;
+4. Pulse en la pestaña del sitio. (Verá dos o más pestañas en la fila de la parte superior de la pantalla.)</message>
+ <locale>es_ES</locale>
+</emailTemplate>
+<emailTemplate>
+	<subject>${localSakaiName} Site Notification</subject>
+	<message>
+		Dear ${userName},
+
+			${currentUserName} added you to the following ${localSakaiName} site:
+				${siteName}
+
+		&lt;#if newNonOfficialAccount == "true" &gt;
+		&lt;#if hasNonOfficialAccountUrl == "true" &gt;
+			To get a guest account, follow the steps on ${nonOfficialAccountUrl}
+
+		&lt;/#if&gt;
+			Once you have your guest account, you can log into ${localSakaiName}:
+
+				1. Visit ${localSakaiName}: ${localSakaiURL}
+				2. In the top right corner of the page, type your guest account user id and password into the login fields, and click the "Log In" button.
+				3. Once you're logged in, find this site using these steps:
+					a. click the "Sites" link in the top right corner, then
+					b. type the site name in the provided search field
+				4. Click on the name of the site that appears to visit it
+
+		&lt;#else&gt;
+			To log in:
+
+				1. Open ${localSakaiName}: ${localSakaiURL}
+				2. In the top right corner of the page, type your user id and password into the login fields, and click the "Log In" button.
+				3. Once you're logged in, find this site using these steps:
+					a. click the "Sites" link in the top right corner, then
+					b. type the site name in the provided search field
+				4. Click on the name of the site that appears to visit it
+		&lt;/#if&gt;
+	</message>
+	<locale></locale>
+</emailTemplate>
+<!-- Default template (english) has to be the last one, to make sure the rest are stored on database -->
 </emailTemplates>

--- a/site-manage/site-manage-impl/impl/src/bundle/notifyNewuser.xml
+++ b/site-manage/site-manage-impl/impl/src/bundle/notifyNewuser.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0"?>
 <emailTemplates>
 <emailTemplate>
- <subject>${localSakaiName} New User Notification </subject>
- <message>Dear ${userName},
-
- An account on ${localSakaiName} (${localSakaiURL}) has been created for you by ${currentUserDisplayName}. To access your account:
-
-	1) Go to:
-		${localSakaiURL}
-	
-	2) Login using:
-		User Id: 	${userEid}
-		password: 	${newPassword} 
- You can change your password after you have logged in, using the Account tool in your Home.
- 
- (This is an automated message from ${localSakaiName}.)
-</message>
- <locale></locale>
-</emailTemplate>
-<emailTemplate>
  <subject>${localSakaiName} Notificaci al nou usuari</subject>
  <message>${userName}:
 
@@ -107,6 +89,25 @@ Puede ir a la herramienta de Cuentas en 'Mi Sito de Trabajo' para inicializarlo.
 </message>
  <locale>es</locale>
 </emailTemplate>
+<emailTemplate>
+ <subject>${localSakaiName} New User Notification </subject>
+ <message>Dear ${userName},
+
+ An account on ${localSakaiName} (${localSakaiURL}) has been created for you by ${currentUserDisplayName}. To access your account:
+
+	1) Go to:
+		${localSakaiURL}
+	
+	2) Login using:
+		User Id: 	${userEid}
+		password: 	${newPassword} 
+ You can change your password after you have logged in, using the Account tool in your Home.
+ 
+ (This is an automated message from ${localSakaiName}.)
+</message>
+ <locale></locale>
+</emailTemplate>
+<!-- Default template (english) has to be the last one, to make sure the rest are stored on database -->
 <!--  
 <emailTemplate>
  <subject>${localSakaiName} </subject>

--- a/site-manage/site-manage-impl/impl/src/bundle/notifySiteImportConfirmation.xml
+++ b/site-manage/site-manage-impl/impl/src/bundle/notifySiteImportConfirmation.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0"?>
 <emailTemplates>
 <emailTemplate>
-<subject>${localSakaiName} Site import completed for "${worksiteName}"</subject>
-<message>The import process you started for "${worksiteName}" has completed.
-
-Visit the site to view the imported materials:
-
-${linkToWorksite}
-		
-Regards,
-		
-The ${localSakaiName} Administrators
-${institution}
-</message>
-<locale>en</locale>
-<version>1</version>
-</emailTemplate>
-<emailTemplate>
 <subject>${localSakaiName} Importación del sitio completada para "${worksiteName}"</subject>
 <message>El proceso de importación que usted comenzó para el sitio "${worksiteName}" ha sido completado.
 
@@ -32,4 +16,21 @@ ${institution}
 <locale>es</locale>
 <version>1</version>
 </emailTemplate>
+<emailTemplate>
+<subject>${localSakaiName} Site import completed for "${worksiteName}"</subject>
+<message>The import process you started for "${worksiteName}" has completed.
+
+Visit the site to view the imported materials:
+
+${linkToWorksite}
+		
+Regards,
+		
+The ${localSakaiName} Administrators
+${institution}
+</message>
+<locale></locale>
+<version>1</version>
+</emailTemplate>
+<!-- Default template (english) has to be the last one, to make sure the rest are stored on database -->
 </emailTemplates>

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
@@ -414,7 +414,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 			if (locale == null)
 			{
 				// use user's locale
-				template = emailTemplateService.getRenderedTemplateForUser(templateName, user!=null?user.getReference():"", replacementValues);
+				template = emailTemplateService.getRenderedTemplateForUser(templateName, user!=null?user.getId():"", replacementValues);
 			}
 			else
 			{


### PR DESCRIPTION
Jira: [SAK-49006](https://sakaiproject.atlassian.net/browse/SAK-49006)

Two issues where causing mails to be received only in English, regardless of the course or user language preferences.

- Only the default mail template was being stored on database. I'm fixing this by putting the default template last.

- `user.getReference()` was being used to get the user locale. It returns _"user/" + internal ID_ instead of just the _internal ID_.
By using `user.getId()` we can make `getRenderedTemplateForUser(...)` work fine.

For the DB changes to get applied,  _email_template_item_ has to be emptied and tomcat restarted.
Or use conversion script: https://github.com/sakaiproject/sakai-reference/pull/211


[SAK-49006]: https://sakaiproject.atlassian.net/browse/SAK-49006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ