### PR TITLE
SAK-49928 Section Info: Need a direct way to navigate back to the main “Student Memberships” page/list of Students after assigning/unassigning a Student

### DIFF
--- a/sections/sections-app/src/webapp/editStudentSections.jsp
+++ b/sections/sections-app/src/webapp/editStudentSections.jsp
@@ -194,11 +194,11 @@
             });
         </script>
 
-        <f:verbatim><span></f:verbatim>
+        <span>
         <h:commandLink action="roster" immediate="true" >
 				<h:outputText value="#{msgs.student_view_view_all} #{msgs.student_member}"/>
 			</h:commandLink>
-        <f:verbatim></span></f:verbatim>
+        </span>
 
         <t:div styleClass="verticalPadding" rendered="#{empty editStudentSectionsBean.sections}">
             <h:outputText value="#{msgs.no_sections_available}"/>

--- a/sections/sections-app/src/webapp/editStudentSections.jsp
+++ b/sections/sections-app/src/webapp/editStudentSections.jsp
@@ -194,6 +194,12 @@
             });
         </script>
 
+        <f:verbatim><span></f:verbatim>
+        <h:commandLink action="roster" immediate="true" >
+				<h:outputText value="#{msgs.student_view_view_all} #{msgs.student_member}"/>
+			</h:commandLink>
+        <f:verbatim></span></f:verbatim>
+
         <t:div styleClass="verticalPadding" rendered="#{empty editStudentSectionsBean.sections}">
             <h:outputText value="#{msgs.no_sections_available}"/>
         </t:div>

--- a/sections/sections-app/src/webapp/editStudentSections.jsp
+++ b/sections/sections-app/src/webapp/editStudentSections.jsp
@@ -195,9 +195,9 @@
         </script>
 
         <span>
-        <h:commandLink action="roster" immediate="true" >
-				<h:outputText value="#{msgs.student_view_view_all} #{msgs.student_member}"/>
-			</h:commandLink>
+            <h:commandLink action="roster" immediate="true" >
+                <h:outputText value="#{msgs.student_view_view_all} #{msgs.student_member}"/>
+            </h:commandLink>
         </span>
 
         <t:div styleClass="verticalPadding" rendered="#{empty editStudentSectionsBean.sections}">


### PR DESCRIPTION
Just added the link from what was on the menu as a link below. Reusing some of the text rather than creating a new string, seems fine for English and Spanish. But maybe this should be a new string? Though this is probably a very lightly used feature. 

![image](https://github.com/sakaiproject/sakai/assets/27447/1800d8ea-9905-421d-832d-b912e5d4a5c6)
