### PR TITLE
SAK-50391 Resources and Samigo ui reponsiveness

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/sakai_resources_list.vm
@@ -250,8 +250,8 @@
     <div id="userId" style="display: none;">$userId</div>
 		######################  Heirarchical list of resource folders/items  ##############
     ## style on table to override margin on small viewports
-		<div class="table-responsive">
-		<table style="margin:0;width:100%;display:table" class="table table-striped table-hover #if (!$dropboxMode) resourcesList #end" cellspacing="0" border="0"  summary="$clang.getString("sh.listsum")">
+		
+		<table class="table table-striped table-hover #if (!$dropboxMode) resourcesList #end" cellspacing="0" border="0"  summary="$clang.getString("sh.listsum")">
 			######################  Column labels, sort controls, expand/collapse all  ##############
 			<caption class="skip"  style="display:none">$clang.getString("sh.listcap")</caption>
 			<tr class="d-none d-sm-table-row"> 
@@ -785,7 +785,7 @@
 			############################################# end of "Other sites" section 
 		
 		</table>
-		</div>
+		
 		
 		#foreach($key in $listActions.keySet())
 			<input type="hidden" id="${key}-count" value="$counter.getValue("${key}selected")" />

--- a/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
@@ -251,7 +251,7 @@
    		}
 		@media #{$phone}{
                         overflow-x: auto;
-		display:block;
+			display: block;
                 }
 
 	}

--- a/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
@@ -249,6 +249,11 @@
 	   	&.listHier td:empty{
    			padding: 0;
    		}
+		@media #{$phone}{
+                        overflow-x: auto;
+		display:block;
+                }
+
 	}
 	
 	#samLiteEntryForm\:data{

--- a/samigo/samigo-app/src/webapp/jsf/author/authorIndex_content.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorIndex_content.jsp
@@ -297,7 +297,6 @@
             <h:panelGroup rendered="#{author.allAssessments.size() == 0}">
                 <h:outputText value="#{authorFrontDoorMessages.datatables_zeroRecords}" styleClass="sak-banner-info" />
             </h:panelGroup>
-	    <div class="table-responsive">
             <t:dataTable cellpadding="0" cellspacing="0" rowClasses="list-row-even,list-row-odd" styleClass="table table-hover table-striped table-bordered table-assessments" id="coreAssessments" value="#{author.allAssessments}" var="assessment" rendered="#{author.allAssessments.size() > 0}" summary="#{authorFrontDoorMessages.sum_coreAssessment}">
                 <%/* Title */%>
                 <t:column headerstyleClass="titlePending" styleClass="titlePending">
@@ -655,7 +654,6 @@
                 <t:column rendered="#{!authorization.deleteAnyAssessment and !authorization.deleteOwnAssessment}" headerstyleClass="d-none" styleClass="d-none">
                 </t:column>
             </t:dataTable>
-	    </div>
 
             <div class="clearfix"></div>
 


### PR DESCRIPTION
Quoting Christina: There was a problem viewing the Actions menu for Tests & Quizzes on a desktop-sized browser. It keeps it within the height of the table and enables a horizontal scroll. It was a side-effect of this Jira. It’s not appearing when there’s multiple tests present, just when there’s one or two - a list shorter than the menu length.

Removed the table-responsive bootstrap class and instead added a media query. The issue has been fixed on Tests & Quizzes and Resources tools. 