### PR TITLE
SAK-50334 Rubrics ensure dom element IDs are unique during rubric deletion

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiItemDelete.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiItemDelete.js
@@ -44,8 +44,8 @@ export class SakaiItemDelete extends RubricsElement {
       <button
           class="btn btn-sm"
           data-bs-toggle="modal"
-          data-bs-target="#delete-${this.item.id}"
-          aria-controls="delete-${this.item.id}"
+          data-bs-target="#delete-${this.type}-${this.item.id}"
+          aria-controls="delete-${this.type}-${this.item.id}"
           aria-expanded="false"
           title="${this.tr("remove", [ this.item.title ])}"
           aria-label="${this.tr("remove", [ this.item.title ])}"
@@ -53,16 +53,16 @@ export class SakaiItemDelete extends RubricsElement {
         <span class="fa fa-times pe-none" style="pointer-events: none;"></span>
       </button>
 
-      <div id="delete-${this.item.id}"
+      <div id="delete-${this.type}-${this.item.id}"
           tabindex="-1"
           class="modal"
           data-bs-backdrop="static"
-          aria-labelledby="delete-modal-label-${this.item.id}"
+          aria-labelledby="delete-modal-label-${this.type}-${this.item.id}"
           aria-hidden="true">
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title" id="delete-modal-label-${this.item.id}">
+              <h5 class="modal-title" id="delete-modal-label-${this.type}-${this.item.id}">
                 ${this.tr("delete_item_title", [ this.type === "criterion" ? this._i18n.criterion : this._i18n.rubric ])}
               </h5>
               <button type="button"


### PR DESCRIPTION
…component gets used for deleting rubrics and criteria.  Deleting a rubric with ID 3 would generate the same elements as deleting a criterion with ID 3.  When that happens, triggering the modals is problematic.  New functionality will now include the type (rubric/criterion) when generating the IDs.