### PR TITLE
SAK-50016 Samigo handle cell character limit exception for question pool export

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages.properties
@@ -114,6 +114,7 @@ then_click_add=then click "Add to Assessment"
 prepend_copy=Copy
 prepend_of=of
 qsfrompart=Questions from Part
+export_cell_limit=ALERT: Reached cell character limit. Probably due to a file being inserted directly, instead of its link to Resources
 
 # add/update
 add_title=Add Pool

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages.properties
@@ -114,7 +114,7 @@ then_click_add=then click "Add to Assessment"
 prepend_copy=Copy
 prepend_of=of
 qsfrompart=Questions from Part
-export_cell_limit=ALERT: Reached cell character limit. Probably due to a file being inserted directly, instead of its link to Resources
+export_cell_limit=ALERT: Reached cell character limit. This error is often caused by a file being inserted directly instead of its link.
 
 # add/update
 add_title=Add Pool

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages_ca.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages_ca.properties
@@ -113,6 +113,7 @@ then_click_add=i feu clic sobre "Afegeix a la prova"
 prepend_copy=Copia
 prepend_of=de
 qsfrompart=Preguntes de la part
+export_cell_limit=ALERTA: S\u2019ha arribat al l\u00edmit de car\u00e0cters de la cel\u00b7la. Probablement perqu\u00e8 s\u2019ha insertat un fitxer directament, en lloc del seu enlla\u00e7 a Recursos
 
 # add/update
 add_title=Afegeix el fons

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages_es.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/QuestionPoolMessages_es.properties
@@ -114,6 +114,7 @@ then_click_add=y haga clic en "A\u00f1adir a un examen"
 prepend_copy=Copia
 prepend_of=de
 qsfrompart=Preguntas desde Parte
+export_cell_limit=ALERTA: Se alcanz\u00f3 el l\u00edmite de caracteres de celda. Probablemente debido a que se insert\u00f3 un archivo directamente, en lugar de su enlace a Recursos
 
 # add/update
 add_title=A\u00f1adir bater\u00eda

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -2630,8 +2630,14 @@ String poolId = ContextUtil.lookupParam("qpid");
 							if (data instanceof Double) {
 								cell.setCellValue(((Double)data).doubleValue());
 							} else {
-								// stripping html for export, SAK-17021
-								cell.setCellValue(data.toString());
+								try {
+									// stripping html for export, SAK-17021
+									cell.setCellValue(data.toString());
+								} catch (IllegalArgumentException e) {
+									String alertMsg = rb.getString("export_cell_limit");
+									log.warn(alertMsg);
+									cell.setCellValue(alertMsg);
+								}
 							}
 						}
 					}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -2635,7 +2635,7 @@ String poolId = ContextUtil.lookupParam("qpid");
 									cell.setCellValue(data.toString());
 								} catch (IllegalArgumentException e) {
 									String alertMsg = rb.getString("export_cell_limit");
-									log.warn(alertMsg);
+									log.warn("{}, {}", alertMsg, e.toString());
 									cell.setCellValue(alertMsg);
 								}
 							}


### PR DESCRIPTION
Jira [SAK-50016](https://sakaiproject.atlassian.net/browse/SAK-50016)

This is an issue we've experienced at UPV, although I haven't been able to reproduce it on nightly servers. Anyway, catching the exception should be harmless.

This makes sure the export is successful despite exceeding the maximum char length in a cell.

It will also set a message in the problematic cell informing that something went wrong and the possible reason:
"ALERT: Reached cell character limit. Probably due to a file being inserted directly, instead of its link to Resources"

[SAK-50016]: https://sakaiproject.atlassian.net/browse/SAK-50016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ