### PR TITLE
SAK-50404 Discussions: Statistics and grading page does not follow responsive mode.

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsList.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/statistics/dfStatisticsList.jsp
@@ -21,7 +21,7 @@
         });
         </script>
         <%@ include file="/jsp/discussionForum/menu/forumsMenu.jsp" %>
-  		<h:panelGrid columns="2" width="100%" styleClass="navPanel  specialLink">
+  		<h:panelGrid columns="1" width="100%" styleClass="navPanel  specialLink">
           <h:panelGroup>
 			  <div class="page-header">
 			 	<f:verbatim><h1></f:verbatim>
@@ -42,7 +42,7 @@
 		  </h:panelGroup>
         </h:panelGrid>
   	
-      <div class="table">
+      <div class="table table-responsive">
   		<h:dataTable styleClass="table table-hover table-striped table-bordered lines nolines" id="members" value="#{mfStatisticsBean.allUserStatistics}" var="stat" rendered="true"
    	 		columnClasses="specialLink,bogus,bogus,bogus,bogus" cellpadding="0" cellspacing="0">
   			<h:column>


### PR DESCRIPTION
Made the Statistics and grading page in Discussions tool responsive by adding "table-responsive" bootstrap class.