### PR TITLE
SAK-50154 CC+Archive refactor merge() calling sequences

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -439,16 +439,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     public String merge(String siteId, Element root, String archivePath, String fromSiteId,
         MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
-        String archiveContext = "";
-        String archiveServerUrl = "";
-
-        Node parent = root.getParentNode();
-        if (parent.getNodeType() == Node.ELEMENT_NODE)
-        {
-            Element parentEl = (Element)parent;
-            archiveContext = parentEl.getAttribute("source");
-            archiveServerUrl = parentEl.getAttribute("serverurl");
-        }
 
         final StringBuilder results = new StringBuilder();
         results.append("begin merging ").append(getLabel()).append(" context ").append(siteId).append(LINE_SEPARATOR);
@@ -465,7 +455,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         for (Element assignmentElement : assignmentElements) {
 
             try {
-                mergeAssignment(siteId, assignmentElement, results, assignmentTitles, mcx, archiveContext, archiveServerUrl);
+                mergeAssignment(siteId, assignmentElement, results, assignmentTitles, mcx);
                 assignmentsMerged++;
             } catch (Exception e) {
                 final String error = "could not merge assignment with id: " + assignmentElement.getFirstChild().getFirstChild().getNodeValue();
@@ -1001,7 +991,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     @Transactional
-    private Assignment mergeAssignment(final String siteId, final Element element, final StringBuilder results, Set<String> assignmentTitles, MergeConfig mcx, String archiveContext, String archiveServerUrl) throws PermissionException {
+    private Assignment mergeAssignment(final String siteId, final Element element, final StringBuilder results, Set<String> assignmentTitles, MergeConfig mcx) throws PermissionException {
 
         if (!allowAddAssignment(siteId)) {
             throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_ADD_ASSIGNMENT, AssignmentReferenceReckoner.reckoner().context(siteId).reckon().getReference());
@@ -1027,7 +1017,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if ( StringUtils.isNotEmpty(mcx.creatorId) ) assignmentFromXml.setAuthor(mcx.creatorId);
 
             String newInstructions = ltiService.fixLtiLaunchUrls(assignmentFromXml.getInstructions(), siteId, mcx);
-            newInstructions = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, newInstructions);
+            newInstructions = linkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, newInstructions);
             assignmentFromXml.setInstructions(newInstructions);
 
             Long contentKey = ltiService.mergeContentFromImport(element, siteId);

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -436,7 +436,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
     @Override
     @Transactional
-    public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
+    public String merge(String siteId, Element root, String archivePath, String fromSiteId,
         MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
         String archiveContext = "";
@@ -465,7 +465,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         for (Element assignmentElement : assignmentElements) {
 
             try {
-                mergeAssignment(siteId, assignmentElement, results, creatorId, assignmentTitles, mcx, archiveContext, archiveServerUrl);
+                mergeAssignment(siteId, assignmentElement, results, assignmentTitles, mcx, archiveContext, archiveServerUrl);
                 assignmentsMerged++;
             } catch (Exception e) {
                 final String error = "could not merge assignment with id: " + assignmentElement.getFirstChild().getFirstChild().getNodeValue();
@@ -1001,7 +1001,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     @Transactional
-    private Assignment mergeAssignment(final String siteId, final Element element, final StringBuilder results, String creatorId, Set<String> assignmentTitles, MergeConfig mcx, String archiveContext, String archiveServerUrl) throws PermissionException {
+    private Assignment mergeAssignment(final String siteId, final Element element, final StringBuilder results, Set<String> assignmentTitles, MergeConfig mcx, String archiveContext, String archiveServerUrl) throws PermissionException {
 
         if (!allowAddAssignment(siteId)) {
             throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_ADD_ASSIGNMENT, AssignmentReferenceReckoner.reckoner().context(siteId).reckon().getReference());
@@ -1024,7 +1024,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             assignmentFromXml.setId(null);
             assignmentFromXml.setContext(siteId);
             assignmentFromXml.setContentId(null);
-            if ( StringUtils.isNotEmpty(creatorId) ) assignmentFromXml.setAuthor(creatorId);
+            if ( StringUtils.isNotEmpty(mcx.creatorId) ) assignmentFromXml.setAuthor(mcx.creatorId);
 
             String newInstructions = ltiService.fixLtiLaunchUrls(assignmentFromXml.getInstructions(), siteId, mcx);
             newInstructions = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, newInstructions);
@@ -1083,7 +1083,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             copy.setAssignmentId(assignmentFromXml.getId());
             copy.setNote(text);
             copy.setShareWith(Integer.parseInt(shareWith));
-            copy.setCreatorId(creatorId);
+            copy.setCreatorId(mcx.creatorId);
             assignmentSupplementItemService.saveNoteItem(copy);
         }
 

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -436,8 +436,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
     @Override
     @Transactional
-    public String merge(String siteId, Element root, String archivePath, String fromSiteId,
-        MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+    public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
 
 
         final StringBuilder results = new StringBuilder();

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -194,7 +194,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.ls.DOMImplementationLS;
 import org.w3c.dom.ls.LSSerializer;
 import org.xml.sax.InputSource;
-
+import org.sakaiproject.util.MergeConfig;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -437,8 +437,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Override
     @Transactional
     public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-        Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
-
+        MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
         String archiveContext = "";
         String archiveServerUrl = "";
@@ -466,7 +465,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         for (Element assignmentElement : assignmentElements) {
 
             try {
-                mergeAssignment(siteId, assignmentElement, results, creatorId, assignmentTitles, attachmentNames, ltiContentItems, archiveContext, archiveServerUrl);
+                mergeAssignment(siteId, assignmentElement, results, creatorId, assignmentTitles, attachmentNames, mcx, archiveContext, archiveServerUrl);
                 assignmentsMerged++;
             } catch (Exception e) {
                 final String error = "could not merge assignment with id: " + assignmentElement.getFirstChild().getFirstChild().getNodeValue();
@@ -1002,7 +1001,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     @Transactional
-    private Assignment mergeAssignment(final String siteId, final Element element, final StringBuilder results, String creatorId, Set<String> assignmentTitles, Map<String, String> attachmentNames, Map<Long, Map<String, Object>> ltiContentItems, String archiveContext, String archiveServerUrl) throws PermissionException {
+    private Assignment mergeAssignment(final String siteId, final Element element, final StringBuilder results, String creatorId, Set<String> assignmentTitles, Map<String, String> attachmentNames, MergeConfig mcx, String archiveContext, String archiveServerUrl) throws PermissionException {
 
         if (!allowAddAssignment(siteId)) {
             throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_ADD_ASSIGNMENT, AssignmentReferenceReckoner.reckoner().context(siteId).reckon().getReference());
@@ -1027,7 +1026,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             assignmentFromXml.setContentId(null);
             if ( StringUtils.isNotEmpty(creatorId) ) assignmentFromXml.setAuthor(creatorId);
 
-            String newInstructions = ltiService.fixLtiLaunchUrls(assignmentFromXml.getInstructions(), siteId, ltiContentItems);
+            String newInstructions = ltiService.fixLtiLaunchUrls(assignmentFromXml.getInstructions(), siteId, mcx);
             newInstructions = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, newInstructions);
             assignmentFromXml.setInstructions(newInstructions);
 

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -1491,7 +1491,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	}
 
 	@Override
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId,
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -1491,7 +1491,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	}
 
 	@Override
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentImportMap,
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 
@@ -1629,7 +1629,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 												// map the attachment area folder name
 												String oldUrl = element5.getAttribute("relative-url");
 												String toolTitle = toolManager.getTool("sakai.schedule").getTitle();
-												ContentResource attachment = contentHostingService.copyAttachment(oldUrl, siteId, toolTitle, attachmentImportMap);
+												ContentResource attachment = contentHostingService.copyAttachment(oldUrl, siteId, toolTitle, mcx);
 												if ( attachment != null ) {
 													String newUrl = attachment.getReference();
 													element5.setAttribute("relative-url", Validator.escapeQuestionMark(newUrl));

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -1495,17 +1495,6 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 
-		String archiveContext = "";
-		String archiveServerUrl = "";
-
-		Node parent = root.getParentNode();
-		if (parent.getNodeType() == Node.ELEMENT_NODE)
-		{
-			Element parentEl = (Element)parent;
-			archiveContext = parentEl.getAttribute("source");
-			archiveServerUrl = parentEl.getAttribute("serverurl");
-		}
-
 		// prepare the buffer for the results log
 		StringBuilder results = new StringBuilder();
 
@@ -1648,7 +1637,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 									}
 									String description = edit.getDescriptionFormatted();
 									description = ltiService.fixLtiLaunchUrls(description, siteId, mcx);
-									description = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, description);
+									description = linkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, description);
 									edit.setDescriptionFormatted(description);
 
 									calendar.commitEvent(edit);

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -1491,8 +1491,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	}
 
 	@Override
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId,
-		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx)
 	{
 
 		// prepare the buffer for the results log

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -103,6 +103,8 @@ import org.sakaiproject.assignment.api.AssignmentServiceConstants;
 import org.sakaiproject.api.app.messageforums.DiscussionForumService;
 import org.sakaiproject.samigo.util.SamigoConstants;
 
+import org.sakaiproject.util.MergeConfig;
+
 /**
  * <p>
  * BaseCalendarService is an base implementation of the CalendarService. Extension classes implement object creation, access and storage.
@@ -1490,7 +1492,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 
 	@Override
 	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentImportMap,
-		Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport)
+		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 
 		String archiveContext = "";
@@ -1645,7 +1647,7 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 										continue;
 									}
 									String description = edit.getDescriptionFormatted();
-									description = ltiService.fixLtiLaunchUrls(description, siteId, ltiContentItems);
+									description = ltiService.fixLtiLaunchUrls(description, siteId, mcx);
 									description = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, description);
 									edit.setDescriptionFormatted(description);
 

--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
@@ -357,8 +357,15 @@ public class SiteMerger {
 						if (service != null) {
 						    if ((system.equalsIgnoreCase(ArchiveService.FROM_SAKAI) || system.equalsIgnoreCase(ArchiveService.FROM_SAKAI_2_8))) {
 						        if (checkSakaiService(filterSakaiService, filteredSakaiService, serviceName)) {
-						            // checks passed so now we attempt to do the merge
-		                            log.debug("Merging archive data for {} ({}) to site {}", serviceName, fileName, siteId);
+                                    // checks passed so now we attempt to do the merge
+                                    Node parent = element.getParentNode();
+                                    if (parent.getNodeType() == Node.ELEMENT_NODE)
+                                    {
+                                        Element parentEl = (Element)parent;
+                                        mcx.archiveContext = parentEl.getAttribute("source");
+                                        mcx.archiveServerUrl = parentEl.getAttribute("serverurl");
+                                    }
+                                    log.debug("Merging archive data for {} ({}) to site {} archive from context {} and server {}", serviceName, fileName, siteId, mcx.archiveContext, mcx.archiveServerUrl);
 		                            msg = service.merge(siteId, element, fileName, fromSite, mcx, new HashMap() /* empty userIdTran map */, usersListAllowImport);
 						        } else {
 						            log.warn("Skipping merge archive data for "+serviceName+" ("+fileName+") to site "+siteId+", checked filter failed (filtersOn="+filterSakaiService+", filters="+Arrays.toString(filteredSakaiService)+")");

--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
@@ -145,6 +145,7 @@ public class SiteMerger {
 		}
 
 		MergeConfig mcx = new MergeConfig();
+		mcx.creatorId = creatorId;
 		
 		// The archive.xml is really a debug log, not actual archive data - it does not participate in any merge
 		// the web.xml is now merged in the site merger
@@ -172,7 +173,7 @@ public class SiteMerger {
 		{
 			if ((files[i] != null) && (files[i].getPath().indexOf("user.xml") != -1))
 			{
-				processMerge(files[i].getPath(), siteId, results, mcx, null, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+				processMerge(files[i].getPath(), siteId, results, mcx, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 				files[i] = null;
 				break;
 			}
@@ -195,7 +196,7 @@ public class SiteMerger {
 		{
 			if ((files[i] != null) && (files[i].getPath().indexOf("attachment.xml") != -1))
 			{
-				processMerge(files[i].getPath(), siteId, results, mcx, null, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+				processMerge(files[i].getPath(), siteId, results, mcx, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 				files[i] = null;
 				break;
 			}
@@ -207,13 +208,13 @@ public class SiteMerger {
 			if (files[i] != null)
 				if (files[i].getPath().endsWith(".xml"))
 				{
-					processMerge(files[i].getPath(), siteId, results, mcx, creatorId, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+					processMerge(files[i].getPath(), siteId, results, mcx, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 				}
 		}
 
 		if (siteFile != null )
 		{
-			processMerge(siteFile, siteId, results, mcx, creatorId, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+			processMerge(siteFile, siteId, results, mcx, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 		}
 
 		// Attachments are of the form
@@ -253,9 +254,8 @@ public class SiteMerger {
 	* @param siteId The id of the site to merge the content into.
 	* @param results A buffer to accumulate result messages.
 	* @param mcx The MergeConfig for this import
-	* @param creatorId The creator id
 	*/
-	protected void processMerge(String fileName, String siteId, StringBuilder results, MergeConfig mcx, String creatorId, boolean filterSakaiService, String[] filteredSakaiService, boolean filterSakaiRoles, String[] filteredSakaiRoles)
+	protected void processMerge(String fileName, String siteId, StringBuilder results, MergeConfig mcx, boolean filterSakaiService, String[] filteredSakaiService, boolean filterSakaiRoles, String[] filteredSakaiRoles)
 	{
 		// correct for windows backslashes
 		fileName = fileName.replace('\\', '/');
@@ -304,11 +304,7 @@ public class SiteMerger {
 			// look for site stuff
 			if (element.getTagName().equals(SiteService.APPLICATION_ID))
 			{	
-				//if the xml file is from WT site, merge it with the translated user ids
-				//if (system.equalsIgnoreCase(ArchiveService.FROM_WT))
-				//	mergeSite(siteId, fromSite, element, userIdTrans, creatorId);
-				//else
-				mergeSite(siteId, fromSite, element, new HashMap()/*empty userIdMap */, creatorId, mcx, filterSakaiRoles, filteredSakaiRoles);
+				mergeSite(siteId, fromSite, element, new HashMap()/*empty userIdMap */, mcx, filterSakaiRoles, filteredSakaiRoles);
 			}
 			else if (element.getTagName().equals(UserDirectoryService.APPLICATION_ID))
 			{	;
@@ -363,7 +359,7 @@ public class SiteMerger {
 						        if (checkSakaiService(filterSakaiService, filteredSakaiService, serviceName)) {
 						            // checks passed so now we attempt to do the merge
 		                            log.debug("Merging archive data for {} ({}) to site {}", serviceName, fileName, siteId);
-		                            msg = service.merge(siteId, element, fileName, fromSite, creatorId, mcx, new HashMap() /* empty userIdTran map */, usersListAllowImport);
+		                            msg = service.merge(siteId, element, fileName, fromSite, mcx, new HashMap() /* empty userIdTran map */, usersListAllowImport);
 						        } else {
 						            log.warn("Skipping merge archive data for "+serviceName+" ("+fileName+") to site "+siteId+", checked filter failed (filtersOn="+filterSakaiService+", filters="+Arrays.toString(filteredSakaiService)+")");
 						        }
@@ -459,10 +455,9 @@ public class SiteMerger {
 	* @param siteId The id of the site getting imported into.
 	* @param fromSiteId The id of the site the archive was made from.
 	* @param element The XML DOM tree of messages to merge.
-	* @param creatorId The creator id
 	* @param mcx The MergeConfig for this import
 	*/
-	protected void mergeSite(String siteId, String fromSiteId, Element element, HashMap useIdTrans, String creatorId, MergeConfig mcx, boolean filterSakaiRoles, String[] filteredSakaiRoles)
+	protected void mergeSite(String siteId, String fromSiteId, Element element, HashMap useIdTrans, MergeConfig mcx, boolean filterSakaiRoles, String[] filteredSakaiRoles)
 	{
 		String source = "";
 
@@ -532,7 +527,7 @@ public class SiteMerger {
 			// merge the site info first
 			try
 			{
-				siteService.merge(siteId, element2, creatorId);
+				siteService.merge(siteId, element2, mcx.creatorId);
 				mergeSiteInfo(element2, siteId);
 			}
 			catch(Exception any)

--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
@@ -92,9 +92,7 @@ public class SiteMerger {
 
 	private String DEV_MERGE_KEEP_ATTACHMENTS = "dev.merge.keep.attachments";
 	private Boolean DEV_MERGE_KEEP_ATTACHMENTS_DEFAULT = false;
-	
-	//SWG TODO I have a feeling this is a bug
-	protected HashSet<String> usersListAllowImport = new HashSet<String>(); 
+
 	/**
 	* Process a merge for the file, or if it's a directory, for all contained files (one level deep).
 	* @param fileName The site name (for the archive file) to read from.
@@ -366,7 +364,7 @@ public class SiteMerger {
                                         mcx.archiveServerUrl = parentEl.getAttribute("serverurl");
                                     }
                                     log.debug("Merging archive data for {} ({}) to site {} archive from context {} and server {}", serviceName, fileName, siteId, mcx.archiveContext, mcx.archiveServerUrl);
-		                            msg = service.merge(siteId, element, fileName, fromSite, mcx, new HashMap() /* empty userIdTran map */, usersListAllowImport);
+		                            msg = service.merge(siteId, element, fileName, fromSite, mcx);
 						        } else {
 						            log.warn("Skipping merge archive data for "+serviceName+" ("+fileName+") to site "+siteId+", checked filter failed (filtersOn="+filterSakaiService+", filters="+Arrays.toString(filteredSakaiService)+")");
 						        }
@@ -565,7 +563,7 @@ public class SiteMerger {
 					if (!element3.getTagName().equals("roles")) continue;
 	
 					try  {	
-						mergeSiteRoles(element3, siteId, useIdTrans, filterSakaiRoles, filteredSakaiRoles);
+						mergeSiteRoles(element3, siteId, mcx, filterSakaiRoles, filteredSakaiRoles);
 					} 
 					catch (PermissionException e1) {
 						log.warn(e1.getMessage(), e1);
@@ -632,7 +630,7 @@ public class SiteMerger {
 	* @param element The XML DOM tree of messages to merge.
 	* @param siteId The id of the site getting imported into.
 	*/
-	protected void mergeSiteRoles(Element el, String siteId, HashMap useIdTrans, boolean filterSakaiRoles, String[] filteredSakaiRoles) throws PermissionException
+	protected void mergeSiteRoles(Element el, String siteId, MergeConfig mcx, boolean filterSakaiRoles, String[] filteredSakaiRoles) throws PermissionException
 	{
 		// heck security (throws if not permitted)
 		unlock(SiteService.SECURE_UPDATE_SITE, siteService.siteReference(siteId));
@@ -696,7 +694,7 @@ public class SiteMerger {
 
 					String userId = element3.getAttribute("userId");	
 					// this user has a qualified role, his/her resource will be imported
-					usersListAllowImport.add(userId);
+					mcx.userListAllowImport.add(userId);
 				}
 			} // for
 		}

--- a/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
+++ b/common/archive-impl/impl2/src/java/org/sakaiproject/archive/impl/SiteMerger.java
@@ -145,9 +145,6 @@ public class SiteMerger {
 		}
 
 		MergeConfig mcx = new MergeConfig();
-
-		// track old to new attachment names
-		Map<String, String> attachmentNames = new HashMap();
 		
 		// The archive.xml is really a debug log, not actual archive data - it does not participate in any merge
 		// the web.xml is now merged in the site merger
@@ -175,7 +172,7 @@ public class SiteMerger {
 		{
 			if ((files[i] != null) && (files[i].getPath().indexOf("user.xml") != -1))
 			{
-				processMerge(files[i].getPath(), siteId, results, attachmentNames, mcx, null, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+				processMerge(files[i].getPath(), siteId, results, mcx, null, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 				files[i] = null;
 				break;
 			}
@@ -198,7 +195,7 @@ public class SiteMerger {
 		{
 			if ((files[i] != null) && (files[i].getPath().indexOf("attachment.xml") != -1))
 			{
-				processMerge(files[i].getPath(), siteId, results, attachmentNames, mcx, null, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+				processMerge(files[i].getPath(), siteId, results, mcx, null, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 				files[i] = null;
 				break;
 			}
@@ -210,21 +207,21 @@ public class SiteMerger {
 			if (files[i] != null)
 				if (files[i].getPath().endsWith(".xml"))
 				{
-					processMerge(files[i].getPath(), siteId, results, attachmentNames, mcx, creatorId, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+					processMerge(files[i].getPath(), siteId, results, mcx, creatorId, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 				}
 		}
 
 		if (siteFile != null )
 		{
-			processMerge(siteFile, siteId, results, attachmentNames, mcx, creatorId, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
+			processMerge(siteFile, siteId, results, mcx, creatorId, filterSakaiServices, filteredSakaiServices, filterSakaiRoles, filteredSakaiRoles);
 		}
 
 		// Attachments are of the form
 		// /attachment/TA-8a7a04de-77e1-497c-9ed3-79f4daa0dfd3/Assignments/fbf7609c-e289-459c-951e-187e70b653e4/ietf-jon-postel-07.png
 		// The first two tokens are a folder we need to remove
 		boolean keepAttachments = serverConfigurationService.getBoolean(DEV_MERGE_KEEP_ATTACHMENTS, DEV_MERGE_KEEP_ATTACHMENTS_DEFAULT);
-		for (String key : attachmentNames.keySet()) {
-			String value = attachmentNames.get(key);
+		for (String key : mcx.attachmentNames.keySet()) {
+			String value = mcx.attachmentNames.get(key);
 			if (!StringUtils.startsWith(value, "/attachment/TA-")) {
 				continue;
 			}
@@ -255,12 +252,10 @@ public class SiteMerger {
 	* @param fileName The site name (for the archive file) to read from.
 	* @param siteId The id of the site to merge the content into.
 	* @param results A buffer to accumulate result messages.
-	* @param attachmentNames A map of old to new attachment names.
-	* @param ltiContentItems A map of LTI Content Items associated with this import
-	* @param useIdTrans A map of old WorkTools id to new Ctools id
+	* @param mcx The MergeConfig for this import
 	* @param creatorId The creator id
 	*/
-	protected void processMerge(String fileName, String siteId, StringBuilder results, Map attachmentNames, MergeConfig mcx, String creatorId, boolean filterSakaiService, String[] filteredSakaiService, boolean filterSakaiRoles, String[] filteredSakaiRoles)
+	protected void processMerge(String fileName, String siteId, StringBuilder results, MergeConfig mcx, String creatorId, boolean filterSakaiService, String[] filteredSakaiService, boolean filterSakaiRoles, String[] filteredSakaiRoles)
 	{
 		// correct for windows backslashes
 		fileName = fileName.replace('\\', '/');
@@ -368,7 +363,7 @@ public class SiteMerger {
 						        if (checkSakaiService(filterSakaiService, filteredSakaiService, serviceName)) {
 						            // checks passed so now we attempt to do the merge
 		                            log.debug("Merging archive data for {} ({}) to site {}", serviceName, fileName, siteId);
-		                            msg = service.merge(siteId, element, fileName, fromSite, creatorId, attachmentNames, mcx, new HashMap() /* empty userIdTran map */, usersListAllowImport);
+		                            msg = service.merge(siteId, element, fileName, fromSite, creatorId, mcx, new HashMap() /* empty userIdTran map */, usersListAllowImport);
 						        } else {
 						            log.warn("Skipping merge archive data for "+serviceName+" ("+fileName+") to site "+siteId+", checked filter failed (filtersOn="+filterSakaiService+", filters="+Arrays.toString(filteredSakaiService)+")");
 						        }

--- a/kernel/api/src/main/java/org/sakaiproject/content/api/ContentHostingService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/api/ContentHostingService.java
@@ -50,6 +50,7 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.time.api.Time;
+import org.sakaiproject.util.MergeConfig;
 import org.w3c.dom.Document;
 
 /**
@@ -1138,14 +1139,13 @@ public interface ContentHostingService extends EntityProducer
 	 * @param toolTitle
 	 *      The title of the tool that the attachment is being added to (i.d. Discussions or Assignments) - this will be 
 	 *      used to generate the new attachment id / path - required
-	 * @param attachmentImportMap
-	 *      A map of the attachment names that are the result of pre-importing attachments at the beginning of the 
-	 *      SiteMerge process.  It maps from the original attachment path from the import file to the pre-imported path for the 
+	 * @param mcx
+	 *      The MergeConfig for this import
      *      attachment.  If the oAttachmentId points to a non-existant or inaccessible resource, the attachmentNames map will 
 	 *      consulted to see id the oAttachmentId has been pre-imported.
 	 * @return The id of the new attachment.
 	 */
-	public ContentResource copyAttachment(String oAttachmentId, String toContext, String toolTitle, Map<String, String> attachmentImportMap) 
+	public ContentResource copyAttachment(String oAttachmentId, String toContext, String toolTitle, MergeConfig mcx) 
 		throws IdUnusedException, TypeException, PermissionException;
 
 	/**

--- a/kernel/api/src/main/java/org/sakaiproject/content/cover/ContentHostingService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/content/cover/ContentHostingService.java
@@ -36,6 +36,7 @@ import org.sakaiproject.content.api.GroupAwareEdit;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
+import org.sakaiproject.util.MergeConfig;
 
 import org.sakaiproject.exception.TypeException;
 
@@ -442,7 +443,7 @@ public class ContentHostingService
 		return service.addAttachmentResource(param0);
 	}
 
-	public static ContentResource copyAttachment(String param0, String param1, String param2, java.util.Map<String, String> param3)
+	public static ContentResource copyAttachment(String param0, String param1, String param2, MergeConfig param3)
         throws IdUnusedException, TypeException, PermissionException
 	{
 		org.sakaiproject.content.api.ContentHostingService service = getInstance();

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
@@ -112,25 +112,22 @@ public interface EntityProducer
 	 *        The path to the folder where we are reading auxilary files.
 	 * @param fromSiteId
 	 *        The site id from which these items were archived.
-	 * @param attachmentNames
-	 *        An empty map should be supplied and during the merge and any attachments that are renamed will be put into this map the key is the old
-	 *        attachment name (as found in the DOM) and the value is the new attachment name.
+	 * @param creatorId
+	 *        The user that is the site owner of the new site
+	 * @param mcx
+	 *        MergeConfig for this import
 	 * @param userIdTrans
 	 *        A map supplied by the called containing keys of old user IDs and values of new user IDs that the content should be attributed to.
 	 * @param userListAllowImport
 	 *        A list of user IDs for which the content should be imported. An importer should ignore content if the user ID of the creator isn't in this
 	 *        set.
-	 * @param creatorId
-	 *        The user that is the site owner of the new site
-	 * @param ltiContentItems
-	 *        A map of LTI Content Items associated with this import
 	 * @return A log of status messages from the merge.
 	 */
 	default String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
-			Map<String, String> attachmentNames, MergeConfig mcx, Map<String, String> userIdTrans,
+			MergeConfig mcx, Map<String, String> userIdTrans,
 			Set<String> userListAllowImport) {
 		// By default call the old merge without creatorId for those impls that don't need the creatorId
-		return merge(siteId, root, archivePath, fromSiteId, attachmentNames, userIdTrans, userListAllowImport);
+		return merge(siteId, root, archivePath, fromSiteId, mcx.attachmentNames, userIdTrans, userListAllowImport);
 	}
 
 	/**

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
@@ -112,8 +112,6 @@ public interface EntityProducer
 	 *        The path to the folder where we are reading auxilary files.
 	 * @param fromSiteId
 	 *        The site id from which these items were archived.
-	 * @param creatorId
-	 *        The user that is the site owner of the new site
 	 * @param mcx
 	 *        MergeConfig for this import
 	 * @param userIdTrans
@@ -123,7 +121,7 @@ public interface EntityProducer
 	 *        set.
 	 * @return A log of status messages from the merge.
 	 */
-	default String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
+	default String merge(String siteId, Element root, String archivePath, String fromSiteId,
 			MergeConfig mcx, Map<String, String> userIdTrans,
 			Set<String> userListAllowImport) {
 		// By default call the old merge without creatorId for those impls that don't need the creatorId

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
@@ -32,6 +32,8 @@ import java.util.Stack;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import org.sakaiproject.util.MergeConfig;
+
 /**
  * <p>
  * Services which implement EntityProducer declare themselves as producers of Sakai entities.
@@ -125,7 +127,7 @@ public interface EntityProducer
 	 * @return A log of status messages from the merge.
 	 */
 	default String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
-			Map<String, String> attachmentNames, Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans,
+			Map<String, String> attachmentNames, MergeConfig mcx, Map<String, String> userIdTrans,
 			Set<String> userListAllowImport) {
 		// By default call the old merge without creatorId for those impls that don't need the creatorId
 		return merge(siteId, root, archivePath, fromSiteId, attachmentNames, userIdTrans, userListAllowImport);

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
@@ -122,8 +122,7 @@ public interface EntityProducer
 	 * @return A log of status messages from the merge.
 	 */
 	default String merge(String siteId, Element root, String archivePath, String fromSiteId,
-			MergeConfig mcx, Map<String, String> userIdTrans,
-			Set<String> userListAllowImport) {
+			MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 		// By default call the old merge without creatorId for those impls that don't need the creatorId
 		return merge(siteId, root, archivePath, fromSiteId, mcx.attachmentNames, userIdTrans, userListAllowImport);
 	}

--- a/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
+++ b/kernel/api/src/main/java/org/sakaiproject/entity/api/EntityProducer.java
@@ -102,7 +102,7 @@ public interface EntityProducer
 	}
 
 	/**
-	 * Merge the resources from the archive into the given site (adding creatorId)
+	 * Merge the resources from the archive into the given site with MergeConfig
 	 *
 	 * @param siteId
 	 *        The id of the site getting imported into.
@@ -114,17 +114,11 @@ public interface EntityProducer
 	 *        The site id from which these items were archived.
 	 * @param mcx
 	 *        MergeConfig for this import
-	 * @param userIdTrans
-	 *        A map supplied by the called containing keys of old user IDs and values of new user IDs that the content should be attributed to.
-	 * @param userListAllowImport
-	 *        A list of user IDs for which the content should be imported. An importer should ignore content if the user ID of the creator isn't in this
-	 *        set.
 	 * @return A log of status messages from the merge.
 	 */
-	default String merge(String siteId, Element root, String archivePath, String fromSiteId,
-			MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+	default String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
 		// By default call the old merge without creatorId for those impls that don't need the creatorId
-		return merge(siteId, root, archivePath, fromSiteId, mcx.attachmentNames, userIdTrans, userListAllowImport);
+		return merge(siteId, root, archivePath, fromSiteId, mcx.attachmentNames, mcx.userIdTrans, mcx.userListAllowImport);
 	}
 
 	/**

--- a/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
@@ -8,6 +8,7 @@ public class MergeConfig {
     public String fromContext;
     public String fromServerUrl;
     public Map<Long, Map<String, Object>> ltiContentItems = new HashMap();
+    public Map<String, String> attachmentNames = new HashMap();
 
     public MergeConfig() {}
 }

--- a/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
@@ -4,9 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MergeConfig {
-    public String siteId;
-    public String fromContext;
-    public String fromServerUrl;
+    public String creatorId;
     public Map<Long, Map<String, Object>> ltiContentItems = new HashMap();
     public Map<String, String> attachmentNames = new HashMap();
 

--- a/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
@@ -2,13 +2,25 @@ package org.sakaiproject.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
+/**
+ * MergeConfig is a configuration container for merge operations across services.
+ * It acts as a shared context between different services during merge operations,
+ * eliminating the need to pass data through multiple service layers.
+ *
+ * The merge() operations are executed in a specific order, allowing later services
+ * to access data populated by earlier services through this shared configuration.
+ */
 public class MergeConfig {
     public String creatorId;
     public String archiveContext = "";
     public String archiveServerUrl = "";
     public Map<Long, Map<String, Object>> ltiContentItems = new HashMap();
     public Map<String, String> attachmentNames = new HashMap();
+    public Map<String, String> userIdTrans = new HashMap();
+    public Set<String> userListAllowImport = new HashSet();
 
     public MergeConfig() {}
 }

--- a/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
@@ -1,0 +1,13 @@
+package org.sakaiproject.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MergeConfig {
+    public String siteId;
+    public String fromContext;
+    public String fromServerUrl;
+    public Map<Long, Map<String, Object>> ltiContentItems = new HashMap();
+
+    public MergeConfig() {}
+}

--- a/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/MergeConfig.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 public class MergeConfig {
     public String creatorId;
+    public String archiveContext = "";
+    public String archiveServerUrl = "";
     public Map<Long, Map<String, Object>> ltiContentItems = new HashMap();
     public Map<String, String> attachmentNames = new HashMap();
 

--- a/kernel/api/src/main/java/org/sakaiproject/util/api/LinkMigrationHelper.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/api/LinkMigrationHelper.java
@@ -17,7 +17,7 @@ package org.sakaiproject.util.api;
 
 import java.util.Map.Entry;
 import java.util.Set;
-
+import org.sakaiproject.util.MergeConfig;
 
 /**
  * From SAK-22283:
@@ -71,11 +71,10 @@ public interface LinkMigrationHelper {
      * Do several transformations to migrate the content links present in a zip import of RTE content
      *
      * @param siteId the site id (Must not be null or empty)
-     * @param fromContext the context of the original content (Can be null)
-     * @param fromServerUrl the server url of the original content (Can be null)
+     * @param mcx the merge config
      * @param content the content to migrate
      * @return the migrated content
      */
-    public String migrateLinksInMergedRTE(String siteId, String fromContext, String fromServerUrl, String content);
+    public String migrateLinksInMergedRTE(String siteId, MergeConfig mcx, String content);
 
 }

--- a/kernel/api/src/main/java/org/sakaiproject/util/cover/LinkMigrationHelper.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/cover/LinkMigrationHelper.java
@@ -18,6 +18,7 @@ package org.sakaiproject.util.cover;
 import java.util.Set;
 
 import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.util.MergeConfig;
 
 public class LinkMigrationHelper {
 
@@ -45,7 +46,7 @@ public class LinkMigrationHelper {
 		return getLinkMigrationHelper().migrateOneLink(fromContextRef, targetContextRef, msgBody);
 	}
 
-	public static String migrateLinksInMergedRTE(String siteId, String fromContext, String fromServerUrl, String content) {
-		return getLinkMigrationHelper().migrateLinksInMergedRTE(siteId, fromContext, fromServerUrl, content);
+	public static String migrateLinksInMergedRTE(String siteId, MergeConfig mcx, String content) {
+		return getLinkMigrationHelper().migrateLinksInMergedRTE(siteId, mcx, content);
 	}
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -192,6 +192,7 @@ import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
 import org.sakaiproject.util.Xml;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.MergeConfig;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -3828,7 +3829,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 		commitCollection(edit);	
 	}
 
-	public ContentResource copyAttachment(String oAttachmentPath, String toContext, String toolTitle, Map<String, String> attachmentImportMap) 
+	public ContentResource copyAttachment(String oAttachmentPath, String toContext, String toolTitle, MergeConfig mcx) 
 		throws IdUnusedException, TypeException, PermissionException
 	{
 		ContentResource oAttachment = null;
@@ -3840,17 +3841,17 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 			log.debug("Cannot find the attachment with path = {}, checking map {}", oAttachmentPath, e.toString());
 		}
 
-		if (oAttachment == null && attachmentImportMap != null) {
-			String lookupAttachmentPath = attachmentImportMap.get(oAttachmentPath);
+		if (oAttachment == null && mcx != null && mcx.attachmentNames != null) {
+			String lookupAttachmentPath = mcx.attachmentNames.get(oAttachmentPath);
 			if (lookupAttachmentPath == null) {
 				if (oAttachmentPath.startsWith(REFERENCE_ROOT)) {
 					oAttachmentPath = oAttachmentPath.replaceFirst(REFERENCE_ROOT, "");
 				} else {
 					oAttachmentPath = REFERENCE_ROOT + oAttachmentPath;
 				}
-				lookupAttachmentPath = attachmentImportMap.get(oAttachmentPath);
+				lookupAttachmentPath = mcx.attachmentNames.get(oAttachmentPath);
 				if (lookupAttachmentPath == null) {
-					log.warn("Cannot find the attachment in map path = {}, map = {}", oAttachmentPath, attachmentImportMap);
+					log.warn("Cannot find the attachment in map path = {}, map = {}", oAttachmentPath, mcx.attachmentNames);
 					return null;
 				}
 			}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/LinkMigrationHelperImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/LinkMigrationHelperImpl.java
@@ -33,7 +33,7 @@ import org.jsoup.select.Elements;
 
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.util.api.LinkMigrationHelper;
-
+import org.sakaiproject.util.MergeConfig;
 @Slf4j
 public class LinkMigrationHelperImpl implements LinkMigrationHelper {
 	private static final String ESCAPED_SPACE = "%"+"20";
@@ -137,45 +137,44 @@ public class LinkMigrationHelperImpl implements LinkMigrationHelper {
      * Do several transformations to migrate the content links present in a zip import of RTE content
      *
      * @param siteId the site id (Must not be null or empty)
-     * @param fromContext the context of the original content (Can be null)
-     * @param fromServerUrl the server url of the original content (Can be null)
+     * @param mcx the merge config
      * @param content the content to migrate
      * @return the migrated content
      */
-    public String migrateLinksInMergedRTE(String siteId, String fromContext, String fromServerUrl, String content) {
+    public String migrateLinksInMergedRTE(String siteId, MergeConfig mcx, String content) {
 		String before;
         String after = serverConfigurationService.getServerUrl() + ACCESS_CONTENT_GROUP + siteId + "/";
 
         // Replace full match of the fromserverUrl and fromContext (ideal)
-        if ( StringUtils.isNotBlank(fromServerUrl) && StringUtils.isNotBlank(fromContext) ) {
-            before = fromServerUrl + ACCESS_CONTENT_GROUP + fromContext + "/";
+        if ( StringUtils.isNotBlank(mcx.archiveServerUrl) && StringUtils.isNotBlank(mcx.archiveContext) ) {
+            before = mcx.archiveServerUrl + ACCESS_CONTENT_GROUP + mcx.archiveContext + "/";
             content = content.replace(before, after);
         }
 
         // If we don't know the fromServerUrl, but we know the fromContext, replace athe url prefix to get the links onto this server
-        if ( StringUtils.isBlank(fromServerUrl) && StringUtils.isNotBlank(fromContext) ) {
-            before = "https?://[^/]+/" + ACCESS_CONTENT_GROUP + fromContext + "/";
+        if ( StringUtils.isBlank(mcx.archiveServerUrl) && StringUtils.isNotBlank(mcx.archiveContext) ) {
+            before = "https?://[^/]+/" + ACCESS_CONTENT_GROUP + mcx.archiveContext + "/";
             content = content.replaceAll(before, after);
         }
 
         // If we know the fromContext, we can replace urls that start with "/"
-        if ( StringUtils.isNotBlank(fromContext) ) {
-            before = "\"/" + ACCESS_CONTENT_GROUP + fromContext + "/";
+        if ( StringUtils.isNotBlank(mcx.archiveContext) ) {
+            before = "\"/" + ACCESS_CONTENT_GROUP + mcx.archiveContext + "/";
             after = "\"/" + ACCESS_CONTENT_GROUP + siteId + "/";
             content = content.replaceAll(before, after);
         }
 
         // If we know the fromServerUrl and not the fromContext, move old broken urls to this server at a minimum
-        if ( StringUtils.isNotBlank(fromServerUrl) ) {
-            before = fromServerUrl + ACCESS_CONTENT_GROUP;
+        if ( StringUtils.isNotBlank(mcx.archiveServerUrl) ) {
+            before = mcx.archiveServerUrl + ACCESS_CONTENT_GROUP;
             after = serverConfigurationService.getServerUrl() + ACCESS_CONTENT_GROUP;
             content = content.replace(before, after);
         }
 
         // [http://localhost:8080/direct/forum_topic/1]
         // Migrate direct links to the new server if we have the name of the server
-        if ( StringUtils.isNotBlank(fromServerUrl) ) {
-            before = fromServerUrl + DIRECT_LINK;
+        if ( StringUtils.isNotBlank(mcx.archiveServerUrl) ) {
+            before = mcx.archiveServerUrl + DIRECT_LINK;
             after = serverConfigurationService.getServerUrl() + DIRECT_LINK;
             content = content.replace(before, after);
         }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/LinkMigrationHelperImplTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/LinkMigrationHelperImplTest.java
@@ -70,47 +70,45 @@ public class LinkMigrationHelperImplTest {
     @Test
     public void testMigrateLinksInMergedRTE() {
         // Test basic migration of oldId to newId
+        MergeConfig mcx = new MergeConfig();
+        mcx.archiveContext = "oldId";
+        mcx.archiveServerUrl = "http://www.zap.com";
         String content = "this <a href='http://www.zap.com/access/content/group/oldId/ietf-postel-06.png'>text</a>";
-        String migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        String migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         String result  = "this <a href='http://localhost:8080/access/content/group/newId/ietf-postel-06.png'>text</a>";
         assertEquals(result, migrated);
 
         // Test link with different site ID (should remain unchanged)
         content = "this <a href='http://www.zap.com/access/content/group/weirdId/ietf-postel-06.png'>text</a>";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         result = "this <a href='http://localhost:8080/access/content/group/weirdId/ietf-postel-06.png'>text</a>";
         assertEquals(result, migrated);
 
         // Test multiple links in the same content
         content = "this <a href='http://www.zap.com/access/content/group/oldId/file1.pdf'>link1</a> and " +
                  "<a href='http://www.zap.com/access/content/group/oldId/file2.jpg'>link2</a>";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         result = "this <a href='http://localhost:8080/access/content/group/newId/file1.pdf'>link1</a> and " +
                  "<a href='http://localhost:8080/access/content/group/newId/file2.jpg'>link2</a>";
         assertEquals(result, migrated);
 
-        // Test with different source domain
-        content = "this <a href='https://other-domain.com/access/content/group/oldId/file.pdf'>text</a>";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "https://other-domain.com", content);
-        result = "this <a href='http://localhost:8080/access/content/group/newId/file.pdf'>text</a>";
-        assertEquals(result, migrated);
-
+        
         // Test with non-matching URL pattern (should remain unchanged)
         content = "this <a href='http://www.zap.com/different/path/oldId/file.pdf'>text</a>";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         result = "this <a href='http://www.zap.com/different/path/oldId/file.pdf'>text</a>";
         assertEquals(result, migrated);
 
         // Test direct link migration
         content = "Check this discussion [http://www.zap.com/direct/forum_topic/123]";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         result = "Check this discussion [http://localhost:8080/direct/forum_topic/123]";
         assertEquals(result, migrated);
 
         // Test multiple direct links in the same content
         content = "First topic [http://www.zap.com/direct/forum_topic/123] and " +
                  "second topic [http://www.zap.com/direct/forum_topic/456]";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         result = "First topic [http://localhost:8080/direct/forum_topic/123] and " +
                 "second topic [http://localhost:8080/direct/forum_topic/456]";
         assertEquals(result, migrated);
@@ -118,10 +116,18 @@ public class LinkMigrationHelperImplTest {
         // Test mix of direct and content links
         content = "Resource <a href='http://www.zap.com/access/content/group/oldId/file.pdf'>here</a> " +
                  "and discussion [http://www.zap.com/direct/forum_topic/789]";
-        migrated = impl.migrateLinksInMergedRTE("newId", "oldId", "http://www.zap.com", content);
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
         result = "Resource <a href='http://localhost:8080/access/content/group/newId/file.pdf'>here</a> " +
                 "and discussion [http://localhost:8080/direct/forum_topic/789]";
         assertEquals(result, migrated);
+
+        // Test with different source domain
+        mcx.archiveServerUrl = "https://other-domain.com";
+        content = "this <a href='https://other-domain.com/access/content/group/oldId/file.pdf'>text</a>";
+        migrated = impl.migrateLinksInMergedRTE("newId", mcx, content);
+        result = "this <a href='http://localhost:8080/access/content/group/newId/file.pdf'>text</a>";
+        assertEquals(result, migrated);
+
     }
 
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/LinkMigrationHelperImplTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/LinkMigrationHelperImplTest.java
@@ -22,6 +22,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.sakaiproject.component.api.ServerConfigurationService;
 
+import org.sakaiproject.util.MergeConfig;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1131,14 +1131,14 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
    // Externally used for zip import
    @Override
-   public String merge(String siteId, Element root, String archivePath, String fromSiteId, 
-        MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
-       return mergeInternal(siteId, root, archivePath, fromSiteId, mcx, userIdTrans, userListAllowImport, null);
+   public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
+       Map<String, String> entityMap = null;
+       return mergeInternal(siteId, root, archivePath, fromSiteId, mcx, entityMap);
    }
 
    // Internally used for both site copy and zip import
-   public String mergeInternal(String siteId, Element root, String archivePath, String fromSiteId,
-        MergeConfig mcx, Map userIdTrans, Set userListAllowImport, Map<String, String> entityMap)
+   public String mergeInternal(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx,
+       Map<String, String> entityMap)
    {
 
 	  log.debug("Lessons Merge siteId={} fromSiteId={} creatorId={} archiveContext={} archiveServerUrl={}",
@@ -1542,7 +1542,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 		MergeConfig mcx = new MergeConfig();
 		mcx.creatorId = sessionManager.getCurrentSessionUserId();
-		mergeInternal(toContext,  (Element)doc.getFirstChild().getFirstChild(), "/tmp/archive", fromContext, mcx, null, null, entityMap);
+		mergeInternal(toContext,  (Element)doc.getFirstChild().getFirstChild(), "/tmp/archive", fromContext, mcx, entityMap);
 
 		ToolSession session = sessionManager.getCurrentToolSession();
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -145,6 +145,8 @@ import org.w3c.dom.NodeList;
 import lombok.extern.slf4j.Slf4j;
 import uk.org.ponder.messageutil.MessageLocator;
 
+import org.sakaiproject.util.MergeConfig;
+
 /**
  * @author hedrick
  * The goal is to get sites to save and copy. However there's actually no data 
@@ -719,7 +721,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
     // the pages are already made. this adds the elements
     private boolean mergePage(Element element, String oldServer, String siteId, String fromSiteId, Map<Long,Long> pageMap,
-	  Map<Long,Long> itemMap, Map<String,String> entityMap, Map<Long, Map<String, Object>> ltiContentItems,
+	  Map<Long,Long> itemMap, Map<String,String> entityMap, MergeConfig mcx,
 	 String archiveContext, String archiveServerUrl) {
   
        String oldSiteId = element.getAttribute("siteid");
@@ -794,11 +796,11 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		                continue;
 		            }
 		        } else {
-		            if ( ltiContentItems == null ) {
+		            if ( mcx.ltiContentItems == null ) {
 		                log.warn("Unable to look up LTI content item with ID: {}", ltiContentId);
 		                continue;
 		            }
-		            Map<String, Object> ltiContentItem = ltiContentItems.get(ltiContentId);
+		            Map<String, Object> ltiContentItem = mcx.ltiContentItems.get(ltiContentId);
 		            if (ltiContentItem == null) {
 		                log.warn("Unable to find LTI content item with ID: {}", ltiContentId);
 		                continue;
@@ -842,7 +844,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		        }
 		   } else if (type == SimplePageItem.TEXT) {
 		        String html = itemElement.getAttribute("html");
-		        explanation = ltiService.fixLtiLaunchUrls(html, siteId, ltiContentItems);
+		        explanation = ltiService.fixLtiLaunchUrls(html, siteId, mcx);
 				explanation = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, explanation);
 		   } else if (type == SimplePageItem.PAGE) {
 		       // sakaiId should be the new page ID
@@ -1170,13 +1172,13 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
    // Externally used for zip import
    @Override
    public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-        Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
-       return merge(siteId, root, archivePath, fromSiteId, creatorId, attachmentNames, ltiContentItems, userIdTrans, userListAllowImport, null);
+        MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+       return merge(siteId, root, archivePath, fromSiteId, creatorId, attachmentNames, mcx, userIdTrans, userListAllowImport, null);
    }
 
    // Internally used for both site copy and zip import
    public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map attachmentNames,
-        Map<Long, Map<String, Object>> ltiContentItems, Map userIdTrans, Set userListAllowImport, Map<String, String> entityMap)
+        MergeConfig mcx, Map userIdTrans, Set userListAllowImport, Map<String, String> entityMap)
    {
 	  String archiveContext = "";
 	  String archiveServerUrl = "";
@@ -1273,7 +1275,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		     Long oldPageId = Long.valueOf(pageElement.getAttribute("pageid"));
 		     pageElementMap.put(oldPageId, pageElement);
 
-		     if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, ltiContentItems, archiveContext, archiveServerUrl))
+		     if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, mcx, archiveContext, archiveServerUrl))
 
 			 needFix = true;
 		 }

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1171,13 +1171,13 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
    // Externally used for zip import
    @Override
-   public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
+   public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, 
         MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
-       return merge(siteId, root, archivePath, fromSiteId, creatorId, attachmentNames, mcx, userIdTrans, userListAllowImport, null);
+       return merge(siteId, root, archivePath, fromSiteId, creatorId, mcx, userIdTrans, userListAllowImport, null);
    }
 
    // Internally used for both site copy and zip import
-   public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map attachmentNames,
+   public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
         MergeConfig mcx, Map userIdTrans, Set userListAllowImport, Map<String, String> entityMap)
    {
 	  String archiveContext = "";
@@ -1589,7 +1589,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		stack.pop();
 	  
 		String creatorId = sessionManager.getCurrentSessionUserId();
-		merge(toContext,  (Element)doc.getFirstChild().getFirstChild(), "/tmp/archive", fromContext, creatorId, null, null, null, null, entityMap);
+		merge(toContext,  (Element)doc.getFirstChild().getFirstChild(), "/tmp/archive", fromContext, creatorId, null, null, null, entityMap);
 
 		ToolSession session = sessionManager.getCurrentToolSession();
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -682,8 +682,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
     // the pages are already made. this adds the elements
     private boolean mergePage(Element element, String oldServer, String siteId, String fromSiteId, Map<Long,Long> pageMap,
-	  Map<Long,Long> itemMap, Map<String,String> entityMap, MergeConfig mcx,
-	 String archiveContext, String archiveServerUrl) {
+	  Map<Long,Long> itemMap, Map<String,String> entityMap, MergeConfig mcx) {
   
        String oldSiteId = element.getAttribute("siteid");
        String oldPageIdString = element.getAttribute("pageid");
@@ -806,7 +805,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		   } else if (type == SimplePageItem.TEXT) {
 		        String html = itemElement.getAttribute("html");
 		        explanation = ltiService.fixLtiLaunchUrls(html, siteId, mcx);
-				explanation = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, explanation);
+				explanation = linkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, explanation);
 		   } else if (type == SimplePageItem.PAGE) {
 		       // sakaiId should be the new page ID
 		       Long newPageId = pageMap.get(Long.valueOf(sakaiId));
@@ -1141,17 +1140,9 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
    public String mergeInternal(String siteId, Element root, String archivePath, String fromSiteId,
         MergeConfig mcx, Map userIdTrans, Set userListAllowImport, Map<String, String> entityMap)
    {
-	  String archiveContext = "";
-	  String archiveServerUrl = "";
-	  Node parent = root.getParentNode();
-	  if (parent.getNodeType() == Node.ELEMENT_NODE)
-	  {
-		  Element parentEl = (Element)parent;
-		  archiveContext = parentEl.getAttribute("source");
-		  archiveServerUrl = parentEl.getAttribute("serverurl");
-	  }
+
 	  log.debug("Lessons Merge siteId={} fromSiteId={} creatorId={} archiveContext={} archiveServerUrl={}",
-	  	siteId, fromSiteId, mcx.creatorId, archiveContext, archiveServerUrl);
+	  	siteId, fromSiteId, mcx.creatorId, mcx.archiveContext, mcx.archiveServerUrl);
 
       StringBuilder results = new StringBuilder();
       // map old to new page ids
@@ -1236,7 +1227,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		     Long oldPageId = Long.valueOf(pageElement.getAttribute("pageid"));
 		     pageElementMap.put(oldPageId, pageElement);
 
-		     if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, mcx, archiveContext, archiveServerUrl))
+		     if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, mcx))
 
 			 needFix = true;
 		 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -29,6 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
+import org.sakaiproject.util.MergeConfig;
 
 /**
  * <p>
@@ -655,8 +656,8 @@ public interface LTIService extends LTISubstitutionsFilter {
      * Fix LTI launch URLs when copying content between contexts
      * @param text The text containing LTI launch URLs
      * @param toContext The destination context
-     * @param ltiContentItems A map of import content items and their tools
+     * @param mcx A map of import content items and their tools
      * @return The text with updated LTI launch URLs
      */
-    String fixLtiLaunchUrls(String text, String toContext, Map<Long, Map<String, Object>> ltiContentItems);
+    String fixLtiLaunchUrls(String text, String toContext, MergeConfig mcx);
 }

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -60,6 +60,7 @@ import org.sakaiproject.util.foorm.SakaiFoorm;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.sakaiproject.util.foorm.Foorm;
 import org.tsugi.lti.LTIUtil;
+import org.sakaiproject.util.MergeConfig;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.Setter;
@@ -1265,21 +1266,21 @@ public abstract class BaseLTIService implements LTIService {
 	}
 
 	@Override
-	public String fixLtiLaunchUrls(String text, String toContext, Map<Long, Map<String, Object>> ltiContentItems) {
+	public String fixLtiLaunchUrls(String text, String toContext, MergeConfig mcx) {
 		String fromContext = null;
 		Map<String, String> transversalMap = null;
-		return fixLtiLaunchUrls(text, fromContext, toContext, ltiContentItems, transversalMap);
+		return fixLtiLaunchUrls(text, fromContext, toContext, mcx, transversalMap);
 	}
 
 	@Override
 	public String fixLtiLaunchUrls(String text, String fromContext, String toContext, Map<String, String> transversalMap) {
-		Map<Long, Map<String, Object>> ltiContentItems = null;
-		return fixLtiLaunchUrls(text, fromContext, toContext, ltiContentItems, transversalMap);
+		MergeConfig mcx = null;
+		return fixLtiLaunchUrls(text, fromContext, toContext, mcx, transversalMap);
 	}
 
 	// http://localhost:8080/access/lti/site/7d529bf7-b856-4400-9da1-ba8670ed1489/content:1
 	// http://localhost:8080/access/lti/site/7d529bf7-b856-4400-9da1-ba8670ed1489/content:42
-	protected String fixLtiLaunchUrls(String text, String fromContext, String toContext, Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> transversalMap) {
+	protected String fixLtiLaunchUrls(String text, String fromContext, String toContext, MergeConfig mcx, Map<String, String> transversalMap) {
 		if (StringUtils.isBlank(text)) return text;
 		List<String> urls = SakaiLTIUtil.extractLtiLaunchUrls(text);
 		for (String url : urls) {
@@ -1315,9 +1316,9 @@ public abstract class BaseLTIService implements LTIService {
 
 				// If we cannot find the content item and tool on in this server, get skeleton data
 				// from the basiclti.xml import
-				if ( content == null && ltiContentItems != null ) {
+				if ( content == null && mcx.ltiContentItems != null ) {
 					log.debug("Could not find content item {} / {} in site {}, checking ltiContentItems", linkContentId, contentKey, linkSiteId);
-					content = ltiContentItems.get(contentKey);
+					content = mcx.ltiContentItems.get(contentKey);
 					tool = null;  // force creation of a new tool in findOrCreateToolForContentItem
 				}
 
@@ -1327,7 +1328,7 @@ public abstract class BaseLTIService implements LTIService {
 				}
 
 				if ( toolKey == null ) {
-					toolKey = findOrCreateToolForContentItem(content, tool, toContext, fromContext, ltiContentItems);
+					toolKey = findOrCreateToolForContentItem(content, tool, toContext, fromContext, mcx);
 					if (toolKey == null) {
 						log.error("Could not associate new content item {} with a tool in site {}", contentKey, toContext);
 						continue;
@@ -1359,10 +1360,10 @@ public abstract class BaseLTIService implements LTIService {
 	 * @param tool Tool may be null, may or may not be persisted - if this exists, we will reload to verify it is accessible to the user and site
 	 * @param toSiteId Target site ID
 	 * @param fromSiteId Source site ID
-	 * @param ltiContentItems Map of existing content items by content key, imported from basiclti.xml on Archive import can be null
+	 * @param mcx The MergeConfig for this import
 	 * @return New tool ID or null if tool cannot be found/created
 	 */
-	protected Long findOrCreateToolForContentItem(Map<String, Object> content, Map<String, Object> tool, String toSiteId, String fromSiteId, Map<Long, Map<String, Object>> ltiContentItems) {
+	protected Long findOrCreateToolForContentItem(Map<String, Object> content, Map<String, Object> tool, String toSiteId, String fromSiteId, MergeConfig mcx) {
 		if ( StringUtils.isBlank(toSiteId) ) return null;
 
 		// Get launch URL from content
@@ -1414,8 +1415,8 @@ public abstract class BaseLTIService implements LTIService {
 		}
 
 		// If the tool is null or invalid, check if the tool data is available in the imported content items
-		if ( tool == null && ltiContentItems != null ) {
-			Map<String, Object> importedContent = ltiContentItems.get(contentKey);
+		if ( tool == null && mcx.ltiContentItems != null ) {
+			Map<String, Object> importedContent = mcx.ltiContentItems.get(contentKey);
 			if ( importedContent != null ) {
 				try {
 					// In order to pass only one Map through the entirety of the merge() process,

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -1680,7 +1680,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 	 * {@inheritDoc}
 	 */
 	@Override
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 		// get the system name: FROM_WT, FROM_CT, FROM_SAKAI
@@ -1819,7 +1819,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 															String toolTitle = getToolTitle(oldUrl);
 															if ( StringUtils.isBlank(toolTitle) ) toolTitle = "Messages";
 															log.debug("toolTitle: {} oldUrl {}", toolTitle, oldUrl);
-															ContentResource attachment = contentHostingService.copyAttachment(oldUrl, siteId, toolTitle, attachmentNames);
+															ContentResource attachment = contentHostingService.copyAttachment(oldUrl, siteId, toolTitle, mcx);
 															if ( attachment != null ) {
 																String newUrl = attachment.getReference();
 																element5.setAttribute("relative-url", Validator.escapeQuestionMark(newUrl));

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -106,6 +106,7 @@ import org.sakaiproject.util.EntityCollections;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.MergeConfig;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -1680,7 +1681,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 	 */
 	@Override
 	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-		Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport)
+		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 		// get the system name: FROM_WT, FROM_CT, FROM_SAKAI
 		// root: <service> node
@@ -1992,7 +1993,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 										}
 
 										String description = edit.getBody();
-										description = ltiService.fixLtiLaunchUrls(description, siteId, ltiContentItems);
+										description = ltiService.fixLtiLaunchUrls(description, siteId, mcx);
 										description = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, description);
 										log.debug("description {}", description);
 										edit.setBody(description);

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -1680,8 +1680,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 	 * {@inheritDoc}
 	 */
 	@Override
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId,
-		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx)
 	{
 		// get the system name: FROM_WT, FROM_CT, FROM_SAKAI
 		// root: <service> node
@@ -1690,7 +1689,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 		log.debug("merge ltiService={} contentHostingService={} class={} archiveContext={} archiveServerUrl={}",
 		  ltiService, contentHostingService, this.getClass().getName(), mcx.archiveContext, mcx.archiveServerUrl);
 
-		HashSet userSet = (HashSet) userListAllowImport;
+		HashSet userSet = (HashSet) mcx.userListAllowImport;
 
 		Map ids = new HashMap();
 
@@ -1776,11 +1775,11 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 												String oldUserId = element4.getAttribute("from");
 
 												// userIdTrans is not empty only when from WT
-												if (!userIdTrans.isEmpty())
+												if (!mcx.userIdTrans.isEmpty())
 												{
-													if (userIdTrans.containsKey(oldUserId))
+													if (mcx.userIdTrans.containsKey(oldUserId))
 													{
-														element4.setAttribute("from", (String) userIdTrans.get(oldUserId));
+														element4.setAttribute("from", (String) mcx.userIdTrans.get(oldUserId));
 													}
 												}
 

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -1680,7 +1680,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 	 * {@inheritDoc}
 	 */
 	@Override
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId,
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
 	{
 		// get the system name: FROM_WT, FROM_CT, FROM_SAKAI

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -1686,20 +1686,9 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 		// get the system name: FROM_WT, FROM_CT, FROM_SAKAI
 		// root: <service> node
 		String source = "";
-		String archiveContext = "";
-		String archiveServerUrl = "";
-
-		Node parent = root.getParentNode();
-		if (parent.getNodeType() == Node.ELEMENT_NODE)
-		{
-			Element parentEl = (Element)parent;
-			archiveContext = parentEl.getAttribute("source");
-			archiveServerUrl = parentEl.getAttribute("serverurl");
-			source = parentEl.getAttribute("system");
-		}
 
 		log.debug("merge ltiService={} contentHostingService={} class={} archiveContext={} archiveServerUrl={}",
-		  ltiService, contentHostingService, this.getClass().getName(), archiveContext, archiveServerUrl);
+		  ltiService, contentHostingService, this.getClass().getName(), mcx.archiveContext, mcx.archiveServerUrl);
 
 		HashSet userSet = (HashSet) userListAllowImport;
 
@@ -1994,7 +1983,7 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 
 										String description = edit.getBody();
 										description = ltiService.fixLtiLaunchUrls(description, siteId, mcx);
-										description = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, description);
+										description = linkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, description);
 										log.debug("description {}", description);
 										edit.setBody(description);
 

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -732,8 +732,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		return transversalMap;
 	}
 
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId,
-		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
 
 		log.debug("merge archiveContext={} archiveServerUrl={}", mcx.archiveContext, mcx.archiveServerUrl);
 

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -732,7 +732,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		return transversalMap;
 	}
 
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
 		String archiveContext = "";
@@ -765,7 +765,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 				final List<Element> messageForumElementList = elements.stream()
 						.filter(element -> MESSAGEFORUM.equals(element.getTagName())).collect(Collectors.toList());
 				if (!messageForumElementList.isEmpty()) {
-					mergeMessageForumElements(siteId, fromSiteId, attachmentNames, messageForumElementList.get(0), discussionTitles, mcx, archiveContext, archiveServerUrl);
+					mergeMessageForumElements(siteId, fromSiteId, messageForumElementList.get(0), discussionTitles, mcx, archiveContext, archiveServerUrl);
 				}
 			} catch (Exception e) {
 				results.append("merging ").append(getLabel()).append(" failed.\n");
@@ -776,7 +776,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 	}
 
 	private void mergeMessageForumElements(final String siteId, final String fromSiteId,
-		final Map<String, String> attachmentNames, final Element siteElement, Set<String> discussionTitles,
+		final Element siteElement, Set<String> discussionTitles,
 		MergeConfig mcx, String archiveContext, String archiveServerUrl) throws Exception {
 
 		final NodeList messageForumChildNodeList = siteElement.getChildNodes();
@@ -791,12 +791,12 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 			if (discussionTitles.contains(title)) {
 				continue;
 			}
-			mergeDiscussionForumElements(siteId, fromSiteId, attachmentNames, discussionForumElement, mcx, archiveContext, archiveServerUrl);
+			mergeDiscussionForumElements(siteId, fromSiteId, discussionForumElement, mcx, archiveContext, archiveServerUrl);
 		}
 	}
 
 	private void mergeDiscussionForumElements(final String siteId, final String fromSiteId,
-			final Map<String, String> attachmentNames, final Element discussionForumElement,
+			final Element discussionForumElement,
 			MergeConfig mcx, String archiveContext, String archiveServerUrl) throws Exception {
 
 		final DiscussionForum discussionForum = forumManager.createDiscussionForum();
@@ -856,12 +856,12 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		discussionForum.setArea(area);
 
 		// Discussion Forum is saved inside this method
-		mergeDiscussionForumDetailNodeList(siteId, fromSiteId, attachmentNames, discussionForumElement,
+		mergeDiscussionForumDetailNodeList(siteId, fromSiteId, discussionForumElement,
 				discussionForum, mcx, archiveContext, archiveServerUrl);
 	}
 
 	private void mergeDiscussionForumDetailNodeList(final String siteId, final String fromSiteId,
-		final Map<String, String> attachmentNames, final Element discussionForumElement,
+		final Element discussionForumElement,
 		DiscussionForum discussionForum, MergeConfig mcx,
 		String archiveContext, String archiveServerUrl) throws Exception {
 
@@ -872,7 +872,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 		final List<Element> attachmentElementList = getAttachmentElementList(elements);
 		for (Element attachmentElement : attachmentElementList) {
-			final Attachment newAttachment = mergeAttachmentElement(siteId, fromSiteId, attachmentNames,
+			final Attachment newAttachment = mergeAttachmentElement(siteId, fromSiteId, mcx,
 					attachmentElement);
 			if (newAttachment != null) {
 				discussionForum.addAttachment(newAttachment);
@@ -895,7 +895,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 		final List<Element> discussionTopicElementList = getDiscussionTopicElementList(elements);
 		for (Element discussionTopicElement : discussionTopicElementList) {
-			mergeDiscussionTopicElement(siteId, fromSiteId, attachmentNames, discussionForumReturn, discussionTopicElement, mcx, archiveContext, archiveServerUrl);
+			mergeDiscussionTopicElement(siteId, fromSiteId, discussionForumReturn, discussionTopicElement, mcx, archiveContext, archiveServerUrl);
 		}
 	}
 
@@ -919,16 +919,16 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 	}
 
 	private Attachment mergeAttachmentElement(final String siteId, final String fromSiteId,
-											  final Map<String, String> attachmentNames, final Element attachmentElement) {
+											  final MergeConfig mcx, final Element attachmentElement) {
 		String oldAttachId = attachmentElement.getAttribute(ATTACH_ID);
 		if (StringUtils.isNotBlank(oldAttachId)) {
-			return copyAttachment(oldAttachId, siteId, attachmentNames);
+			return copyAttachment(oldAttachId, siteId, mcx);
 		}
 		return null;
 	}
 
 	private void mergeDiscussionTopicElement(final String siteId, final String fromSiteId,
-		final Map<String, String> attachmentNames, final DiscussionForum discussionForum,
+		final DiscussionForum discussionForum,
 		final Element discussionTopicElement, MergeConfig mcx, String archiveContext, String archiveServerUrl) throws Exception {
 
 		DiscussionTopic discussionTopic = forumManager.createDiscussionForumTopic(discussionForum);
@@ -945,7 +945,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 		final List<Element> attachmentElementList = getAttachmentElementList(elements);
 		for (Element attachmentElement : attachmentElementList) {
-			final Attachment newAttachment = mergeAttachmentElement(siteId, fromSiteId, attachmentNames,
+			final Attachment newAttachment = mergeAttachmentElement(siteId, fromSiteId, mcx,
 					attachmentElement);
 			if (newAttachment != null) {
 				discussionTopic.addAttachment(newAttachment);
@@ -966,7 +966,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		// "onReplyTo" attribute
 		final List<Element> messagesElementList = getMessagesElementList(elements);
 		for (Element messagesElement : messagesElementList) {
-			mergeDiscussionTopicMessagesElement(siteId, fromSiteId, attachmentNames, discussionTopic, messagesElement, null);
+			mergeDiscussionTopicMessagesElement(siteId, fromSiteId, mcx, discussionTopic, messagesElement, null);
 		}
 	}
 
@@ -1110,7 +1110,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		}
 	}
 
-	private void mergeDiscussionTopicMessagesElement(final String siteId, final String fromSiteId, final Map<String, String> attachmentNames, final DiscussionTopic discussionTopic,
+	private void mergeDiscussionTopicMessagesElement(final String siteId, final String fromSiteId, MergeConfig mcx, final DiscussionTopic discussionTopic,
 													 final Element messagesElement, final String messageIdInReplyTo) throws Exception {
 		final NodeList messagesNodeList = messagesElement.getChildNodes();
 		for (int m = 0; m < messagesNodeList.getLength(); m++) {
@@ -1125,7 +1125,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 			final List<Element> attachmentElementList = getAttachmentElementList(elements);
 
 			for (Element attachmentElement : attachmentElementList) {
-				final Attachment newAttachment = mergeAttachmentElement(siteId, fromSiteId, attachmentNames,
+				final Attachment newAttachment = mergeAttachmentElement(siteId, fromSiteId, mcx,
 						attachmentElement);
 				if (newAttachment != null) {
 					message.addAttachment(newAttachment);
@@ -1137,7 +1137,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 			final List<Element> messagesElementList = getMessagesElementList(elements);
 			for (Element messagesChildElement : messagesElementList) {
-				mergeDiscussionTopicMessagesElement(siteId, fromSiteId, attachmentNames, discussionTopic, messagesChildElement, messageId);
+				mergeDiscussionTopicMessagesElement(siteId, fromSiteId, mcx, discussionTopic, messagesChildElement, messageId);
 			}
 		}
 	}
@@ -1335,9 +1335,9 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		return value;
 	}
 	
-	private Attachment copyAttachment(String attachmentId, String toContext, Map<String, String> attachmentNames) {
+	private Attachment copyAttachment(String attachmentId, String toContext, MergeConfig mcx) {
 		try {			
-			ContentResource attachment = contentHostingService.copyAttachment(attachmentId, toContext, toolManager.getTool("sakai.forums").getTitle(), attachmentNames);
+			ContentResource attachment = contentHostingService.copyAttachment(attachmentId, toContext, toolManager.getTool("sakai.forums").getTitle(), mcx);
 
 			Attachment thisDFAttach = dfManager.createDFAttachment(
 				attachment.getId(), 

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -80,6 +80,7 @@ import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.cover.LinkMigrationHelper;
+import org.sakaiproject.util.MergeConfig;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -732,7 +733,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 	}
 
 	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-		Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
 		String archiveContext = "";
 		String archiveServerUrl = "";
@@ -764,7 +765,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 				final List<Element> messageForumElementList = elements.stream()
 						.filter(element -> MESSAGEFORUM.equals(element.getTagName())).collect(Collectors.toList());
 				if (!messageForumElementList.isEmpty()) {
-					mergeMessageForumElements(siteId, fromSiteId, attachmentNames, messageForumElementList.get(0), discussionTitles, ltiContentItems, archiveContext, archiveServerUrl);
+					mergeMessageForumElements(siteId, fromSiteId, attachmentNames, messageForumElementList.get(0), discussionTitles, mcx, archiveContext, archiveServerUrl);
 				}
 			} catch (Exception e) {
 				results.append("merging ").append(getLabel()).append(" failed.\n");
@@ -776,7 +777,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 	private void mergeMessageForumElements(final String siteId, final String fromSiteId,
 		final Map<String, String> attachmentNames, final Element siteElement, Set<String> discussionTitles,
-		Map<Long, Map<String, Object>> ltiContentItems, String archiveContext, String archiveServerUrl) throws Exception {
+		MergeConfig mcx, String archiveContext, String archiveServerUrl) throws Exception {
 
 		final NodeList messageForumChildNodeList = siteElement.getChildNodes();
 
@@ -790,13 +791,13 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 			if (discussionTitles.contains(title)) {
 				continue;
 			}
-			mergeDiscussionForumElements(siteId, fromSiteId, attachmentNames, discussionForumElement, ltiContentItems, archiveContext, archiveServerUrl);
+			mergeDiscussionForumElements(siteId, fromSiteId, attachmentNames, discussionForumElement, mcx, archiveContext, archiveServerUrl);
 		}
 	}
 
 	private void mergeDiscussionForumElements(final String siteId, final String fromSiteId,
 			final Map<String, String> attachmentNames, final Element discussionForumElement,
-			Map<Long, Map<String, Object>> ltiContentItems, String archiveContext, String archiveServerUrl) throws Exception {
+			MergeConfig mcx, String archiveContext, String archiveServerUrl) throws Exception {
 
 		final DiscussionForum discussionForum = forumManager.createDiscussionForum();
 
@@ -844,7 +845,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		}
 
 		String extendedDescription = getDecodedString(discussionForumElement.getAttribute(DISCUSSION_FORUM_DESC));
-		extendedDescription = ltiService.fixLtiLaunchUrls(extendedDescription, siteId, ltiContentItems);
+		extendedDescription = ltiService.fixLtiLaunchUrls(extendedDescription, siteId, mcx);
 		discussionForum
 				.setExtendedDescription(extendedDescription);
 
@@ -856,12 +857,12 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 		// Discussion Forum is saved inside this method
 		mergeDiscussionForumDetailNodeList(siteId, fromSiteId, attachmentNames, discussionForumElement,
-				discussionForum, ltiContentItems, archiveContext, archiveServerUrl);
+				discussionForum, mcx, archiveContext, archiveServerUrl);
 	}
 
 	private void mergeDiscussionForumDetailNodeList(final String siteId, final String fromSiteId,
 		final Map<String, String> attachmentNames, final Element discussionForumElement,
-		DiscussionForum discussionForum, Map<Long, Map<String, Object>> ltiContentItems,
+		DiscussionForum discussionForum, MergeConfig mcx,
 		String archiveContext, String archiveServerUrl) throws Exception {
 
 		final NodeList discussionForumDetailNodeList = discussionForumElement.getChildNodes();
@@ -894,7 +895,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 		final List<Element> discussionTopicElementList = getDiscussionTopicElementList(elements);
 		for (Element discussionTopicElement : discussionTopicElementList) {
-			mergeDiscussionTopicElement(siteId, fromSiteId, attachmentNames, discussionForumReturn, discussionTopicElement, ltiContentItems, archiveContext, archiveServerUrl);
+			mergeDiscussionTopicElement(siteId, fromSiteId, attachmentNames, discussionForumReturn, discussionTopicElement, mcx, archiveContext, archiveServerUrl);
 		}
 	}
 
@@ -928,7 +929,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 
 	private void mergeDiscussionTopicElement(final String siteId, final String fromSiteId,
 		final Map<String, String> attachmentNames, final DiscussionForum discussionForum,
-		final Element discussionTopicElement, Map<Long, Map<String, Object>> ltiContentItems, String archiveContext, String archiveServerUrl) throws Exception {
+		final Element discussionTopicElement, MergeConfig mcx, String archiveContext, String archiveServerUrl) throws Exception {
 
 		DiscussionTopic discussionTopic = forumManager.createDiscussionForumTopic(discussionForum);
 
@@ -939,7 +940,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		final List<Element> propertiesElementList = elements.stream().filter(e -> PROPERTIES.equals(e.getTagName()))
 				.collect(Collectors.toList());
 		for (Element propertiesElement : propertiesElementList) {
-			mergeDiscussionTopicPropertiesNodes(discussionTopic, propertiesElement, siteId, ltiContentItems, archiveContext, archiveServerUrl);
+			mergeDiscussionTopicPropertiesNodes(discussionTopic, propertiesElement, siteId, mcx, archiveContext, archiveServerUrl);
 		}
 
 		final List<Element> attachmentElementList = getAttachmentElementList(elements);
@@ -1079,7 +1080,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 				.collect(Collectors.toList());
 	}
 
-	private void mergeDiscussionTopicPropertiesNodes(final DiscussionTopic discussionTopic, final Element propertiesElement, final String siteId, final Map<Long, Map<String, Object>> ltiContentItems, String archiveContext, String archiveServerUrl) {
+	private void mergeDiscussionTopicPropertiesNodes(final DiscussionTopic discussionTopic, final Element propertiesElement, final String siteId, final MergeConfig mcx, String archiveContext, String archiveServerUrl) {
 		final NodeList propertyList = propertiesElement.getChildNodes();
 		for (int n = 0; n < propertyList.getLength(); n++) {
 			final Node propertyNode = propertyList.item(n);
@@ -1091,7 +1092,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 						discussionTopic.setShortDescription(shortDescription);
 					} else if (TOPIC_LONG_DESC.equals(propertyElement.getAttribute(NAME))) {
 						String extendedDescription = getDescriptionFromPropertyElement(propertyElement);
-						extendedDescription = ltiService.fixLtiLaunchUrls(extendedDescription, siteId, ltiContentItems);
+						extendedDescription = ltiService.fixLtiLaunchUrls(extendedDescription, siteId, mcx);
 						extendedDescription = LinkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, extendedDescription);
 						discussionTopic.setExtendedDescription(extendedDescription);
 					}

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -732,7 +732,7 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		return transversalMap;
 	}
 
-	public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
+	public String merge(String siteId, Element root, String archivePath, String fromSiteId,
 		MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
 		String archiveContext = "";

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -463,18 +463,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
     public String merge(String siteId, Element root, String archivePath, String fromSiteId,
             MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
-        String archiveContext = "";
-        String archiveServerUrl = "";
-
-        Node parent = root.getParentNode();
-        if (parent.getNodeType() == Node.ELEMENT_NODE)
-        {
-            Element parentEl = (Element)parent;
-            archiveContext = parentEl.getAttribute("source");
-            archiveServerUrl = parentEl.getAttribute("serverurl");
-        }
-
-        log.debug("merge archiveContext={} archiveServerUrl={}", archiveContext, archiveServerUrl);
+        log.debug("merge archiveContext={} archiveServerUrl={}", mcx.archiveContext, mcx.archiveServerUrl);
 
         List<Poll> pollsList = findAllPolls(siteId);
         Set<String> pollTexts = pollsList.stream().map(Poll::getText).collect(Collectors.toCollection(LinkedHashSet::new));
@@ -493,7 +482,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
             poll.setOwner(mcx.creatorId);
             String details = poll.getDetails();
             details = ltiService.fixLtiLaunchUrls(details, siteId, mcx);
-            details = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, details);
+            details = linkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, details);
             poll.setDetails(details);
 
             savePoll(poll);
@@ -506,7 +495,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
                 option.setPollId(poll.getPollId());
                 String text = option.getText();
                 text = ltiService.fixLtiLaunchUrls(text, siteId, mcx);
-                text = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, text);
+                text = linkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, text);
                 option.setText(text);
                 saveOption(option);
                 poll.addOption(option);

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -68,6 +68,7 @@ import org.sakaiproject.poll.model.Vote;
 import org.sakaiproject.poll.util.PollUtil;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.MergeConfig;
 
 @Slf4j
 @Data
@@ -460,7 +461,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
     }
 
     public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-            Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+            MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
         String archiveContext = "";
         String archiveServerUrl = "";
@@ -491,7 +492,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
             poll.setSiteId(siteId);
             poll.setOwner(creatorId);
             String details = poll.getDetails();
-            details = ltiService.fixLtiLaunchUrls(details, siteId, ltiContentItems);
+            details = ltiService.fixLtiLaunchUrls(details, siteId, mcx);
             details = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, details);
             poll.setDetails(details);
 
@@ -504,7 +505,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
                 option.setUuid(UUID.randomUUID().toString());
                 option.setPollId(poll.getPollId());
                 String text = option.getText();
-                text = ltiService.fixLtiLaunchUrls(text, siteId, ltiContentItems);
+                text = ltiService.fixLtiLaunchUrls(text, siteId, mcx);
                 text = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, text);
                 option.setText(text);
                 saveOption(option);

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -460,7 +460,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
         return results.toString();
     }
 
-    public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
+    public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
             MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
         String archiveContext = "";

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -460,8 +460,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
         return results.toString();
     }
 
-    public String merge(String siteId, Element root, String archivePath, String fromSiteId,
-            MergeConfig mcx) {
+    public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
 
         log.debug("merge archiveContext={} archiveServerUrl={}", mcx.archiveContext, mcx.archiveServerUrl);
 

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -460,7 +460,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
         return results.toString();
     }
 
-    public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId,
+    public String merge(String siteId, Element root, String archivePath, String fromSiteId,
             MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
 
         String archiveContext = "";
@@ -490,7 +490,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
             if ( pollTexts.contains(pollText) ) continue;
 
             poll.setSiteId(siteId);
-            poll.setOwner(creatorId);
+            poll.setOwner(mcx.creatorId);
             String details = poll.getDetails();
             details = ltiService.fixLtiLaunchUrls(details, siteId, mcx);
             details = linkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, details);

--- a/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
+++ b/polls/impl/src/java/org/sakaiproject/poll/service/impl/PollListManagerImpl.java
@@ -461,7 +461,7 @@ public class PollListManagerImpl implements PollListManager,EntityTransferrer {
     }
 
     public String merge(String siteId, Element root, String archivePath, String fromSiteId,
-            MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport) {
+            MergeConfig mcx) {
 
         log.debug("merge archiveContext={} archiveServerUrl={}", mcx.archiveContext, mcx.archiveServerUrl);
 

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/mocks/MockContentHostingService.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/mocks/MockContentHostingService.java
@@ -50,7 +50,7 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.time.api.Time;
-
+import org.sakaiproject.util.MergeConfig;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -91,7 +91,7 @@ public class MockContentHostingService implements ContentHostingService
     }
 
     @Override
-    public ContentResource copyAttachment(String oAttachmentId, String toContext, String toolTitle, Map<String, String> attachmentImportMap) throws IdUnusedException, TypeException, PermissionException {
+    public ContentResource copyAttachment(String oAttachmentId, String toContext, String toolTitle, MergeConfig mcx) throws IdUnusedException, TypeException, PermissionException {
         throw new UnsupportedOperationException( "Not supported yet." );
     }
 

--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
@@ -457,17 +457,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
       Map<String, String> userIdTrans, Set<String> userListAllowImport)
   {
 
-	String archiveContext = "";
-	String archiveServerUrl = "";
-
-	Node parent = root.getParentNode();
-	if (parent.getNodeType() == Node.ELEMENT_NODE)
-	{
-		Element parentEl = (Element)parent;
-		archiveContext = parentEl.getAttribute("source");
-		archiveServerUrl = parentEl.getAttribute("serverurl");
-	}
-	log.debug("merge archiveContext={} archiveServerUrl={}", archiveContext, archiveServerUrl);
+	log.debug("merge archiveContext={} archiveServerUrl={}", mcx.archiveContext, mcx.archiveServerUrl);
 
     // Get the existing titles for duplicate removal
     Set<String> syllabusTitles = new LinkedHashSet<>();
@@ -580,7 +570,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
                                           byte[] decoded = Base64.decodeBase64(body.getBytes("UTF-8"));
                                           body = new String(decoded, charset);
                                           body = ltiService.fixLtiLaunchUrls(body, siteId, mcx);
-                                          body = LinkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, body);
+                                          body = LinkMigrationHelper.migrateLinksInMergedRTE(siteId, mcx, body);
                                         }
                                         catch (Exception e)
                                         {

--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
@@ -75,6 +75,8 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.BaseResourcePropertiesEdit;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.cover.LinkMigrationHelper;
+import org.sakaiproject.util.MergeConfig;
+
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -452,7 +454,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
    */
   @Transactional
   public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-      Map<Long, Map<String, Object>> ltiContentItems, Map<String, String> userIdTrans, Set<String> userListAllowImport) 
+      MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
   {
 
 	String archiveContext = "";
@@ -577,7 +579,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
                                         {
                                           byte[] decoded = Base64.decodeBase64(body.getBytes("UTF-8"));
                                           body = new String(decoded, charset);
-                                          body = ltiService.fixLtiLaunchUrls(body, siteId, ltiContentItems);
+                                          body = ltiService.fixLtiLaunchUrls(body, siteId, mcx);
                                           body = LinkMigrationHelper.migrateLinksInMergedRTE(siteId, archiveContext, archiveServerUrl, body);
                                         }
                                         catch (Exception e)

--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
@@ -453,8 +453,8 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
    *      java.util.Set)
    */
   @Transactional
-  public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, Map<String, String> attachmentNames,
-      MergeConfig mcx, Map<String, String> userIdTrans, Set<String> userListAllowImport)
+  public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, MergeConfig mcx,
+      Map<String, String> userIdTrans, Set<String> userListAllowImport)
   {
 
 	String archiveContext = "";
@@ -599,7 +599,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
                                     {
                                       Element attachElement = (Element) child3;
                                       String oldUrl = attachElement.getAttribute("relative-url");
-                                      String newUrl = transferAttachment(oldUrl, siteId, attachmentNames);
+                                      String newUrl = transferAttachment(oldUrl, siteId, mcx);
                                       if (newUrl != null)
                                       {
                                         attachElement.setAttribute("relative-url", Validator.escapeQuestionMark(newUrl));
@@ -665,10 +665,10 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
     return results.toString();
   }
 
-  private String transferAttachment(String oAttachmentId, String toContext, Map<String, String> attachmentImportMap) {
+  private String transferAttachment(String oAttachmentId, String toContext, MergeConfig mcx) {
     String toolTitle = toolManager.getTool("sakai.syllabus").getTitle();
     try {
-        ContentResource attachment = contentHostingService.copyAttachment(oAttachmentId, toContext, toolTitle, attachmentImportMap);
+        ContentResource attachment = contentHostingService.copyAttachment(oAttachmentId, toContext, toolTitle, mcx);
         if ( attachment != null ) {
             return attachment.getReference();
         }

--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
@@ -453,8 +453,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
    *      java.util.Set)
    */
   @Transactional
-  public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx,
-      Map<String, String> userIdTrans, Set<String> userListAllowImport)
+  public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx)
   {
 
 	log.debug("merge archiveContext={} archiveServerUrl={}", mcx.archiveContext, mcx.archiveServerUrl);

--- a/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
+++ b/syllabus/syllabus-impl/src/java/org/sakaiproject/component/app/syllabus/SyllabusServiceImpl.java
@@ -453,7 +453,7 @@ public class SyllabusServiceImpl implements SyllabusService, EntityTransferrer
    *      java.util.Set)
    */
   @Transactional
-  public String merge(String siteId, Element root, String archivePath, String fromSiteId, String creatorId, MergeConfig mcx,
+  public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx,
       Map<String, String> userIdTrans, Set<String> userListAllowImport)
   {
 


### PR DESCRIPTION
This is a refactor for @ern - I have been adding to merge / archive for a while and the method signatures have gotten too long.  The invents a MergeConfig (similar to CCConfig) to gather these loop-carried data structures that cut across the multiple steps of the merge() process.