### PR TITLE
SAK-49895 Lessons border color property  of css class .col<color>-trans takes no effect

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -215,8 +215,8 @@
 			$shade4: #{$color}--#{$lighterOrDarker}-7;
 		}
 		.coln#{$name}, .coln#{$name}-trans {
-			background: var(--sakai-background-color-1);
-			border: 1px solid var($shade1);
+			background: var(--sakai-background-color-1) !important;
+			border: 1px solid var($shade1) !important;
 		}
 		.coln#{$name}-header, .coln#{$name}-trans-header {
 			@extend .sakai-colorize#{$shade2};
@@ -291,7 +291,7 @@
 	@include sakaiLessonsLayoutColorScheme('--sakai-lessons-navy', 'lighter', 'navy' );
 	@include sakaiLessonsLayoutColorScheme('--sakai-lessons-navy', 'darker', 'navy2' );
 
-	.colngray-trans, .colnblack-trans, .colnblue-trans, .colnblue2-trans, .colnred-trans, .colnnavy-trans, .colnnavy2-trans, .colnorange-trans, .colngold-trans, .colnteal-trans, .colnpurple-tran,
+	.colngray-trans, .colnblack-trans, .colnblue-trans, .colnblue2-trans, .colnred-trans, .colnnavy-trans, .colnnavy2-trans, .colnorange-trans, .colngold-trans, .colnteal-trans, .colnpurple-trans,
 	.colgray-trans, .colred-trans, .colblue-trans, .colgreen-trans, .colyellow-trans, .colngreen-trans {
 		border-color: transparent;
 		box-shadow: none;


### PR DESCRIPTION
Adding !important to the color overrides
Fixing Purple color

This is what it looks like with the fix. I'm not entirely sure if that's the problem here but the color styles were not getting precedence. 

![image](https://github.com/sakaiproject/sakai/assets/27447/c6011aa3-95e3-48d7-8213-4975847c52b9)
