### PR TITLE
SAK-51279 conversations Fix duplicate key violation when marking posts as viewed

### DIFF
--- a/conversations/api/src/main/java/org/sakaiproject/conversations/api/repository/TopicStatusRepository.java
+++ b/conversations/api/src/main/java/org/sakaiproject/conversations/api/repository/TopicStatusRepository.java
@@ -28,4 +28,5 @@ public interface TopicStatusRepository extends SpringCrudRepository<TopicStatus,
     List<Object[]> countBySiteIdAndViewed(String siteId, Boolean viewed);
     Integer setViewedByTopicId(String topicId, Boolean viewed);
     Integer setViewedByTopicIdAndUserId(String topicId, String userId, Boolean viewed);
+    TopicStatus saveTopicStatus(String topicId, String userId, boolean viewed);
 }

--- a/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/ConversationsServiceImpl.java
+++ b/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/ConversationsServiceImpl.java
@@ -1674,15 +1674,8 @@ public class ConversationsServiceImpl implements ConversationsService, EntityTra
             .findByTopicIdAndUserIdAndViewed(topicId, currentUserId, true).stream().count();
         long numberOfUnreadPosts = numberOfPosts - read;
 
-        TopicStatus topicStatus = topicStatusRepository.findByTopicIdAndUserId(topicId, currentUserId)
-            .orElseGet(() -> new TopicStatus(topic, currentUserId));
-        topicStatus.setViewed(numberOfUnreadPosts == 0L);
-        try {
-            topicStatusRepository.save(topicStatus);
-        } catch (PersistenceException pe) {
-            log.debug("Caught an exception while saving topic status. This can happen "
-                    + "due to the way the client detects posts scrolling into view", pe);
-        }
+        // Using the new method that handles concurrent updates with a safer approach
+        topicStatusRepository.saveTopicStatus(topicId, currentUserId, numberOfUnreadPosts == 0L);
 
         Map<String, Map<String, Object>> topicCache = postsCache.get(topicId);
         if (topicCache != null) topicCache.remove(currentUserId);

--- a/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/ConversationsServiceImpl.java
+++ b/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/ConversationsServiceImpl.java
@@ -1099,8 +1099,8 @@ public class ConversationsServiceImpl implements ConversationsService, EntityTra
             topicRepository.save(topic);
         }
 
-        TopicStatus topicStatus = topicStatusRepository.findByTopicIdAndUserId(topic.getId(), currentUserId)
-            .orElse(new TopicStatus(topic, currentUserId));
+        // Using the safer method to handle concurrent updates
+        TopicStatus topicStatus = topicStatusRepository.saveTopicStatus(topic.getId(), currentUserId, false);
         topicStatus.setPosted(true);
         boolean topicWasViewed = topicStatus.getViewed();
         topicStatusRepository.save(topicStatus);

--- a/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/ConversationsServiceImpl.java
+++ b/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/ConversationsServiceImpl.java
@@ -820,10 +820,8 @@ public class ConversationsServiceImpl implements ConversationsService, EntityTra
 
         String currentUserId = getCheckedCurrentUserId();
 
-        ConversationsTopic topic = topicRepository.getReferenceById(topicId);
-
-        TopicStatus topicStatus = topicStatusRepository.findByTopicIdAndUserId(topicId, currentUserId)
-            .orElseGet(() -> new TopicStatus(topic, currentUserId));
+        // Using our safer method to handle concurrent creation/update
+        TopicStatus topicStatus = topicStatusRepository.saveTopicStatus(topicId, currentUserId, false);
         topicStatus.setBookmarked(bookmarked);
         topicStatusRepository.save(topicStatus);
     }

--- a/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/repository/TopicStatusRepositoryImpl.java
+++ b/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/repository/TopicStatusRepositoryImpl.java
@@ -55,6 +55,7 @@ public class TopicStatusRepositoryImpl extends SpringCrudRepositoryImpl<TopicSta
         return session.createQuery(query).uniqueResultOptional();
     }
     
+    @Override
     @Transactional
     public TopicStatus saveTopicStatus(String topicId, String userId, boolean viewed) {
         Session session = sessionFactory.getCurrentSession();
@@ -76,7 +77,7 @@ public class TopicStatusRepositoryImpl extends SpringCrudRepositoryImpl<TopicSta
             if (status != null) {
                 // Update existing record
                 status.setViewed(viewed);
-                return session.merge(status);
+                return (TopicStatus) session.merge(status);
             } else {
                 // Get the topic entity
                 CriteriaQuery<ConversationsTopic> topicQuery = cb.createQuery(ConversationsTopic.class);
@@ -104,11 +105,11 @@ public class TopicStatusRepositoryImpl extends SpringCrudRepositoryImpl<TopicSta
                         .orElseThrow(() -> new IllegalStateException("Expected to find TopicStatus after constraint violation"));
                     
                     status.setViewed(viewed);
-                    return session.merge(status);
+                    return (TopicStatus) session.merge(status);
                 }
             }
         } catch (Exception e) {
-            log.warn("Error in saveTopicStatus: {}", e.getMessage());
+            log.warn("Error in saveTopicStatus: {}", e.toString());
             throw e;
         }
     }

--- a/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/repository/TopicStatusRepositoryImpl.java
+++ b/conversations/impl/src/main/java/org/sakaiproject/conversations/impl/repository/TopicStatusRepositoryImpl.java
@@ -76,8 +76,7 @@ public class TopicStatusRepositoryImpl extends SpringCrudRepositoryImpl<TopicSta
             if (status != null) {
                 // Update existing record
                 status.setViewed(viewed);
-                session.merge(status);
-                return status;
+                return session.merge(status);
             } else {
                 // Get the topic entity
                 CriteriaQuery<ConversationsTopic> topicQuery = cb.createQuery(ConversationsTopic.class);
@@ -93,7 +92,7 @@ public class TopicStatusRepositoryImpl extends SpringCrudRepositoryImpl<TopicSta
                 TopicStatus newStatus = new TopicStatus(topic, userId);
                 newStatus.setViewed(viewed);
                 try {
-                    session.save(newStatus);
+                    session.persist(newStatus);
                     return newStatus;
                 } catch (ConstraintViolationException | DataIntegrityViolationException e) {
                     // Another thread created the record first, so let's get it and update it
@@ -105,8 +104,7 @@ public class TopicStatusRepositoryImpl extends SpringCrudRepositoryImpl<TopicSta
                         .orElseThrow(() -> new IllegalStateException("Expected to find TopicStatus after constraint violation"));
                     
                     status.setViewed(viewed);
-                    session.merge(status);
-                    return status;
+                    return session.merge(status);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
This fix addresses the issue where concurrent requests to mark posts as viewed can result in duplicate key violations and transaction rollbacks due to race conditions when creating
TopicStatus records.

The solution:
1. Added a new atomic saveTopicStatus method to TopicStatusRepository
2. Updated ConversationsServiceImpl to use the new method
3. Implemented safe handling of concurrent updates with proper transaction management

    🤖 Generated with [Claude Code](https://claude.ai/code)