### PR TITLE
SAK-49716 Scheduled (un)publishing not pinning/removing sites correctly

### DIFF
--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -170,7 +170,7 @@ public class PortalServiceImpl implements PortalService, Observer
 				try {
 					Site site = siteService.getSite(siteId);
 					for (String userId : site.getUsers()) {
-						if (!isSiteUnpinnedByUser(userId, siteId) && (canUserUpdateSite(userId, event.getContext()) || isUserActiveMemberInPublishedSite(userId, siteId))) {
+						if (!isSiteUnpinnedByUser(userId, siteId) && (canUserUpdateSite(userId, siteId) || isUserActiveMemberInSite(userId, siteId))) {
 							addPinnedSite(userId, siteId, true);
 						}
 					}
@@ -183,18 +183,19 @@ public class PortalServiceImpl implements PortalService, Observer
 			}
 			case SiteService.EVENT_SITE_UNPUBLISH: {
 				try {
-					Site site = siteService.getSite(event.getContext());
+					final String siteId = StringUtils.isNotBlank(event.getContext()) ? event.getContext() : siteService.idFromSiteReference(event.getResource());
+					Site site = siteService.getSite(siteId);
 					site.getMembers().forEach(m -> {
-						if (!canUserUpdateSite(m.getUserId(), event.getContext())) {
+						if (!canUserUpdateSite(m.getUserId(), siteId)) {
 							// Remove pinned site if it actually exists and was not explicitly unpinned
-							if (!isSiteUnpinnedByUser(m.getUserId(), event.getContext())) {
-								removePinnedSite(m.getUserId(), event.getContext());
+							if (!isSiteUnpinnedByUser(m.getUserId(), siteId)) {
+								removePinnedSite(m.getUserId(), siteId);
 							}
 
 							List<RecentSite> recentSites = recentSiteRepository.findByUserId(m.getUserId());
 							for (RecentSite recentSite : recentSites) {
-								if (StringUtils.equals(recentSite.getSiteId(), event.getContext())) {
-									recentSiteRepository.deleteByUserIdAndSiteId(m.getUserId(), event.getContext());
+								if (StringUtils.equals(recentSite.getSiteId(), siteId)) {
+									recentSiteRepository.deleteByUserIdAndSiteId(m.getUserId(), siteId);
 									break;
 								}
 							}
@@ -782,11 +783,20 @@ public class PortalServiceImpl implements PortalService, Observer
 		return securityService.unlock(userId, SiteService.SECURE_UPDATE_SITE, siteService.siteReference(siteId));
 	}
 
+
+	private boolean isUserActiveMemberInSite(String userId, String siteId) {
+		return isUserActiveMemberInSiteImpl(userId, siteId, true);
+        }
+
 	private boolean isUserActiveMemberInPublishedSite(String userId, String siteId) {
+		return isUserActiveMemberInSiteImpl(userId, siteId, false);
+        }
+
+	private boolean isUserActiveMemberInSiteImpl(String userId, String siteId, boolean excludePublishedState) {
 		try {
 			Site site = siteService.getSite(siteId);
 			Member m = site.getMember(userId);
-			return (m != null && (site.isPublished() && m.isActive()));
+			return (m != null && ((site.isPublished() || excludePublishedState) && m.isActive()));
 		} catch (IdUnusedException idue) {
 			log.warn("Could not access site with id [{}], {}", siteId, idue.toString());
 			return false;

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -786,11 +786,11 @@ public class PortalServiceImpl implements PortalService, Observer
 
 	private boolean isUserActiveMemberInSite(String userId, String siteId) {
 		return isUserActiveMemberInSiteImpl(userId, siteId, true);
-        }
+	}
 
 	private boolean isUserActiveMemberInPublishedSite(String userId, String siteId) {
 		return isUserActiveMemberInSiteImpl(userId, siteId, false);
-        }
+	}
 
 	private boolean isUserActiveMemberInSiteImpl(String userId, String siteId, boolean excludePublishedState) {
 		try {
@@ -800,8 +800,8 @@ public class PortalServiceImpl implements PortalService, Observer
 		} catch (IdUnusedException idue) {
 			log.warn("Could not access site with id [{}], {}", siteId, idue.toString());
 			return false;
-        }
-    }
+		}
+	}
 
 	@Transactional
 	@Override

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/PublishingSiteScheduleServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/PublishingSiteScheduleServiceImpl.java
@@ -19,20 +19,22 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.Setter;
 import java.time.Instant;
 import org.sakaiproject.api.app.scheduler.ScheduledInvocationManager;
-import org.sakaiproject.authz.api.SecurityAdvisor;
-import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.sitemanage.api.UnpublishingSiteScheduleService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
 
 @Slf4j
 public class PublishingSiteScheduleServiceImpl implements org.sakaiproject.sitemanage.api.PublishingSiteScheduleService {
     @Setter private ScheduledInvocationManager scheduledInvocationManager;
     @Setter private SiteService siteService;
-    @Setter private SecurityService securityService;
+    @Setter private EventTrackingService eventTrackingService;
+    @Setter private SessionManager sessionManager;
     private final String GROUPMEMEBERSHIP = "site.upd.grp.mbrshp";
     private final String SITEUPDATE = "site.upd";
     private final String READANNOUNCEMENTS = "annc.read";
@@ -47,22 +49,23 @@ public class PublishingSiteScheduleServiceImpl implements org.sakaiproject.sitem
     }
 
     public void execute(String siteId){
-        SecurityAdvisor advisor = (userId, function, reference) -> {
-            if(function.equals(GROUPMEMEBERSHIP) || function.equals(SITEUPDATE) || function.equals(READANNOUNCEMENTS)){
-                return SecurityAdvisor.SecurityAdvice.ALLOWED;  //allow only three special permissions for publishing
-            } else {
-                return SecurityAdvisor.SecurityAdvice.PASS;
-            }
-        };
-        securityService.pushAdvisor(advisor);   //add special authorization for the operation
+        Session session = null;
         try{
+	    session = sessionManager.getCurrentSession();
+	    session.setUserEid("admin");
+	    session.setUserId("admin");
             Site gettingPublished = siteService.getSite(siteId);
+            if (!gettingPublished.isPublished()) {
+		    eventTrackingService.post(eventTrackingService.newEvent(siteService.EVENT_SITE_PUBLISH, gettingPublished.getReference(), true));
+            }
             gettingPublished.setPublished(true);
             siteService.save(gettingPublished);
         } catch (IdUnusedException | PermissionException i){
             log.error("Unable to schedule publishing for site: " + siteId);
         } finally {
-            securityService.popAdvisor(advisor);   //remove special authorization
+            if (session != null) {
+		    session.clear();
+            }
         }
     }
 }

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/PublishingSiteScheduleServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/PublishingSiteScheduleServiceImpl.java
@@ -51,12 +51,12 @@ public class PublishingSiteScheduleServiceImpl implements org.sakaiproject.sitem
     public void execute(String siteId){
         Session session = null;
         try{
-	    session = sessionManager.getCurrentSession();
-	    session.setUserEid("admin");
-	    session.setUserId("admin");
+            session = sessionManager.getCurrentSession();
+            session.setUserEid("admin");
+            session.setUserId("admin");
             Site gettingPublished = siteService.getSite(siteId);
             if (!gettingPublished.isPublished()) {
-		    eventTrackingService.post(eventTrackingService.newEvent(siteService.EVENT_SITE_PUBLISH, gettingPublished.getReference(), true));
+              eventTrackingService.post(eventTrackingService.newEvent(siteService.EVENT_SITE_PUBLISH, gettingPublished.getReference(), true));
             }
             gettingPublished.setPublished(true);
             siteService.save(gettingPublished);
@@ -64,7 +64,7 @@ public class PublishingSiteScheduleServiceImpl implements org.sakaiproject.sitem
             log.error("Unable to schedule publishing for site: " + siteId);
         } finally {
             if (session != null) {
-		    session.clear();
+              session.clear();
             }
         }
     }

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UnpublishingSiteScheduleServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UnpublishingSiteScheduleServiceImpl.java
@@ -19,20 +19,22 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.Setter;
 import java.time.Instant;
 import org.sakaiproject.api.app.scheduler.ScheduledInvocationManager;
-import org.sakaiproject.authz.api.SecurityAdvisor;
-import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.sitemanage.api.UnpublishingSiteScheduleService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
 
 @Slf4j
 public class UnpublishingSiteScheduleServiceImpl implements org.sakaiproject.sitemanage.api.UnpublishingSiteScheduleService {
     @Setter private ScheduledInvocationManager scheduledInvocationManager;
     @Setter private SiteService siteService;
-    @Setter private SecurityService securityService;
+    @Setter private EventTrackingService eventTrackingService;
+    @Setter private SessionManager sessionManager;
     private final String GROUPMEMEBERSHIP = "site.upd.grp.mbrshp";
     private final String SITEUPDATE = "site.upd";
     private final String READANNOUNCEMENTS = "annc.read";
@@ -47,22 +49,23 @@ public class UnpublishingSiteScheduleServiceImpl implements org.sakaiproject.sit
     }
 
     public void execute(String siteId){
-        SecurityAdvisor advisor = (userId, function, reference) -> {
-            if(function.equals(GROUPMEMEBERSHIP) || function.equals(SITEUPDATE) || function.equals(READANNOUNCEMENTS)){
-                return SecurityAdvisor.SecurityAdvice.ALLOWED;  //allow only three special permissions for unpublishing
-            } else {
-                return SecurityAdvisor.SecurityAdvice.PASS;
-            }
-        };
-        securityService.pushAdvisor(advisor);   //add special authorization for the operation
+        Session session = null;
         try{
+	    session = sessionManager.getCurrentSession();
+	    session.setUserEid("admin");
+	    session.setUserId("admin");
             Site gettingUnpublished = siteService.getSite(siteId);
+            if (gettingUnpublished.isPublished()) {
+		    eventTrackingService.post(eventTrackingService.newEvent(siteService.EVENT_SITE_UNPUBLISH, gettingUnpublished.getReference(), true));
+            }
             gettingUnpublished.setPublished(false);
             siteService.save(gettingUnpublished);
         } catch (IdUnusedException | PermissionException i){
             log.error("Unable to schedule unpublishing for site: " + siteId);
         } finally {
-            securityService.popAdvisor(advisor);   //remove special authorization
+            if (session != null) {
+		    session.clear();
+            }
         }
     }
 }

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UnpublishingSiteScheduleServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/UnpublishingSiteScheduleServiceImpl.java
@@ -50,21 +50,21 @@ public class UnpublishingSiteScheduleServiceImpl implements org.sakaiproject.sit
 
     public void execute(String siteId){
         Session session = null;
-        try{
-	    session = sessionManager.getCurrentSession();
-	    session.setUserEid("admin");
-	    session.setUserId("admin");
+        try {
+            session = sessionManager.getCurrentSession();
+            session.setUserEid("admin");
+            session.setUserId("admin");
             Site gettingUnpublished = siteService.getSite(siteId);
             if (gettingUnpublished.isPublished()) {
-		    eventTrackingService.post(eventTrackingService.newEvent(siteService.EVENT_SITE_UNPUBLISH, gettingUnpublished.getReference(), true));
+              eventTrackingService.post(eventTrackingService.newEvent(siteService.EVENT_SITE_UNPUBLISH, gettingUnpublished.getReference(), true));
             }
             gettingUnpublished.setPublished(false);
             siteService.save(gettingUnpublished);
-        } catch (IdUnusedException | PermissionException i){
+        } catch (IdUnusedException | PermissionException i) {
             log.error("Unable to schedule unpublishing for site: " + siteId);
         } finally {
             if (session != null) {
-		    session.clear();
+                session.clear();
             }
         }
     }

--- a/site-manage/site-manage-impl/impl/src/webapp/WEB-INF/components.xml
+++ b/site-manage/site-manage-impl/impl/src/webapp/WEB-INF/components.xml
@@ -45,13 +45,15 @@
 		  class="org.sakaiproject.sitemanage.impl.UnpublishingSiteScheduleServiceImpl">
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 		<property name="scheduledInvocationManager" ref="org.sakaiproject.api.app.scheduler.ScheduledInvocationManager" />
-		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+		<property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
+		<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
 	</bean>
 	<bean id="org.sakaiproject.sitemanage.api.PublishingSiteScheduleService"
 		  class="org.sakaiproject.sitemanage.impl.PublishingSiteScheduleServiceImpl">
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 		<property name="scheduledInvocationManager" ref="org.sakaiproject.api.app.scheduler.ScheduledInvocationManager" />
-		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+		<property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
+		<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
 	</bean>
 	
 	<bean id="org.sakaiproject.sitemanage.api.SectionFieldProvider"


### PR DESCRIPTION
jira: https://sakaiproject.atlassian.net/browse/SAK-49716

I revised PortalServiceImpl.canUserUpdateSite because securityService.unlock-- the basis for that method-- failed to deliver the desired value for students for the scheduled unpublishing test case. Whereas use of site.isAllowed(userId, SiteService.SECURE_UPDATE_SITE) instead provided consistent results for all test cases.
