### PR TITLE
SAK-50729 Assignments fix assignment links in by student view

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_student_list_submissions.vm
@@ -175,7 +175,7 @@
 											</span>
 										</td>
 										<td headers="assignment" data-order="$assignmentTitle">
-											#if ($submission)
+											#if ($submission && $submission.submitted)
 												<a href="#toolLinkParam("AssignmentAction" "doGrade_submission" "assignmentId=$formattedText.escapeUrl($assignmentReference)&submissionId=$formattedText.escapeUrl($submissionReference)&submitterId=$formattedText.escapeUrl($member.Id)&option=lisofass2")">$assignmentTitle</a>
 											#else
 												$assignmentTitle


### PR DESCRIPTION
Fix issue where assignment links appeared for all students once any single student submitted to that assignment. Changed condition from checking if submission object exists to checking if submission is actually submitted.

Now assignment links only appear for students who have actually submitted.

🤖 Generated with [Claude Code](https://claude.ai/code)

I have not tested this code.