### PR TITLE
SAK-46662 Assignments Fix constraint violation during site copy of assignments

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -4607,7 +4607,6 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     AssignmentAllPurposeItem oAllPurposeItem = assignmentSupplementItemService.getAllPurposeItem(oAssignmentId);
                     if (oAllPurposeItem != null) {
                         AssignmentAllPurposeItem nAllPurposeItem = assignmentSupplementItemService.newAllPurposeItem();
-                        assignmentSupplementItemService.saveAllPurposeItem(nAllPurposeItem);
                         nAllPurposeItem.setAssignmentId(nAssignment.getId());
                         nAllPurposeItem.setTitle(oAllPurposeItem.getTitle());
                         nAllPurposeItem.setText(oAllPurposeItem.getText());


### PR DESCRIPTION
Fix a constraint violation error that occurs during site copy operations when copying assignments with AllPurposeItem supplements. The error occurred because the AssignmentAllPurposeItem was being saved to the database before its required assignmentId field was set.

This fix removes the premature save operation and ensures the entity is only saved after all required fields are properly initialized.

🤖 Generated with [Claude Code](https://claude.ai/code)