### PR TITLE
SAK-49082 DateManager improvements to additional nullable date support

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -76,6 +76,16 @@
 			margin-bottom: 0;
 			table-layout: fixed;
 
+			.field-required {
+				&:after {
+					content: "*";
+					color: var(--errorBanner-color);
+					position: relative;
+					top: 3px;
+					left: 3px;
+				}
+			}
+
 			td {
 				&.ajax-error {
 					background-color: var(--errorBanner-bgcolor);
@@ -94,6 +104,35 @@
 					border-bottom-right-radius: 0;
 				}
 
+				.hasDatepicker {
+					padding-right: 22%;
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
+
+				.ui-datepicker-trigger {
+					position: absolute;
+					top: 0;
+					right: 8px;
+				}
+
+				.ui-datepicker-clear-date {
+					position: relative;
+					top: 16%;
+					right: 22px;
+					cursor: text;
+					text-decoration: none;
+				}
+
+				.ui-datapicker-clear-date-icon {
+					cursor: pointer;
+				}
+
+				.ui-datepicker-clear-date > i[disabled] {
+					cursor: not-allowed;
+					color:#757575;
+				}
+				
 				.day-of-week {
 					text-transform: capitalize;
 				}

--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
@@ -60,11 +60,13 @@ public interface DateManagerService {
 	public JSONArray getResourcesForContext(String siteId);
 	public DateManagerValidation validateResources(String siteId, JSONArray resources) throws Exception;
 	public void updateResources(DateManagerValidation resourceValidation) throws Exception;
+	public void clearUpdateResourceLocks(DateManagerValidation resourceValidation) throws Exception;
 
 	// Calendar methods
 	public JSONArray getCalendarEventsForContext(String siteId);
 	public DateManagerValidation validateCalendarEvents(String siteId, JSONArray calendarEvents) throws Exception;
 	public void updateCalendarEvents(DateManagerValidation calendarValidation) throws Exception;
+	public void clearUpdateCalendarLocks(DateManagerValidation calendarValidation) throws Exception;
 
 	// Forum methods
 	public JSONArray getForumsForContext(String siteId);
@@ -75,6 +77,7 @@ public interface DateManagerService {
 	public JSONArray getAnnouncementsForContext(String siteId);
 	public DateManagerValidation validateAnnouncements(String siteId, JSONArray announcements) throws Exception;
 	public void updateAnnouncements(DateManagerValidation announcementValidation) throws Exception;
+	public void clearUpdateAnnouncementLocks(DateManagerValidation announcementValidation) throws Exception;
 
 	// Lessons methods
 	public JSONArray getLessonsForContext(String siteId);

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -1553,7 +1553,7 @@ public class DateManagerServiceImpl implements DateManagerService {
                                 aChannel.commitMessage(msg, NotificationService.NOTI_IGNORE);
                         }
                 } catch (Exception e) {
-                        log.error("Announcement channel {} doesn't exist. {}", anncRef, e.getMessage());
+                        log.warn("Announcement channel {} doesn't exist. {}", anncRef, e.toString());
                 }
 	}
 

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -1034,7 +1034,7 @@ public class DateManagerServiceImpl implements DateManagerService {
                                 }
                         }
                 } catch (Exception e) {
-                        log.error("Exception thrown: {}", e.getMessage());
+                        log.warn("Could not clear update for resource, {}", e.toString());
                 }
         }
 

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -1364,7 +1364,7 @@ public class DateManagerServiceImpl implements DateManagerService {
 	@Override
 	public void updateForums(DateManagerValidation forumValidation) throws Exception {
                 for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) forumValidation.getUpdates()) {
-                if (update.object instanceof BaseForum) {
+                    if (update.object instanceof BaseForum) {
                                 DiscussionForum forum = (DiscussionForum) update.object;
                                 if(forum.getAvailabilityRestricted()) {
                                         Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -306,7 +306,7 @@ public class DateManagerServiceImpl implements DateManagerService {
 			try {
 
 				if (assignmentId == null) {
-					errors.add(new DateManagerError("assignment", rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.assignments.item.name")}), "assignments", toolTitle, idx));
+                                        errors.add(new DateManagerError("assignment", rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.assignments.item.name")}), "assignments", toolTitle, idx));
 					continue;
 				}
 
@@ -317,11 +317,23 @@ public class DateManagerServiceImpl implements DateManagerService {
 					continue;
 				}
 
-				Instant openDate = userTimeService.parseISODateInUserTimezone((String)jsonAssignment.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME)).toInstant();
-				Instant dueDate = userTimeService.parseISODateInUserTimezone((String)jsonAssignment.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME)).toInstant();
-				Instant acceptUntil = userTimeService.parseISODateInUserTimezone((String)jsonAssignment.get(DateManagerConstants.JSON_ACCEPTUNTIL_PARAM_NAME)).toInstant();
+                                boolean errored = false;
+                                String openDateRaw = (String) jsonAssignment.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME);
+                                String dueDateRaw = (String) jsonAssignment.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME);
+                                String acceptUntilRaw = (String) jsonAssignment.get(DateManagerConstants.JSON_ACCEPTUNTIL_PARAM_NAME);
+                                Instant openDate = null;
+                                Instant dueDate = null;
+                                Instant acceptUntil = null;
 
-				boolean errored = false;
+				if (StringUtils.isNotBlank(openDateRaw)) {
+                                    openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
+				}
+				if (StringUtils.isNotBlank(dueDateRaw)) {
+                                    dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
+				}
+				if (StringUtils.isNotBlank(acceptUntilRaw)) {
+                                    acceptUntil = userTimeService.parseISODateInUserTimezone(acceptUntilRaw).toInstant();
+				} 
 
 				if (openDate == null) {
 					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.not.found"), "assignments", toolTitle, idx));
@@ -559,18 +571,6 @@ public class DateManagerServiceImpl implements DateManagerService {
 
 				log.debug("Open {} ; Due {} ; Until {} ; Feedback Start {} ; Feedback End {}", jsonAssessment.get(DateManagerConstants.JSON_OPENDATELABEL_PARAM_NAME), jsonAssessment.get(DateManagerConstants.JSON_DUEDATELABEL_PARAM_NAME),
 								jsonAssessment.get("accept_until_label"), jsonAssessment.get(DateManagerConstants.JSON_FEEDBACKSTARTLABEL_PARAM_NAME), jsonAssessment.get(DateManagerConstants.JSON_FEEDBACKENDLABEL_PARAM_NAME));
-				if(StringUtils.isBlank((String)jsonAssessment.get(DateManagerConstants.JSON_DUEDATELABEL_PARAM_NAME))) {
-					dueDate = null;
-				}
-				if(StringUtils.isBlank((String)jsonAssessment.get("accept_until_label"))) {
-					acceptUntil = null;
-				}
-				if(StringUtils.isBlank((String)jsonAssessment.get(DateManagerConstants.JSON_FEEDBACKSTARTLABEL_PARAM_NAME))) {
-					feedbackStart = null;
-				}
-				if(StringUtils.isBlank((String)jsonAssessment.get(DateManagerConstants.JSON_FEEDBACKENDLABEL_PARAM_NAME))) {
-					feedbackEnd = null;
-				}
 
 				DateManagerUpdate update = new DateManagerUpdate(assessment, openDate, dueDate, acceptUntil);
 				update.setFeedbackStartDate(feedbackStart);
@@ -624,9 +624,9 @@ public class DateManagerServiceImpl implements DateManagerService {
 				}
 				if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(assessment.getAssessmentFeedback().getFeedbackDelivery())) {
 					control.setFeedbackDate(Date.from(update.feedbackStartDate));
-					if (update.feedbackEndDate != null) {
-						control.setFeedbackEndDate(Date.from(update.feedbackEndDate));
-					}
+					Date feedbackEndDateTemp = 
+                                        update.feedbackEndDate != null ? Date.from(update.feedbackEndDate) : null;
+                                        control.setFeedbackEndDate(feedbackEndDateTemp);
 				}
 				assessment.setAssessmentAccessControl(control);
 				assessmentServiceQueries.saveOrUpdate(assessment);
@@ -819,10 +819,27 @@ public class DateManagerServiceImpl implements DateManagerService {
 					continue;
 				}
 
-				Instant openDate = userTimeService.parseISODateInUserTimezone((String)jsonMeeting.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME)).toInstant();
-				Instant dueDate = userTimeService.parseISODateInUserTimezone((String)jsonMeeting.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME)).toInstant();
-				Instant signupBegins = userTimeService.parseISODateInUserTimezone((String)jsonMeeting.get(DateManagerConstants.JSON_SIGNUPBEGINS_PARAM_NAME)).toInstant();
-				Instant signupDeadline = userTimeService.parseISODateInUserTimezone((String)jsonMeeting.get(DateManagerConstants.JSON_SIGNUPDEADLINE_PARAM_NAME)).toInstant();
+				String openDateRaw = (String) jsonMeeting.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME);
+				String dueDateRaw = (String) jsonMeeting.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME);
+				String signupBeginsRaw = (String) jsonMeeting.get(DateManagerConstants.JSON_SIGNUPBEGINS_PARAM_NAME);
+				String signupDeadlineRaw = (String) jsonMeeting.get(DateManagerConstants.JSON_SIGNUPDEADLINE_PARAM_NAME);
+				Instant openDate = null;
+				Instant dueDate = null;
+				Instant signupBegins = null;
+				Instant signupDeadline = null;
+
+				if (StringUtils.isNotBlank(openDateRaw)) {
+                                        openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
+				}
+				if (StringUtils.isNotBlank(dueDateRaw)) {
+                                        dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
+				}
+				if (StringUtils.isNotBlank(signupBeginsRaw)) {
+                                        signupBegins = userTimeService.parseISODateInUserTimezone(signupBeginsRaw).toInstant();
+				}
+				if (StringUtils.isNotBlank(signupDeadlineRaw)) {
+                                        signupDeadline = userTimeService.parseISODateInUserTimezone(signupDeadlineRaw).toInstant();
+				}
 				boolean errored = false;
 				if (openDate == null) {
 					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.not.found"), "signupMeetings", toolTitle, idx));
@@ -849,23 +866,23 @@ public class DateManagerServiceImpl implements DateManagerService {
 				DateManagerUpdate update = new DateManagerUpdate(meeting, openDate, dueDate, null, null, null);
 				update.setSignupBegins(signupBegins);
 				update.setSignupDeadline(signupDeadline);
-				if (!update.openDate.isBefore(update.dueDate)) {
-					errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.before.due.date"), "signupMeetings", toolTitle, idx));
-					continue;
-				}
-				if (update.signupBegins.isAfter(update.openDate)) {
-					errors.add(new DateManagerError(DateManagerConstants.JSON_SIGNUPBEGINS_PARAM_NAME, rb.getString("error.signup.begins.after.open.date"), "signupMeetings", toolTitle, idx));
-					continue;
-				}
-				if (update.signupDeadline.isAfter(update.dueDate)) {
-					errors.add(new DateManagerError(DateManagerConstants.JSON_SIGNUPDEADLINE_PARAM_NAME, rb.getString("error.signup.deadline.after.due.date"), "signupMeetings", toolTitle, idx));
-					continue;
-				}
-				if (update.signupBegins.isAfter(update.signupDeadline)) {
-					errors.add(new DateManagerError(DateManagerConstants.JSON_SIGNUPBEGINS_PARAM_NAME, rb.getString("error.signup.begins.after.signup.deadline"), "signupMeetings", toolTitle, idx));
-					continue;
-				}
-				updates.add(update);
+                                if (update.openDate != null && update.dueDate != null && !update.openDate.isBefore(update.dueDate)) {
+                                        errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.before.due.date"), "signupMeetings", toolTitle, idx));
+                                        continue;
+                                }
+                                if (update.signupBegins != null && update.openDate != null && update.signupBegins.isAfter(update.openDate)) {
+                                        errors.add(new DateManagerError(DateManagerConstants.JSON_SIGNUPBEGINS_PARAM_NAME, rb.getString("error.signup.begins.after.open.date"), "signupMeetings", toolTitle, idx));
+                                        continue;
+                                }
+                                if (update.signupDeadline != null && update.dueDate != null && update.signupDeadline.isAfter(update.dueDate)) {
+                                        errors.add(new DateManagerError(DateManagerConstants.JSON_SIGNUPDEADLINE_PARAM_NAME, rb.getString("error.signup.deadline.after.due.date"), "signupMeetings", toolTitle, idx));
+                                        continue;
+                                }
+                                if (update.signupBegins != null && update.signupDeadline != null && update.signupBegins.isAfter(update.signupDeadline)) {
+                                        errors.add(new DateManagerError(DateManagerConstants.JSON_SIGNUPBEGINS_PARAM_NAME, rb.getString("error.signup.begins.after.signup.deadline"), "signupMeetings", toolTitle, idx));
+                                        continue;
+                                }
+                                updates.add(update);
 
 			} catch (Exception ex) {
 				errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.uncaught"), "signupMeetings", toolTitle, idx));
@@ -956,13 +973,6 @@ public class DateManagerServiceImpl implements DateManagerService {
 					dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
 				}
 
-				log.debug("Open {} ; Due {}", jsonResource.get(DateManagerConstants.JSON_OPENDATELABEL_PARAM_NAME), jsonResource.get(DateManagerConstants.JSON_DUEDATELABEL_PARAM_NAME));
-				if(StringUtils.isBlank((String)jsonResource.get(DateManagerConstants.JSON_OPENDATELABEL_PARAM_NAME))) {
-					openDate = null;
-				}
-				if(StringUtils.isBlank((String)jsonResource.get(DateManagerConstants.JSON_DUEDATELABEL_PARAM_NAME))) {
-					dueDate = null;
-				}
 				if (openDate != null && dueDate != null && !openDate.isBefore(dueDate)) {
 					errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.before.due.date"), "resources", toolTitle, idx));
 					continue;
@@ -1011,6 +1021,22 @@ public class DateManagerServiceImpl implements DateManagerService {
 		resourcesValidate.setUpdates(updates);
 		return resourcesValidate;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void clearUpdateResourceLocks(DateManagerValidation resourceValidation) throws Exception {
+                try {
+                        for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) resourceValidation.getUpdates()) {
+                                if (update.object instanceof ContentResourceEdit) { 
+                                        contentHostingService.cancelResource((ContentResourceEdit) update.getObject());
+                                }
+                        }
+                } catch (Exception e) {
+                        log.error("Exception thrown: {}", e.getMessage());
+                }
+        }
 
 	/**
 	 * {@inheritDoc}
@@ -1108,22 +1134,30 @@ public class DateManagerServiceImpl implements DateManagerService {
 					errors.add(new DateManagerError("calendar", rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.calendar.item.name")}), "calendarEvents", toolTitle, idx));
 					continue;
 				}
-
-				Instant openDate = userTimeService.parseISODateInUserTimezone((String)jsonEvent.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME)).toInstant();
-				Instant dueDate = userTimeService.parseISODateInUserTimezone((String)jsonEvent.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME)).toInstant();
+				String openDateRaw = (String) jsonEvent.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME);
+				String dueDateRaw = (String) jsonEvent.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME);
+				Instant openDate = null;
+				Instant dueDate = null;
 				boolean errored = false;
-				if (openDate == null) {
-					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.not.found"), "calendarEvents", toolTitle, idx));
-				}
-				else if (dueDate == null) {
-					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_DUEDATE_PARAM_NAME, rb.getString("error.due.date.not.found"), "calendarEvents", toolTitle, idx));
-				}
-				else if (dueDate.isBefore(openDate)) {
-					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.before.end.date"), "calendarEvents", toolTitle, idx));
-				}
-				if (errored) {
-					continue;
-				}
+
+                                if (StringUtils.isNotBlank(openDateRaw)) {
+                                        openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
+                                }
+                                if (StringUtils.isNotBlank(dueDateRaw)) {
+                                        dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
+                                }	
+                                if (openDate == null) {
+                                        errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.not.found"), "calendarEvents", toolTitle, idx));
+                                }
+                                if (dueDate == null) {
+                                        errored = errors.add(new DateManagerError(DateManagerConstants.JSON_DUEDATE_PARAM_NAME, rb.getString("error.due.date.not.found"), "calendarEvents", toolTitle, idx));
+                                }
+                                if (openDate != null && dueDate != null && dueDate.isBefore(openDate)) {
+                                        errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.before.end.date"), "calendarEvents", toolTitle, idx));
+                                }
+                                if (errored) {
+                                        continue;
+                                }
 
 				if (!c.allowEditEvent(eventId)) {
 					errors.add(new DateManagerError("calendar", rb.getString("error.event.permission"), "calendarEvents", toolTitle, idx));
@@ -1152,6 +1186,24 @@ public class DateManagerServiceImpl implements DateManagerService {
 		calendarValidate.setErrors(errors);
 		calendarValidate.setUpdates(updates);
 		return calendarValidate;
+	}
+
+		/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void clearUpdateCalendarLocks(DateManagerValidation calendarValidate) throws Exception {
+		Calendar c = getCalendar();
+		if (c != null) { 
+                        try {
+                                for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) calendarValidate.getUpdates()) {
+                                        CalendarEventEdit edit = (CalendarEventEdit) update.object;
+                                        c.cancelEvent(edit);
+                                }
+                        } catch (Exception e) {
+                                log.error("Exception thrown: {}", e.getMessage());
+                        }
+		} 
 	}
 
 	/**
@@ -1260,30 +1312,32 @@ public class DateManagerServiceImpl implements DateManagerService {
 				Instant openDate = null;
 				Instant dueDate = null;
 
-				if (openDateRaw != null && !openDateRaw.isEmpty())
-					openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
-				if (dueDateRaw != null && !dueDateRaw.isEmpty())
-					dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
+                                if (StringUtils.isNotBlank(openDateRaw)) {					
+                                        openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
+                                }
+                                if (StringUtils.isNotBlank(dueDateRaw)) {	
+                                        dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
+                                }
 
-				String entityType = (String)jsonForum.get(DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME);
-				DateManagerUpdate update;
-				if(rb.getString("itemtype.forum").equals(entityType)) {
-					BaseForum forum = forumManager.getForumById(true, forumId);
-					if (forum == null) {
-						errors.add(new DateManagerError("forum",rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.forums.item.name")}), "forums", toolTitle, idx));
-						continue;
-					}
+                                String entityType = (String)jsonForum.get(DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME);
+                                DateManagerUpdate update;
+                                if(rb.getString("itemtype.forum").equals(entityType)) {
+                                        BaseForum forum = forumManager.getForumById(true, forumId);
+                                        if (forum == null) {
+                                                errors.add(new DateManagerError("forum",rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.forums.item.name")}), "forums", toolTitle, idx));
+                                                continue;
+                                        }
 
-					update = new DateManagerUpdate(forum, openDate, dueDate, null, null, null);
-				} else {
-					Topic topic = forumManager.getTopicById(true, forumId);
-					if (topic == null) {
-						errors.add(new DateManagerError("forum", rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.topics.item.name")}), "forums", toolTitle, idx));
-						continue;
-					}
+                                        update = new DateManagerUpdate(forum, openDate, dueDate, null, null, null);
+                                } else {
+                                        Topic topic = forumManager.getTopicById(true, forumId);
+                                        if (topic == null) {
+                                                errors.add(new DateManagerError("forum", rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.topics.item.name")}), "forums", toolTitle, idx));
+                                                continue;
+                                        }
 
-					update = new DateManagerUpdate(topic, openDate, dueDate, null, null, null);
-				}
+                                        update = new DateManagerUpdate(topic, openDate, dueDate, null, null, null);
+                                }
 
 				if (update.openDate != null
 						&& update.dueDate != null
@@ -1309,27 +1363,49 @@ public class DateManagerServiceImpl implements DateManagerService {
 	 */
 	@Override
 	public void updateForums(DateManagerValidation forumValidation) throws Exception {
-		for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) forumValidation.getUpdates()) {
-			if (update.object instanceof BaseForum) {
-				DiscussionForum forum = (DiscussionForum) update.object;
-				if(forum.getAvailabilityRestricted()) {
-					Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
-					Date closeDateTemp = update.dueDate != null ? Date.from(update.dueDate) : null;
-					forum.setOpenDate(openDateTemp);
-					forum.setCloseDate(closeDateTemp);
-				}
-				forumManager.saveDiscussionForum(forum);
-			} else {
-				DiscussionTopic topic = (DiscussionTopic) update.object;
-				if(topic.getAvailabilityRestricted()) {
-					Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
-					Date closeDateTemp = update.dueDate != null ? Date.from(update.dueDate) : null;
-					topic.setOpenDate(openDateTemp);
-					topic.setCloseDate(closeDateTemp);
-				}
-				forumManager.saveDiscussionForumTopic(topic);
-			}
-		}
+                for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) forumValidation.getUpdates()) {
+                if (update.object instanceof BaseForum) {
+                                DiscussionForum forum = (DiscussionForum) update.object;
+                                if(forum.getAvailabilityRestricted()) {
+                                        Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
+                                        Date closeDateTemp = update.dueDate != null ? Date.from(update.dueDate) : null;
+                                        if (update.openDate == null && update.dueDate == null) {
+                                                forum.setAvailabilityRestricted(false);
+                                        }
+                                        forum.setOpenDate(openDateTemp);
+                                        forum.setCloseDate(closeDateTemp);
+                                } else {
+                                        Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
+                                        Date closeDateTemp = update.dueDate != null ? Date.from(update.dueDate) : null;
+                                        if (update.openDate != null || update.dueDate != null) {
+                                                forum.setAvailabilityRestricted(true);
+                                                forum.setOpenDate(openDateTemp);
+                                                forum.setCloseDate(closeDateTemp);
+                                        }
+                                }
+                                forumManager.saveDiscussionForum(forum);
+                        } else {
+                                DiscussionTopic topic = (DiscussionTopic) update.object;
+                                if(topic.getAvailabilityRestricted()) {
+                                        Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
+                                        Date closeDateTemp = update.dueDate != null ? Date.from(update.dueDate) : null;
+                                        topic.setOpenDate(openDateTemp);
+                                        topic.setCloseDate(closeDateTemp);
+                                        if (update.openDate == null && update.dueDate == null) {
+                                                topic.setAvailabilityRestricted(false);
+                                        }
+                                } else {
+                                        Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
+                                        Date closeDateTemp = update.dueDate != null ? Date.from(update.dueDate) : null;
+                                        if (update.openDate != null || update.dueDate != null) {
+                                                topic.setAvailabilityRestricted(true);
+                                                topic.setOpenDate(openDateTemp);
+                                                topic.setCloseDate(closeDateTemp);
+                                        }
+                                }
+                                forumManager.saveDiscussionForumTopic(topic);
+                        }
+                }
 	}
 
 	/***** ANNOUNCEMENTS *****/
@@ -1395,24 +1471,23 @@ public class DateManagerServiceImpl implements DateManagerService {
 					continue;
 				}
 
-				Instant openDate = userTimeService.parseISODateInUserTimezone((String)jsonAnnouncement.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME)).toInstant();
-				Instant dueDate = userTimeService.parseISODateInUserTimezone((String)jsonAnnouncement.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME)).toInstant();
+				String openDateRaw = (String) jsonAnnouncement.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME);
+				String dueDateRaw = (String) jsonAnnouncement.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME);
+				Instant openDate = null;
+				Instant dueDate = null;
+				if (StringUtils.isNotBlank(openDateRaw)) {	
+					openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
+				} 
+
+				if (StringUtils.isNotBlank(dueDateRaw)) {		
+					dueDate = userTimeService.parseISODateInUserTimezone(dueDateRaw).toInstant();
+				} 
 				boolean errored = false;
-				if (openDate == null) {
-					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.not.found"), "announcements", toolTitle, idx));
-				}
-				if (dueDate == null) {
-					errored = errors.add(new DateManagerError(DateManagerConstants.JSON_DUEDATE_PARAM_NAME, rb.getString("error.due.date.not.found"), "announcements", toolTitle, idx));
-				}
+
 				if (errored) {
 					continue;
 				}
-				if(StringUtils.isBlank((String)jsonAnnouncement.get(DateManagerConstants.JSON_OPENDATELABEL_PARAM_NAME))) {
-					openDate = null;
-				}
-				if(StringUtils.isBlank((String)jsonAnnouncement.get(DateManagerConstants.JSON_DUEDATELABEL_PARAM_NAME))) {
-					dueDate = null;
-				}
+
 				if (openDate != null && dueDate != null && !openDate.isBefore(dueDate)) {
 					errors.add(new DateManagerError(DateManagerConstants.JSON_OPENDATE_PARAM_NAME, rb.getString("error.open.date.before.due.date"), "announcements", toolTitle, idx));
 					continue;
@@ -1441,23 +1516,45 @@ public class DateManagerServiceImpl implements DateManagerService {
 		return announcementValidate;
 	}
 
+		/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void clearUpdateAnnouncementLocks(DateManagerValidation announcementValidate) throws Exception {
+                try {
+                        for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) announcementValidate.getUpdates()) {
+                                announcementService.cancelMessage((AnnouncementMessageEdit) update.getObject());
+                        }
+                } catch (Exception e) {
+                        log.error("Exception thrown: {}", e.getMessage());
+                }
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public void updateAnnouncements(DateManagerValidation announcementValidate) {
 		String anncRef = announcementService.channelReference(getCurrentSiteId(), SiteService.MAIN_CONTAINER);
-		try {
-			AnnouncementChannel aChannel = announcementService.getAnnouncementChannel(anncRef);
-			for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) announcementValidate.getUpdates()) {
-				AnnouncementMessageEdit msg = (AnnouncementMessageEdit) update.object;
-				msg.getPropertiesEdit().addProperty(AnnouncementService.RELEASE_DATE, timeService.newTime(Date.from(update.openDate).getTime()).toString());
-				msg.getPropertiesEdit().addProperty(AnnouncementService.RETRACT_DATE, timeService.newTime(Date.from(update.dueDate).getTime()).toString());
-				aChannel.commitMessage(msg, NotificationService.NOTI_IGNORE);
-			}
-		} catch (Exception e) {
-			log.error("Announcement channel {} doesn't exist. {}", anncRef, e.getMessage());
-		}
+                try {
+                        AnnouncementChannel aChannel = announcementService.getAnnouncementChannel(anncRef);
+                        for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) announcementValidate.getUpdates()) {
+                                AnnouncementMessageEdit msg = (AnnouncementMessageEdit) update.object;
+                                if (update.openDate != null) {				
+                                        msg.getPropertiesEdit().addProperty(AnnouncementService.RELEASE_DATE, timeService.newTime(Date.from(update.openDate).getTime()).toString());
+                                } else {
+                                        msg.getPropertiesEdit().removeProperty(AnnouncementService.RELEASE_DATE);
+                                }	
+                                if (update.dueDate != null) {
+                                        msg.getPropertiesEdit().addProperty(AnnouncementService.RETRACT_DATE, timeService.newTime(Date.from(update.dueDate).getTime()).toString());
+                                } else {
+                                        msg.getPropertiesEdit().removeProperty(AnnouncementService.RETRACT_DATE);		
+                                }				
+                                aChannel.commitMessage(msg, NotificationService.NOTI_IGNORE);
+                        }
+                } catch (Exception e) {
+                        log.error("Announcement channel {} doesn't exist. {}", anncRef, e.getMessage());
+                }
 	}
 
 	/***** LESSONS *****/
@@ -1519,17 +1616,17 @@ public class DateManagerServiceImpl implements DateManagerService {
 
 			try {
 
+				String openDateRaw = (String) jsonItem.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME);
+				Instant openDate = null;
 				Long itemId = (Long)jsonItem.get(DateManagerConstants.JSON_ID_PARAM_NAME);
 				if (itemId == null) {
 					errors.add(new DateManagerError("page", rb.getFormattedMessage("error.item.not.found", new Object[]{rb.getString("tool.lessons.item.name")}), "lessons", toolTitle, idx));
 					continue;
 				}
 
-				Instant openDate = userTimeService.parseISODateInUserTimezone((String)jsonItem.get(DateManagerConstants.JSON_OPENDATE_PARAM_NAME)).toInstant();
-				if (openDate == null) {
-					errors.add(new DateManagerError(DateManagerConstants.JSON_DUEDATE_PARAM_NAME, rb.getString("error.release.date.not.found"), "lessons", toolTitle, idx));
-					continue;
-				}
+				if (StringUtils.isNotBlank(openDateRaw)) {
+					openDate = userTimeService.parseISODateInUserTimezone(openDateRaw).toInstant();
+				}	
 
 				SimplePage page = simplePageToolDao.getPage(itemId);
 				if (page == null) {
@@ -1555,11 +1652,12 @@ public class DateManagerServiceImpl implements DateManagerService {
 	 */
 	@Override
 	public void updateLessons(DateManagerValidation lessonsValidation) throws Exception {
-		for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) lessonsValidation.getUpdates()) {
-			SimplePage page = (SimplePage) update.object;
-			page.setReleaseDate(Date.from(update.openDate));
-			log.debug("Saving changes on lessons : {}", simplePageToolDao.quickUpdate(page));
-		}
+                for (DateManagerUpdate update : (List<DateManagerUpdate>)(Object) lessonsValidation.getUpdates()) {
+                        SimplePage page = (SimplePage) update.object;
+                        Date openDateTemp = update.openDate != null ? Date.from(update.openDate) : null;
+                        page.setReleaseDate(openDateTemp);
+                        log.debug("Saving changes on lessons : {}", simplePageToolDao.quickUpdate(page));
+                }
 	}
 
 	private JSONArray orderJSONArrayByTitle(JSONArray jsonArray) {

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -1526,7 +1526,7 @@ public class DateManagerServiceImpl implements DateManagerService {
                                 announcementService.cancelMessage((AnnouncementMessageEdit) update.getObject());
                         }
                 } catch (Exception e) {
-                        log.error("Exception thrown: {}", e.getMessage());
+                        log.warn("Could not clear update for announcement, {}", e.toString());
                 }
 	}
 

--- a/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -1201,7 +1201,7 @@ public class DateManagerServiceImpl implements DateManagerService {
                                         c.cancelEvent(edit);
                                 }
                         } catch (Exception e) {
-                                log.error("Exception thrown: {}", e.getMessage());
+                                log.warn("Could not clear update for calendar, {}", e.toString());
                         }
 		} 
 	}

--- a/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
+++ b/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
@@ -205,6 +205,10 @@ public class MainController {
 				}
 
 				jsonResponse = String.format("{\"status\": \"ERROR\", \"errors\": %s}", errorReport.toJSONString());
+				// Unlock any locks initiated by Resources, Calendar, and Announcements tools
+				dateManagerService.clearUpdateResourceLocks(resourcesValidate);
+				dateManagerService.clearUpdateCalendarLocks(calendarValidate);
+				dateManagerService.clearUpdateAnnouncementLocks(announcementValidate);
 			}
 
 		} catch (Exception e) {

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -7,39 +7,39 @@
 					<th th:text="#{column.title}">Title</th>
 					<th:block th:switch="${toolId}">
 						<th:block th:case="'gradebookItems'"></th:block>
-						<th th:case="'assignments'" th:text="#{column.open.date}">Open Date</th>
-						<th th:case="'assessments'" th:text="#{column.available.date}">Available Date</th>
-						<th th:case="'signupMeetings'" th:text="#{column.start.date}">Start Date</th>
+						<th th:case="'assignments'" th:text="#{column.open.date}" class="field-required" title="Required">Open Date</th>
+						<th th:case="'assessments'" th:text="#{column.available.date}" class="field-required" title="Required">Available Date</th>
+						<th th:case="'signupMeetings'" th:text="#{column.start.date}" class="field-required" title="Required">Start Date</th>
 						<th th:case="'resources'" th:text="#{column.show.from.date}">Show From Date</th>
-						<th th:case="'calendarEvents'" th:text="#{column.start.date}">Start Date</th>
+						<th th:case="'calendarEvents'" th:text="#{column.start.date}" class="field-required" title="Required">Start Date</th>
 						<th th:case="'forums'" th:text="#{column.open.date}">Open Date</th>
 						<th th:case="'announcements'" th:text="#{column.start.date}">Start Date</th>
 						<th th:case="'lessons'" th:text="#{column.hide.until}">Hide Until Date</th>
 					</th:block>
 					<th:block th:switch="${toolId}">
 						<th:block th:case="'lessons'"></th:block>
-						<th th:case="'assignments'" th:text="#{column.due.date}">Due Date</th>
+						<th th:case="'assignments'" th:text="#{column.due.date}" class="field-required" title="Required">Due Date</th>
 						<th th:case="'assessments'" th:text="#{column.due.date}">Due Date</th>
-						<th th:case="'signupMeetings'" th:text="#{column.end.date}">End Date</th>
+						<th th:case="'signupMeetings'" th:text="#{column.end.date}" class="field-required" title="Required">End Date</th>
 						<th th:case="'gradebookItems'" th:text="#{column.due.date}">Due Date</th>
 						<th th:case="'resources'" th:text="#{column.show.until}">Show Until Date</th>
-						<th th:case="'calendarEvents'" th:text="#{column.end.date}">End Date</th>
+						<th th:case="'calendarEvents'" th:text="#{column.end.date}" class="field-required" title="Required">End Date</th>
 						<th th:case="'forums'" th:text="#{column.close.date}">Close Date</th>
 						<th th:case="'announcements'" th:text="#{column.end.date}">End Date</th>
 					</th:block>
 					<th:block th:switch="${toolId}">
-						<th th:case="'assignments'" th:text="#{column.accept.until}">Accept Until Date</th>
+						<th th:case="'assignments'" th:text="#{column.accept.until}" class="field-required" title="Required">Accept Until Date</th>
 						<th th:case="'assessments'" th:text="#{column.assessments.accept.until}">Late Submission Deadline</th>
 						<th:block th:case="*"></th:block>
 					</th:block>
 					<th:block th:switch="${toolId}">
 						<th th:case="'assessments'" th:text="#{column.feedback.start.date}">Show Feedback On</th>
-						<th th:case="'signupMeetings'" th:text="#{column.signup.begins.date}">Sign-up Begins Date</th>
+						<th th:case="'signupMeetings'" th:text="#{column.signup.begins.date}" class="field-required" title="Required">Sign-up Begins Date</th>
 						<th:block th:case="*"></th:block>
 					</th:block>
 					<th:block th:switch="${toolId}">
 						<th th:case="'assessments'" th:text="#{column.feedback.end.date}">Show Feedback Until</th>
-						<th th:case="'signupMeetings'" th:text="#{column.signup.deadline.date}">Sign-up Ends Date</th>
+						<th th:case="'signupMeetings'" th:text="#{column.signup.deadline.date}" class="field-required" title="Required">Sign-up Ends Date</th>
 						<th:block th:case="*"></th:block>
 					</th:block>
 				</tr>
@@ -58,7 +58,11 @@
 							<td th:case="*">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.open_date}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="open_date" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.open_date}" th:data-null-date="(${item.open_date} == null OR ${item.open_date} == '')? true : false"
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="open_date" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>
@@ -69,7 +73,11 @@
 							<td th:case="*">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.due_date}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="due_date" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.due_date}" th:data-null-date="(${item.due_date} == null OR ${item.due_date} == '')? true : false"
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="due_date" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>
@@ -86,7 +94,11 @@
 							<td th:case="*">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.accept_until}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="accept_until" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.accept_until}" th:data-null-date="(${item.accept_until} == null OR ${item.accept_until} == '')? true : false"
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="accept_until" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>
@@ -96,7 +108,11 @@
 							<td th:case="'assessments'">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.feedback_start}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="feedback_start" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.feedback_start}" th:data-null-date="(${item.feedback_start} == null OR ${item.feedback_start} == '')? true : false"
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="feedback_start" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>
@@ -104,7 +120,11 @@
 							<td th:case="'signupMeetings'">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.signup_begins}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="signup_begins" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.signup_begins}" th:data-null-date="${item.signup_begins} ? false : true"
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="signup_begins" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>
@@ -116,7 +136,11 @@
 							<td th:case="'assessments'">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.feedback_end}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="feedback_end" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.feedback_end}" th:data-null-date="(${item.feedback_end} == null OR ${item.feedback_end} == '')? true : false"
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="feedback_end" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>
@@ -124,7 +148,11 @@
 							<td th:case="'signupMeetings'">
 								<div>
 									<input type="text" class="form-control datepicker" />
-									<input type="hidden" th:value="${item.signup_deadline}" th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="signup_deadline" />
+									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
+										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
+									</a>
+									<input type="hidden" th:value="${item.signup_deadline}" th:data-null-date="${item.signup_deadline} ? false : true" 
+									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="signup_deadline" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
 								</div>


### PR DESCRIPTION
This pull request adds UX features to Date Manager and fixes several open issues. 
Fixed are the following:
From the re-opened [SAK-46023 - Date Manager > Nullable fields for some activities needs to be allowed](https://sakaiproject.atlassian.net/browse/SAK-46023)

- Tests & Quizzes hide feedback date - No error, but no change in the settings. When you reload date manager, these dates re-appear
- Announcements start/end dates - “Uncaught Error” in Date Manager when trying to save after clearing out dates
- Lessons hide until date- “Uncaught Error” in Date Manager when trying to save after clearing out dates

Also fixed:

- [SAK-46212 - Date Manager: unable to change announcement dates if open date set without hide date](https://sakaiproject.atlassian.net/browse/SAK-46212)
- [SAK-48788 - Date Manager: Announcements - Uncaught error (SQL lock) if fixing date from previous error](https://sakaiproject.atlassian.net/browse/SAK-48788)
- [SAK-48789 - Date Manager: Calendar - Uncaught error (SQL lock) if fixing date from previous error](https://sakaiproject.atlassian.net/browse/SAK-48789)
- Resources affecting Files (not Folders): Uncaught error (SQL lock) if fixing date from previous error

UX Features added to Date Manager:

- Ability to clear any date - required date fields subject to validation upon Save
- Assessible Clear date button 
- Date input field value now shows in title element (helpful for Accessibility and when dates fields compressed due to narrow screen widths (tablets, etc.)

![image](https://github.com/sakaiproject/sakai/assets/50058682/6e03f11c-4a2b-4a8c-9359-85b1fdb85949)
![image](https://github.com/sakaiproject/sakai/assets/50058682/0cf932b2-0bd5-4360-8d66-fa6288cfe65c)

