### PR TITLE
SAK-49180 Lessons: 'Add' menu in file picker has UX issues

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_filepicker_select.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_filepicker_select.vm
@@ -30,36 +30,6 @@ table.listHier .attach {
 			}
 		}
 </script>
-<script  type="text/javascript">
-$(document).ready(function() {
-	jQuery('.portletBody').click(function(e) { 
-
-		if ( e.target.className !='menuOpen' &&e.target.className !='dropdn'  ){
-			$('.makeMenuChild').hide();
-		} else {
-			if( e.target.className =='dropdn' ){
-			    $('.makeMenuChild').hide();
-			    var menuid = $(e.target).parent('li').attr('id');
-			    var menuopen = $('#menu-' + menuid);
-			    if (typeof(menuopen.dialog('instance')) === "undefined") {
-				menuopen.dialog({
-				    autoOpen: false,
-				    modal: true,
-				    resizable: false,
-				    draggable: false
-				});
-			    }
-			    menuopen.dialog('open');
-			} else {
-			    var targetId=e.target.id;
-			    $('.makeMenuChild').hide();
-			    $('#menu-' + targetId).show();
-			}
-		}
-	});
-	$('.makeMenuChild').hide();	
-	});
-</script>
 <div class="portletBody specialLink">
 	#if ($alertMessage)
 		<div class="sak-banner-error">$tlang.getString("gen.alert") $formattedText.escapeHtml($alertMessage)</div>
@@ -303,26 +273,21 @@ $(document).ready(function() {
 						#if($can_attach_more)
 							#if($item.isCollection())
 								#if($item.addActions && !$item.addActions.isEmpty())
-									<ul style="z-index:$actionCount;margin:0;display:block" class="makeMenu">
-										<li class="menuOpen" id="$actionCount">
-		    							&nbsp;$tlang.getString('gen.add')
-											<span class="fa fa-caret-square-o-down" aria-hidden="true"></span>
-											<span class="sr-only">$tlang.getString('gen.add')</span>
-											<ul  id="menu-$actionCount" class="makeMenuChild">
+									<ul style="z-index:$actionCount;margin:0;display:block" class="makeMenu ps-0">
+										<li class="dropdown menuOpenLi"><button type="button" class="menuOpen btn btn-primary dropdown-toggle m-2" data-bs-toggle="dropdown" aria-expanded="false">
+		    							$tlang.getString('gen.add')
+											<span class="sr-only">$tlang.getString('gen.add')</span></button>
+											<ul class="dropdown-menu">
 							        	#foreach($action in $item.addActions)
 													<li>
-														<a href="#" onclick="document.getElementById('selectedItemId').value='$item.id';document.getElementById('rt_action').value='${action.typeId}${ACTION_DELIMITER}$action.id';document.getElementById('sakai_action').value='doDispatchAction';submitform('attachForm');">
+														<a class="dropdown-item" href="#" onclick="document.getElementById('selectedItemId').value='$item.id';document.getElementById('rt_action').value='${action.typeId}${ACTION_DELIMITER}$action.id';document.getElementById('sakai_action').value='doDispatchAction';submitform('attachForm');">
 										                    $labeler.getLabel($action)
 														</a>
 													</li>							
 				                #end
-												<li style="height:1px;width:1px;display:inline;">
-													<a href="#"  class="skip" onfocus="document.getElementById('menu-$actionCount').style.display='none';document.getElementById('last-$actionCount').focus()" >$tlang.getString("att.menu.end")</a>
-												</li>
 											</ul>
 										</li>
 									</ul>
-									<a href="#" id="last-$actionCount"></a>							
 								#end
 							#elseif($item.canSelect())
 								<div class="itemAction" style="margin:0;">
@@ -482,28 +447,21 @@ $(document).ready(function() {
 								#if($can_attach_more)
 									#if($item.isCollection())
 										#if($item.addActions && !$item.addActions.isEmpty())
-											<ul style="z-index:$actionCount;margin:0;display:block" class="makeMenu">
-												<li class="menuOpen" id="$actionCount">
-												&nbsp;$tlang.getString('gen.add')
-													<span class="fa fa-caret-square-o-down" aria-hidden="true"></span>
-													<span class="sr-only">$tlang.getString('button.add')</span>
-													<ul  id="menu-$actionCount" class="makeMenuChild">
+											<ul style="z-index:$actionCount;margin:0;display:block" class="makeMenu ps-0">
+												<li class="dropdown menuOpenLi"><button type="button" class="menuOpen btn btn-primary dropdown-toggle m-2">
+												$tlang.getString('gen.add')
+													<span class="sr-only">$tlang.getString('button.add')</span></button>
+													<ul class="dropdown-menu">
 													#foreach($action in $item.addActions)
 															<li>
-																<a href="#" onclick="document.getElementById('selectedItemId').value='$item.id';document.getElementById('rt_action').value='${action.typeId}${ACTION_DELIMITER}$action.id';document.getElementById('sakai_action').value='doDispatchAction';submitform('attachForm');">
+																<a class="dropdown-item" href="#" onclick="document.getElementById('selectedItemId').value='$item.id';document.getElementById('rt_action').value='${action.typeId}${ACTION_DELIMITER}$action.id';document.getElementById('sakai_action').value='doDispatchAction';submitform('attachForm');">
 																	$labeler.getLabel($action)
 																</a>
 															</li>							
 													#end                                           
-													<li>
-														<a href="#"  class="skip" onfocus="document.getElementById('menu-$actionCount').style.display='none';document.getElementById('last-$actionCount').focus()" >$tlang.getString("button.endadd")</a>
-													</li>
 												</ul>
 											</li>
 										</ul>
-										<a href="#" id="last-$actionCount"></a>							
-
-
 
 #*
 

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_folders.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_folders.vm
@@ -7,7 +7,7 @@
 	#if ($itemAlertMessage)
 		<div id="resourceAlert" class="sak-banner-error">$tlang.getString("label.alert") $formattedText.escapeHtml($itemAlertMessage)</div>
 	#else
-		<div id="resourceAlert" class="sak-banner-error hide"></div>
+		<div id="resourceAlert" class="sak-banner-error d-none"></div>
 	#end
 	<nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
 	<ol class="breadcrumb">

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_create_uploads.vm
@@ -16,12 +16,12 @@
     #if ($itemAlertMessage)
         <div  id="resourceAlert" class="sak-banner-success">$itemAlertMessage</div>
     #else
-        <div  id="resourceAlert" class="sak-banner-error hide"></div>
+        <div  id="resourceAlert" class="sak-banner-error d-none"></div>
     #end
     <div id="dragDropWrapper">
     <form name="dropzone-form" action="#toolLink("ResourcesHelperAction" "doPost")&flow=save" class="dropzone" id="file-uploader">
         <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
-        <div class="dz-default dz-message"><button type="button">$tlang.getString("label.dragZoneMessage")</button></div>
+        <div class="dz-default dz-message"><button class="btn btn-outline-secondary" type="button">$tlang.getString("label.dragZoneMessage")</button></div>
     </form>
     <br />
     <div id="fileUploaderDesc" class="instruction">

--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_dropbox_multiple_folders_upload.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_dropbox_multiple_folders_upload.vm
@@ -9,7 +9,7 @@
 	#if ($alertMessage)
 		<br /><div class="sak-banner-error" id="resourceAlert">$clang.getString("gen.alert") $formattedText.escapeHtml($alertMessage)</div>
 	#else
-		<br /><div id="resourceAlert" class="sak-banner-error hide"></div>
+		<br /><div id="resourceAlert" class="sak-banner-error d-none"></div>
 	#end
 	#if (!$!alreadyUploadedFile)
 	<p class="instruction">

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -586,13 +586,13 @@
                     <div class="card-body">
                       <label id="select-resource-label" rsf:id="msg=simplepage.choose_existing_caption" for="mm-choose">resource</label>
                       <p class="required mm-resources-section" style="">
-                        <a role="button" class="btn btn-default" href="#" id="mm-choose" rsf:id="mm-choose">...or choose existing file</a>
+                        <a role="button" class="btn btn-outline-secondary mt-2" href="#" id="mm-choose" rsf:id="mm-choose">...or choose existing file</a>
                       </p>
                     </div>
                   </div>
                 </div>
               </div>
-              <p rsf:id="mm-prerequisite-section" class="checkbox mm-prerequisite-section">
+              <p rsf:id="mm-prerequisite-section" class="checkbox mm-prerequisite-section my-3">
                 <input type="checkbox" name="mm-prerequisite" id="mm-prerequisite" rsf:id="mm-prerequisite" />
                 <label for="mm-prerequisite"><span rsf:id="msg=simplepage.prerequisites_label"></span></label>
               </p>

--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -33,11 +33,11 @@
 			 line-height: 1em;
 		}
 	}
-	/*.portletBody > * {
-		position: inherit;
-		top: 0;
+
+	.menuOpenLi {
+		list-style-type: none;
 	}
-    */
+
 	.mainList {
 		list-style: none;
 		padding: 0 0 0 0;

--- a/library/src/skins/default/src/sass/modules/tool/resources/_resources.scss
+++ b/library/src/skins/default/src/sass/modules/tool/resources/_resources.scss
@@ -277,6 +277,11 @@
 	#content-display-columns-dropdown {
 		margin-left: auto;
 	}
+
+        .specialLink .resource-name {
+	    position: relative;
+	    top: 5px;
+       }
 }
 
 /* this belongs to resources but it is accessed out of its namespace */


### PR DESCRIPTION
For sakai_filepicker_select.vm, I've supplanted most of the custom jquery and selectors in favor of a bootstrap dropdown control. 

With this PR, I've also restyled a few related items in Resources and Lessons. This is demonstrated in the screencast, SAK-49180-ProposedFixDemo.mp4, attached to the [corresponding jira](https://sakaiproject.atlassian.net/browse/SAK-49180).
