### PR TITLE
SAK-51561 Wiki icons from the text editor are incorrect

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/wiki/_wiki.scss
+++ b/library/src/skins/default/src/sass/modules/tool/wiki/_wiki.scss
@@ -78,7 +78,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F259"; /* save */
+      content: "\F7D8"; /* floppy */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -90,7 +90,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F5FC"; /* type-bold */
+      content: "\F5F0"; /* type-bold */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -102,7 +102,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F5FD"; /* type-italic */
+      content: "\F5F4"; /* type-italic */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -114,7 +114,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F607"; /* type-h1 */
+      content: "\F849"; /* superscript */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -126,7 +126,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F607"; /* type-h2 */
+      content: "\F848"; /* subscript */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -139,7 +139,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F564"; /* table */
+      content: "\F5AA"; /* table */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -151,7 +151,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F341"; /* link */
+      content: "\F470"; /* link-45deg */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;
@@ -163,7 +163,7 @@
     background: none;
     position: relative;
     &:before {
-      content: "\F302"; /* image */
+      content: "\F42A"; /* image */
       font-family: "bootstrap-icons";
       position: absolute;
       top: 50%;


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51561

On 22
![image](https://github.com/user-attachments/assets/20f301af-ca4b-41b2-869a-89d68066053f)

Before
![image](https://github.com/user-attachments/assets/16681c3f-a004-401f-bdb2-8f6a84ccfbae)

After
![image](https://github.com/user-attachments/assets/f5672f93-072a-4e9f-845b-61cd1a20fae3)

