### PR TITLE
SAK-50094 Gradebook titles can overflow and grid can become misaligned

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.html
@@ -8,7 +8,7 @@
         <script id="courseGradeHeaderTemplate" type="text/template">
             <span class="colHeader d-none" data-col-index="${col}">${col}</span>
             <div class="relative">
-                <a class="gb-title" wicket:message="title:sortbygrade,aria-label:sortbygrade">
+                <a class="gb-title d-block overflow-hidden text-truncate" wicket:message="title:sortbygrade,aria-label:sortbygrade">
                     <wicket:message key="column.header.coursegrade"/>
                 </a>
                 <div class="gb-title gb-grade-item-flags">
@@ -78,15 +78,17 @@
                           wicket:message="title:label.gradeitem.externalapplabel">
                     </span>
                 {/if}
-                <a class="gb-title" title="${tooltip}">
-                    ${abbrevTitle}
+                <div class="{if extraCredit && externallyMaintained} gb-item-title-3 {elseif extraCredit || externallyMaintained} gb-item-title-2 {else} gb-item-title-1 {/if} d-inline-block overflow-hidden text-truncate">
+                    <a class="gb-title" title="${tooltip}">
+                        ${abbrevTitle}
+                    </a>
                     {if hasAssociatedRubric}
                         <span class="si si-sakai-rubrics" wicket:message="title:rubrics.question_use_rubric"></span>
                     {/if}
-                </a>
+                </div>
                 {if settings.isCategoriesEnabled}
                     {if categoryId}
-                        <div class="gb-category">
+                        <div class="gb-category overflow-hidden text-truncate">
                             <wicket:message key="label.category"/>
                             {if categoryExtraCredit}
                                 <span class="gb-flag-extra-credit" wicket:message="title:label.gradeitem.extracreditcategory"></span>
@@ -94,18 +96,18 @@
                             {if categoryEqualWeight}
                                 <span class="gb-flag-equal-weight" wicket:message="title:label.gradeitem.equalweightcategory"></span>
                             {/if}
-                            <span>${categoryName}</span>
+                            <span title="${categoryName}">${categoryName}</span>
                             {if settings.isCategoryTypeWeighted}
                                 <span class="gb-category-weight">[${categoryWeight}]</span>
                             {/if}
                         </div>
                     {else}
-                        <div class="gb-uncategorized">
+                        <div class="gb-uncategorized overflow-hidden text-truncate">
                             <wicket:message key="gradebookpage.uncategorised"/>
                         </div>
                     {/if}
                 {/if}
-                <div class="gb-grade-section">
+                <div class="gb-grade-section overflow-hidden text-truncate">
                     {if settings.isPercentageGradeEntry}
                         <wicket:message key="label.relativeweight"/>
                     {else}
@@ -115,7 +117,7 @@
                         ${points}
                     </span>
                 </div>
-                <div class="gb-due-date">
+                <div class="gb-due-date overflow-hidden text-truncate">
                     <wicket:message key="label.due"/> 
                     <span>${dueDate}</span>
                 </div>
@@ -177,12 +179,12 @@
                 {if equalWeight}
                     <span class="gb-flag-equal-weight" wicket:message="title:label.gradeitem.equalweightcategory"></span>
                 {/if}
-                <a class="gb-title" title="${tooltip}">
+                <a class="gb-title {if getExtraCredit && equalWeight} gb-category-title-3 {elseif getExtraCredit || equalWeight} gb-category-title-2 {else} gb-category-title-1 {/if} d-block overflow-hidden text-truncate" title="${tooltip}">
                     <span class="gb-category">
                         <span class="swatch" style="background-color: #${color}"></span>
                         ${categoryName}
                         {if settings.isCategoryTypeWeighted}
-                            <div class="gb-category-weight-label">
+                            <div class="gb-category-weight-label overflow-hidden text-truncate">
                                 <wicket:message key="label.gradeitem.categoryaveragelabel"/>
                                 <span class="gb-category-weight" wicket:message="title:label.gradeitem.categoryweight">
                                     [${weight}]
@@ -191,7 +193,7 @@
                         {/if}
                     </span>
                 </a>
-                <div class="gb-grade-section gb-category-points-section">
+                <div class="gb-grade-section gb-category-points-section overflow-hidden text-truncate">
                     {if settings.isPercentageGradeEntry}
                         <wicket:message key="label.relativeweight"/>
                     {else}
@@ -202,7 +204,7 @@
                     </span>
                 </div>	
                 {for info in dropInfo}
-                <div class="gb-drop-info">${info}</div>
+                <div class="gb-drop-info overflow-hidden text-truncate">${info}</div>
                 {/for}
                 <div class="dropdown dropend">
                     <button type="button"
@@ -222,7 +224,7 @@
         <script id="studentHeaderTemplate" type="text/template">
             <div class="relative">
                 <div class="colHeader" data-col-index="${col}">
-                    <a class="gb-title" wicket:message="title:sortbyname,aria-label:sortbyname">
+                    <a class="gb-title d-block overflow-hidden text-truncate" wicket:message="title:sortbyname,aria-label:sortbyname">
                         <wicket:message key="column.header.students"/>
                     </a>
                     <div class="dropdown dropend">

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/model/GbGradebookData.java
@@ -560,7 +560,7 @@ public class GbGradebookData {
 			}
 			result.add(new AssignmentDefinition(a1.getId(),
 					FormatHelper.stripLineBreaks(a1.getName()),
-					FormatHelper.abbreviateMiddle(a1.getName()),
+					a1.getName(),
 					FormatHelper.formatDoubleToDecimal(a1.getPoints()),
 					FormatHelper.formatDate(a1.getDueDate(), getString("label.studentsummary.noduedate")),
 
@@ -575,7 +575,7 @@ public class GbGradebookData {
 					getIconCSSForExternalAppName(a1.getExternalAppName()),
 
 					nullable(a1.getCategoryId()),
-					FormatHelper.abbreviateMiddle(a1.getCategoryName()),
+					a1.getCategoryName(),
 					userSettings.getCategoryColor(a1.getCategoryName()),
 					nullable(categoryWeight),
 					a1.getCategoryExtraCredit(),
@@ -590,7 +590,7 @@ public class GbGradebookData {
 					&& a1.getCategoryId() != null
 					&& (a2 == null || !a1.getCategoryId().equals(a2.getCategoryId()))) {
 				result.add(new CategoryAverageDefinition(a1.getCategoryId(),
-						FormatHelper.abbreviateMiddle(a1.getCategoryName()),
+						a1.getCategoryName(),
 						(new StringResourceModel("label.gradeitem.categoryaverage").setParameters(a1.getCategoryName()))
 								.getString(),
 						nullable(categoryWeight),
@@ -616,7 +616,7 @@ public class GbGradebookData {
 					}
 					result.add(new CategoryAverageDefinition(
 							category.getId(),
-							FormatHelper.abbreviateMiddle(category.getName()),
+							category.getName(),
 							(new StringResourceModel("label.gradeitem.categoryaverage").setParameters(category.getName()))
 									.getString(),
 							nullable(categoryWeight),

--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -93,7 +93,7 @@
     padding: 4px;
   }
   #gradeTableWrapper .handsontable th > .relative > * {
-    white-space: normal;
+    white-space: nowrap;
   }
   #gradeTableWrapper .handsontable th {
     background-color: var(--sakai-background-color-2);
@@ -136,26 +136,22 @@
   }
   #gradeTableWrapper .gb-title {
     font-weight: bold;
-    white-space: normal;
     text-align: left;
     line-height: 1.2em;
-    display: inline-block;
     cursor: pointer;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   #gradeTableWrapper .gb-title.gb-sorted-asc:after {
     font-family: 'bootstrap-icons';
     content: '\F573';
     position: absolute;
-    right: 5px;
+    right: 1px;
     top: 5px;
   }
   #gradeTableWrapper .gb-title.gb-sorted-desc:after {
     font-family: 'bootstrap-icons';
     content: '\F571';
     position: absolute;
-    right: 5px;
+    right: 1px;
     top: 5px;
   }
   #gradeTableWrapper .gb-title .gb-category {
@@ -172,7 +168,8 @@
   #gradeTableWrapper .gb-grade-section,
   #gradeTableWrapper .gb-due-date,
   #gradeTableWrapper .gb-category,
-  #gradeTableWrapper .gb-drop-info {
+  #gradeTableWrapper .gb-drop-info,
+  #gradeTableWrapper .gb-uncategorized {
     text-align: left;
     font-size: 0.9em;
     line-height: 1.3em;
@@ -536,6 +533,18 @@
     box-shadow: var(--elevation-8dp);
     overflow: auto;
     clip: auto;
+  }
+  #gradeTableWrapper .gb-item-title-1,
+  #gradeTableWrapper .gb-category-title-1 {
+    width: calc(100% - 11px);
+  }
+  #gradeTableWrapper .gb-item-title-2,
+  #gradeTableWrapper .gb-category-title-2 {
+    width: calc(100% - 29px);
+  }
+  #gradeTableWrapper .gb-item-title-3,
+  #gradeTableWrapper .gb-category-title-3 {
+    width: calc(100% - 49px);
   }
   .handsontable th {
     overflow: visible; /* to allow visual cue to be rendered nicely */


### PR DESCRIPTION
Gradebook item titles and Category titles can overflow into adjacent cells (if the title doesn't have word breaks). Also column resizing allows narrowing of columns which can exacerbate the overflow issue while additionally introducing misalignment for gradebook - Student/Course grade columns may no longer line up with the grade book item columns for rows.

I have approached this by changing the overflow behavior to the use of ellipses instead of trying word wrap within the cells.