### PR TITLE
SAK-50592 Meetings default option and updating of teachers not included in the meeting

### DIFF
--- a/meetings/ui/src/main/frontend/src/components/sakai-input.vue
+++ b/meetings/ui/src/main/frontend/src/components/sakai-input.vue
@@ -173,5 +173,13 @@ export default {
         color: var(--sakai-text-color-disabled);
     }
   }
+  .form-check-coorganizers {
+    appearance: none;
+    height: 15px;
+    width: 15px;
+    border-radius: 3px;
+    background-color: var(--sakai-background-color-1);
+    border: 1px solid var(--sakai-color-black) !important;
+  }
 }
 </style>

--- a/meetings/ui/src/main/frontend/src/views/CreateMeeting.vue
+++ b/meetings/ui/src/main/frontend/src/views/CreateMeeting.vue
@@ -67,7 +67,7 @@
         <div class="mt-3">
             <div class="form-check">
               <input
-                class="form-check-input"
+                class="form-check-coorganizers"
                 type="checkbox"
                 id="enableCoorganizers"
                 v-model="formdata.enableCoorganizers"
@@ -185,7 +185,7 @@ export default {
         notificationType: "0",
         groups: [],
         participantOption: "SITE",
-        enableCoorganizers: false
+        enableCoorganizers: true
       },
       groups: [],
       participants: [],

--- a/microsoft-integration/api/src/java/org/sakaiproject/microsoft/api/MicrosoftCommonService.java
+++ b/microsoft-integration/api/src/java/org/sakaiproject/microsoft/api/MicrosoftCommonService.java
@@ -113,7 +113,7 @@ public interface MicrosoftCommonService {
 	
 	// ---------------------------------------- ONLINE MEETINGS --------------------------------------------------
 	TeamsMeetingData createOnlineMeeting(String userEmail, String subject, Instant startDate, Instant endDate, List<String> coorganizerEmails) throws MicrosoftCredentialsException;
-	void updateOnlineMeeting(String userEmail, String meetingId, String subject, Instant startDate, Instant endDate) throws MicrosoftCredentialsException;
+	void updateOnlineMeeting(String userEmail, String meetingId, String subject, Instant startDate, Instant endDate, List<String> coorganizerEmails) throws MicrosoftCredentialsException;
 	List<MeetingRecordingData> getOnlineMeetingRecordings(String onlineMeetingId, List<String> teamIdsList, boolean force) throws MicrosoftCredentialsException;
 	
 	// ---------------------------------------- ONE-DRIVE (APPLICATION) --------------------------------------------------------


### PR DESCRIPTION
If, once the meeting is created, a mantain user is added to the site, in order to add that participant to the meeting there would have to be an option to update the meeting and also make the option that only organizers and co-organizers can present in the microsoft meeting configuration to be activated by default.