### PR TITLE
SAK-48161 Account: Cannot modify details without resetting password

### DIFF
--- a/admin-tools/src/webapp/js/userEditValidation.js
+++ b/admin-tools/src/webapp/js/userEditValidation.js
@@ -82,7 +82,7 @@ USER.verifyPasswordsMatch = function () {
   const pass = USER.get("user_pw")?.value;
   USER.passwordsMatch = false;
 
-  if (pass) {
+  if (pass !== null) {
     const verPass = USER.get("user_pw0")?.value;
     USER.passwordsMatch = pass === verPass;
 
@@ -128,7 +128,7 @@ USER.validateCurrentPassword = function () {
 
   const pwcur = USER.get("user_pwcur")?.value;
   USER.currentPassValid = true;
-  if (pwcur) {
+  if (pwcur !== null) {
     USER.currentPassValid = pwcur.length > 0;
   }
 


### PR DESCRIPTION
I've restored the conditional logic from an earlier version of Sakai where this bug did not exist.