### PR TITLE
SAK-50359 Portal: Background not darkened when timeout warning displays

### DIFF
--- a/library/src/webapp/bundled-js/sakai.morpheus.session.js
+++ b/library/src/webapp/bundled-js/sakai.morpheus.session.js
@@ -41,7 +41,7 @@ function createDHTMLMask(callback) {
   portalMask.id = 'portalMask';
   portalMask.style.height = `${document.documentElement.scrollHeight}px`;
   portalMask.style.width = '100%';
-  portalMask.style.zIndex = '1300';
+  portalMask.style.zIndex = '1000';
   portalMask.style.top = '0';
   portalMask.style.left = '0';
   portalMask.style.position = 'absolute';
@@ -142,8 +142,8 @@ function show_timeout_alert(min){
   }
   
   if (!$PBJQ("#portalMask").get(0)) {
-    createDHTMLMask(dismiss_session_alert);
-    $PBJQ("#portalMask").css("z-index", 1300);
+    createDHTMLMask();
+    $PBJQ("#portalMask").css("z-index", 1000);
   }
   if ($PBJQ("#timeout_alert_body").get(0)) {
     //its there, just update the min


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50359

The dismiss_session_alert callback function when calling createDHTMLMask immediately calls that function which removes the portalMask div. Omitting this callback function prevents that, so that the portalMask div is removed when the timeout warning is dismissed by the user.

Also, the portalMask's z-index when set to 1300 overlaps the timeout warning modal. Setting it to 1000 places portalMask behind that modal.

Refer to the 'PortalMaskExpected-*.png' attachments in the jira for the results of implementing the proposed fix.