### PR TITLE
SAK-49149 SiteInfo provide option to email maintainers when someone joins a joinable site

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -833,7 +833,14 @@ public interface SiteService extends EntityProducer
      * @return true if the user has same user account type that the site is restricted to, or if the option is disabled system-wide
      */
     boolean isAllowedToJoin(String id);
-    
+
+    /**
+     * determine if current user is actually logged into the system
+     *
+     * @return true if user is logged in with an account
+     */
+    boolean isUserLoggedIn();
+
     /**
      * Get the group that a joining user will be added to upon joining a site, if option is available system-wide
      * 
@@ -863,7 +870,25 @@ public interface SiteService extends EntityProducer
      * @return true if the join site is limiting account types
      */
     boolean isLimitByAccountTypeEnabled(String id);
-    
+
+    /**
+     * Retrieves the boolean value of a boolean site property
+     *
+     * @param id
+     *        The site to retrieve the property from
+     * @return boolean value of the site property; true if the boolean property is found and is set to true
+     */
+    boolean getBooleanSiteProperty(String id, String propertyName);
+
+    /**
+     * Check if the system and the provided site has the ability to send email notifications when a user joins the site
+     *
+     * @param id
+     *        The site to check if the join email notification option is enabled
+     * @return true if the join email notification options are enabled at the system and passed-in site's levels
+     */
+    boolean isJoinNotificationToggled(String id);
+
     /**
      * Get the list of allowed account type categories
      * 
@@ -895,7 +920,13 @@ public interface SiteService extends EntityProducer
      * @return true/false (enabled/disabled)
      */
     boolean isGlobalJoinGroupEnabled();
-    
+
+    /**
+     * Check if join email notification is enabled/disabled globally (sakai.property)
+     * @return true/false (enabled/disabled)
+     */
+    boolean isGlobalJoinNotificationEnabled();
+
     /**
      * Check if exclude from public list is enabled/disabled globally (sakai.property)
      * 
@@ -1326,7 +1357,44 @@ public interface SiteService extends EntityProducer
 	 * @return true if the site is allowed to addRoleSwap(id), false if not.
 	 */
 	boolean allowRoleSwap(String id);
-	
+
+	/**
+	 * Access a list of sites that the specified user can visit, sorted by title, optionally requiring descriptions.
+	 *
+	 * This is a convenience and performance wrapper for getSites.
+	 *
+	 * Unpublished sites are not included; use getSites(String, boolean) to control if unpublished sites are included or not.
+	 *
+	 * The sites returned follow the same semantics as those from
+	 * {@link #getSites(SelectionType, Object, String, Map, SortType, PagingPosition, boolean, String) getSites}.
+	 *
+	 * @param userId the returned sites will be those which can be accessed by the user with this internal ID. Uses the current user if null.
+	 * @return a List<Site> of those sites the user can access.
+	 */
+	List<Site> getUserSites(String userId);
+
+	/**
+	 * Access a list of Site objects that meet specified criteria.
+	 * NOTE: The sites returned will not have child objects loaded. If these sites need to be saved
+	 * a completely populated site should be retrieved from {@link #getSite(String)}
+	 * @param type
+	 *        The SelectionType specifying what sort of selection is intended.
+	 * @param ofType
+	 *        Site type criteria: null for any type; a String to match a single type; A String[], List or Set to match any type in the collection.
+	 * @param criteria
+	 *        Additional selection criteria: sites returned will match this string somewhere in their id, title, description, or skin.
+	 * @param propertyCriteria
+	 *        Additional selection criteria: sites returned will have a property named to match each key in the map, whose values match (somewhere in their value) the value in the map (may be null or empty).
+	 * @param sort
+	 *        A SortType indicating the desired sort. For no sort, set to SortType.NONE.
+	 * @param page
+	 *        The PagePosition subset of items to return.
+	 * @param userId
+	 *        The returned sites will be those which can be accessed by the user with this internal ID. Uses the current user if null.
+	 * @return The List<Site> of Site objects that meet the specified criteria.
+	 */
+	List<Site> getSites(SelectionType type, Object ofType, String criteria, Map<String, String> propertyCriteria, SortType sort, PagingPosition page, String userId);
+
 	/**
 	 * returns all type strings that are associated with specified site type.
 	 * Following is an example of site type settings, which defines two strings as "course"-type

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -2726,8 +2726,6 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 				}
 			}
 
-			String sql = "";
-
 			// Note: the realm is still lazy - we have the realm id but don't need to worry about changing grants
 
 			// get the latest userEid -> role name map from the provider
@@ -2937,7 +2935,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 				// caused by transactions modifying more than one row at a time.
 
 				// delete
-				sql = dbAuthzGroupSql.getDeleteRealmRoleGroup4Sql();
+				String sql = dbAuthzGroupSql.getDeleteRealmRoleGroup4Sql();
 				Object[] fields = new Object[2];
 				fields[0] = caseId(realm.getId());
 				for (String userId : toDelete)

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -59,6 +59,7 @@ import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entity.api.ContextObserver;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityAccessOverloadException;
@@ -462,7 +463,12 @@ public abstract class BaseSiteService implements SiteService, Observer
 	 * @return the AuthzGroupService collaborator.
 	 */
 	protected abstract AuthzGroupService authzGroupService();
-	
+
+	/**
+	 * @return the EmailService collaborator.
+	 */
+	protected abstract EmailService emailService();
+
 	/**
 	 * @return the ActiveToolManager collaborator.
 	 */
@@ -551,7 +557,7 @@ public abstract class BaseSiteService implements SiteService, Observer
                         
             // sfoster9@uwo.ca
             // assign a new JoinSiteDelegate to handle the join methods; provide it services from this class
-            joinSiteDelegate = new JoinSiteDelegate( this, securityService(), userDirectoryService() );
+            joinSiteDelegate = new JoinSiteDelegate( this, securityService(), userDirectoryService(), emailService() );
 			
 			// SAK-29138
 			m_siteTitleAdvisor = (SiteTitleAdvisor) ComponentManager.get( SiteTitleAdvisor.class );
@@ -1811,6 +1817,13 @@ public abstract class BaseSiteService implements SiteService, Observer
 			throw new PermissionException(user, AuthzGroupService.SECURE_UPDATE_OWN_AUTHZ_GROUP, siteReference(id));
 		}
 
+		// the user must have an allowed account type, if enabled
+		if (!isAllowedToJoin(id))
+		{
+			log.warn("User attempted to join the site '{}', but doesn't have the allowed account type:", id);
+			throw new PermissionException(user, AuthzGroupService.SECURE_UPDATE_OWN_AUTHZ_GROUP, siteReference(id));
+		}
+
 		// the role to assign
 		String roleId = site.getJoinerRole();
 		if (roleId == null)
@@ -1850,6 +1863,19 @@ public abstract class BaseSiteService implements SiteService, Observer
 		{
 			log.error(String.format("Unexpected exception joining user %s to group in site %s: ", user, id), e);
 		}
+
+		try
+		{
+			// if email notifications are set to be sent on join, send the email(s)
+			if (isJoinNotificationToggled(id))
+			{
+				joinSiteDelegate.sendEmailNotification(id);
+			}
+		}
+		catch (Exception e)
+		{
+			log.error("Unexpected exception when sending join notification email for user {} joined site {}", user, id, e);
+		}
 	}
         
     /**
@@ -1871,6 +1897,15 @@ public abstract class BaseSiteService implements SiteService, Observer
         
         // pass to the JoinDelegate method to handle the logic
         return joinSiteDelegate.isAllowedToJoin(site);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public boolean isUserLoggedIn()
+	{
+		// pass to the JoinDelegate method to handle the logic
+		return joinSiteDelegate.isUserLoggedIn();
 	}
 
 	/**
@@ -1932,7 +1967,23 @@ public abstract class BaseSiteService implements SiteService, Observer
     {
         return joinSiteDelegate.isLimitByAccountTypeEnabled(siteID);
     }
-    
+
+    /**
+     * @inheritDoc
+     */
+    public boolean getBooleanSiteProperty(String siteID, String propertyName)
+    {
+        return joinSiteDelegate.getBooleanSiteProperty(siteID, propertyName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public boolean isJoinNotificationToggled(String siteID)
+    {
+        return joinSiteDelegate.isJoinNotificationToggled(siteID);
+    }
+
     /** 
      * @inheritDoc
      */
@@ -1964,7 +2015,15 @@ public abstract class BaseSiteService implements SiteService, Observer
     {
     	return joinSiteDelegate.getGlobalJoinGroupEnabled();
     }
-    
+
+    /**
+     * @inheritDoc
+     */
+    public boolean isGlobalJoinNotificationEnabled()
+    {
+        return joinSiteDelegate.getGlobalJoinNotificationEnabled();
+    }
+
     /** 
      * @inheritDoc
      */
@@ -2317,6 +2376,23 @@ public abstract class BaseSiteService implements SiteService, Observer
 	 */
 	public List<String> getSiteIds(SelectionType type, Object ofType, String criteria, Map<String, String> propertyCriteria, SortType sort, PagingPosition page) {
 	    return storage().getSiteIds(type, ofType, criteria, propertyCriteria, sort, page);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public List<Site> getUserSites(String userId)
+	{
+		return getSites(org.sakaiproject.site.api.SiteService.SelectionType.ACCESS, null, null, null,
+			org.sakaiproject.site.api.SiteService.SortType.TITLE_ASC, null, userId);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public List<Site> getSites(SelectionType type, Object ofType, String criteria, Map propertyCriteria, SortType sort, PagingPosition page, String userId)
+	{
+		return m_storage.getSites(type, ofType, criteria, propertyCriteria, sort, page, userId);
 	}
 
 	/**
@@ -3225,7 +3301,28 @@ public abstract class BaseSiteService implements SiteService, Observer
 		 * @return The List of Site objects that meet specified criteria.
 		 */
 		public List<Site> getSites(SelectionType type, Object ofType, String criteria, Map propertyCriteria, SortType sort, PagingPosition page, boolean requireDescription, String userId);
-		
+
+		/**
+		 * Access a list of Site objects that meet specified criteria.
+		 *
+		 * @param type
+		 *        The SelectionType specifying what sort of selection is intended.
+		 * @param ofType
+		 *        Site type criteria: null for any type; a String to match a single type; A String[], List or Set to match any type in the collection.
+		 * @param criteria
+		 *        Additional selection criteria: sites returned will match this string somewhere in their id, title, description, or skin.
+		 * @param propertyCriteria
+		 *        Additional selection criteria: sites returned will have a property named to match each key in the map, whose return values match (somewhere in their value) the value in the map (may be null or empty).
+		 * @param sort
+		 *        A SortType indicating the desired sort. For no sort, set to SortType.NONE.
+		 * @param page
+		 *        The PagePosition subset of items to return.
+		 * @param userId
+		 *        The returned sites will be those which can be accessed by the user with this internal ID. Uses the current user if null.
+		 * @return The List (Site) of Site objects that meet specified criteria.
+		 */
+		public List<Site> getSites(SelectionType type, Object ofType, String criteria, Map propertyCriteria, SortType sort, PagingPosition page, String userId);
+
 		/**
 		 * Access a list of Site objects that meet specified criteria, with control over description retrieval.
 		 * Note that this signature is primarily provided to help with performance when retrieving lists of

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
@@ -1198,6 +1198,14 @@ public abstract class DbSiteService extends BaseSiteService
 		/**
 		 * @inheritDoc
 		 */
+		public List<Site> getSites(SelectionType type, Object ofType, String criteria, Map propertyCriteria, SortType sort, PagingPosition page, String userId)
+		{
+			return getSites(type, ofType, criteria, propertyCriteria, sort, page, true, userId);
+		}
+
+		/**
+		 * @inheritDoc
+		 */
 		@SuppressWarnings("unchecked")
 		public List getSites(SelectionType type, Object ofType, String criteria, Map propertyCriteria,  List excludedSites, SortType sort, PagingPosition page, boolean requireDescription, String userId)
 		{

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/JoinSiteDelegate.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/JoinSiteDelegate.java
@@ -17,8 +17,13 @@ package org.sakaiproject.site.impl;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,9 +32,14 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.email.api.EmailService;
+import org.sakaiproject.emailtemplateservice.api.EmailTemplateService;
+import org.sakaiproject.emailtemplateservice.api.RenderedTemplate;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.site.api.AllowedJoinableAccount;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
@@ -48,10 +58,14 @@ public class JoinSiteDelegate
     private SiteService             siteService;
     private SecurityService         securityService;
     private UserDirectoryService    userDirectoryService;
+    private EmailService            emailService;
 
     // class members
     private static final String COMMA_DELIMITER					= ",";										// Comma delimiter (for csv parsing)
     private static final String JOINSITE_GROUP_NO_SELECTION		= "noSelection";							// The value of the joiner group site
+    private static final String TMPLT_VAR_SITE_NAME				= "worksiteName";							// The name of the worksite name template variable
+    private static final String TMPLT_VAR_INSTITUTE				= "institution";							// The name of the institution template variable
+    private static final String TMPLT_VAR_SHORT_NAME			= "currentUserShortName";					// The name of the current user short name template variable
     private static final String SAK_PERM_SITE_UPD				= "site.upd";								// The name of the site update permission
 
     // sakai.properties
@@ -59,17 +73,23 @@ public class JoinSiteDelegate
     private static final String SAK_PROP_JOIN_LIMIT_ACCOUNT_TYPES 		= "sitemanage.join.limitAccountTypes.enabled";
     private static final String SAK_PROP_JOIN_ACCOUNT_TYPES	 			= "sitemanage.join.allowedJoinableAccountTypes";
     private static final String SAK_PROP_JOIN_ACCOUNT_TYPE_LABELS		= "sitemanage.join.allowedJoinableAccountTypeLabels";
+    private static final String SAK_PROP_JOIN_NOTIFICATION_ENABLED		= "sitemanage.join.notification.enabled";
     private static final String SAK_PROP_JOIN_ACCOUNT_TYPE_CATEGORIES	= "sitemanage.join.allowedJoinableAccountTypeCategories";
     private static final String SAK_PROP_JOIN_EXCLUDE_FROM_PUBLIC_LIST 	= "sitemanage.join.excludeFromPublicList.enabled";
     private static final String SAK_PROP_SITE_BROWSER_JOIN_ENABLED		= "sitebrowser.join.enabled";
+    private static final String SAK_PROP_UI_INSTITUTION					= "ui.institution";
+    private static final String SAK_PROP_SUPPORT_EMAIL					= "mail.support";
     
     // site properties
+    private static final String EMAIL_TEMPLATE_KEY				= "sitemanage.joinNotification";			// The name (key) of the email template
     private static final String SITE_PROP_JOIN_LIMIT_OFFICIAL 	= "joinLimitByAccountType";					// The name (key) of the join limit official site property
     private static final String SITE_PROP_JOIN_ACCOUNT_TYPES 	= "joinLimitedAccountTypes";				// The name (key) of the limit join to account types site property
     private static final String SITE_PROP_JOINSITE_GROUP_ID 	= "joinerGroup";							// The name (key) of the joiner group site property
+    private static final String SITE_PROP_JOIN_NOTIFY			= "joinNotification";						// The name (key) of the join notification site property
     
     // global switches
     private static final boolean GLOBAL_JOIN_GROUP_ENABLED					= ServerConfigurationService.getBoolean( SAK_PROP_JOIN_GROUP_ENABLED, Boolean.FALSE );
+    private static final boolean GLOBAL_JOIN_NOTIFICATION_ENABLED			= ServerConfigurationService.getBoolean( SAK_PROP_JOIN_NOTIFICATION_ENABLED, Boolean.FALSE );
     private static final boolean GLOBAL_JOIN_EXCLUDE_FROM_PUBLIC_ENABLED	= ServerConfigurationService.getBoolean( SAK_PROP_JOIN_EXCLUDE_FROM_PUBLIC_LIST, Boolean.FALSE );
     private static       boolean GLOBAL_JOIN_LIMIT_BY_ACCOUNT_TYPE_ENABLED	= ServerConfigurationService.getBoolean( SAK_PROP_JOIN_LIMIT_ACCOUNT_TYPES, Boolean.FALSE );
     private static final boolean GLOBAL_SITE_BROWSER_JOIN_ENABLED			= ServerConfigurationService.getBoolean( SAK_PROP_SITE_BROWSER_JOIN_ENABLED, Boolean.FALSE );
@@ -87,12 +107,13 @@ public class JoinSiteDelegate
      * 
      * @author bjones86@uwo.ca
      */
-    public JoinSiteDelegate( SiteService siteService, SecurityService securityService, UserDirectoryService userDirectoryService )
+    public JoinSiteDelegate( SiteService siteService, SecurityService securityService, UserDirectoryService userDirectoryService, EmailService emailService )
     {
     	// Assign the APIs
     	this.siteService 			= siteService;
     	this.securityService 		= securityService;
     	this.userDirectoryService 	= userDirectoryService;
+    	this.emailService			= emailService;
     	
     	// If join limit by account types is enabled globally in sakai.properties, check to make sure the lists are actually valid
     	if( GLOBAL_JOIN_LIMIT_BY_ACCOUNT_TYPE_ENABLED )
@@ -165,7 +186,17 @@ public class JoinSiteDelegate
     {
     	return JoinSiteDelegate.GLOBAL_JOIN_GROUP_ENABLED;
     }
-    
+
+    /**
+     * Get the global join email notification enabled setting
+     *
+     * @return true/false (enabled/disabled)
+     */
+    public boolean getGlobalJoinNotificationEnabled()
+    {
+        return JoinSiteDelegate.GLOBAL_JOIN_NOTIFICATION_ENABLED;
+    }
+
     /**
      * Get the global join exclude from public list enabled setting
      * 
@@ -220,7 +251,21 @@ public class JoinSiteDelegate
     	// otherwise, check if the user's account type is an allowed joinable account type for the site
         return !isLimitByAccountTypeEnabled(site.getId()) || hasAllowedAccountTypeToJoin(user, site);
     }
-    
+
+    /**
+     * Check if the current user is logged in
+     *
+     * @return true if the current user is logged in
+     */
+    public boolean isUserLoggedIn()
+    {
+        // get current user
+        User user = userDirectoryService.getCurrentUser();
+
+        // user is logged in if user id is not null and not empty
+        return user.getId() != null && !"".equals(user.getId());
+    }
+
     /**
      * Checks if the system and the provided site allows account types of joining users to be limited
      * 
@@ -373,8 +418,114 @@ public class JoinSiteDelegate
             // pop the Security Advisor off no matter what happens
             securityService.popAdvisor(yesMan);
         }
-    }    
-    
+    }
+
+    /**
+     * Check if the system and the provided site has the ability to send email notifications when a user joins the site
+     * @param siteID
+     *          The site to check if the join email notification option is enabled
+     * @return true if the join email notification options are enabled at the system and passed-in site's levels
+     */
+    public boolean isJoinNotificationToggled(String siteID)
+    {
+        // if system has join notifications enabled
+        if (GLOBAL_JOIN_NOTIFICATION_ENABLED && siteID != null)
+        {
+            // determine whether the site's options are to send join email notifications upon user joining a site
+            return getBooleanSiteProperty(siteID, SITE_PROP_JOIN_NOTIFY);
+        }
+        else
+        {
+            // options not enabled
+            return false;
+        }
+    }
+
+    /**
+     * Send email notification to the worksite's maintainers when a user joins their site
+     *
+     * @param siteID
+     *        Site to send email to its maintainers
+     */
+    public void sendEmailNotification(String siteID)
+    {
+        if (StringUtils.isBlank(siteID))
+        {
+            return;
+        }
+
+        try
+        {
+            // Get the current site, current user
+            Site site = siteService.getSite(siteID);
+            User currentUser = userDirectoryService.getCurrentUser();
+
+            // Add all the maintainers to the list of recipients
+            List<InternetAddress> emailRecipients = new ArrayList<>();
+            for (String userRef : site.getUsersHasRole(site.getMaintainRole()))
+            {
+                User user = null;
+                try
+                {
+                    user = userDirectoryService.getUser(userRef);
+                }
+                catch (UserNotDefinedException ex)
+                {
+                    // skip and continue to next user
+                    continue;
+                }
+
+                if (user != null)
+                {
+                    try
+                    {
+                        emailRecipients.add(new InternetAddress(user.getEmail()));
+                    }
+                    catch (AddressException ex)
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            // Create a map of replacement values
+            Map<String, Object> replacementValues = new HashMap<>();
+            replacementValues.put(TMPLT_VAR_SITE_NAME, site.getTitle());
+            replacementValues.put(TMPLT_VAR_INSTITUTE, ServerConfigurationService.getString(SAK_PROP_UI_INSTITUTION));
+            if (!StringUtils.isBlank(currentUser.getFirstName()))
+            {
+                replacementValues.put(TMPLT_VAR_SHORT_NAME, currentUser.getFirstName());
+            }
+            else
+            {
+                replacementValues.put(TMPLT_VAR_SHORT_NAME, currentUser.getDisplayId());
+            }
+
+            // Get the configured sender address from sakai.properties
+            String emailFrom = ServerConfigurationService.getString(SAK_PROP_SUPPORT_EMAIL);
+
+            // Get Email Template Service
+            EmailTemplateService emailTemplateService = (EmailTemplateService) ComponentManager.get(EmailTemplateService.class);
+
+            // get emplate
+            RenderedTemplate template = emailTemplateService.getRenderedTemplate(EMAIL_TEMPLATE_KEY, Locale.ENGLISH, replacementValues);
+            try
+            {
+                // send the email(s)
+                emailService.sendMail(new InternetAddress(emailFrom), emailRecipients.toArray(new InternetAddress[0]), template.getRenderedSubject(),
+                    template.getRenderedMessage(), null, null, null);
+            }
+            catch (AddressException ex)
+            {
+                log.error("Problem sending join notification email: " + ex.getMessage(), ex);
+            }
+        }
+        catch (IdUnusedException e)
+        {
+            log.error(String.format("Site ID %s not found; not sending join notification email", siteID), e);
+        }
+    }
+
     /**
      * Helper method to get the value of a boolean property
      * 
@@ -384,7 +535,7 @@ public class JoinSiteDelegate
      * 		The boolean property name to retrieve
      * @return true if the boolean property is found and is set to true
      */
-    private boolean getBooleanSiteProperty(String siteID, String propertyName)
+    public boolean getBooleanSiteProperty(String siteID, String propertyName)
     {
         try 
         {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/JoinSiteDelegate.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/JoinSiteDelegate.java
@@ -492,7 +492,7 @@ public class JoinSiteDelegate
             Map<String, Object> replacementValues = new HashMap<>();
             replacementValues.put(TMPLT_VAR_SITE_NAME, site.getTitle());
             replacementValues.put(TMPLT_VAR_INSTITUTE, ServerConfigurationService.getString(SAK_PROP_UI_INSTITUTION));
-            if (!StringUtils.isBlank(currentUser.getFirstName()))
+            if (StringUtils.isNotBlank(currentUser.getFirstName()))
             {
                 replacementValues.put(TMPLT_VAR_SHORT_NAME, currentUser.getFirstName());
             }

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/site-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/site-components.xml
@@ -29,6 +29,7 @@
 		<lookup-method name="activeToolManager" bean="org.sakaiproject.tool.api.ActiveToolManager" />
 		<lookup-method name="idManager" bean="org.sakaiproject.id.api.IdManager" />
 		<lookup-method name="notificationService" bean="org.sakaiproject.event.api.NotificationService" />
+		<lookup-method name="emailService" bean="org.sakaiproject.email.api.EmailService" />
 
  		<property name="autoDdl"><value>${auto.ddl}</value></property>
         <property name="databaseBeans">

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
@@ -30,6 +30,7 @@ import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.db.api.SqlService;
+import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.api.NotificationService;
@@ -186,6 +187,11 @@ public class SiteServiceTest extends DbSiteService
 	@Override
 	protected NotificationService notificationService() {
 		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	protected EmailService emailService() {
 		return null;
 	}
 }

--- a/site-manage/site-manage-impl/impl/src/bundle/joinNotification.xml
+++ b/site-manage/site-manage-impl/impl/src/bundle/joinNotification.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<emailTemplates>
+<emailTemplate>
+<subject>${localSakaiName} Join Notification: Someone has joined your "${worksiteName}" site!</subject>
+<message>${currentUserFirstName} ${currentUserLastName} (${currentUserDisplayId}) has joined your "${worksiteName}" site on ${localSakaiName}.
+You will now see ${currentUserDisplayName} listed in your site's Site Info participant list.
+
+If you would like to turn Join Notifications off for this site, please:
+
+    1) Log into ${localSakaiName}
+    2) Navigate to ${worksiteName}
+    3) Click 'Site Info' from the list of tools on the left hand side
+    4) Click 'Manage Access' from the menu bar at the top
+    5) Uncheck 'Notify site maintainers by email when a user joins this site'
+    6) Click the 'Update' button
+
+Regards,
+
+The ${localSakaiName} Administrators
+${institution}
+</message>
+<locale>en</locale>
+<version>1</version>
+</emailTemplate>
+</emailTemplates>

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/ETSUserNotificationProviderImpl.java
@@ -75,7 +75,11 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 	private static final String SITE_IMPORT_EMAIL_TEMPLATE_VAR_LINK 		= "linkToWorksite";
 	private static final String SITE_IMPORT_EMAIL_TEMPLATE_VAR_INSTITUTION 	= "institution";
 	private static final String SAK_PROP_UI_INSTITUTION						= "ui.institution";
-	
+
+	// email template sent during site join; see JoinSIteDelegate class in kernel
+	private static final String JOIN_EMAIL_TEMPLATE_FILE_NAME = "joinNotification.xml";
+	private static final String JOIN_EMAIL_TEMPLATE_KEY = "sitemanage.joinNotification";
+
 	@Setter
 	private UserTimeService userTimeService;
 
@@ -119,6 +123,7 @@ public class ETSUserNotificationProviderImpl implements UserNotificationProvider
 		emailTemplateService.importTemplateFromXmlFile(loader.getResourceAsStream("notifyAboutJoinableSet.xml"), NOTIFY_ABOUT_JOINABLE_SET);
 		emailTemplateService.importTemplateFromXmlFile(loader.getResourceAsStream("notifyJoinableSetDayLeft.xml"), NOTIFY_JOINABLE_SET_DAY_LEFT);
 		emailTemplateService.importTemplateFromXmlFile(loader.getResourceAsStream(SITE_IMPORT_EMAIL_TEMPLATE_FILE_NAME), SITE_IMPORT_EMAIL_TEMPLATE_KEY);
+		emailTemplateService.importTemplateFromXmlFile(loader.getResourceAsStream(JOIN_EMAIL_TEMPLATE_FILE_NAME), JOIN_EMAIL_TEMPLATE_KEY);
 	}
 	
 	@Override

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1021,6 +1021,7 @@ archive.createsite.confirm = Creating site from archive
 archive.createsite.confirm.none = None
 
 ## SAK-24423 - joinable site settings
+ediacc.joinNotification = Notify site maintainers by email when a user joins this site
 ediacc.joinExcludeFromPublic = Exclude this site from the publicly available list of joinable sites
 ediacc.joinLimitByAccountType = Limit join to specific accounts
 ediacc.additionJoinAccessOptions = Additional Options:

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/JoinableSiteSettings.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/JoinableSiteSettings.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.sakaiproject.cheftool.Context;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
@@ -59,7 +60,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JoinableSiteSettings
 {
-
 	// API's
 	private static final UserDirectoryService 		userDirectoryService 	= (UserDirectoryService) 		ComponentManager.get( UserDirectoryService.class );
 	private static final SiteService 				siteService 			= (SiteService) 				ComponentManager.get( SiteService.class );
@@ -68,6 +68,7 @@ public class JoinableSiteSettings
 	
 	// State variable names
 	private static final String STATE_JOIN_SITE_GROUP_ID				= "state_join_site_group";
+	private static final String STATE_JOIN_SITE_NOTIFICATION			= "state_join_site_notification";
 	private static final String STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST		= "state_join_site_exclude_public_list";
 	private static final String STATE_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE	= "state_join_site_limit_by_account_type";
 	private static final String STATE_JOIN_SITE_ACCOUNT_TYPES 			= "state_join_site_account_types";
@@ -76,7 +77,8 @@ public class JoinableSiteSettings
 	
 	// Site property names
 	private static final String SITE_PROP_JOIN_SITE_GROUP_ID 				= "joinerGroup";
-	private static final String SITE_PROP_JOIN_SITE_GROUP_NO_SEL				= "noSelection";
+	private static final String SITE_PROP_JOIN_SITE_GROUP_NO_SEL			= "noSelection";
+	private static final String SITE_PROP_JOIN_SITE_NOTIFICATION			= "joinNotification";
 	private static final String SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST		= "joinExcludeFromPublicList";
 	private static final String SITE_PROP_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE 	= "joinLimitByAccountType";
 	private static final String SITE_PROP_JOIN_SITE_ACCOUNT_TYPES 			= "joinLimitedAccountTypes";
@@ -84,15 +86,18 @@ public class JoinableSiteSettings
 	// Context variable/element names
 	private static final String CONTEXT_JOIN_SITE_GROUPS										= "siteGroups";
 	private static final String CONTEXT_JOIN_SITE_GROUP_DROP_DOWN								= "selectJoinerGroup";
+	private static final String CONTEXT_JOIN_SITE_NOTIFY_CHECKBOX								= "chkJoinNotification";
 	private static final String CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST_CHECKBOX					= "chkJoinExcludeFromPublicList";
 	private static final String CONTEXT_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE_CHECKBOX				= "chkJoinLimitByAccountType";
 	private static final String CONTEXT_JOIN_SITE_ACCOUNT_TYPES									= "joinableAccountTypes";
 	private static final String CONTEXT_JOIN_SITE_ACCOUNT_CATEGORIES							= "joinableAccountTypeCategories";
 	private static final String CONTEXT_JOIN_SITE_ACCOUNT_TYPE_CHECKBOX_PREFIX 					= "chkJoin-";
 	private static final String CONTEXT_JOIN_SITE_GROUP_ENABLED									= "joinGroupEnabled";
+	private static final String CONTEXT_JOIN_SITE_NOTIFICATION_ENABLED							= "joinNotificationEnabled";
 	private static final String CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST_ENABLED					= "joinExcludeFromPublicListEnabled";
 	private static final String CONTEXT_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE_ENABLED					= "joinLimitAccountTypesEnabled";
 	private static final String CONTEXT_JOIN_SITE_GROUP_ID										= SITE_PROP_JOIN_SITE_GROUP_ID;
+	private static final String CONTEXT_JOIN_SITE_NOTIFICATION									= SITE_PROP_JOIN_SITE_NOTIFICATION;
 	private static final String CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST							= SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST;
 	private static final String CONTEXT_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE							= SITE_PROP_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE;
 	private static final String CONTEXT_JOIN_SITE_LIMIT_ACCOUNT_TYPES							= SITE_PROP_JOIN_SITE_ACCOUNT_TYPES;
@@ -105,14 +110,15 @@ public class JoinableSiteSettings
 	private static final String CONTEXT_JOIN_SITE_LINK											= "link";
 	private static final String CONTEXT_JOIN_SITE_SITE_BROWSER_JOIN_ENABLED						= "siteBrowserJoinEnabled";
 	private static final String CONTEXT_JOIN_SITE_GROUP_ENABLED_LOCAL_DISABLED_GLOBAL 			= "joinGroupEnabledLocalDisabledGlobal";
-	private static final String CONTEXT_JOIN_SITE_EXCLUDE_ENABLED_LOCAL_DISABLED_GLOBAL 			= "joinExcludeEnabledLocalDisabledGlobal";
+	private static final String CONTEXT_JOIN_SITE_NOTIFICATION_ENABLED_LOCAL_DISABLED_GLOBAL	= "joinNotifyEnabledLocalDisabledGlobal";
+	private static final String CONTEXT_JOIN_SITE_EXCLUDE_ENABLED_LOCAL_DISABLED_GLOBAL 		= "joinExcludeEnabledLocalDisabledGlobal";
 	private static final String CONTEXT_JOIN_SITE_LIMIT_ENABLED_LOCAL_DISABLED_GLOBAL 			= "joinLimitEnabledLocalDisabledGlobal";
 	private static final String CONTEXT_UI_SERVICE = "uiService";
 	
 	// Message keys
 	private static final String MSG_KEY_UNJOINABLE 			= "join.unjoinable";
 	private static final String MSG_KEY_LOGIN				= "join.login";
-	private static final String MSG_KEY_ALREADY_MEMBER_1		= "join.alreadyMember1";
+	private static final String MSG_KEY_ALREADY_MEMBER_1	= "join.alreadyMember1";
 	private static final String MSG_KEY_ALREADY_MEMBER_2	= "join.alreadyMember2";
 	private static final String MSG_KEY_NOT_ALLOWED_TO_JOIN	= "join.notAllowed";
 	private static final String MSG_KEY_JOIN_SUCCESS		= "join.success";
@@ -547,7 +553,12 @@ public class JoinableSiteSettings
 		{
 			siteInfo.joinerGroup = params.getString( SITE_PROP_JOIN_SITE_GROUP_ID );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() && params.getString( SITE_PROP_JOIN_SITE_NOTIFICATION ) != null)
+		{
+			siteInfo.joinNotifications = Boolean.valueOf( params.getString( SITE_PROP_JOIN_SITE_NOTIFICATION ) );
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() && params.getString( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST ) != null )
 		{
 			siteInfo.joinExcludePublic = Boolean.valueOf( params.getString( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST ) );
@@ -586,7 +597,13 @@ public class JoinableSiteSettings
 		{
 			siteInfo.joinerGroup = props.getProperty( SITE_PROP_JOIN_SITE_GROUP_ID );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() && props.getProperty( SITE_PROP_JOIN_SITE_NOTIFICATION ) != null )
+		{
+			try { siteInfo.joinNotifications = Boolean.valueOf( props.getBooleanProperty( SITE_PROP_JOIN_SITE_NOTIFICATION ) ); }
+			catch( Exception ex ) { siteInfo.joinNotifications = false; }
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() && props.getProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST ) != null )
 		{
 			try { siteInfo.joinExcludePublic = Boolean.valueOf( props.getBooleanProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST ) ); }
@@ -628,7 +645,12 @@ public class JoinableSiteSettings
 		{
 			props.addProperty( SITE_PROP_JOIN_SITE_GROUP_ID, siteInfo.joinerGroup );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() )
+		{
+			props.addProperty( SITE_PROP_JOIN_SITE_NOTIFICATION, Boolean.toString( siteInfo.joinNotifications ) );
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 		{
 			props.addProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST, Boolean.toString( siteInfo.joinExcludePublic ) );
@@ -691,7 +713,12 @@ public class JoinableSiteSettings
 		{
 			props.addProperty( SITE_PROP_JOIN_SITE_GROUP_ID, (String) state.getAttribute( FORM_PREFIX + CONTEXT_JOIN_SITE_GROUP_DROP_DOWN ) );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() )
+		{
+			props.addProperty( SITE_PROP_JOIN_SITE_NOTIFICATION, (String) state.getAttribute( FORM_PREFIX + CONTEXT_JOIN_SITE_NOTIFY_CHECKBOX ) );
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 		{
 			props.addProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST, (String) state.getAttribute( FORM_PREFIX + CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST_CHECKBOX ) );
@@ -730,7 +757,12 @@ public class JoinableSiteSettings
 		{
 			props.addProperty( SITE_PROP_JOIN_SITE_GROUP_ID, state.getAttribute( STATE_JOIN_SITE_GROUP_ID ).toString() );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() )
+		{
+			props.addProperty( SITE_PROP_JOIN_SITE_NOTIFICATION, state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ).toString() );
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 		{
 			props.addProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST, state.getAttribute( STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST ).toString() );
@@ -773,7 +805,16 @@ public class JoinableSiteSettings
 			{
 				siteInfo.joinerGroup = "";
 			}
-			
+
+			if( siteService.isGlobalJoinNotificationEnabled() && state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ) != null )
+			{
+				siteInfo.joinNotifications = Boolean.valueOf( state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ).toString() );
+			}
+			else
+			{
+				siteInfo.joinNotifications = false;
+			}
+
 			if( siteService.isGlobalJoinExcludedFromPublicListEnabled() && state.getAttribute( STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST ) != null )
 			{
 				siteInfo.joinExcludePublic = Boolean.valueOf( state.getAttribute( STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST ).toString() );
@@ -854,7 +895,12 @@ public class JoinableSiteSettings
 		{
 			readInputAndUpdateStateVariable( state, params, CONTEXT_JOIN_SITE_GROUP_DROP_DOWN, STATE_JOIN_SITE_GROUP_ID, false );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() )
+		{
+			readInputAndUpdateStateVariable( state, params, CONTEXT_JOIN_SITE_NOTIFY_CHECKBOX, STATE_JOIN_SITE_NOTIFICATION, true );
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 		{
 			readInputAndUpdateStateVariable( state, params, CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST_CHECKBOX, STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST, true );
@@ -893,7 +939,10 @@ public class JoinableSiteSettings
 		// Get these site properties regardless of if the global toggles are disabled, as we may need them in the state anyways
 		// for clarity to the user (the checkboxes will still hold their initial choices, but will be disabled)
 		state.setAttribute( STATE_JOIN_SITE_GROUP_ID, props.getProperty( SITE_PROP_JOIN_SITE_GROUP_ID ) );
-		
+
+		try { state.setAttribute( STATE_JOIN_SITE_NOTIFICATION, Boolean.valueOf( props.getBooleanProperty( SITE_PROP_JOIN_SITE_NOTIFICATION ) ) ); }
+		catch( Exception ex) { state.setAttribute( STATE_JOIN_SITE_NOTIFICATION, Boolean.FALSE ); }
+
 		try { state.setAttribute( STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST, Boolean.valueOf( props.getBooleanProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST ) ) ); }
 		catch( Exception ex ) { state.setAttribute( STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST, Boolean.FALSE ); }
 		
@@ -924,7 +973,10 @@ public class JoinableSiteSettings
 		
 		try { siteInfo.joinerGroup = props.getProperty( SITE_PROP_JOIN_SITE_GROUP_ID ); }
 		catch( Exception ex ) { siteInfo.joinerGroup = SITE_PROP_JOIN_SITE_GROUP_NO_SEL; }
-		
+
+		try { siteInfo.joinNotifications = props.getBooleanProperty( SITE_PROP_JOIN_SITE_NOTIFICATION ); }
+		catch( Exception ex ) { siteInfo.joinNotifications = false; }
+
 		try { siteInfo.joinExcludePublic = props.getBooleanProperty( SITE_PROP_JOIN_SITE_EXCLUDE_PUBLIC_LIST ); }
 		catch( Exception ex ) { siteInfo.joinExcludePublic = false; }
 		
@@ -1021,7 +1073,25 @@ public class JoinableSiteSettings
 					context.put( CONTEXT_JOIN_SITE_GROUP_ENABLED_LOCAL_DISABLED_GLOBAL, Boolean.TRUE );
 				}
 			}
-			
+
+			// Repeat the above process for join notification
+			if ( siteService.isGlobalJoinNotificationEnabled() )
+			{
+				if( state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ) != null )
+				{
+					context.put( CONTEXT_JOIN_SITE_NOTIFICATION, state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ) );
+				}
+			}
+			else
+			{
+				if( state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ) != null &&
+					Boolean.valueOf( state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ).toString() ) == Boolean.TRUE )
+				{
+					context.put( CONTEXT_JOIN_SITE_NOTIFICATION, state.getAttribute( STATE_JOIN_SITE_NOTIFICATION ) );
+					context.put( CONTEXT_JOIN_SITE_NOTIFICATION_ENABLED_LOCAL_DISABLED_GLOBAL, Boolean.TRUE );
+				}
+			}
+
 			// Repeat the above process for exclude from public
 			if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 			{
@@ -1126,7 +1196,12 @@ public class JoinableSiteSettings
 			{
 				state.removeAttribute( STATE_JOIN_SITE_GROUP_ID );
 			}
-			
+
+			if (siteService.isGlobalJoinNotificationEnabled() )
+			{
+				state.removeAttribute( STATE_JOIN_SITE_NOTIFICATION );
+			}
+
 			if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 			{
 				state.removeAttribute( STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST );
@@ -1231,7 +1306,12 @@ public class JoinableSiteSettings
 		{
 			context.put( CONTEXT_JOIN_SITE_GROUP_ID, siteInfo.joinerGroup );
 		}
-		
+
+		if( siteService.isGlobalJoinNotificationEnabled() )
+		{
+			context.put( CONTEXT_JOIN_SITE_NOTIFICATION, Boolean.valueOf( siteInfo.joinNotifications ) );
+		}
+
 		if( siteService.isGlobalJoinExcludedFromPublicListEnabled() )
 		{
 			context.put( CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST, Boolean.valueOf( siteInfo.joinExcludePublic ) );
@@ -1258,6 +1338,7 @@ public class JoinableSiteSettings
 		}
 		
 		context.put( CONTEXT_JOIN_SITE_GROUP_ENABLED, Boolean.valueOf( siteService.isGlobalJoinGroupEnabled() ) );
+		context.put( CONTEXT_JOIN_SITE_NOTIFICATION_ENABLED, Boolean.valueOf( siteService.isGlobalJoinNotificationEnabled() ) );
 		context.put( CONTEXT_JOIN_SITE_EXCLUDE_PUBLIC_LIST_ENABLED, Boolean.valueOf( siteService.isGlobalJoinExcludedFromPublicListEnabled() ) );
 		context.put( CONTEXT_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE_ENABLED, Boolean.valueOf( siteService.isGlobalJoinLimitByAccountTypeEnabled() ) );
 	}
@@ -1368,7 +1449,7 @@ public class JoinableSiteSettings
 		String paramValue = StringUtils.trimToNull( params.getString( paramName ) );
 		
 		// If the state attribute name is one of the joinable site setting's, flip the value from 'on'/'off' to 'true'/'false'
-		if( STATE_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE.equalsIgnoreCase( stateAttributeName ) ||
+		if( STATE_JOIN_SITE_NOTIFICATION.equalsIgnoreCase( stateAttributeName ) || STATE_JOIN_SITE_LIMIT_BY_ACCOUNT_TYPE.equalsIgnoreCase( stateAttributeName ) ||
 				STATE_JOIN_SITE_EXCLUDE_PUBLIC_LIST.equalsIgnoreCase( stateAttributeName ) || stateAttributeName.startsWith( STATE_JOIN_SITE_ACCOUNT_TYPE_PREFIX ) )
 		{
 			if( paramValue != null && paramValue.equalsIgnoreCase( ON_STRING ) )

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -15,7 +15,6 @@
  */
 package org.sakaiproject.site.tool;
 
-import static org.sakaiproject.site.util.SiteConstants.SITE_PUBLISH_DATE;
 import static org.sakaiproject.site.util.SiteConstants.STATE_TEMPLATE_INDEX;
 
 import java.io.File;
@@ -30,7 +29,6 @@ import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.Year;
 import java.time.ZoneId;
 import java.time.LocalDateTime;
 import java.time.Year;
@@ -79,7 +77,6 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.velocity.tools.generic.SortTool;
 import org.sakaiproject.alias.api.Alias;
 import org.sakaiproject.alias.api.AliasService;
-import org.sakaiproject.api.app.scheduler.ScheduledInvocationCommand;
 import org.sakaiproject.api.privacy.PrivacyManager;
 import org.sakaiproject.archive.api.ArchiveService;
 import org.sakaiproject.archive.api.ImportMetadata;
@@ -13550,7 +13547,13 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		{ 
 			return joinerGroup;
 		}
-		
+
+		public boolean joinNotifications = false;
+		public boolean getJoinNotifications()
+		{
+			return joinNotifications;
+		}
+
 		public boolean joinExcludePublic = false;
 		public boolean getJoinExcludePublic()
 		{ 

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -425,9 +425,8 @@
 				</p>
 				
 				## SAK-24423 - joinable site settings title
-				#if( $joinGroupEnabled || $joinExcludeFromPublicListEnabled || $joinLimitAccountTypesEnabled ||
-						$joinGroupEnabledLocalDisabledGlobal || $joinExcludeEnabledLocalDisabledGlobal ||
-						$joinLimitEnabledLocalDisabledGlobal )
+				#if( $joinGroupEnabled || $joinNotificationEnabled || $joinExcludeFromPublicListEnabled || $joinLimitAccountTypesEnabled ||
+						$joinGroupEnabledLocalDisabledGlobal || $joinExcludeEnabledLocalDisabledGlobal || $joinLimitEnabledLocalDisabledGlobal )
 					<p class="indnt3">$tlang.getString( "ediacc.additionJoinAccessOptions" )</p>
 				#end
 				
@@ -448,7 +447,23 @@
 						#end
 					</p>
 				#end
-				
+
+				## joinable site settings - join notification
+				#if( $joinNotificationEnabled || $joinNotifyEnabledLocalDisabledGlobal )
+					<p class="checkbox indnt4">
+						<input name="chkJoinNotification" id="chkJoinNotification" type="checkbox"
+							#if( $joinNotification ) checked="checked" #end
+							#if( !$joinNotificationEnabled || $joinNotifyEnabledLocalDisabledGlobal ) disabled #end
+						/>
+						<label for="chkJoinNotification" #if( !$joinNotificationEnabled || $joinNotifyEnabledLocalDisabledGlobal ) class="instruction" #end>
+							$tlang.getString( "ediacc.joinNotification" )
+						</label>
+					</p>
+					#if( $joinNotifyEnabledLocalDisabledGlobal )
+						<p class="indnt7 messageInformation">$tlang.getString( "ediacc.notifyEnabledLocalDisabledGlobal" )</p>
+					#end
+				#end
+
 				## SAK-24423 - joinable site settings - exclude from public list
 				#if( $joinExcludeFromPublicListEnabled || $joinExcludeEnabledLocalDisabledGlobal )
 					<p class="checkbox indnt4">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49149

Supplemental to SAK-24423, this will provide a new option within “Manage Access” under the joinable site settings: email notifications when someone elects to join the site, which will be sent to all site maintainers.

**NOTE:** introduces a new sakai.property to enable/disable this feature globally: `sitemanage.join.notification.enabled=[true/false]` (defaults to `false`)