### PR TITLE
SAK-51392 Grader  If switching submissions and the inline editor for …

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
@@ -134,6 +134,12 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
 
   set _submission(newValue) {
 
+    // If switching submissions and the inline editor for the PREVIOUS submission is open,
+    // close and destroy it by simulating a cancel action.
+    if (this._submission && newValue.id !== this._submission.id && this._inlineFeedbackEditorShowing) {
+      this._toggleInlineFeedback(null, true); // Pass true for cancelling
+    }
+
     if (!this._nonEditedSubmission || newValue.id !== this._nonEditedSubmission.id) {
       this._nonEditedSubmission = {};
       Object.assign(this._nonEditedSubmission, newValue);

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/SakaiGrader.js
@@ -136,7 +136,7 @@ export class SakaiGrader extends graderRenderingMixin(gradableDataMixin(SakaiEle
 
     // If switching submissions and the inline editor for the PREVIOUS submission is open,
     // close and destroy it by simulating a cancel action.
-    if (this._submission && newValue.id !== this._submission.id && this._inlineFeedbackEditorShowing) {
+    if (newValue.id !== this._submission?.id && this._inlineFeedbackEditorShowing) {
       this._toggleInlineFeedback(null, true); // Pass true for cancelling
     }
 


### PR DESCRIPTION
…the PREVIOUS submission is open, close and destroy it by simulating a cancel action.

Credit to @jumarub for the original PR