### PR TITLE
SAK-48875 - Profile: Options for editing “Basic Information” and “Name Pronunciation” are no longer keyboard/screen reader accessible

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/profile2/_profile2.scss
+++ b/library/src/skins/default/src/sass/modules/tool/profile2/_profile2.scss
@@ -45,13 +45,18 @@
 		display: none;
 	}
 
-	.editable:hover > .edit-button, .edit-button:focus {
+	/* Reusable class to show the edit-button */
+	.show-edit-button {
 		@include sakai_secondary_button();
 		margin: 3px 0 0 0;
 		float: right;
 		clear: none;
 		display: block;
 		clip: unset;
+	}
+
+	.editable:hover > .edit-button, .edit-button:focus {
+		@extend .show-edit-button;
 	}
 
 	.edit-image-button {

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyBusinessDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyBusinessDisplay.html
@@ -25,7 +25,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Business Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
             <i class="si si-edit"></i>
 			<span wicket:id="heading">[Contact Information]</span>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInfoDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInfoDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Basic Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInterestsDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInterestsDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Personal Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyNamePronunciationDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyNamePronunciationDisplay.html
@@ -6,7 +6,7 @@
 <body>
 <wicket:panel>
 
-    <div class="mainSection editable">
+    <div class="mainSection editable" tabindex=0>
         <div class="mainSectionHeading">
             <span wicket:id="heading">[Name Pronunciation and Pronouns]</span>
         </div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MySocialNetworkingDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MySocialNetworkingDisplay.html
@@ -25,7 +25,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Social Networking Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStaffDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStaffDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[University Staff]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStudentDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStudentDisplay.html
@@ -25,7 +25,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable">
+	<div class="mainSection editable" tabindex=0>
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Student Information]</span>
 		</div>

--- a/profile2/tool/src/webapp/javascript/profile2.js
+++ b/profile2/tool/src/webapp/javascript/profile2.js
@@ -77,4 +77,24 @@ window.addEventListener("DOMContentLoaded", () => {
       }
     });
   });
+
+  //Keyboard navigation for the edit buttons
+  const editableDivs = document.querySelectorAll('.editable');
+  //All edit buttons in the panel
+  const panelEditButtons = document.querySelectorAll('.main-profile-tabpanel .edit-button');
+
+  editableDivs.forEach(editableDiv => {
+    const editButton = editableDiv.querySelector('.edit-button');
+    //Show buttons when focused on the div
+    editableDiv.addEventListener('focus', () => {
+      //When we get focus hide all buttons except the one in this
+      panelEditButtons.forEach(panelEditButton => { 
+          panelEditButton.style.display = 'none';
+          panelEditButton.setAttribute('tabindex', '-1');
+      });
+      editButton.classList.add('show-edit-button');
+      editButton.setAttribute('tabindex', '0');
+      editButton.style.display = 'block';
+    });
+  });
 });


### PR DESCRIPTION
This feels a little bit of a hack but I couldn't figure out how to get this to work with how this page was implemented otherwise.

My idea was to set all of the divs to be tab navigable. And when then the edit button will be displayed. When you navigate to another div it will just clean up all the edit buttons.

The _best_ way might be to redesign this page to not have hidden buttons like this, and I'm not sure why it's implemented this was with the hidden buttons.

The downside of this is that the last edit button will remain if you tab past the last element. And you also can't directly shift-tab to the previous edit button as you'd have to shift-tab then tab again to get to edit. 

If there's a better way someone has to do this go for it, but this at least makes this fully navigable with the keyboard.