### PR TITLE
SAK-50635 Samigo incorrect value of hidden input for attempt date

### DIFF
--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -241,7 +241,7 @@ document.links[newindex].onclick();
 <h:inputHidden id="lastSubmittedDate2" value="0"
    rendered ="#{delivery.assessmentGrading.submittedDate==null}"/>
 <h:inputHidden id="hasTimeLimit" value="#{delivery.hasTimeLimit}"/>   
-<h:inputHidden id="attemptDate" value="#{delivery.assessmentGrading.attemptDate}" rendered ="#{delivery.assessmentGrading.attemptDate!=null}"/>   
+<h:inputHidden id="attemptDate" value="#{delivery.assessmentGrading.attemptDate.time}" rendered ="#{delivery.assessmentGrading.attemptDate!=null}"/>   
 <h:inputHidden id="showTimeWarning" value="#{delivery.showTimeWarning}"/>
 <h:inputHidden id="showTimer" value="#{delivery.showTimer}"/>
 <h:inputHidden id="dueDate" value="#{delivery.dueDate.time}" rendered="#{delivery.dueDate != null}" />


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50635

In test & quizzes, there is an input that stores the variable attemptDate, which is the date and time when the student starts the exam. However, the value of this field is currently incorrect, as it only saves the date instead of both the date and time.