### PR TITLE
SAK-49631 - "Exit Student View" not working on other tabs except "Overview" tab

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
+++ b/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
@@ -130,20 +130,13 @@
   }
 }
 
-.non-home-tool-link {
-  padding-right: 10.5em;
-  height: 45px;
-  margin-bottom: -22px;
+.role-switcher {
+    margin-right: 5px;
 }
 
-.non-home-tool-link-published {
-  margin-top: -37px;
-
-  @media #{$phone} {
-    &.non-home-tool-link-lessons {
-      margin-top: -50px;
-    }
-  }
+.non-home-tool-link {
+  height: 45px;
+  margin-bottom: -22px;
 }
 
 .non-home-tool-link-unpublished {

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
@@ -60,6 +60,8 @@
 
 
                             <nav class="Mrphs-toolTitleNav Mrphs-container--toolTitleNav" aria-label="${rloader.sit_toolnavigation}">
+                                #*  Role Switcher  *#
+                                #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
 
                                 #if (${tool.toolShowResetButton})
 
@@ -233,7 +235,9 @@
 
                         #if (${tool.hasRenderResult})
                             <nav class="Mrphs-toolTitleNav Mrphs-container Mrphs-container--toolTitleNav">
-                                    
+                                #*  Role Switcher  *#
+                                #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
+
                                 #if (${tool.toolShowResetButton})
                                     <h2 class="Mrphs-toolTitleNav__title">
                                         <a href="${tool.toolResetActionUrl}" target="${tool.toolPlacementIDJS}" title="${rloader.sit_reset}: ${tool.toolRenderResult.getTitle()}">
@@ -281,6 +285,8 @@
                         #else
                         
                             <nav class="Mrphs-toolTitleNav Mrphs-container Mrphs-container--toolTitleNav">
+                                #*  Role Switcher  *#
+                                #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
 
                                 #if (${tool.toolShowResetButton})
                                     <h2 class="Mrphs-toolTitleNav__title">

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteHierarchy.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteHierarchy.vm
@@ -115,9 +115,6 @@
         #end
     #end
 
-    #*  Role Switcher  *#
-    #if ($viewAsStudentLink)
-        #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
-    #end
+
     </ol>
 </nav>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/roleSwitch-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/roleSwitch-snippet.vm
@@ -1,5 +1,7 @@
 ## Adds $viewAsStudentLink options
 
+## Only display this if we're in view as student mode and it's one column layout
+#if ($viewAsStudentLink && $pageColumnLayout == 'col1')
 <div id="roleSwitch" class="role-switcher">
     #if ($roleSwitchState)
     	<span>$rloader.getFormattedMessage("rs_roleSwapAdvice", $roleUrlValue)</span>
@@ -25,3 +27,4 @@
         </div>
     #end ## END of IF ($roleSwitchState)
 </div>
+#end ## END of if ($viewAsStudentLink && $pageColumnLayout == 'col1')


### PR DESCRIPTION
Some ideas for review.

I'm going to leave this as draft for now and am happy if someone does this differently or if this is almost good and I can fix it up.

Some things I didn't like:

I don't think these dropdowns should appear on the overview (iframe) divs but I don't see a better way to detect this other than `$pageColumnLayout == 'col1'`

I'm also not sure why some of these negative margins were in there and they made the link no longer appear. 

I'm not sure if there's any other edge cases here or if there's a better place this dropdown could be placed.