### PR TITLE
SAK-50205 - Fix display of stores in Shopping Cart Dialog

### DIFF
--- a/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
+++ b/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
@@ -2718,7 +2718,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 				toolsCI.add(lt);
 			}
 
-			if (foorm.getLong(lt.get(LTIService.LTI_PL_CONTENTEDITOR)) > 0) {
+			if (foorm.getLong(lt.get(LTIService.LTI_MT_LAUNCH)) > 0) {
 				toolsLaunch.add(lt);
 			}
 		}


### PR DESCRIPTION
While this may seem related to the general LTI / Ckeditor issues identified in https://sakaiproject.atlassian.net/browse/SAK-50202 and https://sakaiproject.atlassian.net/browse/SAK-47327 it is not related to the JavaScript “bootstrap missing error” that causes those overall problems.

This just fixes the stores mistakenly showing up in both the top and bottom of the shopping cart dialog.