### PR TITLE
SAK-50772 Tests & Quizzes: IP list sorting in Allowo only specified IP addresses

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -500,11 +501,16 @@ public class AssessmentSettingsBean extends SpringBeanAutowiringSupport implemen
       this.ipAddresses = "";
       Set ipAddressSet = assessment.getSecuredIPAddressSet();
       if (ipAddressSet != null){
+        List<String> ipList = new ArrayList<>();
         Iterator iter = ipAddressSet.iterator();
         while (iter.hasNext()) {
           SecuredIPAddressIfc ip = (SecuredIPAddressIfc) iter.next();
           if (ip.getIpAddress()!=null)
-            this.ipAddresses = ip.getIpAddress()+"\n"+this.ipAddresses;
+            ipList.add(ip.getIpAddress());
+        }
+        Collections.sort(ipList);
+        for (String ip : ipList) {
+    	    this.ipAddresses += ip + "\n";
         }
       }
       // attachment

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1141,11 +1142,16 @@ public void setFeedbackComponentOption(String feedbackComponentOption) {
       this.ipAddresses = "";
       Set ipAddressSet = assessment.getSecuredIPAddressSet();
       if (ipAddressSet != null){
+    	  List<String> ipList = new ArrayList<>();
     	  Iterator iter = ipAddressSet.iterator();
     	  while (iter.hasNext()) {
     		  SecuredIPAddressIfc ip = (SecuredIPAddressIfc) iter.next();
     		  if (ip.getIpAddress()!=null)
-    			  this.ipAddresses = ip.getIpAddress()+"\n"+this.ipAddresses;
+    			  ipList.add(ip.getIpAddress());
+    	  }
+    	  Collections.sort(ipList);
+    	  for (String ip : ipList) {
+    		  this.ipAddresses += ip + "\n";
     	  }
       }
   }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50772

The "Allow only specified IP addresses" list in the "Security and Proctoring" section retrieves the IP addresses in a random order, causing confusion for instructors when verifying that the list is correct. This list should be displayed in a sorted order, for example, from smallest to largest.