### PR TITLE
SAK-49419 Rubrics: Students can’t view rubric comments within modal

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
+++ b/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
@@ -587,3 +587,7 @@
   color: var(--sakai-text-color-1);
   background-color: var(--sakai-background-color-2);
 }
+
+.bs-popover-auto {
+    z-index: 99999;
+}


### PR DESCRIPTION
The z-index of 99999 might seem excessive, but '9999' is not enough. I also use "bs-popover-auto" as the selector because "popover" is used in other contexts as a class name.