### PR TITLE
SAK-49339 Lessons: Imported Tests with prereqs not accessible util instructor visits the page

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -3336,7 +3336,13 @@ public class SimplePageBean {
 						ourGroupName = utf8truncate(ourGroupName, 99);
 					    else if (ourGroupName.length() > 99) 
 						ourGroupName = ourGroupName.substring(0, 99);
-					    String groupId = GroupPermissionsService.makeGroup(getCurrentPage().getSiteId(), ourGroupName, oldGroupName, i.getSakaiId(), this);
+					    String groupId = null;
+					    try {
+						securityService.pushAdvisor(siteUpdAdvisor);
+						groupId = GroupPermissionsService.makeGroup(getCurrentPage().getSiteId(), ourGroupName, oldGroupName, i.getSakaiId(), this);
+					    } finally {
+						securityService.popAdvisor(siteUpdAdvisor);
+					    }
 					    saveItem(simplePageToolDao.makeGroup(i.getSakaiId(), groupId, groups, getCurrentPage().getSiteId()));
 
 					    // update the tool access control to point to our access control group
@@ -4540,19 +4546,8 @@ public class SimplePageBean {
 		}
 
 		if (pageTitle != null && pageItem.getPageId() == 0) {
-				// we need a security advisor because we're allowing users to edit the page if they
-				// have
-				// simplepage.upd privileges, but site.save requires site.upd.
-				SecurityAdvisor siteUpdAdvisor = new SecurityAdvisor() {
-					public SecurityAdvice isAllowed(String userId, String function, String reference) {
-						if (function.equals(SiteService.SECURE_UPDATE_SITE) && reference.equals("/site/" + getCurrentSiteId())) {
-							return SecurityAdvice.ALLOWED;
-						} else {
-							return SecurityAdvice.PASS;
-						}
-					}
-				};
-
+			// we need a security advisor because we're allowing users to edit the page if they
+			// have simplepage.upd privileges, but site.save requires site.upd.
 			try {
 				securityService.pushAdvisor(siteUpdAdvisor);
 
@@ -7719,7 +7714,17 @@ public class SimplePageBean {
 		
 		return map;
 	}
-	
+
+	private SecurityAdvisor siteUpdAdvisor = new SecurityAdvisor() {
+		public SecurityAdvice isAllowed(String userId, String function, String reference) {
+			if (function.equals(SiteService.SECURE_UPDATE_SITE) && reference.equals("/site/" + getCurrentSiteId())) {
+				return SecurityAdvice.ALLOWED;
+			} else {
+				return SecurityAdvice.PASS;
+			}
+		}
+	};
+
 	private SecurityAdvisor pushAdvisorAlways() {
 	    SecurityAdvisor alwaysAdvisor = new SecurityAdvisor() {
 		    public SecurityAdvice isAllowed(String userId, String function, String reference) {


### PR DESCRIPTION
Jira [SAK-49339](https://sakaiproject.atlassian.net/browse/SAK-49339)

T&Q (with 1 exam) and Lessons (with the exam attached) is imported to a second Site.
There, instructor publishes the exam to make it available on Lessons.
When Lessons is accessed for the first time, a new access group has to be created to manage the exam item (as it has prerequisite options).

The issue comes when the first user is a student, as it won't have the permissions for this action to be performed.
So we're making an exception for this case.


Relocated `siteUpdAdvisor` as a global variable, to reuse the SecurityAdvisor.


[SAK-49339]: https://sakaiproject.atlassian.net/browse/SAK-49339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ