### PR TITLE
SAK-51605 GradebookNG fix undefined assignmentId in drag and drop for category columns

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -2395,6 +2395,13 @@ GbGradeTable.setupDragAndDrop = function () {
 
     const sourceAssignmentId = column.getElement().dataset.assignmentId;
     const sourceCategoryId = column.getElement().dataset.categoryId;
+    const columnType = column.getElement().dataset.columnType;
+
+    // Only process assignment columns, not category columns
+    if (columnType !== "assignment" || !sourceAssignmentId) {
+      console.debug("Skipping drag and drop for non-assignment column");
+      return;
+    }
 
     let newIndex = columns.findIndex(c => c._column.field === column._column.field) - GbGradeTable.FIXED_COLUMN_OFFSET;
 


### PR DESCRIPTION
The fix:

1. Added a check for columnType to ensure only assignment columns trigger the POST request
2. Added a guard clause that returns early if the column isn't an assignment or doesn't have an assignmentId
3. Added a debug log to help with troubleshooting

This prevents the POST request with assignmentId: undefined when users drag category columns in the gradebook.