### PR TITLE
S2U-42 SAK-49271 Card game: Fix "null" displayed in info banner

### DIFF
--- a/roster2/tool/src/webapp/js/card-game/card-game.js
+++ b/roster2/tool/src/webapp/js/card-game/card-game.js
@@ -368,7 +368,7 @@ export default class CardGame extends BaseGame {
 
         const { hits, misses } = user;
 
-        const attempts = hits || misses ? hits + misses : null;
+        const attempts = hits || misses ? hits + misses : 0;
 
         const userNotLearned = !isUserLearned(user, this.config);
 


### PR DESCRIPTION
Fix  "null" displayed instead of "0" in  info banner

https://sakaiproject.atlassian.net/browse/SAK-49271