### PR TITLE
SAK-49731 - Overview: View Site As drop-down missing

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
@@ -60,9 +60,6 @@
 
 
                             <nav class="Mrphs-toolTitleNav Mrphs-container--toolTitleNav align-items-center" aria-label="${rloader.sit_toolnavigation}">
-                                #*  Role Switcher  *#
-                                #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
-
                                 #if (${tool.toolShowResetButton})
 
                                     #if ($!{tool.toolInline})
@@ -207,9 +204,6 @@
 
                         #if (${tool.hasRenderResult})
                             <nav class="Mrphs-toolTitleNav Mrphs-container Mrphs-container--toolTitleNav align-items-center">
-                                #*  Role Switcher  *#
-                                #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
-
                                 #if (${tool.toolShowResetButton})
                                     <h2 class="Mrphs-toolTitleNav__title">
                                         <a href="${tool.toolResetActionUrl}" target="${tool.toolPlacementIDJS}" title="${rloader.sit_reset}: ${tool.toolRenderResult.getTitle()}">
@@ -257,9 +251,6 @@
                         #else
                         
                             <nav class="Mrphs-toolTitleNav Mrphs-container Mrphs-container--toolTitleNav align-items-center">
-                                #*  Role Switcher  *#
-                                #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
-
                                 #if (${tool.toolShowResetButton})
                                     <h2 class="Mrphs-toolTitleNav__title">
                                         <a href="${tool.toolResetActionUrl}" target="${tool.toolPlacementIDJS}" title="${sitReset}: ${tool.toolTitle}">

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteHierarchy.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteHierarchy.vm
@@ -115,6 +115,7 @@
         #end
     #end
 
+    #parse("/vm/morpheus/snippets/roleSwitch-snippet.vm")
 
     </ol>
 </nav>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/roleSwitch-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/roleSwitch-snippet.vm
@@ -1,7 +1,6 @@
 ## Adds $viewAsStudentLink options
-
 ## Only display this if we're in view as student mode and it's not the home page
-#if ($viewAsStudentLink && !$isHomePage)
+#if ($viewAsStudentLink)
 <div id="roleSwitch" class="role-switcher me-1">
     #if ($roleSwitchState)
     	<span>$rloader.getFormattedMessage("rs_roleSwapAdvice", $roleUrlValue)</span>
@@ -27,4 +26,4 @@
         </div>
     #end ## END of IF ($roleSwitchState)
 </div>
-#end ## END of if ($viewAsStudentLink && !$isHomePage)
+#end ## END of if ($viewAsStudentLink)


### PR DESCRIPTION
@ottenhoff I know you asked about this the other day. I just pushed this snipped up to the page title and it seems to be working fine on every tool I've tried including Overview for entering and exiting Student View. I tested that it comes up fine in every Sakai tool but only verified that it works in about 10. 

I'm not sure if or why I didn't try this originally, I think I was concerned that the `<nav class="sakai-pageNav"` wasn't correctly formatted. It has a `<ol>` but not everything is in an `<li> `and many things in there were set to `d-md-none` and didn't display. But with the suggestions from @kunaljaykam to drop the css it looks like it "just works" now. I didn't try this change after that suggestion. Only Overview seems to have anything else that displays currently in that pagenav. 

This would probably need some more formatting if that pageNav ever was used. 

![image](https://github.com/sakaiproject/sakai/assets/27447/e2cd09a4-2a56-49e3-8c8c-70620398da16)
