### PR TITLE
SAK-44225 SakaiGrader keep the selected submission

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4394,7 +4394,7 @@ public class AssignmentAction extends PagedResourceActionII {
             } else {
                 context.put("method", "doGrade_assignment");
                 context.put("urlParams", "assignmentId=" + assignmentRef);
-                context.put("viewFilterGroup", state.getAttribute(VIEW_SUBMISSION_LIST_OPTION));
+                context.put("selectedGroup", state.getAttribute(VIEW_SUBMISSION_LIST_OPTION));
             }
             return template + TEMPLATE_INSTRUCTOR_GRADE_SUBMISSION_WITH_GRADER;
         } else {

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4394,6 +4394,7 @@ public class AssignmentAction extends PagedResourceActionII {
             } else {
                 context.put("method", "doGrade_assignment");
                 context.put("urlParams", "assignmentId=" + assignmentRef);
+                context.put("viewFilterGroup", state.getAttribute(VIEW_SUBMISSION_LIST_OPTION));
             }
             return template + TEMPLATE_INSTRUCTOR_GRADE_SUBMISSION_WITH_GRADER;
         } else {

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission_withgrader.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission_withgrader.vm
@@ -17,6 +17,7 @@
         user-list-url="#toolLinkParam("$action" "$method" "$urlParams")"
         current-student-id="$!submitterId"
         has-associated-rubric="$!hasAssociatedRubric"
+        view-filter-group="$viewFilterGroup"
         #if ($!hasAssociatedRubric)
         tool-id="sakai.assignment.grades"
         entity-id="$assignment.Id"

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission_withgrader.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission_withgrader.vm
@@ -17,7 +17,7 @@
         user-list-url="#toolLinkParam("$action" "$method" "$urlParams")"
         current-student-id="$!submitterId"
         has-associated-rubric="$!hasAssociatedRubric"
-        view-filter-group="$viewFilterGroup"
+        selected-group="$selectedGroup"
         #if ($!hasAssociatedRubric)
         tool-id="sakai.assignment.grades"
         entity-id="$assignment.Id"

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
@@ -12,7 +12,7 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
     submissionId: { attribute: "submission-id", type: String },
     currentStudentId: { attribute: "current-student-id", type: String },
     gradableTitle: { attribute: "gradable-title", type: String },
-    viewFilterGroup: { attribute: "view-filter-group", type: String },
+    selectedGroup: { attribute: "selected-group", type: String },
     hasAssociatedRubric: { attribute: "has-associated-rubric", type: String },
     entityId: { attribute: "entity-id", type: String },
     toolId: { attribute: "tool-id", type: String },

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
@@ -673,14 +673,22 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
     }
 
     if (filtered.length > 0) {
-      const firstSubmissionId = filtered[0].id;
-      this._hydrateCluster(firstSubmissionId).then(submission => {
-
-        if (submission) {
-          this._submissions = [ ...filtered ];
-          this._submission = submission;
-        }
-      });
+      if (filtered.some(s => s.id === this._submission.id)) {
+        this._hydrateCluster(this._submission.id).then(submission => {
+          if (submission) {
+            this._submissions = [ ...filtered ];
+            this._submission = submission;
+          }
+        });
+      } else {
+        const firstSubmissionId = filtered[0].id;
+        this._hydrateCluster(firstSubmissionId).then(submission => {
+          if (submission) {
+            this._submissions = [ ...filtered ];
+            this._submission = submission;
+          }
+        });
+      }
     } else {
       this._submission = new Submission();
     }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
@@ -12,6 +12,7 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
     submissionId: { attribute: "submission-id", type: String },
     currentStudentId: { attribute: "current-student-id", type: String },
     gradableTitle: { attribute: "gradable-title", type: String },
+    viewFilterGroup: { attribute: "view-filter-group", type: String },
     hasAssociatedRubric: { attribute: "has-associated-rubric", type: String },
     entityId: { attribute: "entity-id", type: String },
     toolId: { attribute: "tool-id", type: String },

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
@@ -53,7 +53,7 @@ export const graderRenderingMixin = Base => class extends Base {
                   ${this.groups ? html`
                   <div class="grader-groups">
                     <div>${this.i18n.group_label}</div>
-                    <sakai-group-picker .groups=${this.groups} @groups-selected=${this._groupsSelected}></sakai-group-picker>
+                    <sakai-group-picker .groups=${this.groups} @groups-selected=${this._groupsSelected} group-ref=${this.viewFilterGroup !== "all" ? this.viewFilterGroup : "/site/" + portal.siteId}></sakai-group-picker>
                   </div>
                   ` : nothing }
                 `}

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
@@ -53,7 +53,10 @@ export const graderRenderingMixin = Base => class extends Base {
                   ${this.groups ? html`
                   <div class="grader-groups">
                     <div>${this.i18n.group_label}</div>
-                    <sakai-group-picker .groups=${this.groups} @groups-selected=${this._groupsSelected} group-ref=${this.viewFilterGroup !== "all" ? this.viewFilterGroup : "/site/" + portal.siteId}></sakai-group-picker>
+                    <sakai-group-picker .groups=${this.groups}
+                        @groups-selected=${this._groupsSelected}
+                        group-ref=${ifDefined(this.selectedGroup)}>
+                    </sakai-group-picker>
                   </div>
                   ` : nothing }
                 `}

--- a/webcomponents/tool/src/main/frontend/packages/sakai-group-picker/src/SakaiGroupPicker.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-group-picker/src/SakaiGroupPicker.js
@@ -18,6 +18,7 @@ export class SakaiGroupPicker extends SakaiElement {
     super();
 
     this.loadTranslations("group-picker").then(t => this._i18n = t);
+    this.initialUpdateDone = false;
   }
 
   connectedCallback() {
@@ -49,6 +50,22 @@ export class SakaiGroupPicker extends SakaiElement {
 
   shouldUpdate() {
     return this._i18n && this.groups;
+  }
+
+  set groupRef(newValue) {
+    if (this._groupRef !== newValue) {
+      this._groupRef = newValue;
+      this.updateComplete.then(() => {
+        if (!this.initialUpdateDone) {
+          this.initialUpdateDone = true;
+          this.groupChanged({ target: { value: newValue } });
+        }
+      });
+    }
+  }
+
+  get groupRef() {
+    return this._groupRef;
   }
 
   render() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-group-picker/src/SakaiGroupPicker.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-group-picker/src/SakaiGroupPicker.js
@@ -18,7 +18,6 @@ export class SakaiGroupPicker extends SakaiElement {
     super();
 
     this.loadTranslations("group-picker").then(t => this._i18n = t);
-    this.initialUpdateDone = false;
   }
 
   connectedCallback() {
@@ -48,24 +47,16 @@ export class SakaiGroupPicker extends SakaiElement {
     this.dispatchEvent(new CustomEvent("groups-selected", { detail: { value: groups }, bubbles: true }));
   }
 
-  shouldUpdate() {
-    return this._i18n && this.groups;
-  }
+  firstUpdated() {
 
-  set groupRef(newValue) {
-    if (this._groupRef !== newValue) {
-      this._groupRef = newValue;
-      this.updateComplete.then(() => {
-        if (!this.initialUpdateDone) {
-          this.initialUpdateDone = true;
-          this.groupChanged({ target: { value: newValue } });
-        }
-      });
+    if (this.groupRef) {
+      // An initial group has been specified. We only want to do this on the first update.
+      this.groupChanged({ target: { value: this.groupRef } });
     }
   }
 
-  get groupRef() {
-    return this._groupRef;
+  shouldUpdate() {
+    return this._i18n && this.groups;
   }
 
   render() {


### PR DESCRIPTION
After thoroughly testing the previous PR, I found that with the change, the selected student is lost, and the first one is set by default. Similarly (as was already happening), when changing groups, the displayed student is not retained if they are in the group being filtered.