### PR TITLE
SAK-49446 - Changing Passwords in Admin is Broken

### DIFF
--- a/admin-tools/src/webapp/js/userEditValidation.js
+++ b/admin-tools/src/webapp/js/userEditValidation.js
@@ -128,7 +128,7 @@ USER.validateCurrentPassword = function () {
 
   const pwcur = USER.get("user_pwcur")?.value;
   USER.currentPassValid = true;
-  if (pwcur !== null) {
+  if (pwcur != null) {
     USER.currentPassValid = pwcur.length > 0;
   }
 


### PR DESCRIPTION
This somewhat awkward conditional is necessary for both [SAK-49446](https://sakaiproject.atlassian.net/browse/SAK-49446) and [SAK-48161](https://sakaiproject.atlassian.net/browse/SAK-48161) to pass. The use of a conditional like "(pwcur)" -- i.e., without comparing it to null-- makes SAK-48161 fail.

[SAK-49446]: https://sakaiproject.atlassian.net/browse/SAK-49446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAK-48161]: https://sakaiproject.atlassian.net/browse/SAK-48161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ