### PR TITLE
SAK-50716 DA SiteStats fix Wicket9 upgrade use of onchange

### DIFF
--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/EditablePanelDate.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/EditablePanelDate.java
@@ -76,7 +76,7 @@ public class EditablePanelDate  extends Panel{
 		final HiddenField hiddenInput = new HiddenField<String>("hiddenDateTextField", new PropertyModel<String>(this, "hiddenDateTextField"));
 		String hiddenInputId = String.format((startDate) ? HIDDEN_START_ISO8601 : HIDDEN_END_ISO8601, nodeModel.getNodeId());
 		hiddenInput.setMarkupId(hiddenInputId);
-		hiddenInput.add(new AjaxFormComponentUpdatingBehavior("onchange")
+		hiddenInput.add(new AjaxFormComponentUpdatingBehavior("change")
 		{
 			@Override
 			protected void onUpdate(AjaxRequestTarget target)

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/EditablePanelDropdown.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/EditablePanelDropdown.java
@@ -130,7 +130,7 @@ public class EditablePanelDropdown extends Panel
 				return super.isDisabled(object, index, selected);
 			}
 		};
-		choice.add(new AjaxFormComponentUpdatingBehavior("onchange")
+		choice.add(new AjaxFormComponentUpdatingBehavior("change")
 		{
 			@Override
 			protected void onUpdate(AjaxRequestTarget target)

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.java
@@ -153,7 +153,7 @@ public class SearchAccessPage extends BasePage implements Serializable {
 		hierarchyLabel.add(new Label("searchByHierarchyLabelText", new StringResourceModel("searchByHierarchyLabel")));
 		group.add(hierarchyRadio);
 		group.add(hierarchyLabel);
-		group.add(hierarchyRadio.add(new AjaxEventBehavior("onchange") {
+		group.add(hierarchyRadio.add(new AjaxEventBehavior("change") {
 			@Override
 			protected void onEvent(AjaxRequestTarget arg0) {
 				selectedSearchType = searchTypeHierarchy;
@@ -165,7 +165,7 @@ public class SearchAccessPage extends BasePage implements Serializable {
 		eidRadioLabel.add(new Label("searchByEidLabelText", new StringResourceModel("searchByEidLabel")));
 		group.add(eidRadio);
 		group.add(eidRadioLabel);
-		group.add(eidRadio.add(new AjaxEventBehavior("onchange") {
+		group.add(eidRadio.add(new AjaxEventBehavior("change") {
 			@Override
 			protected void onEvent(AjaxRequestTarget arg0) {
 				selectedSearchType = searchTypeEid;

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/SearchAccessPage.java
@@ -249,7 +249,7 @@ public class SearchAccessPage extends BasePage implements Serializable {
 				final DropDownChoice choice = new DropDownChoice("hierarchyLevel", new NodeSelectModel(itemNodeId), hierarchySelectOptions.get(itemNodeId), choiceRenderer);
 				//keeps the null option (choose one) after a user selects an option
 				choice.setNullValid(true);
-				choice.add(new AjaxFormComponentUpdatingBehavior("onchange"){
+				choice.add(new AjaxFormComponentUpdatingBehavior("change"){
 					protected void onUpdate(AjaxRequestTarget target) {
 						List<String> newOrder = new ArrayList<String>();
 						for(String nodeId : nodeSelectOrder){

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserPage.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserPage.java
@@ -349,7 +349,7 @@ public class UserPage  extends BaseTreePage{
 				choice.setNullValid(true);
 				choice.add(new AjaxFormComponentUpdatingBehavior("change"){
 					@Override
-						protected void onUpdate(AjaxRequestTarget target) {
+					protected void onUpdate(AjaxRequestTarget target) {
 						Map<String, String> searchParams = new HashMap<String, String>();
 						for(Entry<String, SelectOption> entry : hierarchySearchMap.entrySet()){
 							searchParams.put(entry.getKey(), entry.getValue() == null ? "" : entry.getValue().getValue());

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserPage.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserPage.java
@@ -347,9 +347,9 @@ public class UserPage  extends BaseTreePage{
 				final DropDownChoice choice = new DropDownChoice("hierarchyLevel", new NodeSelectModel(hierarchyLevel), hierarchySelectOptions.get(hierarchyLevel), choiceRenderer);
 				//keeps the null option (choose one) after a user selects an option
 				choice.setNullValid(true);
-				choice.add(new AjaxFormComponentUpdatingBehavior("onchange"){
+				choice.add(new AjaxFormComponentUpdatingBehavior("change"){
 					@Override
-                    protected void onUpdate(AjaxRequestTarget target) {
+						protected void onUpdate(AjaxRequestTarget target) {
 						Map<String, String> searchParams = new HashMap<String, String>();
 						for(Entry<String, SelectOption> entry : hierarchySearchMap.entrySet()){
 							searchParams.put(entry.getKey(), entry.getValue() == null ? "" : entry.getValue().getValue());

--- a/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserPageSiteSearch.java
+++ b/delegatedaccess/tool/src/java/org/sakaiproject/delegatedaccess/tool/pages/UserPageSiteSearch.java
@@ -433,7 +433,7 @@ public class UserPageSiteSearch extends BasePage {
 				
 				//keeps the null option (choose one) after a user selects an option
 				choice.setNullValid(true);
-				choice.add(new AjaxFormComponentUpdatingBehavior("onchange"){
+				choice.add(new AjaxFormComponentUpdatingBehavior("change"){
 					@Override
 					protected void onUpdate(AjaxRequestTarget target) {
 						Map<String, String> searchParams = new HashMap<String, String>();

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ActivityLinkPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ActivityLinkPanel.java
@@ -163,7 +163,7 @@ public class ActivityLinkPanel extends Panel
         {
             super( id, model );
 
-            add( new ActivityAjaxEventBehavior( "onclick", lms.canUseRelativeUrls() )
+            add( new ActivityAjaxEventBehavior( "click", lms.canUseRelativeUrls() )
             {
                 private static final long serialVersionUID = 1L;
 

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/ReportsEditPage.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/ReportsEditPage.java
@@ -336,7 +336,7 @@ public class ReportsEditPage extends BasePage {
 		titleLocalizedContainer.setVisible(getReportDef().isTitleLocalized());
 		titleLocalizedContainer.add(new Label("titleLocalized"));
 		reportDetails.add(titleLocalizedContainer);
-		title.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		title.add(new AjaxFormComponentUpdatingBehavior("change") {
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {
 				titleLocalizedContainer.setVisible(getReportDef().isTitleLocalized());
@@ -354,7 +354,7 @@ public class ReportsEditPage extends BasePage {
 		descriptionLocalizedContainer.setVisible(getReportDef().isDescriptionLocalized());
 		descriptionLocalizedContainer.add(new Label("descriptionLocalized"));
 		reportDetails.add(descriptionLocalizedContainer);
-		description.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		description.add(new AjaxFormComponentUpdatingBehavior("change") {
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {
 				descriptionLocalizedContainer.setVisible(getReportDef().isDescriptionLocalized());

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/UserActivityPage.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/UserActivityPage.java
@@ -126,7 +126,7 @@ public class UserActivityPage extends BasePage
 
 		DropDownChoice<DisplayUser> userFilter = new DropDownChoice<>("userFilter", new PropertyModel<>(this, "displayUser"),
 				new LoadableDisplayUserListModel(siteId), userChoiceRenderer);
-		userFilter.add(new AjaxFormComponentUpdatingBehavior("onchange")
+		userFilter.add(new AjaxFormComponentUpdatingBehavior("change")
 		{
 			@Override
 			protected void onUpdate(AjaxRequestTarget target)

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/widget/WidgetTabTemplate.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/widget/WidgetTabTemplate.java
@@ -298,7 +298,7 @@ public abstract class WidgetTabTemplate extends Panel {
 			}		
 		};
 		IndicatingAjaxDropDownChoice dateFilter = new IndicatingAjaxDropDownChoice("dateFilter", dateFilterOptions, dateFilterRenderer);
-		dateFilter.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		dateFilter.add(new AjaxFormComponentUpdatingBehavior("change") {
 			private static final long	serialVersionUID	= 1L;
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {
@@ -340,7 +340,7 @@ public abstract class WidgetTabTemplate extends Panel {
 			}		
 		};
 		IndicatingAjaxDropDownChoice roleFilter = new IndicatingAjaxDropDownChoice("roleFilter", roleFilterOptions, roleFilterRenderer);
-		roleFilter.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		roleFilter.add(new AjaxFormComponentUpdatingBehavior("change") {
 			private static final long	serialVersionUID	= 1L;
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {
@@ -374,7 +374,7 @@ public abstract class WidgetTabTemplate extends Panel {
 			}		
 		};
 		IndicatingAjaxDropDownChoice toolFilter = new IndicatingAjaxDropDownChoice("toolFilter", toolFilterOptions, toolFilterRenderer);
-		toolFilter.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		toolFilter.add(new AjaxFormComponentUpdatingBehavior("change") {
 			private static final long	serialVersionUID	= 1L;
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {
@@ -419,7 +419,7 @@ public abstract class WidgetTabTemplate extends Panel {
 				return "";
 			}
 		};
-		resactionFilter.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		resactionFilter.add(new AjaxFormComponentUpdatingBehavior("change") {
 			private static final long	serialVersionUID	= 1L;
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {
@@ -468,7 +468,7 @@ public abstract class WidgetTabTemplate extends Panel {
 				return "";
 			}
 		};
-		lessonActionFilter.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+		lessonActionFilter.add(new AjaxFormComponentUpdatingBehavior("change") {
 			private static final long	serialVersionUID	= 1L;
 			@Override
 			protected void onUpdate(AjaxRequestTarget target) {


### PR DESCRIPTION
Wicket 6 deprecated the usage of JS event names like "onclick","onblur", etc...in favor of their short version without 'on' prefix, i.e. "click","blur", etc... Starting from this version the event old names won't work anymore.
