### PR TITLE
SAK-49527 Assignments: Extension submit btn is disabled if instructor…

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2384,10 +2384,13 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 // If an Extension exists for the user, we switch out the assignment's overall
                 // Close date for the extension deadline. We do this if the grade has been actually
                 // released, or if the submission object has not actually been submitted yet.
+                // Or when instructor granted an extension without returning grade/feedback
+                // and the user has created a submission that is ready to be submitted.
                 // Additionally, we make sure that a Resubmission date is not set [make sure it's null],
                 // so that this date-switching happens ONLY under Extension-related circumstances.
                 if (submission.getProperties().get(AssignmentConstants.ALLOW_EXTENSION_CLOSETIME) != null
-                        && (submission.getReturned() || !submission.getUserSubmission())) {
+                        && ((submission.getReturned() || !submission.getUserSubmission()) ||
+                            (!submission.getReturned() && submission.getUserSubmission()))) {
                     Instant extensionCloseTime = Instant.ofEpochMilli(Long.parseLong(submission.getProperties().get(AssignmentConstants.ALLOW_EXTENSION_CLOSETIME)));
                     isBeforeAssignmentCloseDate = !currentTime.isAfter(extensionCloseTime);
                 }


### PR DESCRIPTION
… used 'Save' as opposed to 'Save and Release to Student'

Assignment extensions should not require that the Instructor to 'Return' the assignment to the student, selecting 'Save' should be sufficient. Currently it is required to use 'Save and Release to Student'.

This pull request provides the ability to create an 'Exception' as an accommodation similar to the capability in Tests & Quizzes using 'Save'.
This allows the student to see the extension date without the potentially confusing status of 'Returned' and to see the extension date as soon as the instructor creates the extension, be that before or after the assignment's normal due date.