### PR TITLE
SAK-48898 - Roster Click Here needs to have the user's name explination for screenreaders.

### DIFF
--- a/roster2/bundle/src/bundle/roster.properties
+++ b/roster2/bundle/src/bundle/roster.properties
@@ -94,7 +94,7 @@ title_msg_permissions = Define permissions for the roles in the current site.
 no_participants = No results found
 
 profile_link_text = Click Here
-profile_link_tooltip = Click here to launch this user\u0027s profile
+profile_link_tooltip = Profile of
 
 # Permissions
 roster_permissions_role = Role

--- a/roster2/tool/src/handlebars/members_cards.handlebars
+++ b/roster2/tool/src/handlebars/members_cards.handlebars
@@ -41,8 +41,8 @@
                 <div class="roster-card-label">{{tr 'facet_profile_link'}}</div>
                 <div class="roster-card-value">
                     <a href="{{{profileLink}}}"
-                            title="{{tr 'profile_link_tooltip'}}"
-                            aria-label="{{tr 'profile_link_tooltip'}}">
+                            title="{{tr 'profile_link_text'}} : {{tr 'profile_link_tooltip'}} {{displayName}}"
+                            aria-label="{{tr 'profile_link_tooltip'}} {{displayName}}">
                         {{tr 'profile_link_text'}}
                     </a>
                 </div>


### PR DESCRIPTION
This link now says

```
<a href="http://localhost:8080/portal/site/~4372ed7b-ddd7-4b5a-a944-96cd80771e04/tool/d5fe1d77-9b5e-4a41-9055-bf0b85bc2340/viewprofile/e279941b-8ca8-4441-ac18-db68c5cba455" title="Click Here : Profile of Albert Albertson" aria-label="Profile of Albert Albertson">Click Here</a>
```