### PR TITLE
SAK-49276 Lessons: Add dataDirectory field to lesson endpoint for RESOURCE_FOLDER type

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/entityproviders/LessonsEntityProvider.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/entityproviders/LessonsEntityProvider.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -631,6 +632,23 @@ public class LessonsEntityProvider extends AbstractEntityProvider implements Ent
 	        }
 	    }
 	}
+
+	@Data
+	@EqualsAndHashCode(callSuper = false)
+	public class DecoratedResourceFolder extends DecoratedLesson {
+
+
+		private String dataDirectory;
+
+
+		public DecoratedResourceFolder(SimplePageItem item) {
+			super(item);
+
+			if (item != null) {
+				dataDirectory = item.getAttribute("dataDirectory");
+			}
+		}
+	}
         
 	// For properties related to grading a DecoratedLesson
         @NoArgsConstructor
@@ -1027,6 +1045,9 @@ public class LessonsEntityProvider extends AbstractEntityProvider implements Ent
 					break;
 				case SimplePageItem.RESOURCE:
 					lesson = new DecoratedResource(item);
+					break;
+				case SimplePageItem.RESOURCE_FOLDER:
+					lesson = new DecoratedResourceFolder(item);
 					break;
 				case SimplePageItem.ASSIGNMENT:
 					lesson = new GradedDecoratedLesson(item);


### PR DESCRIPTION
Added missing dataDirectory field to response of lesson endpoint for the resource folder item type.

https://sakaiproject.atlassian.net/browse/SAK-49276