### PR TITLE
SAK-51357 PASystem define a meaningful deterministic order for banners and popups

### DIFF
--- a/pasystem/pasystem-impl/impl/src/java/org/sakaiproject/pasystem/impl/banners/BannerStorage.java
+++ b/pasystem/pasystem-impl/impl/src/java/org/sakaiproject/pasystem/impl/banners/BannerStorage.java
@@ -61,7 +61,7 @@ public class BannerStorage implements Banners, Acknowledger {
                             @Override
                             public List<Banner> call(DBConnection db) throws SQLException {
                                 List<Banner> banners = new ArrayList<Banner>();
-                                try (DBResults results = db.run("SELECT * from pasystem_banner_alert")
+                                try (DBResults results = db.run("SELECT * from pasystem_banner_alert ORDER BY start_time DESC")
                                         .executeQuery()) {
                                     for (ResultSet result : results) {
                                         banners.add(new Banner(result.getString("uuid"),

--- a/pasystem/pasystem-impl/impl/src/java/org/sakaiproject/pasystem/impl/popups/PopupStorage.java
+++ b/pasystem/pasystem-impl/impl/src/java/org/sakaiproject/pasystem/impl/popups/PopupStorage.java
@@ -24,7 +24,6 @@
 
 package org.sakaiproject.pasystem.impl.popups;
 
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.Clob;
 import java.sql.ResultSet;
@@ -134,7 +133,7 @@ public class PopupStorage implements Popups, Acknowledger {
                             @Override
                             public List<Popup> call(DBConnection db) throws SQLException {
                                 List<Popup> popups = new ArrayList<Popup>();
-                                try (DBResults results = db.run("SELECT * from pasystem_popup_screens")
+                                try (DBResults results = db.run("SELECT * from pasystem_popup_screens ORDER BY start_time DESC")
                                         .executeQuery()) {
                                     for (ResultSet result : results) {
                                         popups.add(Popup.create(result.getString("uuid"),

--- a/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/views/index.hbs
+++ b/pasystem/pasystem-tool/tool/src/java/org/sakaiproject/pasystem/tool/views/index.hbs
@@ -16,7 +16,7 @@
         <th>{{{t this "Message"}}}</th>
         <th>{{{t this "Type"}}}</th>
         <th>{{{t this "Active"}}}</th>
-        <th>{{{t this "From"}}}</th>
+        <th>{{{t this "From"}}}<span class="si si-down" aria-hidden="true"></span></th>
         <th>{{{t this "Until"}}}</th>
         <th><!-- actions --></th>
       </tr>
@@ -28,7 +28,7 @@
         <td>{{{t this "banner_type" this.type}}}</td>
         <td>{{this.active}}</td>
         <td>{{show-time this this.startTime}}</td>
-        <td>{{show-time this this.endTime}}</td>    
+        <td>{{show-time this this.endTime}}</td>
         <td class="actions">
             <a href="{{{actionURL this 'banners' this.uuid "edit"}}}"><button type="button" class="btn btn-primary btn-xs">{{{t this "Edit"}}}</button></a>
             <a href="{{{actionURL this 'banners' this.uuid "delete"}}}" class="pasystem-delete-btn" data-record-type="banner"><button type="button" class="btn btn-danger btn-xs"><i class="si si-trash"></i></button></a>
@@ -51,7 +51,7 @@
       <tr>
         <th>{{{t this "Description"}}}</th>
         <th>{{{t this "Active"}}}</th>
-        <th>{{{t this "From"}}}</th>
+        <th>{{{t this "From"}}}<span class="si si-down" aria-hidden="true"></span></th>
         <th>{{{t this "Until"}}}</th>
         <th><!-- actions --></th>
       </tr>


### PR DESCRIPTION
This change adds **sorting by start time** (descending) to the **Banners** and **Popups** lists. Applying a consistent order improves usability by making the most recent or upcoming items easier to find, rather than leaving the lists in an unpredictable state.