### PR TITLE
SAK-51268 Icons in resources are not aligned

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/resources/_resources.scss
+++ b/library/src/skins/default/src/sass/modules/tool/resources/_resources.scss
@@ -282,6 +282,11 @@
 		position: relative;
 		top: 5px;
 	}
+	
+	.specialLink.title a.si::before {
+		margin-left: -1.1rem;
+		position: relative;
+	}
 
 	#content-display-columns-dropdown .btn {
 		color: var(--button-text-color);


### PR DESCRIPTION
The problem here is that there are two different icon libraries coexisting with different icon sizes.
I've updated the position for the Bootstrap library icons to align them with the previous look, the font awesome one.