### PR TITLE
SAK-47385 Lessons: Links to T&Q not visible in imported site unless instructor visits the page

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -5574,7 +5574,8 @@ public class SimplePageBean {
 				return false;
 			    break;
 			case SimplePageItem.ASSESSMENT:
-			    if (quizEntity.notPublished(item.getSakaiId()))
+				entity = quizEntity.getEntity(item.getSakaiId(), this);
+				if (entity == null || entity.notPublished())
 				return false;
 			    break;
 			case SimplePageItem.FORUM:


### PR DESCRIPTION
Jira  [SAK-47385](https://sakaiproject.atlassian.net/browse/SAK-47385)

This affects published exams that have been imported from another site, and were present on a lessons page that has also been imported. They won't show for students until the instructor views the lessons page.

To fix it:
On the isItemVisible method
Before checking if the assessment is published or not, [getEntity(...)](https://github.com/sakaiproject/sakai/blob/defdc46fdd6597978006ddf446b0bece3a1a2c4a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java#L293) will update the assessment id from "sam_core/x" to "sam_pub/x" if it is present on SAM_PUBLISHEDASSESSMENT_T table (published on samigo).


[SAK-47385]: https://sakaiproject.atlassian.net/browse/SAK-47385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ