### PR TITLE
SAK-50616 LTI 1.3 Synchronizing grades doesn't work well when Tomcat language's decimal separator is a comma

### DIFF
--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -2694,7 +2694,9 @@ public class SakaiBLTIUtil {
 				} else {
 					assignedGrade = (scoreGiven / scoreMaximum) * gradebookColumnPoints;
 				}
-				g.setAssignmentScoreString(siteId, gradebookColumn.getId(), userId, assignedGrade.toString(), "External Outcome");
+				String gradeI18n = assignedGrade.toString();
+				gradeI18n = (",").equals((ComponentManager.get(FormattedText.class)).getDecimalSeparator()) ? gradeI18n.replace(".",",") : gradeI18n;
+				g.setAssignmentScoreString(siteId, gradebookColumn.getId(), userId, gradeI18n, "External Outcome");
 				if ( StringUtils.isBlank(comment) ) {
 					g.deleteAssignmentScoreComment(siteId, gradebookColumn.getId(), userId);
 				} else {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50616

Same patch as https://github.com/sakaiproject/sakai/pull/9020/files but on LTI1.3 method