### PR TITLE
S2U-21 Tests & Quizzes: Fixes seb.enabled=site

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -805,7 +805,7 @@ public class DeliveryBean implements Serializable {
 	  setSecureDeliveryHTMLFragment( "" );
 	  setBlockDelivery( false );
 	  SecureDeliveryServiceAPI secureDelivery = SamigoApiFactory.getInstance().getSecureDeliveryServiceAPI();
-	  if ( secureDelivery.isSecureDeliveryAvaliable() ) {
+	  if (secureDelivery.isSecureDeliveryAvaliable(Long.valueOf(assessmentId))) {
 		  String moduleId = publishedAssessment.getAssessmentMetaDataByLabel( SecureDeliveryServiceAPI.MODULE_KEY );
 		  if (moduleExists(moduleId)) {
 			  
@@ -1553,8 +1553,9 @@ public class DeliveryBean implements Serializable {
   }
 
   public boolean isSebActive() {
+    log.info("assessmentId {}", assessmentId);
     SecureDeliveryServiceAPI secureDelivery = SamigoApiFactory.getInstance().getSecureDeliveryServiceAPI();
-    return secureDelivery.isSecureDeliveryAvaliable()
+    return secureDelivery.isSecureDeliveryAvaliable(Long.valueOf(assessmentId))
         && StringUtils.equals(SecureDeliverySeb.MODULE_NAME, publishedAssessment.getAssessmentMetaDataByLabel(SecureDeliveryServiceAPI.MODULE_KEY));
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -293,7 +293,7 @@ public class DeliveryActionListener
               delivery.setOutcome("takeAssessment");
               delivery.setSecureDeliveryHTMLFragment( "" );
               delivery.setBlockDelivery( false );
-              if ( secureDelivery.isSecureDeliveryAvaliable() ) {
+              if (secureDelivery.isSecureDeliveryAvaliable(Long.valueOf(id))) {
 
             	  String moduleId = publishedAssessment.getAssessmentMetaDataByLabel( SecureDeliveryServiceAPI.MODULE_KEY );
             	  if ( moduleId != null && ! SecureDeliveryServiceAPI.NONE_ID.equals( moduleId ) ) {
@@ -359,7 +359,7 @@ public class DeliveryActionListener
             	  }
 
                   // #3. secure delivery START phase
-                  if ( secureDelivery.isSecureDeliveryAvaliable() ) {
+                  if (secureDelivery.isSecureDeliveryAvaliable(Long.valueOf(id))) {
                       String moduleId = publishedAssessment.getAssessmentMetaDataByLabel( SecureDeliveryServiceAPI.MODULE_KEY );
                       if ( moduleId != null && ! SecureDeliveryServiceAPI.NONE_ID.equals( moduleId ) ) {
                           HttpServletRequest request = (HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest();

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/LinearAccessDeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/LinearAccessDeliveryActionListener.java
@@ -117,7 +117,7 @@ public class LinearAccessDeliveryActionListener extends DeliveryActionListener
           
           // #3. secure delivery START phase
           SecureDeliveryServiceAPI secureDelivery = SamigoApiFactory.getInstance().getSecureDeliveryServiceAPI();
-          if ( secureDelivery.isSecureDeliveryAvaliable() ) {
+          if (secureDelivery.isSecureDeliveryAvaliable(Long.valueOf(id))) {
               String moduleId = publishedAssessment.getAssessmentMetaDataByLabel( SecureDeliveryServiceAPI.MODULE_KEY );
               if ( moduleId != null && ! SecureDeliveryServiceAPI.NONE_ID.equals( moduleId ) ) {
                   HttpServletRequest request = (HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest();

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/SecureDeliverySeb.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/SecureDeliverySeb.java
@@ -76,6 +76,7 @@ public class SecureDeliverySeb implements SecureDeliveryModuleIfc {
     private static final String SAMIGO_PATH = "/samigo-app";
     private static final String LOGIN_SERVLET_PATH = SAMIGO_PATH + "/servlet/Login";
     private static final String SEB_ALWAYS_ENABLED = "always";
+    private static final String SEB_SITE_ENABLED = "site";
     private static final String SEB_ALWAYS_ENABLED_PROPERTY = "seb.enabled";
     private static final String SEB_SCRIPT_PATH = "/samigo-app/js/deliverySafeExamBrowser.js";
     // The property added to a site
@@ -112,26 +113,16 @@ public class SecureDeliverySeb implements SecureDeliveryModuleIfc {
     }
 
     public boolean isEnabled() {
-        if (!StringUtils.equals(sebEnabled, SEB_ALWAYS_ENABLED)) {
-            // This will come back null if from an assessment URL
-            String siteId = AgentFacade.getCurrentSiteId();
-            return isSiteSebEnabled(siteId);
-        }
-
-        return true;
+        String siteId = AgentFacade.getCurrentSiteId();
+        return isEnabled(siteId);
     }
 
     public boolean isEnabled(Long assessmentId) {
-        if (!StringUtils.equals(sebEnabled, SEB_ALWAYS_ENABLED)) {
-
-            PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
-            publishedAssessmentService.getPublishedAssessmentStatus(assessmentId);
-            PublishedAssessmentFacade publishedAssessment = publishedAssessmentService.getPublishedAssessment(assessmentId.toString());
-            String siteId = publishedAssessment.getOwnerSiteId();
-            return isSiteSebEnabled(siteId);
-        }
-
-        return true;
+        PublishedAssessmentService publishedAssessmentService = new PublishedAssessmentService();
+        publishedAssessmentService.getPublishedAssessmentStatus(assessmentId);
+        PublishedAssessmentFacade publishedAssessment = publishedAssessmentService.getPublishedAssessment(assessmentId.toString());
+        String siteId = publishedAssessment.getOwnerSiteId();
+        return isEnabled(siteId);
     }
 
     public String getModuleName(Locale locale) {
@@ -412,6 +403,16 @@ public class SecureDeliverySeb implements SecureDeliveryModuleIfc {
 
     private String hashString(String string) {
         return HashingUtil.hashString(string);
+    }
+
+    private boolean isEnabled(String siteId) {
+        switch(sebEnabled) {
+            case SEB_ALWAYS_ENABLED:
+                return true;
+            default:
+            case SEB_SITE_ENABLED:
+                return isSiteSebEnabled(siteId);
+        }
     }
 
     private boolean isSiteSebEnabled(final String siteId) {


### PR DESCRIPTION
The main change here is passing the published assessment id to the `secureDelivery.isSecureDeliveryAvaliable` call. This will give some context so the seb module can figure out the siteId even when the assessment is not taken through the portal. The param is added to the places that are related to the delivery.

https://sakaiproject.atlassian.net/browse/S2U-21