### PR TITLE
SAK-47869 Corrected client-side file size limit check issue when uplo…

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
@@ -580,7 +580,43 @@ public class FilePickerAction extends PagedResourceHelperAction
 		context.put("stlang",srb);
 
 		ToolSession toolSession = sessionManager.getCurrentToolSession();
-		context.put("maxUploadFileSize", toolSession.getAttribute(STATE_FILE_UPLOAD_MAX_SIZE));
+
+		String uploadCeiling = ServerConfigurationService.getString("content.upload.ceiling");
+		String uploadMax = (String) toolSession.getAttribute(STATE_FILE_UPLOAD_MAX_SIZE);
+
+		if (!uploadCeiling.isBlank()) 
+		{
+			int uploadCeilingNum = Integer.MAX_VALUE;
+			int uploadMaxNum = Integer.MAX_VALUE;
+			try
+			{
+				uploadCeilingNum = Integer.parseInt(uploadCeiling);
+			}
+			catch(Exception e)
+			{
+			}
+			try
+			{
+				uploadMaxNum = Integer.parseInt(uploadMax);
+			}
+			catch(Exception e)
+			{
+			}	
+
+			if (uploadCeilingNum < uploadMaxNum) 
+			{
+				context.put("maxUploadFileSize", uploadCeiling);
+			}
+			else 
+			{
+				context.put("maxUploadFileSize", toolSession.getAttribute(STATE_FILE_UPLOAD_MAX_SIZE));
+			}
+		}
+		else 
+		{
+			context.put("maxUploadFileSize", toolSession.getAttribute(STATE_FILE_UPLOAD_MAX_SIZE));
+		}
+
 		context.put("alertMessage", "");
 		context.put("googledriveJson", toolSession.getAttribute(STATE_GOOGLEDRIVE_JSON));
 		toolSession.removeAttribute(STATE_GOOGLEDRIVE_JSON);


### PR DESCRIPTION
This is correcting a gap in the client-side file limit check of SAK-47869.  I determined that server side code sets the tool size limit to the value from content.upload.ceiling if the content.upload.max is > that the ceiling.  (see: /kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java :
	// limit to the ceiling
	if (uploadMax > m_uploadCeiling)
	{
		/**
		 * KNL-602 This is the expected behaviour of the request filter honouring the globaly configured
		 * value -DH
		 */
		log.debug("Upload size exceeds ceiling: " + ((uploadMax / 1024L) / 1024L) + " > "
				+ ((m_uploadCeiling / 1024L) / 1024L) + " megs");

		uploadMax = m_uploadCeiling;
	} 

)

 I have adjusted my code in FilePickerAction.java so that the client-side check accounts for this.
 Now, all instances of exceeding the size limit will be caught first on client.side.
 Note: this is for the attachment widget used in Announcements, Assignments, Tests & Quizzes, Calendar, Discussions, Messages.