### PR TITLE
SAK-50274 Profile: When looking at another user's profile, the birthdate is not formatted correctly

### DIFF
--- a/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
+++ b/profile2/api/src/java/org/sakaiproject/profile2/util/ProfileConstants.java
@@ -261,7 +261,7 @@ public class ProfileConstants {
 	
 	//date format display
 	public static final String DEFAULT_DATE_FORMAT = "dd MM yyyy";
-	public static final String DEFAULT_DATE_FORMAT_HIDE_YEAR = "dd MMMM";
+	public static final String DEFAULT_DATE_FORMAT_HIDE_YEAR = "MMMM dd";
 	
 	//max number of connections to show per page
 	public static final int MAX_CONNECTIONS_PER_PAGE = 15;

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/ViewProfilePanel.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/ViewProfilePanel.java
@@ -101,9 +101,9 @@ public class ViewProfilePanel extends Panel {
 		if(dateOfBirth != null) {
 			
 			if(privacyLogic.isBirthYearVisible(userUuid)) {
-				birthday = ProfileUtils.convertDateToString(dateOfBirth, ProfileConstants.DEFAULT_DATE_FORMAT);
+				birthday = ProfileUtils.convertDateToString(dateOfBirth, null);
 			} else {
-				birthday = ProfileUtils.convertDateToString(dateOfBirth, ProfileConstants.DEFAULT_DATE_FORMAT_HIDE_YEAR);
+				birthday = ProfileUtils.convertDateToString(dateOfBirth, ProfileConstants.DEFAULT_DATE_FORMAT_HIDE_YEAR, true);
 			}
 		}
 		

--- a/profile2/util/src/java/org/sakaiproject/profile2/util/ProfileUtils.java
+++ b/profile2/util/src/java/org/sakaiproject/profile2/util/ProfileUtils.java
@@ -157,28 +157,46 @@ public class ProfileUtils {
 	
 	/**
 	 * Convert a Date into a String according to format, or, if format
-	 * is set to null, do a current locale based conversion.
+	 * is set to null, use DateFormat.MEDIUM.
+	 * Do not use locale to preserve old behavior
 	 *
 	 * @param date			date to convert
-	 * @param format		format in SimpleDateFormat syntax. Set to null to force as locale based conversion.
+	 * @param format		format in SimpleDateFormat syntax. Set to null to force DateFormat.MEDIUM.
 	 */
 	public static String convertDateToString(Date date, String format) {
+		return convertDateToString(date, format, false);
+	}
+	
+	/**
+	 * Convert a Date into a String according to format, or, if format
+	 * is set to null, use DateFormat.MEDIUM and also force using locale.
+	 *
+	 * @param date			date to convert
+	 * @param format		format in SimpleDateFormat syntax. Set to null to force DateFormat.MEDIUM and locale.
+	 * @param useLocale		Use the users locale, added a default to reduce chance of regression for code that was expecting the previous format when format 
+     *                      was not set.
+	 */
+	public static String convertDateToString(Date date, String format, boolean useLocale) {
 		
 		if(date == null || "".equals(format)) { 
 			throw new IllegalArgumentException("Null Argument in Profile.convertDateToString()");	 
 		}
 		
         String dateStr = null;
+		DateFormat formatter;
         
+        Locale userLocale = (new ResourceLoader()).getLocale();
         if(format != null) {
-        	SimpleDateFormat dateFormat = new SimpleDateFormat(format);
-        	dateStr = dateFormat.format(date);
+            if (useLocale == false) {
+                formatter = new SimpleDateFormat(format);
+            }
+            else {
+                formatter = new SimpleDateFormat(format, userLocale);
+            }
         } else {
-        	// Since no specific format has been specced, we use the user's locale.
-        	Locale userLocale = (new ResourceLoader()).getLocale();
-        	DateFormat formatter = DateFormat.getDateInstance(DateFormat.MEDIUM, userLocale);
-        	dateStr = formatter.format(date);
+        	formatter = DateFormat.getDateInstance(DateFormat.MEDIUM, userLocale);
         }
+        dateStr = formatter.format(date);
         
         if(log.isDebugEnabled()) {
         	log.debug("Profile.convertDateToString(): Input date: " + date.toString()); 


### PR DESCRIPTION
Much of the code changes in here are because I wasn't sure if adding locale support to all calls of this method would be be a regression or not, so I left that as false. I was looking at the code and it seems like it's using these strings in some places for internal use with the pickers and such and that might have problems if it was doing locale formatting. But we do want it for the display in this case. 