### PR TITLE
S2U-37 5.2.1.2 Announcements: Ability to highlight announcements - Master

### DIFF
--- a/announcement/announcement-api/api/src/bundle/announcement.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement.properties
@@ -196,6 +196,9 @@ revise.required.star = Required items marked with a <span class="reqStarInline">
 revise.update = Update the form, then choose the appropriate button at the bottom.
 revise.announce = Announcement
 revise.announcement.body = Body
+revise.highlight.title = Highlight
+revise.highlight = <strong>Highlight this announcement.</strong> It will be more prominent in the announcement list.
+revise.star.title = This announcement has been highlighted
 ### (moot) revise.none = None
 
 revise.subject = Announcement title

--- a/announcement/announcement-api/api/src/bundle/announcement_ca.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement_ca.properties
@@ -196,6 +196,9 @@ revise.required.star=Els elements obligatoris estan marcats amb un <span class\=
 revise.update=Actualitzeu el formulari i trieu el bot\u00f3 corresponent al final.
 revise.announce=Av\u00eds
 revise.announcement.body=Cos
+revise.highlight.title=Destacat
+revise.highlight = <strong>Destacar aquest anunci.</strong> Ser\u00e0 m\u00e9s prominent a la llista d\u0027anuncis.
+revise.star.title = Aquest anunci est\u00e1 destacat
 ### (moot) revise.none = None
 
 revise.subject=T\u00edtol de l\u2019av\u00eds

--- a/announcement/announcement-api/api/src/bundle/announcement_es.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement_es.properties
@@ -196,6 +196,9 @@ revise.required.star=Los elementos requeridos est\u00e1n marcados con un <span c
 revise.update=Actualice el formulario y pulse el bot\u00f3n adecuado.
 revise.announce=Anuncio
 revise.announcement.body=Cuerpo
+revise.highlight.title=Destacado
+revise.highlight = <strong>Destacar este anuncio.</strong> Ser\u00e1 m\u00e1s prominente en la lista de anuncios.
+revise.star.title = Este anuncio est\u00e1 destacado
 ### (moot) revise.none = None
 
 revise.subject=T\u00edtulo del anuncio

--- a/announcement/announcement-api/api/src/bundle/announcement_eu.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement_eu.properties
@@ -196,6 +196,9 @@ revise.required.star=Ezinbesteko itemak izartxo batekin markatuak daude\: <span 
 revise.update=Eguneratu inprimakia eta sakatu botoi egokia.
 revise.announce=Oharra
 revise.announcement.body=Gorputza
+revise.highlight.title=Nabarmendu
+revise.highlight = <strong>Nabarmendu iragarki hau.</strong> Jarri iragarkien zerrendan gehiago ikusteko moduan.
+revise.star.title = Iragarki hau nabarmendu da
 ### (moot) revise.none = None
 
 revise.subject=Oharraren izenburua

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -334,6 +334,7 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 		da.setCreatedOn(new Date(a.getHeader().getDate().getTime()));
 		da.setSiteId(siteId);
 		da.setSiteTitle(siteTitle);
+		da.setHighlight(a.getProperties().getProperty("highlight"));
 		
 		//get attachments
 		List<DecoratedAttachment> attachments = new ArrayList<DecoratedAttachment>();
@@ -736,6 +737,7 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 		@Getter @Setter private List<DecoratedAttachment> attachments;
 		@Getter @Setter private String siteId;
 		@Getter @Setter private String announcementId;
+		@Getter @Setter private String highlight;
 		@Getter @Setter private String siteTitle;
 		@Getter @Setter private String channel;
 

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1969,6 +1969,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		context.put("newAnn", (state.getIsNewAnnouncement()) ? "true" : "else");
 
 		context.put("announceToGroups", state.getTempAnnounceToGroups());
+		context.put("highlight", state.getTempHighlight());
 
 		context.put("publicDisable", sstate.getAttribute(PUBLIC_DISPLAY_DISABLE_BOOLEAN));
 
@@ -2365,6 +2366,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		state.setTempBody("");
 		state.setTempSubject("");
 		state.setStatus(ADD_STATUS);
+		state.setTempHighlight(false);
 
 		sstate.setAttribute(AnnouncementAction.SSTATE_PUBLICVIEW_VALUE, null);
 		sstate.setAttribute(AnnouncementAction.SSTATE_NOTI_VALUE, null);
@@ -2436,12 +2438,14 @@ public class AnnouncementAction extends PagedResourceActionII
 		// *** make sure the subject and body won't be empty
 		// read in the subject input from announcements-new.vm
 		final String subject = params.getString("subject");
+		boolean highlight = params.getBoolean("highlight"); 
 		// read in the body input
 		String body = params.getString("body");
 		body = processFormattedTextFromBrowser(sstate, body);
 
 		state.setTempSubject(subject);
 		state.setTempBody(body);
+		state.setTempHighlight(highlight);
 
 		if (checkForm)
 		{
@@ -2600,6 +2604,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		final Time tempReleaseDate = state.getTempReleaseDate();
 		final Time tempRetractDate = state.getTempRetractDate();
 		final Boolean tempHidden = state.getTempHidden();
+		final boolean tempHighlight = state.getTempHighlight();
 		
 		// announce to public?
 		final String announceTo = state.getTempAnnounceTo();
@@ -2672,6 +2677,9 @@ public class AnnouncementAction extends PagedResourceActionII
 				// values stored here if saving from Add/Revise page
 				ParameterParser params = rundata.getParameters();
 				
+				// Adding the highlight to the properties
+				msg.getPropertiesEdit().addProperty("highlight", String.valueOf(tempHighlight));
+
 				// get release/retract dates
 				final String specify = params.getString(HIDDEN);
 				final boolean use_start_date = params.getBoolean("use_start_date");

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementActionState.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementActionState.java
@@ -607,6 +607,9 @@ public class AnnouncementActionState extends ControllerState implements SessionB
 	// temporary storage for new announcement body
 	private String m_tempBody;
 
+	// temporary storage for announcement highlight
+	private boolean m_tempHighlight = false;
+
 	// temporary storage for new announcement release date
 	private Time m_releaseDate = null;
 	
@@ -662,6 +665,15 @@ public class AnnouncementActionState extends ControllerState implements SessionB
 		return m_tempBody;
 
 	} // getTempBody()
+
+	/**
+	 * Get
+	 */
+	public boolean getTempHighlight()
+	{
+		return m_tempHighlight;
+
+	} // getTempHighlight()
 
 	/**
 	 * Get
@@ -730,6 +742,17 @@ public class AnnouncementActionState extends ControllerState implements SessionB
 		}
 
 	} // setTempBody()
+
+	/**
+	 * Set
+	 */
+	public void setTempHighlight(boolean tempHighlight)
+	{
+		if (tempHighlight != m_tempHighlight)
+		{
+			m_tempHighlight = tempHighlight;
+		}
+	} // setTempHighlight()
 
 	public void setTempReleaseDate(Time tempDate) 
 	{

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
@@ -172,6 +172,24 @@ function resizeFrame(){
 					#chef_setupformattedtextarea("body")
 				</div>
 			</div>
+			<div class="row">
+				<div class="col-md-12">
+					<fieldset>
+						<legend>
+							<h4>$tlang.getString("revise.highlight.title")</h4>
+						</legend>
+						<div class="checkbox">
+							<label for="annc-highl-key">
+								<label class="annc-highl-label" for="highlight" name="highlight-key">
+									#set($isHightlighted = $message.getProperties().getProperty("highlight") == "true" || $highlight)
+									<input type="checkbox" id="highlight" #if ($isHightlighted) checked="" #end name="highlight" value="true">
+									$tlang.getString("revise.highlight")
+								</label>
+							</label>
+						</div>
+					</fieldset>
+				</div>
+			</div>
 
 			<div class="row">
 				<div class="col-md-12">

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -250,11 +250,13 @@
 						#foreach ($ann_item in $showMessagesList)
 							#set ($rowCount =$rowCount + 1)
 							#set($ann_item_props=$ann_item.getProperties())
+							#set($isHightlighted = (true == $ann_item_props.getProperty("highlight")) )
 
 							<tr #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft) >
-
-								<th headers="subject" scope="row">
-									<strong>
+									<td headers="subject" #if ($isHightlighted=="true") class="font-bold-highlighted" #end scope="row">
+										#if ($isHightlighted == "true")
+											<i aria-hidden="true" title="$tlang.getString('revise.star.title')" class="fa fa-star"></i>
+										#end
 										## show the paperclip if existing
 										#set ($size = 0)
 										#if (!$ann_item.Header.Attachments.isEmpty())
@@ -279,9 +281,8 @@
 											<a href="#toolLinkParam("AnnouncementAction" "doShowmetadata" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.viewann.subject', $formattedText.escapeHtml($ann_item.Header.subject))">
 											$formattedText.escapeHtml($ann_item.Header.subject) <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a>
 										#end
-									</strong>	
-								</th>
-								<td headers="author" class="d-none d-sm-table-cell">
+									</td>
+								<td headers="author" class="hidden-xs">
 									$formattedText.escapeHtml($ann_item.AuthorDisplayName)
 								</td>
 								#if ($toolId.equals("sakai.announcements"))
@@ -368,12 +369,17 @@
 					#set ($rowCount=0)
 					<ul class="synopticList">
 					#foreach ($ann_item in $showMessagesList)
-					<li>
+						#set ($isHightlighted = $ann_item.getProperties().getProperty("highlight"))
+						<td headers="subject" scope="row">
+						<li>
 						#set ($rowCount =$rowCount + 1)
 							#if ($ann_item.Header.draft)
 							#else
-							<div class="textPanelHeader">
-								<a href="#toolLinkParam("AnnouncementAction" "doShowmetadata" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.viewann.subject', $formattedText.escapeHtml($ann_item.Header.subject))" class="font-weight-bold">
+							<div class="textPanelHeader#if($isHightlighted=='true') font-bold-highlighted#end" >
+								#if ($isHightlighted == "true")
+									<i aria-hidden="true" title="$tlang.getString('revise.star.title')" class="fa fa-star"></i>
+								#end
+								<a href="#toolLinkParam("AnnouncementAction" "doShowmetadata" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.viewann.subject', $formattedText.escapeHtml($ann_item.Header.subject))" class="">
 								$formattedText.escapeHtml($ann_item.Header.subject)</a>
 								#set ($size = 0)
 								#if (!$ann_item.Header.Attachments.isEmpty())
@@ -540,12 +546,13 @@
 							 #foreach ($ann_item in $showMessagesList)
 								#set ($rowCount =$rowCount + 1)
 								#set($ann_item_props=$ann_item.getProperties())
-
+								#set($isHightlighted = (true == $ann_item_props.getProperty("highlight")) )
+								
 								<tr #rowTRconstruct($ann_item_props $displayOptions $ann_item.Header.draft) >
-
-									<th headers="subject" scope="row">
-										<strong>
-
+									<td headers="subject" #if ($isHightlighted=="true") class="font-bold-highlighted" #end scope="row">
+										#if ($isHightlighted == "true")
+											<i aria-hidden="true" title="$tlang.getString('revise.star.title')" class="fa fa-star"></i>
+										#end
 										## show the paperclip if existing
 										#set ($size = 0)
 										#if (!$ann_item.Header.Attachments.isEmpty())
@@ -570,11 +577,9 @@
 											<a href="#toolLinkParam("AnnouncementAction" "doShowmetadata" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.viewann.subject', $formattedText.escapeHtml($ann_item.Header.subject))">
 											$formattedText.escapeHtml($ann_item.Header.subject) <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a>
 										#end
-										</strong>
 										#if ($channel.allowEditMessage($ann_item.Id))
 											<div class="itemAction"><a href="#toolLinkParam("AnnouncementAction" "doReviseannouncement" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.editann.subject', $formattedText.escapeHtml($ann_item.Header.subject))"><i class="fa fa-lg fa-pencil-square-o"></i> $tlang.getString("gen.revise") <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a></div>
 										#end
-                                                                                                                                                                                                     
 									</td>
 									<td headers="author" class="d-none d-sm-table-cell">
 										$formattedText.escapeHtml($ann_item.Header.From.DisplayName)

--- a/lessonbuilder/tool/src/webapp/js/announcements.js
+++ b/lessonbuilder/tool/src/webapp/js/announcements.js
@@ -40,7 +40,17 @@ function showAnnouncements(url, tool_href, number, announcementsDiv){
 						var href = tool_href + this["announcementId"]+"&sakai_action=doShowmetadata&persist_to_iframe=itemReference";
 						var entityTitle = this["entityTitle"].replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
 						var createdByDisplayName = this["createdByDisplayName"].replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-						text_for_announcements += '<div><a href="'+href+'" target="_top">'+ entityTitle +'</a> '+msg("simplepage.created-by")+' '+ createdByDisplayName +'</div>';
+
+						// Highlighted announcements.
+						const isHighlighted = "true" === this["highlight"];
+						let highlightClass = '';
+						text_for_announcements += '<div>';
+						if (isHighlighted) {
+  						    text_for_announcements += '<i aria-hidden="true" class="fa fa-star"></i>';
+  						    highlightClass = 'font-bold-highlighted';
+  						}
+						const byString = msg("simplepage.created-by");
+  						text_for_announcements += `<a href="${href}" class="${highlightClass}" target="_top">${entityTitle}</a> ${byString} ${createdByDisplayName}</div>`;
 						text_for_announcements += '<div class="itemDate">'+date_time+'</div>';
 						text_for_announcements += '</li>';
 					});

--- a/library/src/skins/default/src/sass/modules/tool/announcements/_announcements.scss
+++ b/library/src/skins/default/src/sass/modules/tool/announcements/_announcements.scss
@@ -40,4 +40,8 @@
 			@include sakai_secondary_button();
 		}
 	}
+	.font-bold-highlighted{
+		font-weight: bold;
+		font-size: 1.15em;
+	}
 }

--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -412,10 +412,11 @@
 		border: 0;
 		background: transparent;
 	}
-  .font-bold-highlighted{
-		font-weight: bold;
-		font-size: 1.15em;
-	}
+
+  .font-bold-highlighted {
+    font-weight: bold;
+    font-size: 1.15em;
+  }
 
   #content label,.ui-dialog label,body[onload] label {
     display: inline;

--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -412,6 +412,10 @@
 		border: 0;
 		background: transparent;
 	}
+  .font-bold-highlighted{
+		font-weight: bold;
+		font-size: 1.15em;
+	}
 
   #content label,.ui-dialog label,body[onload] label {
     display: inline;

--- a/library/src/skins/default/src/sass/modules/tool/synoptic/_synoptic.scss
+++ b/library/src/skins/default/src/sass/modules/tool/synoptic/_synoptic.scss
@@ -11,6 +11,10 @@ body > .portletBody {
 	iframe{
 		z-index: 0;
 	}
+	.font-bold-highlighted{
+		font-weight: bold;
+		font-size: 1.15em;
+	}
 }
 .#{$namespace}sakai-iframe-site{
 	.siteDescription{


### PR DESCRIPTION
It looks like that:
When creating an announcement:
![imagen](https://github.com/sakaiproject/sakai/assets/94039846/75611a9b-d199-466a-8f58-2629539f7b4d)
In announcement page:
![imagen](https://github.com/sakaiproject/sakai/assets/94039846/788d6f82-fd11-475c-b585-c1cd473b5163)
In the homepage:
![imagen](https://github.com/sakaiproject/sakai/assets/94039846/7acc836a-a941-48f9-9a81-18ac395b3d2d)
In content page (lessons) > when embedding the announcements:
![imagen](https://github.com/sakaiproject/sakai/assets/94039846/8a04ef01-dca6-4f82-b65d-0ac01c124b9d)
