### PR TITLE
SAK-51010 Calendar : frequency not working in Spanish with unset hour

### DIFF
--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -6388,7 +6388,7 @@ extends VelocityPortletStateAction
 		int houri;
 		
 		String hour = "";
-		hour = rundata.getParameters().getString("startHour");
+		hour = rundata.getParameters().getString("startHour") != null ? rundata.getParameters().getString("startHour") : "100"; // SAK-51010 applying same default value as non-24h format
 		String title ="";
 		title = rundata.getParameters().getString("activitytitle");
 		String minute = "";


### PR DESCRIPTION
The problem seems to come from a very old, very ugly js+vm related to the 24h vs am/pm formats, that should probably be rewritten entirely. In the meantime, I think it's fine to fix this specific bug by adding the same default value used by the English format.

The value is not even used, but it's just preventing from accessing and using the frequency feature.