### PR TITLE
SAK-49666 Preferences: Set users default option for Announcement notifications through a property

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/user/prefs/AnnouncementUserNotificationPreferencesRegistrationImpl.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/user/prefs/AnnouncementUserNotificationPreferencesRegistrationImpl.java
@@ -21,13 +21,23 @@
 
 package org.sakaiproject.announcement.user.prefs;
 
+import lombok.Setter;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.util.UserNotificationPreferencesRegistrationImpl;
 import org.sakaiproject.util.ResourceLoader;
 
 public class AnnouncementUserNotificationPreferencesRegistrationImpl extends UserNotificationPreferencesRegistrationImpl {
 
+	private static final String NOTIFICATION_ANNOUNCEMENTS_DEFAULT_OPTION = "prefs.notification.announcements.default.option";
 	public ResourceLoader getResourceLoader(String location) {
 		return new ResourceLoader(location);
 	}
 
+	@Setter
+	private ServerConfigurationService serverConfigurationService;
+
+	public void init() {
+		super.init();
+		setDefaultValue(serverConfigurationService.getString(NOTIFICATION_ANNOUNCEMENTS_DEFAULT_OPTION));
+	}
 }

--- a/announcement/announcement-impl/impl/src/webapp/WEB-INF/components.xml
+++ b/announcement/announcement-impl/impl/src/webapp/WEB-INF/components.xml
@@ -61,11 +61,11 @@
       parent="org.sakaiproject.user.api.UserNotificationPreferencesRegistration"
       class="org.sakaiproject.announcement.user.prefs.AnnouncementUserNotificationPreferencesRegistrationImpl"
       init-method="init">
+      <property name="serverConfigurationService"><ref bean="org.sakaiproject.component.api.ServerConfigurationService"/></property>
       <property name="bundleLocation"><value>annc-noti-prefs</value></property>
       <property name="sectionTitleBundleKey"><value>prefs_title</value></property>
       <property name="sectionDescriptionBundleKey"><value>prefs_description</value></property>
       <property name="overrideSectionTitleBundleKey"><value>prefs_title_override</value></property>
-      <property name="defaultValue"><value>3</value></property>
       <property name="type"><value>sakai:announcement</value></property>
       <property name="prefix"><value>annc</value></property>
       <property name="toolId"><value>sakai.announcements</value></property>

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3974,6 +3974,13 @@
 # ########################################################################
 # Notification Preferences
 # ########################################################################
+
+# Modify the default option users will have for Announcement notifications (User Preferences).
+# 1 = Do not send me low priority announcements
+# 2 = Send me one email per day summarizing all low priority announcements
+# 3 = Send me each notification separately [DEFAULT]
+# prefs.notification.announcements.default.option=3
+
 # prefs.tool.order.count=4
 # prefs.tool.order.1=sakai.announcements
 # prefs.tool.order.2=sakai.resources

--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -116,6 +116,10 @@ invalidEmailInIdAccountString=
 # DEFAULT: none (null)
 nonOfficialAccount.url=
 
+# Notification Preferences:
+# Option 3 is the default for Announcements (Send me each notification separately)
+prefs.notification.announcements.default.option=3
+
 # for worksite setup... ???
 titleEditableSiteType.count=1
 titleEditableSiteType.1=project


### PR DESCRIPTION
Jira [SAK-49666](https://sakaiproject.atlassian.net/browse/SAK-49666)

We'll get the value form a property using `serverConfigurationService`, instead of the hard coded XML.

The default property value is set on _kernel.properties_

[SAK-49666]: https://sakaiproject.atlassian.net/browse/SAK-49666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ