### PR TITLE
SAK-49729 Rubrics: Adding comments displays CKEditor warning

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGradingComment.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGradingComment.js
@@ -88,6 +88,7 @@ export class SakaiRubricGradingComment extends RubricsElement {
       */
       const commentEditor = sakai.editor.launch(editorKey, {
         startupFocus: true,
+        versionCheck: false,
         toolbarSet: "BasicText",
         removePlugins: "wordcount",
         height: 60,


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-49729

Setting versionCheck to false here conforms to the solution applied elsewhere with the versionCheck setting in ckeditor.launch.js implemented for SAK-49518.

Also, note that to fix this for 23.x, a different implementation is necessary, given prior webcomponent reorganizing. The relevant source file to fix for 23.x would instead be:

webcomponents/tool/src/main/frontend/js/rubrics/sakai-rubric-grading-comment.js