### PR TITLE
SAK-49599 Portal: Fix lost focus on eid and pw fields

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeBodyScripts.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeBodyScripts.vm
@@ -84,15 +84,6 @@
         }
       }
     });
-
-    // Add an on-load listener to focus the password field
-    window.addEventListener("load", () => {
-
-      // Check if window is above xs breakpoint
-      if (BreakpointManager.compare(portal.breakpointManager.currentBreakpoint, "xs") > 1) {
-        document.querySelector("#eid")?.focus()
-      }
-    });
   //--end-logged-out-scripts
   #end
 } /* if ( ! inPlusPortal() ) */

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -164,8 +164,10 @@
 
         // put the focus back on the portal wrapper so that keyboard navigation works
         setTimeout(function() {
-
-            document.querySelector('.Mrphs-portalWrapper').focus();
+            // Do not mess with the focus if the login fields are in focus right now
+            if (!["eid", "pw"].includes(document.activeElement?.id)) {
+                document.querySelector('.Mrphs-portalWrapper').focus();
+            }
         }, 50);
 
         [...document.querySelectorAll('[data-bs-toggle="popover"]')].forEach((el) => {

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -164,7 +164,7 @@
 
         // put the focus back on the portal wrapper so that keyboard navigation works
         setTimeout(function() {
-            // Do not mess with the focus if the login fields are in focus right now
+            // Preserve focus on login fields if they're currently active
             if (!["eid", "pw"].includes(document.activeElement?.id)) {
                 document.querySelector('.Mrphs-portalWrapper').focus();
             }


### PR DESCRIPTION
The added if clause clause will prevent loosing the focus from the login fields to the focus on the portal wrapper.

Removing the "focus password field" code will prevent the username field from becoming focus while typing the password. This piece of code was already inactive due to the code focusing on the portal wrapper.

https://sakaiproject.atlassian.net/browse/SAK-49599