### PR TITLE
SAK-49909 "u" or "d" cannot be entered as Tool Title

### DIFF
--- a/site-manage/pageorder/tool/src/webapp/content/js/orderUtil.js
+++ b/site-manage/pageorder/tool/src/webapp/content/js/orderUtil.js
@@ -34,6 +34,11 @@ $(document).ready(function(){
 
     li.addEventListener("keydown", e => {
 
+      // If user is inside input box, don't prevent them from using U or D
+      if (e.target.matches('input, textarea')) {
+        return;
+      }
+
       const el = e.target;
 
       if (e.keyCode == 68) {


### PR DESCRIPTION
Classic fix updated for a new UI!