### PR TITLE
SAK-49811 Gradebook: ‘Excuse/Include Grade’ with percentage entry distorts scores

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -816,17 +816,13 @@ public class GradebookNgBusinessService {
 		// trim the .0 (and the ,0) from the grades if present. UI removes it so lets standardise
 		// trim to null so we can better compare against no previous grade being recorded (as it will be null)
 		// Note that we also trim newGrade so that don't add the grade if the new grade is blank and there was no grade previously
-		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ".0"));
-		oldGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(oldGradeAdjusted, ".0"));
-		newGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(newGradeAdjusted, ".0"));
+		storedGradeAdjusted = FormatHelper.normalizeGrade(storedGradeAdjusted);
+		oldGradeAdjusted = FormatHelper.normalizeGrade(oldGradeAdjusted);
+		newGradeAdjusted = FormatHelper.normalizeGrade(newGradeAdjusted);
 
-		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ",0"));
-		oldGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(oldGradeAdjusted, ",0"));
-		newGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(newGradeAdjusted, ",0"));
-
-                log.debug("storedGradeAdjusted: {}", storedGradeAdjusted);
-                log.debug("oldGradeAdjusted: {}", oldGradeAdjusted);
-                log.debug("newGradeAdjusted: {}", newGradeAdjusted);
+		log.debug("storedGradeAdjusted: {}", storedGradeAdjusted);
+		log.debug("oldGradeAdjusted: {}", oldGradeAdjusted);
+		log.debug("newGradeAdjusted: {}", newGradeAdjusted);
 
 		// if comment longer than MAX_COMMENT_LENGTH chars, error.
 		// SAK-33836 - MAX_COMMENT_LENGTH controlled by sakai.property 'gradebookng.maxCommentLength'; defaults to 20,000
@@ -930,27 +926,25 @@ public class GradebookNgBusinessService {
 		String storedGradeAdjusted = storedGrade;
 		final Integer gradingType = gradebook.getGradeType();
 		if (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradingType)) {
-                        // the stored grade represents points so the number needs to be adjusted back to percentage
-                        Double storedGradePoints = new Double("0.0");
-                        if(StringUtils.isNotBlank(storedGrade)){
-                                storedGradePoints = FormatHelper.validateDouble(storedGrade);
-                        }
+			// the stored grade represents points so the number needs to be adjusted back to percentage
+			Double storedGradePoints = new Double("0.0");
+			if (StringUtils.isNotBlank(storedGrade)) {
+				storedGradePoints = FormatHelper.validateDouble(storedGrade);
+			}
 
-                        final Double maxPoints = this.getAssignment(assignmentId).getPoints();
-                        final Double storedGradePointsFromPercentage = (storedGradePoints * 100) / maxPoints;
-                        storedGradeAdjusted = FormatHelper.formatDoubleToDecimal(storedGradePointsFromPercentage);
+			final Double maxPoints = this.getAssignment(assignmentId).getPoints();
+			final Double storedGradePointsFromPercentage = (storedGradePoints * 100) / maxPoints;
+			storedGradeAdjusted = FormatHelper.formatDoubleToDecimal(storedGradePointsFromPercentage);
 		}
 		// trim the .0 (and ,0) from the grades if present. UI removes it so lets standardise.
-		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ".0"));
-		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ",0"));
+		storedGradeAdjusted = FormatHelper.normalizeGrade(storedGradeAdjusted);
 
-                log.debug("storedGradeAdjusted: {}", storedGradeAdjusted);
+		log.debug("storedGradeAdjusted: {}", storedGradeAdjusted);
 
 		GradeSaveResponse rval = null;
 
 		// save
 		try {
-			//must pass in the raw grade as the service does conversions between percentage etc
 			this.gradingService.saveGradeAndExcuseForStudent(gradebook.getUid(), assignmentId, studentUuid,
 					storedGradeAdjusted, excuse);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -813,7 +813,7 @@ public class GradebookNgBusinessService {
 			// we dont need processing of the stored grade as the service does that when persisting.
 		}
 
-		// trim the .0 from the grades if present. UI removes it so lets standardise
+		// trim the .0 (and the ,0) from the grades if present. UI removes it so lets standardise
 		// trim to null so we can better compare against no previous grade being recorded (as it will be null)
 		// Note that we also trim newGrade so that don't add the grade if the new grade is blank and there was no grade previously
 		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ".0"));
@@ -824,11 +824,9 @@ public class GradebookNgBusinessService {
 		oldGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(oldGradeAdjusted, ",0"));
 		newGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(newGradeAdjusted, ",0"));
 
-		if (log.isDebugEnabled()) {
-			log.debug("storedGradeAdjusted: " + storedGradeAdjusted);
-			log.debug("oldGradeAdjusted: " + oldGradeAdjusted);
-			log.debug("newGradeAdjusted: " + newGradeAdjusted);
-		}
+                log.debug("storedGradeAdjusted: {}", storedGradeAdjusted);
+                log.debug("oldGradeAdjusted: {}", oldGradeAdjusted);
+                log.debug("newGradeAdjusted: {}", newGradeAdjusted);
 
 		// if comment longer than MAX_COMMENT_LENGTH chars, error.
 		// SAK-33836 - MAX_COMMENT_LENGTH controlled by sakai.property 'gradebookng.maxCommentLength'; defaults to 20,000
@@ -928,13 +926,33 @@ public class GradebookNgBusinessService {
 		final String storedGrade = this.gradingService.getAssignmentScoreString(gradebook.getUid(), assignmentId,
 				studentUuid);
 
+		// if percentage entry type, reformat the grade, otherwise use points as is
+		String storedGradeAdjusted = storedGrade;
+		final Integer gradingType = gradebook.getGradeType();
+		if (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradingType)) {
+                        // the stored grade represents points so the number needs to be adjusted back to percentage
+                        Double storedGradePoints = new Double("0.0");
+                        if(StringUtils.isNotBlank(storedGrade)){
+                                storedGradePoints = FormatHelper.validateDouble(storedGrade);
+                        }
+
+                        final Double maxPoints = this.getAssignment(assignmentId).getPoints();
+                        final Double storedGradePointsFromPercentage = (storedGradePoints * 100) / maxPoints;
+                        storedGradeAdjusted = FormatHelper.formatDoubleToDecimal(storedGradePointsFromPercentage);
+		}
+		// trim the .0 (and ,0) from the grades if present. UI removes it so lets standardise.
+		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ".0"));
+		storedGradeAdjusted = StringUtils.trimToNull(StringUtils.removeEnd(storedGradeAdjusted, ",0"));
+
+                log.debug("storedGradeAdjusted: {}", storedGradeAdjusted);
+
 		GradeSaveResponse rval = null;
 
 		// save
 		try {
 			//must pass in the raw grade as the service does conversions between percentage etc
 			this.gradingService.saveGradeAndExcuseForStudent(gradebook.getUid(), assignmentId, studentUuid,
-					storedGrade, excuse);
+					storedGradeAdjusted, excuse);
 
 			if (rval == null) {
 				// if we don't have some other warning, it was all OK

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/util/FormatHelper.java
@@ -476,4 +476,23 @@ public class FormatHelper {
 			throw new NumberFormatException("Grade is not a number.");
 		}
 	}
+
+
+	/*
+	 *
+	 * Method to normalize a grade by removing trailing ".0" or ",0" and trimming it to null if it becomes empty
+	 * @param grade String to transform
+	 * @return normalized grade stripped of trailing .0 or ,0
+	 */
+	public static String normalizeGrade(String grade) {
+		if (grade == null) {
+			return null;
+		}
+
+		// Remove ".0" and ",0" suffixes, then trim the result to null if it's empty
+		String adjustedGrade = StringUtils.removeEnd(grade, ".0");
+		adjustedGrade = StringUtils.removeEnd(adjustedGrade, ",0");
+		return StringUtils.trimToNull(adjustedGrade);
+	}
+
 }

--- a/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestFormatHelper.java
+++ b/gradebookng/tool/src/test/org/sakaiproject/gradebookng/business/util/TestFormatHelper.java
@@ -89,4 +89,44 @@ public class TestFormatHelper {
 
 		Assert.assertEquals(resultScale, gradeNumber);
 	}
+	@Test
+	public void normalizeGradeRemovesTrailingZero() {
+		String grade = "89.0";
+		String expected = "89";
+
+		String actual = FormatHelper.normalizeGrade(grade);
+
+		Assert.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void normalizeGradeRemovesTrailingZeroWithComma() {
+		String grade = "89,0";
+		String expected = "89";
+
+		String actual = FormatHelper.normalizeGrade(grade);
+
+		Assert.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void normalizeGradeReturnsNullForEmptyString() {
+		String grade = "";
+		String expected = null;
+
+		String actual = FormatHelper.normalizeGrade(grade);
+
+		Assert.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void normalizeGradeReturnsNullForNullInput() {
+		String grade = null;
+		String expected = null;
+
+		String actual = FormatHelper.normalizeGrade(grade);
+
+		Assert.assertEquals(expected, actual);
+	}
+
 }


### PR DESCRIPTION
jira: https://sakaiproject.atlassian.net/browse/SAK-49811

Much of the logic added to saveExclude is adapted from the sibling methd, saveGrade. I also removed a redundant block of calls from the saveGrade method; the three deleted lines are a repetition of three lines directly above.