### PR TITLE
SAK-49107 Gradebook: Excess info logs from GradingServiceImpl

### DIFF
--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -1293,7 +1293,7 @@ public class GradingServiceImpl implements GradingService {
 
         if (studentUids.isEmpty()) {
             // If there are no enrollments, no need to execute the query.
-            log.info("No enrollments were specified.  Returning an empty List of grade records");
+            log.debug("No enrollments were specified.  Returning an empty List of grade records");
             return Collections.<AssignmentGradeRecord>emptyList();
         } else {
             List<AssignmentGradeRecord> unfilteredRecords = gradingPersistenceManager.getAllAssignmentGradeRecordsForGradebook(gradebookId);
@@ -1305,7 +1305,7 @@ public class GradingServiceImpl implements GradingService {
 
         if (studentUids.isEmpty()) {
             // If there are no enrollments, no need to execute the query.
-            log.info("No enrollments were specified.  Returning an empty List of grade records");
+            log.debug("No enrollments were specified.  Returning an empty List of grade records");
             return Collections.<AssignmentGradeRecord>emptyList();
         } else {
             List<AssignmentGradeRecord> unfilteredRecords = gradingPersistenceManager.getAllAssignmentGradeRecordsForAssignment(gradableObjectId);


### PR DESCRIPTION
The intent of [this jira](https://sakaiproject.atlassian.net/browse/SAK-49107) is to remove excess noise from catalina.out, generated merely by instructors' navigating Sakai. 