### PR TITLE
SAK-50004 Rubrics criteria comments not saved while grading

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGradingComment.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGradingComment.js
@@ -87,8 +87,7 @@ export class SakaiRubricGradingComment extends RubricsElement {
     if (sakai && sakai.editor) {
       editorOptions.toolbarSet = "BasicText";
       editorFunction = sakai.editor.launch;
-    }
-    else {
+    } else {
       editorOptions.toolbar = [ [ "Bold", "Italic", "Underline" ] ] ;
       editorFunction = CKEDITOR.replace;
     }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGradingComment.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGradingComment.js
@@ -77,15 +77,24 @@ export class SakaiRubricGradingComment extends RubricsElement {
   setupEditor() {
 
     const editorKey = `criterion-${this.criterion.id}-${this.evaluatedItemId}-comment-${this.randombit}`;
+    const editorOptions = {
+      startupFocus: true,
+      versionCheck: false,
+      removePlugins: "wordcount",
+      height: 60,
+    };
+    let editorFunction;
+    if (sakai && sakai.editor) {
+      editorOptions.toolbarSet = "BasicText";
+      editorFunction = sakai.editor.launch;
+    }
+    else {
+      editorOptions.toolbar = [ [ "Bold", "Italic", "Underline" ] ] ;
+      editorFunction = CKEDITOR.replace;
+    }
 
     try {
-      const commentEditor = sakai.editor.launch(editorKey, {
-        startupFocus: true,
-        versionCheck: false,
-        toolbarSet: "BasicText",
-        removePlugins: "wordcount",
-        height: 60,
-      });
+      const commentEditor = editorFunction(editorKey, editorOptions);
 
       commentEditor.focus();
 


### PR DESCRIPTION
jira: https://sakaiproject.atlassian.net/browse/SAK-50004

The ‘Grade’ views in Discussions where rubrics are displayed occur within an iframe. The means for setting up the comment editor between 22.x and 23.x/25.x changed such that the latter breaks when displayed within an iframe. 

The solution proposed here resolves that critical issue by using a method to set up an editor used in Sakai 22 and earlier. However, that solution is not entirely satisfactory because only Bold and Italic buttons actually display in the toolbar. Underline doesn’t seem to be defined any longer (with 4.22?) when creating an editor via CKEDITOR.replace. I’ve attached a screenshot of the tools available when [config.toolbar is set to null](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-toolbar) (i.e., display all tools). This corroborates that Underline is not available.

![UnderlineNotDefined](https://github.com/sakaiproject/sakai/assets/1661251/7cf4bde1-9f2b-4cf5-ba54-e7d5a69c91a5)
