### PR TITLE
SAK-51211 The custom site icon is too small

### DIFF
--- a/library/src/skins/default/src/sass/modules/_toolmenu.scss
+++ b/library/src/skins/default/src/sass/modules/_toolmenu.scss
@@ -185,7 +185,7 @@ body.is-logged-out{
   width: 100%;
   height: auto;
   margin: 4px auto;
-	border-radius: 4px;
+  border-radius: 4px;
   @media #{$phone}{
     display: none;
   }

--- a/library/src/skins/default/src/sass/modules/_toolmenu.scss
+++ b/library/src/skins/default/src/sass/modules/_toolmenu.scss
@@ -181,15 +181,16 @@ body.is-logged-out{
 	}
 }
 
-#toolMenuWrap .img_site_toolmenu{
+#toolMenu .img_site_toolmenu{
   width: 100%;
-  max-width: $tool-menu-width;
   height: auto;
-  margin: 0 auto;
+  margin: 4px auto;
+	border-radius: 4px;
   @media #{$phone}{
     display: none;
   }
 }
+
 
 #toolMenuWrap{
 	#toolMenu {

--- a/library/src/skins/default/src/sass/modules/_toolmenu.scss
+++ b/library/src/skins/default/src/sass/modules/_toolmenu.scss
@@ -191,7 +191,6 @@ body.is-logged-out{
   }
 }
 
-
 #toolMenuWrap{
 	#toolMenu {
 		position: relative;

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -22,6 +22,9 @@
     #end
 
     <li id="site-list-${type}-item-${safeSiteId}" class="site-list-item py-1 px-2 mx-3 mt-3 $!{currentSiteClass}" data-type="${type}" data-site="${site.id}">
+        #if ($site.isCurrent && ${sitePages.pageNavIconUrl} != "")
+            <img src="${sitePages.pageNavIconUrl}" alt="${rloader.sit_icon_alt}" class="img_site_toolmenu">
+        #end
         <div class="site-list-item-head d-flex align-items-center py-1 w-100 justify-content-between">
             <div class="site-link-block d-flex align-items-center rounded-end me-1 pe-2">
                 <button class="btn icon-button collapsed px-2 me-1"
@@ -33,10 +36,6 @@
                         aria-controls="${type}-site-${safeSiteId}-page-list">
                     <i class="bi bi-chevron-right" aria-hidden="true"></i>
                 </button>
-
-                #if ($site.isCurrent && ${sitePages.pageNavIconUrl} != "")
-                    <img src="${sitePages.pageNavIconUrl}" alt="${rloader.sit_icon_alt}" class="img_site_toolmenu">
-                #end
 
                 #set ($siteTitle = $ftext.escapeHtml(${site.title}))
                 #set ($displayTitle = $siteTitle)


### PR DESCRIPTION
On sites where a custom icon has been defined using the Icon URL site property it comes out very small and is not distinguishable no matter how big the image is set.