### PR TITLE
SAK-49742 Portal: Prevent tutorial launching for View Site As role

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1521,7 +1521,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
             rcontext.put("neoChatVideo", Boolean.valueOf(portalChatVideo));
             rcontext.put("portalVideoChatTimeout", portalChatVideoTimeout);
 
-            if (sakaiTutorialEnabled && thisUser != null) {
+            if (sakaiTutorialEnabled && thisUser != null && ! userDirectoryService.isRoleViewType(thisUser)) {
                 String userTutorialPref = preferences.getProperties() != null ? preferences.getProperties().getProperty("sakaiTutorialFlag") : "";
                 log.debug("Fetched tutorial config [{}] from user [{}] preferences", userTutorialPref, thisUser);
                 if (!StringUtils.equals("1", userTutorialPref)) {


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-49742

Building on a new method introduced with SAK-49726, check that the user is not a pseudo-user for 'View Site As' before proceeding to launch the tutorial.