### PR TITLE
SAK-51269 Gradebook order based on feedback from core call

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
@@ -10,7 +10,6 @@
   padding: 4px 10px;
   background-color: var(--sakai-background-color-3);
   margin-bottom: 4px;
-  cursor: move;
   position: relative;
 }
 


### PR DESCRIPTION
The mouse drag couldn’t start because our new handles are real <button> elements. jQuery-UI’s Sortable treats clicks on interactive elements as “cancel”, so when the first mousedown lands on a <button> it aborts the drag. I’ve updated ksortable-plugin.js so, before the sortable is initialised, we copy the incoming options and override the cancel selector to leave out button: default cancel is now input,textarea,select,option (everything it was before except button). all subsequent logic uses the tweaked options, so keyboard support is unchanged.

Space keys can be reported as " ", "Space", or the older "Spacebar" - and some code still relies on keyCode === 32. I’ve broadened the test so we detect all of those (plus a keyCode fallback) before toggling the grab/drop state. Enter continues to work via the same pattern. Windows browsers should now react to the spacebar just like macOS.