### PR TITLE
SAK-50697 Accessibility Grade submission successful message not announced

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewSearchBarThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewSearchBarThread.jsp
@@ -13,7 +13,7 @@
 
 <h:messages styleClass="alertMessage" id="errorMessages" rendered="#{! empty facesContext.maximumSeverity}" />
 <f:verbatim>
-	<div class="success" id="gradesSavedDiv" class="success" style="display:none">
+	<div class="success" id="gradesSavedDiv" class="success" style="display:none" role="alert" aria-live="assertive">
 </f:verbatim>
 	<h:outputText value="#{msgs.cdfm_grade_successful}"/>
 <f:verbatim>


### PR DESCRIPTION
Added aria-live="assertive" to enable the screen reader when grade submission is successful. 