### PR TITLE
SAK-49784 Gradebook: Extra credit warning is not readable in dark mode.

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -286,6 +286,7 @@
   #gradeTableWrapper .gb-extra-credit,
   #gradeTableWrapper .currentRow .gb-extra-credit,
   #gradeTableWrapper .currentCol .gb-extra-credit {
+    color:var(--sakai-color-gold--darker-5);
     background-color: var(--sakai-color-gold--lighter-5) !important;
   }
   .gb-flag-equal-weight:before {


### PR DESCRIPTION
Added an explicit gold color to match the background.