### PR TITLE
SAK-50787 Portal footer on Commons page: build info no pop-up

### DIFF
--- a/commons/tool/src/webapp/js/commons.js
+++ b/commons/tool/src/webapp/js/commons.js
@@ -152,9 +152,7 @@ commons.switchState = function (state, arg) {
             });
             if(commons.currentUserPermissions.postDeleteAny){   //if the user can delete any post, we will give them access to Hi-Priority posting too.
                 document.getElementById('commons-editor-priority-container').removeAttribute('style');
-                document.querySelectorAll("[data-bs-toggle='popover']").forEach(t => {
-                  (new bootstrap.Popover(t));
-                });
+                bootstrap.Popover.getOrCreateInstance(document.body); // Initializes all popovers
             }
             editorPostButton.click(function (e) {
 

--- a/commons/tool/src/webapp/js/commons_utils.js
+++ b/commons/tool/src/webapp/js/commons_utils.js
@@ -429,9 +429,7 @@ commons.utils = {
             var numberOfLikes = $('.commons-likes-count');
             numberOfLikes.each(function(){commons.utils.addLikeCount(this)});
             commons.utils.getUserLikes();
-            document.querySelectorAll("[data-bs-toggle='popover']").forEach(t => {
-              (new bootstrap.Popover(t));
-            });
+            bootstrap.Popover.getOrCreateInstance(document.body); // Initializes all popovers
             var textarea = $('#commons-comment-textarea-' + post.id);
             textarea.each(function () { autosize(this); });
             var creator = $('#commons-comment-creator-' + post.id);


### PR DESCRIPTION
Existing popover safe version of initializing popovers. This `getOrCreateInstance `method was added in Bootstrap 5. 

Alternatively I was going to check 
`  if (!bootstrap.Popover.getInstance(t)) {  ... } 
`

But this worked and seemed more straightforward. I tested on some of the popups in commons as well as the information popup. 