### PR TITLE
SAK-49137 Assignments: Some chars in assignment title affect download all submissions

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -547,7 +547,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 // if subtype is assignment then were downloading all submissions for an assignment
                                 try {
                                     Assignment a = getAssignment(refReckoner.getId());
-                                    String filename = a.getTitle() + "_" + date;
+                                    String filename = escapeInvalidCharsEntry(a.getTitle()) + "_" + date;
                                     res.setContentType("application/zip");
                                     res.setHeader("Content-Disposition", "attachment; filename = \"" + filename + ".zip\"");
 
@@ -2775,6 +2775,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         String decomposed = Normalizer.normalize(accentedString, Normalizer.Form.NFD);
         decomposed = decomposed.replaceAll("\\p{InCombiningDiacriticalMarks}+", StringUtils.EMPTY);
         decomposed = decomposed.replaceAll("\\?", StringUtils.EMPTY);
+        // To avoid issues, dash variations will be replaced by a regular dash.
+        decomposed = decomposed.replaceAll("\\p{Pd}", "-");
         return decomposed;
     }
 


### PR DESCRIPTION
Jira: [SAK-49137](https://sakaiproject.atlassian.net/browse/SAK-49137)

- The assignment title will be escaped for the zip filename.
- The escape function will replace some dash variants by a regular dash.

[SAK-49137]: https://sakaiproject.atlassian.net/browse/SAK-49137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ