### PR TITLE
SAK-50878 Adding overflow hidden for the large sites on the menu

### DIFF
--- a/library/src/skins/default/src/sass/modules/more-sites/_more-sites.scss
+++ b/library/src/skins/default/src/sass/modules/more-sites/_more-sites.scss
@@ -266,7 +266,7 @@ div.fav-title-myworkspace {
 
 .fav-title {
   width: 240px;
-  //overflow: hidden;
+  overflow: hidden;
   display: inline-block;
   vertical-align: middle;
   a {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50878

Before:
![image](https://github.com/user-attachments/assets/db165839-8033-4c59-bd06-6ca1dd364225)

After:
![image](https://github.com/user-attachments/assets/c283867d-1f0c-44f8-8fd7-5ce6e87df527)

In 22.x is OK. This was removed in Trinity
