### PR TITLE
SAK-47868 Lessons client side check for exceeding file size limit before uploading

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -4627,6 +4627,9 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		UILink.make(tofill, "mm-additional-website-instructions", messageLocator.getMessage("simplepage.additional-website-instructions-label"), 
 			    getLocalizedURL( "website.html", true));
 
+		
+		
+		UIOutput.make(tofill, "mm-max-file-upload-size", String.valueOf(uploadMax));
 		UIForm form = UIForm.make(tofill, "add-multimedia-form");
 		makeCsrf(form, "csrf9");
 

--- a/lessonbuilder/tool/src/resources/messages.properties
+++ b/lessonbuilder/tool/src/resources/messages.properties
@@ -955,3 +955,5 @@ simplepage.content.items = Simple Content Items
 simplepage.linked.content.items = Linked or Embedded Items
 simplepage.advanced.content.items = Advanced Content Items
 simplepage.layout.elements = Layout Elements
+simplepage.max-file-upload-size=The upload size limit of
+simplepage.max-file-upload-size-save=MB has been exceeded. Remove one or more files below to proceed. Other files may be uploaded assuming the total file size does not exceed this limit.

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -510,6 +510,7 @@
             <div class="sak-banner-error" id="mm-error">
             </div>
           </div>
+          <span id="mm-max-file-upload-size" style="display: none" rsf:id="mm-max-file-upload-size">max</span>  
           <form action="#" rsf:id="add-multimedia-form" method="post" enctype="multipart/form-data">
             <input type="hidden" rsf:id="csrf9" />
             <div class="">
@@ -3339,6 +3340,8 @@
         <p rsf:id="msg=simplepage.columnopen" id="simplepage.columnopen"></p>
         <p rsf:id="msg=simplepage.remove_from_uploads" id="simplepage.remove_from_uploads"></p>
         <p rsf:id="msg=simplepage.title_for_upload" id="simplepage.title_for_upload"></p>
+        <p rsf:id="msg=simplepage.max-file-upload-size" id="simplepage.max-file-upload-size"></p>
+        <p rsf:id="msg=simplepage.max-file-upload-size-save" id="simplepage.max-file-upload-size-save"></p>
         <p rsf:id="siteid" id="siteid"></p>
         <p rsf:id="locale" id="locale"></p>
       </div>

--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -704,9 +704,20 @@
   .mm-file-input {
     display:inline;
   }
-  span.mm-file-input-name {
+  .mm-file-input-name {
+    display: inline-block;
+    line-height: 1.6 !important;
+    vertical-align: bottom;
+    white-space: nowrap;
+    max-width: 300px !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+  span.mm-file-input-name,
+  span.mm-file-input-size {
     margin-bottom: 0;
     margin-right: 14px;
+    width: 300px;
   }
   .mm-file-input-delete {
     cursor: pointer;
@@ -744,6 +755,7 @@
   }
   span.remove-upload {
     margin-left: 6px;
+    margin-top: 11px;
     font-size: 22px;
     float: right;
   }
@@ -2063,7 +2075,7 @@
   }
   .PagePicker {
     margin-top:12px;
-  }
+  }   
   /* 800 is when the left margin collapses */
   @media only screen and (max-width: 800px) {
     .Mrphs-container--toolTitleNav {


### PR DESCRIPTION
Adds client side file size testing vs sakai.properties limit for Lessons tool:

- File size test when adding content links, embedding content, uploading ZIP files content 

- if size limit exceeded a warning banner is displayed and the Save button is disabled

- removing file(s) such that limit is no longer exceeded removes the banner and re-enables the Save button

- displays file size (in KB or MB) next to file name