### PR TITLE
SAK-48579 - Site Info: Screen Reader/Keyboard Users Unable to Edit Items Using Date Manager

### DIFF
--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -269,7 +269,11 @@
               var $cell = $('#' + id);
               $cell.addClass('ajax-error');
               $cell.find('.errors').text(elt.msg);
-              $('#form-errors').find('ul').append('<li>' + elt.toolTitle + ' - ' + elt.msg + '</li>');
+              if ('toolTitle' in elt) {
+                $('#form-errors').find('ul').append('<li>' + elt.toolTitle + ' - ' + elt.msg + '</li>');
+              } else {
+                $('#form-errors').find('ul').append('<li>' + elt + '</li>');
+              }
             });
             $('html, body').animate({ scrollTop: 0 }, 'slow');
           }
@@ -344,7 +348,8 @@
             var json = '{"assignments": ' + assignmentsStr + ', "assessments": ' + assessmentsStr + ', "gradebookItems": ' + gradebookStr + ', "signupMeetings": ' + signupStr + ', "resources": ' + resourcesStr + ', "calendarEvents": ' + calendarStr + ', "forums": ' + forumsStr + ', "announcements": ' + announcementsStr + ', "lessons": ' + lessonsStr + '}';
 
             $.ajax({
-              url: window.location + '/date-manager/update',
+              // This replace is here to remove any anchor from the end of the URL
+              url: window.location.href.replace(/#.*$/, '') + '/date-manager/update',
               processData: false,
               dataType : 'json',
               contentType: 'application/json; charset=utf-8',
@@ -359,6 +364,12 @@
                 } else {
                   printSuccess();
                 }
+              },
+              error: function(xhr, textStatus, errorThrown) {
+                  var parser = new DOMParser();
+                  var responseDoc = parser.parseFromString(xhr.responseText, 'text/html');
+                  errors = [responseDoc.body.innerHTML];
+                  printErrors();
               }
             });
           }

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -366,8 +366,8 @@
                 }
               },
               error: function(xhr, textStatus, errorThrown) {
-                  var parser = new DOMParser();
-                  var responseDoc = parser.parseFromString(xhr.responseText, 'text/html');
+                  const parser = new DOMParser();
+                  const responseDoc = parser.parseFromString(xhr.responseText, 'text/html');
                   errors = [responseDoc.body.innerHTML];
                   printErrors();
               }


### PR DESCRIPTION
The main fix is 
`+              url: window.location.href.replace(/#.*$/, '') + '/date-manager/update',`

I used the error handler to help debug this so I left it in. Normally that shouldn't be ever hit but I think it would be useful to retain. There was an error handler code in the success method and I don't know how that would ever trigger.