### PR TITLE
SAK-48624 Gradebook: No blue line around currently active tabs(Grade Summary/Student Review Mode)

### DIFF
--- a/library/src/skins/default/src/sass/base/_extendables.scss
+++ b/library/src/skins/default/src/sass/base/_extendables.scss
@@ -221,9 +221,11 @@ input::placeholder {
 }
 
 .nav.nav-tabs, .sakai_tabs{
-	margin: 0 0.4em 0 0;
+	margin: 0; /* Reset margin */
 	> li{
+	    margin: 0 0.4em 0 $standard-space;
 		&.active, &.selected, &.activeTab{
+	        position: relative;
 			> a{
 				background: var(--tool-tab-active-background-color);
 				border-top: 1px solid var(--sakai-border-color);
@@ -261,7 +263,6 @@ input::placeholder {
 			border: 1px solid var(--sakai-border-color);
 			color: var(--sakai-text-color-1);
 			cursor: pointer;
-			margin: 0 0 0 $standard-space;
 			text-decoration: none;
 		}
 	}


### PR DESCRIPTION
Not sure if this is the best fix or but this does fix it. I had to move some margins around and set the position to be relative for  the active tab so it would highlight over that but it looks like it's working nice and similar to the rest other non-bootstrap tabs.

![image](https://github.com/sakaiproject/sakai/assets/27447/f18b7796-c7db-41b1-ab00-cc1b24db5d9d)

I was kind of wondering if we could get rid of this custom code and theme this directly in bootstrap but this code hasn't been touched for awhile and maybe that was tried? 