### PR TITLE
SAK-50230 Library Revert to bootstrap-5.2.0 due to broken dark mode

### DIFF
--- a/library/src/skins/default/package-lock.json
+++ b/library/src/skins/default/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "skin-default",
       "dependencies": {
-        "bootstrap": "^5.3.3",
+        "bootstrap": "^5.2.0",
         "bootstrap-icons": "^1.11.3"
       },
       "devDependencies": {
@@ -462,9 +462,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
       "funding": [
         {
           "type": "github",
@@ -476,7 +476,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
+        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/bootstrap-icons": {

--- a/library/src/skins/default/package.json
+++ b/library/src/skins/default/package.json
@@ -14,7 +14,7 @@
     "test": "npm run css-lint && npm run css-compile"
   },
   "dependencies": {
-    "bootstrap": "^5.3.3",
+    "bootstrap": "^5.2.0",
     "bootstrap-icons": "^1.11.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading to 5.3 will require more changes to our dark mode codes