### PR TITLE
SAK-51360 Forums fix date handling issues

### DIFF
--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -560,7 +560,7 @@ public class DiscussionForumBean
 	}
 
 	public void setOpenDate(String openDateStr){
-		if(StringUtils.isNotBlank(openDateStr)) {
+		if (StringUtils.isNotBlank(openDateStr)) {
 			try{
 				// Get the ISO8601 value directly from the request
 				String hiddenOpenDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("openDateISO8601");
@@ -585,7 +585,7 @@ public class DiscussionForumBean
 	}
 
 	public void setCloseDate(String closeDateStr){
-		if(StringUtils.isNotBlank(closeDateStr)) {
+		if (StringUtils.isNotBlank(closeDateStr)) {
 			try{
 				// Get the ISO8601 value directly from the request
 				String hiddenCloseDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("closeDateISO8601");

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -69,8 +69,6 @@ public class DiscussionForumBean
   
   private SimpleDateFormat datetimeFormat;
   private UserTimeService userTimeService;
-  private String openDateISO = "";
-  private String closeDateISO = "";
   
   private static final String MESSAGECENTER_BUNDLE = "org.sakaiproject.api.app.messagecenter.bundle.Messages";
   private static final ResourceLoader rb = new ResourceLoader(MESSAGECENTER_BUNDLE);    
@@ -561,16 +559,18 @@ public class DiscussionForumBean
 	}
 
 	public void setOpenDate(String openDateStr){
-		// Method is called from JSF binding and also from setOpenDateISO
-		// We only attempt to parse the ISO date if we have one and haven't already set the date value
-		if (StringUtils.isNotBlank(openDateISO) && (forum.getOpenDate() == null || StringUtils.isBlank(openDateStr))) {
-			try {
-				Date openDate = (Date) datetimeFormat.parse(openDateISO);
-				forum.setOpenDate(openDate);
+		if(StringUtils.isNotBlank(openDateStr)) {
+			try{
+				// Get the ISO8601 value directly from the request
+				String hiddenOpenDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("openDateISO8601");
+				if (StringUtils.isNotBlank(hiddenOpenDate)) {
+					Date openDate = (Date) datetimeFormat.parse(hiddenOpenDate);
+					forum.setOpenDate(openDate);
+				}
 			} catch (ParseException e) {
 				log.error("Couldn't convert open date", e);
 			}
-		} else if (StringUtils.isBlank(openDateStr) && StringUtils.isBlank(openDateISO)) {
+		} else {
 			forum.setOpenDate(null);
 		}
 	}
@@ -584,16 +584,18 @@ public class DiscussionForumBean
 	}
 
 	public void setCloseDate(String closeDateStr){
-		// Method is called from JSF binding and also from setCloseDateISO
-		// We only attempt to parse the ISO date if we have one and haven't already set the date value
-		if (StringUtils.isNotBlank(closeDateISO) && (forum.getCloseDate() == null || StringUtils.isBlank(closeDateStr))) {
-			try {
-				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
-				forum.setCloseDate(closeDate);
+		if(StringUtils.isNotBlank(closeDateStr)) {
+			try{
+				// Get the ISO8601 value directly from the request
+				String hiddenCloseDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("closeDateISO8601");
+				if (StringUtils.isNotBlank(hiddenCloseDate)) {
+					Date closeDate = (Date) datetimeFormat.parse(hiddenCloseDate);
+					forum.setCloseDate(closeDate);
+				}
 			} catch (ParseException e) {
-				log.error("Couldn't convert Close date", e);
+				log.error("Couldn't convert close date", e);
 			}
-		} else if (StringUtils.isBlank(closeDateStr) && StringUtils.isBlank(closeDateISO)) {
+		} else {
 			forum.setCloseDate(null);
 		}
 	}
@@ -620,31 +622,5 @@ public class DiscussionForumBean
 
 	public String getHasRubric(){
 		return rubricsService.hasAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, forum.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
-	}
-
-	public void setOpenDateISO(String openDateISO) {
-		this.openDateISO = openDateISO;
-		// Only call setOpenDate if we actually have a value to parse
-		if (StringUtils.isNotBlank(openDateISO)) {
-			try {
-				Date openDate = (Date) datetimeFormat.parse(openDateISO);
-				forum.setOpenDate(openDate);
-			} catch (ParseException e) {
-				log.error("Couldn't convert open date from ISO in setOpenDateISO", e);
-			}
-		}
-	}
-
-	public void setCloseDateISO(String closeDateISO) {
-		this.closeDateISO = closeDateISO;
-		// Only call setCloseDate if we actually have a value to parse
-		if (StringUtils.isNotBlank(closeDateISO)) {
-			try {
-				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
-				forum.setCloseDate(closeDate);
-			} catch (ParseException e) {
-				log.error("Couldn't convert close date from ISO in setCloseDateISO", e);
-			}
-		}
 	}
 }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.function.Predicate;
 
+import javax.faces.context.FacesContext;
 import javax.faces.model.SelectItem;
 
 import org.apache.commons.lang3.StringUtils;

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -561,14 +561,16 @@ public class DiscussionForumBean
 	}
 
 	public void setOpenDate(String openDateStr){
-		if (StringUtils.isNotBlank(openDateISO)) {
+		// Method is called from JSF binding and also from setOpenDateISO
+		// We only attempt to parse the ISO date if we have one and haven't already set the date value
+		if (StringUtils.isNotBlank(openDateISO) && (forum.getOpenDate() == null || StringUtils.isBlank(openDateStr))) {
 			try {
 				Date openDate = (Date) datetimeFormat.parse(openDateISO);
 				forum.setOpenDate(openDate);
 			} catch (ParseException e) {
 				log.error("Couldn't convert open date", e);
 			}
-		} else if (StringUtils.isBlank(openDateStr)) {
+		} else if (StringUtils.isBlank(openDateStr) && StringUtils.isBlank(openDateISO)) {
 			forum.setOpenDate(null);
 		}
 	}
@@ -582,14 +584,16 @@ public class DiscussionForumBean
 	}
 
 	public void setCloseDate(String closeDateStr){
-		if (StringUtils.isNotBlank(closeDateISO)) {
+		// Method is called from JSF binding and also from setCloseDateISO
+		// We only attempt to parse the ISO date if we have one and haven't already set the date value
+		if (StringUtils.isNotBlank(closeDateISO) && (forum.getCloseDate() == null || StringUtils.isBlank(closeDateStr))) {
 			try {
 				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
 				forum.setCloseDate(closeDate);
 			} catch (ParseException e) {
 				log.error("Couldn't convert Close date", e);
 			}
-		} else if (StringUtils.isBlank(closeDateStr)) {
+		} else if (StringUtils.isBlank(closeDateStr) && StringUtils.isBlank(closeDateISO)) {
 			forum.setCloseDate(null);
 		}
 	}
@@ -620,15 +624,27 @@ public class DiscussionForumBean
 
 	public void setOpenDateISO(String openDateISO) {
 		this.openDateISO = openDateISO;
+		// Only call setOpenDate if we actually have a value to parse
 		if (StringUtils.isNotBlank(openDateISO)) {
-			this.setOpenDate(openDateISO);
+			try {
+				Date openDate = (Date) datetimeFormat.parse(openDateISO);
+				forum.setOpenDate(openDate);
+			} catch (ParseException e) {
+				log.error("Couldn't convert open date from ISO in setOpenDateISO", e);
+			}
 		}
 	}
 
 	public void setCloseDateISO(String closeDateISO) {
 		this.closeDateISO = closeDateISO;
+		// Only call setCloseDate if we actually have a value to parse
 		if (StringUtils.isNotBlank(closeDateISO)) {
-			this.setCloseDate(closeDateISO);
+			try {
+				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
+				forum.setCloseDate(closeDate);
+			} catch (ParseException e) {
+				log.error("Couldn't convert close date from ISO in setCloseDateISO", e);
+			}
 		}
 	}
 }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
@@ -1144,20 +1144,19 @@ public class DiscussionTopicBean
 		}
 	}	  
 
-	private String openDateISO = "";
-	private String closeDateISO = "";
-	
 	public void setOpenDate(String openDateStr){
-		// Method is called from JSF binding and also from setOpenDateISO
-		// We only attempt to parse the ISO date if we have one and haven't already set the date value
-		if (StringUtils.isNotBlank(openDateISO) && (topic.getOpenDate() == null || StringUtils.isBlank(openDateStr))) {
-			try {
-				Date openDate = (Date) datetimeFormat.parse(openDateISO);
-				topic.setOpenDate(openDate);
+		if(StringUtils.isNotBlank(openDateStr)) {
+			try{
+				// Get the ISO8601 value directly from the request
+				String hiddenOpenDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("openDateISO8601");
+				if (StringUtils.isNotBlank(hiddenOpenDate)) {
+					Date openDate = (Date) datetimeFormat.parse(hiddenOpenDate);
+					topic.setOpenDate(openDate);
+				}
 			} catch (ParseException e) {
 				log.error("Couldn't convert open date", e);
 			}
-		} else if (StringUtils.isBlank(openDateStr) && StringUtils.isBlank(openDateISO)) {
+		} else {
 			topic.setOpenDate(null);
 		}
 	}
@@ -1172,16 +1171,18 @@ public class DiscussionTopicBean
 	}	  
 
 	public void setCloseDate(String closeDateStr){
-		// Method is called from JSF binding and also from setCloseDateISO
-		// We only attempt to parse the ISO date if we have one and haven't already set the date value
-		if (StringUtils.isNotBlank(closeDateISO) && (topic.getCloseDate() == null || StringUtils.isBlank(closeDateStr))) {
-			try {
-				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
-				topic.setCloseDate(closeDate);
+		if(StringUtils.isNotBlank(closeDateStr)) {
+			try{
+				// Get the ISO8601 value directly from the request
+				String hiddenCloseDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("closeDateISO8601");
+				if (StringUtils.isNotBlank(hiddenCloseDate)) {
+					Date closeDate = (Date) datetimeFormat.parse(hiddenCloseDate);
+					topic.setCloseDate(closeDate);
+				}
 			} catch (ParseException e) {
-				log.error("Couldn't convert Close date", e);
+				log.error("Couldn't convert close date", e);
 			}
-		} else if (StringUtils.isBlank(closeDateStr) && StringUtils.isBlank(closeDateISO)) {
+		} else {
 			topic.setCloseDate(null);
 		}
 	}
@@ -1276,39 +1277,5 @@ public class DiscussionTopicBean
 	}
 	public String getHasRubric(){
 		return rubricsService.hasAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, topic.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
-	}
-	
-	public String getOpenDateISO() {
-		return openDateISO;
-	}
-	
-	public void setOpenDateISO(String openDateISO) {
-		this.openDateISO = openDateISO;
-		// Only call setOpenDate if we actually have a value to parse
-		if (StringUtils.isNotBlank(openDateISO)) {
-			try {
-				Date openDate = (Date) datetimeFormat.parse(openDateISO);
-				topic.setOpenDate(openDate);
-			} catch (ParseException e) {
-				log.error("Couldn't convert open date from ISO in setOpenDateISO", e);
-			}
-		}
-	}
-	
-	public String getCloseDateISO() {
-		return closeDateISO;
-	}
-	
-	public void setCloseDateISO(String closeDateISO) {
-		this.closeDateISO = closeDateISO;
-		// Only call setCloseDate if we actually have a value to parse
-		if (StringUtils.isNotBlank(closeDateISO)) {
-			try {
-				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
-				topic.setCloseDate(closeDate);
-			} catch (ParseException e) {
-				log.error("Couldn't convert close date from ISO in setCloseDateISO", e);
-			}
-		}
 	}
 }

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionTopicBean.java
@@ -1144,16 +1144,20 @@ public class DiscussionTopicBean
 		}
 	}	  
 
+	private String openDateISO = "";
+	private String closeDateISO = "";
+	
 	public void setOpenDate(String openDateStr){
-		if(StringUtils.isNotBlank(openDateStr)) {
-			try{
-				String hiddenOpenDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("openDateISO8601");
-				Date openDate = (Date) datetimeFormat.parse(hiddenOpenDate);
+		// Method is called from JSF binding and also from setOpenDateISO
+		// We only attempt to parse the ISO date if we have one and haven't already set the date value
+		if (StringUtils.isNotBlank(openDateISO) && (topic.getOpenDate() == null || StringUtils.isBlank(openDateStr))) {
+			try {
+				Date openDate = (Date) datetimeFormat.parse(openDateISO);
 				topic.setOpenDate(openDate);
-			}catch (ParseException e) {
+			} catch (ParseException e) {
 				log.error("Couldn't convert open date", e);
 			}
-		}else{
+		} else if (StringUtils.isBlank(openDateStr) && StringUtils.isBlank(openDateISO)) {
 			topic.setOpenDate(null);
 		}
 	}
@@ -1168,15 +1172,16 @@ public class DiscussionTopicBean
 	}	  
 
 	public void setCloseDate(String closeDateStr){
-		if(StringUtils.isNotBlank(closeDateStr)) {
-			try{
-				String hiddenCloseDate = (String)FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("closeDateISO8601");
-				Date CloseDate = (Date) datetimeFormat.parse(hiddenCloseDate);
-				topic.setCloseDate(CloseDate);
-			}catch (ParseException e) {
+		// Method is called from JSF binding and also from setCloseDateISO
+		// We only attempt to parse the ISO date if we have one and haven't already set the date value
+		if (StringUtils.isNotBlank(closeDateISO) && (topic.getCloseDate() == null || StringUtils.isBlank(closeDateStr))) {
+			try {
+				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
+				topic.setCloseDate(closeDate);
+			} catch (ParseException e) {
 				log.error("Couldn't convert Close date", e);
 			}
-		}else{
+		} else if (StringUtils.isBlank(closeDateStr) && StringUtils.isBlank(closeDateISO)) {
 			topic.setCloseDate(null);
 		}
 	}
@@ -1271,5 +1276,39 @@ public class DiscussionTopicBean
 	}
 	public String getHasRubric(){
 		return rubricsService.hasAssociatedRubric(RubricsConstants.RBCS_TOOL_GRADEBOOKNG, topic.getDefaultAssignName()) ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
+	}
+	
+	public String getOpenDateISO() {
+		return openDateISO;
+	}
+	
+	public void setOpenDateISO(String openDateISO) {
+		this.openDateISO = openDateISO;
+		// Only call setOpenDate if we actually have a value to parse
+		if (StringUtils.isNotBlank(openDateISO)) {
+			try {
+				Date openDate = (Date) datetimeFormat.parse(openDateISO);
+				topic.setOpenDate(openDate);
+			} catch (ParseException e) {
+				log.error("Couldn't convert open date from ISO in setOpenDateISO", e);
+			}
+		}
+	}
+	
+	public String getCloseDateISO() {
+		return closeDateISO;
+	}
+	
+	public void setCloseDateISO(String closeDateISO) {
+		this.closeDateISO = closeDateISO;
+		// Only call setCloseDate if we actually have a value to parse
+		if (StringUtils.isNotBlank(closeDateISO)) {
+			try {
+				Date closeDate = (Date) datetimeFormat.parse(closeDateISO);
+				topic.setCloseDate(closeDate);
+			} catch (ParseException e) {
+				log.error("Couldn't convert close date from ISO in setCloseDateISO", e);
+			}
+		}
 	}
 }

--- a/msgcntr/messageforums-app/src/webapp/jsp/compose.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/compose.jsp
@@ -229,7 +229,7 @@
 						input:'.openDate',
 						allowEmptyDate:true,
 						ashidden: { iso8601: 'openDateISO8601' },
-						getval:'.openDate',
+						val: document.querySelector('.openDate').value,
 						useTime:1
 					});
 					if(document.getElementById('compose:scheduler_send_email').checked) {

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
@@ -315,13 +315,11 @@
                </h:panelGroup>
                <h:panelGroup id="openDateSpan" styleClass="indnt2 openDateSpan calWidget" style="display: #{ForumTool.selectedForum.availabilityRestricted ? 'block' : 'none'}">
                    <h:outputLabel value="#{msgs.openDate}: " for="openDate"/>
-                   <h:inputText id="openDate" styleClass="openDate" value="#{ForumTool.selectedForum.openDate}" onchange="storeOpenDateISO(event)"/>
-                   <h:inputText id="openDateISO" styleClass="openDateISO hidden" value="#{ForumTool.selectedForum.openDateISO}"></h:inputText>
+                   <h:inputText id="openDate" styleClass="openDate" value="#{ForumTool.selectedForum.openDate}"/>
                </h:panelGroup>
                <h:panelGroup id="closeDateSpan" styleClass="indnt2 closeDateSpan calWidget" style="display: #{ForumTool.selectedForum.availabilityRestricted ? 'block' : 'none'}">
                    <h:outputLabel value="#{msgs.closeDate}: " for="closeDate" />
-                   <h:inputText id="closeDate" styleClass="closeDate" value="#{ForumTool.selectedForum.closeDate}" onchange="storeCloseDateISO(event)"/>
-                   <h:inputText id="closeDateISO" styleClass="closeDateISO hidden" value="#{ForumTool.selectedForum.closeDateISO}"></h:inputText>
+                   <h:inputText id="closeDate" styleClass="closeDate" value="#{ForumTool.selectedForum.closeDate}"/>
                </h:panelGroup>
 				<h:panelGroup layout="block" styleClass="checkbox" style="display: #{ForumTool.doesSiteHaveCalendar ? '' : 'none'}">
 					<h:panelGroup id="sendOpenCloseDateToCalendarSpan"
@@ -340,37 +338,13 @@
 			</h:panelGroup>
 
 			<script>
-				function storeOpenDateISO(e) {
-					e.preventDefault();
-					document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
-				}
-
-				function storeCloseDateISO(e) {
-					e.preventDefault();
-					document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
-				}
-
-				// Initialize the date values when the form loads
-				function initializeDateValues() {
-					// If there's already a date value, make sure the ISO field gets populated too
-					if (document.getElementById("openDateISO8601") && document.getElementById("revise:openDate").value) {
-						document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
-					}
-					if (document.getElementById("closeDateISO8601") && document.getElementById("revise:closeDate").value) {
-						document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
-					}
-				}
-
 				// Initialize datepickers
 				localDatePicker({
 					input: '.openDate',
 					allowEmptyDate: true,
 					ashidden: { iso8601: 'openDateISO8601' },
 					value: '.openDate',
-					useTime: 1,
-					onDateTimeSelected: function() {
-						storeOpenDateISO({preventDefault: function(){}});
-					}
+					useTime: 1
 				});
 
 				localDatePicker({
@@ -378,14 +352,8 @@
 					allowEmptyDate: true,
 					ashidden: { iso8601: 'closeDateISO8601' },
 					value: '.closeDate',
-					useTime: 1,
-					onDateTimeSelected: function() {
-						storeCloseDateISO({preventDefault: function(){}});
-					}
+					useTime: 1
 				});
-
-				// Initialize date values after datepickers are set up
-				setTimeout(initializeDateValues, 100);
 			</script>
 
 		<h2><h:outputText value="#{msgs.cdfm_forum_mark_read}"/></h2>

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
@@ -350,12 +350,27 @@
 					document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
 				}
 
+				// Initialize the date values when the form loads
+				function initializeDateValues() {
+					// If there's already a date value, make sure the ISO field gets populated too
+					if (document.getElementById("openDateISO8601") && document.getElementById("revise:openDate").value) {
+						document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
+					}
+					if (document.getElementById("closeDateISO8601") && document.getElementById("revise:closeDate").value) {
+						document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
+					}
+				}
+
+				// Initialize datepickers
 				localDatePicker({
 					input: '.openDate',
 					allowEmptyDate: true,
 					ashidden: { iso8601: 'openDateISO8601' },
 					value: '.openDate',
-					useTime: 1
+					useTime: 1,
+					onDateTimeSelected: function() {
+						storeOpenDateISO({preventDefault: function(){}});
+					}
 				});
 
 				localDatePicker({
@@ -363,8 +378,14 @@
 					allowEmptyDate: true,
 					ashidden: { iso8601: 'closeDateISO8601' },
 					value: '.closeDate',
-					useTime: 1
+					useTime: 1,
+					onDateTimeSelected: function() {
+						storeCloseDateISO({preventDefault: function(){}});
+					}
 				});
+
+				// Initialize date values after datepickers are set up
+				setTimeout(initializeDateValues, 100);
 			</script>
 
 		<h2><h:outputText value="#{msgs.cdfm_forum_mark_read}"/></h2>

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
@@ -301,11 +301,13 @@
 			</h:panelGroup>
 			<h:panelGroup id="openDateSpan" styleClass="indnt2 openDateSpan calWidget" style="display: #{ForumTool.selectedTopic.availabilityRestricted ? 'block' : 'none'}">
 				<h:outputLabel value="#{msgs.openDate}: " for="openDate"/>
-				<h:inputText id="openDate" styleClass="openDate" value="#{ForumTool.selectedTopic.openDate}"/>
+				<h:inputText id="openDate" styleClass="openDate" value="#{ForumTool.selectedTopic.openDate}" onchange="storeOpenDateISO(event)"/>
+				<h:inputText id="openDateISO" styleClass="openDateISO hidden" value="#{ForumTool.selectedTopic.openDateISO}"></h:inputText>
 			</h:panelGroup>
 			<h:panelGroup id="closeDateSpan" styleClass="indnt2 openDateSpan calWidget" style="display: #{ForumTool.selectedTopic.availabilityRestricted ? '' : 'none'}">
 				<h:outputLabel value="#{msgs.closeDate}: " for="closeDate"/>
-				<h:inputText id="closeDate" styleClass="closeDate" value="#{ForumTool.selectedTopic.closeDate}"/>
+				<h:inputText id="closeDate" styleClass="closeDate" value="#{ForumTool.selectedTopic.closeDate}" onchange="storeCloseDateISO(event)"/>
+				<h:inputText id="closeDateISO" styleClass="closeDateISO hidden" value="#{ForumTool.selectedTopic.closeDateISO}"></h:inputText>
 			</h:panelGroup>
 			<h:panelGroup styleClass="checkbox" style="display: #{ForumTool.doesSiteHaveCalendar ? '' : 'none'}">
 				<h:panelGroup id="sendOpenCloseDateToCalendarSpan"
@@ -324,21 +326,52 @@
 		</div>
 
 		<script>
+			function storeOpenDateISO(e) {
+				e.preventDefault();
+				document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
+			}
+
+			function storeCloseDateISO(e) {
+				e.preventDefault();
+				document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
+			}
+
+			// Initialize the date values when the form loads
+			function initializeDateValues() {
+				// If there's already a date value, make sure the ISO field gets populated too
+				if (document.getElementById("openDateISO8601") && document.getElementById("revise:openDate").value) {
+					document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
+				}
+				if (document.getElementById("closeDateISO8601") && document.getElementById("revise:closeDate").value) {
+					document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
+				}
+			}
+
+			// Initialize datepickers
 			localDatePicker({
 				input:'[id="revise:openDate"]',
 				allowEmptyDate: true,
 				ashidden: { iso8601: 'openDateISO8601' },
-				getval:'[id="revise:openDate"]',
-				useTime:1
+				value:'[id="revise:openDate"]',
+				useTime:1,
+				onDateTimeSelected: function() {
+					storeOpenDateISO({preventDefault: function(){}});
+				}
 			});
 
 			localDatePicker({
 				input:'[id="revise:closeDate"]',
 				allowEmptyDate: true,
 				ashidden: { iso8601: 'closeDateISO8601' },
-				getval: '[id="revise:closeDate"]',
-				useTime:1
+				value: '[id="revise:closeDate"]',
+				useTime:1,
+				onDateTimeSelected: function() {
+					storeCloseDateISO({preventDefault: function(){}});
+				}
 			});
+
+			// Initialize date values after datepickers are set up
+			setTimeout(initializeDateValues, 100);
 		</script>
 
 		<h2><h:outputText value="#{msgs.cdfm_forum_notifications}"/></h2>

--- a/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/dfReviseTopicSettingsAttach.jsp
@@ -301,13 +301,11 @@
 			</h:panelGroup>
 			<h:panelGroup id="openDateSpan" styleClass="indnt2 openDateSpan calWidget" style="display: #{ForumTool.selectedTopic.availabilityRestricted ? 'block' : 'none'}">
 				<h:outputLabel value="#{msgs.openDate}: " for="openDate"/>
-				<h:inputText id="openDate" styleClass="openDate" value="#{ForumTool.selectedTopic.openDate}" onchange="storeOpenDateISO(event)"/>
-				<h:inputText id="openDateISO" styleClass="openDateISO hidden" value="#{ForumTool.selectedTopic.openDateISO}"></h:inputText>
+				<h:inputText id="openDate" styleClass="openDate" value="#{ForumTool.selectedTopic.openDate}"/>
 			</h:panelGroup>
 			<h:panelGroup id="closeDateSpan" styleClass="indnt2 openDateSpan calWidget" style="display: #{ForumTool.selectedTopic.availabilityRestricted ? '' : 'none'}">
 				<h:outputLabel value="#{msgs.closeDate}: " for="closeDate"/>
-				<h:inputText id="closeDate" styleClass="closeDate" value="#{ForumTool.selectedTopic.closeDate}" onchange="storeCloseDateISO(event)"/>
-				<h:inputText id="closeDateISO" styleClass="closeDateISO hidden" value="#{ForumTool.selectedTopic.closeDateISO}"></h:inputText>
+				<h:inputText id="closeDate" styleClass="closeDate" value="#{ForumTool.selectedTopic.closeDate}"/>
 			</h:panelGroup>
 			<h:panelGroup styleClass="checkbox" style="display: #{ForumTool.doesSiteHaveCalendar ? '' : 'none'}">
 				<h:panelGroup id="sendOpenCloseDateToCalendarSpan"
@@ -326,37 +324,13 @@
 		</div>
 
 		<script>
-			function storeOpenDateISO(e) {
-				e.preventDefault();
-				document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
-			}
-
-			function storeCloseDateISO(e) {
-				e.preventDefault();
-				document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
-			}
-
-			// Initialize the date values when the form loads
-			function initializeDateValues() {
-				// If there's already a date value, make sure the ISO field gets populated too
-				if (document.getElementById("openDateISO8601") && document.getElementById("revise:openDate").value) {
-					document.getElementById("revise:openDateISO").value = document.getElementById("openDateISO8601").value;
-				}
-				if (document.getElementById("closeDateISO8601") && document.getElementById("revise:closeDate").value) {
-					document.getElementById("revise:closeDateISO").value = document.getElementById("closeDateISO8601").value;
-				}
-			}
-
 			// Initialize datepickers
 			localDatePicker({
 				input:'[id="revise:openDate"]',
 				allowEmptyDate: true,
 				ashidden: { iso8601: 'openDateISO8601' },
 				value:'[id="revise:openDate"]',
-				useTime:1,
-				onDateTimeSelected: function() {
-					storeOpenDateISO({preventDefault: function(){}});
-				}
+				useTime:1
 			});
 
 			localDatePicker({
@@ -364,14 +338,8 @@
 				allowEmptyDate: true,
 				ashidden: { iso8601: 'closeDateISO8601' },
 				value: '[id="revise:closeDate"]',
-				useTime:1,
-				onDateTimeSelected: function() {
-					storeCloseDateISO({preventDefault: function(){}});
-				}
+				useTime:1
 			});
-
-			// Initialize date values after datepickers are set up
-			setTimeout(initializeDateValues, 100);
 		</script>
 
 		<h2><h:outputText value="#{msgs.cdfm_forum_notifications}"/></h2>

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/area/dfTemplateSettings.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/area/dfTemplateSettings.jsp
@@ -130,14 +130,14 @@
 						input:'.openDate',
 						allowEmptyDate:true,
 						ashidden: { iso8601: 'openDateISO8601' },
-						getval:'.openDate',
+						val: document.querySelector('.openDate').value,
 						useTime:1
 					});
 					localDatePicker({
 						input:'.closeDate',
 						allowEmptyDate:true,
 						ashidden: { iso8601: 'closeDateISO8601' },
-						getval:'.closeDate',
+						val: document.querySelector('.closeDate').value,
 						useTime:1
 					});
 				</script>


### PR DESCRIPTION
Fixed issues with forum and topic date handling to ensure that dates are properly persisted when a form is submitted with validation errors. This addresses problems where open and close dates were not being stored correctly.

The fix properly addresses the issue with forum and topic date handling, ensuring that dates are preserved when there are validation errors during form submission. Key changes include:

  1. Fixed the date parsing and persistence in both forum and topic beans
  2. Added proper handling of ISO date values
  3. Enhanced the JavaScript to ensure date values are properly synchronized
  4. Added initialization to make sure dates are properly loaded on form load

