### PR TITLE
SAK-49921 Rubrics: Removing a newly-created criterion before refreshing the page shows the wrong name

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricCriteria.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricCriteria.js
@@ -310,7 +310,12 @@ export class SakaiRubricCriteria extends RubricsElement {
     criterion.new = false;
     this.requestUpdate();
 
-    this.querySelector(`sakai-item-delete[criterion-id="${e.detail.id}"]`).requestUpdate("criterion", criterion);
+    const del = this.querySelector(`sakai-item-delete[criterion-id="${e.detail.id}"]`);
+    del.criterion = criterion;
+    del.requestUpdate();
+    const edit = this.querySelector(`sakai-rubric-criterion-edit[id="criterion-edit-${e.detail.id}"]`);
+    edit.criterion = criterion;
+    edit.requestUpdate();
   }
 
   saveWeights() {


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-49921

Besides sakai-item-delete, the sakai-rubric-criterion-edit needs updating too, in light of a pending fix to its tooltip in SAK-49934. Empirically testing with a "this.requestUpdate" at the end of criterionEdited method does not propagate the necessary changes to these webcomponents. Furthermore, the absence of this.requestUpdate doesn't produce the desired changes either, so I left it at its current position (line 311).