### PR TITLE
SAK-50227 Announcements access options reset after returning from attachments view with anon role enabled

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1888,6 +1888,7 @@ public class AnnouncementAction extends PagedResourceActionII
 				context.put(HIDDEN,state.getTempHidden());
 			} 
 			
+			context.put("pubviewset", isChannelPublic(channelId));
 
 			final boolean pubview = Boolean.valueOf((String) sstate.getAttribute(SSTATE_PUBLICVIEW_VALUE)).booleanValue();
 			if (pubview)


### PR DESCRIPTION
Jira [SAK-50227](https://sakaiproject.atlassian.net/browse/SAK-50227)

In this case, the 'Access' options on the ‘Post Announcement’ view ([chef_announcements-revise.vm](https://github.com/sakaiproject/sakai/blob/cc81ae9ad4fff75bd7f0c9c6d42bb28a060dc3c3/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm#L233)) are displayed based on `pubviewset`

The issue comes when returning from the 'Add Attachments' view, as the template reloads without `pubviewset` being added into
the context

[SAK-50227]: https://sakaiproject.atlassian.net/browse/SAK-50227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ