### PR TITLE
SAK-50908 Portal a11y fix all accessibility issues on home

### DIFF
--- a/library/src/skins/default/src/sass/themes/_light.scss
+++ b/library/src/skins/default/src/sass/themes/_light.scss
@@ -618,7 +618,7 @@
 
     --sakai-pin-hover-color: black;
 
-    --sakai-selected-page-bg-color: var(--sakai-color-blue--darker-4);
+    --sakai-selected-page-bg-color: var(--sakai-color-blue--darker-5);
     --sakai-selected-page-color: white;
 
     --sakai-thumbnail-background-color: var(--sakai-background-color-1);

--- a/library/src/skins/default/src/sass/tool.scss
+++ b/library/src/skins/default/src/sass/tool.scss
@@ -229,10 +229,6 @@ label {
   margin: 2px;
 }
 
-.form-floating > label {
-  color: var(--sakai-lessons-navy--lighter-5);
-}
-
 .form-group {
 	margin-bottom: 15px;
 }

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -75,7 +75,7 @@
 
 #macro( pageListItem $page $url $icon $indentation)
     
-    <li class="nav-item" tabindex="1">
+    <li class="nav-item">
         <a class="btn btn-nav w-100 ps-${indentation} #if ($activePageId == $page.id)selected-page#end" data-page-id="${page.id}"
                 href="$!{url}"
                 title="${page.title}: ${page.description}">


### PR DESCRIPTION
1. This reverts SAK-50849 Accessibility WCAG 1.4.3 Color Contrast on Gateway Welcome Page (#13207)
2. WAVE does not seem trustworthy here. It clear that this is not 1:1 (e.g., the same color) contrast
3. We should also use manual testing to confirm color contrast
4. Cypress now has a pre-login test that will fail if any issues are found
5. This fixes all other items that were triggering aXe