### PR TITLE
SAK-50477 Assignments allow partial searches in the assignments list

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -13319,7 +13319,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 String searchTerm = (String) state.getAttribute(SEARCH_ASSIGNMENTS);
                 if (searchTerm != null && !searchTerm.isEmpty()) {
                     returnResources = ((List<Assignment>)returnResources).stream()
-                        .filter(a -> a.getTitle().equalsIgnoreCase(searchTerm))
+                        .filter(a -> a.getTitle().toLowerCase().contains(searchTerm.toLowerCase()))
                         .collect(Collectors.toList());
                 }
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50477

Andrea Schmidt: The assignment cannot be found on a partial name search, which doesn’t make it any easier when trying to find an assignment in a huge list of assignments. My expectations are to be able to search on a partial name (as most search engines work).