### PR TITLE
SAK-50376 Roster print button does not work

### DIFF
--- a/roster2/tool/src/webapp/js/roster.js
+++ b/roster2/tool/src/webapp/js/roster.js
@@ -22,7 +22,7 @@ roster.setupPrintButton = function () {
           Promise.all(Array.from(document.querySelectorAll("sakai-user-photo"))
             .map(sup => sup.updateComplete)).then(() => {
 
-            imagesLoaded("#roster-members-content", () => {
+            $().imagesLoaded("#roster-members-content", () => {
 
               button.disabled = false;
               window.print();
@@ -42,7 +42,7 @@ roster.setupPrintButton = function () {
 
   // Exit "printMode" after print is done
   window.addEventListener('afterprint', event => {
-    roster.renderMembership({ renderAll: true, printMode: false });
+    roster.renderMembership({ runAsync: true, renderAll: true, printMode: false });
   });
 };
 
@@ -351,6 +351,7 @@ roster.renderMembership = function (options) {
     $('#roster-members').empty();
   }
 
+  const runAsync = (options.runAsync) ? true : false;
   let url = "/direct/roster-membership/" + roster.siteId;
 
   if (roster.userIds) {
@@ -399,7 +400,7 @@ roster.renderMembership = function (options) {
     url: url,
     dataType: "json",
     cache: false,
-    async: false,
+    async: runAsync,
     success: function (data) {
 
       if (data.status && data.status === 'END') {


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50376

The revision to line 25 now makes a valid reference where imagesLoaded is defined.

When the Print action ends, the ajax part of the renderMembership function needs to be run with async set to true. Thus I've added a new option in order to retain the changes made to fix SAK-50196 (where async needs to be set to false).

In the course of troubleshooting this jira, I've also found that includeStandardHead.vm in the portal code for 23.x is loading /webcomponents/bundles/base.js (where imagesLoaded is defined during runtime) twice:
https://github.com/sakaiproject/sakai/blob/23.x/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeStandardHead.vm

Because the duplication is not a problem in master, the second instance (line 91 currently) should probably be removed if/when merging a fix to 23.x.