### PR TITLE
SAK-50164 Double scrollbars at bottom of Gradebook are not user-friendly

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -5,6 +5,7 @@
   #gradebookSpreadsheet,
   #gradebookGradesToolbar {
     margin-top: 15px;
+    overflow-x: hidden;
   }
   #gradeTableWrapper {
     position: relative;


### PR DESCRIPTION
Added overflow-x: hidden to remove the double scrollbar.