### PR TITLE
SAK-49294 Group assignments with prerequisites inaccessible in Lessons

### DIFF
--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -90,6 +90,7 @@ import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
+import org.sakaiproject.util.BaseResourceProperties;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Xml;
 import org.sakaiproject.util.api.FormattedText;
@@ -1498,9 +1499,11 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         Site site = mock(Site.class);
         Group group = mock(Group.class);
         when(group.getReference()).thenReturn(groupRef);
+        when(group.getProperties()).thenReturn(new BaseResourceProperties());
         Collection<Group> groups = new HashSet<>();
         groups.add(group);
         when(site.getGroups()).thenReturn(groups);
+        when(site.getGroup(groupRef)).thenReturn(group);
         when(site.getGroup(groupSubmitter)).thenReturn(group);
         Set<Member> members = new HashSet<>();
         submitters.forEach(s -> {


### PR DESCRIPTION
Jira: [SAK-49294](https://sakaiproject.atlassian.net/browse/SAK-49294)

> In Lessons, the student can't access the group assignment (to which he belongs) despite having completed the prerequisite

An assignment with assigned group(s) will be managed through a single ACCESS group on Lessons.
To access the assignment after completing the prerequisite, the user should be automatically added to the ACCESS group - if it's present on the original group(s).

To allow this behavior to work, membership won't be locked for ACCESS groups ✅ 
___
Also within this commit, the locks won't be removed for the initial group after being 'replaced' by the ACCESS one.
As they can prevent inconsistent behaviors.

![BA_GroupList](https://github.com/sakaiproject/sakai/assets/81161239/59722969-c442-496c-8b6a-724687bc17d0)
_img B/A this fix - result of setting "Don't release item until all prerequisites are completed"_

[SAK-49294]: https://sakaiproject.atlassian.net/browse/SAK-49294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ