### PR TITLE
SAK-51045 Lessons embedding calendar in a collapsible section (start collapsed) does not display correctly

### DIFF
--- a/lessonbuilder/tool/src/webapp/js/lessons-calendar.js
+++ b/lessonbuilder/tool/src/webapp/js/lessons-calendar.js
@@ -108,6 +108,10 @@ $(function(){
                 }
             });
             calendar.render();
+
+            $('.collapsibleSectionHeader').on('click', function() {
+                calendar.updateSize();
+            });
         });
     }
 });


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51045

If you embed a calendar in a Lessons section that starts collapsed, the calendar is rendered with a height of 0px.