### PR TITLE
SAK-50736 Assignments raw code displayed in grades column

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -559,19 +559,24 @@
 							</td>
 							#if ($allowAddAssignment == false)
 								<td headers="grade">
+									#if ($submission)
+										#set ($gradeForSubmitter = $service.getGradeForSubmitter($submission, $user.getId()))
+									#else
+										#set ($gradeForSubmitter = "")
+									#end
 									#if ($submission.Graded && ($submission.GradeReleased || $submission.Returned))
 										#if ((($service.getSubmissionStatus($submission.Id, false) == $tlang.getString("gen.returned")) || ($service.getSubmissionStatus($submission.Id, false) == $tlang.getString("gen.pending_resubmit"))) && $submission.grade)
-											#if ($service.getGradeForSubmitter($submission, $user.getId()).equals(""))
+											#if ($gradeForSubmitter.equals(""))
 												<span>$tlang.getString("unchecked")</span>
-												<span>$service.getGradeForSubmitter($submission, $user.getId())</span>
+												<span>$gradeForSubmitter</span>
 											#else
-												<span>$service.getGradeForSubmitter($submission, $user.getId())#if ($assignment.TypeOfGrade.ordinal() == 3)/$service.getMaxPointGradeDisplay($assignment.ScaleFactor, $assignment.MaxGradePoint)#end</span>
+												<span>$gradeForSubmitter#if ($assignment.TypeOfGrade.ordinal() == 3)/$service.getMaxPointGradeDisplay($assignment.ScaleFactor, $assignment.MaxGradePoint)#end</span>
 											#end
 										#else
-											#if ($service.getGradeForSubmitter($submission, $user.getId()).equals("") || ($service.getSubmissionStatus($submission.Id) == $tlang.getString("gen.notsta")))
+											#if ($gradeForSubmitter.equals("") || ($service.getSubmissionStatus($submission.Id) == $tlang.getString("gen.notsta")))
 												<span>-#if ($assignment.TypeOfGrade.ordinal() == 3)/$service.getMaxPointGradeDisplay($assignment.ScaleFactor, $assignment.MaxGradePoint)#end</span>
 											#else
-												<span>$service.getGradeForSubmitter($submission, $user.getId())#if ($assignment.TypeOfGrade.ordinal() == 3)/$service.getMaxPointGradeDisplay($assignment.ScaleFactor, $assignment.MaxGradePoint)#end</span>
+												<span>$gradeForSubmitter#if ($assignment.TypeOfGrade.ordinal() == 3)/$service.getMaxPointGradeDisplay($assignment.ScaleFactor, $assignment.MaxGradePoint)#end</span>
 											#end
 										#end
 									#end


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50736

The assignment grades column (for students) displays "$service.getGradeForSubmitter($submission, $user.getId())" when $submission is null.

It is important to handle the case where a submission is null or the service returns an incorrect value.

![getgrades](https://github.com/user-attachments/assets/1c3fcd94-b32d-41d8-9f12-34c0acc73f7d)
