### PR TITLE
SAK-50849 Accessibility WCAG 1.4.3 Color Contrast on Gateway Welcome Page

### DIFF
--- a/library/src/skins/default/src/sass/tool.scss
+++ b/library/src/skins/default/src/sass/tool.scss
@@ -229,6 +229,10 @@ label {
   margin: 2px;
 }
 
+.form-floating > label {
+  color: var(--sakai-lessons-navy--lighter-5);
+}
+
 .form-group {
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
Added a Sakai-color with better color contrast ratio that meets the WCAG 1.4.3 standard for username and password labels.