### PR TITLE
SAK-47797 Gradebook: Unable to add Rubric to existing item

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-association.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-association.js
@@ -90,11 +90,6 @@ class SakaiRubricAssociation extends RubricsElement {
       if (r.ok) {
         return r.json();
       }
-
-      if (r.status === 404) {
-        this.style.display = "none";
-      }
-
       throw new Error("Network error while getting association");
     })
     .then(assoc => {


### PR DESCRIPTION
Setting display to none caused the regression. I've also tested the removal of setting display to none with a site that does not contain rubrics; the rubric association does not display unless site rubrics are present. 

I'm not aware of a use case where this web component needs to be hidden via display:none.