### PR TITLE
SAK-51453 sitestats Default to always collecting stats

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -98,7 +98,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 	@Getter private boolean				collectThreadEnabled				= true;
 	@Getter @Setter public long			collectThreadUpdateInterval			= 4000L;
 	@Getter @Setter private boolean		collectAdminEvents					= false;
-	@Getter @Setter private boolean		collectEventsForSiteWithToolOnly	= true;
+	@Getter @Setter private boolean		collectEventsForSiteWithToolOnly	= false;
 	@Getter @Setter private boolean		collectDetailedEvents				= false;
 	@Setter private TransactionTemplate	transactionTemplate;
 

--- a/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
+++ b/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
@@ -255,7 +255,7 @@
 		<property name="collectAdminEvents" value="false" />
 
 		<!-- Aggregate events ONLY for sites with SiteStats tool? (default: true) -->
-		<property name="collectEventsForSiteWithToolOnly" value="true" />
+		<property name="collectEventsForSiteWithToolOnly" value="false" />
 		<!-- /OPTIONS -->
 
 		<!-- Sakai services -->


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51453

This commit will switch the stats service to always collect stats, even if the sitestats tool has not been added to the site. The previous behaviour can be restored by adding:

collectEventsForSiteWithToolOnly@org.sakaiproject.sitestats.api.StatsUpdateManager.target=true

to your sakai properties.