### PR TITLE
SAK-50917 WC SakaiGrader when grading move peer review rubrics to an accordion

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -378,11 +378,12 @@
                             <div class="textPanel borderPanel">$formattedText.escapeHtmlFormattedText($review.getComment())</div>
                         #end
                         <sakai-rubric-student
-                            tool-id="sakai.assignment.grades"
+                            site-id="$!assignment.Context"
                             entity-id="$assignment.Id"
+                            tool-id="sakai.assignment.grades"
+                            instructor
+                            is-peer-or-self
                             evaluated-item-id="$review.id.assessorUserId"
-                            instructor="true"
-                            is-peer-or-self="true"
                             #if ($!assignment.isGroup)
                                 evaluated-item-owner-id="$ownerGroupId"
                             #else
@@ -403,8 +404,8 @@
                 site-id="$!assignment.Context"
                 entity-id="$assignment.Id"
                 tool-id="sakai.assignment.grades"
-                instructor="true"
-                is-peer-or-self="true"
+                instructor
+                is-peer-or-self
                 #if ($!assignment.isGroup)
                     evaluated-item-id="$ownerGroupId"
                     evaluated-item-owner-id="$ownerGroupId"

--- a/webcomponents/bundle/src/main/bundle/grader_ca.properties
+++ b/webcomponents/bundle/src/main/bundle/grader_ca.properties
@@ -1,6 +1,9 @@
 done=Fet
 no_submission=Sense enviaments
 no_submission_for=Sense lliuraments de
+peer_reviews=Revisi\u00f3 per part dels companys
+reviewer_comments=Comentaris del revisor
+reviewer_attachments=Adjunts del revisor
 grading_rubric_tooltip=Qualifica el lliurament usant una r\u00fabrica
 rubric=R\u00fabrica
 autoevaluation=Autoavaluaci\u00f3:

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/sakai-grader-rendering-mixin.js
@@ -184,32 +184,49 @@ export const graderRenderingMixin = Base => class extends Base {
             ` : nothing }
           `}
           ${this.gradable.allowPeerAssessment && this._submission.peerReviews?.length > 0 ? html`
-          <div class="mt-4">
+          <div class="mt-5">
             <h3 class="mb-3">${this._i18n.peer_reviews}</h3>
-            ${this._submission.peerReviews.map(pr => html`
-
-              <div class="card mb-2">
-                <div class="card-header fw-bold">${pr.assessorDisplayName}</div>
-                <div class="card-body">
-                  <div class="card-text">
-                    <div>
-                      <span class="fw-bold me-2">${this._i18n.grade}</span>
-                      <span>${pr.scoreDisplay}</span>
+            <div class="accordion" id="peer-reviews">
+              ${this._submission.peerReviews.map(pr => html`
+                <div class="accordion-item">
+                  <h2 class="accordion-header" id="peer-heading-${pr.assessorUserId}">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#peer-collapse-${pr.assessorUserId}" aria-expanded="true" aria-controls="peer-collapse-${pr.assessorUserId}">
+                      ${pr.assessorDisplayName}
+                    </button>
+                  </h2>
+                  <div id="peer-collapse-${pr.assessorUserId}" class="accordion-collapse collapse" aria-labelledby="peer-heading-${pr.assessorUserId}" data-bs-parent="#peer-reviews">
+                    <div class="accordion-body">
+                      ${this.hasAssociatedRubric === "true" ? html`
+                        <sakai-rubric-student
+                          site-id="${portal.siteId}"
+                          tool-id="${this.toolId}"
+                          entity-id="${this.entityId}"
+                          instructor
+                          is-peer-or-self
+                          evaluated-item-id="${pr.assessorUserId}"
+                          evaluated-item-owner-id="${this._submission.groupId || this._submission.firstSubmitterId}">
+                        </sakai-rubric-student>
+                        <hr class="itemSeparator">
+                      ` : nothing}
+                      <div class="mt-2 mb-3">
+                        <span class="fw-bold me-2">${this._i18n.grade}</span>
+                        <span>${pr.scoreDisplay}</span>
+                      </div>
+                      <div class="mt-2 mb-2 fw-bold">${this._i18n.reviewer_comments}</div>
+                      <div>${unsafeHTML(pr.comment)}</div>
+                      ${pr.attachmentUrlList?.length > 0 ? html`
+                        <div class="fw-bold mb-2">${this._i18n.reviewer_attachments}</div>
+                        ${pr.attachmentUrlList.map((url, i) => html`
+                          <div class="feedback-attachment">
+                            <a href="${url}" title="${this._i18n.feedback_attachment_tooltip}" target="_blank">${this._i18n.attachment} ${i + 1}</a>
+                          </div>
+                        `)}
+                      ` : nothing}
                     </div>
-                    <div class="mt-2 mb-2 fw-bold">${this._i18n.reviewer_comments}</div>
-                    <div>${unsafeHTML(pr.comment)}</div>
-                    ${pr.attachmentUrlList && pr.attachmentUrlList.length > 0 ? html`
-                      <div class="fw-bold mb-2">${this._i18n.reviewer_attachments}</div>
-                      ${pr.attachmentUrlList.map((url, i) => html`
-                        <div class="feedback-attachment">
-                          <a href="${url}" title="${this._i18n.feedback_attachment_tooltip}" target="_blank">${this._i18n.attachment} ${i + 1}</a>
-                        </div>
-                      `)}
-                    ` : nothing}
                   </div>
                 </div>
-              </div>
-            `)}
+              `)}
+            </div>
           </div>
           ` : nothing }
         ` : nothing }
@@ -493,8 +510,8 @@ export const graderRenderingMixin = Base => class extends Base {
                   site-id="${portal.siteId}"
                   tool-id="${this.toolId}"
                   entity-id="${this.entityId}"
-                  instructor="true"
-                  is-peer-or-self="true"
+                  instructor
+                  is-peer-or-self
                   evaluated-item-id="${this._submission.groupId || this._submission.firstSubmitterId}"
                   evaluated-item-owner-id="${this._submission.groupId || this._submission.firstSubmitterId}">
                 </sakai-rubric-student>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-50917

After adding the rubrics, the content of each peer review may be too lengthy to display all of them expanded. I have changed the format to an accordion (as it is in the classic grader).

![image](https://github.com/user-attachments/assets/d6d7378c-bcd1-43cf-ae3e-35ba745c6100)
![image](https://github.com/user-attachments/assets/50da06d3-8b4e-4b60-b4be-71cdcfb184b3)
![image](https://github.com/user-attachments/assets/054ddf35-0f02-4294-9ab4-11e3eba42856)

![image](https://github.com/user-attachments/assets/378f4436-435f-4e72-a7a5-a1f605d0b881)
