### PR TITLE
SAK-50289 Resources display columns controls not hiding whole columns

### DIFF
--- a/content/content-tool/tool/src/webapp/js/content.js
+++ b/content/content-tool/tool/src/webapp/js/content.js
@@ -319,7 +319,7 @@ var setupColumnToggle = function(){
         // hides columns and sets the checkbox values
         $.each(data, function(key, value){
             if (value === 'false' || value === false) {
-                $('.' + key).hide();
+                $('.' + key).removeClass('d-md-table-cell').addClass('d-none');
                 $('#' + key + 'Tog').find('input').attr('checked', false);
             }
             else {
@@ -415,10 +415,10 @@ var setupColumnToggle = function(){
         var target = $(this).closest('span').attr('id').replace('Tog', '');
         e.stopPropagation();
         if ($(this).prop('checked') === true) {
-            $('.' + target).show();
+            $('.' + target).removeClass('d-none').addClass('d-md-table-cell');
         }
         else {
-            $('.' + target).hide();
+            $('.' + target).removeClass('d-md-table-cell').addClass('d-none');
         }
         massageColWidths();
     });

--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -193,7 +193,7 @@
     					#end
     				</div>
     		#end
-        <div class="col-xs-12 col-lg-6 col-md-4 col-sm-4 col-xs-4 btn-group-sm form-inline" style="text-align: right;padding-right:0">
+        <div class="col-xs-12 col-lg-6 col-md-4 col-sm-4 col-xs-4 btn-group-sm form-inline d-flex" style="text-align: right;padding-right:0">
             #if($showHotDropboxWidget)
               <label for="dropboxHighlight">
                   <small>$clang.getString("dropbox_highlight")</small>
@@ -210,7 +210,7 @@
               </select>
             #end
             #if (!$dropboxMode)
-              <div id="content-display-columns-dropdown" class="d-none d-sm-block dropdown">
+              <div id="content-display-columns-dropdown" class="d-none d-sm-block dropdown flex-row-reverse">
                 <button style="margin:0" type="button"
                     class="btn btn-link btn-default btn-sm resources-dropdown colPicker"
                     aria-expanded="false"
@@ -220,8 +220,8 @@
                 </button>
                 <ul class="dropdown-menu" id="columnTog">
                   <li>
-                    <span class="dropdown-item" id="accessTog">
-                      <input type="checkbox" id="accessCol" checked="checked" /><label for="accessCol">&nbsp;&nbsp;$clang.getString("gen.access")</label>
+                    <span class="dropdown-item" id="contentAccessTog">
+                      <input type="checkbox" id="contentAccessCol" checked="checked" /><label for="contentAccessCol">&nbsp;&nbsp;$clang.getString("gen.access")</label>
                     </span>
                   </li>
                   <li>
@@ -239,7 +239,7 @@
                       <input type="checkbox" id="sizeCol" checked="checked"/><label for="sizeCol">&nbsp;&nbsp;$clang.getString("gen.size")</label>
                     </span>
                   </li>
-                  <li><button class="active dropdown-item" id="saveCols">$clang.getString("gen.save")</button></li>
+                  <li><button class="active btn-primary m-2 ms-3" id="saveCols">$clang.getString("gen.save")</button></li>
                 </ul>
               </div>
             #end
@@ -293,7 +293,7 @@
 				<th id="actions2" class="actions2" scope="col">
 					##$tlang.getString("gen.actions")
 				</th>
-				<th id="access" class="access" scope="col">
+				<th id="access" class="contentAccess" scope="col">
 					$clang.getString("gen.access")
 				</th>
 				<th id="creator" class="creator" scope="col">
@@ -520,7 +520,7 @@
                         </div>
 					</td>
 					#if($item.depth > 0)
-						<td headers="access" class="d-none d-md-table-cell access" title="$item.getLongAccessLabel()#if(!$item.isAvailable()) $clang.getString('access.hidden')#end">
+						<td headers="access" class="d-none d-md-table-cell contentAccess" title="$item.getLongAccessLabel()#if(!$item.isAvailable()) $clang.getString('access.hidden')#end">
 							<span class="resource-access">$item.getShortAccessLabel()#if(!$item.isAvailable()) $clang.getString('access.hidden')#end</span>
 						</td>
 						<td headers="creator" class="creator d-none d-md-table-cell">
@@ -533,7 +533,7 @@
 							<span class="resource-size">$item.size</span>
 						</td>
 					#else
-                        <td class="access d-none d-md-table-cell" title="#if(!$item.isAvailable()) $clang.getString('access.hidden')#end">
+                        <td class="contentAccess d-none d-md-table-cell" title="#if(!$item.isAvailable()) $clang.getString('access.hidden')#end">
                           <span class="resource-access">#if(!$item.isAvailable()) $clang.getString('access.hidden')#end</span>
                         </td>
                         <td class="creator d-none d-md-table-cell">
@@ -739,7 +739,7 @@
 							<td headers="actions2" class="attach"></td>
 							<td headers="actions3" class="attach"></td>
 							#if($item.depth > 0)
-								<td class="access d-none d-md-table-cell" headers="access" title="$item.getShortAccessLabel()">
+								<td class="contentAccess d-none d-md-table-cell" headers="access" title="$item.getShortAccessLabel()">
 									<span class="resource-access">$item.getShortAccessLabel()#if(!$item.isAvailable()) $clang.getString('access.hidden')#end</span>
 								</td>
 								<td class="creator d-none d-md-table-cell" headers="creator">
@@ -752,7 +752,7 @@
 									<span class="resource-size">$item.size</span>
 								</td>
 							#else
-                                <td class="access d-none d-md-table-cell" headers="access">
+                                <td class="contentAccess d-none d-md-table-cell" headers="access">
                                   <span class="resource-access">#if(!$item.isAvailable()) $clang.getString('access.hidden')#end</span>
                                 </td>
                                 <td class="creator d-none d-md-table-cell" headers="creator">


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50289

For expedience, I retained the predominant jquery syntax for proposed fixes in the JS file. While I’m not sure why the template seeds both the d-none and d-md-table-cell to the target elements, I make sure to remove one class before adding another when either showing or hiding a given element.

I recall that the ‘access’ class is (with Trinity) used either in portal or some framework in a broader way than with Sakai 22 and earlier. Thus, I supplanted it with “contentAccess” to distinguish between the intent in Resources and intent for “access” elsewhere.

I added d-flex and flex-row-reverse classes to relevant elements to prevent the Display Columns from jumping around when it’s clicked.

Finally, I reverted the styling of the Save button back to looking like a button which seems more intuitive from a UX perspective (instead of the current look in 23 and 25 of a generic dropdown menu item).