### PR TITLE
SAK-50978 Lessons cc+ import does not import content unless the file is imported twice

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSitePage.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSitePage.java
@@ -882,6 +882,19 @@ public class BaseSitePage implements SitePage, Identifiable
 	}
 
 	/**
+	 *
+	 */
+	public void regenerateIds()
+	{
+		m_id = siteService.idManager().createUuid();
+		for (Iterator iTools = getTools().iterator(); iTools.hasNext();)
+		{
+			BaseToolConfiguration tool = (BaseToolConfiguration) iTools.next();
+			tool.regenerateId();
+		}
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public Element toXml(Document doc, Stack stack)

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -3626,12 +3626,12 @@ public abstract class BaseSiteService implements SiteService, Observer
 
 				// addPage
 				BaseSitePage page = new BaseSitePage(this, pageEl, site);
+				page.regenerateIds();
 				site.getPages().add(page);
 				changed = true;
 			}
 
 			if ( changed ) {
-				site.regenerateIds();
 				save(site);
 			}
 		}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseToolConfiguration.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseToolConfiguration.java
@@ -606,4 +606,13 @@ public class BaseToolConfiguration extends org.sakaiproject.util.Placement imple
 		
 		return localizedTitle;
 	}
+
+	/**
+	 * Regenerate the Id for this tool
+	 */
+
+	public void regenerateId()
+	{
+		m_id = siteService.idManager().createUuid();
+	}
 }

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -966,12 +966,11 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		for (int i = 0; i < list.size(); i++) {
 			page = (SimplePage) list.get(i);
 			List<SimplePageItem> items = this.findItemsOnPage(page.getPageId());
-			if ( items.size() == 0 ) {
-				log.debug("Page {} {} is empty", i, page.getPageId());
-				continue;
+			if ( items.size() > 0 ) {
+				log.warn("Multiple top level pages found, choosing page {} {} with {} items", i, page.getPageId(), items.size());
+				return page.getPageId();
 			}
-			log.warn("Multiple top level pages found, choosing page {} {} with {} items", i, page.getPageId(), items.size());
-			return page.getPageId();
+			log.debug("Page {} {} is empty", i, page.getPageId());
 		}
 		log.warn("Multiple top level pages found, Returning {} page", (page != null ? page.getPageId() : null));
 		return page != null ? page.getPageId() : null;

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -53,6 +53,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.Order;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
@@ -946,19 +947,29 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	}
 
 	public Long getTopLevelPageId(String toolId) {
-		DetachedCriteria d = DetachedCriteria.forClass(SimplePage.class).add(Restrictions.eq("toolId", toolId)).add(Restrictions.isNull("parent"));
+		DetachedCriteria d = DetachedCriteria.forClass(SimplePage.class).add(Restrictions.eq("toolId", toolId))
+			.add(Restrictions.isNull("parent")).addOrder(Order.desc("pageId"));
 
 		List list = getHibernateTemplate().findByCriteria(d);
 
-		if (list.size() > 1) {
-			log.warn("Multiple top level pages for placement.  Doing the best we can.");
-		}
+		if ( list == null || list.size() < 1 ) return null;
 
-		if (list != null && list.size() > 0) {
-			return ((SimplePage) list.get(0)).getPageId();
-		} else {
-			return null;
+		if ( list.size() == 1)  return ((SimplePage) list.get(0)).getPageId();
+
+		log.debug("Scanning {} top pages for placment toolId=", list.size(), toolId);
+		SimplePage page = null;
+		for (int i = 0; i < list.size(); i++) {
+			page = (SimplePage) list.get(i);
+			List<SimplePageItem> items = this.findItemsOnPage(page.getPageId());
+			if ( items.size() == 0 ) {
+				log.debug("Page {} {} is empty", i, page.getPageId());
+				continue;
+			}
+			log.debug("Page {} {} has {} items", i, page.getPageId(), items.size());
+			return page.getPageId();
 		}
+		log.debug("Returning {} page", (page != null ? page.getPageId() : null));
+		return page != null ? page.getPageId() : null;
 	}
 
 	public SimplePage getPage(long pageId) {

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -958,7 +958,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 
 		// When there is more than one page associated with a placement, the data model is
 		// broken due to an errant import, timing problem, system crash, NPE or whatever.
-		// hen it happens // we ignore empty pages and return the non-empty page with
+		// when it happens // we ignore empty pages and return the non-empty page with
 		// the largest primary key (a weak proxy for "latest" but it is all we have)
 		// with a warning message.
 		log.debug("Scanning {} top pages for placment toolId=", list.size(), toolId);

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -951,7 +951,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 		List list = getHibernateTemplate().findByCriteria(d);
 
 		if (list.size() > 1) {
-			log.warn("Problem finding which page we should be on.  Doing the best we can.");
+			log.warn("Multiple top level pages for placement.  Doing the best we can.");
 		}
 
 		if (list != null && list.size() > 0) {

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -956,6 +956,11 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 
 		if ( list.size() == 1)  return ((SimplePage) list.get(0)).getPageId();
 
+		// When there is more than one page associated with a placement, the data model is
+		// broken due to an errant import, timing problem, system crash, NPE or whatever.
+		// hen it happens // we ignore empty pages and return the non-empty page with
+		// the largest primary key (a weak proxy for "latest" but it is all we have)
+		// with a warning message.
 		log.debug("Scanning {} top pages for placment toolId=", list.size(), toolId);
 		SimplePage page = null;
 		for (int i = 0; i < list.size(); i++) {
@@ -965,10 +970,10 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 				log.debug("Page {} {} is empty", i, page.getPageId());
 				continue;
 			}
-			log.debug("Page {} {} has {} items", i, page.getPageId(), items.size());
+			log.warn("Multiple top level pages found, choosing page {} {} with {} items", i, page.getPageId(), items.size());
 			return page.getPageId();
 		}
-		log.debug("Returning {} page", (page != null ? page.getPageId() : null));
+		log.warn("Multiple top level pages found, Returning {} page", (page != null ? page.getPageId() : null));
 		return page != null ? page.getPageId() : null;
 	}
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -684,6 +684,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	private boolean mergePage(Element element, String oldServer, String siteId, String fromSiteId, Map<Long,Long> pageMap,
 			Map<Long,Long> itemMap, Map<String,String> entityMap, MergeConfig mcx) {
 
+		log.debug("mergePage: element {} siteId {} fromSiteId {}", element, siteId, fromSiteId);
 		String oldSiteId = element.getAttribute("siteid");
 		String oldPageIdString = element.getAttribute("pageid");
 		Long oldPageId = Long.valueOf(oldPageIdString);
@@ -706,6 +707,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		} catch (Exception impossible) {
 			fromSite = null;
 		};
+
 		boolean isSameServer = fromSite != null;
 
 		NodeList allChildrenNodes = element.getChildNodes();
@@ -716,6 +718,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			if (node.getNodeType() != Node.ELEMENT_NODE) continue;
 			Element itemElement = (Element) node;
 			if (!itemElement.getTagName().equals("item")) continue;
+
 			String s = itemElement.getAttribute("sequence");
 			int sequence = new Integer(s);
 			s = itemElement.getAttribute("type");
@@ -1123,6 +1126,11 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		log.debug("Lessons Merge siteId={} fromSiteId={} creatorId={} archiveContext={} archiveServerUrl={}",
 				siteId, fromSiteId, mcx.creatorId, mcx.archiveContext, mcx.archiveServerUrl);
 
+		if (StringUtils.isBlank(siteId) ) {
+			log.debug("Lessons merge stopped siteId is not provided");
+			return "Lessons merge stopped siteId is not provided";
+		}
+
 		// Check if there is nothing to import
 		NodeList lessonBuilderTools = root.getElementsByTagName("lessonbuilder");
 		boolean lessonHasContent = false;
@@ -1162,243 +1170,246 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 		String oldServer = root.getAttribute("server");
 
-		if (siteId != null && siteId.trim().length() > 0)
-		{
-			try {
-				// create pages first, build up map of old to new page
-				NodeList pageNodes = root.getElementsByTagName("page");
-				int numPages = pageNodes.getLength();
-				for (int p = 0; p < numPages; p++) {
-					Node pageNode = pageNodes.item(p);
-					if (pageNode.getNodeType() != Node.ELEMENT_NODE) continue;
+		try {
+			// create pages first, build up map of old to new page
+			NodeList pageNodes = root.getElementsByTagName("page");
+			int numPages = pageNodes.getLength();
+			for (int p = 0; p < numPages; p++) {
+				Node pageNode = pageNodes.item(p);
+				if (pageNode.getNodeType() != Node.ELEMENT_NODE) continue;
 
+				Element pageElement = (Element) pageNode;
+				String title = pageElement.getAttribute("title");
+				if (title == null) title = "Page";
+				String oldPageIdString = pageElement.getAttribute("pageid");
+				if (oldPageIdString == null) oldPageIdString = "0";
+				Long oldPageId = Long.valueOf(oldPageIdString);
+				log.debug("oldPageId: {} title: {}", oldPageId, title);
+				SimplePage page = simplePageToolDao.makePage("0", siteId, title, 0L, 0L);
+				String gradebookPoints = pageElement.getAttribute("gradebookpoints");
+				if (StringUtils.isNotEmpty(gradebookPoints)) {
+					page.setGradebookPoints(Double.valueOf(gradebookPoints));
+				}
+				String folder = pageElement.getAttribute("folder");
+				if (StringUtils.isNotEmpty(folder)) page.setFolder(folder);
+				//get new page's Date Release property
+				String dateString = pageElement.getAttribute("releasedate");
+				if (StringUtils.isNotEmpty(dateString)){
+					DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+					Date date = formatter.parse(dateString);
+					page.setReleaseDate(date);
+				}
+				//get new page's Hidden property
+				String hiddenString = pageElement.getAttribute("hidden");
+				if (StringUtils.isNotEmpty(hiddenString)) page.setHidden(Boolean.valueOf(hiddenString));
+				// Carry over the custom CSS sheet if present. These are of the form
+				// "/group/SITEID/LB-CSS/whatever.css", so we need to map the SITEID
+				String cssSheet = pageElement.getAttribute("csssheet");
+				if (StringUtils.isNotEmpty(cssSheet)) page.setCssSheet(cssSheet.replace("/group/"+fromSiteId+"/", "/group/"+siteId+"/"));
+				log.debug("saving page: {}", page);
+				simplePageToolDao.quickSaveItem(page);
+				log.debug("saved page: {}", page);
+				if (StringUtils.isNotEmpty(gradebookPoints)) {
+					try {
+						gradebookIfc.addExternalAssessment(siteId, "lesson-builder:" + page.getPageId(), null,
+								title, Double.valueOf(gradebookPoints), null, LessonBuilderConstants.TOOL_ID);
+					} catch(ConflictingAssignmentNameException cane){
+						log.error("merge: ConflictingAssignmentNameException for title {}.", title);
+					}
+				}
+				pageMap.put(oldPageId, page.getPageId());
+			}
+
+			log.debug("Starting pass over pages/items pageMap: {}", pageMap);
+
+			// process pages again to create the items
+			pageNodes = root.getElementsByTagName("page");
+			numPages = pageNodes.getLength();
+			for (int p = 0; p < numPages; p++) {
+				Node pageNode = pageNodes.item(p);
+				if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
 					Element pageElement = (Element) pageNode;
-					String title = pageElement.getAttribute("title");
-					if (title == null) title = "Page";
-					String oldPageIdString = pageElement.getAttribute("pageid");
-					if (oldPageIdString == null) oldPageIdString = "0";
-					Long oldPageId = Long.valueOf(oldPageIdString);
-					log.debug("oldPageId: {} title: {}", oldPageId, title);
-					SimplePage page = simplePageToolDao.makePage("0", siteId, title, 0L, 0L);
-					String gradebookPoints = pageElement.getAttribute("gradebookpoints");
-					if (StringUtils.isNotEmpty(gradebookPoints)) {
-						page.setGradebookPoints(Double.valueOf(gradebookPoints));
-					}
-					String folder = pageElement.getAttribute("folder");
-					if (StringUtils.isNotEmpty(folder)) page.setFolder(folder);
-					//get new page's Date Release property
-					String dateString = pageElement.getAttribute("releasedate");
-					if (StringUtils.isNotEmpty(dateString)){
-						DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
-						Date date = formatter.parse(dateString);
-						page.setReleaseDate(date);
-					}
-					//get new page's Hidden property
-					String hiddenString = pageElement.getAttribute("hidden");
-					if (StringUtils.isNotEmpty(hiddenString)) page.setHidden(Boolean.valueOf(hiddenString));
-					// Carry over the custom CSS sheet if present. These are of the form
-					// "/group/SITEID/LB-CSS/whatever.css", so we need to map the SITEID
-					String cssSheet = pageElement.getAttribute("csssheet");
-					if (StringUtils.isNotEmpty(cssSheet)) page.setCssSheet(cssSheet.replace("/group/"+fromSiteId+"/", "/group/"+siteId+"/"));
-					log.debug("saving page: {}", page);
-					simplePageToolDao.quickSaveItem(page);
-					log.debug("saved page: {}", page);
-					if (StringUtils.isNotEmpty(gradebookPoints)) {
-						try {
-							gradebookIfc.addExternalAssessment(siteId, "lesson-builder:" + page.getPageId(), null,
-									title, Double.valueOf(gradebookPoints), null, LessonBuilderConstants.TOOL_ID);
-						} catch(ConflictingAssignmentNameException cane){
-							log.error("merge: ConflictingAssignmentNameException for title {}.", title);
-						}
-					}
-					pageMap.put(oldPageId, page.getPageId());
+
+					// The pageElementMap will be referenced later when SimplePageItems corresponding to
+					// top level pages are created. (These are distinct from the SimplePageItems representing
+					// items on the page.)
+					Long oldPageId = Long.valueOf(pageElement.getAttribute("pageid"));
+					pageElementMap.put(oldPageId, pageElement);
+
+					if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, mcx))
+
+						needFix = true;
 				}
+			}
 
-				log.debug("Starting pass over pages/items pageMap: {}", pageMap);
+			if (needFix) {
+				Site site = siteService.getSite(siteId);
+				ResourcePropertiesEdit rp = site.getPropertiesEdit();
+				rp.addProperty("lessonbuilder-needsfixup", "2");
+				siteService.save(site);
+				// unfortunately in duplicate site, site-admin has the site open, so this doesn't actually do anything
+				// site-manage will stomp on it. However it does work for the other import operations, which is where
+				// we need it, since site manage will call the fixup itself for duplicate
 
-				// process pages again to create the items
-				pageNodes = root.getElementsByTagName("page");
-				numPages = pageNodes.getLength();
-				for (int p = 0; p < numPages; p++) {
-					Node pageNode = pageNodes.item(p);
-					if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-						Element pageElement = (Element) pageNode;
+			}
 
-						// The pageElementMap will be referenced later when SimplePageItems corresponding to
-						// top level pages are created. (These are distinct from the SimplePageItems representing
-						// items on the page.)
-						Long oldPageId = Long.valueOf(pageElement.getAttribute("pageid"));
-						pageElementMap.put(oldPageId, pageElement);
-
-						if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, mcx))
-
-							needFix = true;
-					}
+			for (int p = 0; p < numPages; p++) {
+				Node pageNode = pageNodes.item(p);
+				if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
+					Element pageElement = (Element) pageNode;
+					fixItems(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap);
 				}
+			}
 
-				if (needFix) {
-					Site site = siteService.getSite(siteId);
-					ResourcePropertiesEdit rp = site.getPropertiesEdit();
-					rp.addProperty("lessonbuilder-needsfixup", "2");
-					siteService.save(site);
-					// unfortunately in duplicate site, site-admin has the site open, so this doesn't actually do anything
-					// site-manage will stomp on it. However it does work for the other import operations, which is where
-					// we need it, since site manage will call the fixup itself for duplicate
+			// process tools and top-level pages
+			// need to fill in the tool id for top level pages and set parents to null
+			NodeList tools = root.getElementsByTagName("lessonbuilder");
+			int numTools =  tools.getLength();
+			for (int i = 0; i < numTools; i++) {
+				Node node = tools.item(i);
+				if (node.getNodeType() == Node.ELEMENT_NODE) {
+					Element element = (Element) node;
+					// there's an element at top level with no attributes. ignore it
+					String oldToolId = trimToNull(element.getAttribute("toolid"));
+					if (oldToolId != null) {
 
-				}
+						String toolTitle = trimToNull(element.getAttribute("name"));
+						String rolelist = element.getAttribute("functions.require");
+						String pagePosition = element.getAttribute("pagePosition");
+						String pageVisibility = element.getAttribute("pageVisibility");
 
-				for (int p = 0; p < numPages; p++) {
-					Node pageNode = pageNodes.item(p);
-					if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-						Element pageElement = (Element) pageNode;
-						fixItems(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap);
-					}
-				}
+						if(toolTitle != null) {
+							Tool tr = toolManager.getTool(LessonBuilderConstants.TOOL_ID);
+							SitePage page = null;
+							ToolConfiguration tool = null;
+							Site site = siteService.getSite(siteId);
 
-				// process tools and top-level pages
-				// need to fill in the tool id for top level pages and set parents to null
-				NodeList tools = root.getElementsByTagName("lessonbuilder");
-				int numTools =  tools.getLength();
-				for (int i = 0; i < numTools; i++) {
-					Node node = tools.item(i);
-					if (node.getNodeType() == Node.ELEMENT_NODE) {
-						Element element = (Element) node;
-						// there's an element at top level with no attributes. ignore it
-						String oldToolId = trimToNull(element.getAttribute("toolid"));
-						if (oldToolId != null) {
-
-							String toolTitle = trimToNull(element.getAttribute("name"));
-							String rolelist = element.getAttribute("functions.require");
-							String pagePosition = element.getAttribute("pagePosition");
-							String pageVisibility = element.getAttribute("pageVisibility");
-
-							if(toolTitle != null) {
-								Tool tr = toolManager.getTool(LessonBuilderConstants.TOOL_ID);
-								SitePage page = null;
-								ToolConfiguration tool = null;
-								Site site = siteService.getSite(siteId);
-
-								// some code in site action creates all the pages and tools and some doesn't
-								// so see if we already have this page and tool
-								Collection<ToolConfiguration> toolConfs = site.getTools(myToolIds());
-								if (toolConfs != null && !toolConfs.isEmpty())  {
-									for (ToolConfiguration config: toolConfs) {
-										if (config.getToolId().equals(LessonBuilderConstants.TOOL_ID)) {
-											SitePage p = config.getContainingPage();
-											// only use the Sakai page if it has the right title
-											// and we don't already have lessson builder info for it
-											log.debug("checking top level page bash toolTitle: {} pageTitle: {}", toolTitle, p.getTitle());
-											if (p != null && toolTitle.equals(p.getTitle()) ) {
-												Long topLevelPageId = simplePageToolDao.getTopLevelPageId(config.getPageId());
-												log.debug("checking page and tool: {} pageTitle: {} topLevelPageId: {}", p, config, topLevelPageId);
-												if (topLevelPageId != null) {
-													List<SimplePageItem> items = simplePageToolDao.findItemsOnPage(topLevelPageId);
-													log.debug("items: {}", items);
-													if (items.isEmpty()) {
-														// TODO: REMOVE THIS ERROR AFTER DEBUGGING
-														log.error("reusing page and tool: {} pageTitle: {}", p, config);
-														page = p;
-														tool = config;
-														break;
-													}
+							// some code in site action creates all the pages and tools and some doesn't
+							// so see if we already have this page and tool
+							Collection<ToolConfiguration> toolConfs = site.getTools(myToolIds());
+							if (toolConfs != null && !toolConfs.isEmpty())  {
+								for (ToolConfiguration config: toolConfs) {
+									if (config.getToolId().equals(LessonBuilderConstants.TOOL_ID)) {
+										SitePage p = config.getContainingPage();
+										// only use the Sakai page if it has the right title
+										// and we don't already have lessson builder info for it
+										log.debug("checking top level page bash toolTitle: {} pageTitle: {}", toolTitle, p.getTitle());
+										if (p != null && toolTitle.equals(p.getTitle()) ) {
+											Long topLevelPageId = simplePageToolDao.getTopLevelPageId(config.getPageId());
+											log.debug("checking page and tool: {} pageTitle: {} topLevelPageId: {}", p, config, topLevelPageId);
+											if (topLevelPageId != null) {
+												List<SimplePageItem> items = simplePageToolDao.findItemsOnPage(topLevelPageId);
+												log.debug("items: {}", items);
+												if (items.isEmpty()) {
+													// TODO: REMOVE THIS ERROR AFTER DEBUGGING
+													log.error("reusing page and tool: {} pageTitle: {}", p, config);
+													page = p;
+													tool = config;
+													break;
 												}
 											}
 										}
 									}
 								}
-
-								// if we alrady have an appropriate blank page from the template, page and tool are set
-								if (page == null) {
-									page = site.addPage();
-									tool = page.addTool(LessonBuilderConstants.TOOL_ID);
-									if (StringUtils.isNotBlank(pagePosition)) {
-										int integerPosition = Integer.parseInt(pagePosition);
-										page.setPosition(integerPosition);
-									}
-								}
-
-								String toolId = tool.getPageId();
-								if (toolId == null) {
-									log.error("unable to find new toolid for copy of " + oldToolId);
-									continue;
-								}
-
-								if (StringUtils.isNotBlank(rolelist)) {
-									tool.getPlacementConfig().setProperty("functions.require", rolelist);
-								}
-								if (StringUtils.isNotBlank(pageVisibility)) {
-									tool.getPlacementConfig().setProperty(ToolManager.PORTAL_VISIBLE, pageVisibility);
-								}
-								tool.setTitle(toolTitle);
-								page.setTitle(toolTitle);
-								page.setTitleCustom(true);
-								siteService.save(site);
-								count++;
-
-								// now fix up the page. new format has it as attribute
-								String pageId = trimToNull(element.getAttribute("pageId"));
-								if (pageId == null) {
-									// old format. we should have a page node
-									// normally just one
-									Node pageNode = element.getFirstChild();
-									if (pageNode == null || pageNode.getNodeType() != Node.ELEMENT_NODE) {
-										log.error("page node not element");
-										continue;
-									}
-									Element pageElement = (Element)pageNode;
-									pageId = trimToNull(pageElement.getAttribute("pageid"));
-								}
-								if (pageId == null) {
-									log.error("page node without old pageid");
-									continue;
-								}
-
-								// fix up the new copy of the page to be top level
-								SimplePage simplePage = simplePageToolDao.getPage(pageMap.get(Long.valueOf(pageId)));
-								if (simplePage == null) {
-									log.error("can't find new copy of top level page");
-									continue;
-								}
-								simplePage.setParent(null);
-								simplePage.setTopParent(null);
-								simplePage.setToolId(toolId);
-								simplePageToolDao.quickUpdate(simplePage);
-								log.debug("updated top level page: {} to point to tool: {}", simplePage, toolId);
-								// create the vestigial item for this top level page
-								log.debug("creating vestigial item for top level page: {}", simplePage.getPageId());
-								SimplePageItem item = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, Long.toString(simplePage.getPageId()), simplePage.getTitle());
-
-								// Revise the top level page's SimplePageItem based on its corresponding pageElement attributes
-								Element pageElement = pageElementMap.get(Long.valueOf(pageId));
-								String pageAttribute = pageElement.getAttribute("required");
-								if (StringUtils.isNotEmpty(pageAttribute)) {
-									item.setRequired(Boolean.valueOf(pageAttribute));
-								}
-								pageAttribute = pageElement.getAttribute("prerequisite");
-								if (StringUtils.isNotEmpty(pageAttribute)) {
-									item.setPrerequisite(Boolean.valueOf(pageAttribute));
-								}
-								log.debug("saving vestigial item: {}", item);
-								simplePageToolDao.quickSaveItem(item);
 							}
+
+							// if we alrady have an appropriate blank page from the template, page and tool are set
+							if (page == null) {
+								page = site.addPage();
+								tool = page.addTool(LessonBuilderConstants.TOOL_ID);
+								if (StringUtils.isNotBlank(pagePosition)) {
+									int integerPosition = Integer.parseInt(pagePosition);
+									page.setPosition(integerPosition);
+								}
+								log.debug("added new Lessons toolTitle={} page={} tool={} to site", toolTitle, page.getId(), tool.getId());
+
+							}
+
+							String toolId = tool.getPageId();
+							if (toolId == null) {
+								log.error("unable to find new toolid for copy of " + oldToolId);
+								continue;
+							}
+
+							if (StringUtils.isNotBlank(rolelist)) {
+								tool.getPlacementConfig().setProperty("functions.require", rolelist);
+							}
+							if (StringUtils.isNotBlank(pageVisibility)) {
+								tool.getPlacementConfig().setProperty(ToolManager.PORTAL_VISIBLE, pageVisibility);
+							}
+							tool.setTitle(toolTitle);
+							page.setTitle(toolTitle);
+							page.setTitleCustom(true);
+							log.debug("saving site {}", site.getId());
+							siteService.save(site);
+							count++;
+
+							// now fix up the page. new format has it as attribute
+							String pageId = trimToNull(element.getAttribute("pageId"));
+							if (pageId == null) {
+								// old format. we should have a page node
+								// normally just one
+								Node pageNode = element.getFirstChild();
+								if (pageNode == null || pageNode.getNodeType() != Node.ELEMENT_NODE) {
+									log.error("page node not element");
+									continue;
+								}
+								Element pageElement = (Element)pageNode;
+								pageId = trimToNull(pageElement.getAttribute("pageid"));
+							}
+							if (pageId == null) {
+								log.error("page node without old pageid");
+								continue;
+							}
+
+							log.debug("old pageId: {} new pageId: {}", pageId, pageMap.get(Long.valueOf(pageId)));
+
+							// fix up the new copy of the page to be top level
+							SimplePage simplePage = simplePageToolDao.getPage(pageMap.get(Long.valueOf(pageId)));
+							if (simplePage == null) {
+								log.error("can't find new copy of top level page");
+								continue;
+							}
+							simplePage.setParent(null);
+							simplePage.setTopParent(null);
+							simplePage.setToolId(toolId);
+							simplePageToolDao.quickUpdate(simplePage);
+							log.debug("updated top level page: {} to point to tool: {}", simplePage, toolId);
+							// create the vestigial item for this top level page
+							log.debug("creating vestigial item for top level page: {} type: {}", simplePage.getPageId(), SimplePageItem.PAGE);
+							SimplePageItem item = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, Long.toString(simplePage.getPageId()), simplePage.getTitle());
+
+							// Revise the top level page's SimplePageItem based on its corresponding pageElement attributes
+							Element pageElement = pageElementMap.get(Long.valueOf(pageId));
+							String pageAttribute = pageElement.getAttribute("required");
+							if (StringUtils.isNotEmpty(pageAttribute)) {
+								item.setRequired(Boolean.valueOf(pageAttribute));
+							}
+							pageAttribute = pageElement.getAttribute("prerequisite");
+							if (StringUtils.isNotEmpty(pageAttribute)) {
+								item.setPrerequisite(Boolean.valueOf(pageAttribute));
+							}
+							log.debug("saving vestigial item: {}", item);
+							simplePageToolDao.quickSaveItem(item);
 						}
 					}
 				}
-				results.append("merging link tool " + siteId + " (" + count
-						+ ") items.\n");
 			}
-			catch (DOMException e)
-			{
-				log.error(e.getMessage(), e);
-				results.append("merging " + getLabel()
-						+ " failed during xml parsing.\n");
-			}
-			catch (Exception e)
-			{
-				log.error(e.getMessage(), e);
-				results.append("merging " + getLabel() + " failed.\n");
-			}
+			results.append("merging link tool " + siteId + " (" + count
+					+ ") items.\n");
 		}
+		catch (DOMException e)
+		{
+			log.error(e.getMessage(), e);
+			results.append("merging " + getLabel()
+					+ " failed during xml parsing.\n");
+		}
+		catch (Exception e)
+		{
+			log.error(e.getMessage(), e);
+			results.append("merging " + getLabel() + " failed.\n");
+		}
+
 		return results.toString();
 
 	} // merge

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -126,6 +126,8 @@ import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.thread_local.cover.ThreadLocalManager;
+import org.sakaiproject.time.api.Time;
+import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.Tool;
@@ -196,6 +198,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	private LessonBuilderAccessAPI lessonBuilderAccessAPI;
 	private MessageSource messageSource;
 	private LTIService ltiService;
+	private TimeService timeService;
 	private LinkMigrationHelper linkMigrationHelper;
 	public void setLessonBuilderAccessAPI(LessonBuilderAccessAPI l) {
 		lessonBuilderAccessAPI = l;
@@ -1121,7 +1124,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 							}
 						}
 					} catch (ParseException pe) {
-						log.warn("Exception caught while parsing checklist array: {}", pe.toString());
+						log.warn("Exception caught while parsing simple question: {}", pe.toString());
 						break;
 					}
 					break;
@@ -1145,7 +1148,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 							}
 						}
 					} catch (ParseException pe) {
-						log.warn("Exception caught while parsing checklist array: {}", pe.toString());
+						log.warn("Exception caught while parsing resource folder: {}", pe.toString());
 						break;
 					}
 					break;
@@ -1153,6 +1156,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				default:
 			}
 			if (itemUpdated) {
+				log.debug("Updating item...");
 				simplePageToolDao.quickUpdate(item);
 			}
 		}
@@ -1858,11 +1862,13 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			log.debug("lesson builder transferCopyEntities");
 			Document doc = Xml.createDocument();
 			Stack stack = new Stack();
+			Time now = timeService.newTime();
 			Element root = doc.createElement("archive");
 			doc.appendChild(root);
 			root.setAttribute("source", fromContext);
-			root.setAttribute("server", "foo");
-			root.setAttribute("date", "now");
+			root.setAttribute("server", ServerConfigurationService.getServerId());
+			root.setAttribute("serverurl", ServerConfigurationService.getServerUrl());
+			root.setAttribute("date", now.toString());
 			root.setAttribute("system", "sakai");
 
 			stack.push(root);
@@ -1873,6 +1879,8 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 			MergeConfig mcx = new MergeConfig();
 			mcx.creatorId = sessionManager.getCurrentSessionUserId();
+			mcx.archiveContext = fromContext;
+			mcx.archiveServerUrl = ServerConfigurationService.getServerUrl();
 			mergeInternal(toContext,  (Element)doc.getFirstChild().getFirstChild(), "/tmp/archive", fromContext, mcx, entityMap);
 
 			ToolSession session = sessionManager.getCurrentToolSession();
@@ -2192,6 +2200,11 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	public void setLtiService(LTIService s) {
 		ltiService = s;
 	}
+
+	public void setTimeService(TimeService s) {
+		timeService = s;
+	}
+
 
 	// sitestats support
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -591,7 +591,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				}
 			}
 
-			log.info("Skipped over " + orphansSkipped + " orphaned pages while archiving site " + siteId);
+			log.info("Skipped over {} orphaned pages while archiving site {} ", orphansSkipped, siteId);
 
 			Collection<ToolConfiguration> tools = site.getTools(myToolIds());
 			int count = 0;
@@ -615,7 +615,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					if (simplePageToolDao.getTopLevelPageId(config.getPageId()) != null)
 						addAttr(doc, element, "pageId", Long.toString(simplePageToolDao.getTopLevelPageId(config.getPageId())));
 					else
-						log.warn("archive site " + siteId + " tool page " + config.getPageId() + " null lesson");
+						log.warn("archive site {} tool page {} null lesson", siteId, config.getPageId());
 					// addPage(doc, element,  simplePageToolDao.getTopLevelPageId(config.getPageId()));
 
 					lessonbuilder.appendChild(element);
@@ -637,7 +637,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		}
 		catch (Exception any)
 		{
-			log.warn("archive: exception archiving service: " + any + " " +  serviceName());
+			log.warn("archive: exception archiving service: {} {}", any.toString(), serviceName());
 		}
 
 		stack.pop();
@@ -1008,7 +1008,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		try {
 			oldSite = siteService.getSite(fromSiteId);
 		} catch (Exception e) {
-			log.debug("site " + fromSiteId + " not found.", e);
+			log.debug("site {} not found.", fromSiteId);
 		}
 		// For each old group, get the corresponding new group id
 		if (!groups.isEmpty() && siteGroups != null && oldSite != null) {
@@ -1728,7 +1728,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					}
 				}
 			} catch (Exception e) {
-				log.warn("Problem migrating links in Lessonbuilder"+e);
+				log.warn("Problem migrating links in Lessonbuilder {}", e.toString());
 			}
 		}
 	}
@@ -1778,7 +1778,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			try {
 				site = siteService.getSite(toContext);
 			} catch (Exception e) {
-				log.error("can't get site " + toContext + " " + e);
+				log.error("can't get site {} {}", toContext, e.toString());
 				return;
 			}
 
@@ -2156,7 +2156,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				// don't set until we know the save worked
 				dummyPageId = page.getId();
 			} catch (Exception e) {
-				log.info("can't add dummy page to site " + e);
+				log.info("can't add dummy page to site {} {}", siteId, e.toString());
 			}
 			toolSession = ses.getToolSession(tool.getId());
 			sessionManager.setCurrentToolSession(toolSession);
@@ -2202,8 +2202,8 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			return ret;
 
 		} catch (Exception e) {
-			log.info("exception in createentity " + e);
-			return "exception in createentity " + e;
+			log.info("exception in createentity {} {}", siteId, e.toString());
+			return "exception in createentity " + siteId + " " + e.toString();
 		} finally {
 			try {
 				deleteRecursive(root);
@@ -2360,9 +2360,9 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		} else if ( result instanceof Long ) {
 			sakaiId = "/blti/" + result.toString();
 		} else if ( result instanceof String ) {
-			log.error("Could not insert content - "+result);
+			log.error("Could not insert content - {}", result);
 		} else {
-			log.debug("Adding LTI tool "+result);
+			log.debug("Adding LTI tool {}", result);
 		}
 
 		return sakaiId;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *             http://opensource.org/licenses/ecl2
+ *			 http://opensource.org/licenses/ecl2
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.opensource.org/licenses/ECL-2.0
+ *	   http://www.opensource.org/licenses/ECL-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -156,7 +156,7 @@ import org.sakaiproject.util.MergeConfig;
  */
 @Slf4j
 public class LessonBuilderEntityProducer extends AbstractEntityProvider
-    implements EntityProducer, EntityTransferrer, Serializable,
+	implements EntityProducer, EntityTransferrer, Serializable,
 			   CoreEntityProvider, AutoRegisterEntityProvider, Statisticable, InputTranslatable, Createable, ToolApi  {
 	private static final String ARCHIVE_VERSION = "2.4"; // in case new features are added in future exports
 	private static final String VERSION_ATTR = "version";
@@ -208,26 +208,26 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 * There are several types of updating when we move a lesson from one site to another:
 	 * Fixing HTML text:
 	 *  fixItems - during load, called on the XML structure for each page
-	 *    for each item object in the new page, if it's text, fixup the URLs (fixUrls)
+	 *	for each item object in the new page, if it's text, fixup the URLs (fixUrls)
 	 *  fixUrls - for a piece of HTML, fixup urls on it, with convertHtmlContent
 	 *  convertHtmlContent - for a piece of HTML, fixup urls on it
-	 *      finds all URLs in a text and calls processUrl
+	 *	  finds all URLs in a text and calls processUrl
 	 *  processUrl
-	 *      for special dummy "http://lessonbuilder.sakaiproject.org/ITEMID update the ID
-	 *      for /access/content, etc, update site ID
-	 *      see migrateEmbeddedlinks below for updating references to other sakai objects
+	 *	  for special dummy "http://lessonbuilder.sakaiproject.org/ITEMID update the ID
+	 *	  for /access/content, etc, update site ID
+	 *	  see migrateEmbeddedlinks below for updating references to other sakai objects
 	 *
 	 * Fixing sakaiid's so that Sakai items point to the assignment, test, etc. in the new site
 	 *   updateEntityReferences - called by Sakai as part of load with map of old and new references
-	 *          one-argument version called from tool to get anything that couldn't be done during load
-	 *      if the kernel supports migrateAllLinks, call migrateEmbeddedLinks
-	 *      look up the all items in the map, and update the sakaiId to the new assignment, test, etc, id
-	 *          Sakai supplies a map for objects in old site to new site. However not all tools support it
-	 *          the one-argument version constructs a map when the entry is an "objectid". This is returned
-	 *             from the tool-specific Lessons code, and may be different for assignments, test, quizes, etc.
-	 *             but normally the objectid uses the title of the object in the tool since titles of quizes, etc
-	 *             are unique in a given site. the update operation calls findobject in the tool-specific interface
-	 *             to locate the quiz with that title
+	 *		  one-argument version called from tool to get anything that couldn't be done during load
+	 *	  if the kernel supports migrateAllLinks, call migrateEmbeddedLinks
+	 *	  look up the all items in the map, and update the sakaiId to the new assignment, test, etc, id
+	 *		  Sakai supplies a map for objects in old site to new site. However not all tools support it
+	 *		  the one-argument version constructs a map when the entry is an "objectid". This is returned
+	 *			 from the tool-specific Lessons code, and may be different for assignments, test, quizes, etc.
+	 *			 but normally the objectid uses the title of the object in the tool since titles of quizes, etc
+	 *			 are unique in a given site. the update operation calls findobject in the tool-specific interface
+	 *			 to locate the quiz with that title
 	 *   migrateEmbedded links - for all text items in site, call kernel linkMigrationHelper
 	 */
 
@@ -1050,13 +1050,13 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 		for (SimplePageItem item : items) {
 			boolean itemUpdated = false;
-			log.debug("checking item {} for fixing type: {}", item.getId(), item.getType());
 			switch (item.getType()) {
 				case SimplePageItem.TEXT:
 					String html = item.getHtml();
 					if (StringUtils.isNotBlank(html)) {
 						String fixed = fixUrls(html, oldServer, siteId, fromSiteId, itemMap);
 						if (!StringUtils.equals(html, fixed)) {
+							log.debug("Fixing HTML {} {}", item.getId(), html);
 							item.setHtml(fixed);
 							itemUpdated = true;
 						}
@@ -1089,6 +1089,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 												parsedAttribute.put("checklistItems", checklistItems); // Update the JSON object for the JSON attribute with the modified checklist
 												item.setAttributeString(parsedAttribute.toJSONString());
 												itemUpdated = true;
+												log.debug("fixing checklist {} {}", item.getId(), parsedAttribute.toJSONString());
 											}
 										}
 									}
@@ -1104,7 +1105,6 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				default:
 			}
 			if (itemUpdated) {
-				log.debug("fixing items updating item: {}", item.getId());
 				simplePageToolDao.quickUpdate(item);
 			}
 		}
@@ -1168,8 +1168,8 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		try {
 			site = siteService.getSite(siteId);
 		} catch(IdUnusedException e) {
-			log.warn("Lessons merge stopped siteId is not provided");
-			return "Lessons merge stopped siteId is not provided";
+			log.warn("Lessons merge stopped site {} could not be loaded {}", siteId, e.toString());
+			return "Lessons merge stopped site "+siteId+" could not be loaded "+e.toString();
 		}
 
 		Map<String, Long> emptyPlacements = new HashMap<>();
@@ -1181,28 +1181,21 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			for (ToolConfiguration config: toolConfs) {
 				if (!config.getToolId().equals(LessonBuilderConstants.TOOL_ID)) continue;
 				SitePage p = config.getContainingPage();
-				log.debug("found lessons tool: {} page: {} pageTitle: {}", config.getId(), p.getId(), p.getTitle());
 				if (p == null ) continue;
 				Long topLevelPageId = simplePageToolDao.getTopLevelPageId(config.getPageId());
-				log.debug("Found topLevelPageId {} {}", p.getTitle(), topLevelPageId);
 				if (topLevelPageId == null) continue;
 				SimplePage topLevelPage = simplePageToolDao.getPage(topLevelPageId);
-				log.debug("topLevelPage={}", topLevelPage);
 				if ( topLevelPage == null ) continue;
 				List<SimplePageItem> items = simplePageToolDao.findItemsOnPage(topLevelPageId);
-				log.debug("items: {}", items);
 				if (items.isEmpty()) {
-					// TODO: REMOVE THIS ERROR AFTER DEBUGGING
-					log.error("found reusble lesson placement: {} {} {} ", p.getId(), p.getTitle(), topLevelPageId);
+					log.debug("found reusble lesson placement: {} {} {} ", p.getId(), p.getTitle(), topLevelPageId);
 					emptyPlacements.put(p.getTitle(), topLevelPageId);
 				}
 			}
 		}
-		log.debug("Empty placements {}", emptyPlacements);
 
-
+		// Lets start the actual merge()
 		StringBuilder results = new StringBuilder();
-		// map old to new page ids
 		Map <Long,Long> pageMap = new HashMap<Long,Long>();
 		Map <Long,Long> itemMap = new HashMap<Long,Long>();
 
@@ -1226,21 +1219,24 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				Element pageElement = (Element) pageNode;
 				String title = pageElement.getAttribute("title");
 				if (title == null) title = "Page";
-				log.debug("Extracting page {} from archive", title);
 
 				String oldPageIdString = pageElement.getAttribute("pageid");
 				if (oldPageIdString == null) oldPageIdString = "0";
 				Long oldPageId = Long.valueOf(oldPageIdString);
-				Long emptyPageId = emptyPlacements.get(title);
-				log.debug("oldPageId: {} title: {} emptyid {}", oldPageId, title, emptyPageId);
 
-				// TODO don't just make a new page :)  Get an old one maybe
+				// Check to see is we want to reuse an existing empty page placement
+				Long emptyPageId = emptyPlacements.get(title);
+				log.debug("Extracting page {} oldPageId: {} emptyPageId {}", title, oldPageId, emptyPageId);
+
+				// See if we can load the existing and empty page
 				SimplePage page = null;
 				boolean reused = false;
 				if ( emptyPageId != null && emptyPageId > 0 ) {
 					page = simplePageToolDao.getPage(emptyPageId);
 					log.debug("loaded top levelpage {} found {}", emptyPageId, page.getPageId());
 				}
+
+				// If we could reuse an empty page, lets add one and remember
 				if ( page != null ) {
 					toolsReused.add(title);
 					reused = true;
@@ -1249,12 +1245,14 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					log.debug("Created new page {}", page.getPageId());
 				}
 
+				// Fill the page with all the data from the archive
 				String gradebookPoints = pageElement.getAttribute("gradebookpoints");
 				if (StringUtils.isNotEmpty(gradebookPoints)) {
 					page.setGradebookPoints(Double.valueOf(gradebookPoints));
 				}
 				String folder = pageElement.getAttribute("folder");
 				if (StringUtils.isNotEmpty(folder)) page.setFolder(folder);
+
 				//get new page's Date Release property
 				String dateString = pageElement.getAttribute("releasedate");
 				if (StringUtils.isNotEmpty(dateString)){
@@ -1262,15 +1260,19 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					Date date = formatter.parse(dateString);
 					page.setReleaseDate(date);
 				}
+
 				//get new page's Hidden property
 				String hiddenString = pageElement.getAttribute("hidden");
 				if (StringUtils.isNotEmpty(hiddenString)) page.setHidden(Boolean.valueOf(hiddenString));
+
 				// Carry over the custom CSS sheet if present. These are of the form
 				// "/group/SITEID/LB-CSS/whatever.css", so we need to map the SITEID
 				String cssSheet = pageElement.getAttribute("csssheet");
 				if (StringUtils.isNotEmpty(cssSheet)) page.setCssSheet(cssSheet.replace("/group/"+fromSiteId+"/", "/group/"+siteId+"/"));
+
+				// Save or update the new pag
 				if ( reused ) {
-			        List<String>elist = new ArrayList<>();
+					List<String>elist = new ArrayList<>();
 					boolean requiresEditPermission = true;
 					simplePageToolDao.update(page, elist, messageLocator.getMessage("simplepage.nowrite"), requiresEditPermission);
 					log.debug("updated page: {}", page.getPageId());
@@ -1290,7 +1292,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				pageMap.put(oldPageId, page.getPageId());
 			}
 
-			log.debug("Starting pass II over pages/items pageMap: {}", pageMap);
+			log.debug("Starting second pass over pages/items pageMap: {}", pageMap);
 
 			// process pages again to create the items
 			pageNodes = root.getElementsByTagName("page");
@@ -1328,14 +1330,14 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				Node pageNode = pageNodes.item(p);
 				if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
 					Element pageElement = (Element) pageNode;
-					log.debug("fixing items pageElement oldPageId: {}", pageElement.getAttribute("pageid"));
 					fixItems(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap);
 				}
 			}
 
-			// Need to make sure all the tools are added unless we reused an existing tool placement
-			// and page when we imported the page.  When we add a tool to the site, we
-			// need to fill in the tool id for top level pages and set parents to null
+			// Add necessary placements / pages to the left navigation.  Of course if we
+			// reused and existing placement / page we skip those
+			// When we add a tool to the site, we need to fill in the tool id for
+			// top level pages and set parents to null
 			NodeList tools = root.getElementsByTagName("lessonbuilder");
 			int numTools =  tools.getLength();
 			for (int i = 0; i < numTools; i++) {
@@ -1350,7 +1352,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				String toolTitle = trimToNull(element.getAttribute("name"));
 				if(StringUtils.isBlank(toolTitle)) continue;
 				if ( toolsReused.contains(toolTitle) ) {
-					log.debug("Not adding new placement for {}", toolTitle);
+					log.debug("Reusing existing placement for {}", toolTitle);
 					continue;
 				}
 
@@ -1365,11 +1367,11 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					int integerPosition = Integer.parseInt(pagePosition);
 					page.setPosition(integerPosition);
 				}
-				log.debug("Added Lessons toolTitle={} new page={} new tool={} to site", toolTitle, page.getId(), tool.getId());
+				log.debug("Added Lessons placement toolTitle={} new page={} new tool={} to site", toolTitle, page.getId(), tool.getId());
 
-				String toolId = tool.getPageId();
-				if (toolId == null) {
-					log.error("unable to find new toolid for copy of " + oldToolId);
+				String sakaiPageId = tool.getPageId();
+				if (sakaiPageId == null) {
+					log.error("unable to find new sakaiPageId for copy of {}", toolTitle);
 					continue;
 				}
 
@@ -1414,9 +1416,9 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				}
 				simplePage.setParent(null);
 				simplePage.setTopParent(null);
-				simplePage.setToolId(toolId);
+				simplePage.setToolId(sakaiPageId);
 				simplePageToolDao.quickUpdate(simplePage);
-				log.debug("updated top level lessons page: {} to point to site tool: {}", simplePage.getPageId(), toolId);
+				log.debug("updated top level lessons page: {} to point to site nav page: {}", simplePage.getPageId(), sakaiPageId);
 
 				// create the vestigial item for this top level page
 				log.debug("creating vestigial item for top level page: {} type: {}", simplePage.getPageId(), SimplePageItem.PAGE);

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1302,7 +1302,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 												log.debug("items: {}", items);
 												if (items.isEmpty()) {
 													// TODO: REMOVE THIS ERROR AFTER DEBUGGING
-													log.error("reusing page and tool: {} pageTitle: {}", p, config);
+													log.error("reusing page and tool: {} config {} pageTitle: {}", p.getId(), config.getPageId());
 													page = p;
 													tool = config;
 													break;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1358,6 +1358,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					// create the vestigial item for this top level page
 					log.debug("creating vestigial item for top level page: {} type: {}", topLevelPageId, SimplePageItem.PAGE);
 					SimplePageItem item = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, Long.toString(topLevelPageId), title);
+					simplePageToolDao.quickSaveItem(item);
 
 					emptyTopLevelPageIds.put(title, topLevelPageId);
 					emptySakaiIds.put(title, p.getId());
@@ -1533,7 +1534,6 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			boolean needFix = false;
 			Map <Long,Long> itemMap = new HashMap<Long,Long>();
 			for (Map.Entry<Long, Element> entry : pageElementMap.entrySet()) {
-				Long oldPageId = entry.getKey();
 				Element pageElement = entry.getValue();
 
 				if (mergePage(pageElement, oldServer, siteId, fromSiteId, pageMap, itemMap, entityMap, mcx)) needFix = true;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1123,6 +1123,67 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		return mergeInternal(siteId, root, archivePath, fromSiteId, mcx, entityMap);
 	}
 
+	/*
+	 * To give some context in why merge is so complex, here is a description of the merge process.
+	 *
+	 * An archive of a site is an XML document that describes the site's Lessons content.
+	 * It is created by the export tool.  It contains one or more trees of pages and
+	 * the items within those pages.  Trees in lessons are single parent.  Each page belongs to one
+	 * and only one parent page.  The root page is the only page that does not have a parent.
+	 *
+	 * There is also a list to tool placements in the site left nav that link to the root of each of the
+	 * page trees.  All the pages and items should be accssible by starting at the placeement,
+	 * navigating to the top page for the placement and then going down to each of the
+	 * pages in the tree.  There should be one left nav lesosns placement in the archive for each tree of pages.
+	 *
+	 * The site may or may not already have tool placements.  For each of the tool placements in
+	 * the archive, the placement in the site can be in one of three states:
+	 *
+	 * 1.  The placement exists in the site and contains content.  In this case, the placement is ignored
+	 *      in the import as a duplicate import.
+	 *
+	 * 2.  The placement does not exist in the site.  In this case, the placement is created by
+	 *     adding the placement to the site and adding a vestigial page and item for the placement.
+	 * 	   Then the root page is linked to the placement.
+	 *
+	 * 3.  The placement exists in the site but is empty.  In this case the placement is reused and
+	 *     the ultimate root node for the placement is linked to the placement.
+	 *
+	 * Empty placements are those added to the site that have no content.  Because the creation of the
+	 * vestigial page and item
+	 * are triggered when you navigate to the Lessons placement in the Sakai UI after adding the
+	 * placement in Site Info.  If you add a Lessons placement without navigating to it in the UI first
+	 * and go staight to an merge(), the merge processess detects tha lack of a so the vestigial page and
+	 * item are creates them before reusing the placement for the imported content.
+	 *
+	 * To properly process empty placements and duplicate page removal, the merge process must scan the XML
+	 * content for pages and items and build a transitive closure of the page tree.  It then looks
+	 * through the Site structures to make an inventory of existing Lessons placements ans assess them
+	 * to see if they are full or empty or non-existant.
+	 *
+	 * Then it imports the non-duplicate pages and items from the archive into the site.
+	 *
+	 * At the end it looks at the placements in the XML and creates new placements with a vestigial page and item
+	 * and links the newly created root page and its tree of pages and items into the left navigation of the site.
+	 *
+	 * One note on duplicate removal is that it is done based on the name of the tool in the left navigation.
+	 * If you have a tool labelled "Week 1" with content and you import a site with a tool labelled "Week 1"
+	 * and a set of pages, the imported pages will not be imported a seconds time. However if you rename the
+	 * link to be "Week 1X" and do another import, a new "Week 1" will be imported and the site will have both
+	 * a "Week 1" and "Week 1X " Lessons placements.
+	 *
+	 * One note on the wonderfully named "vestigial" page and item.  They are essential to the proper functioning
+	 * of Lessons.  Not having them leads to the data model getting messed up.  In the Lesosns UI if there are not
+	 * in place, lessons will freak out and make new ones.  The result in this situation is that a bunch of pages
+	 * might disappear.
+	 *
+	 * As Lessons tries to revover from the bad situation, it tends to add more pages and point the new page at
+	 * the placement in the left nav.  This is not good.  It means that there are multiple pages that are somewhat
+	 * non-deterministically chosen as *the* page when a user navigates to a placement in the left nav.  Lessons
+	 * is very careful not to create this situation and we need to make very sure we don't create the
+	 * "multiple page to one placement situation" during impot / merge.
+	 */
+
 	// Internally used for both site copy and zip import
 	public String mergeInternal(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx,
 			Map<String, String> entityMap)
@@ -1307,7 +1368,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		Set<String> toolsReused = new HashSet<>();
 
 		// create pages first, build up map of old to new page.
-		// Do not create pages if they are already in an existing tree associated with a 
+		// Do not create pages if they are already in an existing tree associated with a
 		// placement (duplicate removal)
 		try {
 			numPages = pageNodes.getLength();

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -357,7 +357,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 		Element pageElement = doc.createElement("page");
 
-		addAttr(doc, pageElement, "pageid", new Long(pageId).toString());
+		addAttr(doc, pageElement, "pageid", Long.valueOf(pageId).toString());
 		addAttr(doc, pageElement, "toolid", page.getToolId());
 		addAttr(doc, pageElement, "siteid", page.getSiteId());
 		addAttr(doc, pageElement, "title", page.getTitle());
@@ -404,10 +404,10 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			for (SimplePageItem item: items) {
 
 				Element itemElement = doc.createElement("item");
-				addAttr(doc, itemElement, "id", new Long(item.getId()).toString());
-				addAttr(doc, itemElement, "pageId", new Long(item.getPageId()).toString());
-				addAttr(doc, itemElement, "sequence", new Integer(item.getSequence()).toString());
-				addAttr(doc, itemElement, "type", new Integer(item.getType()).toString());
+				addAttr(doc, itemElement, "id", Long.valueOf(item.getId()).toString());
+				addAttr(doc, itemElement, "pageId", Long.valueOf(item.getPageId()).toString());
+				addAttr(doc, itemElement, "sequence", Integer.valueOf(item.getSequence()).toString());
+				addAttr(doc, itemElement, "type", Integer.valueOf(item.getType()).toString());
 				addAttr(doc, itemElement, "sakaiid", item.getSakaiId());
 				if (!(SimplePageItem.DUMMY).equals(item.getSakaiId())) {
 					if (item.getType() == SimplePageItem.FORUM || item.getType() == SimplePageItem.ASSESSMENT || item.getType() == SimplePageItem.ASSIGNMENT) {
@@ -720,16 +720,16 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			if (!itemElement.getTagName().equals("item")) continue;
 
 			String s = itemElement.getAttribute("sequence");
-			int sequence = new Integer(s);
+			int sequence = Integer.valueOf(s);
 			s = itemElement.getAttribute("type");
-			int type = new Integer(s);
+			int type = Integer.valueOf(s);
 			String sakaiId = itemElement.getAttribute("sakaiid");
 			String name = itemElement.getAttribute("name");
 			String explanation = null;
 			String sakaiTitle = itemElement.getAttribute("sakaititle");
 			log.debug("Processing item {}", sakaiTitle);
 			String id = itemElement.getAttribute("id");
-			Long itemId = new Long(id);
+			Long itemId = Long.valueOf(id);
 
 			// URL is probably no longer used, but if it is, it probably doesn't need mapping
 			if (type == SimplePageItem.RESOURCE || type == SimplePageItem.MULTIMEDIA) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -1183,35 +1183,35 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 * the items within those pages.  Trees in lessons are single parent.  Each page belongs to one
 	 * and only one parent page.  The root page is the only page that does not have a parent.
 	 *
-	 * There is also a list to tool placements in the site left nav that link to the root of each of the
-	 * page trees.  All the pages and items should be accssible by starting at the placeement,
+	 * There is also a list of tool placements in the site left nav that link to the root of each of the
+	 * page trees.  All the pages and items should be accessible by starting at the placement,
 	 * navigating to the top page for the placement and then going down to each of the
-	 * pages in the tree.  There should be one left nav lesosns placement in the archive for each tree of pages.
+	 * pages in the tree.  There should be one left nav lessons placement in the archive for each tree of pages.
 	 *
 	 * The site may or may not already have tool placements.  For each of the tool placements in
 	 * the archive, the placement in the site can be in one of three states:
 	 *
 	 * 1.  The placement exists in the site and contains content.  In this case, the placement is ignored
-	 *	  in the import as a duplicate import.
+	 *     in the import as a duplicate import.
 	 *
 	 * 2.  The placement does not exist in the site.  In this case, the placement is created by
-	 *	 adding the placement to the site and adding a vestigial page and item for the placement.
-	 * 	 Then the root page is linked to the placement.
+	 *     adding the placement to the site and adding a vestigial page and item for the placement.
+	 *     Then the root page is linked to the placement.
 	 *
 	 * 3.  The placement exists in the site but is empty.  In this case the placement is reused and
-	 *	 the ultimate root node for the placement is linked to the placement.
+	 *     the ultimate root node for the placement is linked to the placement.
 	 *
 	 * Empty placements are those added to the site that have no content.  Because the creation of the
 	 * vestigial page and item
 	 * are triggered when you navigate to the Lessons placement in the Sakai UI after adding the
 	 * placement in Site Info.  If you add a Lessons placement without navigating to it in the UI first
-	 * and go staight to an merge(), the merge processess detects tha lack of a so the vestigial page and
-	 * item are creates them before reusing the placement for the imported content.
+	 * and go straight to a merge(), the merge process detects the lack of the vestigial page and
+	 * item are creates it before reusing the placement for the imported content.
 	 *
 	 * To properly process empty placements and duplicate page removal, the merge process must scan the XML
 	 * content for pages and items and build a transitive closure of the page tree.  It then looks
 	 * through the Site structures to make an inventory of existing Lessons placements ans assess them
-	 * to see if they are full or empty or non-existant.
+	 * to see if they are full or empty or non-existent.
 	 *
 	 * Then it imports the non-duplicate pages and items from the archive into the site.
 	 *
@@ -1219,21 +1219,21 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 * and links the newly created root page and its tree of pages and items into the left navigation of the site.
 	 *
 	 * One note on duplicate removal is that it is done based on the name of the tool in the left navigation.
-	 * If you have a tool labelled "Week 1" with content and you import a site with a tool labelled "Week 1"
-	 * and a set of pages, the imported pages will not be imported a seconds time. However if you rename the
+	 * If you have a tool labeled "Week 1" with content and you import a site with a tool labeled "Week 1"
+	 * and a set of pages, the imported pages will not be imported a second time. However if you rename the
 	 * link to be "Week 1X" and do another import, a new "Week 1" will be imported and the site will have both
 	 * a "Week 1" and "Week 1X " Lessons placements.
 	 *
 	 * One note on the wonderfully named "vestigial" page and item.  They are essential to the proper functioning
-	 * of Lessons.  Not having them leads to the data model getting messed up.  In the Lesosns UI if there are not
+	 * of Lessons.  Not having them leads to the data model getting messed up.  In the Lessons UI if there are not
 	 * in place, lessons will freak out and make new ones.  The result in this situation is that a bunch of pages
 	 * might disappear.
 	 *
-	 * As Lessons tries to revover from the bad situation, it tends to add more pages and point the new page at
+	 * As Lessons tries to recover from the bad situation, it tends to add more pages and point the new page at
 	 * the placement in the left nav.  This is not good.  It means that there are multiple pages that are somewhat
 	 * non-deterministically chosen as *the* page when a user navigates to a placement in the left nav.  Lessons
 	 * is very careful not to create this situation and we need to make very sure we don't create the
-	 * "multiple page to one placement situation" during impot / merge.
+	 * "multiple page to one placement situation" during import / merge.
 	 */
 
 	// Internally used for both site copy and zip import
@@ -1311,7 +1311,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		}
 		log.debug("Post-transitive closure {} {}", placementPageMap, parentPage);
 
-		// Check if there are existing Lessons placments in the site that has no real content
+		// Check if there are existing Lessons placements in the site that has no real content
 		// that we can reuse.
 		Site site;
 		try {
@@ -1339,7 +1339,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				Long topLevelPageId = simplePageToolDao.getTopLevelPageId(config.getPageId());
 				log.debug("Looking at tool placement {} page placement {} {} topLevelPageId {}", config.getId(), p.getId(), title, topLevelPageId);
 
-				// If there is no top level page associated with a lessonbuilder placement it
+				// If there is no top level page associated with a lessonbuilder placement
 				// we need to create a vestigial page and item so it can have its tree of pages
 				// linked into it later
 				if (topLevelPageId == null) {
@@ -1379,7 +1379,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			}
 		}
 
-		// Note that non existant placements (neither empty nor full) are created later
+		// Note that non existent placements (neither empty nor full) are created later
 		log.debug("Finished scanning placements full {} empty {} / {}", fullPlacements, emptyTopLevelPageIds, emptySakaiIds);
 
 		// Lets start the actual merge()

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2677,7 +2677,6 @@ public class SimplePageBean {
 				log.debug("no page found, making new page toolId {} siteId {} title {}", toolId, getCurrentSiteId(), title);
 
 				// during creation
-				log.debug("Top level page not found, creating new page {}", title);
 				SimplePage page = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, null, null);
 				if (!saveItem(page)) {
 					currentPage = null;
@@ -2689,9 +2688,9 @@ public class SimplePageBean {
 					l = page.getPageId();
 
 					// and dummy item, the site is the notional top level page
-					log.debug("Top level page not found, creating new  vestigial item {}", title);
 					SimplePageItem i = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, l.toString(), title);
 					saveItem(i);
+					log.debug("Top level page not found, creating new vestigial item {} for page {} itemId {}", title, l, i.getId());
 					updatePageItem(i.getId());
 				} catch (PermissionException e) {
 					log.warn("getCurrentPageId Permission failed setting to new page");

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2645,8 +2645,6 @@ public class SimplePageBean {
 			// No recent activity. Let's go to the top level page.
 			String placementPageId = ((ToolConfiguration) placement).getPageId();
 			l = simplePageToolDao.getTopLevelPageId(placementPageId);
-			// l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) placement).getPageId());
-			// l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) toolManager.getCurrentPlacement()).getPageId());
 			log.debug("Top level page for placement {} is {}", placementPageId, l);
 
 			if (l != null) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2643,15 +2643,18 @@ public class SimplePageBean {
 			return l;
 		} else {
 			// No recent activity. Let's go to the top level page.
-
-			l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) placement).getPageId());
+			String placementPageId = ((ToolConfiguration) placement).getPageId();
+			l = simplePageToolDao.getTopLevelPageId(placementPageId);
+			// l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) placement).getPageId());
 			// l = simplePageToolDao.getTopLevelPageId(((ToolConfiguration) toolManager.getCurrentPlacement()).getPageId());
+			log.debug("Top level page for placement {} is {}", placementPageId, l);
 
 			if (l != null) {
 				try {
 					// TODO: A lot of things can go wrong here methinks -- Chuck
 					updatePageObject(l);
 					// this should exist except if the page was created by old code
+					log.debug("findTopLevelPageItemBySakaiId {}",l);
 					SimplePageItem i = simplePageToolDao.findTopLevelPageItemBySakaiId(String.valueOf(l));
 					if (i == null) {
 						// add vestigial item, the site is the notional top level page
@@ -2676,6 +2679,7 @@ public class SimplePageBean {
 				log.debug("no page found, making new page toolId {} siteId {} title {}", toolId, getCurrentSiteId(), title);
 
 				// during creation
+				log.debug("Top level page not found, creating new page {}", title);
 				SimplePage page = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, null, null);
 				if (!saveItem(page)) {
 					currentPage = null;
@@ -2687,6 +2691,7 @@ public class SimplePageBean {
 					l = page.getPageId();
 
 					// and dummy item, the site is the notional top level page
+					log.debug("Top level page not found, creating new  vestigial item {}", title);
 					SimplePageItem i = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, l.toString(), title);
 					saveItem(i);
 					updatePageItem(i.getId());

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2644,6 +2644,7 @@ public class SimplePageBean {
 		} else {
 			// No recent activity. Let's go to the top level page.
 			String placementPageId = ((ToolConfiguration) placement).getPageId();
+			log.debug("Current placement.getId() {} placementPageId {}", placement.getId(), placementPageId);
 			l = simplePageToolDao.getTopLevelPageId(placementPageId);
 			log.debug("Top level page for placement {} is {}", placementPageId, l);
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2649,11 +2649,13 @@ public class SimplePageBean {
 
 			if (l != null) {
 				try {
+					// TODO: A lot of things can go wrong here methinks -- Chuck
 					updatePageObject(l);
 					// this should exist except if the page was created by old code
 					SimplePageItem i = simplePageToolDao.findTopLevelPageItemBySakaiId(String.valueOf(l));
 					if (i == null) {
-						// and dummy item, the site is the notional top level page
+						// add vestigial item, the site is the notional top level page
+						log.debug("no vestigial page found, making new item pageId {} title {}", l.toString(), currentPage.getTitle());
 						i = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, l.toString(), currentPage.getTitle());
 						saveItem(i);
 					}
@@ -2671,6 +2673,7 @@ public class SimplePageBean {
 				// No page found. Let's make a new one.
 				String toolId = ((ToolConfiguration) toolManager.getCurrentPlacement()).getPageId();
 				String title = getCurrentSite().getPage(toolId).getTitle(); // Use title supplied
+				log.debug("no page found, making new page toolId {} siteId {} title {}", toolId, getCurrentSiteId(), title);
 
 				// during creation
 				SimplePage page = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, null, null);

--- a/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -313,6 +313,7 @@ simplePageBean.addForumSummary,
     <property name="contentHostingService"><ref bean="org.sakaiproject.content.api.ContentHostingService"/></property>
     <property name="sessionManager"><ref bean="org.sakaiproject.tool.api.SessionManager"/></property>
     <property name="ltiService" ref="org.sakaiproject.lti.api.LTIService" />
+    <property name="timeService" ref="org.sakaiproject.time.api.TimeService" />
     <property name="toolManager" ref="org.sakaiproject.tool.api.ActiveToolManager" />
     <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
     <property name="memoryService"><ref bean="org.sakaiproject.memory.api.MemoryService"/></property>


### PR DESCRIPTION
This is quite a change.  I redid the spacing on the file.  It was impossible to seriously work on this code - not only did it use inconsistent indentation, mixing spaces and tabs - it also used a pattern where there was a for loop with a bunch of sanity checks at the top of the loop so by the time the loop body was starting the code was about 4-5 unnecessary indents in.  Further as the body of the loop did more sanity checks as it progressed, instead of just doing "continue" it indented further.  But actually it added a open brace but often did *not* indent the code because the original author did not want to be looking at code 7 indents deep. Impossible to look at.  Impossible to understand. It is best to review this with white space turned off - and then ignore any apparent white space weirdness because the changed code you are looking at matches the code you are note seeing :)