### PR TITLE
SAK-50326 Prevent frequent webcomponents build failures

### DIFF
--- a/webcomponents/tool/pom.xml
+++ b/webcomponents/tool/pom.xml
@@ -131,6 +131,15 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>npm cache clean</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>cache clean --force</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>npm install</id>
                         <goals>
                             <goal>npm</goal>


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50326

Attached to the jira are three out of many frequent examples where I've encountered build failures with webcomponents/tool/pom.xml during the 'npm install' step. These have occurred since the changes introduced with SAK-50230. Since introducing the proposed changes which force the npm cache to be clearnd, I've not experienced any further build failures due to the npm install step. (The additional time it takes to execute this extra step of clearing the npm's cache is negligible, in my experience.)