### PR TITLE
SAK-50646 Assignments-Grader: Grader fails to load with corrupted file submissions

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -757,7 +757,9 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                             log.info("There was an attachment on submission {} that was invalid", as.getId());
                             return null;
                         }
-                    }).collect(Collectors.toList());
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
 
                 if (!submittedAttachments.isEmpty()) {
                     submission.put("submittedAttachments", submittedAttachments);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50646

The new Sakai grader breaks when a submission contains corrupted files, resulting in a 404 error. In contrast, the classic grader successfully filtered out these corrupted files. The new grader, however, does not, and gets stuck on the message: 

'Loading the grading data... This may take a few seconds.'