### PR TITLE
SAK-50062 Console log error for incorrect use of label for

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/search-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/search-snippet.vm
@@ -7,7 +7,7 @@
     <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="$rloader.close_search_panel"></button>
   </div>
   <div class="offcanvas-body">
-    <label class="visually-hidden" for="sakai-search-field">$rloader.enter_search_terms_instruction</label>
+    <label class="visually-hidden" for="sakai-search-input">$rloader.enter_search_terms_instruction</label>
     ## sakai search webcomponent
     <sakai-search page-size="${portalSearchPageSize}"></sakai-search>
   </div>


### PR DESCRIPTION
Looks like the webcomponent is actually creating something calledcalled `sakai-search-input `and not `sakai-search-field.` 

Not sure if we want to be more explicit about that as an attribute for this webcomponent or not?