### PR TITLE
SAK-49164 Escape label filename attribute for EMI QTI export

### DIFF
--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/item/ItemHelper12Impl.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/item/ItemHelper12Impl.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -2252,7 +2253,7 @@ public class ItemHelper12Impl extends ItemHelperBase
 			}else{
 				throw new IllegalArgumentException("Don't know this Mime-type: " + attach.getMimeType());
 			}
-			mat.setAttribute("label", attach.getFilename());
+			mat.setAttribute("label", StringEscapeUtils.escapeXml10(attach.getFilename()));
 			mat.setAttribute("size", String.valueOf(attach.getFileSize()));
 			mat.setAttribute("uri", attach.getLocation());
 			material.appendChild(mat);


### PR DESCRIPTION
Escape reserved xml characters in the label attribute for EMI attachment filenames.
