### PR TITLE
SAK-50055 Portal add pageBody id to portal

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/site.vm
@@ -44,7 +44,8 @@
             #set ($roleSwitchClass = "swapped-view")
         #end
 
-        <div class="Mrphs-portalWrapper vh-100 portal-container $!{roleSwitchClass} $!{sidebarCollapsedClass}" tabindex="0">
+        <div id="pageBody"
+             class="Mrphs-portalWrapper vh-100 portal-container $!{roleSwitchClass} $!{sidebarCollapsedClass}" tabindex="0">
             <div class="portal-pasystem"></div>
             ## Skip Nav (a11y links)
             #parse("/vm/morpheus/snippets/skipNav-snippet.vm")


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50055

The pageBody div was removed in the trinity refactor. Instead of adding a the div back it seemed reasonable to simply add it to an existing div that encompasses the same elements as pre trinity.