### PR TITLE
S2U-21 5.1.1.17 Tests & Quizzes: Support for Safe Exam Browser

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/BeginDeliveryActionListener.java
@@ -189,7 +189,7 @@ public class BeginDeliveryActionListener implements ActionListener
     delivery.setFileUploadSizeMax(Math.round(sizeMax.floatValue()/1024));
     delivery.setPublishedAssessment(pub);
 
-    if (secureDelivery.isSecureDeliveryAvaliable()) {
+    if (secureDelivery.isSecureDeliveryAvaliable(Long.valueOf(delivery.getPublishedAssessment().getPublishedAssessmentId()))) {
       String secureDeliveryModuleId = pub.getAssessmentMetaDataByLabel(SecureDeliveryServiceAPI.MODULE_KEY);
 
       if (StringUtils.equals(secureDeliveryModuleId, SecureDeliverySeb.MODULE_NAME)) {

--- a/samigo/samigo-app/src/webapp/js/authoringSecureDeliverySettings.js
+++ b/samigo/samigo-app/src/webapp/js/authoringSecureDeliverySettings.js
@@ -300,7 +300,6 @@ function initSecureDeliverySettings(isPublishedSettingsPage) {
                 formElements.secureDeliveryModuleExitPassword.hide();
                 break;
             default:
-                formElements.secureDeliveryModuleExitPassword.show();
                 break;
         }
     }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/S2U-21

**IMPORTANT**
Both problems with seb.enabled=site


- siteId is null

```
023-08-17T11:21:43,811 DEBUG [org.sakaiproject.event.impl.ClusterEventTracking$$EnhancerBySpringCGLIB$$e098a3c6] umu.sakai.login.event.UmuLoginEvent.update Evento: sam.assessment.submit.from_last::siteId=null, submissionId=2505840
2023-08-17T11:21:43,811 DEBUG [org.sakaiproject.event.impl.ClusterEventTracking$$EnhancerBySpringCGLIB$$e098a3c6] umu.sakai.login.event.UmuLoginEvent.update Evento: sam.assessment.submit.click_sub::siteId=null, submissionId=2505840
2023-08-17T11:21:43,811 DEBUG [org.sakaiproject.event.impl.ClusterEventTracking$$EnhancerBySpringCGLIB$$e098a3c6] umu.sakai.login.event.UmuLoginEvent.update Evento: sam.assessment.submit.checked::siteId=null, submissionId=2505840
2023-08-17T11:21:43,811 DEBUG [org.sakaiproject.event.impl.ClusterEventTracking$$EnhancerBySpringCGLIB$$e098a3c6] umu.sakai.login.event.UmuLoginEvent.update Evento: sam.assessment.graded.auto::siteId=null, submissionId=2505840, publishedAssessmentId=626299
2023-08-17T11:21:43,811 DEBUG [org.sakaiproject.event.impl.ClusterEventTracking$$EnhancerBySpringCGLIB$$e098a3c6] umu.sakai.login.event.UmuLoginEvent.update Evento: sam.assessment.submit.via_url::siteId=null, submissionId=2505840
2023-08-17T11:21:43,812 DEBUG [org.sakaiproject.event.impl.ClusterEventTracking$$EnhancerBySpringCGLIB$$e098a3c6] umu.sakai.login.event.UmuLoginEvent.update Evento: sam.assessment.submit.noti::{assessmentGradingID=2505840, publishedAssessmentID=626299, confirmationNumber=2505840-626299-dfcfb5ff-b184-4978-9e58-a1f5d3046cc9-1692264101791, submissionDate=Thu Aug 17 11:21:41 CEST 2023, userID=dfcfb5ff-b184-4978-9e58-a1f5d3046cc9}
```

- Error on javascript when clicking settings on a site without the property sebEnabled=true

![image](https://github.com/sakaiproject/sakai/assets/15141743/83f10744-2d46-425f-b7e9-530feb3779ec)
