### PR TITLE
SAK-49726 Kernel view site as updates

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/model/EntityMember.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/model/EntityMember.java
@@ -328,9 +328,4 @@ public class EntityMember implements Member {
         }
     }
 
-    @Override
-    public boolean isRoleViewUser() {
-        return false;
-    }
-
 }

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/Member.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/Member.java
@@ -80,10 +80,4 @@ public interface Member extends Comparable, Serializable
 	 */
 	void setActive(boolean active);
 	
-	/**
-	 * Check if the user is a fake one to simulate role views 
-	 * 
-	 * @return true if the user is only for role view purposes
-	 */
-	boolean isRoleViewUser();
 }

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/SecurityService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/SecurityService.java
@@ -183,13 +183,4 @@ public interface SecurityService
 	 */
 	public boolean isUserRoleSwapped() throws IdUnusedException;
 	
-	/**
-	 * Change to a new role view with a mockup student logged in
-	 * 
-	 * @param site
-	 * @param role
-	 * @throws SakaiException
-	 */
-	public void changeToRoleViewOnSite(Site site, String role) throws SakaiException;
-
 }

--- a/kernel/api/src/main/java/org/sakaiproject/event/api/UsageSessionService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/event/api/UsageSessionService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.sakaiproject.exception.SakaiException;
 import org.sakaiproject.user.api.Authentication;
 
 /**
@@ -52,6 +53,12 @@ public interface UsageSessionService
 	 * Note: This must be a constant and not based on classname - it must stay the same regardless of the name of the implementing class.
 	 */
 	public static final String USAGE_SESSION_KEY = "org.sakaiproject.event.api.UsageSessionService";
+
+	/** Session attribute to store roleswap state **/
+	String ROLEVIEW_PREFIX = "roleview";
+	String EVENT_ROLEVIEW_BECOME = ROLEVIEW_PREFIX + ".become";
+	String EVENT_ROLEVIEW_EXIT = ROLEVIEW_PREFIX + ".exit";
+	String EVENT_ROLEVIEW_START = ROLEVIEW_PREFIX + ".start";
 
 	/**
 	 * Establish a usage session associated with the current request or thread.
@@ -216,4 +223,6 @@ public interface UsageSessionService
 	 */
 	int closeSessionsOnInvalidServers(List<String> validServerIds);
 
+	void impersonateUser(String userId) throws SakaiException;
+	void restoreUser() throws SakaiException;
 }

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -35,6 +35,7 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.IdUsedException;
 import org.sakaiproject.exception.InUseException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.exception.SakaiException;
 import org.sakaiproject.javax.PagingPosition;
 import org.w3c.dom.Element;
 
@@ -1301,6 +1302,14 @@ public interface SiteService extends EntityProducer
 	 * @return A log of status messages from the archive.
 	 */
 	String merge(String toSiteId, Element e, String creatorId);
+
+	/**
+	 * Activates viewing a site with a different role
+	 * @param site the site to activate
+	 * @param role the new role the user will have
+	 * @throws SakaiException
+	 */
+	void activateRoleViewOnSite(String siteReference, String role) throws SakaiException;
 
 	/**
 	 * Access a Group object, given a reference string or id.

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/User.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/User.java
@@ -33,9 +33,6 @@ import org.sakaiproject.time.api.Time;
  */
 public interface User extends Entity, Comparable
 {
-	
-	public static final String ROLEVIEW_USER_TYPE = "roleview";
-	
 	/**
 	 * @return the user who created this.
 	 */

--- a/kernel/api/src/main/java/org/sakaiproject/user/api/UserDirectoryService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/UserDirectoryService.java
@@ -78,6 +78,9 @@ public interface UserDirectoryService extends EntityProducer
 	static final String EIDCACHE = "eid:";
 	static final String IDCACHE = "id:";
 
+	// A user type used for simulating other user types
+	String ROLEVIEW_USER_TYPE = "roleview";
+
 	/**
 	 * This function returns a boolean value of true/false,
 	 * depending on if the given password meets the validation criteria.
@@ -500,6 +503,14 @@ public interface UserDirectoryService extends EntityProducer
 	 * @return The user id portion, the bit after the last slash
 	 */
 	String idFromReference(String reference);
+
+	/**
+	 * Check if the user is a fake one to simulate role views
+	 *
+	 * @param id the user id to check
+	 * @return true if the user is only for role view purposes
+	 */
+	boolean isRoleViewType(String id);
 
 	/**
 	 * Indicates if a password is valid and if it has passed the validation check

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroup.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroup.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -82,7 +83,7 @@ public class BaseAuthzGroup implements AuthzGroup
 	protected ResourcePropertiesEdit m_properties = null;
 
 	/** Map of userId to Member */
-	protected Map m_userGrants = null;
+	protected Map<String, Member> m_userGrants = null;
 
 	/** Map of Role id to a Role defined in this AuthzGroup. */
 	protected Map m_roles = null;
@@ -806,92 +807,54 @@ public class BaseAuthzGroup implements AuthzGroup
 		return false;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public Set getUsers()
+	@Override
+	public Set<String> getUsers()
 	{
 		if (m_lazy) baseAuthzGroupService.m_storage.completeGet(this);
 
-		Set rv = new HashSet();
-		for (Iterator it = m_userGrants.entrySet().iterator(); it.hasNext();)
-		{
-			Map.Entry entry = (Map.Entry) it.next();
-			String user = (String) entry.getKey();
-			Member grant = (Member) entry.getValue();
-			if (grant.isActive() && !grant.isRoleViewUser())
-			{
-				rv.add(user);
-			}
-		}
-
-		return rv;
+		return m_userGrants.entrySet().stream()
+				.filter(e -> e.getValue().isActive() && !userDirectoryService.isRoleViewType(e.getKey()))
+				.map(Map.Entry::getKey)
+				.collect(Collectors.toSet());
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public Set getMembers()
+	@Override
+	public Set<Member> getMembers()
 	{
 		// Note: this is the only way to see non-active grants
 
 		if (m_lazy) baseAuthzGroupService.m_storage.completeGet(this);
 
-		Set rv = new HashSet();
-		for (Iterator it = m_userGrants.entrySet().iterator(); it.hasNext();)
-		{
-			Map.Entry entry = (Map.Entry) it.next();
-			Member grant = (Member) entry.getValue();
-			if (!grant.isRoleViewUser()) {
-				rv.add(grant);
-			}
-		}
-
-		return rv;
+		return m_userGrants.entrySet().stream()
+				.filter(e -> !userDirectoryService.isRoleViewType(e.getKey()))
+				.map(Map.Entry::getValue)
+				.collect(Collectors.toSet());
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public Set getUsersIsAllowed(String lock)
+	@Override
+	public Set<String> getUsersIsAllowed(String lock)
 	{
 		if (m_lazy) baseAuthzGroupService.m_storage.completeGet(this);
 
-		Set rv = new HashSet();
-		for (Iterator it = m_userGrants.entrySet().iterator(); it.hasNext();)
-		{
-			Map.Entry entry = (Map.Entry) it.next();
-			String user = (String) entry.getKey();
-			BaseMember grant = (BaseMember) entry.getValue();
-			if (grant.active && grant.role.isAllowed(lock) && !grant.isRoleViewUser())
-			{
-				rv.add(user);
-			}
-		}
-
-		return rv;
+		return m_userGrants.entrySet().stream()
+				.filter(e -> e.getValue().isActive()
+						&& e.getValue().getRole().isAllowed(lock)
+						&& !userDirectoryService.isRoleViewType(e.getKey()))
+				.map(Map.Entry::getKey)
+				.collect(Collectors.toSet());
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public Set getUsersHasRole(String role)
+	@Override
+	public Set<String> getUsersHasRole(String role)
 	{
 		if (m_lazy) baseAuthzGroupService.m_storage.completeGet(this);
 
-		Set rv = new HashSet();
-		for (Iterator it = m_userGrants.entrySet().iterator(); it.hasNext();)
-		{
-			Map.Entry entry = (Map.Entry) it.next();
-			String user = (String) entry.getKey();
-			BaseMember grant = (BaseMember) entry.getValue();
-			if (grant.active && grant.role.getId().equals(role) && !grant.isRoleViewUser())
-			{
-				rv.add(user);
-			}
-		}
-
-		return rv;
+		return m_userGrants.entrySet().stream()
+				.filter(e -> e.getValue().isActive()
+						&& e.getValue().getRole().equals(role)
+						&& !userDirectoryService.isRoleViewType(e.getKey()))
+				.map(Map.Entry::getKey)
+				.collect(Collectors.toSet());
 	}
 
 	/**

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseMember.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseMember.java
@@ -142,16 +142,4 @@ public class BaseMember implements Member
 
 		return compare;
 	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	public boolean isRoleViewUser() {
-		try {
-			User user = userDirectoryService.getUser(userId);
-			return User.ROLEVIEW_USER_TYPE.equals(user.getType());
-		} catch (UserNotDefinedException e) {
-			return false;
-		}
-	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/SakaiSecurity.java
@@ -72,10 +72,6 @@ public abstract class SakaiSecurity implements SecurityService, Observer
 	/** ThreadLocalManager key for our SecurityAdvisor Stack. */
 	protected final static String ADVISOR_STACK = "SakaiSecurity.advisor.stack";
 
-	/** Session attribute to store roleswap state **/
-	protected final static String ROLESWAP_PREFIX = "roleswap";
-	
-	protected final static String EVENT_ROLESWAP_EXIT = "roleswap.exit";
 
 	/** The update event to post to clear cached security lookups involving the authz group **/
 	protected final static String EVENT_ROLESWAP_CLEAR = "realm.clear.cache";
@@ -843,7 +839,7 @@ public abstract class SakaiSecurity implements SecurityService, Observer
 		// convert the set of Users into a sorted list of users
 		// and filter them so that only real users are displayed (not simulated users for the role view)
 		List<User> users = userDirectoryService().getUsers(ids);
-		users = users.stream().filter(user -> !User.ROLEVIEW_USER_TYPE.equals(user.getType())).collect(Collectors.toList());
+		users = users.stream().filter(user -> !UserDirectoryService.ROLEVIEW_USER_TYPE.equals(user.getType())).collect(Collectors.toList());
 		Collections.sort(users);
 
 		return users;
@@ -1045,16 +1041,6 @@ public abstract class SakaiSecurity implements SecurityService, Observer
 				resetSecurityCache(site.getReference());
 			}
 		}
-
-		if (EVENT_ROLESWAP_EXIT.equals(event.getEvent()))
-		{
-		  try {
-		    restoreUser();
-		  } catch (SakaiException e) {
-		   log.warn("Security invalidation error when handling an event ({}), for user {}", event.getEvent(), event.getResource());
-		  }
-		}
-
 	}
 
 	/**
@@ -1065,106 +1051,5 @@ public abstract class SakaiSecurity implements SecurityService, Observer
 		return StringUtils.isNotBlank(effectiveRole);
 	}
 	
-	/**
-	 * {@inheritDoc}
-	 * @throws SakaiException 
-	 */
-	public void changeToRoleViewOnSite(Site site, String role) throws SakaiException {
-		if (!unlock(SiteService.SITE_ROLE_SWAP, site.getReference())) {
-			throw new SakaiException("User don't have permissions to swap roles.");
-		}
-		User newUser = getMockupStudentInSite(site, role);
-		impersonateUser(newUser.getId());
-		setUserEffectiveRole(site.getReference(), role);
-	}
-	
-	protected User getMockupStudentInSite(Site site, String role) throws SakaiException {
-		String eid = site.getId() + "#" + role;
-		User mockupUser = null;
-		try {
-			mockupUser = userDirectoryService().getUserByEid(eid);
-		} catch (UserNotDefinedException e) {
-			return newMockupStudentInSite(site, eid, role);
-		}
-		return mockupUser;
-	}
-	
-	protected User newMockupStudentInSite(Site site, String eid, String role) throws SakaiException {
-		User newUser = null;
-		if (site != null && StringUtils.isNoneBlank(eid, role)) {
-			try {
-				newUser = userDirectoryService().addUser(null, eid, role, role, "mockup@mockup.sakai.student.com", eid, User.ROLEVIEW_USER_TYPE, null);
-				String realmId = site.getReference();
-				AuthzGroup realmEdit = authzGroupService().getAuthzGroup(realmId);
-				if (authzGroupService().allowUpdate(realmId) || siteService().allowUpdateSiteMembership(site.getId())) {
-					realmEdit.addMember(newUser.getId(), role, true, false);
-					authzGroupService().save(realmEdit);
-				}
-			} catch (Exception e) {
-				log.warn(this + ".newMockupStudentInSite: " + e.getMessage(), e);
-				throw new SakaiException(e);
-			}
-		}
-		return newUser;
-	}
-	
-	// Instance variables to store original user's session information
-	private String originalUserId;
-	private String originalUserEid;
-
-	protected void impersonateUser(String userId) throws SakaiException {
-		Session sakaiSession = sessionManager().getCurrentSession();
-
-		// Save the original user's session information
-		originalUserId = sakaiSession.getUserId();
-		originalUserEid = sakaiSession.getUserEid();
-
-		User userinfo = null;
-		String validatedUserId = null;
-		String validatedUserEid = null;
-		try {
-			// try with the user id
-			userinfo = userDirectoryService().getUser(userId);
-			validatedUserId = userinfo.getId();
-			validatedUserEid = userinfo.getEid();
-		} catch (UserNotDefinedException e) {
-			log.warn("[Portal] Exception: " + e.getLocalizedMessage());
-			throw new SakaiException(e);
-		}
-		// while keeping the official usage session under the real user id, switch over everything else to be the SU'ed user
-		// Modeled on UsageSession's logout() and login()
-		// Post an event
-		Event event = eventTrackingService().newEvent("su.become", userDirectoryService().userReference(validatedUserId), false);
-		eventTrackingService().post(event);
-		// logout - clear, but do not invalidate, preserve the usage session's current session
-		Vector saveAttributes = new Vector();
-		saveAttributes.add(UsageSessionService.USAGE_SESSION_KEY);
-		saveAttributes.add(UsageSessionService.SAKAI_CSRF_SESSION_ATTRIBUTE);
-		sakaiSession.clearExcept(saveAttributes);
-		// login - set the user id and eid into session, and refresh this user's authz information
-		sakaiSession.setUserId(validatedUserId);
-		sakaiSession.setUserEid(validatedUserEid);
-		authzGroupService().refreshUser(validatedUserId);
-		log.info("Enter into Role-Swap mode, user " + validatedUserId + " is impersonated");
-	}
-
-	protected void restoreUser() throws SakaiException {
-		if (originalUserId == null || originalUserEid == null) {
-			throw new SakaiException("Original user session information is missing");
-		}
-
-		Session sakaiSession = sessionManager().getCurrentSession();
-
-		// Restore the original user session
-		Vector saveAttributes = new Vector();
-		saveAttributes.add(UsageSessionService.USAGE_SESSION_KEY);
-		saveAttributes.add(UsageSessionService.SAKAI_CSRF_SESSION_ATTRIBUTE);
-		sakaiSession.clearExcept(saveAttributes);
-
-		sakaiSession.setUserId(originalUserId);
-		sakaiSession.setUserEid(originalUserEid);
-		authzGroupService().refreshUser(originalUserId);
-		log.info("Exit from Role-Swap mode, user " + originalUserId + " is restored");
-	}
 
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BaseUserDirectoryService.java
@@ -240,6 +240,15 @@ public abstract class BaseUserDirectoryService implements UserDirectoryService, 
 		return reference.substring(lastSeparatorIndex + 1);
 	}
 
+	public boolean isRoleViewType(String id) {
+		try {
+			User user = getUser(id);
+			return ROLEVIEW_USER_TYPE.equals(user.getType());
+		} catch (UserNotDefinedException e) {
+			return false;
+		}
+	}
+
 	/**
 	 * Access the user id extracted from a user reference.
 	 *

--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/site-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/site-components.xml
@@ -30,6 +30,7 @@
 		<lookup-method name="idManager" bean="org.sakaiproject.id.api.IdManager" />
 		<lookup-method name="notificationService" bean="org.sakaiproject.event.api.NotificationService" />
 		<lookup-method name="microsoftMessagingService" bean="org.sakaiproject.messaging.api.MicrosoftMessagingService" />
+		<lookup-method name="usageSessionService" bean="org.sakaiproject.event.api.UsageSessionService" />
 
  		<property name="autoDdl"><value>${auto.ddl}</value></property>
         <property name="databaseBeans">

--- a/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockSecurityService.java
+++ b/kernel/kernel-impl/src/test/java/org/sakai/memory/impl/test/MockSecurityService.java
@@ -158,11 +158,4 @@ public class MockSecurityService implements SecurityService
 		// TODO Auto-generated method stub
 		return null;
 	}
-
-	@Override
-	public void changeToRoleViewOnSite(Site site, String role) throws SakaiException {
-		// TODO Auto-generated method stub
-		
-	}
-
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/authz/impl/RoleSwapMembershipTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/authz/impl/RoleSwapMembershipTest.java
@@ -102,8 +102,8 @@ public class RoleSwapMembershipTest extends SakaiKernelTestBase {
 		Assert.assertFalse(authzGroupService.isAllowed("maintain", SiteService.SITE_VISIT, group2.getReference()));
 		
 		// Now go to student view
-		securityService.changeToRoleViewOnSite(site, "access");
-		String mockupUserId = site.getId().toLowerCase() + "#" + "access";
+		siteService.activateRoleViewOnSite(site.getReference(), "access");
+		String mockupUserId = site.getId().toLowerCase() + "+" + "access";
 		
 		// Update site information and get current user role on site
 		site = siteService.getSite(site.getId());

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteServiceTest.java
@@ -33,6 +33,8 @@ import org.sakaiproject.db.api.SqlService;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.event.api.UsageSessionService;
+import org.sakaiproject.exception.SakaiException;
 import org.sakaiproject.id.api.IdManager;
 import org.sakaiproject.javax.PagingPosition;
 import org.sakaiproject.memory.api.MemoryService;
@@ -158,6 +160,16 @@ public class SiteServiceTest extends DbSiteService
 	protected IdManager idManager() {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	@Override
+	protected UsageSessionService usageSessionService() {
+		return null;
+	}
+
+	@Override
+	public void activateRoleViewOnSite(String siteReference, String role) throws SakaiException {
+
 	}
 
 	@Override

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchHandler.java
@@ -15,41 +15,43 @@
  */
 package org.sakaiproject.portal.charon.handlers;
 
+import java.util.Collection;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.authz.api.Role;
-import org.sakaiproject.authz.api.SecurityService;
-import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.event.api.UsageSessionService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.portal.util.URLUtils;
 import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.Session;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RoleSwitchHandler extends BasePortalHandler
 {
 	private static final String URL_FRAGMENT = "role-switch";
-	public static final String EVENT_ROLESWAP_START = "roleswap.start";
 
-	final EventTrackingService eventTrackingService;
-	final SecurityService securityService;
-	final SiteService siteService;
+	@Autowired @Qualifier("org.sakaiproject.event.api.EventTrackingService")
+	private EventTrackingService eventTrackingService;
+	@Autowired @Qualifier("org.sakaiproject.site.api.SiteService")
+	private SiteService siteService;
 
 	public RoleSwitchHandler() {
-		eventTrackingService = ComponentManager.get(EventTrackingService.class);
-		securityService = ComponentManager.get(SecurityService.class);
-		siteService = ComponentManager.get(SiteService.class);
+		SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
 		setUrlFragment(RoleSwitchHandler.URL_FRAGMENT);
 	}
 
@@ -116,18 +118,19 @@ public class RoleSwitchHandler extends BasePortalHandler
 
 
 				activeSite.getPages().stream() // get all pages in site
-					.map(page -> page.getTools()) // tools for each page
-					.flatMap(tools -> tools.stream()) // combine all tool lists
+					.map(SitePage::getTools) // tools for each page
+					.flatMap(Collection::stream) // combine all tool lists
 					.peek(tool -> log.debug("Resetting state for site: " + activeSite.getId() + " tool: " + tool.getId()))
 					.forEach(tool -> session.getToolSession(tool.getId()).clearAttributes()); // reset each tool
 
 				portalService.setResetState("true"); // flag the portal to reset
 				
 				// Change to role view
-				securityService.changeToRoleViewOnSite(activeSite, parts[5]);
+				siteService.activateRoleViewOnSite(activeSite.getReference(), parts[5]);
 				
 				// Post an event
-				eventTrackingService.post(eventTrackingService.newEvent(EVENT_ROLESWAP_START, parts[5], parts[2], false, NotificationService.NOTI_NONE));
+				eventTrackingService.post(eventTrackingService
+						.newEvent(UsageSessionService.EVENT_ROLEVIEW_START, parts[5], parts[2], false, NotificationService.NOTI_NONE));
 
 				res.sendRedirect(URLUtils.sanitisePath(siteUrl));
 				return RESET_DONE;

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
@@ -18,12 +18,12 @@ package org.sakaiproject.portal.charon.handlers;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.event.api.UsageSessionService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.PortalHandlerException;
@@ -36,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 public class RoleSwitchOutHandler extends BasePortalHandler
 {
 	private static final String URL_FRAGMENT = "role-switch-out";
-	public static final String EVENT_ROLESWAP_EXIT = "roleswap.exit";
 
 	final EventTrackingService eventTrackingService;
 	final SecurityService securityService;
@@ -90,7 +89,8 @@ public class RoleSwitchOutHandler extends BasePortalHandler
 				portalService.setResetState("true"); // flag the portal to reset
 				
 				// Post an event
-				eventTrackingService.post(eventTrackingService.newEvent(EVENT_ROLESWAP_EXIT, null, parts[2], false, NotificationService.NOTI_NONE));
+				eventTrackingService.post(eventTrackingService
+						.newEvent(UsageSessionService.EVENT_ROLEVIEW_EXIT, null, parts[2], false, NotificationService.NOTI_NONE));
 
 				res.sendRedirect(roleExitUrl);
 				return RESET_DONE;


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49726
- user not being restored correctly
- session switching is not fundamental job of the SecurityService
- mock user email address improvements
- ComponentManager removal in RoleSwitchHandler
- general improvements in related places
- standardized naming convention to roleview