### PR TITLE
SAK-51108 Sitestats filter incorrect context from event in presence records

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -1660,7 +1660,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 		String eventId = e.getEvent();
 		
 		// get contextId (siteId) from new Event.getContext() method, if available
-		if(statsManager.isEventContextSupported()) {
+		if(statsManager.isEventContextSupported() && !(StatsManager.SITEVISIT_EVENTID.equals(eventId) || StatsManager.SITEVISITEND_EVENTID.equals(eventId))) {
 			String contextId = null;
 			try{
 				contextId = (String) e.getClass().getMethod("getContext", (Class<?>[]) null).invoke(e, (Object[]) null);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51108

When a site's session (site 1) expires due to inactivity while the user is browsing another site (site 2), the pres.end event for site 1 incorrectly records the context with the id of site 2. This causes errors in presence time calculations, as the system interprets the session expiration as belonging to site 2.

Typically, there’s no context available.