### PR TITLE
SAK-50073 rubrics can not grade if adjust scores is selected

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
@@ -565,6 +565,8 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
               this._criteria = this._rubric.criteria;
               this._criteria.forEach(c => {
 
+                c.pointoverride = "";
+
                 if (!c.selectedvalue) {
                   c.selectedvalue = 0;
                 }


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50073

For master/25.x the creation of the file SakaiRubricGrading.js for commit f5902019164ca2719cdc03645b424913a541c589 (SAK-48323) omits the line that I've restored (which fixes the bug). Curiously, when merging the fix to 23.x (commit 24b455c19e9bf5d6ee1ce5d508157b0f21400572) the line I've restored is already present (or not removed).

Thus, 23.x does not have this bug and this fix is not need for 23.x.