### PR TITLE
SAK-50164 Double scrollbars at bottom of Gradebook are not user-friendly

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/_gradebook.scss
@@ -5,6 +5,7 @@
   #gradebookSpreadsheet,
   #gradebookGradesToolbar {
     margin-top: 15px;
+    overflow-x: hidden;
   }
   #gradeTableWrapper {
     position: relative;

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePage.vm
@@ -28,7 +28,7 @@
 #else
     #set( $numberTools = $pageColumn0Tools.size() )
 #end
-<div class="portal-main-container container-fluid mt-2">
+<div class="portal-main-container container-fluid mt-2 d-flex flex-column">
     <main id="$pageWrapperClass" class="portal-main-content #if( $numberTools > 1 || $homePage)Mrphs-multipleTools #end" role="main">
         <h2 class="skip visually-hidden" tabindex="-1" id="tocontent">${rloader.sit_contentshead}</h2>
         #parse("/vm/morpheus/includeSiteHierarchy.vm")


### PR DESCRIPTION
Added d-flex and flex-column bootstrap classes. In addition, added an overflow-x: hidden to _gradebook.scss. There is no additional scroll bar on web desktop screen now for Gradebook tool. Only one scrollbar is present for the table.