### PR TITLE
SAK-49940 ckEditor: enabled dark mode results in a white line between toolbar and content

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/editor/_base.scss
@@ -143,6 +143,10 @@
 	display: inline;
 }
 
+.cke_wysiwyg_frame {
+	background: none !important; /* Use  of !important to override CKEditor's styles. */
+}
+
 .cke_dialog_contents_body .cke_tpl_list {
 	height: 430px !important;
 	background: var(--sakai-background-color-1);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49940