### PR TITLE
SAK-49486 Plus improve launch logic and use executor pattern for NRPS retrieval

### DIFF
--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/UserFinderOrCreatorImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/UserFinderOrCreatorImpl.java
@@ -100,7 +100,7 @@ public class UserFinderOrCreatorImpl implements UserFinderOrCreator {
 			Collection<User> findUsersByEmail = userDirectoryService.findUsersByEmail((String) email);
 			if (findUsersByEmail.isEmpty()) {
 				eid = email;
-				log.warn("creating new user with eid based on email={}", eid);
+				log.debug("Using email as eid to create new user eid={}", eid);
 			} else {
 				if (findUsersByEmail.size() > 1) {
 					log.warn("multiple user id's exist for emailaddress= {}", email);
@@ -118,8 +118,8 @@ public class UserFinderOrCreatorImpl implements UserFinderOrCreator {
 
 		try {
 			user = userDirectoryService.getUserByEid(eid);
-		} catch (Exception e) {
-			log.warn("Could not find user: {}: {}", eid, e.toString());
+		} catch (UserNotDefinedException e) {
+			log.debug("Will need to create user: {}", eid);
 			user = null;
 		}
 

--- a/plus/api/src/main/java/org/sakaiproject/plus/api/PlusService.java
+++ b/plus/api/src/main/java/org/sakaiproject/plus/api/PlusService.java
@@ -158,8 +158,12 @@ public interface PlusService {
 	/*
 	 * Retrieve Context Memberships from calling LMS and update the site
 	 */
-	void syncSiteMemberships(String contextGuid, Site site)
-			throws LTIException;
+	void requestSyncSiteMemberships(Context context);
+
+	/*
+	 * Request site memberships if enough time has passed
+	 */
+	void requestSyncSiteMembershipsCheck(Context context, boolean isInstructor);
 
 	/*
 	 * Create a lineItem for a gradebook Column

--- a/plus/api/src/main/java/org/sakaiproject/plus/api/repository/MembershipRepository.java
+++ b/plus/api/src/main/java/org/sakaiproject/plus/api/repository/MembershipRepository.java
@@ -31,4 +31,6 @@ public interface MembershipRepository extends SpringCrudRepository<Membership, L
 
 	Membership upsert(Membership entity);
 
+        Long countMembersInContext(Context context);
+
 }

--- a/plus/impl/src/main/java/org/sakaiproject/plus/impl/PlusServiceImpl.java
+++ b/plus/impl/src/main/java/org/sakaiproject/plus/impl/PlusServiceImpl.java
@@ -600,7 +600,7 @@ public class PlusServiceImpl implements PlusService {
 				} finally {
 					time = (System.currentTimeMillis() - start);
 					refreshQueue.remove(contextGuid);
-					if (log.isDebugEnabled()) log.debug("refreshContextMembershipsTask.run() refresh of context: " + contextGuid + " took " + time/1e3 + " seconds");
+					log.debug("refreshContextMembershipsTask.run() refresh of context: {} took {} seconds", contextGuid, time/1e3);
 				}
 
 				timeRefreshed += time;

--- a/plus/impl/src/main/java/org/sakaiproject/plus/impl/PlusServiceImpl.java
+++ b/plus/impl/src/main/java/org/sakaiproject/plus/impl/PlusServiceImpl.java
@@ -600,7 +600,7 @@ public class PlusServiceImpl implements PlusService {
 				} finally {
 					time = (System.currentTimeMillis() - start);
 					refreshQueue.remove(contextGuid);
-					log.debug("refreshContextMembershipsTask.run() refresh of context: {} took {} seconds", contextGuid, time/1e3);
+					log.debug("Refresh of context: {} took {} seconds", contextGuid, time/1e3);
 				}
 
 				timeRefreshed += time;
@@ -610,8 +610,8 @@ public class PlusServiceImpl implements PlusService {
 				}
 
 			}
-			log.info("refreshContextMembershipsTask.run() refreshed " + numberRefreshed + " contexts in " + timeRefreshed/1e3 +
-				" seconds, longest contexts was " + longestName + " at " + longestRefreshed/1e3 + " seconds");
+			log.info("Refreshed {} contexts in {} seconds, longest context was {} at {} seconds",
+				numberRefreshed, timeRefreshed/1e3, longestName, longestRefreshed/1e3);
 		}
 	}
 

--- a/plus/impl/src/main/java/org/sakaiproject/plus/impl/repository/MembershipRepositoryImpl.java
+++ b/plus/impl/src/main/java/org/sakaiproject/plus/impl/repository/MembershipRepositoryImpl.java
@@ -19,6 +19,8 @@ package org.sakaiproject.plus.impl.repository;
 import java.util.Objects;
 import java.util.List;
 
+import org.hibernate.Session;
+
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
@@ -113,5 +115,18 @@ public class MembershipRepositoryImpl extends SpringCrudRepositoryImpl<Membershi
 		newEntity.setUpdatedAt(entity.getUpdatedAt());
 		return save(newEntity);
 	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public Long countMembersInContext(Context context) {
+		Session session = sessionFactory.getCurrentSession();
+
+		CriteriaBuilder cb = session.getCriteriaBuilder();
+		CriteriaQuery<Long> query = cb.createQuery(Long.class);
+		Root<Membership> post = query.from(Membership.class);
+		query.select(cb.count(post)).where(cb.equal(post.get("context"), context));
+		return session.createQuery(query).uniqueResult();
+	}
+
 
 }

--- a/plus/impl/src/main/webapp/WEB-INF/components.xml
+++ b/plus/impl/src/main/webapp/WEB-INF/components.xml
@@ -68,7 +68,9 @@
     </bean>
 
     <bean id="org.sakaiproject.plus.api.PlusService"
-        class="org.sakaiproject.plus.impl.PlusServiceImpl">
+          class="org.sakaiproject.plus.impl.PlusServiceImpl"
+	  init-method="init"
+	  destroy-method="destroy">
         <!-- all the properties are autowired - Yay -->
     </bean>
 

--- a/plus/provider/src/bundle/plus.properties
+++ b/plus/provider/src/bundle/plus.properties
@@ -16,6 +16,7 @@ plus.launch.id_token.signature=Signature from id_token did not verify in oidc_la
 plus.launch.id_token.load.fail=Could not parse claims in the id_token in an oidc_launch
 plus.target_link_uri.missing=Missing target_link_uri in launch data
 plus.message_type.unsupported=Unsupported Launch Message type
+plus.placement.create.fail=Unable to create tool placement in site
 
 plus.repost.new.window=Open Sakai Plus in a New Window
 plus.repost.loaded=This tool was successfully loaded in a new browser window. Reload the page to access the tool again.

--- a/plus/provider/src/main/java/org/sakaiproject/plus/ProviderServlet.java
+++ b/plus/provider/src/main/java/org/sakaiproject/plus/ProviderServlet.java
@@ -565,7 +565,11 @@ public class ProviderServlet extends HttpServlet {
 
 			// Forward to a tool
 			} else {
-				String toolPlacementId = addOrCreateTool(payload, user, site);
+				String toolPlacementId = findOrCreateTool(payload, user, site);
+				if ( StringUtils.isBlank(toolPlacementId) ) {
+					doError(request, response, "plus.placement.create.fail", "tool_id="+tool_id+" context="+contextGuid, null);
+					return;
+				}
 
 				plusService.connectLinkAndPlacement(launch.getLink(), toolPlacementId);
 
@@ -577,9 +581,7 @@ public class ProviderServlet extends HttpServlet {
 				url.append("?panel=Main");
 			}
 
-			if (log.isDebugEnabled()) {
-				log.debug("url={}", url.toString());
-			}
+			log.debug("Redirecting {}", url.toString());
 
 			response.setContentType("text/html");
 			response.setStatus(HttpServletResponse.SC_FOUND);
@@ -1085,6 +1087,7 @@ public class ProviderServlet extends HttpServlet {
 				tokenKey = LTI13KeySetUtil.getKeyFromKeySetString(kid, cacheKeySet);
 			} catch(Exception e) {
 				// No big thing - just ignore it and move on
+				tokenKey = null;
 				log.debug("Exception loading kid={} tenant={} keyset={}", kid, tenant_guid, cacheKeySet);
 			}
 		}
@@ -1105,7 +1108,7 @@ public class ProviderServlet extends HttpServlet {
 			try {
 				tokenKey = LTI13KeySetUtil.getKeyFromKeySet(kid, keySet);
 			} catch(Exception e) {
-				throw new LTIException( "plus.launch.kid.load.fail", oidcKeySet, null);
+				throw new LTIException( "plus.launch.kid.load.fail", "kid="+kid+" keySet="+oidcKeySet, null);
 			}
 
 			// Store the new keyset in the Tenant
@@ -1151,28 +1154,27 @@ public class ProviderServlet extends HttpServlet {
 
 	  }
 
-	private String addOrCreateTool(Map payload, User user, Site site) throws LTIException {
+	private String findOrCreateTool(Map payload, User user, Site site) throws LTIException {
 		// Check if the site already has the tool
 		String toolPlacementId = null;
 		String tool_id = (String) payload.get("tool_id");
+		ToolConfiguration toolConfig = null;
 		try {
 			site = siteService.getSite(site.getId());
-			ToolConfiguration toolConfig = site.getToolForCommonId(tool_id);
+			toolConfig = site.getToolForCommonId(tool_id);
 			if(toolConfig != null) {
 				toolPlacementId = toolConfig.getId();
+				log.debug("Found existing tool_id={} toolPlacementId={}", tool_id, toolPlacementId);
+			} else {
+				log.debug("Did not find existing tool_id={} siteId={}", tool_id, site.getId());
 			}
 		} catch (Exception e) {
 			log.warn(e.getLocalizedMessage(), e);
 			throw new LTIException( "launch.tool.search", "tool_id="+tool_id, e);
 		}
 
-		if (log.isDebugEnabled()) {
-			log.debug("toolPlacementId={}", toolPlacementId);
-		}
-
 		// If tool not in site, and we are a trusted consumer, error
 		// Otherwise, add tool to the site
-		ToolConfiguration toolConfig = null;
 		if(StringUtils.isBlank(toolPlacementId)) {
 			try {
 				SitePage sitePageEdit = null;
@@ -1194,16 +1196,18 @@ public class ProviderServlet extends HttpServlet {
 				} finally {
 					popAdvisor();
 				}
+
+				// Reload site and tool configuration to find recently created tool placement
+				site = siteService.getSite(site.getId());
+				toolConfig =  site.getToolForCommonId(tool_id);
+				if ( toolConfig == null ) {
+					throw new LTIException( "launch.tool.add", "reloading tool_id="+tool_id + ", siteId="+site.getId(), null);
+				}
 				toolPlacementId = toolConfig.getId();
 
 			} catch (Exception e) {
 				throw new LTIException( "launch.tool.add", "tool_id="+tool_id + ", siteId="+site.getId(), e);
 			}
-		}
-
-		// Get ToolConfiguration for tool if not already setup
-		if(toolConfig == null){
-			toolConfig =  site.getToolForCommonId(tool_id);
 		}
 
 		// Check user has access to this tool in this site
@@ -1212,6 +1216,7 @@ public class ProviderServlet extends HttpServlet {
 			throw new LTIException( "launch.site.tool.denied", "user_id=" + user.getId() + " site="+ site.getId() + " tool=" + tool_id, null);
 
 		}
+
 		return toolPlacementId;
 	}
 


### PR DESCRIPTION
While investigating several other JIRAs, I did a detailed review and testing of the Plus "first launch" code because I thought those JIRAs were caused by my code.  After all the investigation of those JIRAs it turns out the tutorial was the problem all along so I moved the First launch cleanup to a new JIRA.

But during the review, in hopes of catching whatever error was happening, I strengthened some areas of the first launch code.

Some error messages have been improved, some error messages have been added, some extra checking has been added to catch inconsistencies in new site setup earlier, and the initial roster pull has been moved from a Thread in ProviderServlet to an Executor in the PlusServiceImpl - following the example in RefreshAuthZGroups.

This is the pull request formerly known as SAK-49467 :)