### PR TITLE
SAK-49401 SakaiGrader check e.key is undefined before matching

### DIFF
--- a/webcomponents/tool/src/main/frontend/js/grader/sakai-grader.js
+++ b/webcomponents/tool/src/main/frontend/js/grader/sakai-grader.js
@@ -605,7 +605,7 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
 
     if (e.key === "Backspace" || e.key === "ArrowLeft" || e.key === "ArrowRight") {
       return true;
-    } else if (!e.key.match(rgxp)) {
+    } else if (e.key && !e.key.match(rgxp)) {
       e.preventDefault();
       return false;
     }


### PR DESCRIPTION
…match.  This usecase comes from the browser suggesting a value that you choose (with the mouse, I suppose), therefore not having a key event.