### PR TITLE
SAK-50916 SakaiGrader rubrics evaluation should use group id

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
@@ -454,7 +454,7 @@ export const graderRenderingMixin = Base => class extends Base {
                   tool-id="${this.toolId}"
                   entity-id="${this.entityId}"
                   evaluated-item-id="${this._submission.id}"
-                  evaluated-item-owner-id="${this._submission.groupRef || this._submission.firstSubmitterId}"
+                  evaluated-item-owner-id="${this._submission.groupId || this._submission.firstSubmitterId}"
                   ?group=${this._submission.groupId}
                   ?enable-pdf-export=${this.enablePdfExport}
                   @rubric-rating-changed=${this._onRubricRatingChanged}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50916

This bug was introduced by the webcomponents refactor done here -> https://github.com/sakaiproject/sakai/pull/11789

Fix is taken from the original s2u-34 piece which introduced the group submission + rubrics feature -> https://github.com/sakaiproject/sakai/pull/11950