### PR TITLE
SAK-50290 rubrics remove adjusted score when removing rubric

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
@@ -406,6 +406,7 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
     this._criteria.forEach(c => {
 
       c.ratings.forEach(r => r.selected = false);
+      c.pointoverride = "";
       c.comments = "";
       c.selectedvalue = 0;
       this.querySelectorAll("sakai-rubric-grading-comment").forEach(gc => gc.requestUpdate());


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50290

For Sakai 25+ this fix depends on the PR (https://github.com/sakaiproject/sakai/pull/12722) for SAK-50073 to be merged to master. (That dependency is not required for Sakai 23.)