### PR TITLE
SAK-50982 Resources style availability and access option in detail settings

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
+++ b/content/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
@@ -478,7 +478,7 @@ button.btn.btn-default.multiselect-clear-filter{
 					#end
 				#end
 				#if(!$model.isSiteCollection())
-					<p class="text-muted ms-4 mt-1">$model.getAccessInstruction()</p>
+					<p class="text-muted mt-4 mb-2 h5">$model.getAccessInstruction()</p>
 
 					<div class="form-group">
 						#set ($listDisplay="none")

--- a/library/src/skins/default/src/sass/base/_defaults.scss
+++ b/library/src/skins/default/src/sass/base/_defaults.scss
@@ -118,6 +118,14 @@ h4{
   font-size: #{$default-font-size + 2};
 }
 
+h5{
+  font-size: #{$default-font-size};
+}
+
+h6{
+  font-size: #{$default-font-size - 2};
+}
+
 h3.popover-header {
   margin-top: 0;
 }


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-50982

This proposed PR yields the display depicted in the ExpectedLayout.png screenshot attached to the jira. I'm using the h5 bootstrap class because the 'Availability and Access' link is an h4. Presumably, we could instead revise the p element to be h5. I'm open to either approach.