### PR TITLE
SAK-49110 T&Q: Common MS Word docs missing icon

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/shared/mimeicon.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/shared/mimeicon.jsp
@@ -25,6 +25,7 @@
 <h:panelGroup rendered="#{attach.mimeType == 'application/octet-stream'}" styleClass="fa fa-file-o"></h:panelGroup>
 <h:panelGroup rendered="#{attach.mimeType == 'application/pdf'}" styleClass="fa fa-file-pdf-o"></h:panelGroup>
 <h:panelGroup rendered="#{attach.mimeType == 'application/msword'}" styleClass="fa fa-file-word-o"></h:panelGroup>
+<h:panelGroup rendered="#{attach.mimeType == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'}" styleClass="fa fa-file-word-o"></h:panelGroup>
 <h:panelGroup rendered="#{attach.mimeType == 'application/vnd.ms-excel'}" styleClass="fa fa-file-excel-o"></h:panelGroup>
 <h:panelGroup rendered="#{attach.mimeType == 'application/vnd.ms-powerpoint'}" styleClass="fa fa-file-powerpoint-o"></h:panelGroup>
 <h:panelGroup rendered="#{attach.mimeType == 'application/xhtml+xml'}" styleClass="fa fa-file-code-o"></h:panelGroup>


### PR DESCRIPTION
For details refer to the [corresponding jira](https://sakaiproject.atlassian.net/browse/SAK-49110) and the screenshot below which depicts the Word icon restored by this PR.

![Screenshot (122)](https://github.com/sakaiproject/sakai/assets/1661251/19a13961-6a7a-46f1-9504-07da386390bb)
