### PR TITLE
SAK-49311 Cannot change / add profile photo

### DIFF
--- a/profile2/api/src/java/org/sakaiproject/profile2/model/ProfileImage.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/model/ProfileImage.java
@@ -49,6 +49,7 @@ public class ProfileImage {
 	private String altText;
 	private String mimeType;
 	private boolean isDefault;
+	private boolean isInitials;
 		
 	/**
 	 * Get access to the binary data from either the uploaded image or the base64 encoded data

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileImageLogicImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileImageLogicImpl.java
@@ -1116,8 +1116,9 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 				image.setUploadedImage(bytes);
 			} else {
 				image.setExternalImageUrl(getUnavailableImageURL());
+				image.setDefault(true);
 			}
-			image.setDefault(true);
+			image.setInitials(true);
 			cache.put(userUuid, image);
 		}
 		return image;

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/CardGameController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/CardGameController.java
@@ -345,6 +345,6 @@ public class CardGameController extends AbstractSakaiApiController {
             profileImage = profileImageLogic.getProfileImage(userId, null, null, ProfileConstants.PROFILE_IMAGE_MAIN, siteId);
         }
 
-        return profileImage.isDefault();
+        return profileImage.isDefault() || profileImage.isInitials();
     }
 }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49311

The isDefault property on the ProfileImage is not handled by the new profile image editor. For the scope of the issue that caused this problem it makes more sense to not use this property. This might still be another issue depending on sakai.properties, I add a comment to the Jira regarding that.