### PR TITLE
SAK-50715 Samigo issue with calculated questions and angle brackets

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -682,7 +682,7 @@ public class PDFAssessmentBean implements Serializable {
 				contentBuffer.append(getContentQuestionImageMap(item, printSetting, true));
 			}
 			else if(TypeIfc.CALCULATED_QUESTION.equals( item.getItemData().getTypeId() )){
-				contentBuffer.append(item.getAnswerKeyCalcQuestion());
+				contentBuffer.append(item.getAnswerKeyCalcQuestion().replace("<", "&lt;").replace(">", "&gt;"));
 			}
 			else
 				contentBuffer.append(item.getItemData().getAnswerKey());


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50715

When generating a PDF for an assessment that includes a calculated question with a formula containing the < or > operators, the content is rendered incorrectly.