### PR TITLE
SAK-50666 Samigo prevent opening links from SEB by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3703,6 +3703,14 @@
 # DEFAULT: https://safeexambrowser.org/download_en.html
 # seb.download.link=
 
+# S2U-21 Enable URL filtering for Safe Exam browser
+# DEFAULT: false
+# seb.URL.filter.enable=true
+
+# S2U-21 List of URLs to filter for Safe Exam browser
+# DEFAULT: [SERVER_URL]
+# seb.URL.filter.rules=*.nightly.sakaiproject.org
+
 #########################################
 # MEMBERSHIP TOOL
 #########################################


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50666

On the Sakai login screen, there are often external links (e.g., to the APAREO page). When accessing the SEB (Safe Exam Browser), this screen appears, allowing users to open links and navigate to Instagram, Twitter, Google, etc. A student could also type a link (e.g., Google) into a short-answer question and open a new tab.

By default, block access to any link outside the platform itself. If a teacher wants to allow specific links, they can configure them using the SEB app.