### PR TITLE
SAK-51363 Forums deleting a topic that was duplicated would remove attachment used by other topics

### DIFF
--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/ui/DiscussionForumManager.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/ui/DiscussionForumManager.java
@@ -508,6 +508,14 @@ public interface DiscussionForumManager
   public Attachment createDFAttachment(String attachId, String name);
   
   /**
+   * Creates a duplicate of an attachment by making a copy of the actual file
+   * @param attachId The ID of the attachment to duplicate
+   * @param name The name of the attachment
+   * @return A new Attachment object with a unique ID pointing to a new copy of the file
+   */
+  public Attachment createDuplicateDFAttachment(String attachId, String name);
+  
+  /**
    * Get the read status of a list of messages for a given user	  
    * @param msgIds the msg ids to check
    * @param userId the user - can be null

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -8379,7 +8379,7 @@ public class DiscussionForumTool {
 		if (fromForumAttach != null && !fromForumAttach.isEmpty()) {
 			for (int topicAttach=0; topicAttach < fromForumAttach.size(); topicAttach++) {
 				Attachment thisAttach = (Attachment)fromForumAttach.get(topicAttach);
-				Attachment thisDFAttach = forumManager.createDFAttachment(
+				Attachment thisDFAttach = forumManager.createDuplicateDFAttachment(
 						thisAttach.getAttachmentId(),
 						thisAttach.getAttachmentName());
 				forum.addAttachment(thisDFAttach);

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -8265,12 +8265,12 @@ public class DiscussionForumTool {
       }
 	}
 
-	// Add the attachments
+	// Add the attachments - create true copies of the files, not just references
 	List fromTopicAttach = forumManager.getTopicByIdWithAttachments(originalTopicId).getAttachments();
 	if (fromTopicAttach != null && !fromTopicAttach.isEmpty()) {
 		for (int topicAttach=0; topicAttach < fromTopicAttach.size(); topicAttach++) {
 			Attachment thisAttach = (Attachment)fromTopicAttach.get(topicAttach);
-			Attachment thisDFAttach = forumManager.createDFAttachment(
+			Attachment thisDFAttach = forumManager.createDuplicateDFAttachment(
 					thisAttach.getAttachmentId(),
 					thisAttach.getAttachmentName());
 			newTopic.addAttachment(thisDFAttach);

--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -373,7 +373,7 @@ td div.title{
 	vertical-align: top;
 }
 .attachPanel td.attach{
-	width: 1em;
+	width: 2em;
 }
 .permissionTable {
 	width: 675px;

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/includes/dfAreaInclude.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/includes/dfAreaInclude.jsp
@@ -340,7 +340,7 @@ $(document).ready(function() {
                                 <%--//desNote:attach list --%>
                                 <h:dataTable  styleClass="attachListTable" value="#{topic.attachList}" var="eachAttach" rendered="#{!empty topic.attachList}" cellpadding="3" cellspacing="0" columnClasses="attach,bogus" border="0">
                                     <h:column>
-                                        <h:graphicImage url="/images/attachment.gif" alt=""/>
+                                        <span class="bi bi-paperclip" aria-hidden="true"></span>
                                         <h:outputText value=" " />
                                             <h:outputLink value="#{eachAttach.url}" target="_blank">
                                                 <h:outputText value="#{eachAttach.attachment.attachmentName}" />
@@ -356,7 +356,7 @@ $(document).ready(function() {
                                 <%--//desNote:attach list --%>
                                 <h:dataTable  styleClass="attachListTable" value="#{topic.attachList}" var="eachAttach" rendered="#{!empty topic.attachList}" cellpadding="3" cellspacing="0" columnClasses="attach,bogus" style="font-size:.9em;width:auto;margin-left:1em" border="0">
                       <h:column>
-                                        <h:graphicImage url="/images/attachment.gif" alt=""/>
+                                        <span class="bi bi-paperclip" aria-hidden="true"></span>
 <%--                        <h:outputLink value="#{eachAttach.attachmentUrl}" target="_blank">
                             <h:outputText value="#{eachAttach.attachmentName}" />
                         </h:outputLink>--%>

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
@@ -2125,6 +2125,44 @@ public class DiscussionForumManagerImpl extends HibernateDaoSupport implements
       return null;
     }
   }
+  
+  @Override
+  public Attachment createDuplicateDFAttachment(String attachId, String name)
+  {
+    try
+    {
+      // Get the current context
+      String currentContext = toolManager.getCurrentPlacement().getContext();
+
+      // Copy the attachment using the ContentHostingService's copyAttachment method
+      ContentResource attachment = contentHostingService.copyAttachment(
+          attachId, 
+          currentContext, 
+          toolManager.getTool("sakai.forums").getTitle(), 
+          null);  // Using null for MergeConfig as we're duplicating within the same site
+
+      // Now create the attachment object pointing to the new file
+      Attachment attach = messageManager.createAttachment();
+      attach.setAttachmentId(attachment.getId());
+      attach.setAttachmentName(name);
+
+      // Set other properties from the new resource
+      attach.setAttachmentSize((Long.valueOf(attachment.getContentLength())).toString());
+      attach.setCreatedBy(attachment.getProperties().getProperty(
+          attachment.getProperties().getNamePropCreator()));
+      attach.setModifiedBy(attachment.getProperties().getProperty(
+          attachment.getProperties().getNamePropModifiedBy()));
+      attach.setAttachmentType(attachment.getContentType());
+      attach.setAttachmentUrl("/url");
+      
+      return attach;
+    }
+    catch (Exception e)
+    {
+      log.error("Error creating duplicate attachment: {}", e.toString());
+      return null;
+    }
+  }
 
 	public List getDiscussionForumsWithTopics()
 	{


### PR DESCRIPTION
When duplicating a topic with attachments, the original implementation reused the same attachment ID, creating a shared reference to the same underlying file.

This caused problems when a duplicated topic was deleted, as it would try to access attachments that no longer existed.

The fix:

1. Added a new createDuplicateDFAttachment method to properly copy attachment files
2. Modified duplicateTopic to use the new method, ensuring each attachment gets a true copy
3. Uses ContentHostingService.copyAttachment to create actual copies of files