### PR TITLE
SAK-51060 Rubrics avoid throwing an exception when user doesn't have the edit permission

### DIFF
--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
@@ -280,7 +280,8 @@ public class RubricsServiceImpl implements RubricsService, EntityProducer, Entit
     public List<RubricTransferBean> getRubricsForSite(String siteId) {
 
         if (!isCurrentUserEditor(siteId)) {
-            throw new SecurityException("You need to be an editor to get a site's rubrics");
+            log.debug("You need to be an editor to get a site's rubrics: {}", siteId);
+            return Collections.emptyList();
         }
 
         return rubricRepository.findByOwnerId(siteId).stream()

--- a/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
+++ b/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
@@ -231,15 +231,15 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
 
     @Test
     public void getRubrics() {
-
         switchToUser1();
-
-        assertThrows(SecurityException.class, () -> rubricsService.getRubricsForSite(siteId));
+        // Expect empty list instead of exception
+        List<RubricTransferBean> userRubrics = rubricsService.getRubricsForSite(siteId);
+        assertTrue(userRubrics.isEmpty());
 
         switchToTeachingAssistant();
-
-        // Should still throw it as the user doesn't have rubrics.editor
-        assertThrows(SecurityException.class, () -> rubricsService.getRubricsForSite(siteId));
+        // Should also return empty list
+        List<RubricTransferBean> taRubrics = rubricsService.getRubricsForSite(siteId);
+        assertTrue(taRubrics.isEmpty());
 
         switchToInstructor();
         rubricsService.createDefaultRubric(siteId);
@@ -258,7 +258,7 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
         String newDescription = "Sandwiches of the world";
         rubricBean.setTitle(newTitle);
         rubricBean = rubricsService.saveRubric(rubricBean);
-        assertEquals(rubricBean.getTitle(), newTitle);
+        assertEquals(newTitle, rubricBean.getTitle());
     }
 
     @Test

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricAssociation.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricAssociation.js
@@ -91,11 +91,23 @@ export class SakaiRubricAssociation extends RubricsElement {
         if (r.status === 204) {
           return {};
         }
-        return r.json();
+        return r.text().then(text => {
+          if (!text) {
+            this.style.display = "none";
+            return {};
+          }
+          try {
+            return JSON.parse(text);
+          } catch (e) {
+            console.error("Failed to parse response as JSON:", e);
+            return {};
+          }
+        });
       }
 
       if (r.status === 404) {
         this.style.display = "none";
+        return {};
       }
 
       throw new Error("Network error while getting association");


### PR DESCRIPTION
* Throwing an exception just gets buried and user never sees it
* If the user has no permissions, just returning an empty list seems sane.
* There is no way to short-circuit the loading of `<sakai-rubric-association>` if Rubrics is not enabled in the site.
* Add more safety to the JSON.parse to avoid an error preventing normal user behavior