### PR TITLE
SAK-49156: samigo > moment.js errors when taking a timed assessment through the published assessment URL

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/TimerBarRenderer.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/TimerBarRenderer.java
@@ -97,8 +97,8 @@ public class TimerBarRenderer extends Renderer
         }
 
          String contextPath = context.getExternalContext().getRequestContextPath();
-         writer.write("\n<script type=\"text/javascript\" src=\"" +
-           contextPath + SCRIPT_PATH + "timerbar.js\"></script>");
+         writer.write("\n<script>includeWebjarLibrary('momentjs');</script>");
+         writer.write("\n<script type=\"text/javascript\" src=\"" + contextPath + SCRIPT_PATH + "timerbar.js\"></script>");
          writer.write("\n");
 
         if (clientId != null)


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49156

When taking a timed assessment through the published assessment URL, there are some timerbar.js errors in the console. The timer in the UI doesn’t update while sitting on a question, it only updates when you progress to the next question. On the first question, the timer doesn’t show any time at all. The auto redirection after the timer expires can be a little delayed.

It should be noted that momentjs is hard-coded in several other places as well:

> $ ag "momentjs\/2.29.1"
portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm
87:        <script src="${pageWebjarsPath}momentjs/2.29.1/min/moment-with-locales.min.js$!{portalCDNQuery}"></script>
>
> samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/jsf/renderer/TimerBarRenderer.java
100:         writer.write("\n<script type=\"text/javascript\" src=\"/library/webjars/momentjs/2.29.1/min/moment-with-locales.min.js\"></script>");
>
> rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-date-field-input.html
20:     src="/library/webjars/momentjs/2.29.1/min/moment-with-locales.min.js"