### PR TITLE
SAK-50613 Samigo issue with calculated questions using the pipe and comma operators

### DIFF
--- a/samigo/samigo-api/src/java/xml/xsl/dataTransform/import/v1p2/extractItem.xsl
+++ b/samigo/samigo-api/src/java/xml/xsl/dataTransform/import/v1p2/extractItem.xsl
@@ -87,7 +87,7 @@
         <globalvariableNames type="list"><xsl:value-of select="."/></globalvariableNames>
     </xsl:for-each>
     <xsl:for-each select="//globalvariables/globalvariable/formula">
-        <globalvariableTexts type="list"><xsl:value-of select="."/></globalvariableTexts>
+        <globalvariableTexts type="list"><xsl:value-of select="concat(., '|0,0')"/></globalvariableTexts>
     </xsl:for-each>
     <xsl:for-each select="//globalvariables/globalvariable/addedButNotExtracted">
         <globalvariableAddedButNotExtracted type="list"><xsl:value-of select="."/></globalvariableAddedButNotExtracted>

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/CalculatedQuestionBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/CalculatedQuestionBean.java
@@ -164,6 +164,13 @@ public class CalculatedQuestionBean implements Serializable {
                 return new NullComparator().compare(bean1.getName(), bean2.getName());
             }
         });
+        // remove "|0,0" from the global variables
+        for (CalculatedQuestionGlobalVariableBean globalVariable : beanList) {
+            String text = globalVariable.getText();
+            if (text.endsWith("|0,0")) {
+                globalVariable.setText(text.substring(0, text.length() - 4));
+            }
+        }
         return beanList;
     }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/ItemContentsBean.java
@@ -1562,7 +1562,7 @@ public class ItemContentsBean implements Serializable {
 		if(answerKeyToSplit==null){
 			return answerKey;
 		}
-		String keys[] = answerKeyToSplit.split(",");
+		String keys[] = answerKeyToSplit.split(":split:");
 		GradingService gradingService = new GradingService();
 		for(String key: keys){
 			if(!gradingService.extractVariables(key).isEmpty()){

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -1317,7 +1317,7 @@ public String getAddOrEdit()
 			AnswerIfc answer = calcQuestionEntitiesMap.get(entry.getKey());
 			ItemGradingData data = new ItemGradingData();
 			String answerKey = (String)answersMapValues.get(answer.getLabel());
-			int decimalPlaces = Integer.valueOf(answerKey.substring(answerKey.indexOf(',')+1, answerKey.length()));
+			int decimalPlaces = Integer.valueOf(answerKey.substring(answerKey.lastIndexOf(',')+1, answerKey.length()));
 			answerKey = answerKey.substring(0, answerKey.lastIndexOf("|")); // cut off extra data e.g. "|2,3"
 			//We need the key formatted in scientificNotation
 			answerKey = delegate.toScientificNotation(answerKey, decimalPlaces);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -1318,7 +1318,7 @@ public String getAddOrEdit()
 			ItemGradingData data = new ItemGradingData();
 			String answerKey = (String)answersMapValues.get(answer.getLabel());
 			int decimalPlaces = Integer.valueOf(answerKey.substring(answerKey.indexOf(',')+1, answerKey.length()));
-			answerKey = answerKey.substring(0, answerKey.indexOf("|")); // cut off extra data e.g. "|2,3"
+			answerKey = answerKey.substring(0, answerKey.lastIndexOf("|")); // cut off extra data e.g. "|2,3"
 			//We need the key formatted in scientificNotation
 			answerKey = delegate.toScientificNotation(answerKey, decimalPlaces);
 			keysString = keysString.concat(answerKey + ", ");

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemAddListener.java
@@ -1652,6 +1652,14 @@ public class ItemAddListener implements ActionListener {
 	      list.addAll(calcBean.getFormulas().values());
 	      list.addAll(calcBean.getVariables().values());
 	      list.addAll(calcBean.getGlobalvariables().values());
+
+	      // add "|0,0" to global variables
+	      for (CalculatedQuestionAnswerIfc varFormula : list) {
+	          if (varFormula instanceof CalculatedQuestionGlobalVariableBean) {
+	              CalculatedQuestionGlobalVariableBean globalVariable = (CalculatedQuestionGlobalVariableBean) varFormula;
+	              globalVariable.setText(globalVariable.getText() + "|0,0");
+	          }
+	      }
 	      
 	      // loop through all variables, global variables and formulas to create ItemText objects
 	      for (CalculatedQuestionAnswerIfc varFormula : list) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ItemModifyListener.java
@@ -804,7 +804,20 @@ public class ItemModifyListener implements ActionListener
         for (AnswerIfc answer : answers) {
           if (answer.getIsCorrect()) {
             String text = answer.getText();
-            if (text.contains("|")) { //could be a global variable which not appear on the instructions
+            if (text.endsWith("|0,0") || !text.contains("|")) {
+                // could be a global variable which not appear on the instructions
+                // a formula would have the format |0.0,0
+                // !text.contains("|") because there are previous global variables without |0,0
+                CalculatedQuestionGlobalVariableBean globalvariableformula = new CalculatedQuestionGlobalVariableBean();
+                globalvariableformula.setName(itemBean.getText());
+                globalvariableformula.setSequence(itemBean.getSequence());
+                globalvariableformula.setAddedButNotExtracted(itemBean.isAddedButNotExtracted());
+                globalvariableformula.setText(answer.getText());
+                calcQuestionBean.addGlobalVariable(globalvariableformula);
+                break;
+            }
+            else {
+                // is a formula
                 formula.setName(itemBean.getText());
                 formula.setSequence(itemBean.getSequence());
                 String[] partsText = text.split("\\|");
@@ -826,14 +839,6 @@ public class ItemModifyListener implements ActionListener
                   log.error("Calculated question answer text {} is not formatted correctly.", text);
                 }
                 calcQuestionBean.addFormula(formula);
-                break;
-            } else { // it is a global variable
-                CalculatedQuestionGlobalVariableBean globalvariableformula = new CalculatedQuestionGlobalVariableBean();
-                globalvariableformula.setName(itemBean.getText());
-                globalvariableformula.setSequence(itemBean.getSequence());
-                globalvariableformula.setAddedButNotExtracted(itemBean.isAddedButNotExtracted());
-                globalvariableformula.setText(answer.getText());
-                calcQuestionBean.addGlobalVariable(globalvariableformula);
                 break;
             }
           }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -3053,7 +3053,7 @@ public class DeliveryActionListener
 	int decimalPlaces = 3;
 	while(answerSequence <= service.getAnswersMap().size()) {
 		  answer = (String)service.getAnswersMap().get(answerSequence);
-		  decimalPlaces = Integer.valueOf(answer.substring(answer.indexOf(',')+1, answer.length()));
+		  decimalPlaces = Integer.valueOf(answer.substring(answer.lastIndexOf(',')+1, answer.length()));
 		  answer = answer.substring(0, answer.lastIndexOf("|")); // cut off extra data e.g. "|2,3"
 		  // searching and replacing recursively global variables on the answer
 		  answer = service.checkingEmptyGlobalVariables(answer, service.getMainvariablesWithValues(), service.getGlobalanswersMapValues());

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -3054,7 +3054,7 @@ public class DeliveryActionListener
 	while(answerSequence <= service.getAnswersMap().size()) {
 		  answer = (String)service.getAnswersMap().get(answerSequence);
 		  decimalPlaces = Integer.valueOf(answer.substring(answer.indexOf(',')+1, answer.length()));
-		  answer = answer.substring(0, answer.indexOf("|")); // cut off extra data e.g. "|2,3"
+		  answer = answer.substring(0, answer.lastIndexOf("|")); // cut off extra data e.g. "|2,3"
 		  // searching and replacing recursively global variables on the answer
 		  answer = service.checkingEmptyGlobalVariables(answer, service.getMainvariablesWithValues(), service.getGlobalanswersMapValues());
 		  try {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -820,7 +820,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 							// Answers Keys
 							answerKey = (String)answersMap.get(i);
 							decimalPlaces = Integer.valueOf(answerKey.substring(answerKey.indexOf(',')+1, answerKey.length()));
-							answerKey = answerKey.substring(0, answerKey.indexOf("|")); // cut off extra data e.g. "|2,3"
+							answerKey = answerKey.substring(0, answerKey.lastIndexOf("|")); // cut off extra data e.g. "|2,3"
 							// We need the key formatted in scientificNotation
 							answerKey = delegate.toScientificNotation(answerKey, decimalPlaces);
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -819,7 +819,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 						else if (bean.getTypeId().equals("15")) {  // CALCULATED_QUESTION
 							// Answers Keys
 							answerKey = (String)answersMap.get(i);
-							decimalPlaces = Integer.valueOf(answerKey.substring(answerKey.indexOf(',')+1, answerKey.length()));
+							decimalPlaces = Integer.valueOf(answerKey.substring(answerKey.lastIndexOf(',')+1, answerKey.length()));
 							answerKey = answerKey.substring(0, answerKey.lastIndexOf("|")); // cut off extra data e.g. "|2,3"
 							// We need the key formatted in scientificNotation
 							answerKey = delegate.toScientificNotation(answerKey, decimalPlaces);

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
@@ -771,9 +771,9 @@ public class PublishedItemData
 							answerKey = a.getText();
 						} else if (TypeD.CALCULATED_QUESTION.equals(this.getTypeId())) {
 							if (StringUtils.isEmpty(answerKey)) {
-								answerKey = a.getLabel() +" = "+ a.getText().substring(0, a.getText().indexOf("|")) ;
+								answerKey = a.getLabel() +" = "+ a.getText().substring(0, a.getText().lastIndexOf("|")) ;
 							} else {
-								answerKey += "," + a.getLabel() +" = "+ a.getText().substring(0, a.getText().indexOf("|")) ;
+								answerKey += "," + a.getLabel() +" = "+ a.getText().substring(0, a.getText().lastIndexOf("|")) ;
 							}
 						} else {
 							if (("").equals(answerKey)) {

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/assessment/PublishedItemData.java
@@ -773,7 +773,7 @@ public class PublishedItemData
 							if (StringUtils.isEmpty(answerKey)) {
 								answerKey = a.getLabel() +" = "+ a.getText().substring(0, a.getText().lastIndexOf("|")) ;
 							} else {
-								answerKey += "," + a.getLabel() +" = "+ a.getText().substring(0, a.getText().lastIndexOf("|")) ;
+								answerKey += ":split:" + a.getLabel() +" = "+ a.getText().substring(0, a.getText().lastIndexOf("|")) ;
 							}
 						} else {
 							if (("").equals(answerKey)) {

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/item/ItemHelper12Impl.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/item/ItemHelper12Impl.java
@@ -571,8 +571,8 @@ public class ItemHelper12Impl extends ItemHelperBase
               if (answer.getIsCorrect()) {
                   String text = answer.getText();
                   String min = text.substring(0, text.lastIndexOf("|"));
-                  String max = text.substring(text.lastIndexOf("|") + 1, text.indexOf(","));
-                  String decimalPlaces = text.substring(text.indexOf(",") + 1);
+                  String max = text.substring(text.lastIndexOf("|") + 1, text.lastIndexOf(","));
+                  String decimalPlaces = text.substring(text.lastIndexOf(",") + 1);
                   
                   // add nodes
                   itemXml.add(updatedXpath, "name");

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/item/ItemHelper12Impl.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/item/ItemHelper12Impl.java
@@ -570,8 +570,8 @@ public class ItemHelper12Impl extends ItemHelperBase
           for (AnswerIfc answer : answers) {
               if (answer.getIsCorrect()) {
                   String text = answer.getText();
-                  String min = text.substring(0, text.indexOf("|"));
-                  String max = text.substring(text.indexOf("|") + 1, text.indexOf(","));
+                  String min = text.substring(0, text.lastIndexOf("|"));
+                  String max = text.substring(text.lastIndexOf("|") + 1, text.indexOf(","));
                   String decimalPlaces = text.substring(text.indexOf(",") + 1);
                   
                   // add nodes
@@ -611,6 +611,10 @@ public class ItemHelper12Impl extends ItemHelperBase
           for (AnswerIfc answer : answers) {
               if (answer.getIsCorrect()) {
                   String text = answer.getText();
+                  // remove "|0,0" from the global variables
+                  if (text.endsWith("|0,0")) {
+                    text = text.substring(0, text.length() - 4);
+                  }
 
                   // add nodes
                   itemXml.add(updatedXpath, "name");
@@ -647,10 +651,10 @@ public class ItemHelper12Impl extends ItemHelperBase
           for (AnswerIfc answer : answers) {
               if (answer.getIsCorrect()) {
                   String text = answer.getText();
-                  String[] partsText = text.split("\\|");
-                  if (partsText != null && partsText.length == 2) {
-                      String formula = partsText[0];
-                      String[] partsTolDp = partsText[1].split(",");
+                  int lastIndex = text.lastIndexOf("|");
+                  if (lastIndex != -1) {
+                      String formula = text.substring(0, lastIndex);
+                      String[] partsTolDp = text.substring(lastIndex + 1).split(",");
                       if (partsTolDp != null && partsTolDp.length == 2) {
                           String tolerance = partsTolDp[0];
                           String decimalPlaces = partsTolDp[1];

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -2312,7 +2312,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  BigDecimal correctAnswer = new BigDecimal(getAnswerExpression(allAnswerText));
 	  
 	  // Determine if the acceptable variance is a constant or a % of the answer
-	  String varianceString = allAnswerText.substring(allAnswerText.lastIndexOf("|")+1, allAnswerText.indexOf(","));
+	  String varianceString = allAnswerText.substring(allAnswerText.lastIndexOf("|")+1, allAnswerText.lastIndexOf(","));
 	  BigDecimal acceptableVariance;
 	  if (varianceString.contains("%")){
 		  double percentage = Double.valueOf(varianceString.substring(0, varianceString.indexOf("%")));
@@ -2356,7 +2356,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  BigDecimal correctAnswer = new BigDecimal(getAnswerExpression(allAnswerText));
 
 	  // Determine if the acceptable variance is a constant or a % of the answer
-	  String varianceString = allAnswerText.substring(allAnswerText.lastIndexOf("|")+1, allAnswerText.indexOf(","));
+	  String varianceString = allAnswerText.substring(allAnswerText.lastIndexOf("|")+1, allAnswerText.lastIndexOf(","));
 	  BigDecimal acceptableVariance;
 	  if (varianceString.contains("%")){
 		  double percentage = Double.valueOf(varianceString.substring(0, varianceString.indexOf("%")));

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -2312,7 +2312,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  BigDecimal correctAnswer = new BigDecimal(getAnswerExpression(allAnswerText));
 	  
 	  // Determine if the acceptable variance is a constant or a % of the answer
-	  String varianceString = allAnswerText.substring(allAnswerText.indexOf("|")+1, allAnswerText.indexOf(","));
+	  String varianceString = allAnswerText.substring(allAnswerText.lastIndexOf("|")+1, allAnswerText.indexOf(","));
 	  BigDecimal acceptableVariance;
 	  if (varianceString.contains("%")){
 		  double percentage = Double.valueOf(varianceString.substring(0, varianceString.indexOf("%")));
@@ -2356,7 +2356,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  BigDecimal correctAnswer = new BigDecimal(getAnswerExpression(allAnswerText));
 
 	  // Determine if the acceptable variance is a constant or a % of the answer
-	  String varianceString = allAnswerText.substring(allAnswerText.indexOf("|")+1, allAnswerText.indexOf(","));
+	  String varianceString = allAnswerText.substring(allAnswerText.lastIndexOf("|")+1, allAnswerText.indexOf(","));
 	  BigDecimal acceptableVariance;
 	  if (varianceString.contains("%")){
 		  double percentage = Double.valueOf(varianceString.substring(0, varianceString.indexOf("%")));
@@ -3155,6 +3155,10 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
       for (int i = 0; i < globalVariableNames.size(); i++) {
           String globalVariableName = globalVariableNames.get(i);
           String longFormula = replaceFormulaNameWithFormula(item, globalVariableName);
+          // remove "|0,0" from longFormula if present
+          if (longFormula.endsWith("|0,0")) {
+            longFormula = longFormula.substring(0, longFormula.length() - 4);
+          }
           globalVariables.put(globalVariableName, longFormula);
       }
 
@@ -3274,7 +3278,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 		  for (int j=0; j<parts.size(); j++) {
 			  String map = answerListValues.get(parts.get(j));
 			  if (map != null) {
-				  String num = map.substring(0, map.indexOf("|"));
+				  String num = map.substring(0, map.lastIndexOf("|"));
 				  parts.set(j, num);
 			  }
 		  }
@@ -3330,7 +3334,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * @return
    */
   private String getAnswerData(String allAnswerText) {
-      String answerData = allAnswerText.substring(allAnswerText.indexOf("|"), allAnswerText.length());
+      String answerData = allAnswerText.substring(allAnswerText.lastIndexOf("|"), allAnswerText.length());
       return answerData;
   }
 
@@ -3342,7 +3346,7 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
    * @return
    */
   private String getAnswerExpression(String allAnswerText) {
-	  String answerExpression = allAnswerText.substring(0, allAnswerText.indexOf("|"));
+	  String answerExpression = allAnswerText.substring(0, allAnswerText.lastIndexOf("|"));
 	  return answerExpression;
   }
 
@@ -3356,14 +3360,19 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	  String defaultVariance = "0.001";
 	  String defaultDecimal = "3";
 	  
-	  if (!allAnswerText.contains("|")) {
-		  if (!allAnswerText.contains(","))
-			  allAnswerText = allAnswerText.concat("|"+defaultVariance+","+defaultDecimal);
-		  else
-			  allAnswerText = allAnswerText.replace(",","|"+defaultVariance+",");
-      }
-	  if (!allAnswerText.contains(","))
-		  allAnswerText = allAnswerText.concat(","+defaultDecimal);
+	  int lastIndex = allAnswerText.lastIndexOf("|");
+	  if (lastIndex == -1) {
+	      // No '|' found, check for ',' and add default values accordingly
+	      if (!allAnswerText.contains(","))
+	          allAnswerText = allAnswerText.concat("|"+defaultVariance+","+defaultDecimal);
+	      else
+	          allAnswerText = allAnswerText.replace(",","|"+defaultVariance+",");
+	  } else {
+	      // '|' found, check for ',' after the last '|'
+	      String afterLastPipe = allAnswerText.substring(lastIndex + 1);
+	      if (!afterLastPipe.contains(","))
+	          allAnswerText = allAnswerText.concat(","+defaultDecimal);
+	  }
 	  
 	  return allAnswerText;
   }

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceTest.java
@@ -309,6 +309,61 @@ public class GradingServiceTest {
         Assert.assertEquals(expected, result);
     }
 
+    @Test
+    public void testGlobalVariablesWithCommaAndPipe() throws SamigoExpressionError {
+        String result = null;
+        Map<String, String> globalVariables = new HashMap<>();
+        globalVariables.put("global1", "iff({var1}<2, {var1}|{var2}, {var1}=2, {var2}*3, {var1}>2, {var2}*6)");
+
+        Map<String, String> variables = new HashMap<>();
+        variables.put("var1", "0");
+        variables.put("var2", "1");
+
+        String input = "Calculation: [[@global1@]]";
+        String expected = "Calculation: [[(iff({var1}<2, {var1}|{var2}, {var1}=2, {var2}*3, {var1}>2, {var2}*6))]]";
+        result = gradingService.replaceGlobalVariablesWithFormulas(input, globalVariables);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(expected, result);
+
+        result = gradingService.replaceMappedVariablesWithNumbers(expected, variables);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Calculation: [[(iff(0<2, 0|1, 0=2, 1*3, 0>2, 1*6))]]", result);
+
+        result = gradingService.replaceCalculationsWithValues(result, 0);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Calculation: 1", result);
+
+        variables.put("var1", "2");
+        input = "Calculation: [[@global1@]]";
+        expected = "Calculation: [[(iff({var1}<2, {var1}|{var2}, {var1}=2, {var2}*3, {var1}>2, {var2}*6))]]";
+        result = gradingService.replaceGlobalVariablesWithFormulas(input, globalVariables);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(expected, result);
+
+        result = gradingService.replaceMappedVariablesWithNumbers(expected, variables);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Calculation: [[(iff(2<2, 2|1, 2=2, 1*3, 2>2, 1*6))]]", result);
+
+        result = gradingService.replaceCalculationsWithValues(result, 0);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Calculation: 3", result);
+
+        variables.put("var1", "3");
+        input = "Calculation: [[@global1@]]";
+        expected = "Calculation: [[(iff({var1}<2, {var1}|{var2}, {var1}=2, {var2}*3, {var1}>2, {var2}*6))]]";
+        result = gradingService.replaceGlobalVariablesWithFormulas(input, globalVariables);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(expected, result);
+
+        result = gradingService.replaceMappedVariablesWithNumbers(expected, variables);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Calculation: [[(iff(3<2, 3|1, 3=2, 1*3, 3>2, 1*6))]]", result);
+
+        result = gradingService.replaceCalculationsWithValues(result, 0);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Calculation: 6", result);
+    }
+
     @Test(timeout = 5000)
     public void testRegexBacktracking() {
         List<String> results;
@@ -385,6 +440,17 @@ public class GradingServiceTest {
         result = gradingService.processFormulaIntoValue("\n  5 \n +  2.0\n +  3  ", 0);
         Assert.assertNotNull(result);
         Assert.assertEquals("10", result);
+
+        // Comma and Pipe
+        result = gradingService.processFormulaIntoValue("iff(0<2, 0|1, 0=2, 1*3, 0>2, 1*6)", 0);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("1", result);
+        result = gradingService.processFormulaIntoValue("iff(2<2, 2|1, 2=2, 1*3, 2>2, 1*6)", 0);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("3", result);
+        result = gradingService.processFormulaIntoValue("iff(3<2, 3|1, 3=2, 1*3, 3>2, 1*6)", 0);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("6", result);
 
         // https://jira.sakaiproject.org/browse/SAM-2157
         // 500 formula processor error occurs when either ^ or / is entered in a Formula (at any time) 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50613

The formulas for calculated questions are stored in the database by concatenating the formula with "|tol,dec". This causes two issues:  
1. The "|" symbol is also used as the OR operator.  
2. The comma is not only used as a decimal separator but is also used in formulas (such as `if`) to separate arguments.  

When a formula is configured, for example, as: `iff({numero}<2, {sub}|{numero}, {numero}=2, {sub}*3, {numero}>2, {sub}*6)`, the question breaks.  