### PR TITLE
SAK-48806 Lessons no icons for links to other tools

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1395,13 +1395,13 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 					    UIOutput itemicon = UIOutput.make(linkdiv,"item-icon");
 					    switch (i.getType()) {
 					    case SimplePageItem.FORUM:
-						itemicon.decorate(new UIStyleDecorator("icon-sakai--sakai-forums"));
+						itemicon.decorate(new UIStyleDecorator("si si-sakai-forums"));
 						break;
 					    case SimplePageItem.ASSIGNMENT:
-						itemicon.decorate(new UIStyleDecorator("icon-sakai--sakai-assignment-grades"));
+						itemicon.decorate(new UIStyleDecorator("si si-sakai-assignment-grades"));
 						break;
 					    case SimplePageItem.ASSESSMENT:
-						itemicon.decorate(new UIStyleDecorator("icon-sakai--sakai-samigo"));
+						itemicon.decorate(new UIStyleDecorator("si si-sakai-samigo"));
 						break;
 					    case SimplePageItem.BLTI:
 						String bltiIcon = "fa-globe";


### PR DESCRIPTION
Adding si for each of the three tools (Assignments, Discussions, and T&Q) is needed for the icon to appear. However, if 'si' was moved to the class list for the element in ShowPage.html, it would break the font-awesome icons used for external tools, etc.

![LessonsIconsRestored](https://github.com/sakaiproject/sakai/assets/1661251/35cddeb7-f0e2-433d-9abd-0e129b097b38)
