### PR TITLE
SAK-49085 Assignments alter group locking

### DIFF
--- a/assignment/README-GROUP-LOCKING.md
+++ b/assignment/README-GROUP-LOCKING.md
@@ -8,17 +8,17 @@ When an assignment is set up with group submission mode, the system locks the gr
 
 ## Group Locking Behavior
 
-### Default Behavior (Prior to SAK-51462)
+### Default Behavior (Prior to SAK-49085)
 
-In Sakai prior to SAK-51462, group locking behavior was as follows:
+In Sakai prior to SAK-49085, group locking behavior was as follows:
 
 1. When an assignment with group submissions is posted (i.e., saved and not in draft mode), the system immediately applies a lock to all associated groups.
 2. Once locked, the group membership cannot be modified until the assignment is deleted or fully graded.
 3. This immediate locking caused issues for instructors who wanted to post assignments in advance but still allow group membership changes until the assignment opened.
 
-### Enhanced Behavior (SAK-51462)
+### Enhanced Behavior (SAK-49085)
 
-The enhanced group locking behavior introduced in SAK-51462 operates as follows:
+The enhanced group locking behavior introduced in SAK-49085 operates as follows:
 
 1. When an assignment with group submissions is posted, the system checks the assignment's open date:
    - If the open date is in the future, the groups remain unlocked

--- a/assignment/README-GROUP-LOCKING.md
+++ b/assignment/README-GROUP-LOCKING.md
@@ -1,0 +1,72 @@
+# Assignment Group Locking Documentation
+
+## Overview
+
+This document describes the group locking behavior in the Assignments tool in Sakai.
+
+When an assignment is set up with group submission mode, the system locks the group membership to prevent changes after the assignment opens. This ensures fair and consistent group assignments and prevents membership changes that could disrupt submissions and grading.
+
+## Group Locking Behavior
+
+### Default Behavior (Prior to SAK-51462)
+
+In Sakai prior to SAK-51462, group locking behavior was as follows:
+
+1. When an assignment with group submissions is posted (i.e., saved and not in draft mode), the system immediately applies a lock to all associated groups.
+2. Once locked, the group membership cannot be modified until the assignment is deleted or fully graded.
+3. This immediate locking caused issues for instructors who wanted to post assignments in advance but still allow group membership changes until the assignment opened.
+
+### Enhanced Behavior (SAK-51462)
+
+The enhanced group locking behavior introduced in SAK-51462 operates as follows:
+
+1. When an assignment with group submissions is posted, the system checks the assignment's open date:
+   - If the open date is in the future, the groups remain unlocked
+   - If the open date has already passed, the groups are locked immediately (same as original behavior)
+
+2. A scheduled job runs periodically to check for assignments about to open (within 5 minutes) and locks their groups at the appropriate time.
+
+3. For assignments with future open dates:
+   - If the assignment has no submissions, instructors can still modify group membership until the open date
+   - If the assignment already has submissions, groups remain locked regardless of open date changes
+
+4. Special handling for Lessons tool integration:
+   - Groups created by Lessons for access control purposes are handled differently
+   - These "access groups" use a different locking mode (DELETE) rather than the full lock (ALL) used for regular groups
+
+## Technical Implementation
+
+The implementation uses the following components:
+
+1. **AuthzGroup Locking Mechanism**: Uses Sakai's built-in group locking functionality with different lock modes:
+   - `RealmLockMode.ALL`: Prevents all membership changes (used for regular groups)
+   - `RealmLockMode.DELETE`: Prevents deletion but allows membership changes (used for Lessons access groups)
+   - `RealmLockMode.NONE`: No locks applied
+
+2. **Scheduled Jobs**:
+   - `AssignmentGroupLockingJob`: Runs periodically to check for assignments about to open and locks their groups
+   - `AssignmentGroupUnlockingJob`: Handles unlocking for assignments that have had their open date pushed to the future
+
+3. **Lock Management**:
+   - Locks are applied and removed through the `AuthzGroupService`
+   - Lock state is maintained even if the server restarts
+
+## Configuration
+
+The group locking jobs are configured through Sakai's Quartz scheduler. Administrators can adjust:
+
+1. Job Frequency: How often the locking job runs (recommended: every 1-5 minutes)
+2. Window Size: How far in advance the job checks for assignments about to open (default: 5 minutes)
+
+## Recommendations for Instructors
+
+1. Create and configure your group assignments in advance
+2. Set an appropriate open date
+3. Post the assignment when ready - group memberships can still be modified until the open date
+4. If you need to extend the open date, you can do so as long as no submissions have been made
+
+## Notes
+
+- The locking behavior applies only to assignments configured for group submission
+- Assignments set to site or individual access do not affect group locks
+- If a group is locked by multiple assignments, all locks must be removed before the group can be modified

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJob.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJob.java
@@ -72,8 +72,8 @@ public class AssignmentGroupLockingJob implements Job {
             
             for (Site site : sites) {
                 try {
-                    // Skip special sites, unpublished sites, or softly deleted sites
-                    if (site.isSpecial() || !site.isPublished() || site.isSoftlyDeleted()) {
+                    // Skip unpublished sites or softly deleted sites
+                    if (!site.isPublished() || site.isSoftlyDeleted()) {
                         continue;
                     }
                     

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJob.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJob.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.assignment.impl.jobs;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.model.Assignment;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.AuthzPermissionException;
+import org.sakaiproject.authz.api.GroupNotDefinedException;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+
+/**
+ * Job to lock assignment groups when they reach their open date.
+ * This job runs periodically and checks for assignments that are about to open
+ * and locks their associated groups to prevent membership changes.
+ */
+@Slf4j
+public class AssignmentGroupLockingJob implements Job {
+
+    @Setter private AssignmentService assignmentService;
+    @Setter private AuthzGroupService authzGroupService;
+    @Setter private SessionManager sessionManager;
+    @Setter private SiteService siteService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        log.info("AssignmentGroupLockingJob started");
+        
+        // Set up the admin user
+        Session session = sessionManager.getCurrentSession();
+        String currentUserId = session.getUserId();
+        session.setUserId("admin");
+        session.setUserEid("admin");
+        
+        try {
+            // Get all assignments that have not been locked yet but will open soon
+            // Using a 5-minute buffer to ensure we don't miss assignments
+            Instant now = Instant.now();
+            Instant fiveMinutesFromNow = now.plusSeconds(5 * 60);
+            
+            List<Site> sites = siteService.getSites(SiteService.SelectionType.ANY, null, null, null, SiteService.SortType.NONE, null);
+            
+            for (Site site : sites) {
+                try {
+                    // Skip special sites, unpublished sites, or softly deleted sites
+                    if (site.isSpecial() || !site.isPublished() || site.isSoftlyDeleted()) {
+                        continue;
+                    }
+                    
+                    // Get all assignments for this site
+                    for (Assignment assignment : assignmentService.getAssignmentsForContext(site.getId())) {
+                        // Check if assignment is:
+                        // 1. Not a draft
+                        // 2. Uses group access
+                        // 3. Open date is between now and 5 minutes from now
+                        if (!assignment.getDraft() &&
+                            assignment.getTypeOfAccess() == Assignment.Access.GROUP &&
+                            assignment.getOpenDate().isAfter(now) &&
+                            assignment.getOpenDate().isBefore(fiveMinutesFromNow)) {
+                            
+                            lockAssignmentGroups(assignment, site);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Error processing site {} in AssignmentGroupLockingJob: {}", site.getId(), e.getMessage(), e);
+                }
+            }
+            
+        } catch (Exception e) {
+            log.error("Error in AssignmentGroupLockingJob: {}", e.getMessage(), e);
+        } finally {
+            // Restore original user
+            if (currentUserId != null) {
+                session.setUserId(currentUserId);
+            } else {
+                session.setUserId(null);
+            }
+            
+            log.info("AssignmentGroupLockingJob completed");
+        }
+    }
+    
+    /**
+     * Locks the groups associated with an assignment
+     * 
+     * @param assignment The assignment to lock groups for
+     * @param site The site that contains the groups
+     */
+    private void lockAssignmentGroups(Assignment assignment, Site site) {
+        log.info("Locking groups for assignment {} in site {}", assignment.getId(), site.getId());
+        
+        String reference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+        
+        for (String groupRef : assignment.getGroups()) {
+            try {
+                Group assignedGroup = site.getGroup(groupRef.replaceFirst(site.getReference() + "/group/", ""));
+                boolean isAccessGroup = assignedGroup != null && 
+                                         assignedGroup.getProperties() != null &&
+                                         assignedGroup.getProperties().getProperty("lessonbuilder_ref") != null &&
+                                         !assignedGroup.getProperties().getProperty("lessonbuilder_ref").isEmpty();
+                
+                if (!isAccessGroup) {
+                    // Lock the group only if it's not an access group (those are handled differently)
+                    AuthzGroup group = authzGroupService.getAuthzGroup(groupRef);
+                    group.setLockForReference(reference, AuthzGroup.RealmLockMode.ALL);
+                    authzGroupService.save(group);
+                    log.debug("Locked group {} for assignment {}", groupRef, assignment.getId());
+                }
+            } catch (GroupNotDefinedException | AuthzPermissionException e) {
+                log.warn("Could not lock group {} for assignment {}: {}", groupRef, assignment.getId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJob.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJob.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.assignment.impl.jobs;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.model.Assignment;
+import org.sakaiproject.assignment.api.model.AssignmentSubmission;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.AuthzPermissionException;
+import org.sakaiproject.authz.api.GroupNotDefinedException;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+
+/**
+ * Job to handle unlocking groups for assignments that have had their open date pushed to the future.
+ * This will only unlock groups if no submissions have been made to the assignment yet.
+ */
+@Slf4j
+public class AssignmentGroupUnlockingJob implements Job {
+
+    @Setter private AssignmentService assignmentService;
+    @Setter private AuthzGroupService authzGroupService;
+    @Setter private SessionManager sessionManager;
+    @Setter private SiteService siteService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        log.info("AssignmentGroupUnlockingJob started");
+        
+        // Set up the admin user
+        Session session = sessionManager.getCurrentSession();
+        String currentUserId = session.getUserId();
+        session.setUserId("admin");
+        session.setUserEid("admin");
+        
+        try {
+            // Get all sites
+            List<Site> sites = siteService.getSites(SiteService.SelectionType.ANY, null, null, null, SiteService.SortType.NONE, null);
+            
+            Instant now = Instant.now();
+            
+            for (Site site : sites) {
+                try {
+                    // Skip special sites, unpublished sites, or softly deleted sites
+                    if (site.isSpecial() || !site.isPublished() || site.isSoftlyDeleted()) {
+                        continue;
+                    }
+                    
+                    // Process assignments that are not drafts, use group access, and haven't opened yet
+                    for (Assignment assignment : assignmentService.getAssignmentsForContext(site.getId())) {
+                        if (!assignment.getDraft() && 
+                            assignment.getTypeOfAccess() == Assignment.Access.GROUP && 
+                            assignment.getOpenDate().isAfter(now)) {
+                            
+                            // Check if any submissions exist
+                            Collection<AssignmentSubmission> submissions = assignmentService.getSubmissions(assignment);
+                            if (submissions == null || submissions.isEmpty()) {
+                                // No submissions, so it's safe to unlock groups
+                                manageGroupLocks(assignment, site, false);
+                            } else {
+                                log.debug("Not unlocking groups for assignment {} because it already has submissions", assignment.getId());
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Error processing site {} in AssignmentGroupUnlockingJob: {}", site.getId(), e.getMessage(), e);
+                }
+            }
+            
+        } catch (Exception e) {
+            log.error("Error in AssignmentGroupUnlockingJob: {}", e.getMessage(), e);
+        } finally {
+            // Restore original user
+            if (currentUserId != null) {
+                session.setUserId(currentUserId);
+            } else {
+                session.setUserId(null);
+            }
+            
+            log.info("AssignmentGroupUnlockingJob completed");
+        }
+    }
+    
+    /**
+     * Manages locks on groups associated with an assignment
+     * 
+     * @param assignment The assignment to manage group locks for
+     * @param site The site that contains the groups
+     * @param lock If true, lock the groups; if false, unlock them
+     */
+    private void manageGroupLocks(Assignment assignment, Site site, boolean lock) {
+        log.info("{} groups for assignment {} in site {}", 
+                (lock ? "Locking" : "Unlocking"), assignment.getId(), site.getId());
+        
+        String reference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+        
+        for (String groupRef : assignment.getGroups()) {
+            try {
+                Group assignedGroup = site.getGroup(groupRef.replaceFirst(site.getReference() + "/group/", ""));
+                boolean isAccessGroup = assignedGroup != null && 
+                                         assignedGroup.getProperties() != null &&
+                                         assignedGroup.getProperties().getProperty("lessonbuilder_ref") != null &&
+                                         !assignedGroup.getProperties().getProperty("lessonbuilder_ref").isEmpty();
+                
+                if (!isAccessGroup) {
+                    // Only manage locks for non-access groups
+                    AuthzGroup group = authzGroupService.getAuthzGroup(groupRef);
+                    
+                    if (lock) {
+                        group.setLockForReference(reference, AuthzGroup.RealmLockMode.ALL);
+                    } else {
+                        group.setLockForReference(reference, AuthzGroup.RealmLockMode.NONE);
+                    }
+                    
+                    authzGroupService.save(group);
+                    log.debug("{} group {} for assignment {}", 
+                            (lock ? "Locked" : "Unlocked"), groupRef, assignment.getId());
+                }
+            } catch (GroupNotDefinedException | AuthzPermissionException e) {
+                log.warn("Could not {} group {} for assignment {}: {}", 
+                        (lock ? "lock" : "unlock"), groupRef, assignment.getId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJob.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJob.java
@@ -71,8 +71,8 @@ public class AssignmentGroupUnlockingJob implements Job {
             
             for (Site site : sites) {
                 try {
-                    // Skip special sites, unpublished sites, or softly deleted sites
-                    if (site.isSpecial() || !site.isPublished() || site.isSoftlyDeleted()) {
+                    // Skip unpublished sites or softly deleted sites
+                    if (!site.isPublished() || site.isSoftlyDeleted()) {
                         continue;
                     }
                     

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java
@@ -27,7 +27,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,7 +77,6 @@ public class AssignmentGroupLockingJobTest {
         // Mock site
         Site site = mock(Site.class);
         when(site.getId()).thenReturn("site-1");
-        when(site.isSpecial()).thenReturn(false);
         when(site.isPublished()).thenReturn(true);
         when(site.isSoftlyDeleted()).thenReturn(false);
         
@@ -91,7 +92,7 @@ public class AssignmentGroupLockingJobTest {
         when(assignment.getOpenDate()).thenReturn(fourMinutesFromNow);
         
         // Set up groups for the assignment
-        List<String> groupRefs = Arrays.asList("group-1", "group-2");
+        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2"));
         when(assignment.getGroups()).thenReturn(groupRefs);
         
         // Set up collections to return from service calls
@@ -135,7 +136,6 @@ public class AssignmentGroupLockingJobTest {
         // Mock site
         Site site = mock(Site.class);
         when(site.getId()).thenReturn("site-1");
-        when(site.isSpecial()).thenReturn(false);
         when(site.isPublished()).thenReturn(true);
         when(site.isSoftlyDeleted()).thenReturn(false);
         
@@ -151,7 +151,7 @@ public class AssignmentGroupLockingJobTest {
         when(assignment.getOpenDate()).thenReturn(tenMinutesFromNow);
         
         // Set up groups for the assignment
-        List<String> groupRefs = Arrays.asList("group-1", "group-2");
+        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2"));
         when(assignment.getGroups()).thenReturn(groupRefs);
         
         // Set up collections to return from service calls

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java
@@ -1,0 +1,170 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2007, 2008 The Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.assignment.impl.jobs;
+
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.quartz.JobExecutionContext;
+import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.model.Assignment;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+
+public class AssignmentGroupLockingJobTest {
+
+    private AssignmentGroupLockingJob job;
+    
+    @Mock private AssignmentService assignmentService;
+    @Mock private AuthzGroupService authzGroupService;
+    @Mock private SessionManager sessionManager;
+    @Mock private SiteService siteService;
+    @Mock private JobExecutionContext jobExecutionContext;
+    @Mock private Session session;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        
+        job = new AssignmentGroupLockingJob();
+        job.setAssignmentService(assignmentService);
+        job.setAuthzGroupService(authzGroupService);
+        job.setSessionManager(sessionManager);
+        job.setSiteService(siteService);
+        
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+    }
+    
+    @Test
+    public void testGroupLockingJobForAssignmentAboutToOpen() throws Exception {
+        // Mock site
+        Site site = mock(Site.class);
+        when(site.getId()).thenReturn("site-1");
+        when(site.isSpecial()).thenReturn(false);
+        when(site.isPublished()).thenReturn(true);
+        when(site.isSoftlyDeleted()).thenReturn(false);
+        
+        // Mock assignment
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getId()).thenReturn("assignment-1");
+        when(assignment.getDraft()).thenReturn(false);
+        when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
+        
+        // Set up a future open date that is within the 5-minute window that the job checks
+        Instant now = Instant.now();
+        Instant fourMinutesFromNow = now.plusSeconds(4 * 60);
+        when(assignment.getOpenDate()).thenReturn(fourMinutesFromNow);
+        
+        // Set up groups for the assignment
+        List<String> groupRefs = Arrays.asList("group-1", "group-2");
+        when(assignment.getGroups()).thenReturn(groupRefs);
+        
+        // Set up collections to return from service calls
+        List<Site> sites = Arrays.asList(site);
+        when(siteService.getSites(any(), any(), any(), any(), any(), any())).thenReturn(sites);
+        
+        Collection<Assignment> assignments = Arrays.asList(assignment);
+        when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
+        
+        // Set up mocked group objects
+        Group group1 = mock(Group.class);
+        when(group1.getProperties()).thenReturn(null);
+        AuthzGroup authzGroup1 = mock(AuthzGroup.class);
+        
+        Group group2 = mock(Group.class);
+        when(group2.getProperties()).thenReturn(null);
+        AuthzGroup authzGroup2 = mock(AuthzGroup.class);
+        
+        // Set up site to return the groups
+        when(site.getGroup("group-1".replaceFirst(site.getReference() + "/group/", ""))).thenReturn(group1);
+        when(site.getGroup("group-2".replaceFirst(site.getReference() + "/group/", ""))).thenReturn(group2);
+        
+        // Set up authz groups
+        when(authzGroupService.getAuthzGroup("group-1")).thenReturn(authzGroup1);
+        when(authzGroupService.getAuthzGroup("group-2")).thenReturn(authzGroup2);
+        
+        // Mock the reference
+        String reference = "assignment/site-1/assignment-1";
+        
+        // Execute the job
+        job.execute(jobExecutionContext);
+        
+        // Verify that the groups were locked with the ALL lock mode
+        verify(authzGroup1).setLockForReference(reference, AuthzGroup.RealmLockMode.ALL);
+        verify(authzGroup2).setLockForReference(reference, AuthzGroup.RealmLockMode.ALL);
+        verify(authzGroupService, times(2)).save(any(AuthzGroup.class));
+    }
+    
+    @Test
+    public void testGroupLockingJobForAssignmentNotReady() throws Exception {
+        // Mock site
+        Site site = mock(Site.class);
+        when(site.getId()).thenReturn("site-1");
+        when(site.isSpecial()).thenReturn(false);
+        when(site.isPublished()).thenReturn(true);
+        when(site.isSoftlyDeleted()).thenReturn(false);
+        
+        // Mock assignment
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getId()).thenReturn("assignment-1");
+        when(assignment.getDraft()).thenReturn(false);
+        when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
+        
+        // Set up a future open date that is OUTSIDE the 5-minute window
+        Instant now = Instant.now();
+        Instant tenMinutesFromNow = now.plusSeconds(10 * 60);
+        when(assignment.getOpenDate()).thenReturn(tenMinutesFromNow);
+        
+        // Set up groups for the assignment
+        List<String> groupRefs = Arrays.asList("group-1", "group-2");
+        when(assignment.getGroups()).thenReturn(groupRefs);
+        
+        // Set up collections to return from service calls
+        List<Site> sites = Arrays.asList(site);
+        when(siteService.getSites(any(), any(), any(), any(), any(), any())).thenReturn(sites);
+        
+        Collection<Assignment> assignments = Arrays.asList(assignment);
+        when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
+        
+        // Execute the job
+        job.execute(jobExecutionContext);
+        
+        // Verify that the authzGroupService.save was never called since the assignment isn't ready to be locked
+        verify(authzGroupService, never()).save(any(AuthzGroup.class));
+    }
+}

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java
@@ -21,6 +21,7 @@
 
 package org.sakaiproject.assignment.impl.jobs;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.time.Instant;
@@ -85,6 +86,7 @@ public class AssignmentGroupLockingJobTest {
         when(assignment.getId()).thenReturn("assignment-1");
         when(assignment.getDraft()).thenReturn(false);
         when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
+        when(assignment.getContext()).thenReturn("site-1");
         
         // Set up a future open date that is within the 5-minute window that the job checks
         Instant now = Instant.now();
@@ -100,7 +102,7 @@ public class AssignmentGroupLockingJobTest {
         when(siteService.getSites(any(), any(), any(), any(), any(), any())).thenReturn(sites);
         
         Collection<Assignment> assignments = Arrays.asList(assignment);
-        when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
+        when(assignmentService.getAssignmentsForContext("site-1")).thenReturn(assignments);
         
         // Set up mocked group objects
         Group group1 = mock(Group.class);
@@ -119,8 +121,12 @@ public class AssignmentGroupLockingJobTest {
         when(authzGroupService.getAuthzGroup("group-1")).thenReturn(authzGroup1);
         when(authzGroupService.getAuthzGroup("group-2")).thenReturn(authzGroup2);
         
-        // Mock the reference
-        String reference = "assignment/site-1/assignment-1";
+        // Create the actual reference that will be used by the job
+        String reference = AssignmentReferenceReckoner.reckoner()
+                .context("site-1")
+                .id("assignment-1")
+                .reckon()
+                .getReference();
         
         // Execute the job
         job.execute(jobExecutionContext);
@@ -144,6 +150,7 @@ public class AssignmentGroupLockingJobTest {
         when(assignment.getId()).thenReturn("assignment-1");
         when(assignment.getDraft()).thenReturn(false);
         when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
+        when(assignment.getContext()).thenReturn("site-1");
         
         // Set up a future open date that is OUTSIDE the 5-minute window
         Instant now = Instant.now();
@@ -159,7 +166,7 @@ public class AssignmentGroupLockingJobTest {
         when(siteService.getSites(any(), any(), any(), any(), any(), any())).thenReturn(sites);
         
         Collection<Assignment> assignments = Arrays.asList(assignment);
-        when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
+        when(assignmentService.getAssignmentsForContext("site-1")).thenReturn(assignments);
         
         // Execute the job
         job.execute(jobExecutionContext);

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java.bak
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupLockingJobTest.java.bak
@@ -24,21 +24,20 @@ package org.sakaiproject.assignment.impl.jobs;
 import static org.mockito.Mockito.*;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.quartz.JobExecutionContext;
+import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
-import org.sakaiproject.assignment.api.model.AssignmentSubmission;
 import org.sakaiproject.authz.api.AuthzGroup;
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.site.api.Group;
@@ -47,9 +46,9 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.SessionManager;
 
-public class AssignmentGroupUnlockingJobTest {
+public class AssignmentGroupLockingJobTest {
 
-    private AssignmentGroupUnlockingJob job;
+    private AssignmentGroupLockingJob job;
     
     @Mock private AssignmentService assignmentService;
     @Mock private AuthzGroupService authzGroupService;
@@ -62,7 +61,7 @@ public class AssignmentGroupUnlockingJobTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         
-        job = new AssignmentGroupUnlockingJob();
+        job = new AssignmentGroupLockingJob();
         job.setAssignmentService(assignmentService);
         job.setAuthzGroupService(authzGroupService);
         job.setSessionManager(sessionManager);
@@ -72,7 +71,7 @@ public class AssignmentGroupUnlockingJobTest {
     }
     
     @Test
-    public void testGroupUnlockingJobForAssignmentWithNoSubmissions() throws Exception {
+    public void testGroupLockingJobForAssignmentAboutToOpen() throws Exception {
         // Mock site
         Site site = mock(Site.class);
         when(site.getId()).thenReturn("site-1");
@@ -85,13 +84,13 @@ public class AssignmentGroupUnlockingJobTest {
         when(assignment.getDraft()).thenReturn(false);
         when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
         
-        // Set up a future open date
+        // Set up a future open date that is within the 5-minute window that the job checks
         Instant now = Instant.now();
-        Instant twoHoursFromNow = now.plusSeconds(2 * 60 * 60);
-        when(assignment.getOpenDate()).thenReturn(twoHoursFromNow);
+        Instant fourMinutesFromNow = now.plusSeconds(4 * 60);
+        when(assignment.getOpenDate()).thenReturn(fourMinutesFromNow);
         
         // Set up groups for the assignment
-        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2"));
+        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2");
         when(assignment.getGroups()).thenReturn(groupRefs);
         
         // Set up collections to return from service calls
@@ -100,9 +99,6 @@ public class AssignmentGroupUnlockingJobTest {
         
         Collection<Assignment> assignments = Arrays.asList(assignment);
         when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
-        
-        // No submissions for this assignment
-        when(assignmentService.getSubmissions(assignment)).thenReturn(Collections.emptySet());
         
         // Set up mocked group objects
         Group group1 = mock(Group.class);
@@ -127,14 +123,14 @@ public class AssignmentGroupUnlockingJobTest {
         // Execute the job
         job.execute(jobExecutionContext);
         
-        // Verify that the groups were unlocked (set to NONE lock mode)
-        verify(authzGroup1).setLockForReference(reference, AuthzGroup.RealmLockMode.NONE);
-        verify(authzGroup2).setLockForReference(reference, AuthzGroup.RealmLockMode.NONE);
+        // Verify that the groups were locked with the ALL lock mode
+        verify(authzGroup1).setLockForReference(reference, AuthzGroup.RealmLockMode.ALL);
+        verify(authzGroup2).setLockForReference(reference, AuthzGroup.RealmLockMode.ALL);
         verify(authzGroupService, times(2)).save(any(AuthzGroup.class));
     }
     
     @Test
-    public void testGroupUnlockingJobForAssignmentWithSubmissions() throws Exception {
+    public void testGroupLockingJobForAssignmentNotReady() throws Exception {
         // Mock site
         Site site = mock(Site.class);
         when(site.getId()).thenReturn("site-1");
@@ -147,13 +143,13 @@ public class AssignmentGroupUnlockingJobTest {
         when(assignment.getDraft()).thenReturn(false);
         when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
         
-        // Set up a future open date
+        // Set up a future open date that is OUTSIDE the 5-minute window
         Instant now = Instant.now();
-        Instant twoHoursFromNow = now.plusSeconds(2 * 60 * 60);
-        when(assignment.getOpenDate()).thenReturn(twoHoursFromNow);
+        Instant tenMinutesFromNow = now.plusSeconds(10 * 60);
+        when(assignment.getOpenDate()).thenReturn(tenMinutesFromNow);
         
         // Set up groups for the assignment
-        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2"));
+        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2");
         when(assignment.getGroups()).thenReturn(groupRefs);
         
         // Set up collections to return from service calls
@@ -163,14 +159,10 @@ public class AssignmentGroupUnlockingJobTest {
         Collection<Assignment> assignments = Arrays.asList(assignment);
         when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
         
-        // Assignment has submissions, so we should NOT unlock the groups
-        Set<AssignmentSubmission> submissions = new HashSet<>(Arrays.asList(mock(AssignmentSubmission.class)));
-        when(assignmentService.getSubmissions(assignment)).thenReturn(submissions);
-        
         // Execute the job
         job.execute(jobExecutionContext);
         
-        // Verify that the authzGroupService.save was never called since the assignment has submissions
+        // Verify that the authzGroupService.save was never called since the assignment isn't ready to be locked
         verify(authzGroupService, never()).save(any(AuthzGroup.class));
     }
 }

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJobTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJobTest.java
@@ -1,0 +1,176 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2003, 2004, 2005, 2006, 2007, 2008 The Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.assignment.impl.jobs;
+
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.quartz.JobExecutionContext;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.model.Assignment;
+import org.sakaiproject.assignment.api.model.AssignmentSubmission;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+
+public class AssignmentGroupUnlockingJobTest {
+
+    private AssignmentGroupUnlockingJob job;
+    
+    @Mock private AssignmentService assignmentService;
+    @Mock private AuthzGroupService authzGroupService;
+    @Mock private SessionManager sessionManager;
+    @Mock private SiteService siteService;
+    @Mock private JobExecutionContext jobExecutionContext;
+    @Mock private Session session;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        
+        job = new AssignmentGroupUnlockingJob();
+        job.setAssignmentService(assignmentService);
+        job.setAuthzGroupService(authzGroupService);
+        job.setSessionManager(sessionManager);
+        job.setSiteService(siteService);
+        
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+    }
+    
+    @Test
+    public void testGroupUnlockingJobForAssignmentWithNoSubmissions() throws Exception {
+        // Mock site
+        Site site = mock(Site.class);
+        when(site.getId()).thenReturn("site-1");
+        when(site.isSpecial()).thenReturn(false);
+        when(site.isPublished()).thenReturn(true);
+        when(site.isSoftlyDeleted()).thenReturn(false);
+        
+        // Mock assignment
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getId()).thenReturn("assignment-1");
+        when(assignment.getDraft()).thenReturn(false);
+        when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
+        
+        // Set up a future open date
+        Instant now = Instant.now();
+        Instant twoHoursFromNow = now.plusSeconds(2 * 60 * 60);
+        when(assignment.getOpenDate()).thenReturn(twoHoursFromNow);
+        
+        // Set up groups for the assignment
+        List<String> groupRefs = Arrays.asList("group-1", "group-2");
+        when(assignment.getGroups()).thenReturn(groupRefs);
+        
+        // Set up collections to return from service calls
+        List<Site> sites = Arrays.asList(site);
+        when(siteService.getSites(any(), any(), any(), any(), any(), any())).thenReturn(sites);
+        
+        Collection<Assignment> assignments = Arrays.asList(assignment);
+        when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
+        
+        // No submissions for this assignment
+        when(assignmentService.getSubmissions(assignment)).thenReturn(Collections.emptyList());
+        
+        // Set up mocked group objects
+        Group group1 = mock(Group.class);
+        when(group1.getProperties()).thenReturn(null);
+        AuthzGroup authzGroup1 = mock(AuthzGroup.class);
+        
+        Group group2 = mock(Group.class);
+        when(group2.getProperties()).thenReturn(null);
+        AuthzGroup authzGroup2 = mock(AuthzGroup.class);
+        
+        // Set up site to return the groups
+        when(site.getGroup("group-1".replaceFirst(site.getReference() + "/group/", ""))).thenReturn(group1);
+        when(site.getGroup("group-2".replaceFirst(site.getReference() + "/group/", ""))).thenReturn(group2);
+        
+        // Set up authz groups
+        when(authzGroupService.getAuthzGroup("group-1")).thenReturn(authzGroup1);
+        when(authzGroupService.getAuthzGroup("group-2")).thenReturn(authzGroup2);
+        
+        // Mock the reference
+        String reference = "assignment/site-1/assignment-1";
+        
+        // Execute the job
+        job.execute(jobExecutionContext);
+        
+        // Verify that the groups were unlocked (set to NONE lock mode)
+        verify(authzGroup1).setLockForReference(reference, AuthzGroup.RealmLockMode.NONE);
+        verify(authzGroup2).setLockForReference(reference, AuthzGroup.RealmLockMode.NONE);
+        verify(authzGroupService, times(2)).save(any(AuthzGroup.class));
+    }
+    
+    @Test
+    public void testGroupUnlockingJobForAssignmentWithSubmissions() throws Exception {
+        // Mock site
+        Site site = mock(Site.class);
+        when(site.getId()).thenReturn("site-1");
+        when(site.isSpecial()).thenReturn(false);
+        when(site.isPublished()).thenReturn(true);
+        when(site.isSoftlyDeleted()).thenReturn(false);
+        
+        // Mock assignment
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getId()).thenReturn("assignment-1");
+        when(assignment.getDraft()).thenReturn(false);
+        when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.GROUP);
+        
+        // Set up a future open date
+        Instant now = Instant.now();
+        Instant twoHoursFromNow = now.plusSeconds(2 * 60 * 60);
+        when(assignment.getOpenDate()).thenReturn(twoHoursFromNow);
+        
+        // Set up groups for the assignment
+        List<String> groupRefs = Arrays.asList("group-1", "group-2");
+        when(assignment.getGroups()).thenReturn(groupRefs);
+        
+        // Set up collections to return from service calls
+        List<Site> sites = Arrays.asList(site);
+        when(siteService.getSites(any(), any(), any(), any(), any(), any())).thenReturn(sites);
+        
+        Collection<Assignment> assignments = Arrays.asList(assignment);
+        when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
+        
+        // Assignment has submissions, so we should NOT unlock the groups
+        Collection<AssignmentSubmission> submissions = Arrays.asList(mock(AssignmentSubmission.class));
+        when(assignmentService.getSubmissions(assignment)).thenReturn(submissions);
+        
+        // Execute the job
+        job.execute(jobExecutionContext);
+        
+        // Verify that the authzGroupService.save was never called since the assignment has submissions
+        verify(authzGroupService, never()).save(any(AuthzGroup.class));
+    }
+}

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJobTest.java.bak
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/jobs/AssignmentGroupUnlockingJobTest.java.bak
@@ -91,7 +91,7 @@ public class AssignmentGroupUnlockingJobTest {
         when(assignment.getOpenDate()).thenReturn(twoHoursFromNow);
         
         // Set up groups for the assignment
-        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2"));
+        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2");
         when(assignment.getGroups()).thenReturn(groupRefs);
         
         // Set up collections to return from service calls
@@ -102,7 +102,7 @@ public class AssignmentGroupUnlockingJobTest {
         when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
         
         // No submissions for this assignment
-        when(assignmentService.getSubmissions(assignment)).thenReturn(Collections.emptySet());
+        when(assignmentService.getSubmissions(assignment)).thenReturn(Collections.emptyList());
         
         // Set up mocked group objects
         Group group1 = mock(Group.class);
@@ -153,7 +153,7 @@ public class AssignmentGroupUnlockingJobTest {
         when(assignment.getOpenDate()).thenReturn(twoHoursFromNow);
         
         // Set up groups for the assignment
-        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2"));
+        Set<String> groupRefs = new HashSet<>(Arrays.asList("group-1", "group-2");
         when(assignment.getGroups()).thenReturn(groupRefs);
         
         // Set up collections to return from service calls
@@ -164,7 +164,7 @@ public class AssignmentGroupUnlockingJobTest {
         when(assignmentService.getAssignmentsForContext(site.getId())).thenReturn(assignments);
         
         // Assignment has submissions, so we should NOT unlock the groups
-        Set<AssignmentSubmission> submissions = new HashSet<>(Arrays.asList(mock(AssignmentSubmission.class)));
+        Collection<AssignmentSubmission> submissions = Arrays.asList(mock(AssignmentSubmission.class));
         when(assignmentService.getSubmissions(assignment)).thenReturn(submissions);
         
         // Execute the job

--- a/assignment/impl/src/webapp/WEB-INF/components.xml
+++ b/assignment/impl/src/webapp/WEB-INF/components.xml
@@ -301,6 +301,39 @@
         <property name="taskService" ref="org.sakaiproject.tasks.api.TaskService"/>
         <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
     </bean>
+    
+    <!-- Group Locking Jobs -->
+    <bean id="org.sakaiproject.assignment.impl.jobs.AssignmentGroupLockingJob"
+          class="org.sakaiproject.assignment.impl.jobs.AssignmentGroupLockingJob">
+        <property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService"/>
+        <property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+    </bean>
+    
+    <bean id="org.sakaiproject.assignment.impl.jobs.AssignmentGroupUnlockingJob"
+          class="org.sakaiproject.assignment.impl.jobs.AssignmentGroupUnlockingJob">
+        <property name="assignmentService" ref="org.sakaiproject.assignment.api.AssignmentService"/>
+        <property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+    </bean>
+    
+    <bean id="org.sakaiproject.assignment.impl.jobs.AssignmentGroupLockingJob.jobWrapper"
+          class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+          init-method="init">
+        <property name="beanId" value="org.sakaiproject.assignment.impl.jobs.AssignmentGroupLockingJob"/>
+        <property name="jobName" value="Assignment Group Locking Job"/>
+        <property name="schedulerManager" ref="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
+    </bean>
+    
+    <bean id="org.sakaiproject.assignment.impl.jobs.AssignmentGroupUnlockingJob.jobWrapper"
+          class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+          init-method="init">
+        <property name="beanId" value="org.sakaiproject.assignment.impl.jobs.AssignmentGroupUnlockingJob"/>
+        <property name="jobName" value="Assignment Group Unlocking Job"/>
+        <property name="schedulerManager" ref="org.sakaiproject.api.app.scheduler.SchedulerManager"/>
+    </bean>
 
     <bean id="org.sakaiproject.assignment.impl.AssignmentSiteFsVolume"
           class="org.sakaiproject.assignment.impl.AssignmentToolFsVolumeFactory"


### PR DESCRIPTION
I have not tested or reviewed.

----------------------------------

1. Modified the AssignmentServiceImpl to not lock groups immediately when an assignment is posted but instead check the open date:
    - If the open date is in the future, groups remain unlocked
    - If the open date has already passed, groups are locked immediately
  2. Created two scheduled jobs:
    - AssignmentGroupLockingJob: Runs periodically to check for assignments about to open and locks their groups
    - AssignmentGroupUnlockingJob: Handles cases where an assignment's open date has been pushed into the future after it was posted
  3. Added unit tests for both jobs to ensure proper locking/unlocking behavior under different scenarios
  4. Created comprehensive documentation explaining the new behavior

  This implementation allows instructors to create and post assignments in advance without immediately locking groups, giving them flexibility to adjust group membership until the assignment actually opens. The system will
  automatically lock groups when the open date arrives to maintain the integrity of group-based submissions.

  The code also handles special cases such as:
  - Assignments with submissions (keeping groups locked even if the open date changes)
  - Lessons access groups (using a different lock mode)