### PR TITLE
SAK-49998 Assignments updates to group filtering, grades viewing, and navigation

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6096,6 +6096,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
         ParameterParser params = data.getParameters();
         String assignmentReference = params.getString("assignmentReference");
+        String id = params.getString("submitterId");
+        state.setAttribute(EXPANDED_USER_ID, id);
 
         if (assignmentReference == null) {
             assignmentReference = params.getString("assignmentId");
@@ -11028,8 +11030,8 @@ public class AssignmentAction extends PagedResourceActionII {
         String assignmentId = params.getString("assignmentId");
         state.setAttribute(EXPORT_ASSIGNMENT_REF, assignmentId);
         String submissionId = params.getString("submissionId");
-        String userId = params.getString("user_id");
-        state.setAttribute(EXPANDED_USER_ID, userId);
+        String id = params.getString("submitterId");
+        state.setAttribute(EXPANDED_USER_ID, id);
         
         // SAK-29314 - put submission information into state
         boolean viewSubsOnlySelected = stringToBool((String) data.getParameters().getString(PARAMS_VIEW_SUBS_ONLY_CHECKBOX));
@@ -11254,7 +11256,7 @@ public class AssignmentAction extends PagedResourceActionII {
         ParameterParser params = data.getParameters();
 
         String id = params.getString("studentId");
-        state.removeAttribute(EXPANDED_USER_ID);
+        state.setAttribute(EXPANDED_USER_ID, id);
         // remove the student id from the table
         t.remove(id);
 

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -138,8 +138,8 @@
 						#else
 							#set($assignments=false)
 							#set($assignments=$!studentAssignmentsTable.get($member))
-							#foreach ($assignment in $!assignments)
-								#if ($assignment.isGroup)
+							#foreach ($assignment in $assignments)
+								#if ($assignment.TypeOfAccess.ordinal() == 1)
 									#set($displayAssignment = $service.permissionCheckInGroups("asn.submit", $assignment, "$member.id"))
 								#else
 									#set($displayAssignment = true)
@@ -165,7 +165,7 @@
 											</span>
 										</td>
 										<td headers="assignment" data-order="$assignmentTitle">
-											<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$formattedText.escapeUrl($assignmentReference)&submissionId=$formattedText.escapeUrl($submissionReference)&option=lisofass2")">$assignmentTitle</a>
+											<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$formattedText.escapeUrl($assignmentReference)&submissionId=$formattedText.escapeUrl($submissionReference)&submitterId=$formattedText.escapeUrl($member.Id)&option=lisofass2")">$assignmentTitle</a>
 											#if ($allowAddAssignment && $allowSubmitByInstructor)
 											#set( $submitSpinnerID = "submitFor_" + $member.Id + "_" + $formattedText.escapeUrl($assignmentReference) )
 											<div class="itemAction spinnerBesideContainer">
@@ -234,14 +234,14 @@
 											#if ($assignment.TypeOfGrade.ordinal() == 1)
 												$tlang.getString("gen.nograd")
 											#elseif ($assignment.TypeOfGrade.ordinal() == 3)
-												#if ($assignment.IsGroup)
-													#if ($grade)
+												#if ($submission.Graded)
+													#if ($assignment.IsGroup)
 														$grade <abbr title="$tlang.getString("gen.group.grade")">($!service.getGradeDisplay($!submission.Grade, $assignment.TypeOfGrade, $assignment.ScaleFactor))</abbr>
-													#else
-														$tlang.getString("gen.nograd")
+													#elseif ($grade)
+														$!grade
 													#end
-												#elseif ($grade)
-													$!grade
+												#else
+													$tlang.getString("gen.nograd")
 												#end
 											#elseif ($grade)
 												$!grade


### PR DESCRIPTION
The following issues have been resolved:
- When collapsing a student or returning from the Grader or Submit on behalf of Student, the view no longer jumps back to the top.
- Assignments that are not visible to each student (group-specific assignments) are now filtered accordingly.
- The display of grades in the list has been improved.