### PR TITLE
SAK-49986 Rubrics allow students to self-report their work checkbox alignment and spacing needed

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricAssociation.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricAssociation.js
@@ -225,6 +225,7 @@ export class SakaiRubricAssociation extends RubricsElement {
                   <input
                       name="rbcs-config-fineTunePoints"
                       type="checkbox"
+                      class="me-1"
                       @click=${this._toggleFineTunePoints}
                       ?checked=${this.selectedConfigOptions.fineTunePoints}
                       value="1"
@@ -237,9 +238,9 @@ export class SakaiRubricAssociation extends RubricsElement {
                 </label>
               </div>
               ${this.showSelfReportCheck ? html`
-                <div class="form-check">
+                <div class="checkbox">
                   <label>
-                    <input @change="${this.updateStudentSelfReportInput}" id="rbcs-config-studentSelfReport" name="rbcs-config-studentSelfReport" type="checkbox" ?checked=${this.selectedConfigOptions.studentSelfReport} value="1" ?disabled=${this.isAssociated != 1 || this.readOnly}>${this.studentSelfReport}
+                    <input @change="${this.updateStudentSelfReportInput}" id="rbcs-config-studentSelfReport" name="rbcs-config-studentSelfReport" type="checkbox" class="me-1" ?checked=${this.selectedConfigOptions.studentSelfReport} value="1" ?disabled=${this.isAssociated != 1 || this.readOnly}>${this.studentSelfReport}
                   </label>
                   <div id="rbcs-multiple-options-config-studentSelfReportMode-container" class="rubrics-list ${!this.selectedConfigOptions.studentSelfReport ? "hidden" : ""}">
                     <div class="rubric-options">


### PR DESCRIPTION
[S2U-34: 5.1.4.5 Assignments and Rubrics: Use Rubrics in Peer Review Assignments](https://sakaiproject.atlassian.net/browse/S2U-34) introduced a new feature in assignments to allow students to self-report using a rubric. The checkbox should be aligned with the other checkboxes (currently it looks almost like it’s part of Hide Rubric from Student) and a space is needed between the checkbox and the word Allow.

https://sakaiproject.atlassian.net/browse/SAK-49986

Also fixed the spacing of Adjust individual student scores.