### PR TITLE
SAK-49123 Fix for NoClassDefFound on PropertyUtils.

### DIFF
--- a/signup/tool/pom.xml
+++ b/signup/tool/pom.xml
@@ -66,6 +66,10 @@
 		
         <!-- third party dependencies -->
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
         </dependency>


### PR DESCRIPTION
This is 22.x direct fix because the commons-beanutils is deployed centrally in master