### PR TITLE
SAK-49493 LTI fix gradebook uid bug and improve initialization

### DIFF
--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
@@ -933,5 +933,6 @@ public interface GradingService extends EntityProducer {
     public Map<String, String> buildCategoryGradebookMap(List<String> selectedGradebookUids, String categoriesString, String siteId);
     public Long getMatchingUserGradebookItemId(String siteId, String userId, String gradebookItemIdString);
     public List<String> getGradebookInstancesForUser(String siteId, String userId);
+    public void initializeGradebooksForSite(String siteId);
 
 }

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -5030,6 +5030,17 @@ public class GradingServiceImpl implements GradingService {
         return userGradebooks;
     }
 
+    @Override
+    public void initializeGradebooksForSite(String siteId) {
+        List<String> gradebookUids = Arrays.asList(siteId);
+        if (isGradebookGroupEnabled(siteId)) {
+            gradebookUids = getGradebookGroupInstancesIds(siteId);
+        }
+        for (String gradebookUid : gradebookUids) {
+            getGradebook(gradebookUid, siteId);
+        }
+    }
+
     private void createDefaultLetterGradeMapping(final Map gradeMap) {
 
         if (getDefaultLetterGradePercentMapping().isEmpty()) {


### PR DESCRIPTION
Applying some retro-compatibility fixes for a better management of the gradebook Uid in the LTI integration. The idea is the LTI can work as always for regular sites, but we'll work too on improving the gradebook for groups + LTI mix (we'll add a warning in the meantime).

Also moving the initialization to the service and renaming it as the original method wasn't too specific.