### PR TITLE
SAK-49894 WC SakaiGrader distorts group assignment scores with overrides

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -679,10 +679,6 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                 submission.put("grade", assignmentService.getGradeDisplay(as.getGrade(), assignment.getTypeOfGrade(), assignment.getScaleFactor()));
             }
 
-            if (StringUtils.isNotBlank(as.getGrade())) {
-                submission.put("grade", as.getGrade());
-            }
-
             boolean draft = assignmentToolUtils.isDraftSubmission(as);
             if (draft) {
                 submission.put("draft", draft);
@@ -897,9 +893,6 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                 }).filter(Objects::nonNull).collect(Collectors.toList());
 
             if (!feedbackAttachments.isEmpty()) submission.put("feedbackAttachments", feedbackAttachments);
-
-            String grade = assignmentService.getGradeForSubmitter(as, as.getSubmitters().isEmpty() ? null : as.getSubmitters().stream().findAny().get().getSubmitter());
-            if (StringUtils.isNotBlank(grade)) submission.put("grade", grade);
 
             String status = assignmentService.getSubmissionStatus(as.getId(), true);
             if (StringUtils.isNotBlank(status)) submission.put("status", status);

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
@@ -257,12 +257,12 @@ export const graderRenderingMixin = Base => class extends Base {
         ${this._renderFailed()}
       ` : nothing }
       ${this.gradeScale === SCORE_GRADE_TYPE ? html`
-        <input id="score-grade-input" aria-label="${this.i18n.number_grade_label}"
+        <input id=${ifDefined(submitter ? undefined : "score-grade-input")} aria-label="${this.i18n.number_grade_label}"
           @keydown=${this._validateGradeInput}
           @keyup=${submitter ? undefined : this._gradeSelected}
           data-user-id="${ifDefined(submitter ? submitter.id : undefined)}"
           type="text"
-          class="points-input ${ifDefined(submitter ? "grader-grade-override" : undefined)}"
+          class="points-input ${ifDefined(submitter ? "grader-grade-override" : "")}"
           .value=${submitter ? submitter.overridden ? submitter.grade : "" : this._submission.grade} />
         ${this._renderSaved()}
         ${this._renderFailed()}


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-49894

The intent of this PR is to share how to fix the specific bug described in the test plan of SAK-49894, the core problem being in AssignmentEntityProvider. The approach I took was to add a new parameter “mergeOverride” that the Grader code could explicitly invoke to solve this issue without breaking some other scenario (which I don’t know if such exists, but erring on the side of caution I thought it might).

Furthermore, the introduction of ‘mergeOverride’ exposed another bug where the “grade” value that would be returned is not formatted for displaying to users. I remove this logic (lines 682-685), given that it seems redundant based on the if-else conditional immediately preceding it (unless there’s something subtle here that I’m missing).

Given my aforementioned caution regarding scenarios to preserve (i.e., where ‘mergeOverride’ should indeed remain ‘true’), I assume that adding a unit test regarding this and other cases would be warranted. I did not attempt that here but others are more than welcome to push a commit here that would take care of that.

Finally, I made two fixes here to Grader’s text field. The “id” attribution should be conditional, displaying only for the Grade field, and not also for the grade override fields. Also, I repaired the “class” attribute such that the value of “points-input” will actually render in the DOM for the Grade field. This is important for decreasing that field’s width; otherwise, for peer evaluations, the info popover icon is forced to a new line/row.