### PR TITLE
SAK-51281 Assignments fix TransientPropertyValueException in transferCopyEntities

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -4628,14 +4628,23 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                             }
                         }
                         nAllPurposeItem.setAttachmentSet(nAllPurposeItemAttachments);
+                        
+                        // First save the AllPurposeItem to persist it before creating access entries
+                        assignmentSupplementItemService.saveAllPurposeItem(nAllPurposeItem);
+                        
+                        // Now clean up existing access entries
                         assignmentSupplementItemService.cleanAllPurposeItemAccess(nAllPurposeItem);
+                        
+                        // Create and save new access entries
                         Set<AssignmentAllPurposeItemAccess> accessSet = new HashSet<>();
                         AssignmentAllPurposeItemAccess access = assignmentSupplementItemService.newAllPurposeItemAccess();
                         access.setAccess(userDirectoryService.getCurrentUser().getId());
                         access.setAssignmentAllPurposeItem(nAllPurposeItem);
-                        assignmentSupplementItemService.saveAllPurposeItemAccess(access);
                         accessSet.add(access);
                         nAllPurposeItem.setAccessSet(accessSet);
+                        
+                        // Save both the access entry and the updated AllPurposeItem
+                        assignmentSupplementItemService.saveAllPurposeItemAccess(access);
                         assignmentSupplementItemService.saveAllPurposeItem(nAllPurposeItem);
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Fixed Hibernate error by ensuring parent AssignmentAllPurposeItem is persisted before creating and saving related AssignmentAllPurposeItemAccess objects, preventing the "transient instance must be saved before current operation" exception.

🤖 Generated with [Claude Code](https://claude.ai/code)