### PR TITLE
SAK-50792 Discussions: insert original text fails

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/dfMessageReply.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfMessageReply.jsp
@@ -122,10 +122,10 @@
             <sakai:inputRichText textareaOnly="#{PrivateMessagesTool.mobileSession}" value="#{ForumTool.composeBody}" id="df_compose_body" rows="#{ForumTool.editorRows}" cols="132">
 			</sakai:inputRichText>
 			<script>
-	        // set the previous message variable
-				var textareas = document.getElementsByTagName("textarea");
-				var rteId = textareas.item(1).id;
-
+	        // Give it a chance to try to detect the name incase it might change
+	        const textarea = document.currentScript.previousElementSibling?.querySelector('textarea'); // Select the first <textarea> in the previous sibling
+	        // Set the value found else default to the one we last used. This value is used in forum.js
+	        const rteId = textarea ? textarea.id : "dfCompose:df_compose_body_inputRichText";
 	        var messagetext = document.forms['dfCompose'].elements['dfCompose:msgHidden'].value;
 	        var titletext = document.forms['dfCompose'].elements['dfCompose:titleHidden'].value;
             </script>

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfMessageReplyThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfMessageReplyThread.jsp
@@ -142,9 +142,10 @@
 				CKEDITOR.on('instanceReady', function() {resizeFrame('grow')});
 			</script --%>
 		<script>
-			var textareas = document.getElementsByTagName("textarea");
-			var rteId = textareas.item(1).id;
-	        // set the previous message variable
+	        // Give it a chance to try to detect the name incase it might change
+	        const textarea = document.currentScript.previousElementSibling?.querySelector('textarea'); // Select the first <textarea> in the previous sibling
+	        // Set the value found else default to the one we last used. This value is used in forum.js
+	        const rteId = textarea ? textarea.id : "dfCompose:df_compose_body_inputRichText";
 	        var messagetext = document.forms['dfCompose'].elements['dfCompose:msgHidden'].value;
 	        var titletext = document.forms['dfCompose'].elements['dfCompose:titleHidden'].value;
             </script>


### PR DESCRIPTION
Uncaught TypeError: document.forms.dfCompose.elements[rteId] is undefined.

This may be an "over-engineered" solution but it will attempt to detect the id from the text area in the previous element rather than using the one I observed as being on the document. 