### PR TITLE
SAK-47101 Sitestats: Use server time for date truncation

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/PresenceConsolidation.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/PresenceConsolidation.java
@@ -17,6 +17,7 @@ package org.sakaiproject.sitestats.impl;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -269,6 +270,8 @@ public class PresenceConsolidation {
     }
 
     private static Instant toDay(@NonNull Instant instant) {
-        return instant.truncatedTo(ChronoUnit.DAYS);
+        return instant.atZone(ZoneId.systemDefault())
+                .truncatedTo(ChronoUnit.DAYS)
+                .toInstant();
     }
 }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/PresenceRecord.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/PresenceRecord.java
@@ -18,6 +18,7 @@ package org.sakaiproject.sitestats.impl;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
@@ -143,7 +144,9 @@ public class PresenceRecord implements Presence, Comparable<PresenceRecord> {
     }
 
     private static Instant toDay(@NonNull Instant instant) {
-        return instant.truncatedTo(ChronoUnit.DAYS);
+        return instant.atZone(ZoneId.systemDefault())
+                .truncatedTo(ChronoUnit.DAYS)
+                .toInstant();
     }
 
     private static Instant today() {


### PR DESCRIPTION
There have been test failures where the truncation of the timestamp resulted in a different day than the begin time of the presence. This is because the truncation of an Instant is UTC based and in some tests a Presence record is inserted into the test db with a Date that is based on an Instant that has not been truncated. Truncating the Instants in the tests would have solved this failures as well, but to keep the behavior consistent with the previous code and other stats I changed my code to use the system timezone - not UTC - for the date truncation of the presence times.

https://sakaiproject.atlassian.net/browse/SAK-47101