### PR TITLE
SAK-51070 Webcomponents fix image url for sakai-user-photo when moving between students

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/SakaiUserPhoto.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/SakaiUserPhoto.js
@@ -42,11 +42,6 @@ export class SakaiUserPhoto extends SakaiElement {
     this.profilePopup = SakaiUserPhoto.OFF;
   }
 
-  connectedCallback() {
-
-    super.connectedCallback();
-  }
-
   close() {
     bootstrap.Popover.getInstance(this.querySelector("div"))?.hide();
   }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/SakaiUserPhoto.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/SakaiUserPhoto.js
@@ -45,20 +45,23 @@ export class SakaiUserPhoto extends SakaiElement {
   connectedCallback() {
 
     super.connectedCallback();
-
-    if (this.blank) {
-      this.url = "/direct/profile/blank/image";
-    } else {
-      this.url = `/direct/profile/${this.userId}/image/${this.official ? "official" : "thumb"}`
-                  + (getSiteId() ? `?siteId=${getSiteId()}` : "");
-    }
   }
 
   close() {
     bootstrap.Popover.getInstance(this.querySelector("div"))?.hide();
   }
 
-  shouldUpdate() { return this.url; }
+  willUpdate(changedProperties) {
+
+    if (changedProperties.has("userId") || changedProperties.has("official") || changedProperties.has("blank")) {
+      if (this.blank) {
+        this.url = "/direct/profile/blank/image";
+      } else {
+        this.url = `/direct/profile/${this.userId}/image/${this.official ? "official" : "thumb"}`
+                    + (getSiteId() ? `?siteId=${getSiteId()}` : "");
+      }
+    }
+  }
 
   firstUpdated() {
 


### PR DESCRIPTION
This work was primarily done by Cursor and the Gemini 2.0 Pro Exp model. 

It was tested and confirmed by a human.


> Fix: Update user photo on property change
> The SakaiUserPhoto component was not updating correctly when the user-id, official, or blank properties were changed because the image URL was only being set in connectedCallback. This commit moves the URL calculation to willUpdate to ensure the URL is updated whenever these properties change. Additionally, the unnecessary shouldUpdate method has been removed, allowing Lit to correctly manage component updates when the url state variable changes.