### PR TITLE
SAK-50335 Resources: link migration not working for URL content

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -7470,7 +7470,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 				ContentResource thisContentResource = (ContentResource) sourceResourceIterator.next();
 				tId = thisContentResource.getId();
 				String sourceType = thisContentResource.getContentType();
-				if(sourceType.startsWith("text/html")){
+				if(sourceType.startsWith(ResourceType.MIME_TYPE_HTML) || sourceType.startsWith(ResourceType.MIME_TYPE_URL)){
 					String oldReference = tId;
 					tId = siteIdSplice(tId, toContext);
 					ContentResource oldSiteContentResource = getResource(oldReference);


### PR DESCRIPTION
Jira: [SAK-50335](https://sakaiproject.atlassian.net/browse/SAK-50335)

Applied the existing linkMigration logic to URLs

Replaced the existing "text/html" by its ResourceType constant