### PR TITLE
SAK-49786 - Mailsender: A previous kernel change was incorrectly comparing a Role object…

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroup.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/BaseAuthzGroup.java
@@ -851,7 +851,7 @@ public class BaseAuthzGroup implements AuthzGroup
 
 		return m_userGrants.entrySet().stream()
 				.filter(e -> e.getValue().isActive()
-						&& e.getValue().getRole().equals(role)
+						&& e.getValue().getRole().getId().equals(role)
 						&& !userDirectoryService.isRoleViewType(e.getKey()))
 				.map(Map.Entry::getKey)
 				.collect(Collectors.toSet());


### PR DESCRIPTION
… to a role string and therefore returning no results

FYI, looks like the previous change was from SAK-49726 (#12371 )