### PR TITLE
SAK-50631 Samigo SEB autosave modal message is sometimes permanently displayed

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -178,6 +178,8 @@ public class DeliveryBean implements Serializable {
   @Getter
   private String timeElapse;
   @Getter @Setter
+  private String backupTimeElapse;
+  @Getter @Setter
   private int sectionIndex;
   @Getter @Setter
   private boolean previous;
@@ -259,6 +261,8 @@ public class DeliveryBean implements Serializable {
   private String courseName;
   @Getter @Setter
   private String timeLimit;
+  @Getter @Setter
+  private String backupTimeLimit;
   @Getter @Setter
   private int timeLimit_hour;
   @Getter @Setter
@@ -546,6 +550,12 @@ public class DeliveryBean implements Serializable {
     try{
       if (timeElapse!=null && !("").equals(timeElapse)
           && getTimeLimit()!=null && !("").equals(getTimeLimit())){
+        if (!"0".equals(timeElapse)) {
+          setBackupTimeElapse(timeElapse);
+        }
+        if (!"0".equals(getTimeLimit())) {
+          setBackupTimeLimit(getTimeLimit());
+        }
         double limit = (new Double(getTimeLimit()));
         double elapsed = (new Double(timeElapse));
         if (limit > elapsed)

--- a/samigo/samigo-app/src/webapp/jsf/delivery/getTimerProgress.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/getTimerProgress.jsp
@@ -2,5 +2,5 @@
 <%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
 <f:view>
-<h:outputText value="[#{delivery.timeLimit},#{delivery.currentTimeElapse},#{delivery.assessmentId}]"/>
+<h:outputText value="[#{delivery.timeLimit},#{delivery.currentTimeElapse},#{delivery.assessmentId},#{delivery.backupTimeLimit},#{delivery.backupTimeElapse}]"/>
 </f:view>

--- a/samigo/samigo-app/src/webapp/jsf/widget/timerBar/timerbar.js
+++ b/samigo/samigo-app/src/webapp/jsf/widget/timerBar/timerbar.js
@@ -352,8 +352,14 @@
       });
 
       $.getJSON(routePrefix + "getTimerProgress" + routeSuffix, ajaxQuery, function(data) {
-          totalTime = data[0];
-          elapsedTime = data[1];
+          if (data[0] === 0) {
+            totalTime = data[3];
+            elapsedTime = data[4];
+          }
+          else {
+            totalTime = data[0];
+            elapsedTime = data[1];
+          }
           lastAid = data[2];
 
           if (totalTime === elapsedTime) {
@@ -368,16 +374,23 @@
           }
 
           disableWarning = (100 - Math.floor(((totalTime - remain) / totalTime) * 100)) < 10; 
-          remain = data[0] - data[1];
+          remain = totalTime - elapsedTime;
           setProgressBar();
-          var requestScale = (data[0] / 100) * 1000;
+          var requestScale = (totalTime / 100) * 1000;
           if (requestScale < minReqScale) {
               requestScale = minReqScale;
           }
 
           ajaxCount = setInterval(function() {
               $.getJSON(routePrefix + "getTimerProgress" + routeSuffix, ajaxQuery, function(data) {
-                  elapsedTime = data[1];
+                  if (data[0] === 0) {
+                    totalTime = data[3];
+                    elapsedTime = data[4];
+                  }
+                  else {
+                    totalTime = data[0];
+                    elapsedTime = data[1];
+                  }
                   lastAid = data[2];
                   if (totalTime === elapsedTime) {
                       clearInterval(localCount);
@@ -388,7 +401,7 @@
                   if (currentAid && lastAid && currentAid > 0 && lastAid > 0 && currentAid !== lastAid) {
                       $("#multiple-tabs-warning").show();
                   }
-                  remain = data[0] - data[1];
+                  remain = totalTime - elapsedTime;
                   setProgressBar();
               });
           }, requestScale);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50631

We have identified some rare cases where the frontend loses the values of timeLimit and timeElapse (resetting them to 0). This leads to the frontend triggering the final submission of the assessment, rendering it inaccessible to the student, which is unacceptable during an assessment. This solution aims to prevent these errors. When the frontend encounters a timeLimit value of 0 (which is not possible in a timed assessment) it should use timeLimit_bck and timeElapse_bck instead.