### PR TITLE
SAK-47741: rubrics > can't expand public rubrics

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
+++ b/webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric.js
@@ -226,12 +226,13 @@ export class SakaiRubric extends RubricsElement {
 
     e && e.preventDefault();
 
+    const isReadOnly = this.tagName === "SAKAI-RUBRIC-READONLY";
     const titlecontainer = this.querySelector(".rubric-title");
 
-    const collapse = $(`#collapse_${this.rubric.id}`);
+    const collapse = isReadOnly ? $(`#collapse_shared_${this.rubric.id}`) : $(`#collapse_${this.rubric.id}`);
     collapse.toggle();
 
-    const icon = $(`#rubric_toggle_${this.rubric.id} span`);
+    const icon = isReadOnly ? $(`#rubric_toggle_shared_${this.rubric.id} span`) : $(`#rubric_toggle_${this.rubric.id} span`);
 
     if (collapse.is(":visible")) {
       this.rubricExpanded = "true";


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-47741

If you are the owner of the public rubric (meaning you have the rubric in both “Site Rubrics” and “Public Rubrics”), attempting to expand the public version of the rubric will expand the “private” version of the rubric because they share the same rubric ID.

If you are not the owner of the public rubric (meaning you only have the rubric in your “Public Rubrics” section), attempting to expand the public rubric will do nothing because you don’t have a corresponding rubric ID in your “Site Rubrics” section.