### PR TITLE
SAK-50065 T&Q: Event log download needs to have user-friendly text for the Errors column instead of the variable value

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/servlet/event/ExportEventLogServlet.java
@@ -141,7 +141,7 @@ public class ExportEventLogServlet extends SamigoBaseServlet {
                     add(csvDateFormat(eventLogData.getStartDate()));
                     add(csvDateFormat(eventLogData.getEndDate()));
                     add(minutes != null ? minutes.toString() : null);
-                    add(StringUtils.trimToEmpty(eventLogData.getErrorMsg()));
+                    add(StringUtils.trimToEmpty(RESOURCE_BUNDLE.getString(eventLogData.getErrorMsg())));
                     if (displayIpAddressColumn) {
                         add(StringUtils.trimToEmpty(eventLogData.getIpAddress()));
                     }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50065

![image](https://github.com/user-attachments/assets/d0b78377-c6c1-4606-8fc2-950a5b159537)