### PR TITLE
SAK-49138: UnboundID > support encrypted candidate details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ rsf/sakai-rsf-web/test/overlays
 assets
 library/src/morpheus-master/
 library/src/webapp/skin/morpheus-default/
+*.key
+*.key.pub

--- a/providers/component/src/webapp/WEB-INF/unboundid-ldap.xml
+++ b/providers/component/src/webapp/WEB-INF/unboundid-ldap.xml
@@ -237,7 +237,19 @@
 	<bean id="org.sakaiproject.unboundid.LdapAttributeMapper"
 			class="org.sakaiproject.unboundid.SimpleLdapAttributeMapper"
 			init-method="init">
-			
+
+	<!-- Non-default bean definition which can be used to support encrypted LDAP properties.
+		 To make use of this, uncomment the bean declaration below (including the 5 properties listed) and comment out the default SimpleLdapAttributeMapper declaration above.-->
+	<!--<bean id="org.sakaiproject.unboundid.LdapAttributeMapper"
+			class="org.sakaiproject.unboundid.SimpleLdapCandidateAttributeMapper"
+			init-method="init">
+
+		<property name="encryption" ref="org.sakaiproject.user.detail.ValueEncryptionUtilities" />
+		<property name="scs" ref="org.sakaiproject.component.api.ServerConfigurationService" />
+		<property name="candidateIdLength"><value>10</value></property>
+		<property name="additionalInfoLength"><value>100</value></property>
+		<property name="studentNumberLength"><value>9</value></property> -->
+
 		<!-- A typical set of attribute mappings. Keys are logical
 		names expected by the application. Values are physical LDAP
 		attribute names. If not specified or empty, defaults to

--- a/providers/unboundid/pom.xml
+++ b/providers/unboundid/pom.xml
@@ -49,6 +49,18 @@
       <version>0.9.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.sakaiproject</groupId>
+      <artifactId>sakai-userdetail-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/providers/unboundid/src/java/org/sakaiproject/unboundid/AttributeMappingConstants.java
+++ b/providers/unboundid/src/java/org/sakaiproject/unboundid/AttributeMappingConstants.java
@@ -105,14 +105,27 @@ public abstract class AttributeMappingConstants {
 	 * the physical name of a user entry's group membership attribute
 	 */
 	public static final String DEFAULT_GROUP_MEMBERSHIP_ATTR = "groupMembership";
-	
+
+	public static final String DEFAULT_CANDIDATE_ID_ATTR = "employeeNumber";
+	public static final String DEFAULT_ADDITIONAL_INFO_ATTR = "description";
+	public static final String DEFAULT_STUDENT_NUMBER_ID_ATTR = "employeeNumber";
+	public static final String CANDIDATE_ID_ATTR_MAPPING_KEY = "candidateID";
+	public static final String ADDITIONAL_INFO_ATTR_MAPPING_KEY = "additionalInfo";
+	public static final String STUDENT_NUMBER_ATTR_MAPPING_KEY = "studentNumber";
+	public final static String SYSTEM_PROP_ENCRYPT_NUMERIC_ID = "encryptInstitutionalNumericID";
+
 	/**
 	 * Default set of user entry attribute mappings. Keys are
 	 * logical names, values are physical names.
 	 */
 	public static final Map<String,String> DEFAULT_ATTR_MAPPINGS = 
 		new HashMap<String,String>();
-	
+
+	/**
+	 * Extension of DEFAULT_ATTR_MAPPINGS
+	 */
+	public static final Map<String,String> CANDIDATE_ATTR_MAPPINGS = new HashMap<>();
+
 	static {
 		
 		DEFAULT_ATTR_MAPPINGS.put(LOGIN_ATTR_MAPPING_KEY, DEFAULT_LOGIN_ATTR);
@@ -122,7 +135,11 @@ public abstract class AttributeMappingConstants {
 		DEFAULT_ATTR_MAPPINGS.put(LAST_NAME_ATTR_MAPPING_KEY, DEFAULT_LAST_NAME_ATTR);
 		DEFAULT_ATTR_MAPPINGS.put(EMAIL_ATTR_MAPPING_KEY, DEFAULT_EMAIL_ATTR);
 		DEFAULT_ATTR_MAPPINGS.put(GROUP_MEMBERSHIP_ATTR_MAPPING_KEY, DEFAULT_GROUP_MEMBERSHIP_ATTR);
-		
+
+		CANDIDATE_ATTR_MAPPINGS.putAll(DEFAULT_ATTR_MAPPINGS);
+		CANDIDATE_ATTR_MAPPINGS.put(CANDIDATE_ID_ATTR_MAPPING_KEY, DEFAULT_CANDIDATE_ID_ATTR);
+		CANDIDATE_ATTR_MAPPINGS.put(ADDITIONAL_INFO_ATTR_MAPPING_KEY, DEFAULT_ADDITIONAL_INFO_ATTR);
+		CANDIDATE_ATTR_MAPPINGS.put(STUDENT_NUMBER_ATTR_MAPPING_KEY, DEFAULT_STUDENT_NUMBER_ID_ATTR);
 	}
 	
 	/**

--- a/providers/unboundid/src/java/org/sakaiproject/unboundid/SimpleLdapCandidateAttributeMapper.java
+++ b/providers/unboundid/src/java/org/sakaiproject/unboundid/SimpleLdapCandidateAttributeMapper.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2003-2023 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.unboundid;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.user.api.UserEdit;
+import org.sakaiproject.user.detail.ValueEncryptionUtilities;
+
+/**
+ * Extension for {@link SimpleLdapAttributeMapper}.
+ * Adds logic to include encrypted CandidateId and additional info into the Sakai user object.
+ */
+@Slf4j
+public class SimpleLdapCandidateAttributeMapper extends SimpleLdapAttributeMapper
+{
+    private static final String USER_PROP_CANDIDATE_ID = "candidateID";
+    private static final String USER_PROP_ADDITIONAL_INFO = "additionalInfo";
+    private static final String USER_PROP_STUDENT_NUMBER = "studentNumber";
+    private static final String EMPTY = "";
+
+    @Setter private ServerConfigurationService scs;
+    @Setter private ValueEncryptionUtilities encryption;
+
+    @Setter private int candidateIdLength;
+    @Setter private int additionalInfoLength;
+    @Setter private int studentNumberLength;
+
+    /**
+     * Completes configuration of this instance.
+     *
+     * <p>Initializes internal mappings to a copy of {@link AttributeMappingConstants#DEFAULT_ATTR_MAPPINGS} if the current map is empty. Initializes user
+     * type mapping strategy to a {@link EmptyStringUserTypeMapper} if no strategy has been specified.</p>
+     * <p>This defaulting enables UDP config forward-compatibility.</p>
+     *
+     */
+    public void init()
+    {
+        log.debug("initializing");
+
+        if (MapUtils.isEmpty(getAttributeMappings()))
+        {
+            setAttributeMappings(AttributeMappingConstants.CANDIDATE_ATTR_MAPPINGS);
+            log.debug("creating default attribute mappings");
+        }
+
+        if (getUserTypeMapper() == null)
+        {
+            setUserTypeMapper(new EmptyStringUserTypeMapper());
+            log.debug("created default user type mapper [mapper = {}]", getUserTypeMapper());
+        }
+        if (getValueMappings() == null)
+        {
+            setValueMappings(Collections.EMPTY_MAP);
+            log.debug("created default value mapper [mapper = {}]", getValueMappings());
+        }
+        else
+        {
+            // Check we have good value mappings and throw any out that aren't (warning user).
+            Iterator<Entry<String, MessageFormat>> iterator = getValueMappings().entrySet().iterator();
+            while (iterator.hasNext())
+            {
+                Entry<String, MessageFormat> entry = iterator.next();
+                if (entry.getValue().getFormats().length != 1)
+                {
+                    iterator.remove();
+                    log.warn("Removed value mapping as it didn't have one format: {} -> {}", entry.getKey(), entry.getValue().toPattern());
+                }
+            }
+        }
+    }
+
+    /**
+     * Caches the given Map reference and takes a snapshot of the values therein for future use by {@link #getSearchResultAttributes()}. (using super method)
+     * @param attributeMappings
+     * @see #getAttributeMappings()
+     */
+    public void setAttributeMappings(Map<String,String> attributeMappings)
+    {
+        if (MapUtils.isEmpty(attributeMappings))
+        {
+            super.setAttributeMappings(AttributeMappingConstants.CANDIDATE_ATTR_MAPPINGS);
+        }
+        else
+        {
+            super.setAttributeMappings(attributeMappings);
+        }
+    }
+
+    /**
+     * Straightforward {@link LdapUserData} to {@link org.sakaiproject.user.api.UserEdit} field-to-field mapping, including properties.
+     * @param userData
+     * @param userEdit
+     */
+    public void mapUserDataOntoUserEdit(LdapUserData userData, UserEdit userEdit)
+    {
+        Properties userDataProperties = userData.getProperties();
+        ResourceProperties userEditProperties = userEdit.getProperties();
+        if (userDataProperties != null)
+        {
+            Object o_prop = userDataProperties.get(AttributeMappingConstants.CANDIDATE_ID_ATTR_MAPPING_KEY);
+            if (o_prop != null)
+            {
+                if (o_prop instanceof String)
+                {
+                    userEditProperties.addProperty(USER_PROP_CANDIDATE_ID, encryption.encrypt((String) o_prop, candidateIdLength));
+                }
+                else if (o_prop instanceof List)
+                {
+                    Set<String> propertySet = new HashSet<>();
+
+                    // Remove duplicate values
+                    for (String value : (List<String>) o_prop)
+                    {
+                        propertySet.add(value);
+                    }
+
+                    // Add candidate ID, if there is only one value
+                    if (propertySet.size() == 1)
+                    {
+                        for (String value : propertySet)
+                        {
+                            userEditProperties.addProperty(USER_PROP_CANDIDATE_ID, encryption.encrypt(value, candidateIdLength));
+                        }
+                    }
+                }
+
+                userDataProperties.remove(AttributeMappingConstants.CANDIDATE_ID_ATTR_MAPPING_KEY);
+            }
+
+            o_prop = userDataProperties.get(AttributeMappingConstants.ADDITIONAL_INFO_ATTR_MAPPING_KEY);
+            if (o_prop != null)
+            {
+                if (o_prop instanceof String)
+                {
+                    userEditProperties.addPropertyToList(USER_PROP_ADDITIONAL_INFO, encryption.encrypt((String) o_prop, additionalInfoLength));
+                }
+                else if (o_prop instanceof List)
+                {
+                    List<String> propertyList = new ArrayList<>();
+
+                    // Remove duplicate values (maintain order)
+                    for (String value : (List<String>) o_prop)
+                    {
+                        if (!propertyList.contains(value))
+                        {
+                            propertyList.add(value);
+                        }
+                    }
+                    for (String value : propertyList)
+                    {
+                        userEditProperties.addPropertyToList(USER_PROP_ADDITIONAL_INFO, encryption.encrypt(value, additionalInfoLength));
+                    }
+                }
+
+                userDataProperties.remove(AttributeMappingConstants.ADDITIONAL_INFO_ATTR_MAPPING_KEY);
+            }
+
+            o_prop = userDataProperties.get(AttributeMappingConstants.STUDENT_NUMBER_ATTR_MAPPING_KEY);
+            if (o_prop != null)
+            {
+                if (o_prop instanceof String)
+                {
+                    addStudentNumberProperty((String) o_prop, userEditProperties);
+                }
+                else if (o_prop instanceof List)
+                {
+                    Set<String> propertySet = new HashSet<>();
+
+                    // Remove duplicate values
+                    for (String value : (List<String>) o_prop)
+                    {
+                        propertySet.add(value);
+                    }
+
+                    // Add student number, if there is only one value
+                    if (propertySet.size() == 1)
+                    {
+                        for (String value : propertySet)
+                        {
+                            addStudentNumberProperty(value, userEditProperties);
+                        }
+                    }
+                }
+
+                userDataProperties.remove(AttributeMappingConstants.STUDENT_NUMBER_ATTR_MAPPING_KEY);
+            }
+
+            // Make sure we have a value for the encrypted properties.
+            if (StringUtils.isEmpty(userEditProperties.getProperty(USER_PROP_CANDIDATE_ID)))
+            {
+                userEditProperties.addProperty(USER_PROP_CANDIDATE_ID, encryption.encrypt(EMPTY, candidateIdLength));
+            }
+            if (userEditProperties.getPropertyList(USER_PROP_ADDITIONAL_INFO)!= null && userEditProperties.getPropertyList(USER_PROP_ADDITIONAL_INFO).isEmpty())
+            {
+                userEditProperties.addPropertyToList(USER_PROP_ADDITIONAL_INFO, encryption.encrypt(EMPTY, additionalInfoLength));
+            }
+            if (userEditProperties.getPropertyList(USER_PROP_STUDENT_NUMBER)!= null && userEditProperties.getPropertyList(USER_PROP_STUDENT_NUMBER).isEmpty())
+            {
+                addStudentNumberProperty(EMPTY, userEditProperties);
+            }
+
+        super.mapUserDataOntoUserEdit(userData, userEdit);
+        }
+    }
+
+    private void addStudentNumberProperty(String number, ResourceProperties userEditProperties)
+    {
+        String studentNumber = number;
+        if (scs.getBoolean(AttributeMappingConstants.SYSTEM_PROP_ENCRYPT_NUMERIC_ID, true))
+        {
+            studentNumber = encryption.encrypt(studentNumber, studentNumberLength);
+        }
+
+        userEditProperties.addProperty(USER_PROP_STUDENT_NUMBER, studentNumber);
+    }
+}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49138

Prior to the move to UnboundID, Sakai had the capability to encrypt (and subsequently decrypt when needed) candidate details through LDAP (for instance student/employee numbers).

This capability was not ported when the move from JLDAP to UnboundID was performed. This is a regression for any institution that was previously using this functionality with JLDAP.