### PR TITLE
SAK-49717 sakai-grader CKEditor does not accept text or a URL for comment when clicking link icon

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
@@ -160,6 +160,8 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
   _setup() {
 
     if (this._submission.ltiSubmissionLaunch) return;
+    //Disable Offcanvas FocusTrap
+    bootstrap.Offcanvas.prototype._initializeFocusTrap = function () { return { activate() {}, deactivate() {} }; };
 
     this.feedbackCommentEditor = this._replaceWithEditor("grader-feedback-comment", data => {
       this._submission.feedbackComment = data;


### PR DESCRIPTION
I researched this awhile and noticed that Offcanvas like Modal has a focus trap which is why this focus is unable to go into the CKEditor popups.

This comment clued me into this https://stackoverflow.com/a/75091146/3708872 but Offcanvas uses the same 
https://github.com/twbs/bootstrap/blob/e20cc0d660f72c12befbfcbe90eef2aa39655c48/js/src/offcanvas.js#L71

I'm not sure if there's a better way to handle this or if  there's a11y regressions but this seems to work with some basic testing I've done on this grader panel.

I did notice in an earlier jira you tried to simplify the editor panel mostly because of this error but it was mentioned that it was a regression from 22 and still gave users the capability of accessing these links. 