### PR TITLE
SAK-49139 site-manage can delete locked groups using multiple tabs

### DIFF
--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/MainController.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/MainController.java
@@ -25,11 +25,14 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -37,6 +40,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.support.RequestContextUtils;
+
 import org.sakaiproject.authz.api.AuthzGroup.RealmLockMode;
 import org.sakaiproject.authz.api.AuthzRealmLockException;
 import org.sakaiproject.groupmanager.constants.GroupManagerConstants;
@@ -51,6 +55,9 @@ import org.sakaiproject.util.comparator.UserSortNameComparator;
 @Slf4j
 @Controller
 public class MainController {
+
+    @Inject
+    private MessageSource messageSource;
 
     @Autowired
     private SakaiService sakaiService;
@@ -166,7 +173,7 @@ public class MainController {
     }
 
     @PostMapping(value = "/removeGroups")
-    public String removeGroups(@ModelAttribute MainForm deleteGroupsForm, Model model) {
+    public String removeGroups(@ModelAttribute MainForm deleteGroupsForm, Model model, HttpServletRequest request, HttpServletResponse response) {
         log.debug("removeGroups called with the following groups {}.", deleteGroupsForm.getDeletedGroupList());
 
         Optional<Site> siteOptional = sakaiService.getCurrentSite();
@@ -180,14 +187,21 @@ public class MainController {
         boolean anyGroupDeleted = false;
 
         // For each group, try to delete it from the site
+        List<Group> lockedGroups = new ArrayList<>(deleteGroupsForm.getDeletedGroupList().size());
         for (String deletedGroupId : deleteGroupsForm.getDeletedGroupList()) {
             log.debug("Deleting the group {}.", deletedGroupId);
             Optional<Group> groupOptional = sakaiService.findGroupById(deletedGroupId);
             if (groupOptional.isPresent()) {
+                // Check if group is locked first, if it's locked don't attempt deletion, just skip to the next group
+                Group group = groupOptional.get();
+                if (RealmLockMode.ALL.equals(group.getRealmLock()) || RealmLockMode.DELETE.equals(group.getRealmLock())) {
+                    lockedGroups.add(group);
+                    continue;
+                }
                 try {
-                    site.deleteGroup(groupOptional.get());
-                    anyGroupDeleted=true;
-                } catch (AuthzRealmLockException e) {
+                    site.deleteGroup(group);
+                    anyGroupDeleted = true;
+                } catch (AuthzRealmLockException e) { // This exception is not thrown in the event that the group list UI is stale; see SAK-49139
                     log.error("The group {} is locked and cannot be deleted.", deletedGroupId);
                 }
             }
@@ -197,7 +211,14 @@ public class MainController {
             sakaiService.saveSite(site);
         }
 
-        //Return to the list of groups after deleting them.
+        // If any groups selected to be deleted could not be due to locks, populate an error message indicating which groups and why
+        if (!lockedGroups.isEmpty()) {
+            String groups = String.join(", ", lockedGroups.stream().map(g -> g.getTitle()).collect(Collectors.toList()));
+            model.addAttribute("errorMessage", messageSource.getMessage("index.error.cantDeleteLockedGroup", new Object[] {groups}, sakaiService.getCurrentUserLocale()));
+            return showIndex(model, request, response);
+        }
+
+        // Return to the list of groups after deleting them.
         return GroupManagerConstants.REDIRECT_MAIN_TEMPLATE;
     }
 

--- a/site-manage/site-group-manager/src/main/resources/Messages.properties
+++ b/site-manage/site-group-manager/src/main/resources/Messages.properties
@@ -28,6 +28,7 @@ index.table.members=members
 index.table.selectallnone=Select All/None
 index.warning.groupempty=There are currently no custom groups defined. You can create new groups using one of the options above.
 index.table.group.locked=Locked Group
+index.error.cantDeleteLockedGroup=The following groups are locked and cannot be deleted: {0}
 
 # Create new Group
 groups.allowviewmembership=Allow members to see the other members of this group

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
@@ -7,6 +7,7 @@
     <div id="menu" th:include="fragments/menus :: main (index)" />
     <div class="page-header"><h1 th:text="#{index.header.grouplist}"></h1></div>
     <div class="sak-banner-info" th:if="${groupList.isEmpty()}" th:text="#{index.warning.groupempty}">No groups in this site.</div>
+    <div class="sak-banner-error" th:if="${errorMessage != null}" th:text="${errorMessage}"></div>
     <div class="instruction" th:if="${anyGroupLocked}"><span class="si si-locked" aria-hidden="true"></span> - <span aria-hidden="true" th:text="#{index.table.grouplocked.info}"></span></div>
     <form th:if="${!groupList.isEmpty()}" id="group-manager-form" action="#" th:action="@{/removeGroups}" th:object="${mainForm}" method="post">
       <table id="groupTable" class="table table-striped table-bordered table-hover">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49139

It is rather simple to delete a locked group using either multiple tabs, or concurrent edits with multiple users. The group deletion prevention is purely in UI code; there is no server side prevention when the UI has stale data.