### PR TITLE
SAK-49876 SiteManage tool order certain permissions can never be granted to students

### DIFF
--- a/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
+++ b/site-manage/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
@@ -120,6 +120,9 @@ public class SitePageEditHandler {
     private Set<String> defaultMultiTools
         = new HashSet(Arrays.asList(new String [] {"sakai.news", "sakai.iframe"}));
 
+    // List of tool permissions that we can never grant to students
+    List<String> instructorPermissionsOnly = Arrays.asList(SiteService.SECURE_UPDATE_SITE, SiteService.SITE_VISIT, "rubrics.manager.view");
+
     /**
      * Gets the current tool
      * @return Tool
@@ -465,7 +468,7 @@ public class SitePageEditHandler {
             return false;
         }
         List<String> permissions = getSingleToolPagePermissions(page).stream().flatMap(Collection::stream).collect(Collectors.toList());
-        return !(permissions.isEmpty() || permissions.contains(SiteService.SECURE_UPDATE_SITE) || permissions.contains(SiteService.SITE_VISIT));
+        return !(permissions.isEmpty() || instructorPermissionsOnly.stream().anyMatch(permissions::contains));
     }
 
     /**


### PR DESCRIPTION
This currently includes site.visit, site.upd, and rubrics.manager.view