### PR TITLE
SAK-47782 Fix server url mapping in RTE link fix

### DIFF
--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -1339,9 +1339,7 @@ public abstract class BaseLTIService implements LTIService {
 				Object result = this.insertContent(content, toContext);
 				if (result instanceof Long) {
 					Long newContentId = (Long) result;
-					String baseUrl = url.substring(0, url.indexOf("/site/") + 6); // +6 to include "/site/"
-					// Upgrade the access prefix from legacy blti to modern lti
-					String newUrl = baseUrl.replace(LTIService.LAUNCH_PREFIX_LEGACY, LTIService.LAUNCH_PREFIX) + toContext + "/content:" + newContentId;
+					String newUrl = serverConfigurationService.getServerUrl() + LTIService.LAUNCH_PREFIX + toContext + "/content:" + newContentId;
 					text = text.replace(url, newUrl);
 					if ( transversalMap != null ) transversalMap.put(url, newUrl);
 					log.debug("Inserted content item {} in site {} newUrl {}", newContentId, toContext, newUrl);


### PR DESCRIPTION
This is a really small change where the RTE mapping code did all the difficult bits but used the old, not new serverURL as the base of the new RTE launch URL.  Easy fix.  I partially blame AI for this because it helped be tweak the URL and the code looked sooo cool.  And it worked until you were moving between servers.