### PR TITLE
SAK-49312 Lessons: 'Require this item' doesn't remain checked on some items completed by the instructor

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1505,6 +1505,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 						// it contains information needed to populate the "edit"
 						// popup dialog
 						UIOutput.make(tableRow, "prerequisite-info", String.valueOf(i.isPrerequisite()));
+						UIOutput.make(tableRow, "required-info", String.valueOf(i.isRequired()));
 
 						if (i.getType() == SimplePageItem.ASSIGNMENT) {
 							// the type indicates whether scoring is letter

--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -1576,6 +1576,14 @@ $(document).ready(function () {
         $("#item-prerequisites").prop("checked", false);
       }
 
+      const itemRequired = row.find(".required-info").text();
+      if (itemRequired === "true") {
+        $("#item-required").prop("checked", true);
+        $("#item-required").attr("defaultChecked", true);
+      } else {
+        $("#item-required").prop("checked", false);
+      }
+
       var samewindow = row.find(".item-samewindow").text();
       if (samewindow !== '') {
         if (samewindow === "true") {
@@ -1837,15 +1845,6 @@ $(document).ready(function () {
           $("#path").html(path);
           $("#pathdiv").show();
         }
-      }
-
-      if (row.find(".status-icon").attr("class") === undefined) {
-        $("#item-required").prop("checked", false);
-      } else if (row.find(".status-icon").attr("class").indexOf("asterisk") > -1) {
-        $("#item-required").prop("checked", true);
-        $("#item-required").attr("defaultChecked", true);
-      } else {
-        $("#item-required").prop("checked", false);
       }
 
       setUpRequirements();

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -2480,6 +2480,7 @@
                     <span rsf:id="custom-css-class" class="custom-css-class"></span>
                     <span rsf:id="current-item-id2" class="current-item-id2"></span>
                     <span rsf:id="prerequisite-info" class="prerequisite-info"></span>
+                    <span rsf:id="required-info" class="required-info"></span>
                     <span rsf:id="type" class="type"></span>
                     <span rsf:id="requirement-text" class="requirement-text"></span>
                     <span rsf:id="page-next" class="page-next"></span>


### PR DESCRIPTION
Jira [SAK-49312](https://sakaiproject.atlassian.net/browse/SAK-49312)

I'm following the existing `prerequisite-info` logic to show the checkbox status.
Instead of relying on the `status-icon` (check/asterisk) - As the item having been completed should not affect the required status.

[SAK-49312]: https://sakaiproject.atlassian.net/browse/SAK-49312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ