### PR TITLE
SAK-48875 - Profile: Options for editing “Basic Information” and “Name Pronunciation” are no longer keyboard/screen reader accessible

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/profile2/_profile2.scss
+++ b/library/src/skins/default/src/sass/modules/tool/profile2/_profile2.scss
@@ -45,18 +45,13 @@
 		display: none;
 	}
 
-	/* Reusable class to show the edit-button */
-	.show-edit-button {
+	.editable:hover > .edit-button, .edit-button:focus {
 		@include sakai_secondary_button();
 		margin: 3px 0 0 0;
 		float: right;
 		clear: none;
 		display: block;
 		clip: unset;
-	}
-
-	.editable:hover > .edit-button, .edit-button:focus {
-		@extend .show-edit-button;
 	}
 
 	.edit-image-button {

--- a/library/src/skins/default/src/sass/modules/tool/profile2/_profile2.scss
+++ b/library/src/skins/default/src/sass/modules/tool/profile2/_profile2.scss
@@ -42,10 +42,6 @@
 	}
 
 	.editable > .edit-button {
-		display: none;
-	}
-
-	.editable:hover > .edit-button, .edit-button:focus {
 		@include sakai_secondary_button();
 		margin: 3px 0 0 0;
 		float: right;

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyBusinessDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyBusinessDisplay.html
@@ -25,7 +25,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Business Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactDisplay.html
@@ -28,11 +28,11 @@
 
 	<div class="mainSection editable">
 		<div class="mainSectionHeading">
-            <i class="si si-edit"></i>
 			<span wicket:id="heading">[Contact Information]</span>
 		</div>
 
 		<a href="#" wicket:id="editButton" class="edit-button" role="button">
+			<i class="si si-edit"></i>
 			<span wicket:id="editButtonLabel">edit</span>
 		</a>
 

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
             <i class="si si-edit"></i>
 			<span wicket:id="heading">[Contact Information]</span>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInfoDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInfoDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Basic Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInterestsDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyInterestsDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Personal Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyNamePronunciationDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyNamePronunciationDisplay.html
@@ -6,7 +6,7 @@
 <body>
 <wicket:panel>
 
-    <div class="mainSection editable" tabindex=0>
+    <div class="mainSection editable">
         <div class="mainSectionHeading">
             <span wicket:id="heading">[Name Pronunciation and Pronouns]</span>
         </div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MySocialNetworkingDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MySocialNetworkingDisplay.html
@@ -25,7 +25,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Social Networking Information]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStaffDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStaffDisplay.html
@@ -26,7 +26,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[University Staff]</span>
 		</div>

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStudentDisplay.html
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyStudentDisplay.html
@@ -25,7 +25,7 @@
 <body>
 <wicket:panel>
 
-	<div class="mainSection editable" tabindex=0>
+	<div class="mainSection editable">
 		<div class="mainSectionHeading">
 			<span wicket:id="heading">[Student Information]</span>
 		</div>

--- a/profile2/tool/src/webapp/javascript/profile2.js
+++ b/profile2/tool/src/webapp/javascript/profile2.js
@@ -77,24 +77,4 @@ window.addEventListener("DOMContentLoaded", () => {
       }
     });
   });
-
-  //Keyboard navigation for the edit buttons
-  const editableDivs = document.querySelectorAll('.editable');
-  //All edit buttons in the panel
-  const panelEditButtons = document.querySelectorAll('.main-profile-tabpanel .edit-button');
-
-  editableDivs.forEach(editableDiv => {
-    const editButton = editableDiv.querySelector('.edit-button');
-    //Show buttons when focused on the div
-    editableDiv.addEventListener('focus', () => {
-      //When we get focus hide all buttons except the one in this
-      panelEditButtons.forEach(panelEditButton => { 
-          panelEditButton.style.display = 'none';
-          panelEditButton.setAttribute('tabindex', '-1');
-      });
-      editButton.classList.add('show-edit-button');
-      editButton.setAttribute('tabindex', '0');
-      editButton.style.display = 'block';
-    });
-  });
 });


### PR DESCRIPTION
After reverting previous commit with JS hack I decided to try to just remove the "coolness" hover factor and have the edit buttons static. This seems to work great for accessibility and I personally don't think it causes any issues with the page design.

Also fixed a small error with placement of an icon that I noticed after doing this.

This reverts commit 6bba6f5.

<img src=https://github.com/sakaiproject/sakai/assets/27447/fb323ef8-f283-4311-854c-f05898287b04 width=400px>
