### PR TITLE
SAK-51565 Gradebook fix reordering in Categories

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsCategoryPanel.java
@@ -155,19 +155,16 @@ public class SettingsCategoryPanel extends BasePanel {
 		final WebMarkupContainer settingsCategoriesAccordionButton = new WebMarkupContainer("settingsCategoriesAccordionButton");
 		final WebMarkupContainer settingsCategoriesPanel = new WebMarkupContainer("settingsCategoriesPanel");
 		
-		// Set up accordion behavior
-		setupAccordionBehavior(settingsCategoriesAccordionButton, settingsCategoriesPanel, this.expanded, 
-			new AccordionStateUpdater() {
-				@Override
-				public void updateState(boolean newState) {
-					SettingsCategoryPanel.this.expanded = newState;
-				}
-				
-				@Override
-				public boolean getState() {
-					return SettingsCategoryPanel.this.expanded;
-				}
-			});
+		// Set initial state for Bootstrap accordion (no AJAX behavior)
+		if (this.expanded) {
+			settingsCategoriesPanel.add(new AttributeModifier("class", "accordion-collapse collapse show"));
+			settingsCategoriesAccordionButton.add(new AttributeModifier("class", "accordion-button fw-bold"));
+			settingsCategoriesAccordionButton.add(new AttributeModifier("aria-expanded", "true"));
+		} else {
+			settingsCategoriesPanel.add(new AttributeModifier("class", "accordion-collapse collapse"));
+			settingsCategoriesAccordionButton.add(new AttributeModifier("class", "accordion-button collapsed fw-bold"));
+			settingsCategoriesAccordionButton.add(new AttributeModifier("aria-expanded", "false"));
+		}
 		
 		add(settingsCategoriesPanel);
 		add(settingsCategoriesAccordionButton);

--- a/gradebookng/tool/src/webapp/scripts/gradebook-settings.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-settings.js
@@ -146,13 +146,37 @@ $(function() {
 
 window.addEventListener("DOMContentLoaded", e => {
 
-	const triggers = document.querySelectorAll("#gradebookSettings .accordion-collapse");
+  const triggers = document.querySelectorAll("#gradebookSettings .accordion-collapse");
 
   document.getElementById("gb-settings-expand-all")?.addEventListener("click", e => {
-		triggers.forEach(el => bootstrap.Collapse.getOrCreateInstance(el)?.show());
+    triggers.forEach(el => bootstrap.Collapse.getOrCreateInstance(el)?.show());
   });
 
   document.getElementById("gb-settings-collapse-all")?.addEventListener("click", e => {
-		triggers.forEach(el => bootstrap.Collapse.getOrCreateInstance(el)?.hide());
+    triggers.forEach(el => bootstrap.Collapse.getOrCreateInstance(el)?.hide());
+  });
+
+  // Persist accordion state in localStorage
+  const accordions = document.querySelectorAll("#gradebookSettings .accordion-collapse");
+
+  accordions.forEach(accordion => {
+    const storageKey = `gradebook-settings-${accordion.id}`;
+
+    // Restore saved state on page load
+    const savedState = localStorage.getItem(storageKey);
+    if (savedState === 'show') {
+      bootstrap.Collapse.getOrCreateInstance(accordion).show();
+    } else if (savedState === 'hide') {
+      bootstrap.Collapse.getOrCreateInstance(accordion).hide();
+    }
+
+    // Save state when accordion changes
+    accordion.addEventListener('shown.bs.collapse', () => {
+      localStorage.setItem(storageKey, 'show');
+    });
+
+    accordion.addEventListener('hidden.bs.collapse', () => {
+      localStorage.setItem(storageKey, 'hide');
+    });
   });
 });


### PR DESCRIPTION
What we changed:

1. Removed Wicket AJAX behavior - No more setupAccordionBehavior() calls that destroy/recreate DOM elements
2. Kept Bootstrap accordion attributes - The HTML already has proper data-bs-toggle="collapse" attributes
3. Added JavaScript state persistence - Uses localStorage instead of server-side state management
4. Set initial CSS classes only - Java just sets the right CSS classes based on this.expanded

Why this fixes the sortable issue:

- No DOM destruction - Bootstrap accordion only toggles CSS classes (show/hide) on existing elements
- jQuery UI sortable survives - Since the table DOM elements are never destroyed, the sortable behavior remains attached
- Pure client-side - No AJAX requests that could interfere with JavaScript behaviors

Benefits:
- Better performance - No server round-trips for accordion state
- Preserves all JavaScript behaviors - Sortable, event handlers, etc. stay intact
- Simpler code - Less Java logic, more standard Bootstrap
- State persistence - Accordion state saved across page reloads via localStorage

The drag-and-drop should now work perfectly because the DOM elements with ksortable attached are never destroyed by AJAX updates!