### PR TITLE
SAK-49664 use the user's preferred timezone to calculate epochMillis as relying on the current timezoneOffset is wrong

### DIFF
--- a/webcomponents/tool/src/main/frontend/package-lock.json
+++ b/webcomponents/tool/src/main/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "lint-staged": "^15.1.0",
         "lit-analyzer": "^2.0.2",
         "sortablejs": "^1.15.0",
-        "temporal-polyfill": "^0.1.1"
+        "temporal-polyfill": "^0.2.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -16651,17 +16651,19 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.1.1.tgz",
-      "integrity": "sha512-/5e4EVRA0wBI/bEhWLirSjwUg1lELhQyTXxw9zNbVhqjKvI9BLczs+3wtsoD9sn3HN2ImAMW5XJQwAiXgWT+GA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.0.tgz",
+      "integrity": "sha512-ra5tfISsVwUlDk9fhvEiIuvfBshV7jDtHYxmC8ACLIVV91MYoVlOBE1RpIrDjqGTYkCrZf0mWhgAW9XSOVPuGw==",
+      "dev": true,
       "dependencies": {
-        "temporal-spec": "~0.1.0"
+        "temporal-spec": "^0.2.0"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.1.0.tgz",
-      "integrity": "sha512-sMNggMeS6trCgMQuudgFHhX1gtBK3e+AT1zGrMsFYG1wlqtRT5E9rcvm3I1iNlvHpJX/3DO6L4qtWAuEl/T04Q=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.0.tgz",
+      "integrity": "sha512-r1AT0XdEp8TMQ13FLvOt8mOtAxDQsRt2QU5rSWCA7YfshddU651Y1NHVrceLANvixKdf9fYO8B/S9fXHodB7HQ==",
+      "dev": true
     },
     "node_modules/text-extensions": {
       "version": "1.9.0",
@@ -17947,6 +17949,19 @@
         "eslint": "^8.53.0",
         "sinon": "^15.0.1"
       }
+    },
+    "packages/sakai-date-picker/node_modules/temporal-polyfill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.1.1.tgz",
+      "integrity": "sha512-/5e4EVRA0wBI/bEhWLirSjwUg1lELhQyTXxw9zNbVhqjKvI9BLczs+3wtsoD9sn3HN2ImAMW5XJQwAiXgWT+GA==",
+      "dependencies": {
+        "temporal-spec": "~0.1.0"
+      }
+    },
+    "packages/sakai-date-picker/node_modules/temporal-spec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.1.0.tgz",
+      "integrity": "sha512-sMNggMeS6trCgMQuudgFHhX1gtBK3e+AT1zGrMsFYG1wlqtRT5E9rcvm3I1iNlvHpJX/3DO6L4qtWAuEl/T04Q=="
     },
     "packages/sakai-dialog-content": {
       "name": "@sakai-ui/sakai-dialog-content",

--- a/webcomponents/tool/src/main/frontend/package.json
+++ b/webcomponents/tool/src/main/frontend/package.json
@@ -62,7 +62,7 @@
     "lint-staged": "^15.1.0",
     "lit-analyzer": "^2.0.2",
     "sortablejs": "^1.15.0",
-    "temporal-polyfill": "^0.1.1"
+    "temporal-polyfill": "^0.2.0"
   },
   "dependencies": {
     "lerna": "^7.1.3"

--- a/webcomponents/tool/src/main/frontend/packages/sakai-date-picker/src/SakaiDatePicker.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-date-picker/src/SakaiDatePicker.js
@@ -44,7 +44,7 @@ export class SakaiDatePicker extends SakaiElement {
     if (value) {
       this._epochMillis = value;
       const instant = Temporal.Instant.fromEpochMilliseconds(value);
-      const zonedDateTime = instant.toZonedDateTime({ timeZone: getTimezone() });
+      const zonedDateTime = instant.toZonedDateTimeISO({ timeZone: getTimezone() });
       this.isoDate = zonedDateTime.toString().substring(0, 16);
     } else {
       this._epochMillis = null;

--- a/webcomponents/tool/src/main/frontend/packages/sakai-date-picker/test/sakai-date-picker.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-date-picker/test/sakai-date-picker.test.js
@@ -44,13 +44,9 @@ describe("sakai-date-picker tests", () => {
     const picker = el.querySelector("input[type='datetime-local']");
     picker.value = "2017-06-01T08:30";
 
-    let dateStub = stub(Date.prototype, 'getTimezoneOffset').returns(0);
-
     picker.dispatchEvent(new Event("change"));
 
     await el.updateComplete;
-
-    dateStub.restore();
 
     expect(el.querySelectorAll("input[type='hidden']").length).to.equal(5);
     expect(el.querySelector("input[name='test-year']").value).to.equal("2017");
@@ -58,11 +54,6 @@ describe("sakai-date-picker tests", () => {
     expect(el.querySelector("input[name='test-day']").value).to.equal("1");
     expect(el.querySelector("input[name='test-hour']").value).to.equal("8");
     expect(el.querySelector("input[name='test-min']").value).to.equal("30");
-
-    dateStub = stub(Date.prototype, 'getTimezoneOffset').returns(120);
-
-    picker.dispatchEvent(new Event("change"));
-    expect(el.isoDate).to.equal("2017-06-01T06:30");
   });
 
   it ("is accessible", async () => {
@@ -71,4 +62,27 @@ describe("sakai-date-picker tests", () => {
 
     await expect(el).to.be.accessible();
   });
+
+  it ("handles timezones and DST correctly", async () => {
+    window.top.portal = { user: { offsetFromServerMillis: 0, timezone: "America/New_York" } };
+
+    let el = await fixture(html`<sakai-date-picker epoch-millis="1710269364000" add-hidden-fields hidden-prefix="test-"></sakai-date-picker>`);
+    expect(el.querySelectorAll("input[type='hidden']").length).to.equal(5);
+    expect(el.querySelector("input[name='test-year']").value).to.equal("2024");
+    expect(el.querySelector("input[name='test-month']").value).to.equal("3");
+    expect(el.querySelector("input[name='test-day']").value).to.equal("12");
+    expect(el.querySelector("input[name='test-hour']").value).to.equal("14");
+    expect(el.querySelector("input[name='test-min']").value).to.equal("49");
+
+    window.top.portal = { user: { offsetFromServerMillis: 0, timezone: "US/Pacific" } };
+
+    el = await fixture(html`<sakai-date-picker epoch-millis="1710269364000" add-hidden-fields hidden-prefix="test-"></sakai-date-picker>`);
+    expect(el.querySelectorAll("input[type='hidden']").length).to.equal(5);
+    expect(el.querySelector("input[name='test-year']").value).to.equal("2024");
+    expect(el.querySelector("input[name='test-month']").value).to.equal("3");
+    expect(el.querySelector("input[name='test-day']").value).to.equal("12");
+    expect(el.querySelector("input[name='test-hour']").value).to.equal("11");
+    expect(el.querySelector("input[name='test-min']").value).to.equal("49");
+  });
+
 });

--- a/webcomponents/tool/src/main/frontend/packages/sakai-tasks/test/sakai-tasks-create-task.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-tasks/test/sakai-tasks-create-task.test.js
@@ -10,7 +10,7 @@ import fetchMock from "fetch-mock/esm/client";
 describe("sakai-tasks-create-task tests", () => {
 
   const minusFiveHours = -5 * 60 * 60 * 1000;
-  window.top.portal = { locale: "en_GB", user: { offsetFromServerMillis: minusFiveHours } };
+  window.top.portal = { locale: "en_GB", user: { offsetFromServerMillis: minusFiveHours, timezone: "America/New_York" } };
   window.moment = { duration: () => { return { humanize: () => "3 days ago" } } };
 
   fetchMock

--- a/webcomponents/tool/src/main/frontend/packages/sakai-tasks/test/sakai-tasks.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-tasks/test/sakai-tasks.test.js
@@ -9,7 +9,7 @@ import fetchMock from "fetch-mock/esm/client";
 describe("sakai-tasks tests", () => {
 
   const minusFiveHours = -5 * 60 * 60 * 1000;
-  window.top.portal = { locale: "en_GB", user: { offsetFromServerMillis: minusFiveHours } };
+  window.top.portal = { locale: "en_GB", user: { offsetFromServerMillis: minusFiveHours, timezone: "America/New_York" } };
 
   fetchMock
     .get(data.i18nUrl, data.i18n, { overwriteRoutes: true })


### PR DESCRIPTION
tested and working locally

I'd like to be able to run the sakai-date-picker-test.js but can't figure out how/where it gets run. maybe adrian can show us and then i can add more tests