### PR TITLE
SAK-51225 Portal site breadcrumb mobile view uses an incorrect site name

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePortalHeaderBreadcrumb.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includePortalHeaderBreadcrumb.vm
@@ -11,9 +11,13 @@
         #end
     #end
 
+    #if (!$currentSiteTitle)
+        #set($currentSiteTitle = $siteTitle)
+    #end
+
     <div id="header-site-title" class="portal-header-breadcrumb-item portal-header-site-title">
-        <a href="$!{siteUrl}" title="$!{siteTitle}">
-            $siteTitle
+        <a href="$!{siteUrl}" title="$!{currentSiteTitle}">
+            $currentSiteTitle
         </a>
     </div>
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51225