### PR TITLE
SAK-51055 Samigo cc+ import issues with embedded image in CKEditor

### DIFF
--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -1313,7 +1313,7 @@ public abstract class BaseLTIService implements LTIService {
 
 				// If we cannot find the content item and tool on in this server, get skeleton data
 				// from the basiclti.xml import
-				if ( content == null && mcx.ltiContentItems != null ) {
+				if ( content == null && mcx != null && mcx.ltiContentItems != null ) {
 					log.debug("Could not find content item {} / {} in site {}, checking ltiContentItems", linkContentId, contentKey, linkSiteId);
 					content = mcx.ltiContentItems.get(contentKey);
 					tool = null;  // force creation of a new tool in findOrCreateToolForContentItem

--- a/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
+++ b/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
@@ -390,6 +390,7 @@
     <property name="publishedAssessmentFacadeQueries" ref="PublishedAssessmentFacadeQueries" />
     <property name="qtiService" ref="QTIService"/>
     <property name="linkMigrationHelper" ref="org.sakaiproject.util.api.LinkMigrationHelper"/>
+    <property name="ltiService" ref="org.sakaiproject.lti.api.LTIService"/>
   </bean>
 
 

--- a/samigo/samigo-services/pom.xml
+++ b/samigo/samigo-services/pom.xml
@@ -156,6 +156,10 @@
             <artifactId>scheduler-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.sakaiproject.lti</groupId>
+            <artifactId>lti-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mariuszgromada.math</groupId>
             <artifactId>MathParser.org-mXparser</artifactId>
         </dependency>

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
@@ -505,8 +505,7 @@ public class AssessmentEntityProducer implements EntityTransferrer, EntityProduc
 
 						boolean itemFeedbacksChanged = false;
 						if ( item.getItemFeedbackSet() != null && !item.getItemFeedbackSet().isEmpty() ) {
-							for (Iterator<ItemFeedbackIfc> j = item.getItemFeedbackSet().iterator(); j.hasNext(); ) {
-								ItemFeedbackIfc itemFeedback = (ItemFeedbackIfc) j.next();
+							for (ItemFeedbackIfc itemFeedback : item.getItemFeedbackSet()) {
 								boolean itemFeedbackCHanged = migrateText(service, toContext, itemFeedback, itemHash, hasCaches, hasDuplicates, true,
 										"feedback" + itemFeedback.getTypeId(), itemContentCache, entrySet, transversalMap,
 										mcx, ItemFeedbackIfc::getText, ItemFeedbackIfc::setText);
@@ -836,8 +835,7 @@ public class AssessmentEntityProducer implements EntityTransferrer, EntityProduc
 					migratedText = itemText;
 				}
 				migratedText = linkMigrationHelper.migrateAllLinks(entrySet, migratedText);
-				String fromContext = null;
-				migratedText = ltiService.fixLtiLaunchUrls(migratedText, fromContext, toContext, transversalMap);
+				migratedText = ltiService.fixLtiLaunchUrls(migratedText, null, toContext, transversalMap);
 			}
 			log.debug("migratedText after {}", migratedText);
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
@@ -484,14 +484,16 @@ public class AssessmentEntityProducer implements EntityTransferrer, EntityProduc
 						if (itemTexts != null) {
 							for (ItemTextIfc itemText : itemTexts) {
 								boolean itemTextChanged = migrateText(service, toContext, itemText, itemHash, hasCaches, hasDuplicates, true,
-										"it-" + itemText.getSequence(), itemContentCache, entrySet, transversalMap, mcx, ItemTextIfc::getText, ItemTextIfc::setText);
+										"it-" + itemText.getSequence(), itemContentCache, entrySet, transversalMap,
+										mcx, ItemTextIfc::getText, ItemTextIfc::setText);
 
 								boolean answersChanged = false;
 								List<AnswerIfc> answers =  itemText.getAnswerArray();
 								if (answers != null) {
 									for (AnswerIfc answer : answers) {
 										boolean answerChanged = migrateText(service, toContext, answer, itemHash, hasCaches, hasDuplicates, true,
-												"at-" + itemText.getSequence() + "-"+ answer.getSequence() , itemContentCache, entrySet, transversalMap, mcx, AnswerIfc::getText, AnswerIfc::setText);
+												"at-" + itemText.getSequence() + "-"+ answer.getSequence() , itemContentCache, entrySet, transversalMap,
+												mcx, AnswerIfc::getText, AnswerIfc::setText);
 
 										answersChanged = answersChanged || answerChanged;
 									}
@@ -506,7 +508,8 @@ public class AssessmentEntityProducer implements EntityTransferrer, EntityProduc
 							for (Iterator<ItemFeedbackIfc> j = item.getItemFeedbackSet().iterator(); j.hasNext(); ) {
 								ItemFeedbackIfc itemFeedback = (ItemFeedbackIfc) j.next();
 								boolean itemFeedbackCHanged = migrateText(service, toContext, itemFeedback, itemHash, hasCaches, hasDuplicates, true,
-										"feedback" + itemFeedback.getTypeId(), itemContentCache, entrySet, transversalMap, mcx, ItemFeedbackIfc::getText, ItemFeedbackIfc::setText);
+										"feedback" + itemFeedback.getTypeId(), itemContentCache, entrySet, transversalMap,
+										mcx, ItemFeedbackIfc::getText, ItemFeedbackIfc::setText);
 
 								itemFeedbacksChanged = itemFeedbacksChanged || itemFeedbackCHanged;
 							}
@@ -840,17 +843,14 @@ public class AssessmentEntityProducer implements EntityTransferrer, EntityProduc
 
 			// Check if there has been a change
 			if (!StringUtils.equals(itemText, migratedText)) {
+				setter.accept(item, migratedText);
 				if (hasDuplicates) {
 					textCache.put(cacheKey, migratedText);
 				}
-			}
-
-			if (!StringUtils.equals(itemText, migratedText)) {
-				setter.accept(item, migratedText);
 				return true;
 			}
 		}
+
 		return false;
 	}
-
 }


### PR DESCRIPTION
There are three steps to this change - they are separate commits below:

1.  Make it so that "Import from Site" fixes embedded images in the correct and incorrect feedback.
2. Make it so that "Import from Site" handles embedded LTI links (shipping cart) in all RTE areas
3. Make it so that "Lessons - Import from CC+" also works across all RTE areas and attachments

To do this, I extended the calling sequences for internal methods for updateEntityReferences() and migrateText() so they can handle the "Import from Site" or "merge()" use cases. The method signatures got a little long but I really wanted to avoid duplicating the complex code that goes through and finds all the RTE areas post copy or post merge.  It seemed more reliable in the long run the have a few more parameters and if tests that a lot of intricate code duplicated.

@stetsche Since this touched your work on performance improvement on Samigo site copy - I think it needs a review from you.

Comments welcome.