### PR TITLE
SAK-50308 Scorm while viewing results and clicking next page produces exception

### DIFF
--- a/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiDataTable.java
+++ b/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiDataTable.java
@@ -21,16 +21,16 @@ package org.sakaiproject.wicket.ajax.markup.html.table;
 import java.util.List;
 
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackDefaultDataTable;
-import org.apache.wicket.extensions.markup.html.repeater.data.table.HeadersToolbar;
+import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackHeadersToolbar;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.ISortableDataProvider;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NoRecordsToolbar;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.ResourceModel;
 
-public class SakaiDataTable extends AjaxFallbackDefaultDataTable
-{
-    private static final long	serialVersionUID	= 1L;
+
+public class SakaiDataTable extends AjaxFallbackDefaultDataTable {
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructor
@@ -44,20 +44,26 @@ public class SakaiDataTable extends AjaxFallbackDefaultDataTable
      * @param pageable
      *            table should have paging controls
      */
-    public SakaiDataTable(String id, final List<IColumn> columns, ISortableDataProvider dataProvider, boolean pageable)
-    {
+    public SakaiDataTable(String id, final List<IColumn> columns, ISortableDataProvider dataProvider, boolean pageable) {
         super(id, columns, dataProvider, 20);
-        ((RepeatingView) get("topToolbars:toolbars")).removeAll();
-        ((RepeatingView) get("bottomToolbars:toolbars")).removeAll();
+        delayAddToolbars(dataProvider, pageable);
+    }
 
-        //((WebMarkupContainer) this.getTopToolbars()).removeAll();
-        //((WebMarkupContainer) this.getBottomToolbars()).removeAll();
-
-        if(pageable)
-        {
+    private void delayAddToolbars (ISortableDataProvider dataProvider, boolean pageable) {
+        if (pageable) {
             addTopToolbar(new SakaiNavigationToolBar(this));
         }
-        addTopToolbar(new HeadersToolbar(this, dataProvider));
+
+        addTopToolbar(new AjaxFallbackHeadersToolbar(this, dataProvider));
         addBottomToolbar(new NoRecordsToolbar(this, new ResourceModel("no_data")));
+    }
+
+    @Override
+	/**
+	 * Overridden method to addToolBars
+	 * @param dataProvider {@link org.apache.wicket.extensions.markup.html.repeater.data.table.ISortableDataProvider}
+	 */
+	protected void addToolBars(final ISortableDataProvider dataProvider) {
+        //Do nothing to prevent toolbar from being created in the super
     }
 }

--- a/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiPagingNavigator.html
+++ b/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiPagingNavigator.html
@@ -22,8 +22,8 @@
 <html xmlns:wicket>
 <body>
   <wicket:panel>
-    <input type="submit" wicket:id="first" wicket:message="value:pager_textFirst"/>
-    <input type="submit" wicket:id="prev" wicket:message="value:pager_textPrev"/>
+    <a wicket:id="first" class="btn btn-light"><wicket:message key="pager_textFirst"/></a>
+    <a wicket:id="prev" rel="prev" class="btn btn-light"><wicket:message key="pager_textPrev"/></a>
     <span wicket:id="navigation">
           <a wicket:id="pageLink" href="#"><span wicket:id="pageNumber">5</span></a>
     </span>
@@ -31,8 +31,8 @@
             <option>10</option>
             <option>20</option>
         </select>
-    <input type="submit" wicket:id="next" wicket:message="value:pager_textNext"/>
-    <input type="submit" wicket:id="last" wicket:message="value:pager_textLast"/>
+    <a wicket:id="next" rel="next" class="btn btn-light"><wicket:message key="pager_textNext"/></a>
+    <a wicket:id="last" class="btn btn-light"><wicket:message key="pager_textLast"/></a>
   </wicket:panel>
 </body>
 </html>

--- a/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiPagingNavigator.html
+++ b/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiPagingNavigator.html
@@ -22,8 +22,8 @@
 <html xmlns:wicket>
 <body>
   <wicket:panel>
-    <a wicket:id="first" class="btn btn-light"><wicket:message key="pager_textFirst"/></a>
-    <a wicket:id="prev" rel="prev" class="btn btn-light"><wicket:message key="pager_textPrev"/></a>
+    <a wicket:id="first" class="btn btn-light first"><wicket:message key="pager_textFirst"/></a>
+    <a wicket:id="prev" rel="prev" class="btn btn-light prev"><wicket:message key="pager_textPrev"/></a>
     <span wicket:id="navigation">
           <a wicket:id="pageLink" href="#"><span wicket:id="pageNumber">5</span></a>
     </span>
@@ -31,8 +31,8 @@
             <option>10</option>
             <option>20</option>
         </select>
-    <a wicket:id="next" rel="next" class="btn btn-light"><wicket:message key="pager_textNext"/></a>
-    <a wicket:id="last" class="btn btn-light"><wicket:message key="pager_textLast"/></a>
+    <a wicket:id="next" rel="next" class="btn btn-light next"><wicket:message key="pager_textNext"/></a>
+    <a wicket:id="last" class="btn btn-light last"><wicket:message key="pager_textLast"/></a>
   </wicket:panel>
 </body>
 </html>

--- a/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiPagingNavigator.java
+++ b/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/table/SakaiPagingNavigator.java
@@ -69,56 +69,18 @@ public class SakaiPagingNavigator extends AjaxPagingNavigator
     }
 
     @Override
-    protected void onBeforeRender()
-    {
-        if (get("pageSizeSelector") == null)
-        {
-            setDefaultModel(new CompoundPropertyModel(this));
+    protected void onInitialize() {
+        super.onInitialize();
+        setDefaultModel(new CompoundPropertyModel(this));
 
-            // Get the row number selector
-            add(newPageSizeSelector(getPageable()));
+        // Get the row number selector
+        add(newPageSizeSelector(getPageable()));
 
-            // Add additional page links
-            replace(newPagingNavigationLink("first", getPageable(), 0));
-            replace(newPagingNavigationIncrementLink("prev", getPageable(), -1));
-            replace(newPagingNavigationIncrementLink("next", getPageable(), 1));
-            replace(newPagingNavigationLink("last", getPageable(), -1));
-        }
-        super.onBeforeRender();
-    }
-
-    /**
-     * Create a new increment link. May be subclassed to make use of specialized links, e.g. Ajaxian
-     * links.
-     *
-     * @param id
-     *            the link id
-     * @param pageable
-     *            the pageable to control
-     * @param increment
-     *            the increment
-     * @return the increment link
-     */
-    protected Link newPagingNavigationIncrementLink(String id, IPageable pageable, int increment)
-    {
-        return new AjaxPagingNavigationIncrementLink(id, pageable, increment);
-    }
-
-    /**
-     * Create a new pagenumber link. May be subclassed to make use of specialized links, e.g.
-     * Ajaxian links.
-     *
-     * @param id
-     *            the link id
-     * @param pageable
-     *            the pageable to control
-     * @param pageNumber
-     *            the page to jump to
-     * @return the pagenumber link
-     */
-    protected Link newPagingNavigationLink(String id, IPageable pageable, int pageNumber)
-    {
-        return new AjaxPagingNavigationLink(id, pageable, pageNumber);
+        // Add additional page links
+        addOrReplace(newPagingNavigationLink("first", getPageable(), 0));
+        addOrReplace(newPagingNavigationIncrementLink("prev", getPageable(), -1));
+        addOrReplace(newPagingNavigationIncrementLink("next", getPageable(), 1));
+        addOrReplace(newPagingNavigationLink("last", getPageable(), -1));
     }
 
     protected DropDownChoice newPageSizeSelector(final IPageable pageable)


### PR DESCRIPTION
Some cleanups I did here
* Cleaned up the code in `SakaiDataTable` that removes components and instead it just overrides the addToolBar to do nothing and adds them in afterward. This wasn't necessary for the fix but it seemed like a better pattern than was there and was something I'd tested earlier. I had to do this to delay to retain the pageable parameter, though it was set to `true `in all instances in Scorm so probably unnecessary.
* Converted the inputs to anchors in the html to match what's in the current base [PagingNavigator](https://github.com/apache/wicket/blob/master/wicket-core/src/main/java/org/apache/wicket/markup/html/navigation/paging/PagingNavigator.html). I believe this was the ultimate fix and these input's no longer worked with the Ajax pattern. 

Since it converted from an input to an anchor, I used the bootstrap styles so they still look like buttons but work fine.
![image](https://github.com/user-attachments/assets/9c833e69-76bb-49e0-b9af-bfcf8e8f3bf2)

This looks _really close_ to the navigation in other tools but not 100% (this is from announcements). 
![image](https://github.com/user-attachments/assets/0a349d68-66e5-4df9-953c-b7f0d4d985c9)

* I removed some unnecessary code and move the code that creates these components to `onInitialize` in `SakaiPagingNavigator`.

Some notes:

* The buttons are not disabled when they won't have do anything like in other tools however. I'm not sure if it's worth the effort to fix this.
* SiteStats has similar components but it doesn't look like it uses them, instead it uses `SakaiInfinitePagingDataTable`. It's probably worth putting this in a more centralized space and maybe even using that other DataTable?