### PR TITLE
SAK-47101 Sitestats: Improve log output of test failure

### DIFF
--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
@@ -531,7 +531,7 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		assertEquals(FakeData.SITE_A_ID, es1.getSiteId());
 		assertEquals(eventBegin2.getUserId(), es1.getUserId());
 		totalDuration = es1.getDuration();
-		assertTrue(totalDuration == firstDuration + secondDuration);
+		assertEquals(firstDuration + secondDuration, totalDuration);
 	}
 
 	@Test


### PR DESCRIPTION
The current log of the test failure does not help much with figuring out why the assert failed. Using `assertEquals`, we should see the duration values that caused the failure.

https://sakaiproject.atlassian.net/browse/SAK-47101