### PR TITLE
SAK-50052 Rubrics max points do not display for imported rubrics

### DIFF
--- a/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/Rubric.java
+++ b/rubrics/api/src/main/java/org/sakaiproject/rubrics/api/model/Rubric.java
@@ -119,6 +119,7 @@ public class Rubric implements PersistableEntity<Long>, Serializable, Cloneable 
                             return clonedCriterion;
                         })
                         .collect(Collectors.toList()));
+        clonedRubric.setMaxPoints(maxPoints);
         return clonedRubric;
     }
 }


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50052

Note that the scope of this fix does not repair rubric listings already imported without this fix. (Some could be fixed if edited to prompt the update of max points, but those would likely be a minority.)