### PR TITLE
SAK-50846 Sitestats successive stats calculated incorrectly

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -1420,7 +1420,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 					}
 				}
 			} else {
-				lastStart = savedBegin.or(() -> firstBeginningPresenceBegin);
+				lastStart = firstBeginningPresenceBegin.or(() -> savedBegin);
 			}
 
 			log.debug("k{} lastStart: {}", key, lastStart);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50846

If a user is connected when the SiteStats Event Aggregator job is run, the user's previously closed session is merged with the active session.

`real time presence   `| `x-----x       x------------x`

`calculation          `| `x--------------------------x`
