### PR TITLE
SAK-51021 Roster switching to list mode photos are not displayed

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/roster/_roster.scss
+++ b/library/src/skins/default/src/sass/modules/tool/roster/_roster.scss
@@ -244,8 +244,19 @@
             display: none;
         }
 
-        .roster-picture-cell {
-            text-align: center;
+        td.roster-picture-cell {
+            margin-right: 10px;
+            min-width: 76px;
+            max-width: 76px;
+            .roster-photo {
+                min-width: 76px;
+                max-width: 76px;
+                width: 76px;
+                height: 76px;
+                border: 1px solid #BBB;
+                border-radius: 0;
+                background-repeat: no-repeat;
+            }
         }
 
         .roster-hide-pictures {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51021

Before:
![image](https://github.com/user-attachments/assets/21321382-532e-4047-a503-dd1813ae8dfa)

After:
![image](https://github.com/user-attachments/assets/f9b9b027-906d-4202-9e59-068b462ff64c)

I'll fix the width on another ticket with other little thing.