### PR TITLE
SAK-50262 Rubrics criterion comments don’t always display

### DIFF
--- a/assignment/tool/src/webapp/js/studentViewSubmission.js
+++ b/assignment/tool/src/webapp/js/studentViewSubmission.js
@@ -4,6 +4,10 @@ var ASN_TS_API = ASN_TS_API || {};
 
 window.i18nWlogTab = [];
 
+if (window.location !== window.parent.location) {
+  includeWebjarLibrary('bootstrap');
+}
+
 /* For the cancel button - if the user made progress, we need them to confirm that they want to discard their progress */
 ASN_SVS.confirmDiscardOrSubmit = function(editorInstanceName, attachmentsModified)
 {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentComment.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentComment.js
@@ -1,6 +1,7 @@
 import { RubricsElement } from "./RubricsElement.js";
 import { html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 export class SakaiRubricStudentComment extends RubricsElement {
 
@@ -15,12 +16,6 @@ export class SakaiRubricStudentComment extends RubricsElement {
     this.triggerId = `criterion-comment-${value.id}-trigger${Math.floor(Math.random() * 90 + 10)}`;
 
     this.requestUpdate("criterion", oldValue);
-    this.updateComplete.then(() => {
-
-      const triggerEl = this.querySelector("button");
-      bootstrap.Popover.getInstance(triggerEl)?.hide();
-      new bootstrap.Popover(triggerEl);
-    });
   }
 
   get criterion() {
@@ -28,27 +23,40 @@ export class SakaiRubricStudentComment extends RubricsElement {
   }
 
   handleClose() {
-    bootstrap.Popover.getInstance(document.getElementById(this.triggerId))?.hide();
+    this.hideComment();
   }
 
   shouldUpdate() {
     return this._i18n;
   }
 
+  hideComment() {
+    bootstrap.Dropdown.getOrCreateInstance(this.querySelector(".dropdown-menu"))?.hide();
+  }
+
   render() {
 
     return html`
-      <button id="${ifDefined(this.triggerId)}"
-          type="button"
-          tabindex="0"
-          data-bs-toggle="popover"
-          data-bs-html="true"
-          data-bs-content="${this.criterion.comments}"
-          data-bs-title="${this.criterion.title}"
-          aria-label="${this._i18n.criterion_comment_student}"
-          class="btn btn-transparent">
-        <i class="bi bi-chat${this.criterion.comments ? "-fill" : ""} ${this.criterion.comments ? "active" : ""}"></i>
-      </button>
+      <div class="dropdown" id="${ifDefined(this.triggerId)}">
+        <button class="btn btn-transparent ${this.criterion.comments ? "" : "disabled"}"
+            type="button"
+            data-bs-toggle="dropdown"
+            data-bs-auto-close="false"
+            aria-label="${this._i18n.criterion_comment_student}"
+            aria-expanded="false">
+          <i class="bi bi-chat${this.criterion.comments ? "-fill" : ""} ${this.criterion.comments ? "active" : ""}"></i>
+        </button>
+
+        <div class="rubric-comment-dropdown dropdown-menu">
+          <div class="m-2 rubric-comment-body">
+            <div class="fw-bold rubric-criterion-comment-title">${this.tr("comment_for_criterion", [ this.criterion.title ])}</div>
+            <div>${unsafeHTML(this.criterion.comments)}</div>
+            <div class="buttons act float-end">
+              <button type="button" class="active btn-xs" @click=${this.hideComment}>${this._i18n.done}</button>
+            </div>
+          </div>
+        </div>
+      </div>
     `;
   }
 }


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50262

Similar to the solution adopted for SAK-50010 and for the sake of consistency with that approach, this proposed solution jettisons the use of bootstrap popovers, supplanting them with bootstrap dropdowns.

The revision for the Assignments javascript is to cover a niche case where a student accesses their assignments feedback by clicking a link within a Lessons page. Note that the conditional loading of the bootstrap webjar library must be qualified. If it's loaded when the Assignments tool is not embedded within an iframe, then the dropdowns will not display when clicked (assuming a comment is present).