### PR TITLE
SAK-38024 Lessons accessibility incorrect heading structure on pages

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -95,7 +95,7 @@
 <div class="row mt-4">
   <div class="column col-12 m-0 p-0 border-0">
     <span rsf:id="tool-bar:" class="navIntraTool" role="application" aria-labelledby="tool-bar::toolbar-label">
-      <h3 id="toolbar-label" rsf:id="msg=simplepage.toolbar" class="lb-offscreen"></h3>
+      <h2 id="toolbar-label" rsf:id="msg=simplepage.toolbar" class="lb-offscreen"></h2>
       <ul id="toolbar" class="d-inline">
         <li class="contentButton">
             <button class="btn btn-link my-1" type="button" data-bs-toggle="modal" rsf:id="addcontent" data-bs-target="#addContentDiv" aria-controls="addContentDiv" aria-expanded="false">
@@ -2384,7 +2384,7 @@
       <input type="hidden" id="activeQuestion" />
       <div style="display:none" rsf:id="current-item-id"></div>
 
-      <h2 rsf:id="msg=simplepage.maincontent" class="lb-offscreen" id="maintablelabel"></h2>
+      <h3 rsf:id="msg=simplepage.maincontent" class="lb-offscreen" id="maintablelabel"></h3>
       <!-- WARNING: javascript for add-break-section adds section, ul, li, and sectionedit markup, so if you change here, keep it in sync -->
       <div rsf:id="sectionWrapper:">
         <h3 rsf:id="sectionHeader" id="sectionHeader" class="sectionHeader">

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
@@ -30,7 +30,7 @@
 #end
 <div class="portal-main-container container-fluid mt-2">
     <main id="$pageWrapperClass" class="portal-main-content #if( $numberTools > 1 || $homePage)Mrphs-multipleTools #end" role="main">
-        <h2 class="skip visually-hidden" tabindex="-1" id="tocontent">${rloader.sit_contentshead}</h2>
+        <h1 class="skip visually-hidden" tabindex="-1" id="tocontent">${rloader.sit_contentshead}</h1>
         #parse("/vm/morpheus/includeSiteHierarchy.vm")
         #parse("/vm/morpheus/snippets/siteStatus-snippet.vm")
         #if ($pageTwoColumn)


### PR DESCRIPTION
Fixed the heading hierarchy structure on the Lessons tool page.