### PR TITLE
SAK-49387 Gradebook: Grade Rubric option unavailable

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -317,7 +317,7 @@
                         tabindex="-1">
                     </button>
                     <ul class="dropdown-menu">
-                        <li class="{if !hasAssociatedRubric || isExternallyMaintained } d-none {/if}"><a class="gb-grade-rubric dropdown-item" href="#"><wicket:message key="rubrics.option.graderubric" /></a></li>
+                        <li class="gb-grade-rubric-li"><a class="gb-grade-rubric dropdown-item" href="#"><wicket:message key="rubrics.option.graderubric" /></a></li>
                         <li><a class="gb-view-log dropdown-item" href="#"><wicket:message key="grade.option.viewlog" /></a></li>
                         <li><a class="gb-edit-comments dropdown-item" href="#"><wicket:message key="comment.option.edit" /></a></li>
                         <li><a class="gb-excuse-grade dropdown-item" href="#"><wicket:message id="excuse-message" key="excuse.grade" /></a></li>

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -384,9 +384,7 @@ GbGradeTable.cellRenderer = function (instance, td, row, col, prop, value, cellP
 
   const gradeRubricClass = "gb-grade-rubric-li";
   const gradeRubricListItem = td.getElementsByClassName(gradeRubricClass)[0];
-  if (gradeRubricListItem) {
-    gradeRubricListItem.setAttribute("class", (!hasAssociatedRubric || isExternallyMaintained) ? gradeRubricClass + " d-none" : gradeRubricClass);
-  }
+  gradeRubricListItem?.setAttribute("class", (!hasAssociatedRubric || isExternallyMaintained) ? `${gradeRubricClass} d-none` : gradeRubricClass);
 
   var $gradeRubricOption = $(td).find(".gb-grade-rubric").parent();
   if (hasAssociatedRubric) {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -369,11 +369,7 @@ GbGradeTable.cellRenderer = function (instance, td, row, col, prop, value, cellP
   if (!wasInitialised || td.getAttribute('scope') == 'row') {
     // First time we've initialised this cell.
     // Or we're replacing the student name cell
-    GbGradeTable.templates.cell.setHTML(td, {
-      value: value,
-      isExternallyMaintained: isExternallyMaintained,
-      hasAssociatedRubric: hasAssociatedRubric
-    });
+    GbGradeTable.templates.cell.setHTML(td, { value: value });
 
     if (td.hasAttribute('scope')) {
       td.removeAttribute('scope');
@@ -384,6 +380,12 @@ GbGradeTable.cellRenderer = function (instance, td, row, col, prop, value, cellP
 
     // This cell was previously holding a different value.  Just patch it.
     GbGradeTable.replaceContents(valueCell, document.createTextNode(value));
+  }
+
+  const gradeRubricClass = "gb-grade-rubric-li";
+  const gradeRubricListItem = td.getElementsByClassName(gradeRubricClass)[0];
+  if (gradeRubricListItem) {
+    gradeRubricListItem.setAttribute("class", (!hasAssociatedRubric || isExternallyMaintained) ? gradeRubricClass + " d-none" : gradeRubricClass);
   }
 
   var $gradeRubricOption = $(td).find(".gb-grade-rubric").parent();


### PR DESCRIPTION
The logic implemented in the HTML template for rendering a 'd-none' was not sufficient for all conditions. I moved that logic from the HTML template to the function, GbGradeTable.cellRenderer.