### PR TITLE
SAK-49757 Samigo: fix attachment to a question response and cleanup

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -44,7 +44,6 @@ import org.apache.commons.math3.util.Precision;
 
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.jsf2.model.PhaseAware;
-import org.sakaiproject.jsf2.renderer.PagerRenderer;
 import org.sakaiproject.portal.util.PortalUtils;
 import org.sakaiproject.rubrics.api.RubricsConstants;
 import org.sakaiproject.tool.api.ToolManager;
@@ -144,7 +143,7 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
   @Getter @Setter
   private int firstRow;
   @Getter @Setter
-  private int maxDisplayedRows = PagerRenderer.MAX_PAGE_SIZE;
+  private int maxDisplayedRows;
   @Getter @Setter
   private int dataRows;
   @Getter @Setter
@@ -203,7 +202,6 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
 		boolean valueChanged = false;
 		if (ContextUtil.lookupParam("resetCache") != null && ContextUtil.lookupParam("resetCache").equals("true")){
 			allAgents = null;
-			valueChanged = true;
 			searchString = null;
 		}
 
@@ -213,26 +211,29 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
 			searchString = defaultSearchString;
 		}
 
+		// Get allAgents only at the first time
+		if (allAgents == null) {
+			allAgents = getAllAgents();
+		}
+
 		List matchingAgents;
 		if (isFilteredSearch()) {
 			matchingAgents = findMatchingAgents(searchString);
 		}
 		else {
-			matchingAgents = getAllAgents(valueChanged);
+			matchingAgents = allAgents;
 		}
 		dataRows = matchingAgents.size();
-		List newAgents = new ArrayList();
+		List newAgents;
 		if (maxDisplayedRows == 0) {
-			newAgents.addAll(matchingAgents);
+			newAgents = matchingAgents;
 		} else {
 			int nextPageRow = Math.min(firstRow + maxDisplayedRows, dataRows);
-			newAgents.addAll(matchingAgents.subList(firstRow, nextPageRow));
-			log.debug("init(): subList " + firstRow + ", " + nextPageRow);
+			newAgents = new ArrayList(matchingAgents.subList(firstRow, nextPageRow));
+			log.debug("init(): subList {},{}", firstRow, nextPageRow);
 		}
 
-		agents.clear();
-		agents.addAll(newAgents);
-
+		agents = newAgents;
 	}
  
 	// Following three methods are for interface PhaseAware
@@ -349,39 +350,6 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
 		return Precision.round(this.getMaxScore(), 2)+ " " + rb.getString("point");
 	}
     }
-
-  /** This is a read-only calculated property.
-   * @return list of uppercase student initials
-   */
-  public String getAgentInitials()
-  {
-    List c = getAgents();
-    
-    
-    StringBuilder initialsbuf = new StringBuilder();  
-    
-    if (c.isEmpty())
-    {
-      return "";
-    }
-
-    for(AgentResults ar : (List<AgentResults>) c)
-    {
-      try
-      {
-        String initial = ar.getLastInitial();
-        initialsbuf.append(initial); 
-      }
-      catch (Exception ex)
-      {
-        log.warn(ex.getMessage());
-        // if there is any problem, we skip, and go on
-      }
-    }
-
-    String initials = initialsbuf.toString();
-    return initials.toUpperCase();
-  }
 
   /**
    * get the total number of students for this assessment
@@ -527,11 +495,11 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
       }
   }
 
-public List getAllAgents(boolean valueChanged)
+public List getAllAgents()
 {
 	  String publishedId = ContextUtil.lookupParam("publishedId");
 	  QuestionScoreListener questionScoreListener = new QuestionScoreListener();
-	  if (!questionScoreListener.questionScores(publishedId, this, valueChanged))
+	  if (!questionScoreListener.questionScores(publishedId, this, false))
 	  {
 		  throw new RuntimeException("failed to call questionScores.");
 	  }
@@ -569,7 +537,7 @@ public void clear(ActionEvent event) {
 		StringBuilder name1;
 		// name2 example: Doe, John
 		StringBuilder name2;
-		for(Iterator iter = getAllAgents(false).iterator(); iter.hasNext();) {
+		for(Iterator iter = allAgents.iterator(); iter.hasNext();) {
 			AgentResults result = (AgentResults)iter.next();
 			// name1 example: John Doe
 			name1 = new StringBuilder(result.getFirstName());

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -202,6 +202,7 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
 		boolean valueChanged = false;
 		if (ContextUtil.lookupParam("resetCache") != null && ContextUtil.lookupParam("resetCache").equals("true")){
 			allAgents = null;
+			valueChanged = true;
 			searchString = null;
 		}
 
@@ -213,7 +214,7 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
 
 		// Get allAgents only at the first time
 		if (allAgents == null) {
-			allAgents = getAllAgents();
+			allAgents = getAllAgents(valueChanged);
 		}
 
 		List matchingAgents;
@@ -495,11 +496,11 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
       }
   }
 
-public List getAllAgents()
+public List getAllAgents(boolean valueChanged)
 {
 	  String publishedId = ContextUtil.lookupParam("publishedId");
 	  QuestionScoreListener questionScoreListener = new QuestionScoreListener();
-	  if (!questionScoreListener.questionScores(publishedId, this, false))
+	  if (!questionScoreListener.questionScores(publishedId, this, valueChanged))
 	  {
 		  throw new RuntimeException("failed to call questionScores.");
 	  }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/SubmissionStatusBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/SubmissionStatusBean.java
@@ -37,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.jsf2.model.PhaseAware;
-import org.sakaiproject.jsf2.renderer.PagerRenderer;
 import org.sakaiproject.tool.assessment.business.entity.RecordingData;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.tool.assessment.ui.bean.util.Validator;
@@ -82,7 +81,7 @@ public class SubmissionStatusBean implements Serializable, PhaseAware {
   
   // Paging.
   private int firstScoreRow;
-  private int maxDisplayedScoreRows = PagerRenderer.MAX_PAGE_SIZE;
+  private int maxDisplayedScoreRows;
   private int scoreDataRows;
   
   // Searching

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
@@ -47,7 +47,6 @@ import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.jsf2.model.PhaseAware;
-import org.sakaiproject.jsf2.renderer.PagerRenderer;
 import org.sakaiproject.portal.util.PortalUtils;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
@@ -150,7 +149,7 @@ public class TotalScoresBean implements Serializable, PhaseAware {
   
   // Paging.
   private int firstScoreRow;
-  private int maxDisplayedScoreRows = PagerRenderer.MAX_PAGE_SIZE;
+  private int maxDisplayedScoreRows;
   private int scoreDataRows;
   
   // Searching

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -257,8 +257,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 				log.debug("item = {}:{}-{}", thisItemTextIfc.getSequence(), thisItemTextIfc.getText(), thisItemTextIfc.getItem().getItemId());
 
 			}
-			Map publishedAnswerHash = pubService
-					.preparePublishedAnswerHash(publishedAssessment);
+			Map<Long, AnswerIfc> publishedAnswerHash = pubService.preparePublishedAnswerHash(publishedAssessment);
 			// re-attach session and load all lazy loaded parent/child stuff
 
 //			Set<Long> publishedAnswerHashKeySet = publishedAnswerHash.keySet();
@@ -270,8 +269,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 //					pubItemService.eagerFetchAnswer(answer);
 //				}
 //			}
-			log.debug("questionScores(): publishedAnswerHash.size = "
-					+ publishedAnswerHash.size());
+			log.debug("questionScores(): publishedAnswerHash.size = {}", publishedAnswerHash.size());
 			Map<Long, AgentResults> agentResultsByItemGradingIdMap = new HashMap<>();
 
 			TotalScoresBean totalBean = (TotalScoresBean) ContextUtil
@@ -326,14 +324,14 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 
 			Map map = getItemScores(Long.valueOf(publishedId), Long
 					.valueOf(itemId), which, isValueChange);
-			log.debug("questionScores(): map .size = " + map.size());
+			log.debug("questionScores(): map .size = {}", map.size());
 			List allscores = new ArrayList();
 			Iterator keyiter = map.keySet().iterator();
 			while (keyiter.hasNext()) {
 				allscores.addAll((List) map.get(keyiter.next()));
 			}
 
-			log.debug("questionScores(): allscores.size = " + allscores.size());
+			log.debug("questionScores(): allscores.size = {}", allscores.size());
 
 			// now we need filter by sections selected
 			List scores = new ArrayList(); // filtered list
@@ -369,7 +367,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 				}
 			}
 
-			log.debug("questionScores(): scores.size = " + scores.size());
+			log.debug("questionScores(): scores.size = {}", scores.size());
 
 			Iterator iter = scores.iterator();
 			List agents = new ArrayList();
@@ -435,8 +433,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 				scoresByItem.put(idata.getAssessmentGradingId() + ":"
 						+ idata.getPublishedItemId(), newList);
 			}
-			log.debug("questionScores(): scoresByItem.size = "
-					+ scoresByItem.size());
+			log.debug("questionScores(): scoresByItem.size = {}", scoresByItem.size());
 			bean.setScoresByItem(scoresByItem);
 
 			try {
@@ -1123,9 +1120,8 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 			QuestionScoresBean bean, TotalScoresBean totalBean,
 			List scores, PublishedAssessmentService pubService) {
 		List sections = new ArrayList();
-		log
-				.debug("questionScores(): populate sctions publishedAssessment.getSectionArraySorted size = "
-						+ publishedAssessment.getSectionArraySorted().size());
+		log.debug("questionScores(): populate sctions publishedAssessment.getSectionArraySorted size = {}",
+				publishedAssessment.getSectionArraySorted().size());
 		Iterator iter = publishedAssessment.getSectionArraySorted().iterator();
 		int i = 1;
 		while (iter.hasNext()) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScorePagerListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScorePagerListener.java
@@ -111,7 +111,7 @@ public class QuestionScorePagerListener
 				  bean.setMaxDisplayedRows(bean.getAudioMaxDisplayedScoreRows());
 			  }
 			  else {
-				  bean.setMaxDisplayedRows(5);
+				  bean.setMaxDisplayedRows(0);
 				  bean.setAudioMaxDisplayedScoreRows(5);
 			  }
 		  }


### PR DESCRIPTION
Hi @bgarciaentornos, I spent a bunch of hours in here. It's really difficult code.

This reverts a lot of the code in SAK-48067 from Vincent. I tested paging, and it works with this code.

This also reverts some code from the Dynamic Rubrics: S2U-5 5.1.1.1 Tests & Quizzes: Dynamic Rubrics - MASTER (#12241)

My main question: is the Dynamic Rubrics code very important? It scares me because I don't understand it. And it seems to touch lots of code. Will it be maintained going forward?

Note that I also revert a bit of code from Fernando in SAK-47090 Test & Quizzes - Set a bigger number of students in Sakai Pager and set it as default selected value (#10374). I don't think that code had much of an effect as the number gets overridden via the setter.
