### PR TITLE
SAK-49896 Lessons: Page layout checklists include custom CSS

### DIFF
--- a/library/src/skins/default/src/sass/base/_extendables.scss
+++ b/library/src/skins/default/src/sass/base/_extendables.scss
@@ -623,7 +623,7 @@ div.wicket-modal div.w_blue a.w_close {
 .text-success,
 .bg-success {
 	color: var(--successBanner-color);
-	background-color: var(--successBanner-bgcolor);
+	background-color: var(--successBanner-bgcolor) !important;
 }
 .text-info,
 .bg-info {
@@ -636,12 +636,12 @@ div.wicket-modal div.w_blue a.w_close {
 .text-warning,
 .bg-warning {
 	color: var(--warnBanner-color);
-	background-color: var(--warnBanner-bgcolor);
+	background-color: var(--warnBanner-bgcolor) !important;
 }
 .text-danger,
 .bg-danger {
 	color: var(--errorBanner-color);
-	background-color: var(--errorBanner-bgcolor);
+	background-color: var(--errorBanner-bgcolor) !important;
 }
 
 .close {


### PR DESCRIPTION
Feels like all of these backgrounds should have precedence for overriding bootstrap?

Not sure about the contrast of the `--successBanner-color` here but it looks a lot better than it currently is against purple. 

![image](https://github.com/sakaiproject/sakai/assets/27447/e689c391-d0ec-4324-8265-d2590834455e)
![image](https://github.com/sakaiproject/sakai/assets/27447/4c1e1fe1-6dda-4584-a7e0-c76ff5359c23)
