### PR TITLE
SAK-50554 Site Import Fails to Import Some Embedded Images

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/LinkMigrationHelperImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/LinkMigrationHelperImpl.java
@@ -38,7 +38,7 @@ import org.sakaiproject.util.api.LinkMigrationHelper;
 public class LinkMigrationHelperImpl implements LinkMigrationHelper {
 	private static final String ESCAPED_SPACE = "%"+"20";
 	private static final String[] ENCODED_IMAGE = {"data:image"};
-	private static final String[] shortenerDomainsToExpand = {"/x/", "bit.ly"};
+	private static final String[] SHORTENER_STRINGS = {"/x/", "bit.ly"};
 
 	private ServerConfigurationService serverConfigurationService;
 
@@ -208,7 +208,7 @@ public class LinkMigrationHelperImpl implements LinkMigrationHelper {
 	}
 
 	private boolean referenceContainsShortenerDomains(String reference) {
-		return Arrays.stream(shortenerDomainsToExpand).anyMatch(reference::contains);
+		return Arrays.stream(SHORTENER_STRINGS).anyMatch(reference::contains);
 	}
 
 	private String expandShortenedUrl(String shortenedUrl){

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/LinkMigrationHelperImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/LinkMigrationHelperImpl.java
@@ -36,7 +36,8 @@ import org.sakaiproject.util.api.LinkMigrationHelper;
 
 @Slf4j
 public class LinkMigrationHelperImpl implements LinkMigrationHelper {
-	private static final String ESCAPED_SPACE= "%"+"20";
+	private static final String ESCAPED_SPACE = "%"+"20";
+	private static final String[] ENCODED_IMAGE = {"data:image"};
 	private static final String[] shortenerDomainsToExpand = {"/x/", "bit.ly"};
 
 	private ServerConfigurationService serverConfigurationService;
@@ -192,14 +193,18 @@ public class LinkMigrationHelperImpl implements LinkMigrationHelper {
 			}
 
 			for(String reference : references){
-				//If doesn't contain the prefix /x/, should ignore the URL.
-				if(referenceContainsShortenerDomains(reference)){
+				//If doesn't contain the prefix /x/ or is an encoded image, should ignore the URL.
+				if(!referenceContainsEncodedImage(reference) && referenceContainsShortenerDomains(reference)){
 					String longUrl = this.expandShortenedUrl(reference);
 					replacedBody = StringUtils.replace(replacedBody, reference, longUrl);
 				}
 			}
 		}
 		return replacedBody;
+	}
+
+	private boolean referenceContainsEncodedImage(String reference) {
+		return Arrays.stream(ENCODED_IMAGE).anyMatch(reference::contains);
 	}
 
 	private boolean referenceContainsShortenerDomains(String reference) {


### PR DESCRIPTION
During the import process, in the migration of links, it is checked whether the links are shortened, and then they are expanded. To do this, it checks if the link includes the string "http://bit.ly/ " or "/x/".

This check fails when we encounter an image inserted with its base64 encoding, a format in which images from the clipboard were pasted in previous versions of Sakai.

`<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA... (rest of the base64 encoding)">`

This string is very long and is highly likely to include "/x/". As a result, a large number of images from a variety of tools are lost.

https://sakaiproject.atlassian.net/browse/SAK-50554