### PR TITLE
SAK-51249 Gradebook oracle doesn't allow inserting empty values GB_GRADING_EVENT_T.IS_EXCLUDED

### DIFF
--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/model/GradingEvent.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/model/GradingEvent.java
@@ -79,7 +79,7 @@ public class GradingEvent implements PersistableEntity<Long>, Comparable<Object>
     private Date dateGraded;
 
     @Column(name = "IS_EXCLUDED")
-    private GradingEventStatus status;
+    private GradingEventStatus status = GradingEventStatus.GRADE_NONE;
 
     public GradingEvent() {
         this.dateGraded = new Date();


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51249