### PR TITLE
SAK-49944 - Fix Add External Tool (LTI 1.1) as an Assignment Type

### DIFF
--- a/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
+++ b/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
@@ -1506,7 +1506,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			}
 		}
 
-		String returnUrl = reqProps.getProperty("returnUrl");
+		String returnUrl = Base64DoubleUrlEncodeSafe.decode(reqProps.getProperty("returnUrl"));
 		String flow = data.getParameters().getString(FLOW_PARAMETER);
 		if (returnUrl != null) {
 			if (id != null) {


### PR DESCRIPTION
This regression was introduced when the returnUrl serialization was switched from URL Encoding to Base-64 serialization in JIRA 49209 and a de-serialization was missed in one place.  This adds the missing de-serialization.