### PR TITLE
SAK-48948 Portal: Pinned status should behave like auto-favorites before Trinity

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -690,6 +690,16 @@ public interface SiteService extends EntityProducer
 	String siteReference(String id);
 
 	/**
+	 * Parse out the site id from the supplied reference
+	 *
+	 * @param ref
+	 *        The site reference.
+	 * @return The the internal reference which can be used to access the site from within the system.
+	 */
+	String idFromSiteReference(String ref);
+
+
+	/**
 	 * Access the internal reference which can be used to access the site page from within the system.
 	 * 
 	 * @param siteId

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -694,7 +694,7 @@ public interface SiteService extends EntityProducer
 	 *
 	 * @param ref
 	 *        The site reference.
-	 * @return The the internal reference which can be used to access the site from within the system.
+	 * @return The site id
 	 */
 	String idFromSiteReference(String ref);
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -1536,17 +1536,9 @@ public abstract class BaseSiteService implements SiteService, Observer
 		return getAccessPoint(true) + Entity.SEPARATOR + id;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	@Override
 	public String idFromSiteReference(String ref) {
-
-		String[] resourceParts = ref.split("/");
-		if (resourceParts.length == 3) {
-			return resourceParts[2];
-		}
-
-		return "";
+		return entityManager().newReference(ref).getId();
 	}
 
 	/**

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -1539,6 +1539,19 @@ public abstract class BaseSiteService implements SiteService, Observer
 	/**
 	 * @inheritDoc
 	 */
+	public String idFromSiteReference(String ref) {
+
+		String[] resourceParts = ref.split("/");
+		if (resourceParts.length == 3) {
+			return resourceParts[2];
+		}
+
+		return "";
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public String sitePageReference(String siteId, String pageId)
 	{
 		return getAccessPoint(true) + Entity.SEPARATOR + siteId + Entity.SEPARATOR + PAGE_SUBTYPE + Entity.SEPARATOR + pageId;

--- a/kernel/kernel-test/src/main/java/org/sakaiproject/test/SakaiTests.java
+++ b/kernel/kernel-test/src/main/java/org/sakaiproject/test/SakaiTests.java
@@ -17,6 +17,7 @@ package org.sakaiproject.test;
 
 import org.sakaiproject.authz.api.AuthzGroup;
 import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalService.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalService.java
@@ -321,6 +321,14 @@ public interface PortalService
 	public void addPinnedSite(String userId, String siteId);
 
 	/**
+	 * Mark a single pinned site as unpinned, for the specified user, so that other events do not automatically "re-pin" it.
+	 *
+	 * @param userId The user to unpin the site for
+	 * @param siteId The site id to unpin
+	 */
+	public void unpinPinnedSite(String userId, String siteId);
+
+	/**
 	 * Remove a single pinned site, for the specified user
 	 *
 	 * @param userId The user to unpin the site for
@@ -348,6 +356,13 @@ public interface PortalService
 	 * @return the list of pinned site ids for the supplied user
 	 */
 	public List<String> getPinnedSites();
+
+	/**
+	 * Get the list of site ids explicitly unpinned by the current user
+	 *
+	 * @return the list of site ids explicitly unpinned by the supplied user
+	 */
+	public List<String> getUnpinnedSites();
 
 	/**
 	 * Get the list of recent site ids for the current user

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalService.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalService.java
@@ -360,9 +360,9 @@ public interface PortalService
 	/**
 	 * Get the list of site ids explicitly unpinned by the current user
 	 *
-	 * @return the list of site ids explicitly unpinned by the supplied user
+	 * @return the list of site ids explicitly unpinned by the current user
 	 */
-	public List<String> getUnpinnedSites();
+	public List<String> getUserUnpinnedSites();
 
 	/**
 	 * Get the list of recent site ids for the current user

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/model/PinnedSite.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/model/PinnedSite.java
@@ -55,4 +55,15 @@ public class PinnedSite implements PersistableEntity<Long> {
 
     @Column(name = "HAS_BEEN_UNPINNED", nullable = false)
     private Boolean hasBeenUnpinned = false;
+
+    public PinnedSite() {
+    }
+
+    public PinnedSite(String userId, String siteId) {
+
+        super();
+
+        this.userId = userId;
+        this.siteId = siteId;
+    }
 }

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/model/PinnedSite.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/model/PinnedSite.java
@@ -37,6 +37,8 @@ import lombok.Setter;
 @Setter
 public class PinnedSite implements PersistableEntity<Long> {
 
+    public static final int UNPINNED_POSITION = -1;
+
     @Id
     @GeneratedValue
     @Column(name = "ID")
@@ -50,4 +52,7 @@ public class PinnedSite implements PersistableEntity<Long> {
 
     @Column(name = "POSITION", nullable = false)
     private int position;
+
+    @Column(name = "HAS_BEEN_UNPINNED", nullable = false)
+    private Boolean hasBeenUnpinned = false;
 }

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/repository/PinnedSiteRepository.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/repository/PinnedSiteRepository.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.portal.api.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.sakaiproject.portal.api.model.PinnedSite;
 import org.sakaiproject.springframework.data.SpringCrudRepository;
@@ -23,6 +24,8 @@ import org.sakaiproject.springframework.data.SpringCrudRepository;
 public interface PinnedSiteRepository extends SpringCrudRepository<PinnedSite, Long> {
 
     List<PinnedSite> findByUserIdOrderByPosition(String userId);
+    List<PinnedSite> findByUserIdOrderByPosition(String userId, boolean hasBeenUnpinned);
+    Optional<PinnedSite> findByUserIdAndSiteId(String userId, String siteId);
     List<PinnedSite> findBySiteId(String siteId);
     Integer deleteByUserId(String userId);
     Integer deleteBySiteId(String siteId);

--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/repository/PinnedSiteRepository.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/repository/PinnedSiteRepository.java
@@ -24,7 +24,7 @@ import org.sakaiproject.springframework.data.SpringCrudRepository;
 public interface PinnedSiteRepository extends SpringCrudRepository<PinnedSite, Long> {
 
     List<PinnedSite> findByUserIdOrderByPosition(String userId);
-    List<PinnedSite> findByUserIdOrderByPosition(String userId, boolean hasBeenUnpinned);
+    List<PinnedSite> findByUserIdAndHasBeenUnpinnedOrderByPosition(String userId, boolean hasBeenUnpinned);
     Optional<PinnedSite> findByUserIdAndSiteId(String userId, String siteId);
     List<PinnedSite> findBySiteId(String siteId);
     Integer deleteByUserId(String userId);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/FavoritesHandler.java
@@ -30,13 +30,19 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.InUseException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.portal.api.PortalService;
+import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.SiteService.SelectionType;
+import org.sakaiproject.site.api.SiteService.SortType;
 import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.user.api.UserDirectoryService;
 
 import org.apache.commons.lang3.StringUtils;
@@ -59,6 +65,7 @@ public class FavoritesHandler extends BasePortalHandler
 	private static final String FIRST_TIME_PROPERTY = "firstTime";
 
 	private PortalService portalService;
+	private PreferencesService preferencesService;
 	private ServerConfigurationService serverConfigurationService;
 	private SiteService siteService;
 	private UserDirectoryService userDirectoryService;
@@ -66,6 +73,7 @@ public class FavoritesHandler extends BasePortalHandler
 	public FavoritesHandler()
 	{
 		setUrlFragment(URL_FRAGMENT);
+		preferencesService = (PreferencesService) ComponentManager.get(PreferencesService.class);
 		portalService = (PortalService) ComponentManager.get(PortalService.class);
 		serverConfigurationService = (ServerConfigurationService) ComponentManager.get(ServerConfigurationService.class);
 		siteService = (SiteService) ComponentManager.get(SiteService.class);
@@ -125,6 +133,46 @@ public class FavoritesHandler extends BasePortalHandler
 			return result;
 		}
 
+		List<String> existingHiddenSiteIds = Collections.<String>emptyList();
+		Preferences prefs = preferencesService.getPreferences(userId);
+		ResourceProperties props = prefs.getProperties(PreferencesService.SITENAV_PREFS_KEY);
+		List propList = props.getPropertyList(PreferencesService.SITENAV_PREFS_EXCLUDE_KEY);
+		if (propList != null) {
+			existingHiddenSiteIds = (List<String>) propList;
+		}
+
+		List<String> existingSiteIds = portalService.getPinnedSites();
+		existingSiteIds.addAll(portalService.getUnpinnedSites());
+
+		// Remove newly hidden sites from pinned and unpinned sites
+		for (String siteId : existingSiteIds) {
+			if (existingHiddenSiteIds.contains(siteId)) {
+				portalService.removePinnedSite(userId, siteId);
+			}
+		}
+		existingSiteIds.addAll(existingHiddenSiteIds);
+
+		// This should not call getUserSites(boolean, boolean) because the property is variable, while the call is cacheable otherwise
+		List<String> userSites = siteService.getSiteIds(SelectionType.MEMBER, null, null, null, SortType.CREATED_ON_DESC, null);
+
+                for (String userSite : userSites) {
+			Site site = null;
+			try {
+				site = siteService.getSite(userSite);
+			} catch (IdUnusedException idue) {
+				log.error("No site for id {}", userSite);
+				continue;
+			}
+
+			// Automatically pin appropriate sites that a user hasn't already explicitly hidden or unpinned.
+			if (!existingSiteIds.contains(userSite) &&
+			    ((site.isPublished() && site.getMember(userId).isActive()) ||
+			     site.isAllowed(userId, SiteService.SECURE_UPDATE_SITE))) {
+                                log.debug("Adding {} as a pinned site for {}", userSite, userId);
+				portalService.addPinnedSite(userId, userSite);
+                        }
+                }
+                
 		result.favoriteSiteIds = portalService.getPinnedSites();
 
 		return result;

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/repository/PinnedSiteRepositoryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/repository/PinnedSiteRepositoryImpl.java
@@ -36,20 +36,20 @@ public class PinnedSiteRepositoryImpl extends SpringCrudRepositoryImpl<PinnedSit
 
     @Transactional(readOnly = true)
     public List<PinnedSite> findByUserIdOrderByPosition(String userId) {
-        return findByUserIdOrderByPosition(userId, false);
+        return findByUserIdAndHasBeenUnpinnedOrderByPosition(userId, false);
     }
 
     @Transactional(readOnly = true)
-    public List<PinnedSite> findByUserIdOrderByPosition(String userId, boolean hasBeenUnpinned) {
+    public List<PinnedSite> findByUserIdAndHasBeenUnpinnedOrderByPosition(String userId, boolean hasBeenUnpinned) {
 
         Session session = sessionFactory.getCurrentSession();
 
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaQuery<PinnedSite> query = cb.createQuery(PinnedSite.class);
         Root<PinnedSite> pinnedSite = query.from(PinnedSite.class);
-	Predicate[] predicates = new Predicate[2];
-	predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
-	predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), hasBeenUnpinned);
+        Predicate[] predicates = new Predicate[2];
+        predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+        predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), hasBeenUnpinned);
         query.where(predicates).orderBy(cb.asc(pinnedSite.get("position")));
 
         return session.createQuery(query).list();
@@ -63,9 +63,9 @@ public class PinnedSiteRepositoryImpl extends SpringCrudRepositoryImpl<PinnedSit
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaQuery<PinnedSite> query = cb.createQuery(PinnedSite.class);
         Root<PinnedSite> pinnedSite = query.from(PinnedSite.class);
-	Predicate[] predicates = new Predicate[2];
-	predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
-	predicates[1] = cb.equal(pinnedSite.get("siteId"), siteId);
+        Predicate[] predicates = new Predicate[2];
+        predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+        predicates[1] = cb.equal(pinnedSite.get("siteId"), siteId);
         query.where(predicates);
 
         return session.createQuery(query).uniqueResultOptional();
@@ -92,9 +92,9 @@ public class PinnedSiteRepositoryImpl extends SpringCrudRepositoryImpl<PinnedSit
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaDelete<PinnedSite> delete = cb.createCriteriaDelete(PinnedSite.class);
         Root<PinnedSite> pinnedSite = delete.from(PinnedSite.class);
-	Predicate[] predicates = new Predicate[2];
-	predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
-	predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), false);
+        Predicate[] predicates = new Predicate[2];
+        predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+        predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), false);
         delete.where(predicates);
 
         return session.createQuery(delete).executeUpdate();

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/repository/PinnedSiteRepositoryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/repository/PinnedSiteRepositoryImpl.java
@@ -16,12 +16,14 @@
 package org.sakaiproject.portal.service.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.hibernate.Session;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.sakaiproject.portal.api.model.PinnedSite;
@@ -34,16 +36,39 @@ public class PinnedSiteRepositoryImpl extends SpringCrudRepositoryImpl<PinnedSit
 
     @Transactional(readOnly = true)
     public List<PinnedSite> findByUserIdOrderByPosition(String userId) {
+        return findByUserIdOrderByPosition(userId, false);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PinnedSite> findByUserIdOrderByPosition(String userId, boolean hasBeenUnpinned) {
 
         Session session = sessionFactory.getCurrentSession();
 
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaQuery<PinnedSite> query = cb.createQuery(PinnedSite.class);
         Root<PinnedSite> pinnedSite = query.from(PinnedSite.class);
-        query.where(cb.equal(pinnedSite.get("userId"), userId))
-            .orderBy(cb.asc(pinnedSite.get("position")));
+	Predicate[] predicates = new Predicate[2];
+	predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+	predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), hasBeenUnpinned);
+        query.where(predicates).orderBy(cb.asc(pinnedSite.get("position")));
 
         return session.createQuery(query).list();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<PinnedSite> findByUserIdAndSiteId(String userId, String siteId) {
+
+        Session session = sessionFactory.getCurrentSession();
+
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<PinnedSite> query = cb.createQuery(PinnedSite.class);
+        Root<PinnedSite> pinnedSite = query.from(PinnedSite.class);
+	Predicate[] predicates = new Predicate[2];
+	predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+	predicates[1] = cb.equal(pinnedSite.get("siteId"), siteId);
+        query.where(predicates);
+
+        return session.createQuery(query).uniqueResultOptional();
     }
 
     @Transactional(readOnly = true)
@@ -67,7 +92,10 @@ public class PinnedSiteRepositoryImpl extends SpringCrudRepositoryImpl<PinnedSit
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaDelete<PinnedSite> delete = cb.createCriteriaDelete(PinnedSite.class);
         Root<PinnedSite> pinnedSite = delete.from(PinnedSite.class);
-        delete.where(cb.equal(pinnedSite.get("userId"), userId));
+	Predicate[] predicates = new Predicate[2];
+	predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+	predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), false);
+        delete.where(predicates);
 
         return session.createQuery(delete).executeUpdate();
     }

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -183,6 +183,9 @@ public class PortalServiceTests extends SakaiTests {
         assertEquals(0, portalService.getPinnedSites().size());
 
         when(event.getEvent()).thenReturn(SiteService.EVENT_SITE_PUBLISH);
+        String ref = "/site/" + site1Id;
+        when(event.getResource()).thenReturn(ref);
+        when(siteService.idFromSiteReference(ref)).thenReturn(site1Id);
         ((PortalServiceImpl) AopTestUtils.getTargetObject(portalService)).update(null, event);
         assertEquals(1, portalService.getPinnedSites().size());
     }
@@ -231,8 +234,8 @@ public class PortalServiceTests extends SakaiTests {
         siteIds.add(site4Id);
         portalService.savePinnedSites(siteIds);
         pinned = pinnedSiteRepository.findByUserIdOrderByPosition(user1);
-        assertEquals(4, pinned.size());
-        assertEquals(site2Id, pinned.get(3).getSiteId());
+        assertEquals(3, pinned.size());
+        assertEquals(site4Id, pinned.get(2).getSiteId());
     }
 
     @Test

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -107,6 +107,9 @@ public class PortalServiceTests extends SakaiTests {
 
         assertEquals(2, portalService.getPinnedSites().size());
 
+        Member m1 = mock(Member.class);
+        when(m1.isActive()).thenReturn(true);
+        when(site3.getMember(user1)).thenReturn(m1);
         when(site3.isPublished()).thenReturn(true);
         ((PortalServiceImpl) AopTestUtils.getTargetObject(portalService)).update(null, event);
         assertEquals(3, portalService.getPinnedSites().size());
@@ -144,11 +147,13 @@ public class PortalServiceTests extends SakaiTests {
 
         Member member1 = mock(Member.class);
         when(member1.getUserId()).thenReturn(user1);
+        when(member1.isActive()).thenReturn(false);
         Set<Member> members = new HashSet<>();
         members.add(member1);
 
         Site site1 = mock(Site.class);
         when(site1.getUsers()).thenReturn(users);
+        when(site1.getMember(user1)).thenReturn(member1);
         when(site1.getMembers()).thenReturn(members);
         when(site1.isPublished()).thenReturn(false);
         try {
@@ -163,12 +168,14 @@ public class PortalServiceTests extends SakaiTests {
         when(event.getContext()).thenReturn(site1Id);
         when(event.getResource()).thenReturn("uid=" + user1 + ";role=access;active=true;siteId=" + site1Id);
         ((PortalServiceImpl) AopTestUtils.getTargetObject(portalService)).update(null, event);
-
         assertEquals(0, portalService.getPinnedSites().size());
 
         when(site1.isPublished()).thenReturn(true);
         ((PortalServiceImpl) AopTestUtils.getTargetObject(portalService)).update(null, event);
+        assertEquals(0, portalService.getPinnedSites().size());
 
+        when(member1.isActive()).thenReturn(true);
+        ((PortalServiceImpl) AopTestUtils.getTargetObject(portalService)).update(null, event);
         assertEquals(1, portalService.getPinnedSites().size());
 
         when(event.getEvent()).thenReturn(SiteService.EVENT_SITE_UNPUBLISH);
@@ -259,13 +266,57 @@ public class PortalServiceTests extends SakaiTests {
 
         when(sessionManager.getCurrentSessionUserId()).thenReturn(user1);
 
+        String user1SiteId = "~user1";
+        when(siteService.getUserSiteId(user1)).thenReturn(user1SiteId);
+
+        Set<String> users = new HashSet<>();
+        users.add(user1);
+
+        Member member1 = mock(Member.class);
+        when(member1.getUserId()).thenReturn(user1);
+        when(member1.isActive()).thenReturn(true);
+        Set<Member> members = new HashSet<>();
+        members.add(member1);
+
+        Site site1 = mock(Site.class);
+        when(site1.getMembers()).thenReturn(members);
+        when(site1.getMember(user1)).thenReturn(member1);
+        when(site1.isPublished()).thenReturn(true);
+        try {
+            when(siteService.getSite(site1Id)).thenReturn(site1);
+        } catch (IdUnusedException idue) {
+            System.out.println(idue.toString());
+        }
+
         portalService.addRecentSite(site1Id);
         assertEquals(1, portalService.getRecentSites().size());
 
-        portalService.addRecentSite("site2");
+        Site site2 = mock(Site.class);
+        String site2Id = "site2";
+        when(site2.getMembers()).thenReturn(members);
+        when(site2.getMember(user1)).thenReturn(member1);
+        when(site2.isPublished()).thenReturn(true);
+        try {
+            when(siteService.getSite(site2Id)).thenReturn(site2);
+        } catch (IdUnusedException idue) {
+            System.out.println(idue.toString());
+        }
+
+        portalService.addRecentSite(site2Id);
         assertEquals(2, portalService.getRecentSites().size());
 
-        portalService.addRecentSite("site3");
+        Site site3 = mock(Site.class);
+        String site3Id = "site3";
+        when(site3.getMembers()).thenReturn(members);
+        when(site3.getMember(user1)).thenReturn(member1);
+        when(site3.isPublished()).thenReturn(true);
+        try {
+            when(siteService.getSite(site3Id)).thenReturn(site3);
+        } catch (IdUnusedException idue) {
+            System.out.println(idue.toString());
+        }
+
+        portalService.addRecentSite(site3Id);
         assertEquals(3, portalService.getRecentSites().size());
 
         portalService.addRecentSite(SiteService.SITE_ERROR);
@@ -276,7 +327,18 @@ public class PortalServiceTests extends SakaiTests {
         assertEquals("site2", recentSites.next());
         assertEquals("site1", recentSites.next());
 
-        portalService.addRecentSite("site4");
+        Site site4 = mock(Site.class);
+        String site4Id = "site4";
+        when(site4.getMembers()).thenReturn(members);
+        when(site4.getMember(user1)).thenReturn(member1);
+        when(site4.isPublished()).thenReturn(true);
+        try {
+            when(siteService.getSite(site4Id)).thenReturn(site4);
+        } catch (IdUnusedException idue) {
+            System.out.println(idue.toString());
+        }
+
+        portalService.addRecentSite(site4Id);
         assertEquals(3, portalService.getRecentSites().size());
 
         recentSites = portalService.getRecentSites().iterator();

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -387,6 +387,11 @@ public class PortalServiceTests extends SakaiTests {
     public void testSoftDeletedSiteRemovalFromPinsAndRecent() {
         when(sessionManager.getCurrentSessionUserId()).thenReturn(user1);
 
+        Member user1Member = mock(Member.class);
+        when(user1Member.isActive()).thenReturn(true);
+        when(site1.getMember(user1)).thenReturn(user1Member);
+        when(site1.isPublished()).thenReturn(true);
+
         portalService.addRecentSite(site1Id);
         portalService.addPinnedSite(user1, site1Id);
         assertEquals(1, portalService.getRecentSites().size());


### PR DESCRIPTION
This proposed PR revises the auto-pinning behavior introduced with [SAK-48809](https://sakaiproject.atlassian.net/browse/SAK-48809) such that auto-pinning would behave like the auto-favorites behavior before Trinity, except that auto-favoriting / auto-pinning would be enabled for all users (instead of controlled per user preference before Sakai 23). The test plan in [SAK-48948](https://sakaiproject.atlassian.net/browse/SAK-48948) has been revised to clarify distinctive changes to be fixed with this PR.  What's key though and not necessarily clear in the test plan is that this PR: a) auto-pins sites for instructors regardless of the published/unpublished state of the site, and b) honors unpinning events for all users by not re-pinning sites a user has explicitly unpinned.

Accordingly, in order to retain user preferences when a user unfavorites / unpins a site-- while forgoing continued reliance on XML parsing for this-- I’ve transposed the autoFavoritesSeenSites user preference from SAKAI_PREFRENCES.XML to a new boolean HAS_BEEN_UNPINNED added to the PINNED_SITES table. By default this value is set to false and-- with one exception described below--- is only set to true when a user explicitly unpins a site. The user can subsequently re-pin the site, which toggles the value back to false.

When a site is unpinned, its corresponding POSITION value is set to -1 (whereas positive integers signify an actual position in the site navigation). Logic in PinnedSiteRepositoryImpl and PortalServiceImpl has been accordingly revised to distinguish pinned from unpinned records, distinguished primarily by the hasBeenUnpinned field of the PinnedSite class. 

The above change to the database schema assumes that the Quartz job described in [SAK-48700](https://sakaiproject.atlassian.net/browse/SAK-48700) (or a subsequent refinement of it, depending on timing) may accommodate the transfer of autoFavoritesSeenSites values to corresponding PINNED_SITES records when migrating user’s favorite sites to pinned sites. A crucial addendum would be to transcribe sites in the Sites drawer (i.e., non-hidden sites) that are not favorites to have records in PINNED_SITES with HAS_BEEN_UNPINNED set to true; this would prevent all such sites from displaying as pinned sites in the site navigation, which could be in the dozens or even hundreds for some instructors.

Finally while working on this PR, I observed a new bug affecting the PortalServiceImpl.update method for the handling of EVENT_SITE_PUBLISH (i.e., site.publish). At some recent point between the release of [SAK-48809](https://sakaiproject.atlassian.net/browse/SAK-48809) and now, e.getContext returns null whereas it used to return the siteId-- at least this was so at the time of the release of SAK-48809. (This behavor is evident in trunk on nightly.) Investigating this further, I observe that the null event context seems to be derived from the current placement’s being null (e.g., returned from ToolComponent.getCurrentPlacement). Though I’m not sure why this is now occurring for (only?) publishing events, I’ve adapted the event handling code in PortalServiceImpl.update to check for a null context and to otherwise parse e.getResource to obtain the siteId. The latter proves to be what is allowing publish events to actually create pinned site records for users. This issue is incorporated into the revised [SAK-48948](https://sakaiproject.atlassian.net/browse/SAK-48948) test plan.

[SAK-48809]: https://sakaiproject.atlassian.net/browse/SAK-48809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAK-48948]: https://sakaiproject.atlassian.net/browse/SAK-48948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAK-48700]: https://sakaiproject.atlassian.net/browse/SAK-48700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ