### PR TITLE
SAK-50433 Samigo separate pathway for single publish and bulk publish

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ActionSelectListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ActionSelectListener.java
@@ -21,6 +21,7 @@
 
 package org.sakaiproject.tool.assessment.ui.listener.author;
 
+import javax.faces.component.UICommand;
 import javax.faces.event.AbortProcessingException;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.ActionListener;
@@ -115,7 +116,7 @@ public class ActionSelectListener implements ActionListener {
 			}
 			else {
 				PublishAssessmentListener publishAssessmentListener = new PublishAssessmentListener();
-				publishAssessmentListener.processAction(null);
+				publishAssessmentListener.processAction(null); // Null here means code will not immediately publish
 				author.setOutcome("saveSettingsAndConfirmPublish");		
 			}
 			author.setFromPage("author");
@@ -140,7 +141,10 @@ public class ActionSelectListener implements ActionListener {
 		}
 		else if ("publish_selected".equals(action)) {
 			PublishAssessmentListener publishAssessmentListener = new PublishAssessmentListener();
-			publishAssessmentListener.processAction(null);
+			UICommand component = new UICommand();
+			component.getAttributes().put("origin", "publish_selected");
+			ActionEvent newActionEvent = new ActionEvent(component);
+			publishAssessmentListener.processAction(newActionEvent);
 			author.setJustPublishedAnAssessment(false);
 		}
 		else if ("scores".equals(action)) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
@@ -162,7 +162,7 @@ public class PublishAssessmentListener
           String origin = (String) eventSource.getAttributes().get("origin");
 
           // This is the bulk publish option: let it through
-          if (origin != null && origin.equals("publish_selected")) {
+          if ("publish_selected".equals(origin)) {
               repeatedPublish = false;
           }
           else if (vb == null) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
@@ -145,40 +145,45 @@ public class PublishAssessmentListener
   @Override
   public void processAction(ActionEvent ae) throws AbortProcessingException {
 
-	  repeatedPublishLock.lock();
+      repeatedPublishLock.lock();
 
-	  try {
-  		//FacesContext context = FacesContext.getCurrentInstance();
-        if (ae == null) {
-            repeatedPublish = false;
-        } else {
-  			UIComponent eventSource = (UIComponent) ae.getSource();
-  			ValueBinding vb = eventSource.getValueBinding("value");
-  			if (vb == null) {
-  				repeatedPublish = false;
-  				return;
-  			}
-  			else {
-  				String buttonValue = (String) vb.getExpressionString(); 
-  				if(buttonValue.endsWith(".button_unique_save_and_publish}"))
-  				{
-  					repeatedPublish = false;
-  					return;
-  				}
-  			}
-  		}
+      // If instructor goes straight to publish from the main authoring page, the ae will be null and the instructor needs to do one more step before publishing
+      if (ae == null) {
+          repeatedPublish = false;
+          return;
+      }
 
-		if (!repeatedPublish) {
+      try {
+          UIComponent eventSource = (UIComponent) ae.getSource();
+          ValueBinding vb = eventSource.getValueBinding("value");
 
-			AuthorBean author = (AuthorBean) ContextUtil.lookupBean("author");
+          // We are coming from a different listener and being thrown over here. This helps determine where we are coming from
+          // See ActionSelectListener
+          String origin = (String) eventSource.getAttributes().get("origin");
 
-  			AuthorizationBean authorization = (AuthorizationBean) ContextUtil.lookupBean("authorization");
+          // This is the bulk publish option: let it through
+          if (origin != null && origin.equals("publish_selected")) {
+              repeatedPublish = false;
+          }
+          else if (vb == null) {
+              repeatedPublish = false;
+              return;
+          }
+          else {
+              String buttonValue = vb.getExpressionString();
+              if (buttonValue.endsWith(".button_unique_save_and_publish}")) {
+                  repeatedPublish = false;
+                  return;
+              }
+          }
 
-  			AssessmentSettingsBean assessmentSettings = (AssessmentSettingsBean) ContextUtil.lookupBean("assessmentSettings");
+          if (!repeatedPublish) {
+              AuthorBean author = (AuthorBean) ContextUtil.lookupBean("author");
+              AuthorizationBean authorization = (AuthorizationBean) ContextUtil.lookupBean("authorization");
+              AssessmentSettingsBean assessmentSettings = (AssessmentSettingsBean) ContextUtil.lookupBean("assessmentSettings");
+              AssessmentService assessmentService = new AssessmentService();
 
-  			AssessmentService assessmentService = new AssessmentService();
-
-			if (assessmentSettings != null && assessmentSettings.getAssessmentId() != null) {
+              if (assessmentSettings != null && assessmentSettings.getAssessmentId() != null) {
 
                 // This is a single publishing operation
                 AssessmentFacade singleAssessment = assessmentService.getAssessment(
@@ -192,7 +197,7 @@ public class PublishAssessmentListener
                 authorActionListener.prepareAssessmentsList(author, authorization, assessmentService, gradingService, publishedAssessmentService);
                 repeatedPublish = true;
                 return;
-            }
+              }
 
             // Assume this is a bulk publishing operation
             List assessmentList = author.getAllAssessments();


### PR DESCRIPTION
The idea here is to use a JSF attribute to tell the PublishAssessmentListener where we are coming from. 

There are multiple scenarios as the bulk publish introduced a new one:

1) Bulk publish from the authoring screen
2) Single publish from the authoring screen
3) Confirmed publish from the notification screen
4) Publish from the settings screen