### PR TITLE
SAK-50169 Gradebook: Custom Export has a small and a large X to close the modal

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.html
@@ -27,7 +27,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="customExportModalTitle"><wicket:message key="importExport.template.button.advancedOptions"/></h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <div class="row">


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50169

<img width="1743" alt="Screenshot 2024-07-02 at 6 52 41 PM" src="https://github.com/sakaiproject/sakai/assets/102482288/ff4f8c12-4171-4b77-8dd8-709466867422">
