### PR TITLE
SAK-49518 CKEditor: Upgrade CKEditor from 4.21.0 to 4.22.1

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>war</packaging>
 	<properties>
 		<!-- This is used in re-write rules as well -->
-		<ckeditor.version>4.21.0</ckeditor.version>
+		<ckeditor.version>4.23.0</ckeditor.version>
 		<bootstrap-version>5.2.0</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<node-version>v16.8.0</node-version>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>war</packaging>
 	<properties>
 		<!-- This is used in re-write rules as well -->
-		<ckeditor.version>4.23.0</ckeditor.version>
+		<ckeditor.version>4.22.1</ckeditor.version>
 		<bootstrap-version>5.2.0</bootstrap-version>
 		<font-awesome-version>4.7.0</font-awesome-version>
 		<node-version>v16.8.0</node-version>

--- a/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
@@ -2,7 +2,7 @@
 .cke {
 	.cke_button__sakaipreview {
 		.cke_button__sakaipreview_icon {
-			background: url(/library/webjars/ckeditor4/4.21.0/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1920px !important;
+			background: url(/library/webjars/ckeditor4/4.23.0/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1920px !important;
 			background-size: 16px !important;
 		}
 	}

--- a/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
@@ -2,7 +2,7 @@
 .cke {
 	.cke_button__sakaipreview {
 		.cke_button__sakaipreview_icon {
-			background: url(/library/webjars/ckeditor4/4.23.0/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1920px !important;
+			background: url(/library/webjars/ckeditor4/4.22.1/skins/moono-lisa/icons_hidpi.png) no-repeat 0 -1920px !important;
 			background-size: 16px !important;
 		}
 	}

--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -758,7 +758,7 @@ function includeWebjarLibrary(library) {
 			document.write(`<script src="${webjars}/datatables.net-rowgroup/js/dataTables.rowGroup.min.js${ver}"></script>`);
 			break;
 		case 'ckeditor4':
-			libraryVersion = "4.21.0";
+			libraryVersion = "4.23.0";
 			jsReferences.push('/ckeditor.js');
 			break;
 		case 'awesomplete':

--- a/library/src/webapp/js/headscripts.js
+++ b/library/src/webapp/js/headscripts.js
@@ -758,7 +758,7 @@ function includeWebjarLibrary(library) {
 			document.write(`<script src="${webjars}/datatables.net-rowgroup/js/dataTables.rowGroup.min.js${ver}"></script>`);
 			break;
 		case 'ckeditor4':
-			libraryVersion = "4.23.0";
+			libraryVersion = "4.22.1";
 			jsReferences.push('/ckeditor.js');
 			break;
 		case 'awesomplete':

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -114,7 +114,7 @@
     <ckeditor.wordcount.version>1.17.9</ckeditor.wordcount.version>
     <ckeditor.a11ychecker.version>1.1.1</ckeditor.a11ychecker.version>
     <ckeditor.balloonpanel.version>4.9.2</ckeditor.balloonpanel.version>
-    <ckeditor.image2.version>4.21.0</ckeditor.image2.version>
+    <ckeditor.image2.version>4.23.0</ckeditor.image2.version>
     <ckeditor.html5video.version>1.1.1</ckeditor.html5video.version>
 
   </properties>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -114,7 +114,7 @@
     <ckeditor.wordcount.version>1.17.9</ckeditor.wordcount.version>
     <ckeditor.a11ychecker.version>1.1.1</ckeditor.a11ychecker.version>
     <ckeditor.balloonpanel.version>4.9.2</ckeditor.balloonpanel.version>
-    <ckeditor.image2.version>4.23.0</ckeditor.image2.version>
+    <ckeditor.image2.version>4.22.1</ckeditor.image2.version>
     <ckeditor.html5video.version>1.1.1</ckeditor.html5video.version>
 
   </properties>

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
@@ -33,7 +33,7 @@ public class EditorRegistryImpl implements EditorRegistry {
 	private HashMap<String, Editor> editors = new HashMap<String, Editor>();
 	
 	public void init() {
-		String ckEditorVersion = "4.23.0";
+		String ckEditorVersion = "4.22.1";
 		//TODO: pull this out to somewhere appropriate
 		register("ckeditor", "CKEditor", String.format("/library/webjars/ckeditor4/%s/ckeditor.js", ckEditorVersion) , "/library/editor/ckeditor.launch.js",
 				String.format("var CKEDITOR_BASEPATH='/library/webjars/ckeditor4/%s/';\n", ckEditorVersion));

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/EditorRegistryImpl.java
@@ -33,7 +33,7 @@ public class EditorRegistryImpl implements EditorRegistry {
 	private HashMap<String, Editor> editors = new HashMap<String, Editor>();
 	
 	public void init() {
-		String ckEditorVersion = "4.21.0";
+		String ckEditorVersion = "4.23.0";
 		//TODO: pull this out to somewhere appropriate
 		register("ckeditor", "CKEditor", String.format("/library/webjars/ckeditor4/%s/ckeditor.js", ckEditorVersion) , "/library/editor/ckeditor.launch.js",
 				String.format("var CKEDITOR_BASEPATH='/library/webjars/ckeditor4/%s/';\n", ckEditorVersion));


### PR DESCRIPTION
This should be broken until the library gets deployed to Maven Central.