### PR TITLE
SAK-50547 Assignments rubrics inconsistency when associating with an existing gradebook

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -419,15 +419,9 @@
             <hr class="itemSeparator" />
             <sakai-rubric-grading
                 site-id="$!assignment.Context"
-                #if ($associatedToGbItem)
-                    tool-id="sakai.gradebookng"
-                    entity-id="$associatedToGbEntityId"
-                    evaluated-item-id="$associatedToGbEntityId.$submitterId"
-                #else
-                    tool-id="sakai.assignment.grades"
-                    entity-id="$assignment.Id"
-                    evaluated-item-id="$submission.Id"
-                #end
+                tool-id="sakai.assignment.grades"
+                entity-id="$assignment.Id"
+                evaluated-item-id="$submission.Id"
                 #if ($assignment.IsGroup && $assignment.getAllowPeerAssessment())
                     is-peer-group-graded="true"
                 #end


### PR DESCRIPTION
When a assignment is set to be graded with a rubric and is linked to an existing gradebook item, there are two distinct behaviors:

- Sakai Grader: The assignment's configuration takes precedence over the gradebook item settings. After consulting with the teachers of the Universitat Politècnica de València, they consider this behavior to be correct.

- Classic Grader: The gradebook item settings take precedence, leading to inconsistencies. For example, although the assignment is set to be graded with a rubric, the rubric does not appear if the gradebook item has no associated rubric. In version 22, a link to download the rubric as a PDF appears, but this generates an error due to the rubric ID being undefined (since there is no association in the gradebook).

The behavior of the Classic Grader should align with that of the Sakai Grader in this regard.