### PR TITLE
SAK-51020 Roster - Export funcionality is broken

### DIFF
--- a/roster2/bundle/src/bundle/roster_es.properties
+++ b/roster2/bundle/src/bundle/roster_es.properties
@@ -127,7 +127,7 @@ roster_user_groups_label=Selector donde se muestran los grupos
 
 
 # S2U-45
-facet_sections=Grupos
+facet_sections=Secciones-Grupos
 facet_sections_category=Secciones de la categor\u00eda\:
 
 # S2U-42


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51020

I've just changed it on Transifex too

![image](https://github.com/user-attachments/assets/c0799d76-c44a-45c9-bebf-6f2c1257dbdb)