### PR TITLE
SAK-49162 Kernel convert 4-byte emojis into HTML entities before saving

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build with Maven
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -Dmaven.wagon.http.retryHandler.count=2 -Dmaven.wagon.http.pool=true
-        run: mvn --show-version --batch-mode -PskipBrokenTests test 
+        run: mvn --show-version --batch-mode -PskipBrokenTests test license:check    

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build with Maven
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -Dmaven.wagon.http.retryHandler.count=2 -Dmaven.wagon.http.pool=true
-        run: mvn --show-version --batch-mode -PskipBrokenTests test license:check    
+        run: mvn --show-version --batch-mode -PskipBrokenTests test 

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -9553,11 +9553,11 @@ public class AssignmentAction extends PagedResourceActionII {
                                   boolean checkIsEstimate,
                                   boolean checkEstimateRequired,
                                   String timeEstimate) {
-        a.setTitle(title);
+        a.setTitle(processFormattedTextFromBrowser(state, title, true));
         a.setContext((String) state.getAttribute(STATE_CONTEXT_STRING));
         a.setSection(section);
         a.setIsGroup(isGroupSubmit);
-        a.setInstructions(description);
+        a.setInstructions(processFormattedTextFromBrowser(state, description, true));
         a.setHonorPledge(checkAddHonorPledge);
         a.setHideDueDate(hideDueDate);
         a.setTypeOfSubmission(submissionType);

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1087,14 +1087,6 @@
 # Default: false (still it could be logged if content.cleaner.errors.handling=logged above) 
 #content.cleaner.errors.logged=true
 
-# KNL-1431 
-# MySQL by default can only store mb3 UTF-8 characters. In future versions we'll have a conversion and be able to store utf8mb4, however this will
-# also require increasing the size of the indexes.
-# It's recommended that if you're running MySQL that you leave this true for now or else you will encounter errors
-# Oracle users can set this to true as Oracle UTF-8 characters already support 4 byte values
-# Default: true (will limit the characters printed as UTF8)
-#content.cleaner.filter.utf8=false
-
 # KNL-1431
 # If you'd like to replace them with something (like for instance a ?) add this here
 # Default: Nothing (just remove)

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>tika-parsers</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>emoji-java</artifactId>
+            <version>5.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.zwobble.mammoth</groupId>
             <artifactId>mammoth</artifactId>
             <version>1.4.2</version>

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -46,6 +46,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import com.vdurmont.emoji.EmojiManager;
+import com.vdurmont.emoji.EmojiParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.validator.routines.UrlValidator;
@@ -262,6 +264,11 @@ public class FormattedTextImpl implements FormattedText
     */
     public String removeSurrogates(String str) {
         StringBuilder sb = new StringBuilder();
+
+        if (EmojiManager.containsEmoji(str)) {
+            str = EmojiParser.parseToHtmlDecimal(str);
+        }
+
         for (int i = 0; i < str.length(); i++) {
             char c = str.charAt(i);
             if (!Character.isSurrogate(c)) {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -265,7 +265,7 @@ public class FormattedTextImpl implements FormattedText
     public String removeSurrogates(String str) {
         StringBuilder sb = new StringBuilder();
 
-        if (EmojiManager.containsEmoji(str)) {
+        if (restrictReplacement == null && EmojiManager.containsEmoji(str)) {
             str = EmojiParser.parseToHtmlDecimal(str);
         }
 
@@ -446,9 +446,6 @@ public class FormattedTextImpl implements FormattedText
         }
 
         try {
-            if (cleanUTF8) {
-                val = removeSurrogates(val);
-            }
             if (replaceWhitespaceTags) {
                 // normalize all variants of the "<br>" HTML tag to be "<br />\n"
                 val = M_patternTagBr.matcher(val).replaceAll("<br />");
@@ -509,6 +506,11 @@ public class FormattedTextImpl implements FormattedText
             // deal with hardcoded empty space character from Firefox 1.5
             if (val.equalsIgnoreCase("&nbsp;")) {
                 val = "";
+            }
+
+            // Replace 4-byte emojis to deal with legacy MySQL databases using utf8mb3
+            if (cleanUTF8) {
+                val = removeSurrogates(val);
             }
 
         } catch (Exception e) {

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/util-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/util-components.xml
@@ -67,6 +67,7 @@
             init-method="init">
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
         <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="sqlService" ref="org.sakaiproject.db.api.SqlService"/>
     </bean>
 
      <bean id="org.sakaiproject.util.api.LinkMigrationHelper"

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -1258,4 +1258,11 @@ public class FormattedTextTest {
     	Assert.assertFalse(result.contains("<html>"));
     }
 
+    @Test
+    public void testEmojiEscaping() {
+        String html = "An 😀 awesome 😃 string with a few 😉 emojis!";
+        String ret = formattedText.removeSurrogates(html);
+        Assert.assertEquals(ret, "An &#128512; awesome &#128515; string with a few &#128521; emojis!");
+    }
+
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -31,6 +31,7 @@ import org.sakaiproject.cluster.api.ClusterService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.impl.BasicConfigurationService;
+import org.sakaiproject.db.api.SqlService;
 import org.sakaiproject.id.api.IdManager;
 import org.sakaiproject.id.impl.UuidV4IdComponent;
 import org.sakaiproject.thread_local.api.ThreadLocalManager;
@@ -41,6 +42,8 @@ import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.tool.impl.SessionComponent;
 import org.sakaiproject.util.BasicConfigItem;
 import org.sakaiproject.util.api.FormattedText.Level;
+
+import static org.mockito.Mockito.mock;
 
 public class FormattedTextTest {
 
@@ -104,6 +107,7 @@ public class FormattedTextTest {
         formattedText = new FormattedTextImpl();
         formattedText.setServerConfigurationService(serverConfigurationService);
         formattedText.setSessionManager(sessionManager);
+        formattedText.setSqlService(mock(SqlService.class));
         formattedText.setDefaultAddBlankTargetToLinks(BLANK_DEFAULT);
 
         formattedText.init();
@@ -985,8 +989,8 @@ public class FormattedTextTest {
         StringBuilder errorMessages = new StringBuilder();
         String etext = new StringBuilder().appendCodePoint(0x1F600).append("smiley face").appendCodePoint(0x1F600).toString();
         //Retrict to utf8 only
-        serverConfigurationService.registerConfigItem(BasicConfigItem.makeConfigItem("content.cleaner.filter.utf8", "true", "FormattedTextTest"));
         formattedText.init();
+        formattedText.setCleanUTF8(true);
         
         Assert.assertEquals("&#128512;smiley face&#128512;",formattedText.processFormattedText(etext, errorMessages));
 
@@ -996,8 +1000,8 @@ public class FormattedTextTest {
         Assert.assertEquals("??smiley face??",formattedText.processFormattedText(etext, errorMessages));
 
         //Don't restrict to UTF8
-        serverConfigurationService.registerConfigItem(BasicConfigItem.makeConfigItem("content.cleaner.filter.utf8", "false", "FormattedTextTest"));
         formattedText.init();
+        formattedText.setCleanUTF8(false);
         Assert.assertEquals(etext,formattedText.processFormattedText(etext, errorMessages));
     }
 

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -988,7 +988,7 @@ public class FormattedTextTest {
         serverConfigurationService.registerConfigItem(BasicConfigItem.makeConfigItem("content.cleaner.filter.utf8", "true", "FormattedTextTest"));
         formattedText.init();
         
-        Assert.assertEquals("smiley face",formattedText.processFormattedText(etext, errorMessages));
+        Assert.assertEquals("&#128512;smiley face&#128512;",formattedText.processFormattedText(etext, errorMessages));
 
         //Test the replacement of ?
         serverConfigurationService.registerConfigItem(BasicConfigItem.makeConfigItem("content.cleaner.filter.utf8.replacement", "?", "FormattedTextTest"));
@@ -1259,10 +1259,14 @@ public class FormattedTextTest {
     }
 
     @Test
-    public void testEmojiEscaping() {
+    public void testFourByteEmojiEscaping() {
         String html = "An 😀 awesome 😃 string with a few 😉 emojis!";
         String ret = formattedText.removeSurrogates(html);
         Assert.assertEquals(ret, "An &#128512; awesome &#128515; string with a few &#128521; emojis!");
+
+        html = "This is a bike \uD83D\uDEB4 and a bathtub 🛁 ";
+        ret = formattedText.removeSurrogates(html);
+        Assert.assertEquals(ret, "This is a bike &#128692; and a bathtub &#128705; ");
     }
 
 }


### PR DESCRIPTION
Legacy Sakai databases use utf8mb3 meaning that 4-byte emojis cannot be stored as a native character. New Sakai orgs or orgs that can do a complete conversion should use utf8mb4 instead.

This code uses an emoji library to convert emojis into the HTML entity. 

We should probably consider changing the default in Sakai or doing automatic detection of the database.