### PR TITLE
SAK-51462 Samigo fix sorting on score column on Questions page

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/QuestionScoresBean.java
@@ -98,6 +98,8 @@ public class QuestionScoresBean implements Serializable, PhaseAware {
   private Collection sections;
   @Getter @Setter
   private Collection deliveryItem;
+  @Getter @Setter
+  private ItemDataIfc itemData;
   @Setter
   private String score;
   @Setter

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreListener.java
@@ -493,6 +493,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 				bean.setItemId(item.getItemId().toString());
 				bean.setPartName(item.getSection().getSequence().toString());
 				bean.setItemName(item.getSequence().toString());
+				bean.setItemData(item);
 				item.setHint("***"); // Keyword to not show student answer
 				// for short answer/ essey question, if there is a model short
 				// answer for this question

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreUpdateListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/QuestionScoreUpdateListener.java
@@ -60,6 +60,8 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.services.GradebookServiceException;
 import org.sakaiproject.tool.assessment.services.GradingService;
+import org.sakaiproject.tool.assessment.services.PublishedItemService;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.ui.bean.evaluation.AgentResults;
 import org.sakaiproject.tool.assessment.ui.bean.evaluation.QuestionScoresBean;
 import org.sakaiproject.tool.assessment.ui.bean.evaluation.TotalScoresBean;
@@ -103,6 +105,15 @@ import org.sakaiproject.tool.cover.SessionManager;
     QuestionScoresBean bean = (QuestionScoresBean) ContextUtil.lookupBean("questionScores");
     TotalScoresBean tbean = (TotalScoresBean) ContextUtil.lookupBean("totalScores");
     log.debug("Calling saveQuestionScores.");
+    
+    // Ensure itemData is set when sorting
+    if (bean.getItemData() == null) {
+        String itemId = ContextUtil.lookupParam("itemId");
+        if (itemId != null && !itemId.isEmpty()) {
+            PublishedItemService itemService = new PublishedItemService();
+            bean.setItemData((ItemDataIfc) itemService.getItem(itemId));
+        }
+    }
     
     Long publishedId = Long.valueOf(ContextUtil.lookupParam("publishedId"));
     Long publishedIdFromBean = tbean.getPublishedAssessment().getPublishedAssessmentId();


### PR DESCRIPTION
1. We added the itemData property to the QuestionScoresBean class to store the item data.
2. We confirmed the bean.setItemData(item) call was already present in the QuestionScoreListener class.
3. We added code to ensure that itemData is properly set even when sorting by modifying the QuestionScoreUpdateListener class to check if itemData is null and set it if needed.
4. We imported the necessary classes to make this work.

The JSP was trying to access the itemData property, but it wasn't being set properly during sorting operations.