### PR TITLE
SAK-48749 Site Info / Manage Groups ->Bulk creation creates duplicate groups

### DIFF
--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/ImportController.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/ImportController.java
@@ -111,8 +111,8 @@ public class ImportController {
 
             //Each line must contain a groupTitle and a userEid
             if (lineContentArray.length == 2) {
-                String groupTitle = StringUtils.trimToNull(lineContentArray[0]);
-                String userEid = StringUtils.trimToNull(lineContentArray[1]);
+                String groupTitle = removeNonPrintableCharacters(StringUtils.trimToNull(lineContentArray[0]));
+                String userEid = removeNonPrintableCharacters(StringUtils.trimToNull(lineContentArray[1]));
 
                 if (StringUtils.isAnyBlank(groupTitle, userEid)) {
                     // One of the items of the line is blank, redirect to the import form again displaying an error. 
@@ -309,6 +309,13 @@ public class ImportController {
     private String returnImportError(Model model, String message, Locale userLocale) {
         model.addAttribute("errorMessage", messageSource.getMessage(message, null, userLocale));
         return showImport(model);
+    }
+
+    private String removeNonPrintableCharacters(String input) {
+        if (input == null) {
+            return null;
+        }
+        return input.replaceAll("\\p{C}", "");
     }
 
 }

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import_confirmation.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import_confirmation.html
@@ -30,8 +30,8 @@
       <input type="hidden" th:value="${importedGroupMap}" name="importedGroupMap" id="importedGroupMap"/>
         <div class="act">
           <input th:if="${!membershipErrors}" accesskey="s" id="bulk-creation-submit-button" type="submit" class="active" th:value="#{import.button.create.bulk}"/>
-          <button type="button" th:data-url="@{/import}" accesskey="b" id="bulk-creation-back-button" th:text="#{import.button.back}">Back</button>
-          <button type="button" th:data-url="@{/}" accesskey="x" id="bulk-creation-cancel-button" th:text="#{import.button.cancel}">Cancel</button>
+          <button type="button" class="btn-link" th:data-url="@{/import}" accesskey="b" id="bulk-creation-back-button" th:text="#{import.button.back}">Back</button>
+          <button type="button" class="btn-link" th:data-url="@{/}" accesskey="x" id="bulk-creation-cancel-button" th:text="#{import.button.cancel}">Cancel</button>
         </div>
       </form>
   </div>


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-48749

The CSV file in the jira's test plan has a non-printable character: first line, first character. Removing such characters when parsing the CSV file results in expected behavior.

I also styled two buttons in the Bulk Creation confirmation view that were missing bootstrap styling.