### PR TITLE
SAK-49093 Announcements notifications persist despite setting a future start date - query update

### DIFF
--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementsUserNotificationHandler.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementsUserNotificationHandler.java
@@ -121,7 +121,8 @@ public class AnnouncementsUserNotificationHandler extends AbstractUserNotificati
                                     .add(Restrictions.eq("ref", ref)).list();
 
 
-                            sessionFactory.getCurrentSession().createQuery("delete UserNotification where event = :newEvent or event = :reviseEvent and ref = :ref")
+                            // Remove notifications related to the same announcement, whether they are 'annc.new' or 'annc.revise.availability'
+                            sessionFactory.getCurrentSession().createQuery("delete UserNotification where (event = :newEvent or event = :reviseEvent) and ref = :ref")
                                 .setString("newEvent", ADD_EVENT)
                                 .setString("reviseEvent", UPDATE_EVENT)
                                 .setString("ref", ref).executeUpdate();


### PR DESCRIPTION
Fix for [SAK-49093 Announcements: Notifications persist despite setting future start date ... #11763](https://github.com/sakaiproject/sakai/pull/11763)
Query was missing parenthesis.