### PR TITLE
SAK-51318 LTI avoid using the same signature by setting a timeout

### DIFF
--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -3162,6 +3162,7 @@ public class SakaiLTIUtil {
 		if ( autosubmit ) {
 			sb.append("  if ( message.subject == 'org.sakailms.lti.prelaunch.response' ) {\n");
 			sb.append("    console.log('submitting based on org.sakailms.lti.prelaunch.response');\n    ");
+			sb.append("    clearTimeout(plTimeOut);\n  "); // Cancel current timeout, POST is launched already
 			sb.append(doSubmit);
 			sb.append("  }\n");
 		}
@@ -3170,7 +3171,7 @@ public class SakaiLTIUtil {
 		sb.append("parent.postMessage('{ \"subject\": \"org.sakailms.lti.prelaunch\" }', '*');\nconsole.log('Sending prelaunch request');\n\n");
 
 		if ( autosubmit ) {
-			sb.append("setTimeout(function() {\n  console.warn('Submitting after prelaunch timeout');\n  ");
+			sb.append("var plTimeOut = setTimeout(function() {\n  console.warn('Submitting after prelaunch timeout');\n  ");
 			sb.append(doSubmit);
 			sb.append("}, 2000);\n");
 		}


### PR DESCRIPTION
The problem is because you cannot reuse the same LTI signature twice due to invalid nonce error.
It is not useful to resubmit the POST in a timeout with the same signature, you have to wait for the current POST to finalize and not cancel it, just wait until the end.